### PR TITLE
Do not modify EventSelector during an event (For OutputModule thread safety)

### DIFF
--- a/FWCore/Framework/interface/EventSelector.h
+++ b/FWCore/Framework/interface/EventSelector.h
@@ -50,20 +50,22 @@ namespace edm
     EventSelector(Strings const& pathspecs);
 
     EventSelector(edm::ParameterSet const& pset,
-		  Strings const& triggernames);
+		  Strings const& pathNames);
 
     bool wantAll() const { return accept_all_; }
-    bool acceptEvent(TriggerResults const&);
+    bool acceptEvent(TriggerResults const&) const;
     bool acceptEvent(unsigned char const*, int) const;
+    void beginRun(ParameterSetID const& psetID);
+    bool forCurrentProcess() const { return results_from_current_process_; }
 
     // 29-Jan-2008, KAB - added methods for testing and using
     // trigger selections (pathspecs).
     static bool selectionIsValid(Strings const& pathspec,
-                                 Strings const& fullTriggerList);
+                                 Strings const& fullPathList);
     static evtSel::OverlapResult
       testSelectionOverlap(Strings const& pathspec1,
                            Strings const& pathspec2,
-                           Strings const& fullTriggerList);
+                           Strings const& fullPathList);
     std::shared_ptr<TriggerResults>
       maskTriggerResults(TriggerResults const& inputResults);
     static std::vector<std::string>
@@ -73,8 +75,10 @@ namespace edm
 
   private:
 
-    void init(Strings const& paths,
-	      Strings const& triggernames);
+    void initPathSpecs();
+
+    void init(Strings const& pathspecs,
+	      Strings const& pathNames);
 
     struct BitInfo
     {
@@ -95,12 +99,11 @@ namespace edm
     std::vector<Bits> all_must_fail_noex_;			// change 3
 
     bool results_from_current_process_;
-    bool psetID_initialized_;
     ParameterSetID psetID_;
 
-    Strings paths_;
+    Strings pathspecs_;
 
-    int nTriggerNames_;
+    int nPathNames_;
     bool notStarPresent_;
 
     bool acceptTriggerPath(HLTPathStatus const&, BitInfo const&) const;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -3,8 +3,7 @@
 
 /*----------------------------------------------------------------------
 
-OutputModule: The base class of all "modules" that write Events to an
-output stream.
+OutputModule: The base class of all "modules" that write Events to an output stream.
 
 ----------------------------------------------------------------------*/
 
@@ -100,7 +99,7 @@ namespace edm {
 
     ParameterSetID selectorConfig() const { return selector_config_id_; }
 
-    void doPreallocate(PreallocationConfiguration const&);
+    void doPreallocate(PreallocationConfiguration const&) {}
 
     void doBeginJob();
     void doEndJob();
@@ -154,10 +153,9 @@ namespace edm {
     ModuleDescription moduleDescription_;
 
     bool wantAllEvents_;
-    std::vector<detail::TriggerResultsBasedEventSelector> selectors_;
+    detail::TriggerResultsBasedEventSelector selectors_;
     // ID of the ParameterSet that configured the event selector
     // subsystem.
-    ParameterSet selectEvents_;
     ParameterSetID selector_config_id_;
 
     // needed because of possible EDAliases.
@@ -201,8 +199,6 @@ namespace edm {
 
     void registerProductsAndCallbacks(OutputModule const*, ProductRegistry const*) {}
     
-    bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
-
     /// Ask the OutputModule if we should end the current file.
     virtual bool shouldWeCloseFile() const {return false;}
 

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -13,13 +13,16 @@
 #include <vector>
 #include <map>
 
-#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
+  class EventPrincipal;
   class ModuleCallingContext;
+  class ParameterSet;
+  class RunPrincipal;
+  class TriggerResults;
 
   namespace detail {
     typedef edm::Handle<edm::TriggerResults> handle_t;
@@ -31,13 +34,15 @@ namespace edm {
 	eventSelector_(s)
       { }
 
-      bool match(TriggerResults const& product) {
+      bool match(TriggerResults const& product) const {
 	return eventSelector_.acceptEvent(product);
       }
 
       InputTag const& inputTag() const {
         return inputTag_;
       }
+
+      void beginRun(ProcessHistory const& ph);
 
     private:
       InputTag            inputTag_;
@@ -51,13 +56,14 @@ namespace edm {
       typedef std::vector<NamedEventSelector>     selectors_t;
       typedef std::pair<std::string, std::string> parsed_path_spec_t;
 
-      void setupDefault(std::vector<std::string> const& triggernames);
+      void setupDefault(std::vector<std::string> const& pathNames);
 
-      void setup(std::vector<parsed_path_spec_t> const& path_specs,
-		 std::vector<std::string> const& triggernames,
-                 const std::string& process_name);
+      void setup(std::vector<parsed_path_spec_t> const& pathSpecs,
+		 std::vector<std::string> const& pathNames,
+                 const std::string& processName);
 
-      bool wantEvent(EventPrincipal const& e, ModuleCallingContext const*);
+      bool wantEvent(EventPrincipal const& e, ModuleCallingContext const*) const;
+      void beginRun(RunPrincipal const& rp);
 
     private:
       selectors_t selectors_;

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -107,7 +107,7 @@ namespace edm {
       
       ParameterSetID selectorConfig() const { return selector_config_id_; }
 
-      void doPreallocate(PreallocationConfiguration const&);
+      void doPreallocate(PreallocationConfiguration const&) {}
 
       void doBeginJob();
       void doEndJob();
@@ -161,8 +161,7 @@ namespace edm {
       ModuleDescription moduleDescription_;
       
       bool wantAllEvents_;
-      std::vector<detail::TriggerResultsBasedEventSelector> selectors_;
-      ParameterSet selectEvents_;
+      detail::TriggerResultsBasedEventSelector selectors_;
       // ID of the ParameterSet that configured the event selector
       // subsystem.
       ParameterSetID selector_config_id_;
@@ -206,8 +205,6 @@ namespace edm {
       
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
-      bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
-      
       // Do the end-of-file tasks; this is only called internally, after
       // the appropriate tests have been done.
       virtual void reallyCloseFile();

--- a/FWCore/Framework/src/EventSelector.cc
+++ b/FWCore/Framework/src/EventSelector.cc
@@ -2,7 +2,7 @@
 //
 // 1 - M Fischler 2/8/08 Enable partial wildcards, as in HLT* or !CAL*
 //			 A version of this code with cerr debugging traces has
-//			 been placed in the doc area.  
+//			 been placed in the doc area.
 // 			 See ../doc/EventSelector-behavior.doc for details of
 //			 reactions to Ready or Exception states.
 // 1a M Fischler 2/13/08 Clear the all_must_fail_ array at the start of init.
@@ -13,12 +13,12 @@
 //			 contents to stick around.
 //
 // 2 - M Fischler 2/21/08 (In preparation for "exception-awareness" features):
-//			 Factored out the decision making logic from the 
+//			 Factored out the decision making logic from the
 //			 two forms of acceptEvent, into the single routine
 //			 selectionDecision().
 //
 // 3 - M Fischler 2/25/08 (Toward commit of "exception-awareness" features):
-//			 @exception and noexception& features 
+//			 @exception and noexception& features
 //
 // 4- M Fischler 2/28/08 Repair ommision in selectionIsValid when pathspecs
 //			is just "!*"
@@ -38,6 +38,7 @@
 #include "FWCore/Utilities/interface/RegexMatch.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include "boost/algorithm/string.hpp"
 
@@ -47,7 +48,7 @@
 namespace edm
 {
   EventSelector::EventSelector(Strings const& pathspecs,
-			       Strings const& names):
+			       Strings const& pathNames):
     accept_all_(false),
     absolute_acceptors_(),
     conditional_acceptors_(),
@@ -55,13 +56,13 @@ namespace edm
     all_must_fail_(),
     all_must_fail_noex_(),
     results_from_current_process_(true),
-    psetID_initialized_(false),
     psetID_(),
-    paths_(),
-    nTriggerNames_(0),
+    pathspecs_(pathspecs),
+    nPathNames_(0),
     notStarPresent_(false)
   {
-    init(pathspecs, names);
+    initPathSpecs();
+    init(pathspecs, pathNames);
   }
 
   EventSelector::EventSelector(Strings const& pathspecs):
@@ -72,16 +73,15 @@ namespace edm
     all_must_fail_(),
     all_must_fail_noex_(),
     results_from_current_process_(false),
-    psetID_initialized_(false),
     psetID_(),
-    paths_(pathspecs),
-    nTriggerNames_(0),
+    pathspecs_(pathspecs),
+    nPathNames_(0),
     notStarPresent_(false)
   {
+    initPathSpecs();
   }
 
-  EventSelector::EventSelector(ParameterSet const& config,
-			       Strings const& triggernames):
+  EventSelector::EventSelector(ParameterSet const& config, Strings const& pathNames):
     accept_all_(false),
     absolute_acceptors_(),
     conditional_acceptors_(),
@@ -89,66 +89,66 @@ namespace edm
     all_must_fail_(),
     all_must_fail_noex_(),
     results_from_current_process_(true),
-    psetID_initialized_(false),
     psetID_(),
-    paths_(),
-    nTriggerNames_(0),
+    pathspecs_(),
+    nPathNames_(0),
     notStarPresent_(false)
   {
-    Strings paths; // default is empty...
-
     if (!config.empty())
-      paths = config.getParameter<Strings>("SelectEvents");
+      pathspecs_ = config.getParameter<Strings>("SelectEvents");
 
-    init(paths, triggernames);
+    initPathSpecs();
+    init(pathspecs_, pathNames);
   }
 
   void
-  EventSelector::init(Strings const& paths,
-		      Strings const& triggernames)
-  {
+  EventSelector::initPathSpecs() {
+    accept_all_ = pathspecs_.empty();
+    if(accept_all_) {
+      return;
+    }
+
+    // The following are for the purpose of establishing accept_all_ by
+    // virtue of an inclusive set of paths:
+    bool unrestricted_star = false;
+    bool negated_star      = false;
+    bool exception_star    = false;
+
+    for(auto& pathspecifier : pathspecs_) {
+      boost::erase_all(pathspecifier, " \t"); // whitespace eliminated
+      if (pathspecifier == "*")           unrestricted_star = true;
+      if (pathspecifier == "!*")          negated_star = true;
+      if (pathspecifier == "exception@*") exception_star = true;
+    }
+    if (unrestricted_star && negated_star && exception_star) accept_all_ = true;
+  }
+
+  void
+  EventSelector::init(Strings const& paths, Strings const& pathNames) {
+    if(accept_all_) {
+      return;
+    }
     // std::cerr << "### init entered\n";
-    accept_all_ = false;
     absolute_acceptors_.clear(),
     conditional_acceptors_.clear(),
     exception_acceptors_.clear(),
     all_must_fail_.clear();
     all_must_fail_noex_.clear();
-    nTriggerNames_ = triggernames.size();
+    nPathNames_ = pathNames.size();
     notStarPresent_ = false;
 
-    if (paths.empty())
-      {
-	accept_all_ = true;
-	return;
-      }
-
-    // The following are for the purpose of establishing accept_all_ by 
-    // virtue of an inclusive set of paths:
-    bool unrestricted_star = false;
-    bool negated_star      = false;
-    bool exception_star    = false;
-    
-    for (Strings::const_iterator i(paths.begin()), end(paths.end()); 
-	 i!=end; ++i)
-    {
-      std::string pathSpecifier(*i);
-      boost::erase_all(pathSpecifier, " \t"); // whitespace eliminated
-      if (pathSpecifier == "*")           unrestricted_star = true;
-      if (pathSpecifier == "!*")          negated_star = true;
-      if (pathSpecifier == "exception@*") exception_star = true;
-
-      std::string basePathSpec(pathSpecifier);
+    for(auto const& pathspecifier : paths) {
+      std::string basePathSpec(pathspecifier);
       bool noex_demanded = false;
-      std::string::size_type 
-	      and_noexception = pathSpecifier.find("&noexception");
+      std::string::size_type
+	      and_noexception = pathspecifier.find("&noexception");
       if (and_noexception != std::string::npos) {
-	basePathSpec = pathSpecifier.substr(0,and_noexception);
+	basePathSpec = pathspecifier.substr(0,and_noexception);
         noex_demanded = true;
       }
-      std::string::size_type and_noex = pathSpecifier.find("&noex");
+      std::string::size_type and_noex = pathspecifier.find("&noex");
       if (and_noex != std::string::npos) {
-	basePathSpec = pathSpecifier.substr(0,and_noexception);
+	basePathSpec = pathspecifier.substr(0,and_noexception);
         noex_demanded = true;
       }
       and_noexception = basePathSpec.find("&noexception");
@@ -158,7 +158,7 @@ namespace edm
           throw edm::Exception(errors::Configuration)
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request a trigger name, but specifying &noexceptions twice\n"
-            << "The improper trigger name is: " << pathSpecifier << "\n";  
+            << "The improper trigger name is: " << pathspecifier << "\n";
 
       std::string realname(basePathSpec);
       bool negative_criterion = false;
@@ -168,57 +168,57 @@ namespace edm
       }
       bool exception_spec = false;
       if (realname.find("exception@") == 0) {
-	exception_spec = true;  
-	realname = realname.substr(10, std::string::npos); 
-	// strip off 10 chars, which is length of "exception@" 
+	exception_spec = true;
+	realname = realname.substr(10, std::string::npos);
+	// strip off 10 chars, which is length of "exception@"
       }	
       if (negative_criterion &&  exception_spec)
           throw edm::Exception(errors::Configuration)
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request a trigger name starting with !exception@.\n"
 	       "This is not supported.\n"
-            << "The improper trigger name is: " << pathSpecifier << "\n";  
+            << "The improper trigger name is: " << pathspecifier << "\n";
       if (noex_demanded &&  exception_spec)
           throw edm::Exception(errors::Configuration)
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request a trigger name starting with exception@ "
 	       "and also demanding no &exceptions.\n"
-            << "The improper trigger name is: " << pathSpecifier << "\n";  
+            << "The improper trigger name is: " << pathspecifier << "\n";
 
 
       // instead of "see if the name can be found in the full list of paths"
       // we want to find all paths that match this name.	
       std::vector<Strings::const_iterator> matches =
-	      regexMatch(triggernames, realname);
+	      regexMatch(pathNames, realname);
 
-      if (matches.empty() && !is_glob(realname)) 
+      if (matches.empty() && !is_glob(realname))
       {
           throw edm::Exception(errors::Configuration)
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request a trigger name that does not exist\n"
-            << "The unknown trigger name is: " << realname << "\n";  
+            << "The unknown trigger name is: " << realname << "\n";
       }
-      if (matches.empty() && is_glob(realname)) 
+      if (matches.empty() && is_glob(realname))
       {
           LogWarning("Configuration")
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request a wildcarded trigger name that does not match any trigger \n"
-            << "The wildcarded trigger name is: " << realname << "\n";  
+            << "The wildcarded trigger name is: " << realname << "\n";
       }
 
       if (!negative_criterion && !noex_demanded && !exception_spec) {
 	for (unsigned int t = 0; t != matches.size(); ++t) {
-	  BitInfo bi(distance(triggernames.begin(),matches[t]), true);
+	  BitInfo bi(distance(pathNames.begin(),matches[t]), true);
 	  absolute_acceptors_.push_back(bi);
 	}
       } else if (!negative_criterion && noex_demanded) {
 	for (unsigned int t = 0; t != matches.size(); ++t) {
-	  BitInfo bi(distance(triggernames.begin(),matches[t]), true);
+	  BitInfo bi(distance(pathNames.begin(),matches[t]), true);
 	  conditional_acceptors_.push_back(bi);
 	}
       } else if (exception_spec) {
 	for (unsigned int t = 0; t != matches.size(); ++t) {
-	  BitInfo bi(distance(triggernames.begin(),matches[t]), true);
+	  BitInfo bi(distance(pathNames.begin(),matches[t]), true);
 	  exception_acceptors_.push_back(bi);
 	}
       } else if (negative_criterion && !noex_demanded) {
@@ -226,16 +226,16 @@ namespace edm
             throw edm::Exception(errors::Configuration)
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request all fails on a set of trigger names that do not exist\n"
-            << "The problematic name is: " << pathSpecifier << "\n";  
+            << "The problematic name is: " << pathspecifier << "\n";
 
 	} else if (matches.size() == 1) {
-	  BitInfo bi(distance(triggernames.begin(),matches[0]), false);
+	  BitInfo bi(distance(pathNames.begin(),matches[0]), false);
 	  absolute_acceptors_.push_back(bi);
 	} else {
 	  Bits mustfail;
 	  for (unsigned int t = 0; t != matches.size(); ++t) {
-	    BitInfo bi(distance(triggernames.begin(),matches[t]), false);
-	    // We set this to false because that will demand bits are Fail. 
+	    BitInfo bi(distance(pathNames.begin(),matches[t]), false);
+	    // We set this to false because that will demand bits are Fail.
 	    mustfail.push_back(bi);
 	  }
 	  all_must_fail_.push_back(mustfail);
@@ -245,82 +245,65 @@ namespace edm
             throw edm::Exception(errors::Configuration)
             << "EventSelector::init, An OutputModule is using SelectEvents\n"
                "to request all fails on a set of trigger names that do not exist\n"
-            << "The problematic name is: " << pathSpecifier << "\n";  
+            << "The problematic name is: " << pathspecifier << "\n";
 
 	} else if (matches.size() == 1) {
-	  BitInfo bi(distance(triggernames.begin(),matches[0]), false);
+	  BitInfo bi(distance(pathNames.begin(),matches[0]), false);
 	  conditional_acceptors_.push_back(bi);
 	} else {
 	  Bits mustfail;
 	  for (unsigned int t = 0; t != matches.size(); ++t) {
-	    BitInfo bi(distance(triggernames.begin(),matches[t]), false);
+	    BitInfo bi(distance(pathNames.begin(),matches[t]), false);
 	    mustfail.push_back(bi);
 	  }
 	  all_must_fail_noex_.push_back(mustfail);
 	}
-      } 
-    } // end of the for loop on i(paths.begin()), end(paths.end())
-
-    if (unrestricted_star && negated_star && exception_star) accept_all_ = true;
+      }
+    } // end of the for loop on paths
 
     // std::cerr << "### init exited\n";
 
   } // EventSelector::init
-  
-  bool EventSelector::acceptEvent(TriggerResults const& tr)
-  {
+
+  // The path names for prior processes may be different in different runs.
+  // Check for this, and modify the selector accordingly if necessary.
+  void EventSelector::beginRun(ParameterSetID const& psetID) {
+    if(psetID_ == psetID) {
+      // The trigger paths parameter set ID is the same as for the previous run.
+      return;
+    }
+    // The process parameter set ID is different than for the previous run,
+    // or this is the first run.
+    psetID_ = psetID;
+    if (results_from_current_process_) {
+      return;
+    }
+    if(accept_all_) {
+      // We are accepting all events, so we do not need to get the paths for the process.
+      return;
+    }
+    ParameterSet const* triggerPathsPSet = pset::Registry::instance()->getMapped(psetID);
+    // Get the path names from the parameter set, and initialize them.
+    Strings pathNames = triggerPathsPSet->getParameter<Strings>("@trigger_paths");
+    init(pathspecs_, pathNames);
+  }
+
+  bool EventSelector::acceptEvent(TriggerResults const& tr) const {
     if (accept_all_) return true;
-    
-    // For the current process we already initialized in the constructor,
-    // The trigger names will not change so we can skip initialization.
+
     if (!results_from_current_process_) {
-  
-      // For previous processes we need to get the trigger names that
-      // correspond to the bits in TriggerResults from the ParameterSet
-      // set registry, which is stored once per file.  The ParameterSetID
-      // stored in TriggerResults is the key used to find the info in the
-      // registry.  We optimize using the fact the ID is unique. If the ID
-      // has not changed since the last time we initialized with new triggernames,
-      // then the names have not changed and we can skip this initialization.
-      if (!(psetID_initialized_ && psetID_ == tr.parameterSetID())) {
-
-        Strings triggernames;
-        bool fromPSetRegistry;
-
-        Service<service::TriggerNamesService> tns;
-        if (tns->getTrigPaths(tr, triggernames, fromPSetRegistry)) {
-
-          init(paths_, triggernames);
-
-          if (fromPSetRegistry) {
-            psetID_ = tr.parameterSetID();
-            psetID_initialized_ = true;
-          }
-          else {
-            psetID_initialized_ = false;
-          }
-        }
-        // This should never happen
-        else {
-          throw edm::Exception(errors::Unknown)
-            << "EventSelector::acceptEvent cannot find the trigger names for\n"
-               "a process for which the configuration has requested that the\n"
-               "OutputModule use TriggerResults to select events from.  This should\n"
-               "be impossible, please send information to reproduce this problem to\n"
-               "the edm developers.\n"; 
-	}
-      }
+      assert(psetID_ == tr.parameterSetID());
     }
 
     // Now make the decision, based on the supplied TriggerResults tr,
     // which of course can be treated as an HLTGlobalStatus by inheritance
-    
+
     return selectionDecision(tr);
-    
+
   } // acceptEvent(TriggerResults const& tr)
 
-  bool 
-  EventSelector::acceptEvent(unsigned char const* array_of_trigger_results, 
+  bool
+  EventSelector::acceptEvent(unsigned char const* array_of_trigger_results,
   			     int number_of_trigger_paths) const
   {
 
@@ -347,27 +330,27 @@ namespace edm
       HLTPathStatus pathStatus(static_cast<hlt::HLTState>(state));
       tr[pathIndex] = pathStatus;
       ++subIndex;
-      if (subIndex == 4)
-      { ++byteIndex;
+      if (subIndex == 4) {
+        ++byteIndex;
         subIndex = 0;
       }
-    }    
+    }
 
     // Now make the decision, based on the HLTGlobalStatus tr,
     // which we have created from the supplied array of results
-    
+
     return selectionDecision(tr);
 
   } // acceptEvent(array_of_trigger_results, number_of_trigger_paths)
 
-  bool 
+  bool
   EventSelector::selectionDecision(HLTGlobalStatus const& tr) const
   {
     if (accept_all_) return true;
 
     bool exceptionPresent = false;
     bool exceptionsLookedFor = false;
-    
+
     if (acceptOneBit(absolute_acceptors_, tr)) return true;
     if (acceptOneBit(conditional_acceptors_, tr)) {
       exceptionPresent = containsExceptions(tr);
@@ -389,12 +372,12 @@ namespace edm
         return (!exceptionPresent);
       }
     }
-    
+
     // If we have not accepted based on any of the acceptors, nor on any one of
     // the all_must_fail_ collections, then we reject this event.
-    
+
     return false;
-  
+
   }  // selectionDecision()
 
 // Obsolete...
@@ -409,28 +392,28 @@ namespace edm
   // Indicate if any bit in the trigger results matches the desired value
   // at that position, based on the Bits array.  If s is Exception, this
   // looks for a Exceptionmatch; otherwise, true-->Pass, false-->Fail.
-  bool 
-  EventSelector::acceptOneBit(Bits const& b, 
-    		       	       HLTGlobalStatus const& tr, 
+  bool
+  EventSelector::acceptOneBit(Bits const& b,
+    		       	       HLTGlobalStatus const& tr,
     		               hlt::HLTState const& s) const
   {
     bool lookForException = (s == hlt::Exception);
     Bits::const_iterator i(b.begin());
     Bits::const_iterator e(b.end());
     for(;i!=e;++i) {
-      hlt::HLTState bstate = 
+      hlt::HLTState bstate =
           lookForException ? hlt::Exception
       			   : i->accept_state_ ? hlt::Pass
 				              : hlt::Fail;
       if (tr[i->pos_].state() == bstate) return true;
     }
-    return false;    
-  } // acceptOneBit			       
+    return false;
+  } // acceptOneBit			
 
   // Indicate if *every* bit in the trigger results matches the desired value
   // at that position, based on the Bits array: true-->Pass, false-->Fail.
-  bool 
-  EventSelector::acceptAllBits(Bits const& b, 
+  bool
+  EventSelector::acceptAllBits(Bits const& b,
     		        	HLTGlobalStatus const& tr) const
   {
     Bits::const_iterator i(b.begin());
@@ -439,11 +422,11 @@ namespace edm
       hlt::HLTState bstate = i->accept_state_ ? hlt::Pass : hlt::Fail;
       if (tr[i->pos_].state() != bstate) return false;
     }
-    return true;    
-  } // acceptAllBits			       
+    return true;
+  } // acceptAllBits			
 
   /**
-   * Tests if the specified trigger selection list (path spec) is valid
+   * Tests if the specified trigger selection list (pathspecs) is valid
    * in the context of the specified full trigger list.  Each element in
    * the selection list is tested to see if it possible for some
    * combination of trigger results to satisfy the selection.  If all
@@ -451,28 +434,28 @@ namespace edm
    * method returns true.  If one or more selection elements could never
    * be satisfied given the input full trigger list, then this method
    * returns false.  At some level, this method tests whether the selection
-   * list is a "subset" of the full trigger list.
+   * list is a "subset" of the full path list.
    *
-   * @param pathspec The trigger selection list (vector of string).
-   * @param fullTriggerList The full list of trigger names (vector of string).
+   * @param pathspecs The trigger selection list (vector of string).
+   * @param fullPathList The full list of path names (vector of string).
    * @return true if the selection list is valid, false otherwise.
    */
-  bool EventSelector::selectionIsValid(Strings const& pathspec,
-                                       Strings const& fullTriggerList)
+  bool EventSelector::selectionIsValid(Strings const& pathspecs,
+                                       Strings const& fullPathList)
   {
     // an empty selection list is not valid
     // (we default an empty "SelectEvents" parameter to {"*","!*"} in
     // the getEventSelectionVString method below to help avoid this)
-    if (pathspec.size() == 0)
+    if (pathspecs.empty())
     {
       return false;
     }
 
     // loop over each element in the selection list
-    for (unsigned int idx = 0; idx < pathspec.size(); idx++)
+    for (unsigned int idx = 0; idx < pathspecs.size(); idx++)
     {
       Strings workingList;
-      workingList.push_back(pathspec[idx]);
+      workingList.push_back(pathspecs[idx]);
 
       // catch exceptions from the EventSelector constructor
       // (and anywhere else) and mark those as failures.
@@ -481,16 +464,16 @@ namespace edm
       try
       {
         // create an EventSelector instance for this selection
-        EventSelector evtSelector(workingList, fullTriggerList);
+        EventSelector evtSelector(workingList, fullPathList);
 
         // create the TriggerResults instance that we'll use for testing
-        unsigned int fullTriggerCount = fullTriggerList.size();
-        HLTGlobalStatus hltGS(fullTriggerCount);
-        TriggerResults sampleResults(hltGS, fullTriggerList);
+        unsigned int fullPathCount = fullPathList.size();
+        HLTGlobalStatus hltGS(fullPathCount);
+        TriggerResults sampleResults(hltGS, fullPathList);
 
         // loop over each path
         bool oneResultMatched = false;
-        for (unsigned int iPath = 0; iPath < fullTriggerCount; iPath++)
+        for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
         {
           // loop over the possible values for the path status
           for (int iState = static_cast<int>(hlt::Pass);
@@ -510,11 +493,11 @@ namespace edm
           if (oneResultMatched) break;
         }
 
-	// Finally, check in case the selection element was a wildcarded 
+	// Finally, check in case the selection element was a wildcarded
 	// negative such as "!*":
 	
         if (!oneResultMatched)  {
-	  for (unsigned int iPath = 0; iPath < fullTriggerCount; iPath++) {
+	  for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
             sampleResults[iPath] = HLTPathStatus(hlt::Fail, 0);
           }
 	  if (evtSelector.acceptEvent(sampleResults)) {
@@ -549,43 +532,43 @@ namespace edm
    *
    * @param pathspec1 The first trigger selection list (vector of string).
    * @param pathspec2 The second trigger selection list (vector of string).
-   * @param fullTriggerList The full list of trigger names (vector of string).
+   * @param fullPathList The full list of trigger names (vector of string).
    * @return OverlapResult which indicates the degree of overlap.
    */
   evtSel::OverlapResult
   EventSelector::testSelectionOverlap(Strings const& pathspec1,
                                       Strings const& pathspec2,
-                                      Strings const& fullTriggerList)
+                                      Strings const& fullPathList)
   {
     bool overlap = false;
-    
+
     // first, test that the selection lists are valid
-    if (!selectionIsValid(pathspec1, fullTriggerList) ||
-        !selectionIsValid(pathspec2, fullTriggerList))
+    if (!selectionIsValid(pathspec1, fullPathList) ||
+        !selectionIsValid(pathspec2, fullPathList))
     {
       return evtSel::InvalidSelection;
     }
- 
+
     // catch exceptions from the EventSelector constructor
     // (and anywhere else) and mark those as failures
     try
     {
       // create an EventSelector instance for each selection list
-      EventSelector a(pathspec1, fullTriggerList);
-      EventSelector b(pathspec2, fullTriggerList);
+      EventSelector a(pathspec1, fullPathList);
+      EventSelector b(pathspec2, fullPathList);
 
-      unsigned int N = fullTriggerList.size();
+      unsigned int N = fullPathList.size();
 
       // create the expanded masks for the various decision lists in a and b
-      std::vector<bool> 
+      std::vector<bool>
       	aPassAbs = expandDecisionList(a.absolute_acceptors_,true,N);
-      std::vector<bool> 
+      std::vector<bool>
       	aPassCon = expandDecisionList(a.conditional_acceptors_,true,N);
-      std::vector<bool> 
+      std::vector<bool>
       	aFailAbs = expandDecisionList(a.absolute_acceptors_,false,N);
-      std::vector<bool> 
+      std::vector<bool>
       	aFailCon = expandDecisionList(a.conditional_acceptors_,false,N);
-      std::vector<bool> 
+      std::vector<bool>
       	aExc = expandDecisionList(a.exception_acceptors_,true,N);
       std::vector< std::vector<bool> > aMustFail;
       for (unsigned int m = 0; m != a.all_must_fail_.size(); ++m) {
@@ -593,19 +576,19 @@ namespace edm
       }
       std::vector< std::vector<bool> > aMustFailNoex;
       for (unsigned int m = 0; m != a.all_must_fail_noex_.size(); ++m) {
-        aMustFailNoex.push_back 
+        aMustFailNoex.push_back
 		(expandDecisionList(a.all_must_fail_noex_[m],false,N));
       }
 
-      std::vector<bool> 
+      std::vector<bool>
       	bPassAbs = expandDecisionList(b.absolute_acceptors_,true,N);
-      std::vector<bool> 
+      std::vector<bool>
       	bPassCon = expandDecisionList(b.conditional_acceptors_,true,N);
-      std::vector<bool> 
+      std::vector<bool>
       	bFailAbs = expandDecisionList(b.absolute_acceptors_,false,N);
-      std::vector<bool> 
+      std::vector<bool>
       	bFailCon = expandDecisionList(b.conditional_acceptors_,false,N);
-      std::vector<bool> 
+      std::vector<bool>
       	bExc = expandDecisionList(b.exception_acceptors_,true,N);
       std::vector< std::vector<bool> > bMustFail;
       for (unsigned int m = 0; m != b.all_must_fail_.size(); ++m) {
@@ -613,7 +596,7 @@ namespace edm
       }
       std::vector< std::vector<bool> > bMustFailNoex;
       for (unsigned int m = 0; m != b.all_must_fail_noex_.size(); ++m) {
-        bMustFailNoex.push_back 
+        bMustFailNoex.push_back
 		(expandDecisionList(b.all_must_fail_noex_[m],false,N));
       }
 
@@ -623,10 +606,10 @@ namespace edm
       std::vector<bool> bFail = combine(bFailAbs, bFailCon);
 
       // Check for overlap in the primary masks
-      overlap = overlapping(aPass, bPass) || 
-      		overlapping(aFail, bFail) || 
+      overlap = overlapping(aPass, bPass) ||
+      		overlapping(aFail, bFail) ||
      		overlapping(aExc, bExc);
-      if (overlap) return identical(a,b,N) ? evtSel::ExactMatch 
+      if (overlap) return identical(a,b,N) ? evtSel::ExactMatch
       					     : evtSel::PartialOverlap;
 
       // Check for overlap of a primary fail mask with a must fail mask
@@ -636,7 +619,7 @@ namespace edm
 	for (unsigned int g = 0; g != bMustFail.size(); ++g) {
           overlap = subset(aMustFail[f], bMustFail[g]);
 	  if (overlap) return evtSel::PartialOverlap;
-	} 
+	}
 	for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
           overlap = subset(aMustFail[f], bMustFailNoex[g]);
 	  if (overlap) return evtSel::PartialOverlap;
@@ -648,7 +631,7 @@ namespace edm
 	for (unsigned int g = 0; g != bMustFail.size(); ++g) {
           overlap = subset(aMustFailNoex[f], bMustFail[g]);
 	  if (overlap) return evtSel::PartialOverlap;
-	} 
+	}
 	for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
           overlap = subset(aMustFailNoex[f], bMustFailNoex[g]);
 	  if (overlap) return evtSel::PartialOverlap;
@@ -683,17 +666,17 @@ namespace edm
    *
    * @param pathspec1 The first trigger selection list (vector of string).
    * @param pathspec2 The second trigger selection list (vector of string).
-   * @param fullTriggerList The full list of trigger names (vector of string).
+   * @param fullPathList The full list of trigger names (vector of string).
    * @return OverlapResult which indicates the degree of overlap.
    */
   evtSel::OverlapResult
   EventSelector::testSelectionOverlap(Strings const& pathspec1,
                                       Strings const& pathspec2,
-                                      Strings const& fullTriggerList)
+                                      Strings const& fullPathList)
   {
     // first, test that the selection lists are valid
-    if (!selectionIsValid(pathspec1, fullTriggerList) ||
-        !selectionIsValid(pathspec2, fullTriggerList))
+    if (!selectionIsValid(pathspec1, fullPathList) ||
+        !selectionIsValid(pathspec2, fullPathList))
     {
       return evtSel::InvalidSelection;
     }
@@ -707,16 +690,16 @@ namespace edm
     try
     {
       // create an EventSelector instance for each selection list
-      EventSelector selector1(pathspec1, fullTriggerList);
-      EventSelector selector2(pathspec2, fullTriggerList);
+      EventSelector selector1(pathspec1, fullPathList);
+      EventSelector selector2(pathspec2, fullPathList);
 
       // create the TriggerResults instance that we'll use for testing
-      unsigned int fullTriggerCount = fullTriggerList.size();
-      HLTGlobalStatus hltGS(fullTriggerCount);
-      TriggerResults sampleResults(hltGS, fullTriggerList);
+      unsigned int fullPathCount = fullPathList.size();
+      HLTGlobalStatus hltGS(fullPathCount);
+      TriggerResults sampleResults(hltGS, fullPathList);
 
       // loop over each path
-      for (unsigned int iPath = 0; iPath < fullTriggerCount; iPath++)
+      for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
       {
         // loop over the possible values for the path status
         for (int iState = static_cast<int>(hlt::Pass);
@@ -772,71 +755,71 @@ namespace edm
   EventSelector::maskTriggerResults(TriggerResults const& inputResults)
   {
     // fetch and validate the total number of paths
-    unsigned int fullTriggerCount = nTriggerNames_;
-    unsigned int N = fullTriggerCount;
-    if (fullTriggerCount != inputResults.size())
+    unsigned int fullPathCount = nPathNames_;
+    unsigned int N = fullPathCount;
+    if (fullPathCount != inputResults.size())
     {
       throw edm::Exception(errors::EventCorruption)
         << "EventSelector::maskTriggerResults, the TriggerResults\n"
         << "size (" << inputResults.size()
         << ") does not match the number of paths in the\n"
-        << "full trigger list (" << fullTriggerCount << ").\n";
+        << "full trigger list (" << fullPathCount << ").\n";
     }
 
     // create a suitable global status object to work with, all in Ready state
-    HLTGlobalStatus mask(fullTriggerCount);
-    
+    HLTGlobalStatus mask(fullPathCount);
+
     // Deal with must_fail acceptors that would cause selection
     for (unsigned int m = 0; m < this->all_must_fail_.size(); ++m) {
-      std::vector<bool>  
+      std::vector<bool>
         f = expandDecisionList(this->all_must_fail_[m],false,N);
       bool all_fail = true;
-      for (unsigned int ipath = 0; ipath < N; ++ipath) {        
-	if  ((f[ipath]) && (inputResults [ipath].state() != hlt::Fail)) { 
+      for (unsigned int ipath = 0; ipath < N; ++ipath) {
+	if  ((f[ipath]) && (inputResults [ipath].state() != hlt::Fail)) {
 	  all_fail = false;
 	  break;
 	}
       }
       if (all_fail) {
 	for (unsigned int ipath = 0; ipath < N; ++ipath) {
-          if  (f[ipath]) { 
+          if  (f[ipath]) {
 	    mask[ipath] = hlt::Fail;
 	  }
 	}
       }
     }
     for (unsigned int m = 0; m < this->all_must_fail_noex_.size(); ++m) {
-      std::vector<bool>  
+      std::vector<bool>
         f = expandDecisionList(this->all_must_fail_noex_[m],false,N);
       bool all_fail = true;
-      for (unsigned int ipath = 0; ipath < N; ++ipath) {        
-	if ((f[ipath]) && (inputResults [ipath].state() != hlt::Fail)) { 
+      for (unsigned int ipath = 0; ipath < N; ++ipath) {
+	if ((f[ipath]) && (inputResults [ipath].state() != hlt::Fail)) {
 	  all_fail = false;
 	  break;
 	}
       }
       if (all_fail) {
 	for (unsigned int ipath = 0; ipath < N; ++ipath) {
-          if  (f[ipath]) { 
+          if  (f[ipath]) {
 	    mask[ipath] = hlt::Fail;
 	  }
 	}
       }
     } // factoring opportunity - work done for fail_noex_ is same as for fail_
-    
+
     // Deal with normal acceptors that would cause selection
-    std::vector<bool> 
+    std::vector<bool>
       aPassAbs = expandDecisionList(this->absolute_acceptors_,true,N);
-    std::vector<bool> 
+    std::vector<bool>
       aPassCon = expandDecisionList(this->conditional_acceptors_,true,N);
-    std::vector<bool> 
+    std::vector<bool>
       aFailAbs = expandDecisionList(this->absolute_acceptors_,false,N);
-    std::vector<bool> 
+    std::vector<bool>
       aFailCon = expandDecisionList(this->conditional_acceptors_,false,N);
-    std::vector<bool> 
+    std::vector<bool>
       aExc = expandDecisionList(this->exception_acceptors_,true,N);
     for (unsigned int ipath = 0; ipath < N; ++ipath) {
-      hlt::HLTState s = inputResults [ipath].state();  
+      hlt::HLTState s = inputResults [ipath].state();
       if (((aPassAbs[ipath]) && (s == hlt::Pass))
       		||
 	  ((aPassCon[ipath]) && (s == hlt::Pass))		
@@ -850,8 +833,8 @@ namespace edm
         mask[ipath] = s;
       }		
     }
- 
-    // Based on the global status for the mask, create and return a 
+
+    // Based on the global status for the mask, create and return a
     // TriggerResults
     auto maskedResults = std::make_shared<TriggerResults>(mask, inputResults.parameterSetID());
     return maskedResults;
@@ -872,7 +855,7 @@ namespace edm
    *
    * @param pathspecs The trigger selection list (vector of string).
    * @param inputResults The raw trigger results object that will be masked.
-   * @param fullTriggerList The full list of trigger names (vector of string).
+   * @param fullPathList The full list of trigger names (vector of string).
    * @return a copy of the input trigger results object with only the path
    *         status results that match the trigger selection.
    * @throws edm::Exception if the number of paths in the TriggerResults
@@ -883,36 +866,36 @@ namespace edm
   std::shared_ptr<TriggerResults>
   EventSelector::maskTriggerResults(Strings const& pathspecs,
                                     TriggerResults const& inputResults,
-                                    Strings const& fullTriggerList)
+                                    Strings const& fullPathList)
   {
     // fetch and validate the total number of paths
-    unsigned int fullTriggerCount = fullTriggerList.size();
-    if (fullTriggerCount != inputResults.size())
+    unsigned int fullPathCount = fullPathList.size();
+    if (fullPathCount != inputResults.size())
     {
       throw edm::Exception(errors::EventCorruption)
         << "EventSelector::maskTriggerResults, the TriggerResults\n"
         << "size (" << inputResults.size()
         << ") does not match the number of paths in the\n"
-        << "full trigger list (" << fullTriggerCount << ").\n";
+        << "full trigger list (" << fullPathCount << ").\n";
     }
 
     // create a working copy of the TriggerResults object
-    HLTGlobalStatus hltGS(fullTriggerCount);
+    HLTGlobalStatus hltGS(fullPathCount);
     auto maskedResults = std::make_shared<TriggerResults>(hltGS, inputResults.parameterSetID());
-    for (unsigned int iPath = 0; iPath < fullTriggerCount; iPath++)
+    for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
     {
       (*maskedResults)[iPath] = inputResults[iPath];
     }
 
     // create an EventSelector to use when testing if a path status passes
-    EventSelector selector(pathspecs, fullTriggerList);
+    EventSelector selector(pathspecs, fullPathList);
 
     // create the TriggerResults instance that we'll use for testing
-    HLTGlobalStatus hltGS2(fullTriggerCount);
-    TriggerResults sampleResults(hltGS2, fullTriggerList);
+    HLTGlobalStatus hltGS2(fullPathCount);
+    TriggerResults sampleResults(hltGS2, fullPathList);
 
     // loop over each path and reset the path status if needed
-    for (unsigned int iPath = 0; iPath < fullTriggerCount; iPath++)
+    for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
     {
       sampleResults[iPath] = (*maskedResults)[iPath];
       if (!selector.wantAll() && !selector.acceptEvent(sampleResults))
@@ -947,7 +930,7 @@ namespace edm
     ParameterSet selectEventsParamSet =
       pset.getUntrackedParameter("SelectEvents", ParameterSet());
     if (!selectEventsParamSet.empty()) {
-      Strings path_specs = 
+      Strings path_specs =
         selectEventsParamSet.getParameter<Strings>("SelectEvents");
       if (!path_specs.empty()) {
         selection = path_specs;
@@ -968,9 +951,9 @@ namespace edm
   }
 
   // The following routines are helpers for testSelectionOverlap
-  
-  bool 
-  EventSelector::identical(std::vector<bool> const& a, 
+
+  bool
+  EventSelector::identical(std::vector<bool> const& a,
   			   std::vector<bool> const& b) {
      unsigned int n = a.size();
      if (n != b.size()) return false;
@@ -979,37 +962,37 @@ namespace edm
      }
      return true;
   }
-  
-  bool 
-  EventSelector::identical(EventSelector const& a, 
+
+  bool
+  EventSelector::identical(EventSelector const& a,
   			   EventSelector const& b,
-			   unsigned int N) 
+			   unsigned int N)
   {
         // create the expanded masks for the various decision lists in a and b
     if (!identical(expandDecisionList(a.absolute_acceptors_,true,N),
-                   expandDecisionList(b.absolute_acceptors_,true,N))) 
+                   expandDecisionList(b.absolute_acceptors_,true,N)))
 		   return false;
     if (!identical(expandDecisionList(a.conditional_acceptors_,true,N),
-                   expandDecisionList(b.conditional_acceptors_,true,N))) 
+                   expandDecisionList(b.conditional_acceptors_,true,N)))
 		   return false;
     if (!identical(expandDecisionList(a.absolute_acceptors_,false,N),
                    expandDecisionList(b.absolute_acceptors_,false,N)))
 		   return false;
     if (!identical(expandDecisionList(a.conditional_acceptors_,false,N),
-                   expandDecisionList(b.conditional_acceptors_,false,N))) 
+                   expandDecisionList(b.conditional_acceptors_,false,N)))
 		   return false;
     if (!identical(expandDecisionList(a.exception_acceptors_,true,N),
                    expandDecisionList(b.exception_acceptors_,true,N)))
 		   return false;
     if (a.all_must_fail_.size() != b.all_must_fail_.size()) return false;
-    
+
     std::vector< std::vector<bool> > aMustFail;
     for (unsigned int m = 0; m != a.all_must_fail_.size(); ++m) {
       aMustFail.push_back(expandDecisionList(a.all_must_fail_[m],false,N));
     }
     std::vector< std::vector<bool> > aMustFailNoex;
     for (unsigned int m = 0; m != a.all_must_fail_noex_.size(); ++m) {
-      aMustFailNoex.push_back 
+      aMustFailNoex.push_back
 	      (expandDecisionList(a.all_must_fail_noex_[m],false,N));
     }
     std::vector< std::vector<bool> > bMustFail;
@@ -1018,10 +1001,10 @@ namespace edm
     }
     std::vector< std::vector<bool> > bMustFailNoex;
     for (unsigned int m = 0; m != b.all_must_fail_noex_.size(); ++m) {
-      bMustFailNoex.push_back 
+      bMustFailNoex.push_back
 	      (expandDecisionList(b.all_must_fail_noex_[m],false,N));
     }
-    
+
     for (unsigned int m = 0; m != aMustFail.size(); ++m) {
       bool match = false;
       for (unsigned int k = 0; k != bMustFail.size(); ++k) {
@@ -1044,11 +1027,11 @@ namespace edm
     }
 
     return true;
-    
+
   } // identical (EventSelector, EventSelector, N);
-  
-  std::vector<bool> 
-  EventSelector::expandDecisionList(Bits const& b,  
+
+  std::vector<bool>
+  EventSelector::expandDecisionList(Bits const& b,
 				      bool PassOrFail,
 				      unsigned int n)
   {
@@ -1058,9 +1041,9 @@ namespace edm
     }
     return x;
   } // expandDecisionList	
-  
+
   // Determines whether a and b share a true bit at any position
-  bool EventSelector::overlapping(std::vector<bool> const& a, 
+  bool EventSelector::overlapping(std::vector<bool> const& a,
     			             std::vector<bool> const& b)
   {
     if (a.size() != b.size()) return false;
@@ -1069,14 +1052,14 @@ namespace edm
     }
     return false;
   } // overlapping
-  
+
   // determines whether the true bits of a are a non-empty subset of those of b,
   // or vice-versa.  The subset need not be proper.
-  bool EventSelector::subset(std::vector<bool> const& a, 
+  bool EventSelector::subset(std::vector<bool> const& a,
     			       std::vector<bool> const& b)
   {
     if (a.size() != b.size()) return false;
-    // First test whether a is a non-empty subset of b 
+    // First test whether a is a non-empty subset of b
     bool aPresent = false;
     bool aSubset = true;
     for (unsigned int i = 0; i != a.size(); ++i) {
@@ -1084,14 +1067,14 @@ namespace edm
         aPresent = true;
         if (!b[i]) {
 	  aSubset = false;
-	  break; 
+	  break;
 	}
       }
-    }   
+    }
     if (!aPresent) return false;
     if (aSubset) return true;
-    
-    // Now test whether b is a non-empty subset of a 
+
+    // Now test whether b is a non-empty subset of a
     bool bPresent = false;
     bool bSubset = true;
     for (unsigned int i = 0; i != b.size(); ++i) {
@@ -1099,29 +1082,29 @@ namespace edm
         bPresent = true;
         if (!a[i]) {
 	  bSubset = false;
-	  break; 
+	  break;
 	}
       }
-    }   
+    }
     if (!bPresent) return false;
     if (bSubset) return true;
- 
-    return false;     				     
+
+    return false;
   } // subset
-  
+
   // Creates a vector of bits which is the OR of a and b
-  std::vector<bool> 
-  EventSelector::combine(std::vector<bool> const& a, 
+  std::vector<bool>
+  EventSelector::combine(std::vector<bool> const& a,
     			  std::vector<bool> const& b)
   {
     assert(a.size() == b.size());
     std::vector<bool> x(a.size());
     for (unsigned int i = 0; i != a.size(); ++i) {
       x[i] = a[i] || b[i];
-    } // a really sharp compiler will optimize the hell out of this, 
+    } // a really sharp compiler will optimize the hell out of this,
       // exploiting word-size OR operations.
     return x;
-  } // combine			   			      
+  } // combine			   			
 
   void
   EventSelector::fillDescription(ParameterSetDescription& desc) {

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -340,6 +340,7 @@ namespace edm {
   SubProcess::doBeginRun(RunPrincipal const& principal, IOVSyncValue const& ts) {
     ServiceRegistry::Operate operate(serviceToken_);
     beginRun(principal,ts);
+    selectors_.beginRun(principal);
   }
 
   void

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -136,9 +136,6 @@ namespace edm {
     virtual std::string workerType() const = 0;
     virtual bool implDo(EventPrincipal&, EventSetup const& c,
                         ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoPrePrefetchSelection(StreamID id,
-                                            EventPrincipal& ep,
-                                            ModuleCallingContext const* mcc) = 0;
     virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) = 0;
     virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,
@@ -288,11 +285,6 @@ namespace edm {
         //Signal sentry is handled by the module
         return iWorker->implDo(ep,es, mcc);
       }
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return iWorker->implDoPrePrefetchSelection(id,ep,mcc);
-      }
     };
 
     template<>
@@ -307,11 +299,6 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoBegin(ep,es, mcc);
       }
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
-      }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>>{
@@ -324,11 +311,6 @@ namespace edm {
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamBegin(id,ep,es, mcc);
-      }
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
       }
     };
     template<>
@@ -343,11 +325,6 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoEnd(ep,es, mcc);
       }
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
-      }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>>{
@@ -360,11 +337,6 @@ namespace edm {
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamEnd(id,ep,es, mcc);
-      }
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
       }
     };
 
@@ -380,12 +352,6 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoBegin(ep,es, mcc);
       }
-
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
-      }
     };
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>>{
@@ -399,13 +365,7 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamBegin(id,ep,es, mcc);
       }
-
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
-      }
-};
+    };
 
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>>{
@@ -419,12 +379,6 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoEnd(ep,es, mcc);
       }
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
-      }
-
     };
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>>{
@@ -437,12 +391,6 @@ namespace edm {
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamEnd(id,ep,es, mcc);
-      }
-      
-      static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
-                                       ModuleCallingContext const* mcc) {
-        return true;
       }
     };
   }
@@ -475,14 +423,7 @@ namespace edm {
 
         if (T::isEvent_) {
           ++timesRun_;
-          
-          //if have TriggerResults based selection we want to reject the event before doing prefetching
-          if( not workerhelper::CallImpl<T>::prePrefetchSelection(this,streamID,ep,&moduleCallingContext_) ) {
-            state_ = Pass;
-            ++timesPassed_;
-            rc = true;
-            return;
-          }
+
           // Prefetch products the module declares it consumes (not including the products it maybe consumes)
           std::vector<ProductHolderIndexAndSkipBit> const& items = itemsToGetFromEvent();
           for(auto const& item : items) {

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -122,33 +122,6 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoPrePrefetchSelection(StreamID id,
-                                          EventPrincipal& ep,
-                                         ModuleCallingContext const* mcc) {
-    return true;
-  }
-
-  template<>
-  inline
-  bool
-  WorkerT<OutputModule>::implDoPrePrefetchSelection(StreamID id,
-                                         EventPrincipal& ep,
-                                         ModuleCallingContext const* mcc) {
-    return module_->prePrefetchSelection(id,ep,mcc);
-  }
-
-  template<>
-  inline
-  bool
-  WorkerT<edm::one::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
-                                                    EventPrincipal& ep,
-                                                    ModuleCallingContext const* mcc) {
-    return module_->prePrefetchSelection(id,ep,mcc);
-  }
-  
-  template<typename T>
-  inline
-  bool
   WorkerT<T>::implDoBegin(RunPrincipal& rp, EventSetup const& c, ModuleCallingContext const* mcc) {
     module_->doBeginRun(rp, c, mcc);
     return true;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -78,9 +78,6 @@ namespace edm {
   private:
     virtual bool implDo(EventPrincipal& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
-    virtual bool implDoPrePrefetchSelection(StreamID id,
-                                            EventPrincipal& ep,
-                                            ModuleCallingContext const* mcc) override;
     virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) override;
     virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,

--- a/FWCore/Framework/test/EventSelExc_t.cpp
+++ b/FWCore/Framework/test/EventSelExc_t.cpp
@@ -183,37 +183,13 @@ void evSelTest (PathSpecifiers const & ps, TrigResults const & tr, bool ans)
     ++number_of_trigger_paths;
   }
 
-  TriggerResults results(bm,trigger_path_names);
-
-  bool a  = select_based_on_pset.acceptEvent(results);
-  bool b  = select_based_on_path_specifiers_and_names.acceptEvent(results);
-  bool c  = select_based_on_path_specifiers_only.acceptEvent(results);
-  bool ab = select_based_on_pset.acceptEvent(&(bitArray[0]), 
-  		number_of_trigger_paths);
-  bool bb = select_based_on_path_specifiers_and_names.acceptEvent
-  		(&(bitArray[0]), number_of_trigger_paths);
-  // select_based_on_path_specifiers_only.acceptEvent(&(bitArray[0]), 
-  //                                     number_of_trigger_paths);
-  // is not a valid way to use acceptEvent.
-
-  if (a  != ans || b  != ans || c != ans || 
-      ab != ans || bb != ans  )
-    {
-      std::cerr << "failed to compare path specifiers with trigger results: "
-	   << "correct=" << ans << " "
-	   << "results=" << a  << "  " << b  << "  " << c  << "  " 
-	                 << ab << "  " << bb <<  "\n"
-	   << "pathspecs = " << ps.path << "\n"
-	   << "trigger results = " << tr << "\n";
-      abort();
-    }
-
   // Repeat putting the list of trigger names in the pset
   // registry
 
   ParameterSet trigger_pset;
   trigger_pset.addParameter<Strings>("@trigger_paths", trigger_path_names);
   trigger_pset.registerIt();
+  select_based_on_path_specifiers_only.beginRun(trigger_pset.id());
 
   TriggerResults results_id(bm, trigger_pset.id());
 

--- a/FWCore/Framework/test/EventSelWildcard_t.cpp
+++ b/FWCore/Framework/test/EventSelWildcard_t.cpp
@@ -100,38 +100,13 @@ void testone(const Strings& paths,
     bitArray[1] = (bitArray[1] & 0xfc) | edm::hlt::Exception;
   }
 
-  TriggerResults results(bm,paths);
-
-  bool a  = select_based_on_pset.acceptEvent(results);
-  bool b  = select_based_on_pattern_paths.acceptEvent(results);
-  bool c  = select_based_on_pattern.acceptEvent(results);
-  bool ab = select_based_on_pset.acceptEvent(&(bitArray[0]), 
-  		number_of_trigger_paths);
-  bool bb = select_based_on_pattern_paths.acceptEvent(&(bitArray[0]), 
-  		number_of_trigger_paths);
-  // select_based_on_pattern.acceptEvent(&(bitArray[0]), 
-  //                                     number_of_trigger_paths);
-  // is not a valid way to use acceptEvent.
-
-  if (a  != answer || b  != answer || c != answer || 
-      ab != answer || bb != answer  )
-    {
-      std::cerr << "failed to compare pattern with mask: "
-	   << "correct=" << answer << " "
-	   << "results=" << a  << "  " << b  << "  " << c  << "  " 
-	                 << ab << "  " << bb <<  "\n"
-	   << "pattern=" << pattern << "\n"
-	   << "mask=" << mask << "\n"
-           << "jmask = " << jmask << "\n"; 
-      abort();
-    }
-
   // Repeat putting the list of trigger names in the pset
   // registry
 
   ParameterSet trigger_pset;
   trigger_pset.addParameter<Strings>("@trigger_paths", paths);
   trigger_pset.registerIt();
+  select_based_on_pattern.beginRun(trigger_pset.id());
 
   TriggerResults results_id(bm, trigger_pset.id());
 

--- a/FWCore/Framework/test/EventSelector_t.cpp
+++ b/FWCore/Framework/test/EventSelector_t.cpp
@@ -90,40 +90,13 @@ void testone(const Strings& paths,
     bitArray[1] = (bitArray[1] & 0xfc) | edm::hlt::Exception;
   }
 
-  TriggerResults results(bm,paths);
-
-//        std::cerr << "pattern=" << pattern 
-//	 	  << "mask=" << mask << "\n";  // DBG
-
-//  	std:: cerr << "a \n";
-  bool a = select.acceptEvent(results);
-//  	std:: cerr << "a1 \n";
-  bool a1 = select1.acceptEvent(results);
-//  	std:: cerr << "a2 \n";
-  bool a2 = select2.acceptEvent(results);
-//  	std:: cerr << "b2 \n";
-  bool b2 = select2.acceptEvent(results);
-//  	std:: cerr << "c1 \n";
-  bool c1 = select1.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
-
-  if (a!=answer || a1 != answer || a2 != answer || b2 != answer || c1 != answer)
-    {
-      std::cerr << "failed to compare pattern with mask: "
-	   << "correct=" << answer << " "
-	   << "results=" << a << "  " << a1 << "  " << a2 
-	   		      << "  " << b2 << "  " << c1 << "\n"
-	   << "pattern=" << pattern << "\n"
-	   << "mask=" << mask << "\n"
-           << "jmask = " << jmask << "\n"; 
-      abort();
-    }
-
   // Repeat putting the list of trigger names in the pset
   // registry
 
   ParameterSet trigger_pset;
   trigger_pset.addParameter<Strings>("@trigger_paths", paths);
   trigger_pset.registerIt();
+  select2.beginRun(trigger_pset.id());
 
   TriggerResults results_id(bm, trigger_pset.id());
 
@@ -143,7 +116,7 @@ void testone(const Strings& paths,
 	   << "results=" << a11 << "  " << a12 << "  " << a13 << "  " << a14 << "\n"
 	   << "pattern=" << pattern << "\n"
 	   << "mask=" << mask << "\n"
-           << "jmask = " << jmask << "\n"; 
+           << "jmask = " << jmask << "\n";
       abort();
     }
 }
@@ -171,7 +144,7 @@ try {
   std::array<char const*, numBits> cpaths = {{"a1","a2","a3","a4","a5"}};
   Strings paths(cpaths.begin(),cpaths.end());
 
-  // 
+  //
 
   std::array<char const*, 2> cw1 = {{ "a1","a2" }};
   std::array<char const*, 2> cw2 = {{ "!a1","!a2" }};
@@ -209,7 +182,7 @@ try {
   std::array<bool,numBits> t9 = {{ false, false, false, false, false }};  // for t9 only, above the
                                                                             // first is reset to ready
                                                                             // last is reset to exception
-                                                                              
+
 
   VBools testmasks(numMasks);
   testmasks[0].insert(testmasks[0].end(),t1.begin(),t1.end());
@@ -236,7 +209,7 @@ try {
   };
 
 
-  // We want to create the TriggerNamesService because it is used in 
+  // We want to create the TriggerNamesService because it is used in
   // the tests.  We do that here, but first we need to build a minimal
   // parameter set to pass to its constructor.  Then we build the
   // service and setup the service system.

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 
 class TTree;

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -10,7 +10,6 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"


### PR DESCRIPTION
This PR is a major step toward a thread safe global::OutputModule.
The EventSelector class currently contains data members  that can be modified during the processing of an event. However, that data, in fact, can only change on a run boundary. This PR implements a beginRun() function for the event selectors, which will modify the data members if needed. In that way, the per event function EventSelector::acceptEvent() no linger needs to modify any data members.  This PR makes it const. This removes a serious impediment in parallel procesing of events in an output module.
This PR also changes the names of some data members and function arguments of EventSelector to be more mnemonic and less confusing,
This PR also modifies the output module base class so that it has only one set of EventSelectors, rather than one set per stream. With this PR, separate EventSelectors per stream are no longer needed.
