### PR TITLE
CSC Beam Halo filter update

### DIFF
--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -39,6 +39,7 @@ namespace reco {
 
     const bool CSCLooseHaloId() const { return CSCHaloReport.size() ? CSCHaloReport[0] : false ; }
     const bool CSCTightHaloId() const { return CSCHaloReport.size() > 1 ? CSCHaloReport[1] : false ; }
+    const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false ; }
     
     const bool GlobalLooseHaloId() const { return GlobalHaloReport.size() ? GlobalHaloReport[0] : false ; }
     const bool GlobalTightHaloId() const { return GlobalHaloReport.size() > 1 ? GlobalHaloReport[1] : false ; }

--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -39,7 +39,8 @@ namespace reco {
 
     const bool CSCLooseHaloId() const { return CSCHaloReport.size() ? CSCHaloReport[0] : false ; }
     const bool CSCTightHaloId() const { return CSCHaloReport.size() > 1 ? CSCHaloReport[1] : false ; }
-    const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false ; }
+    const bool CSCTightHaloIdTrkMuUnveto() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false ; }
+    const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 5 ? CSCHaloReport[5] : false ; }
     
     const bool GlobalLooseHaloId() const { return GlobalHaloReport.size() ? GlobalHaloReport[0] : false ; }
     const bool GlobalTightHaloId() const { return GlobalHaloReport.size() > 1 ? GlobalHaloReport[1] : false ; }

--- a/DataFormats/METReco/interface/CSCHaloData.h
+++ b/DataFormats/METReco/interface/CSCHaloData.h
@@ -31,7 +31,9 @@ namespace reco {
 
     // Number of HaloTriggers in +/- endcap
     int NumberOfHaloTriggers (HaloData::Endcap z= HaloData::both) const ;
+    int NumberOfHaloTriggers_TrkMuUnVeto (HaloData::Endcap z= HaloData::both) const ;
     int NHaloTriggers(HaloData::Endcap z = HaloData::both ) const { return NumberOfHaloTriggers(z);}
+
     // Number of Halo Tracks in +/-  endcap
     int NumberOfHaloTracks(HaloData::Endcap z= HaloData::both) const ;
     int NHaloTracks(HaloData::Endcap z = HaloData::both) const { return NumberOfHaloTracks(z) ;}
@@ -53,7 +55,12 @@ namespace reco {
     // MLR
     short int NFlatHaloSegments() const{ return nFlatHaloSegments; }
     bool GetSegmentsInBothEndcaps() const{ return segments_in_both_endcaps; }
+    bool GetSegmentIsCaloMatched() const{ return segmentiscalomatched; }
     // End MLR
+    short int NFlatHaloSegments_TrkMuUnVeto() const{ return nFlatHaloSegments_TrkMuUnVeto; }
+    bool GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() const{ return segments_in_both_endcaps_loose_TrkMuUnVeto;}
+    bool GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() const{ return segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;}
+
 
     // Get Reference to the Tracks
     edm::RefVector<reco::TrackCollection>& GetTracks(){return TheTrackRefs;}
@@ -61,7 +68,7 @@ namespace reco {
     
     // Set Number of Halo Triggers
     void SetNumberOfHaloTriggers(int PlusZ,  int MinusZ ){ nTriggers_PlusZ =PlusZ; nTriggers_MinusZ = MinusZ ;}
-
+    void SetNumberOfHaloTriggers_TrkMuUnVeto(int PlusZ,  int MinusZ ){ nTriggers_PlusZ_TrkMuUnVeto =PlusZ; nTriggers_MinusZ_TrkMuUnVeto = MinusZ ;}
     // Set number of chamber-level triggers with non-collision timing
     void SetNOutOfTimeTriggers(short int PlusZ,short int MinusZ){ nOutOfTimeTriggers_PlusZ = PlusZ ; nOutOfTimeTriggers_MinusZ = MinusZ;}
     // Set number of CSCRecHits with non-collision timing
@@ -85,6 +92,11 @@ namespace reco {
     void SetNFlatHaloSegments(short int nSegments) {nFlatHaloSegments = nSegments;}
     void SetSegmentsBothEndcaps(bool b) { segments_in_both_endcaps = b; }
     // End MLR
+    void SetNFlatHaloSegments_TrkMuUnVeto(short int nSegments) {nFlatHaloSegments_TrkMuUnVeto = nSegments;}
+    void SetSegmentsBothEndcaps_Loose_TrkMuUnVeto(bool b) { segments_in_both_endcaps_loose_TrkMuUnVeto = b; }
+    void SetSegmentsBothEndcaps_Loose_dTcut_TrkMuUnVeto(bool b) { segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto = b; }
+    void SetSegmentIsCaloMatched(bool b) { segmentiscalomatched = b; }
+
   private:
     edm::RefVector<reco::TrackCollection> TheTrackRefs;
 
@@ -92,7 +104,8 @@ namespace reco {
     std::vector<GlobalPoint> TheGlobalPositions;
     int nTriggers_PlusZ;
     int nTriggers_MinusZ;
-
+    int nTriggers_PlusZ_TrkMuUnVeto;
+    int nTriggers_MinusZ_TrkMuUnVeto;
     // CSC halo trigger reported by the HLT
     bool HLTAccept;
    
@@ -117,7 +130,10 @@ namespace reco {
     short int nFlatHaloSegments;
     bool segments_in_both_endcaps;
     // end MLR
-
+    short int nFlatHaloSegments_TrkMuUnVeto;
+    bool segments_in_both_endcaps_loose_TrkMuUnVeto;
+    bool segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;
+    bool segmentiscalomatched ;
   };
 
 

--- a/DataFormats/METReco/src/BeamHaloSummary.cc
+++ b/DataFormats/METReco/src/BeamHaloSummary.cc
@@ -11,7 +11,7 @@ using namespace reco;
 
 BeamHaloSummary::BeamHaloSummary()
 {
-  for( unsigned int i = 0 ; i < 4 ; i++ )
+  for( unsigned int i = 0 ; i < 6 ; i++ )
     {
       CSCHaloReport.push_back(0);
       if( i < 2 )

--- a/DataFormats/METReco/src/CSCHaloData.cc
+++ b/DataFormats/METReco/src/CSCHaloData.cc
@@ -39,6 +39,19 @@ int CSCHaloData::NumberOfHaloTriggers(HaloData::Endcap z) const
     return nTriggers_MinusZ + nTriggers_PlusZ;
 }
 
+
+
+int CSCHaloData::NumberOfHaloTriggers_TrkMuUnVeto(HaloData::Endcap z) const
+{
+  if( z == HaloData::plus )
+    return nTriggers_PlusZ_TrkMuUnVeto;
+  else if( z == HaloData::minus )
+    return nTriggers_MinusZ_TrkMuUnVeto;
+  else
+    return nTriggers_MinusZ_TrkMuUnVeto + nTriggers_PlusZ_TrkMuUnVeto;
+}
+
+
 short int CSCHaloData::NumberOfOutOfTimeTriggers(HaloData::Endcap z ) const
 {
   if( z == HaloData::plus  ) 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -169,7 +169,8 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
-  <class name="reco::CSCHaloData" ClassVersion="10">
+  <class name="reco::CSCHaloData" ClassVersion="11">
+   <version ClassVersion="11" checksum="1723373351"/>
    <version ClassVersion="10" checksum="3522217120"/>
   </class>
   <class name="edm::Wrapper<reco::CSCHaloData>"/>

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 ## and this triggers an error under unscheduled mode
 from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, hcalLaserEventFilter
 from RecoMET.METFilters.metFilters_cff import EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter
-from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, CSCTightHaloFilter, CSCTightHaloTrkMuUnvetoFilter, CSCTightHalo2015Filter, HcalStripHaloFilter
+from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, CSCTightHaloFilter, CSCTightHaloTrkMuUnvetoFilter, CSCTightHalo2015Filter
 from RecoMET.METFilters.metFilters_cff import goodVertices, trackingFailureFilter, trkPOGFilters, manystripclus53X, toomanystripclus53X, logErrorTooManyClusters
 from RecoMET.METFilters.metFilters_cff import metFilters
 
@@ -14,7 +14,6 @@ Flag_HBHENoiseIsoFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseIsoF
 Flag_CSCTightHaloFilter = cms.Path(CSCTightHaloFilter)
 Flag_CSCTightHaloTrkMuUnvetoFilter = cms.Path(CSCTightHaloTrkMuUnvetoFilter)
 Flag_CSCTightHalo2015Filter = cms.Path(CSCTightHalo2015Filter)
-Flag_HcalStripHaloFilter = cms.Path(HcalStripHaloFilter)
 Flag_hcalLaserEventFilter = cms.Path(hcalLaserEventFilter)
 Flag_EcalDeadCellTriggerPrimitiveFilter = cms.Path(EcalDeadCellTriggerPrimitiveFilter)
 Flag_EcalDeadCellBoundaryEnergyFilter = cms.Path(EcalDeadCellBoundaryEnergyFilter)
@@ -33,13 +32,13 @@ Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 Flag_METFilters = cms.Path(metFilters)
 
 #add your new path here!!
-allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HcalStripHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
+allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
                    'ecalLaserCorrFilter','trkPOGFilters','trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
 
        
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
-    for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HcalStripHaloFilter','HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
+    for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(True)))
     for X in 'manystripclus53X', 'toomanystripclus53X', 'logErrorTooManyClusters':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 ## We don't use "import *" because the cff contains some modules for which the C++ class doesn't exist
 ## and this triggers an error under unscheduled mode
-from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, CSCTightHaloFilter, hcalLaserEventFilter, EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter, primaryVertexFilter 
+from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, hcalLaserEventFilter
+from RecoMET.METFilters.metFilters_cff import EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter
+from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, CSCTightHaloFilter, CSCTightHaloTrkMuUnvetoFilter, CSCTightHalo2015Filter, HcalStripHaloFilter
 from RecoMET.METFilters.metFilters_cff import goodVertices, trackingFailureFilter, trkPOGFilters, manystripclus53X, toomanystripclus53X, logErrorTooManyClusters
 from RecoMET.METFilters.metFilters_cff import metFilters
 
@@ -10,6 +12,9 @@ from RecoMET.METFilters.metFilters_cff import metFilters
 Flag_HBHENoiseFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseFilter)
 Flag_HBHENoiseIsoFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseIsoFilter)
 Flag_CSCTightHaloFilter = cms.Path(CSCTightHaloFilter)
+Flag_CSCTightHaloTrkMuUnvetoFilter = cms.Path(CSCTightHaloTrkMuUnvetoFilter)
+Flag_CSCTightHalo2015Filter = cms.Path(CSCTightHalo2015Filter)
+Flag_HcalStripHaloFilter = cms.Path(HcalStripHaloFilter)
 Flag_hcalLaserEventFilter = cms.Path(hcalLaserEventFilter)
 Flag_EcalDeadCellTriggerPrimitiveFilter = cms.Path(EcalDeadCellTriggerPrimitiveFilter)
 Flag_EcalDeadCellBoundaryEnergyFilter = cms.Path(EcalDeadCellBoundaryEnergyFilter)
@@ -28,13 +33,13 @@ Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 Flag_METFilters = cms.Path(metFilters)
 
 #add your new path here!!
-allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
+allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HcalStripHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
                    'ecalLaserCorrFilter','trkPOGFilters','trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
 
        
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
-    for X in 'CSCTightHaloFilter', 'HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
+    for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HcalStripHaloFilter','HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(True)))
     for X in 'manystripclus53X', 'toomanystripclus53X', 'logErrorTooManyClusters':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))

--- a/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
@@ -148,8 +148,17 @@ class CSCHaloAlgo {
   float max_segment_phi_diff;
   float max_segment_theta;
   // End MLR
-  math::XYZPoint getPosition(const DetId &id, reco::Vertex::Point vtx);
+  float  et_thresh_rh_hbhe, dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe, dr_highthresh_segvsrh_hbhe, dt_lowthresh_segvsrh_hbhe;
+  float  et_thresh_rh_eb, dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb, dr_highthresh_segvsrh_eb, dt_lowthresh_segvsrh_eb;
+  float  et_thresh_rh_ee, dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee, dr_highthresh_segvsrh_ee, dt_lowthresh_segvsrh_ee;
+
+  
+  
   const CaloGeometry *geo;
+  math::XYZPoint getPosition(const DetId &id, reco::Vertex::Point vtx);
+  bool HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float iZ, float iR, float iT, float iPhi);
+  bool ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float iZ, float iR, float iT, float iPhi );
+
 };
 
 #endif

--- a/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
@@ -148,16 +148,16 @@ class CSCHaloAlgo {
   float max_segment_phi_diff;
   float max_segment_theta;
   // End MLR
-  float  et_thresh_rh_hbhe, dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe, dr_highthresh_segvsrh_hbhe, dt_lowthresh_segvsrh_hbhe;
-  float  et_thresh_rh_eb, dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb, dr_highthresh_segvsrh_eb, dt_lowthresh_segvsrh_eb;
-  float  et_thresh_rh_ee, dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee, dr_highthresh_segvsrh_ee, dt_lowthresh_segvsrh_ee;
+  float  et_thresh_rh_hbhe, dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe, dr_highthresh_segvsrh_hbhe, dt_lowthresh_segvsrh_hbhe,dt_highthresh_segvsrh_hbhe;
+  float  et_thresh_rh_eb, dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb, dr_highthresh_segvsrh_eb, dt_lowthresh_segvsrh_eb,dt_highthresh_segvsrh_eb;
+  float  et_thresh_rh_ee, dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee, dr_highthresh_segvsrh_ee, dt_lowthresh_segvsrh_ee,dt_highthresh_segvsrh_ee;
 
   
   
   const CaloGeometry *geo;
   math::XYZPoint getPosition(const DetId &id, reco::Vertex::Point vtx);
-  bool HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float iZ, float iR, float iT, float iPhi);
-  bool ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float iZ, float iR, float iT, float iPhi );
+  bool HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float dt_highthresh_segvsrh , float iZ, float iR, float iT, float iPhi);
+  bool ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float dt_highthresh_segvsrh , float iZ, float iR, float iT, float iPhi );
 
 };
 

--- a/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
@@ -37,11 +37,14 @@
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/L1CSCTrackFinder/interface/L1CSCTrackCollection.h"
 #include "DataFormats/L1CSCTrackFinder/interface/L1CSCStatusDigiCollection.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutRecord.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/MuonDetId/interface/CSCIndexer.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
@@ -56,12 +59,14 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCChamber.h"
 #include "Geometry/CSCGeometry/interface/CSCLayer.h"
 #include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -77,6 +82,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Framework/interface/Event.h"
 
+
 namespace edm {
   class TriggerNames;
 }
@@ -90,9 +96,11 @@ class CSCHaloAlgo {
 			      const edm::Handle<reco::MuonTimeExtraMap> TheCSCTimeMap,
 			      edm::Handle<reco::MuonCollection>& TheMuons, edm::Handle<CSCSegmentCollection>& TheCSCSegments, 
 			      edm::Handle<CSCRecHit2DCollection>& TheCSCRecHits,edm::Handle < L1MuGMTReadoutCollection >& TheL1GMTReadout,
+			      edm::Handle<HBHERecHitCollection>& hbhehits,edm::Handle<EcalRecHitCollection>& ecalebhits,
+			      edm::Handle<EcalRecHitCollection>& ecaleehits,
 			      edm::Handle<edm::TriggerResults>& TheHLTResults, const edm::TriggerNames * triggerNames, 
 			      const edm::Handle<CSCALCTDigiCollection>& TheALCTs, MuonSegmentMatcher *TheMatcher,
-			      const edm::Event &TheEvent);
+			      const edm::Event &TheEvent, const edm::EventSetup &TheEventSetup);
 
   std::vector<edm::InputTag> vIT_HLTBit;
 
@@ -140,6 +148,8 @@ class CSCHaloAlgo {
   float max_segment_phi_diff;
   float max_segment_theta;
   // End MLR
+  math::XYZPoint getPosition(const DetId &id, reco::Vertex::Point vtx);
+  const CaloGeometry *geo;
 };
 
 #endif

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -87,11 +87,12 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
   int imucount=0;
   
   bool calomatched =false;
-  if(!geo){
-    edm::ESHandle<CaloGeometry> pGeo;
-    TheSetup.get<CaloGeometryRecord>().get(pGeo);
-    geo = pGeo.product();
-  }
+  //  if(!geo){
+  geo =0;
+  edm::ESHandle<CaloGeometry> pGeo;
+  TheSetup.get<CaloGeometryRecord>().get(pGeo);
+  geo = pGeo.product();
+  //}
   bool trkmuunvetoisdefault = false; //Pb with low pt tracker muons that veto good csc segments/halo triggers. 
   //Test to "unveto" low pt trk muons. 
   //For now, we just recalculate everything without the veto and add an extra set of variables to the class CSCHaloData. 

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -35,7 +35,7 @@ CSCHaloAlgo::CSCHaloAlgo()
   matching_dwire_threshold = 5.;
 
 
-  et_thresh_rh_hbhe=10; //GeV
+  et_thresh_rh_hbhe=25; //GeV
   et_thresh_rh_ee=10; 
   et_thresh_rh_eb=10; 
 
@@ -43,17 +43,21 @@ CSCHaloAlgo::CSCHaloAlgo()
   dphi_thresh_segvsrh_eb=0.05;
   dphi_thresh_segvsrh_ee=0.05; 
 
-  dr_lowthresh_segvsrh_hbhe=-25; //cm
-  dr_lowthresh_segvsrh_eb=-25; 
-  dr_lowthresh_segvsrh_ee=-25;
+  dr_lowthresh_segvsrh_hbhe=-20; //cm
+  dr_lowthresh_segvsrh_eb=-20; 
+  dr_lowthresh_segvsrh_ee=-20;
 
-  dr_highthresh_segvsrh_hbhe=25; //cm
-  dr_highthresh_segvsrh_eb=25; 
-  dr_highthresh_segvsrh_ee=25;
+  dr_highthresh_segvsrh_hbhe=20; //cm
+  dr_highthresh_segvsrh_eb=20; 
+  dr_highthresh_segvsrh_ee=20;
 
-  dt_lowthresh_segvsrh_hbhe=0;//ns
-  dt_lowthresh_segvsrh_eb=0;
-  dt_lowthresh_segvsrh_ee=0;
+  dt_lowthresh_segvsrh_hbhe=5;//ns
+  dt_lowthresh_segvsrh_eb=5;
+  dt_lowthresh_segvsrh_ee=5;
+
+  dt_highthresh_segvsrh_hbhe=30;//ns
+  dt_highthresh_segvsrh_eb=30;
+  dt_highthresh_segvsrh_ee=30;
 
 
   geo = 0;
@@ -622,12 +626,13 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
        float iR =  TMath::Sqrt(iGlobalPosition.x()*iGlobalPosition.x() + iGlobalPosition.y()*iGlobalPosition.y());
        float iZ = iGlobalPosition.z();
        float iT = iSegment->time();
-       //       if(abs(iZ)<650&& TheEvent.id().run()< 251737) iT-= 25; 
+       //Timing condition, helps removing random segments from next collisions
+       if(iT>15) continue;
        //Calo matching:
 
-       bool hbhematched = HCALSegmentMatching(hbhehits,et_thresh_rh_hbhe,dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe,dr_highthresh_segvsrh_hbhe,dt_lowthresh_segvsrh_hbhe,iZ,iR,iT,iPhi);
-       bool ebmatched = ECALSegmentMatching(ecalebhits,et_thresh_rh_eb,dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb,dr_highthresh_segvsrh_eb,dt_lowthresh_segvsrh_eb,iZ,iR,iT,iPhi);
-       bool eematched = ECALSegmentMatching(ecaleehits,et_thresh_rh_ee,dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee,dr_highthresh_segvsrh_ee,dt_lowthresh_segvsrh_ee,iZ,iR,iT,iPhi); 
+       bool hbhematched = HCALSegmentMatching(hbhehits,et_thresh_rh_hbhe,dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe,dr_highthresh_segvsrh_hbhe,dt_lowthresh_segvsrh_hbhe,dt_highthresh_segvsrh_hbhe,iZ,iR,iT,iPhi);
+       bool ebmatched = ECALSegmentMatching(ecalebhits,et_thresh_rh_eb,dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb,dr_highthresh_segvsrh_eb,dt_lowthresh_segvsrh_eb,dt_highthresh_segvsrh_eb,iZ,iR,iT,iPhi);
+       bool eematched = ECALSegmentMatching(ecaleehits,et_thresh_rh_ee,dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee,dr_highthresh_segvsrh_ee,dt_lowthresh_segvsrh_ee,dt_highthresh_segvsrh_ee,iZ,iR,iT,iPhi); 
        calomatched = calomatched? true: (hbhematched|| ebmatched|| eematched);
 
 
@@ -650,11 +655,15 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 float jR =  TMath::Sqrt(jGlobalPosition.x()*jGlobalPosition.x() + jGlobalPosition.y()*jGlobalPosition.y());
 	 float jZ = jGlobalPosition.z() ;
 	 float jT = jSegment->time();
+	 //Timing condition, helps removing random segments from next collisions
+	 if(jT>15) continue;
 	 //	 if(abs(jZ)<650&& TheEvent.id().run() < 251737)jT-= 25;
-	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= 0.2//max_segment_phi_diff 
-	     //&& abs(jR - iR) <= max_segment_r_diff 
-	     && (abs(jR - iR) <= max_segment_r_diff || (abs(jR - iR)<0.03*abs(jZ - iZ) &&  jZ*iZ<0) )
-	     && (jTheta < max_segment_theta || jTheta > TMath::Pi() - max_segment_theta)) {
+	 if ( abs(deltaPhi(jPhi , iPhi)) <= 0.1//max_segment_phi_diff 
+	      //&& abs(jR - iR) <= max_segment_r_diff 
+	      && (abs(jR - iR)<0.03*abs(jZ - iZ) )
+	      && (abs(jR - iR) <= max_segment_r_diff ||  jZ*iZ < 0) 
+	      && (jTheta < max_segment_theta || jTheta > TMath::Pi() - max_segment_theta)
+	      ) {
 	   //// Check if Segment matches to a colision muon
 	   if( TheMuons.isValid() ) {
 	     for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end()  && (Segment2IsGood||!trkmuunvetoisdefault) ; mu++ ) {
@@ -688,7 +697,11 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
              nSegs_alt++;
              minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
              plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
-             if( abs(jT-iT)<0.05*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && abs(jT-iT)> 0.02*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && minus_endcap&&plus_endcap ) both_endcaps_loose_dtcut_alt =true;
+             if( 
+		abs(jT-iT)<0.05*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && 
+		abs(jT-iT)> 0.02*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && 
+		(iT>-15 || jT>-15)&&
+ 		minus_endcap&&plus_endcap ) both_endcaps_loose_dtcut_alt =true;
            }
 	   
 	 }
@@ -735,7 +748,7 @@ math::XYZPoint CSCHaloAlgo::getPosition(const DetId &id, reco::Vertex::Point vtx
 }
 
 
-bool CSCHaloAlgo::HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float iZ, float iR, float iT, float iPhi){
+bool CSCHaloAlgo::HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float dt_highthresh_segvsrh , float iZ, float iR, float iT, float iPhi){
   reco::Vertex::Point vtx(0,0,0);
   for(size_t ihit = 0; ihit< rechitcoll->size(); ++ ihit){
     const HBHERecHit & rechit = (*rechitcoll)[ ihit ];
@@ -744,16 +757,19 @@ bool CSCHaloAlgo::HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitc
     double dphi_rhseg = abs(deltaPhi(rhpos.phi(),iPhi));
     double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
     double dtcorr_rhseg = rechit.time()- abs(rhpos.z()-iZ)/30- iT; 
-    if(rhet> et_thresh_rh&&
+    if(
+       ( rechit.time()<-3)&&
+       (rhpos.z()*iZ<0|| abs(rhpos.z())<200)&&
+       rhet> et_thresh_rh&&
        dphi_rhseg < dphi_thresh_segvsrh &&
        dr_rhseg < dr_highthresh_segvsrh && dr_rhseg> dr_lowthresh_segvsrh && //careful: asymmetric cut might not be the most appropriate thing 
-       dtcorr_rhseg> dt_lowthresh_segvsrh
+       dtcorr_rhseg> dt_lowthresh_segvsrh && dtcorr_rhseg< dt_highthresh_segvsrh
       ) return true; 
   }
   return false;
 }
 
-bool CSCHaloAlgo::ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float iZ, float iR, float iT, float iPhi ){
+bool CSCHaloAlgo::ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh,float dt_highthresh_segvsrh, float iZ, float iR, float iT, float iPhi ){
   reco::Vertex::Point vtx(0,0,0);
   for(size_t ihit = 0; ihit<rechitcoll->size(); ++ ihit){
     const EcalRecHit & rechit = (*rechitcoll)[ ihit ];
@@ -762,10 +778,13 @@ bool CSCHaloAlgo::ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitc
     double dphi_rhseg = abs(deltaPhi(rhpos.phi(),iPhi));
     double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
     double dtcorr_rhseg = rechit.time()- abs(rhpos.z()-iZ)/30- iT; 
-    if(rhet> et_thresh_rh&&
+    if( 
+       ( rechit.time()<-1)&&
+       (rhpos.z()*iZ<0|| abs(rhpos.z())<200)&&
+       rhet> et_thresh_rh&&
        dphi_rhseg < dphi_thresh_segvsrh &&
        dr_rhseg < dr_highthresh_segvsrh && dr_rhseg> dr_lowthresh_segvsrh && //careful: asymmetric cut might not be the most appropriate thing 
-       dtcorr_rhseg> dt_lowthresh_segvsrh
+       dtcorr_rhseg> dt_lowthresh_segvsrh && dtcorr_rhseg< dr_highthresh_segvsrh
        ) return true; 
   }
   return false;

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -33,7 +33,33 @@ CSCHaloAlgo::CSCHaloAlgo()
   matching_dphi_threshold = 0.18; //radians
   matching_deta_threshold = 0.4;
   matching_dwire_threshold = 5.;
+
+
+  et_thresh_rh_hbhe=10; //GeV
+  et_thresh_rh_ee=10; 
+  et_thresh_rh_eb=10; 
+
+  dphi_thresh_segvsrh_hbhe=0.05; //radians
+  dphi_thresh_segvsrh_eb=0.05;
+  dphi_thresh_segvsrh_ee=0.05; 
+
+  dr_lowthresh_segvsrh_hbhe=-25; //cm
+  dr_lowthresh_segvsrh_eb=-25; 
+  dr_lowthresh_segvsrh_ee=-25;
+
+  dr_highthresh_segvsrh_hbhe=25; //cm
+  dr_highthresh_segvsrh_eb=25; 
+  dr_highthresh_segvsrh_ee=25;
+
+  dt_lowthresh_segvsrh_hbhe=0;//ns
+  dt_lowthresh_segvsrh_eb=0;
+  dt_lowthresh_segvsrh_ee=0;
+
+
   geo = 0;
+
+
+  
 }
 
 reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
@@ -97,14 +123,14 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	      const GlobalPoint TheGlobalPosition = TheSurface.toGlobal(TheLocalPosition);
 
 	      float z = TheGlobalPosition.z();
-	      if( TMath::Abs(z) < innermost_global_z )
+	      if( abs(z) < innermost_global_z )
 		{
-		  innermost_global_z = TMath::Abs(z);
+		  innermost_global_z = abs(z);
 		  InnerMostGlobalPosition = GlobalPoint( TheGlobalPosition);
 		}
-	      if( TMath::Abs(z) > outermost_global_z )
+	      if( abs(z) > outermost_global_z )
 		{
-		  outermost_global_z = TMath::Abs(z);
+		  outermost_global_z = abs(z);
 		  OuterMostGlobalPosition = GlobalPoint( TheGlobalPosition );
 		}
 	      nCSCHits ++;
@@ -126,14 +152,14 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	      const GlobalPoint TheGlobalPosition = TheCSCChamber->toGlobal(TheLocalPosition);
 	      float z = TheGlobalPosition.z();
 	      int TheEndcap = TheCSCDetId.endcap();
-	      if( TMath::Abs(z) < innermost_seg_z[TheEndcap-1] )
+	      if( abs(z) < innermost_seg_z[TheEndcap-1] )
 		{
-		  innermost_seg_z[TheEndcap-1] = TMath::Abs(z);
+		  innermost_seg_z[TheEndcap-1] = abs(z);
 		  InnerSegmentTime[TheEndcap-1] = (*segment)->time();
 		}
-	      if( TMath::Abs(z) > outermost_seg_z[TheEndcap-1] )
+	      if( abs(z) > outermost_seg_z[TheEndcap-1] )
 		{
-		  outermost_seg_z[TheEndcap-1] = TMath::Abs(z);
+		  outermost_seg_z[TheEndcap-1] = abs(z);
 		  OuterSegmentTime[TheEndcap-1] = (*segment)->time();
 		}
 	    }
@@ -160,8 +186,8 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	  //Its a CSC Track,store it if it passes halo selection 
 	  StoreTrack = true;	  
 
-	  float deta = TMath::Abs( OuterMostGlobalPosition.eta() - InnerMostGlobalPosition.eta() );
-	  float dphi = TMath::ACos( TMath::Cos( OuterMostGlobalPosition.phi() - InnerMostGlobalPosition.phi() ) ) ;
+	  float deta = abs( OuterMostGlobalPosition.eta() - InnerMostGlobalPosition.eta() );
+	  float dphi = abs(deltaPhi( OuterMostGlobalPosition.phi() , InnerMostGlobalPosition.phi() )) ;
 	  float theta = Track->outerMomentum().theta();
 	  float innermost_x = InnerMostGlobalPosition.x() ;
 	  float innermost_y = InnerMostGlobalPosition.y();
@@ -316,7 +342,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 				    {
 				      //make sure that this SA muon is not actually a halo-like muon
 				      float theta =  mu->outerTrack()->outerMomentum().theta();
-				      float deta = TMath::Abs(mu->outerTrack()->outerPosition().eta() - mu->outerTrack()->innerPosition().eta());
+				      float deta = abs(mu->outerTrack()->outerPosition().eta() - mu->outerTrack()->innerPosition().eta());
 				      if( theta < min_outer_theta || theta > max_outer_theta )  //halo-like
 					continue;
 				      else if ( deta > deta_threshold ) //halo-like
@@ -347,8 +373,8 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 					  float phi_ = TheGlobalPosition.phi();
 					  float eta_ = TheGlobalPosition.eta();
 					  
-					  deta = deta < TMath::Abs( eta_ - haloeta ) ? deta : TMath::Abs( eta_ - haloeta );
-					  dphi = dphi < TMath::ACos(TMath::Cos(phi_ - halophi)) ? dphi : TMath::ACos(TMath::Cos(phi_ - halophi));
+					  deta = deta < abs( eta_ - haloeta ) ? deta : abs( eta_ - haloeta );
+					  dphi = dphi < abs(deltaPhi(phi_, halophi)) ? dphi : abs(deltaPhi(phi_, halophi));
 					}
 				    }
 				}
@@ -442,7 +468,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 				       if( iHit->cscDetId().ring() != digi_ring ) continue;
 				       if( iHit->cscDetId().chamber() != digi_chamber ) continue;
 				       int hit_wire = iHit->hitWire();
-				       dwire = dwire < TMath::Abs(hit_wire - digi_wire)? dwire : TMath::Abs(hit_wire - digi_wire );
+				       dwire = dwire < abs(hit_wire - digi_wire)? dwire : abs(hit_wire - digi_wire );
 				     }
 				 }
 			     }
@@ -596,54 +622,13 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
        float iR =  TMath::Sqrt(iGlobalPosition.x()*iGlobalPosition.x() + iGlobalPosition.y()*iGlobalPosition.y());
        float iZ = iGlobalPosition.z();
        float iT = iSegment->time();
-       //       if(fabs(iZ)<650&& TheEvent.id().run()< 251737) iT-= 25; 
+       //       if(abs(iZ)<650&& TheEvent.id().run()< 251737) iT-= 25; 
        //Calo matching:
-       reco::Vertex::Point vtx(0,0,0);
-       for(size_t ihit = 0; ihit<hbhehits->size(); ++ ihit){
-	 if(calomatched) break;
-	 const HBHERecHit & rechit = (*hbhehits)[ ihit ];
-	 math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
-	 double rhet = rechit.energy()/cosh(rhpos.eta()); 
-	 double dphi_rhseg = fabs(deltaPhi(rhpos.phi(),iGlobalPosition.phi()));
-	 double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
-	 double dtcorr_rhseg = rechit.time()- fabs(rhpos.z()-iZ)/30- iT; // 
-	 if(rhet>10&& 
-	    dphi_rhseg <0.05 && 
-	    dr_rhseg< 25 && dr_rhseg> -25 && //careful: asymmetric cut might not be the most appropriate thing 
-	    dtcorr_rhseg>0    
-	    ) calomatched= true;
-       }
 
-       for(size_t ihit = 0; ihit<ecalebhits->size(); ++ ihit){
-	 if(calomatched) break;
-	 const EcalRecHit & rechit = (*ecalebhits)[ ihit ];
-	 math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
-	 double rhet = rechit.energy()/cosh(rhpos.eta()); 
-	 double dphi_rhseg = fabs(deltaPhi(rhpos.phi(),iGlobalPosition.phi()));
-	 double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
-	 double dtcorr_rhseg = rechit.time()- fabs(rhpos.z()-iZ)/30- iT; // 
-	 if(rhet>10&& 
-	    dphi_rhseg <0.05 && 
-	    dr_rhseg< 25 && dr_rhseg> -25 && //careful: asymmetric cut might not be the most appropriate thing 
-	    dtcorr_rhseg>0    
-	    ) calomatched= true;
-       }
-       for(size_t ihit = 0; ihit<ecaleehits->size(); ++ ihit){
-         if(calomatched) break;
-         const EcalRecHit & rechit = (*ecaleehits)[ ihit ];
-	 math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
-         double rhet = rechit.energy()/cosh(rhpos.eta());
-         double dphi_rhseg = fabs(deltaPhi(rhpos.phi(),iGlobalPosition.phi()));
-         double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
-         double dtcorr_rhseg = rechit.time()- fabs(rhpos.z()-iZ)/30- iT; //                                                                       
-         if(rhet>10&&
-            dphi_rhseg <0.05 &&
-            dr_rhseg< 25 && dr_rhseg> -25 && //careful: asymmetric cut might not be the most appropriate thing                                  
-	    dtcorr_rhseg>0
-            ) calomatched= true;
-     }
-
-
+       bool hbhematched = HCALSegmentMatching(hbhehits,et_thresh_rh_hbhe,dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe,dr_highthresh_segvsrh_hbhe,dt_lowthresh_segvsrh_hbhe,iZ,iR,iT,iPhi);
+       bool ebmatched = ECALSegmentMatching(ecalebhits,et_thresh_rh_eb,dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb,dr_highthresh_segvsrh_eb,dt_lowthresh_segvsrh_eb,iZ,iR,iT,iPhi);
+       bool eematched = ECALSegmentMatching(ecaleehits,et_thresh_rh_ee,dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee,dr_highthresh_segvsrh_ee,dt_lowthresh_segvsrh_ee,iZ,iR,iT,iPhi); 
+       calomatched = calomatched? true: (hbhematched|| ebmatched|| eematched);
 
 
        short int nSegs = 0;
@@ -665,10 +650,10 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 float jR =  TMath::Sqrt(jGlobalPosition.x()*jGlobalPosition.x() + jGlobalPosition.y()*jGlobalPosition.y());
 	 float jZ = jGlobalPosition.z() ;
 	 float jT = jSegment->time();
-	 //	 if(fabs(jZ)<650&& TheEvent.id().run() < 251737)jT-= 25;
+	 //	 if(abs(jZ)<650&& TheEvent.id().run() < 251737)jT-= 25;
 	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= 0.2//max_segment_phi_diff 
-	     //&& TMath::Abs(jR - iR) <= max_segment_r_diff 
-	     && (TMath::Abs(jR - iR) <= max_segment_r_diff || (TMath::Abs(jR - iR)/ TMath::Abs(jZ - iZ)< 0.03 &&  jZ*iZ<0) )
+	     //&& abs(jR - iR) <= max_segment_r_diff 
+	     && (abs(jR - iR) <= max_segment_r_diff || (abs(jR - iR)<0.03*abs(jZ - iZ) &&  jZ*iZ<0) )
 	     && (jTheta < max_segment_theta || jTheta > TMath::Pi() - max_segment_theta)) {
 	   //// Check if Segment matches to a colision muon
 	   if( TheMuons.isValid() ) {
@@ -697,13 +682,13 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	     nSegs++;
 	     minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
 	     plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
-	     //	     if( fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )<0.05 && fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )>0.02 && minus_endcap&&plus_endcap ) both_endcaps_dtcut =true;
+	     //	     if( abs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )<0.05 && abs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )>0.02 && minus_endcap&&plus_endcap ) both_endcaps_dtcut =true;
 	   }
 	   if(Segment1IsGood_alt && Segment2IsGood_alt) {
              nSegs_alt++;
              minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
              plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
-             if( fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )<0.05 && fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )>0.02 && minus_endcap&&plus_endcap ) both_endcaps_loose_dtcut_alt =true;
+             if( abs(jT-iT)<0.05*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && abs(jT-iT)> 0.02*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && minus_endcap&&plus_endcap ) both_endcaps_loose_dtcut_alt =true;
            }
 	   
 	 }
@@ -747,4 +732,41 @@ math::XYZPoint CSCHaloAlgo::getPosition(const DetId &id, reco::Vertex::Point vtx
   const GlobalPoint& pos=geo->getPosition(id);
   math::XYZPoint posV(pos.x() - vtx.x(),pos.y() - vtx.y(),pos.z() - vtx.z());
   return posV;
+}
+
+
+bool CSCHaloAlgo::HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float iZ, float iR, float iT, float iPhi){
+  reco::Vertex::Point vtx(0,0,0);
+  for(size_t ihit = 0; ihit< rechitcoll->size(); ++ ihit){
+    const HBHERecHit & rechit = (*rechitcoll)[ ihit ];
+    math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+    double rhet = rechit.energy()/cosh(rhpos.eta());
+    double dphi_rhseg = abs(deltaPhi(rhpos.phi(),iPhi));
+    double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+    double dtcorr_rhseg = rechit.time()- abs(rhpos.z()-iZ)/30- iT; 
+    if(rhet> et_thresh_rh&&
+       dphi_rhseg < dphi_thresh_segvsrh &&
+       dr_rhseg < dr_highthresh_segvsrh && dr_rhseg> dr_lowthresh_segvsrh && //careful: asymmetric cut might not be the most appropriate thing 
+       dtcorr_rhseg> dt_lowthresh_segvsrh
+      ) return true; 
+  }
+  return false;
+}
+
+bool CSCHaloAlgo::ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float iZ, float iR, float iT, float iPhi ){
+  reco::Vertex::Point vtx(0,0,0);
+  for(size_t ihit = 0; ihit<rechitcoll->size(); ++ ihit){
+    const EcalRecHit & rechit = (*rechitcoll)[ ihit ];
+    math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+    double rhet = rechit.energy()/cosh(rhpos.eta());
+    double dphi_rhseg = abs(deltaPhi(rhpos.phi(),iPhi));
+    double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+    double dtcorr_rhseg = rechit.time()- abs(rhpos.z()-iZ)/30- iT; 
+    if(rhet> et_thresh_rh&&
+       dphi_rhseg < dphi_thresh_segvsrh &&
+       dr_rhseg < dr_highthresh_segvsrh && dr_rhseg> dr_lowthresh_segvsrh && //careful: asymmetric cut might not be the most appropriate thing 
+       dtcorr_rhseg> dt_lowthresh_segvsrh
+       ) return true; 
+  }
+  return false;
 }

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -1,3 +1,4 @@
+
 #include "RecoMET/METAlgorithms/interface/CSCHaloAlgo.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 /*
@@ -32,6 +33,7 @@ CSCHaloAlgo::CSCHaloAlgo()
   matching_dphi_threshold = 0.18; //radians
   matching_deta_threshold = 0.4;
   matching_dwire_threshold = 5.;
+  geo = 0;
 }
 
 reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
@@ -41,14 +43,29 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 					 edm::Handle<CSCSegmentCollection>& TheCSCSegments, 
 					 edm::Handle<CSCRecHit2DCollection>& TheCSCRecHits,
 					 edm::Handle < L1MuGMTReadoutCollection >& TheL1GMTReadout,
+					 edm::Handle<HBHERecHitCollection>& hbhehits,
+					 edm::Handle<EcalRecHitCollection>& ecalebhits,
+					 edm::Handle<EcalRecHitCollection>& ecaleehits,
 					 edm::Handle<edm::TriggerResults>& TheHLTResults,
 					 const edm::TriggerNames * triggerNames, 
 					 const edm::Handle<CSCALCTDigiCollection>& TheALCTs,
 					 MuonSegmentMatcher *TheMatcher,  
-					 const edm::Event& TheEvent)
+					 const edm::Event& TheEvent,
+					 const edm::EventSetup& TheSetup)
 {
   reco::CSCHaloData TheCSCHaloData;
   int imucount=0;
+  
+  bool calomatched =false;
+  if(!geo){
+    edm::ESHandle<CaloGeometry> pGeo;
+    TheSetup.get<CaloGeometryRecord>().get(pGeo);
+    geo = pGeo.product();
+  }
+  bool trkmuunvetoisdefault = false; //Pb with low pt tracker muons that veto good csc segments/halo triggers. 
+  //Test to "unveto" low pt trk muons. 
+  //For now, we just recalculate everything without the veto and add an extra set of variables to the class CSCHaloData. 
+  //If this is satisfactory, these variables can become the default ones by setting trkmuunvetoisdefault to true. 
   if( TheCosmicMuons.isValid() )
     {
       short int n_tracks_small_beta=0;
@@ -259,6 +276,9 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
        int icsc = 0;
        int PlusZ = 0 ;
        int MinusZ = 0 ;
+       int PlusZ_alt = 0 ;
+       int MinusZ_alt = 0 ;
+
        // Check to see if CSC BeamHalo trigger is tripped
        for (igmtrr = gmt_records.begin (); igmtrr != gmt_records.end (); igmtrr++)
 	 {
@@ -275,16 +295,20 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		      halophi = halophi > TMath::Pi() ? halophi - 2.*TMath::Pi() : halophi;
 		      float haloeta = iter1->etaValue();
 		      bool HaloIsGood = true;
+		      bool HaloIsGood_alt = true;
 		      // Check if halo trigger is faked by any collision muons
 		      if( TheMuons.isValid() )
 			{
 			  float dphi = 9999.;
 			  float deta = 9999.;
-			  for( reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu != TheMuons->end() && HaloIsGood ; mu++ )
+			  for( reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu != TheMuons->end()  && (HaloIsGood ||!trkmuunvetoisdefault) ; mu++ )
 			    {
 			      // Don't match with SA-only muons
+			      bool lowpttrackmu =false;
 			      if( mu->isStandAloneMuon() && !mu->isTrackerMuon() && !mu->isGlobalMuon() )  continue;
-			      
+			      if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3 && trkmuunvetoisdefault) continue;
+			      if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3 ) lowpttrackmu = true;
+
 			      /*
 			      if(!mu->isTrackerMuon())
 				{
@@ -328,16 +352,25 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 					}
 				    }
 				}
-			      if ( dphi < matching_dphi_threshold && deta < matching_deta_threshold) 
+			      if ( dphi < matching_dphi_threshold && deta < matching_deta_threshold){ 
 				HaloIsGood = false; // i.e., collision muon likely faked halo trigger
+				if(!lowpttrackmu)HaloIsGood_alt   = false;
+			      }
 			    }
 			}
-		      if( !HaloIsGood ) 
-			continue;
-		      if( (*iter1).etaValue() > 0 )
-			PlusZ++;
-		      else
-			MinusZ++;
+		      if( HaloIsGood ){ 
+			if( (*iter1).etaValue() > 0 )
+			  PlusZ++;
+			else
+			  MinusZ++;
+		      }
+		      if( HaloIsGood_alt ){
+			if( (*iter1).etaValue() > 0 )
+                          PlusZ_alt++;
+                        else
+                          MinusZ_alt++;
+                      }
+
 		    }
 		  else
 		    icsc++;
@@ -345,6 +378,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	     }
 	 }
        TheCSCHaloData.SetNumberOfHaloTriggers(PlusZ, MinusZ);
+       TheCSCHaloData.SetNumberOfHaloTriggers_TrkMuUnVeto(PlusZ_alt, MinusZ_alt);
      }
    else
      {
@@ -387,8 +421,9 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		       //Check if there are any collision muons with hits in the vicinity of the digi
 		       for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && DigiIsGood ; mu++ )
 			 {
+			   
 			   if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon() ) continue;
-
+			   if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3 &&trkmuunvetoisdefault) continue;
 			   const std::vector<MuonChamberMatch> chambers = mu->matches();
 			   for(std::vector<MuonChamberMatch>::const_iterator iChamber = chambers.begin();
 			       iChamber != chambers.end(); iChamber ++ )
@@ -497,6 +532,14 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
    bool plus_endcap = false;
    bool minus_endcap = false;
    bool both_endcaps = false;
+   bool both_endcaps_loose = false;
+   //   bool both_endcaps_dtcut = false;
+
+   short int maxNSegments_alt = 0;
+   bool both_endcaps_alt = false;
+   bool both_endcaps_loose_alt = false;
+   bool both_endcaps_loose_dtcut_alt = false;
+
    //float r = 0., phi = 0.;
    if (TheCSCSegments.isValid()) {
      for(CSCSegmentCollection::const_iterator iSegment = TheCSCSegments->begin();
@@ -504,13 +547,18 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
          iSegment++) {
 
        CSCDetId iCscDetID = iSegment->cscDetId();
-       bool SegmentIsGood=true;
+       bool Segment1IsGood=true;
+       bool Segment1IsGood_alt=true;
+
        //avoid segments from collision muons
        if( TheMuons.isValid() )
 	 {
-	   for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && SegmentIsGood ; mu++ )
+	   for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && (Segment1IsGood||!trkmuunvetoisdefault)   ; mu++ )
 	     {
+	       bool  lowpttrackmu=false;
 	       if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon() ) continue;
+	       if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon()&&trkmuunvetoisdefault) continue;
+	       if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3) lowpttrackmu=true;
 	       const std::vector<MuonChamberMatch> chambers = mu->matches();
 	       for(std::vector<MuonChamberMatch>::const_iterator kChamber = chambers.begin();
 		   kChamber != chambers.end(); kChamber ++ )
@@ -524,14 +572,15 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		       
 		       if( kCscDetID == iCscDetID ) 
 			 {
-			   SegmentIsGood = false;
+			   Segment1IsGood = false;
+			   if(!lowpttrackmu) Segment1IsGood_alt=false;
 			 }
 		     }
 		 }
 	     }
 	 }
-       if(!SegmentIsGood) continue;
-
+       if(!Segment1IsGood&&!Segment1IsGood_alt) continue;
+       
        // Get local direction vector; if direction runs parallel to beamline,
        // count this segment as beam halo candidate.
        LocalPoint iLocalPosition = iSegment->localPosition();
@@ -545,14 +594,67 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
        
        float iPhi = iGlobalPosition.phi();
        float iR =  TMath::Sqrt(iGlobalPosition.x()*iGlobalPosition.x() + iGlobalPosition.y()*iGlobalPosition.y());
-       short int nSegs = 0;
+       float iZ = iGlobalPosition.z();
+       float iT = iSegment->time();
+       //       if(fabs(iZ)<650&& TheEvent.id().run()< 251737) iT-= 25; 
+       //Calo matching:
+       reco::Vertex::Point vtx(0,0,0);
+       for(size_t ihit = 0; ihit<hbhehits->size(); ++ ihit){
+	 if(calomatched) break;
+	 const HBHERecHit & rechit = (*hbhehits)[ ihit ];
+	 math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+	 double rhet = rechit.energy()/cosh(rhpos.eta()); 
+	 double dphi_rhseg = fabs(deltaPhi(rhpos.phi(),iGlobalPosition.phi()));
+	 double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+	 double dtcorr_rhseg = rechit.time()- fabs(rhpos.z()-iZ)/30- iT; // 
+	 if(rhet>10&& 
+	    dphi_rhseg <0.05 && 
+	    dr_rhseg< 25 && dr_rhseg> -25 && //careful: asymmetric cut might not be the most appropriate thing 
+	    dtcorr_rhseg>0    
+	    ) calomatched= true;
+       }
 
+       for(size_t ihit = 0; ihit<ecalebhits->size(); ++ ihit){
+	 if(calomatched) break;
+	 const EcalRecHit & rechit = (*ecalebhits)[ ihit ];
+	 math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+	 double rhet = rechit.energy()/cosh(rhpos.eta()); 
+	 double dphi_rhseg = fabs(deltaPhi(rhpos.phi(),iGlobalPosition.phi()));
+	 double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+	 double dtcorr_rhseg = rechit.time()- fabs(rhpos.z()-iZ)/30- iT; // 
+	 if(rhet>10&& 
+	    dphi_rhseg <0.05 && 
+	    dr_rhseg< 25 && dr_rhseg> -25 && //careful: asymmetric cut might not be the most appropriate thing 
+	    dtcorr_rhseg>0    
+	    ) calomatched= true;
+       }
+       for(size_t ihit = 0; ihit<ecaleehits->size(); ++ ihit){
+         if(calomatched) break;
+         const EcalRecHit & rechit = (*ecaleehits)[ ihit ];
+	 math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+         double rhet = rechit.energy()/cosh(rhpos.eta());
+         double dphi_rhseg = fabs(deltaPhi(rhpos.phi(),iGlobalPosition.phi()));
+         double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+         double dtcorr_rhseg = rechit.time()- fabs(rhpos.z()-iZ)/30- iT; //                                                                       
+         if(rhet>10&&
+            dphi_rhseg <0.05 &&
+            dr_rhseg< 25 && dr_rhseg> -25 && //careful: asymmetric cut might not be the most appropriate thing                                  
+	    dtcorr_rhseg>0
+            ) calomatched= true;
+     }
+
+
+
+
+       short int nSegs = 0;
+       short int nSegs_alt = 0;
        // Changed to loop over all Segments (so N^2) to catch as many segments as possible.
        for (CSCSegmentCollection::const_iterator jSegment = TheCSCSegments->begin();
          jSegment != TheCSCSegments->end();
          jSegment++) {
 	 if (jSegment == iSegment) continue;
-	 SegmentIsGood=true;
+	 bool Segment2IsGood = true;
+	 bool Segment2IsGood_alt = true;
 	 LocalPoint jLocalPosition = jSegment->localPosition();
 	 LocalVector jLocalDirection = jSegment->localDirection();
 	 CSCDetId jCscDetID = jSegment->cscDetId();
@@ -561,14 +663,19 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 float jTheta = jGlobalDirection.theta();
 	 float jPhi = jGlobalPosition.phi();
 	 float jR =  TMath::Sqrt(jGlobalPosition.x()*jGlobalPosition.x() + jGlobalPosition.y()*jGlobalPosition.y());
-
-	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= max_segment_phi_diff 
-	     && TMath::Abs(jR - iR) <= max_segment_r_diff 
+	 float jZ = jGlobalPosition.z() ;
+	 float jT = jSegment->time();
+	 //	 if(fabs(jZ)<650&& TheEvent.id().run() < 251737)jT-= 25;
+	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= 0.2//max_segment_phi_diff 
+	     //&& TMath::Abs(jR - iR) <= max_segment_r_diff 
+	     && (TMath::Abs(jR - iR) <= max_segment_r_diff || (TMath::Abs(jR - iR)/ TMath::Abs(jZ - iZ)< 0.03 &&  jZ*iZ<0) )
 	     && (jTheta < max_segment_theta || jTheta > TMath::Pi() - max_segment_theta)) {
 	   //// Check if Segment matches to a colision muon
 	   if( TheMuons.isValid() ) {
-	     for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && SegmentIsGood ; mu++ ) {
+	     for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end()  && (Segment2IsGood||!trkmuunvetoisdefault) ; mu++ ) {
+	       bool  lowpttrackmu=false;
 	       if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon() ) continue;
+	       if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3) lowpttrackmu= true;
 	       const std::vector<MuonChamberMatch> chambers = mu->matches();
 	       for(std::vector<MuonChamberMatch>::const_iterator kChamber = chambers.begin();
 		   kChamber != chambers.end(); kChamber ++ ) {
@@ -579,21 +686,37 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		   CSCDetId kCscDetID = cscSegRef->cscDetId();
 		   
 		   if( kCscDetID == jCscDetID ) {
-		     SegmentIsGood = false;
+		     Segment2IsGood = false;
+		     if(!lowpttrackmu) Segment2IsGood_alt=false;
 		   }
 		 }
 	       }
 	     }
 	   }   
-	   if(SegmentIsGood) {
+	   if(Segment1IsGood && Segment2IsGood) {
 	     nSegs++;
 	     minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
 	     plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
+	     //	     if( fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )<0.05 && fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )>0.02 && minus_endcap&&plus_endcap ) both_endcaps_dtcut =true;
 	   }
+	   if(Segment1IsGood_alt && Segment2IsGood_alt) {
+             nSegs_alt++;
+             minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
+             plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
+             if( fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )<0.05 && fabs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )>0.02 && minus_endcap&&plus_endcap ) both_endcaps_loose_dtcut_alt =true;
+           }
+	   
 	 }
        }
        // Correct the fact that the way nSegs counts will always be short by 1
        if (nSegs > 0) nSegs++;
+       
+       // The opposite endcaps segments do not need to belong to the longest chain. 
+       if (nSegs > 0) both_endcaps_loose =  both_endcaps_loose ? both_endcaps_loose : minus_endcap && plus_endcap;
+       if (nSegs_alt > 0) nSegs_alt++;
+       if (nSegs_alt > 0) both_endcaps_loose_alt =  both_endcaps_loose_alt ? both_endcaps_loose_alt : minus_endcap && plus_endcap;
+
+       //       if (nSegs > 0) both_endcaps_dt20ns = both_endcaps_dt20ns ? both_endcaps_dt20ns : minus_endcap && plus_endcap &&dt20ns;
        if (nSegs > maxNSegments) {
 	 // Use value of r, phi to collect halo CSCSegments for examining timing (not coded yet...)
 	 //r = iR;
@@ -601,12 +724,27 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 maxNSegments = nSegs;
 	 both_endcaps = both_endcaps ? both_endcaps : minus_endcap && plus_endcap;
        }
+      
+       if (nSegs_alt > maxNSegments_alt) {
+       	 maxNSegments_alt = nSegs_alt;
+         both_endcaps_alt = both_endcaps_alt ? both_endcaps_alt : minus_endcap && plus_endcap;
+       }
+ 
      }
    }
    TheCSCHaloData.SetNFlatHaloSegments(maxNSegments);
    TheCSCHaloData.SetSegmentsBothEndcaps(both_endcaps);
-   // End MLR
+   TheCSCHaloData.SetNFlatHaloSegments_TrkMuUnVeto(maxNSegments_alt);
+   TheCSCHaloData.SetSegmentsBothEndcaps_Loose_TrkMuUnVeto(both_endcaps_loose_alt);
+   TheCSCHaloData.SetSegmentsBothEndcaps_Loose_dTcut_TrkMuUnVeto(both_endcaps_loose_dtcut_alt);
+   TheCSCHaloData.SetSegmentIsCaloMatched(calomatched);
 
    return TheCSCHaloData;
 }
 
+math::XYZPoint CSCHaloAlgo::getPosition(const DetId &id, reco::Vertex::Point vtx){
+
+  const GlobalPoint& pos=geo->getPosition(id);
+  math::XYZPoint posV(pos.x() - vtx.x(),pos.y() - vtx.y(),pos.z() - vtx.z());
+  return posV;
+}

--- a/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
@@ -36,7 +36,7 @@ bool CSCTightHalo2015Filter::filter(edm::StreamID iID, edm::Event & iEvent, cons
 
   iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
 
-  return taggingMode_ || !pass;  // return false if it is a beamhalo event
+  return taggingMode_ || pass;  // return false if it is a beamhalo event
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
@@ -4,12 +4,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/METReco/interface/BeamHaloSummary.h"
 
-class CSCTightHaloFilter : public edm::global::EDFilter<> {
+class CSCTightHalo2015Filter : public edm::global::EDFilter<> {
 
   public:
 
-    explicit CSCTightHaloFilter(const edm::ParameterSet & iConfig);
-    ~CSCTightHaloFilter() {}
+    explicit CSCTightHalo2015Filter(const edm::ParameterSet & iConfig);
+    ~CSCTightHalo2015Filter() {}
 
   private:
 
@@ -19,7 +19,7 @@ class CSCTightHaloFilter : public edm::global::EDFilter<> {
     edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
 };
 
-CSCTightHaloFilter::CSCTightHaloFilter(const edm::ParameterSet & iConfig)
+CSCTightHalo2015Filter::CSCTightHalo2015Filter(const edm::ParameterSet & iConfig)
   : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
   , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
 {
@@ -27,17 +27,17 @@ CSCTightHaloFilter::CSCTightHaloFilter(const edm::ParameterSet & iConfig)
   produces<bool>();
 }
 
-bool CSCTightHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
+bool CSCTightHalo2015Filter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
   iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);
 
-  const bool pass = !beamHaloSummary->CSCTightHaloId();
+  const bool pass = !beamHaloSummary->CSCTightHaloId2015();
 
   iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
 
-  return taggingMode_ || pass;  // return false if it is a beamhalo event
+  return taggingMode_ || !pass;  // return false if it is a beamhalo event
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE(CSCTightHaloFilter);
+DEFINE_FWK_MODULE(CSCTightHalo2015Filter);

--- a/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
@@ -4,12 +4,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/METReco/interface/BeamHaloSummary.h"
 
-class CSCTightHaloFilter : public edm::global::EDFilter<> {
+class CSCTightHaloTrkMuUnvetoFilter : public edm::global::EDFilter<> {
 
   public:
 
-    explicit CSCTightHaloFilter(const edm::ParameterSet & iConfig);
-    ~CSCTightHaloFilter() {}
+    explicit CSCTightHaloTrkMuUnvetoFilter(const edm::ParameterSet & iConfig);
+    ~CSCTightHaloTrkMuUnvetoFilter() {}
 
   private:
 
@@ -19,7 +19,7 @@ class CSCTightHaloFilter : public edm::global::EDFilter<> {
     edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
 };
 
-CSCTightHaloFilter::CSCTightHaloFilter(const edm::ParameterSet & iConfig)
+CSCTightHaloTrkMuUnvetoFilter::CSCTightHaloTrkMuUnvetoFilter(const edm::ParameterSet & iConfig)
   : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
   , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
 {
@@ -27,12 +27,12 @@ CSCTightHaloFilter::CSCTightHaloFilter(const edm::ParameterSet & iConfig)
   produces<bool>();
 }
 
-bool CSCTightHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
+bool CSCTightHaloTrkMuUnvetoFilter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
   iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);
 
-  const bool pass = !beamHaloSummary->CSCTightHaloId();
+  const bool pass = !beamHaloSummary->CSCTightHaloIdTrkMuUnveto();
 
   iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
 
@@ -40,4 +40,4 @@ bool CSCTightHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const ed
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE(CSCTightHaloFilter);
+DEFINE_FWK_MODULE(CSCTightHaloTrkMuUnvetoFilter);

--- a/RecoMET/METFilters/python/CSCTightHalo2015Filter_cfi.py
+++ b/RecoMET/METFilters/python/CSCTightHalo2015Filter_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+CSCTightHalo2015Filter = cms.EDFilter(
+  "CSCTightHalo2015Filter",
+  taggingMode = cms.bool(False)
+)

--- a/RecoMET/METFilters/python/CSCTightHaloTrkMuUnvetoFilter_cfi.py
+++ b/RecoMET/METFilters/python/CSCTightHaloTrkMuUnvetoFilter_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+CSCTightHaloTrkMuUnvetoFilter = cms.EDFilter(
+  "CSCTightHaloTrkMuUnvetoFilter",
+  taggingMode = cms.bool(False),
+)

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -7,6 +7,15 @@ from CommonTools.RecoAlgos.HBHENoiseFilter_cfi import *
 ## The CSC beam halo tight filter ____________________________________________||
 from RecoMET.METFilters.CSCTightHaloFilter_cfi import *
 
+## The CSC beam halo tight filter ____________________________________________||
+from RecoMET.METFilters.CSCTightHaloTrkMuUnvetoFilter_cfi import *
+
+## The CSC beam halo tight filter ____________________________________________||
+from RecoMET.METFilters.CSCTightHalo2015Filter_cfi import *
+
+## The hcal problematic strip halo filter ____________________________________________||
+from RecoMET.METFilters.HcalStripHaloFilter_cfi import *
+
 ## The HCAL laser filter _____________________________________________________||
 from RecoMET.METFilters.hcalLaserEventFilter_cfi import *
 
@@ -57,8 +66,11 @@ metFilters = cms.Sequence(
    HBHENoiseFilter *
    primaryVertexFilter*
 #   HBHENoiseIsoFilter*
+#   HcalStripHaloFilter *
    CSCTightHaloFilter *
 #   hcalLaserEventFilter *
+#  CSCTightHaloTrkMuUnvetoFilter *
+# CSCTightHalo2015Filter *
    EcalDeadCellTriggerPrimitiveFilter* 
 #   *goodVertices * trackingFailureFilter *
    eeBadScFilter

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -13,9 +13,6 @@ from RecoMET.METFilters.CSCTightHaloTrkMuUnvetoFilter_cfi import *
 ## The CSC beam halo tight filter ____________________________________________||
 from RecoMET.METFilters.CSCTightHalo2015Filter_cfi import *
 
-## The hcal problematic strip halo filter ____________________________________________||
-from RecoMET.METFilters.HcalStripHaloFilter_cfi import *
-
 ## The HCAL laser filter _____________________________________________________||
 from RecoMET.METFilters.hcalLaserEventFilter_cfi import *
 

--- a/RecoMET/METProducers/interface/CSCHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/CSCHaloDataProducer.h
@@ -158,6 +158,10 @@ class CSCHaloDataProducer : public edm::stream::EDProducer<> {
     //RecHit Level
     edm::InputTag IT_CSCRecHit;
 
+    //Calo rechits
+    edm::InputTag IT_HBHErh;
+    edm::InputTag IT_ECALBrh;
+    edm::InputTag IT_ECALErh;
     //Higher Level Reco
     edm::InputTag IT_CosmicMuon;
     edm::InputTag IT_CSCSegment;
@@ -170,6 +174,9 @@ class CSCHaloDataProducer : public edm::stream::EDProducer<> {
     edm::EDGetTokenT<reco::MuonCollection> muon_token_;
     edm::EDGetTokenT<CSCSegmentCollection> cscsegment_token_;
     edm::EDGetTokenT<CSCRecHit2DCollection> cscrechit_token_;
+    edm::EDGetTokenT<HBHERecHitCollection> hbhereco_token_; 
+    edm::EDGetTokenT<EcalRecHitCollection> EcalRecHitsEB_token_;
+    edm::EDGetTokenT<EcalRecHitCollection> EcalRecHitsEE_token_;
     edm::EDGetTokenT<CSCALCTDigiCollection> cscalct_token_;
     edm::EDGetTokenT<L1MuGMTReadoutCollection> l1mugmtro_token_;
     edm::EDGetTokenT<edm::TriggerResults> hltresult_token_;

--- a/RecoMET/METProducers/python/CSCHaloData_cfi.py
+++ b/RecoMET/METProducers/python/CSCHaloData_cfi.py
@@ -23,6 +23,11 @@ CSCHaloData = cms.EDProducer("CSCHaloDataProducer",
 
                              # RecHit Level
                              CSCRecHitLabel = cms.InputTag("csc2DRecHits"),
+
+                             # Calo rec hits 
+                             HBHErhLabel = cms.InputTag("hbhereco"),
+                             ECALBrhLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+                             ECALErhLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
                              
                              # Higher Level Reco
                              CSCSegmentLabel= cms.InputTag("cscSegments"),

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -84,6 +84,7 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
       (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks()) ))
     TheBeamHaloSummary->GetCSCHaloReport()[1] = 1;
 
+
   //CSCLoose Id from 2010
   if( CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks() || CSCData.NumberOfOutOfTimeTriggers() )
     TheBeamHaloSummary->GetCSCHaloReport()[2] = 1;
@@ -93,6 +94,24 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
       (CSCData.NumberOfHaloTriggers() && CSCData.NumberOfOutOfTimeTriggers()) ||
       (CSCData.NumberOfHaloTracks() && CSCData.NumberOfOutOfTimeTriggers() ) )
     TheBeamHaloSummary->GetCSCHaloReport()[3] = 1;
+
+  //CSCTight Id for 2015
+
+  if( (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NumberOfHaloTracks()) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTriggers_TrkMuUnVeto() ) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTracks() ) ||
+      CSCData.GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() ||
+      (CSCData.NTracksSmalldT() && CSCData.NumberOfHaloTracks() ) ||
+      (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() || CSCData.NumberOfHaloTracks()) ))
+    TheBeamHaloSummary->GetCSCHaloReport()[4] = 1; 
+
+
+  //Update
+  if(  (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NFlatHaloSegments_TrkMuUnVeto() ) ||
+       CSCData.GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() ||
+       CSCData.GetSegmentIsCaloMatched()
+      )
+    TheBeamHaloSummary->GetCSCHaloReport()[5] = 1;
 
 
   //Ecal Specific Halo Data

--- a/RecoMET/METProducers/src/CSCHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/CSCHaloDataProducer.cc
@@ -25,6 +25,10 @@ CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
   //RecHit Level
   IT_CSCRecHit   = iConfig.getParameter<edm::InputTag>("CSCRecHitLabel");
 
+  //Calo RecHit 
+  IT_HBHErh = iConfig.getParameter<edm::InputTag>("HBHErhLabel");
+  IT_ECALBrh= iConfig.getParameter<edm::InputTag>("ECALBrhLabel");
+  IT_ECALErh= iConfig.getParameter<edm::InputTag>("ECALErhLabel");
   //Higher Level Reco 
   IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");  
   IT_CosmicMuon = iConfig.getParameter<edm::InputTag>("CosmicMuonLabel"); 
@@ -69,6 +73,9 @@ CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
   cscrechit_token_  = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
   cscalct_token_    = consumes<CSCALCTDigiCollection>(IT_ALCT);
   l1mugmtro_token_  = consumes<L1MuGMTReadoutCollection>(IT_L1MuGMTReadout);
+  hbhereco_token_   = consumes<HBHERecHitCollection>(IT_HBHErh); 
+  EcalRecHitsEB_token_ = consumes<EcalRecHitCollection>(IT_ECALBrh); 
+  EcalRecHitsEE_token_ = consumes<EcalRecHitCollection>(IT_ECALErh); 
   hltresult_token_  = consumes<edm::TriggerResults>(IT_HLTResult);
 
   produces<CSCHaloData>();
@@ -115,6 +122,16 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel (IT_ALCT, TheALCTs);
   iEvent.getByToken(cscalct_token_, TheALCTs);
 
+  //Calo rec hits 
+  Handle<HBHERecHitCollection> hbhehits;
+  iEvent.getByToken(hbhereco_token_,hbhehits);
+  Handle<EcalRecHitCollection> ecalebhits;
+  iEvent.getByToken(EcalRecHitsEB_token_, ecalebhits);// iEvent.getByToken("ecalRecHit","EcalRecHitsEB",ecalebhits);
+  Handle<EcalRecHitCollection> ecaleehits;
+  iEvent.getByToken(EcalRecHitsEE_token_,ecaleehits); // iEvent.getByToken("ecalRecHit","EcalRecHitsEE",ecaleehits);
+
+
+
   //Get HLT Results                                                                                                                                                       
   edm::Handle<edm::TriggerResults> TheHLTResults;
   //  iEvent.getByLabel( IT_HLTResult , TheHLTResults);
@@ -125,7 +142,7 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
     triggerNames = &iEvent.triggerNames(*TheHLTResults);
   }
 
-  std::auto_ptr<CSCHaloData> TheCSCData(new CSCHaloData( CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent) ) );
+  std::auto_ptr<CSCHaloData> TheCSCData(new CSCHaloData( CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, hbhehits,ecalebhits,ecaleehits,TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent, iSetup) ) );
   // Put it in the event                                                                                                                                                
   iEvent.put(TheCSCData);
   return;


### PR DESCRIPTION
CSC Beam Halo Filter update. 
-Pairs of segments in opposite endcaps are now matched with a dr/dz condition (rather than dr previously) 
-New flat CSC segment matching added (the old one remains the default for now): unvetoing CSC segments associated to tracker muons with pt < 3 gev 
-Optional dt matching of opposite endcaps segments 
-Testing a CSC segment/calorechit  matching. 
-Two new working points added in BeamHaloSummary. 
