### PR TITLE
Streamer output modules ported to one::OutputModule (76X)

### DIFF
--- a/DQMServices/StreamerIO/test/DQMStreamerOutputModule.cc
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputModule.cc
@@ -36,10 +36,10 @@ class DQMStreamerOutputModule : public edm::StreamerOutputModuleBase {
   virtual void doOutputEvent(EventMsgBuilder const& msg) const;
 
   virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&,
-                                    edm::ModuleCallingContext const*);
+                                    edm::ModuleCallingContext const*) override;
 
   virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&,
-                                  edm::ModuleCallingContext const*);
+                                  edm::ModuleCallingContext const*) override;
 
  private:
   std::string streamLabel_;
@@ -56,7 +56,8 @@ class DQMStreamerOutputModule : public edm::StreamerOutputModuleBase {
 };  //end-of-class-def
 
 DQMStreamerOutputModule::DQMStreamerOutputModule(edm::ParameterSet const& ps)
-    : edm::StreamerOutputModuleBase(ps),
+    : edm::one::OutputModuleBase::OutputModuleBase(ps),
+      edm::StreamerOutputModuleBase(ps),
       streamLabel_(ps.getUntrackedParameter<std::string>("streamLabel")),
       runInputDir_(ps.getUntrackedParameter<std::string>("runInputDir", "")),
       processed_(0),

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -43,7 +43,7 @@ namespace evf {
     virtual void doOutputHeader(InitMsgBuilder const& init_message) const;
     virtual void doOutputEvent(EventMsgBuilder const& msg) const;
     //virtual void beginRun(edm::RunPrincipal const&, edm::ModuleCallingContext const*);
-    virtual void beginJob();
+    virtual void beginJob() override;
     virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
     virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
 

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -44,8 +44,8 @@ namespace evf {
     virtual void doOutputEvent(EventMsgBuilder const& msg) const;
     //virtual void beginRun(edm::RunPrincipal const&, edm::ModuleCallingContext const*);
     virtual void beginJob();
-    virtual void doBeginLuminosityBlock_(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
-    virtual void doEndLuminosityBlock_(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
+    virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
+    virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
 
   private:
     std::auto_ptr<Consumer> c_;
@@ -244,7 +244,7 @@ namespace evf {
 
 
   template<typename Consumer>
-  void RecoEventOutputModuleForFU<Consumer>::doBeginLuminosityBlock_(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
+  void RecoEventOutputModuleForFU<Consumer>::beginLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
   {
     //edm::LogInfo("RecoEventOutputModuleForFU") << "begin lumi";
     openDatFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),stream_label_);
@@ -254,7 +254,7 @@ namespace evf {
   }
 
   template<typename Consumer>
-  void RecoEventOutputModuleForFU<Consumer>::doEndLuminosityBlock_(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
+  void RecoEventOutputModuleForFU<Consumer>::endLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
   {
     //edm::LogInfo("RecoEventOutputModuleForFU") << "end lumi";
     long filesize=0;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -44,8 +44,8 @@ namespace evf {
     virtual void doOutputEvent(EventMsgBuilder const& msg) const;
     //virtual void beginRun(edm::RunPrincipal const&, edm::ModuleCallingContext const*);
     virtual void beginJob();
-    virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
-    virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
+    virtual void doBeginLuminosityBlock_(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
+    virtual void doEndLuminosityBlock_(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
 
   private:
     std::auto_ptr<Consumer> c_;
@@ -72,6 +72,7 @@ namespace evf {
 
   template<typename Consumer>
   RecoEventOutputModuleForFU<Consumer>::RecoEventOutputModuleForFU(edm::ParameterSet const& ps) :
+    edm::one::OutputModuleBase::OutputModuleBase(ps),
     edm::StreamerOutputModuleBase(ps),
     c_(new Consumer(ps)),
     stream_label_(ps.getParameter<std::string>("@module_label")),
@@ -243,7 +244,7 @@ namespace evf {
 
 
   template<typename Consumer>
-  void RecoEventOutputModuleForFU<Consumer>::beginLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
+  void RecoEventOutputModuleForFU<Consumer>::doBeginLuminosityBlock_(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
   {
     //edm::LogInfo("RecoEventOutputModuleForFU") << "begin lumi";
     openDatFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),stream_label_);
@@ -253,7 +254,7 @@ namespace evf {
   }
 
   template<typename Consumer>
-  void RecoEventOutputModuleForFU<Consumer>::endLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
+  void RecoEventOutputModuleForFU<Consumer>::doEndLuminosityBlock_(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)
   {
     //edm::LogInfo("RecoEventOutputModuleForFU") << "end lumi";
     long filesize=0;

--- a/IOPool/Streamer/interface/StreamerOutputModule.h
+++ b/IOPool/Streamer/interface/StreamerOutputModule.h
@@ -26,6 +26,8 @@ namespace edm {
     virtual void stop() const;
     virtual void doOutputHeader(InitMsgBuilder const& init_message) const;
     virtual void doOutputEvent(EventMsgBuilder const& msg) const;
+    virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
+    virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
 
   private:
     std::auto_ptr<Consumer> c_;
@@ -66,6 +68,14 @@ namespace edm {
   StreamerOutputModule<Consumer>::doOutputEvent(EventMsgBuilder const& msg) const {
     c_->doOutputEvent(msg); // You can't use msg in StreamerOutputModule after this point
   }
+
+  template<typename Consumer>
+  void
+  StreamerOutputModule<Consumer>::beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) {}
+
+  template<typename Consumer>
+  void
+  StreamerOutputModule<Consumer>::endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) {}
 
   template<typename Consumer>
   void

--- a/IOPool/Streamer/interface/StreamerOutputModule.h
+++ b/IOPool/Streamer/interface/StreamerOutputModule.h
@@ -33,8 +33,10 @@ namespace edm {
 
   template<typename Consumer>
   StreamerOutputModule<Consumer>::StreamerOutputModule(ParameterSet const& ps) :
+    edm::one::OutputModuleBase::OutputModuleBase(ps),
     StreamerOutputModuleBase(ps),
-    c_(new Consumer(ps)) {
+    c_(new Consumer(ps))
+    {
   }
 
   template<typename Consumer>

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -1,7 +1,7 @@
 #ifndef IOPool_Streamer_StreamerOutputModuleBase_h
 #define IOPool_Streamer_StreamerOutputModuleBase_h
 
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "IOPool/Streamer/interface/StreamSerializer.h"
@@ -14,15 +14,17 @@ namespace edm {
   class ModuleCallingContext;
   class ParameterSetDescription;
 
-  class StreamerOutputModuleBase : public OutputModule {
+  typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
+
+  class StreamerOutputModuleBase : public one::OutputModule<> {
   public:
-    explicit StreamerOutputModuleBase(ParameterSet const& ps);  
+    explicit StreamerOutputModuleBase(ParameterSet const& ps);
     virtual ~StreamerOutputModuleBase();
     static void fillDescription(ParameterSetDescription & desc);
 
   private:
-    virtual void beginRun(RunPrincipal const&, ModuleCallingContext const*) override;
-    virtual void endRun(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void doBeginRun_(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void doEndRun_(RunPrincipal const&, ModuleCallingContext const*) override;
     virtual void beginJob() override;
     virtual void endJob() override;
     virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) override;
@@ -36,6 +38,7 @@ namespace edm {
 
     std::auto_ptr<InitMsgBuilder> serializeRegistry();
     std::auto_ptr<EventMsgBuilder> serializeEvent(EventPrincipal const& e, ModuleCallingContext const* mcc); 
+    Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventPrincipal const& ep, ModuleCallingContext const*) const;
     void setHltMask(EventPrincipal const& e, ModuleCallingContext const*);
     void setLumiSection();
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -16,7 +16,7 @@ namespace edm {
 
   typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
-  class StreamerOutputModuleBase : public one::OutputModule<one::outputmodule::RunWatcher, one::outputmodule::LuminosityBlockWatcher> {
+  class StreamerOutputModuleBase : public one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks> {
   public:
     explicit StreamerOutputModuleBase(ParameterSet const& ps);
     virtual ~StreamerOutputModuleBase();

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -16,15 +16,15 @@ namespace edm {
 
   typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
-  class StreamerOutputModuleBase : public one::OutputModule<> {
+  class StreamerOutputModuleBase : public one::OutputModule<one::outputmodule::RunWatcher, one::outputmodule::LuminosityBlockWatcher> {
   public:
     explicit StreamerOutputModuleBase(ParameterSet const& ps);
     virtual ~StreamerOutputModuleBase();
     static void fillDescription(ParameterSetDescription & desc);
 
   private:
-    virtual void doBeginRun_(RunPrincipal const&, ModuleCallingContext const*) override;
-    virtual void doEndRun_(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void beginRun(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void endRun(RunPrincipal const&, ModuleCallingContext const*) override;
     virtual void beginJob() override;
     virtual void endJob() override;
     virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) override;

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -57,7 +57,7 @@ namespace {
 namespace edm {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps) :
     one::OutputModuleBase::OutputModuleBase(ps),
-    one::OutputModule<>(ps),
+    one::OutputModule<one::outputmodule::RunWatcher, one::outputmodule::LuminosityBlockWatcher>(ps),
     selections_(&keptProducts()[InEvent]),
     maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
     useCompression_(ps.getUntrackedParameter<bool>("use_compression")),

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Framework/interface/PrincipalGetAdapter.h"
 //#include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -55,7 +56,8 @@ namespace {
 
 namespace edm {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps) :
-    OutputModule(ps),
+    one::OutputModuleBase::OutputModuleBase(ps),
+    one::OutputModule<>(ps),
     selections_(&keptProducts()[InEvent]),
     maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
     useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
@@ -105,14 +107,14 @@ namespace edm {
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
 
   void
-  StreamerOutputModuleBase::beginRun(RunPrincipal const&, ModuleCallingContext const*) {
+  StreamerOutputModuleBase::doBeginRun_(RunPrincipal const&, ModuleCallingContext const*) {
     start();
     std::auto_ptr<InitMsgBuilder>  init_message = serializeRegistry();
     doOutputHeader(*init_message);
   }
 
   void
-  StreamerOutputModuleBase::endRun(RunPrincipal const&, ModuleCallingContext const*) {
+  StreamerOutputModuleBase::doEndRun_(RunPrincipal const&, ModuleCallingContext const*) {
     stop();
   }
 
@@ -194,12 +196,23 @@ namespace edm {
     return init_message;
   }
 
+  Trig
+  StreamerOutputModuleBase::getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventPrincipal const& ep, ModuleCallingContext const* mcc) const {
+    //This cast is safe since we only call const functions of the EventPrincipal after this point
+    PrincipalGetAdapter adapter(const_cast<EventPrincipal&>(ep), moduleDescription());
+    adapter.setConsumer(this);
+    Trig result;
+    auto bh = adapter.getByToken_(TypeID(typeid(TriggerResults)),PRODUCT_TYPE, token, mcc);
+    convert_handle(std::move(bh), result);
+    return result;
+  }
+
   void
   StreamerOutputModuleBase::setHltMask(EventPrincipal const& e, ModuleCallingContext const* mcc) {
 
     hltbits_.clear();  // If there was something left over from last event
 
-    Handle<TriggerResults> const& prod = getTriggerResults(trToken_,e, mcc);
+    Handle<TriggerResults> const& prod = getTriggerResults(trToken_, e, mcc);
     //Trig const& prod = getTrigMask(e);
     std::vector<unsigned char> vHltState;
 

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -57,7 +57,7 @@ namespace {
 namespace edm {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps) :
     one::OutputModuleBase::OutputModuleBase(ps),
-    one::OutputModule<one::outputmodule::RunWatcher, one::outputmodule::LuminosityBlockWatcher>(ps),
+    one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
     selections_(&keptProducts()[InEvent]),
     maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
     useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
@@ -107,14 +107,14 @@ namespace edm {
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
 
   void
-  StreamerOutputModuleBase::doBeginRun_(RunPrincipal const&, ModuleCallingContext const*) {
+  StreamerOutputModuleBase::beginRun(RunPrincipal const&, ModuleCallingContext const*) {
     start();
     std::auto_ptr<InitMsgBuilder>  init_message = serializeRegistry();
     doOutputHeader(*init_message);
   }
 
   void
-  StreamerOutputModuleBase::doEndRun_(RunPrincipal const&, ModuleCallingContext const*) {
+  StreamerOutputModuleBase::endRun(RunPrincipal const&, ModuleCallingContext const*) {
     stop();
   }
 


### PR DESCRIPTION
Migrates EvFOutputModule (DAQ) and EventStreamFileWriter from legacy to one::OutputModule interface
