### PR TITLE
Update HI vtx smearing according to newly updated beta*. 

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -38,6 +38,7 @@ VtxSmeared = {
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',
     'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
     'NominalHICollision2015':      'IOMC.EventVertexGenerators.VtxSmearedNominalHICollision2015_cfi',
+    'UpdatedHICollision2015':      'IOMC.EventVertexGenerators.VtxSmearedUpdatedHICollision2015_cfi',
     'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi',
     'Realistic50ns13TeVCollisionZeroTesla': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollisionZeroTesla_cfi',
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -510,3 +510,17 @@ NominalHICollision2015VtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.),
     Z0 = cms.double(0.)
 )
+
+# Update based on latest beta* presented at the WGM
+# Beamspot centroid updated to according to the current pp conditions (Realistic50ns13TeVCollisionZeroTesla)
+UpdatedHICollision2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(80.0),
+    Emittance = cms.double(1.70e-07),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(7.06),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.08533),
+    Y0 = cms.double(0.16973),
+    Z0 = cms.double(-1.2230)
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedUpdatedHICollision2015_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedUpdatedHICollision2015_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import UpdatedHICollision2015VtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    UpdatedHICollision2015VtxSmearingParameters,
+    VtxSmearedCommon
+)
+
+
+


### PR DESCRIPTION
The beam conditions expected for the PbPb run have been changed.
See Tiziano's slides from the WGM:
https://indico.cern.ch/event/442020/contribution/0/attachments/1148526/1647556/WGM241.pdf

This PR updates the beta*.
I also took the opportunity to shift the beamspot centroid to the current pp locations.
Last time around in 2011, the centroid stayed fairly close between pp and PbPb, so this should be a better assumption than the origin.

This new vertex smearing is not the default, so there will be no change in relval.
We propose to switch this to the default when we reevaluate the reco beamspot and update the GT in a PR to come shortly, once we can produce some samples with this vertex smearing.

A PR for 75X is also coming.
