### PR TITLE
Maintainability cleanup for EventSelector

### DIFF
--- a/FWCore/Framework/interface/EventSelector.h
+++ b/FWCore/Framework/interface/EventSelector.h
@@ -50,7 +50,7 @@ namespace edm
     EventSelector(Strings const& pathspecs);
 
     EventSelector(edm::ParameterSet const& pset,
-		  Strings const& triggernames);
+		  Strings const& pathNames);
 
     bool wantAll() const { return accept_all_; }
     bool acceptEvent(TriggerResults const&);
@@ -59,11 +59,11 @@ namespace edm
     // 29-Jan-2008, KAB - added methods for testing and using
     // trigger selections (pathspecs).
     static bool selectionIsValid(Strings const& pathspec,
-                                 Strings const& fullTriggerList);
+                                 Strings const& fullPathList);
     static evtSel::OverlapResult
       testSelectionOverlap(Strings const& pathspec1,
                            Strings const& pathspec2,
-                           Strings const& fullTriggerList);
+                           Strings const& fullPathList);
     std::shared_ptr<TriggerResults>
       maskTriggerResults(TriggerResults const& inputResults);
     static std::vector<std::string>
@@ -72,9 +72,6 @@ namespace edm
     static void fillDescription(ParameterSetDescription& desc);
 
   private:
-
-    void init(Strings const& paths,
-	      Strings const& triggernames);
 
     struct BitInfo
     {
@@ -85,23 +82,30 @@ namespace edm
       bool accept_state_;
     };
 
+    // These three data members never change after being initialized.
+    Strings const pathspecs_;
+    bool const results_from_current_process_;
+    bool const accept_all_;
+
     typedef std::vector<BitInfo> Bits;
 
-    bool accept_all_;
     Bits absolute_acceptors_;					// change 3
     Bits conditional_acceptors_;				// change 3
     Bits exception_acceptors_;					// change 3
     std::vector<Bits> all_must_fail_;				// change 1
     std::vector<Bits> all_must_fail_noex_;			// change 3
 
-    bool results_from_current_process_;
-    bool psetID_initialized_;
     ParameterSetID psetID_;
 
-    Strings paths_;
+    int nPathNames_;
 
-    int nTriggerNames_;
-    bool notStarPresent_;
+    // private member functions
+
+    Strings initPathSpecs(Strings const& pathSpecs);
+
+    bool initAcceptAll();
+
+    void initPathNames(Strings const& pathNames);
 
     bool acceptTriggerPath(HLTPathStatus const&, BitInfo const&) const;
 


### PR DESCRIPTION
This PR is a cleanup of the EventSelector class for maintainability and clarity. The changes include:
1) Removing one unused and one unnecessary data member.
2) Renaming some data members, function members, and function parameters to be more mnemonic
3) The three data members that are never changed are made const (more for clarity than for const correctness) and initialized in the initializer lists of the class. They are no longer modified in init() (renamed to initPathNames()), because they were just being reset to the same values.
4) The three const data members are the first three data members.
5) Iterator loops are changed to range for loops.
