### PR TITLE
Made BeamCurrentInfo thread-safe via use of iorules

### DIFF
--- a/DataFormats/Luminosity/interface/BeamCurrentInfo.h
+++ b/DataFormats/Luminosity/interface/BeamCurrentInfo.h
@@ -39,7 +39,6 @@ class BeamCurrentInfo {
     beam2IntensitiesUnpacked_.assign(LumiConstants::numBX, 0.0);
     beam1IntensitiesPacked_.assign(LumiConstants::numBX, 0);
     beam2IntensitiesPacked_.assign(LumiConstants::numBX, 0);
-    unpackedReady_ = true;
   } 
   
   /// constructor with fill
@@ -47,7 +46,6 @@ class BeamCurrentInfo {
                   const std::vector<float>& beam2Intensities) {
     beam1IntensitiesUnpacked_.assign(beam1Intensities.begin(), beam1Intensities.end());
     beam2IntensitiesUnpacked_.assign(beam2Intensities.begin(), beam2Intensities.end());
-    unpackedReady_ = true;
     packData();
   }
   
@@ -77,14 +75,17 @@ class BeamCurrentInfo {
   void fill(const std::vector<float>& beam1Intensities,
 	    const std::vector<float>& beam2Intensities);
   
+
+  // used by ROOT iorules
+  static void unpackData( const std::vector<uint16_t>& packed, std::vector<float>& unpacked);
+
  private:
   std::vector<uint16_t> beam1IntensitiesPacked_;
   std::vector<uint16_t> beam2IntensitiesPacked_;
-  mutable std::vector<float> beam1IntensitiesUnpacked_;
-  mutable std::vector<float> beam2IntensitiesUnpacked_;
-  void packData(void);
-  void unpackData(void) const;
-  mutable bool unpackedReady_;
+  std::vector<float> beam1IntensitiesUnpacked_;
+  std::vector<float> beam2IntensitiesUnpacked_;
+  void packData();
+  void unpackData();
 }; 
 
 std::ostream& operator<<(std::ostream& s, const BeamCurrentInfo& beamInfo);

--- a/DataFormats/Luminosity/src/BeamCurrentInfo.cc
+++ b/DataFormats/Luminosity/src/BeamCurrentInfo.cc
@@ -8,22 +8,18 @@
 const float BeamCurrentInfo::scaleFactor = 1e10;
 
 float BeamCurrentInfo::getBeam1IntensityBX(int bx) const {
-  unpackData();
   return beam1IntensitiesUnpacked_.at(bx);
 }
 
 const std::vector<float>& BeamCurrentInfo::getBeam1Intensities() const { 
-  unpackData();
   return beam1IntensitiesUnpacked_;
 
 }
 
 float BeamCurrentInfo::getBeam2IntensityBX(int bx) const {
-  unpackData();
   return beam2IntensitiesUnpacked_.at(bx); }
 
 const std::vector<float>& BeamCurrentInfo::getBeam2Intensities() const {
-  unpackData();
   return beam2IntensitiesUnpacked_;
 }
 
@@ -36,7 +32,6 @@ void BeamCurrentInfo::fillBeamIntensities(const std::vector<float>& beam1Intensi
 					  const std::vector<float>& beam2Intensities) {
   beam1IntensitiesUnpacked_.assign(beam1Intensities.begin(), beam1Intensities.end());
   beam2IntensitiesUnpacked_.assign(beam2Intensities.begin(), beam2Intensities.end());
-  unpackedReady_ = true;
   packData();
 }
 
@@ -46,7 +41,7 @@ void BeamCurrentInfo::fill(const std::vector<float>& beam1Intensities,
 }
 
 // Convert unpacked data to packed data (when it is filled).
-void BeamCurrentInfo::packData(void) {
+void BeamCurrentInfo::packData() {
   beam1IntensitiesPacked_.resize(beam1IntensitiesUnpacked_.size());
   beam2IntensitiesPacked_.resize(beam2IntensitiesUnpacked_.size());
 
@@ -58,24 +53,22 @@ void BeamCurrentInfo::packData(void) {
   }
 
   // Re-unpack the data so that it matches the packed data.
-  unpackedReady_ = false;
   unpackData();
 }
 
-// Convert packed data to unpacked data when accessors are called.
-void BeamCurrentInfo::unpackData(void) const {
-  if (unpackedReady_) return;
+// Convert packed data to unpacked data when reading back data
+void BeamCurrentInfo::unpackData(const std::vector<uint16_t>& packed, std::vector<float>& unpacked ) {
+  unpacked.resize(packed.size());
 
-  beam1IntensitiesUnpacked_.resize(beam1IntensitiesPacked_.size());
-  beam2IntensitiesUnpacked_.resize(beam2IntensitiesPacked_.size());
+  for (unsigned int i=0; i<packed.size(); i++) {
+    unpacked[i] = MiniFloatConverter::float16to32(packed[i])*scaleFactor;
+  }
+}
 
-  for (unsigned int i=0; i<beam1IntensitiesPacked_.size(); i++) {
-    beam1IntensitiesUnpacked_[i] = MiniFloatConverter::float16to32(beam1IntensitiesPacked_[i])*scaleFactor;
-  }
-  for (unsigned int i=0; i<beam2IntensitiesPacked_.size(); i++) {
-    beam2IntensitiesUnpacked_[i] = MiniFloatConverter::float16to32(beam2IntensitiesPacked_[i])*scaleFactor;
-  }
-  unpackedReady_ = true;
+void BeamCurrentInfo::unpackData() {
+
+  unpackData(beam1IntensitiesPacked_,beam1IntensitiesUnpacked_);
+  unpackData(beam2IntensitiesPacked_,beam2IntensitiesUnpacked_);
 }
        
 
@@ -85,17 +78,17 @@ std::ostream& operator<<(std::ostream& s, const BeamCurrentInfo& beamInfo) {
   const std::vector<float>& b1int = beamInfo.getBeam1Intensities();
   const std::vector<uint16_t>& b1intPacked = beamInfo.getBeam1IntensitiesPacked();
   for (unsigned int i=0; i<10 && i<b1int.size(); ++i) {
-    s << b1int.at(i) << " ";
+    s << b1int[i] << " ";
   }
   s << "..." << std::endl << "     (packed: ";
   for (unsigned int i=0; i<10 && i<b1intPacked.size(); ++i) {
-    s << b1intPacked.at(i) << " ";
+    s << b1intPacked[i] << " ";
   }
   s << "...)" << std::endl;
   s << "  beam2Intensities = ";
   const std::vector<float>& b2int = beamInfo.getBeam2Intensities();
   for (unsigned int i=0; i<10 && i<b2int.size(); ++i) {
-    s << b2int.at(i) << " ";
+    s << b2int[i] << " ";
   }
   s << " ..." << std::endl;
 

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -21,10 +21,13 @@
    <version ClassVersion="10" checksum="706652033"/>
    <field name="beam1IntensitiesUnpacked_" transient="true"/>
    <field name="beam2IntensitiesUnpacked_" transient="true"/>
-   <field name="unpackedReady_" transient="true"/>
   </class>
-  <ioread sourceClass="BeamCurrentInfo" version="[1-]" targetClass="BeamCurrentInfo" source="" target="unpackedReady_">
-  <![CDATA[ unpackedReady_=false;
+  <ioread sourceClass="BeamCurrentInfo" version="[1-]" targetClass="BeamCurrentInfo" source="std::vector<uint16_t> beam1IntensitiesPacked_" target="beam1IntensitiesUnpacked_">
+  <![CDATA[ BeamCurrentInfo::unpackData(onfile.beam1IntensitiesPacked_,beam1IntensitiesUnpacked_);
+  ]]>
+  </ioread>
+  <ioread sourceClass="BeamCurrentInfo" version="[1-]" targetClass="BeamCurrentInfo" source="std::vector<uint16_t> beam2IntensitiesPacked_" target="beam2IntensitiesUnpacked_">
+  <![CDATA[ BeamCurrentInfo::unpackData(onfile.beam2IntensitiesPacked_,beam2IntensitiesUnpacked_);
   ]]>
   </ioread>
   <class name="LumiSummary::HLT" ClassVersion="11">


### PR DESCRIPTION
BeamCurrentInfo has transient data members which were previously being
filled in on first request. Such behavior would require special handling
when used in a threaded environment. Instead, the code has been changed
to directly fill in the transient data members when the object is read
back by ROOT.
