### PR TITLE
Release shared resources when use mayConsumes

### DIFF
--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -54,6 +54,7 @@ namespace edm {
   class EDConsumerBase;
   class EDProductGetter;
   class ProducerBase;
+  class SharedResourcesAcquirer;
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
   }
@@ -66,6 +67,8 @@ namespace edm {
     
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
+    
+    void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
     
     // AUX functions are defined in EventBase
     EventAuxiliary const& eventAuxiliary() const {return aux_;}

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -184,6 +184,7 @@ namespace edm {
     edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID) const;
 
     virtual bool unscheduledFill(std::string const& moduleLabel,
+                                 SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
 
     virtual void readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const override;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -35,6 +35,8 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 namespace edm {
   class ModuleCallingContext;
   class ProducerBase;
+  class SharedResourcesAcquirer;
+  
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
   }
@@ -65,6 +67,9 @@ namespace edm {
     
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
+    
+    void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
+
     template <typename PROD>
     bool
     getByLabel(std::string const& label, Handle<PROD>& result) const;

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -111,6 +111,7 @@ namespace edm {
     virtual bool isComplete_() const override {return complete_;}
 
     virtual bool unscheduledFill(std::string const&,
+                                 SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const*) const override {return false;}
 
     virtual unsigned int transitionIndex_() const override;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -45,6 +45,7 @@ namespace edm {
   class ProcessHistoryRegistry;
   class ProductHolderIndexHelper;
   class EDConsumerBase;
+  class SharedResourcesAcquirer;
 
   struct FilledProductPtr {
     bool operator()(std::shared_ptr<ProductHolderBase> const& iObj) { return bool(iObj);}
@@ -108,6 +109,7 @@ namespace edm {
                             TypeID const& typeID,
                             InputTag const& inputTag,
                             EDConsumerBase const* consumes,
+                            SharedResourcesAcquirer* sra,
                             ModuleCallingContext const* mcc) const;
 
     BasicHandle  getByLabel(KindOfType kindOfType,
@@ -116,6 +118,7 @@ namespace edm {
                             std::string const& instance,
                             std::string const& process,
                             EDConsumerBase const* consumes,
+                            SharedResourcesAcquirer* sra,
                             ModuleCallingContext const* mcc) const;
     
     BasicHandle getByToken(KindOfType kindOfType,
@@ -123,6 +126,7 @@ namespace edm {
                            ProductHolderIndex index,
                            bool skipCurrentProcess,
                            bool& ambiguous,
+                           SharedResourcesAcquirer* sra,
                            ModuleCallingContext const* mcc) const;
 
     void prefetch(ProductHolderIndex index,
@@ -132,6 +136,7 @@ namespace edm {
     void getManyByType(TypeID const& typeID,
                        BasicHandleVec& results,
                        EDConsumerBase const* consumes,
+                       SharedResourcesAcquirer* sra,
                        ModuleCallingContext const* mcc) const;
 
     ProcessHistory const& processHistory() const {
@@ -184,6 +189,7 @@ namespace edm {
     }
 
     virtual bool unscheduledFill(std::string const& moduleLabel,
+                                 SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const = 0;
 
     std::vector<unsigned int> const& lookupProcessOrder() const { return lookupProcessOrder_; }
@@ -220,12 +226,14 @@ namespace edm {
     void findProducts(std::vector<ProductHolderBase const*> const& holders,
                       TypeID const& typeID,
                       BasicHandleVec& results,
+                      SharedResourcesAcquirer* sra,
                       ModuleCallingContext const* mcc) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
                                           InputTag const& inputTag,
                                           EDConsumerBase const* consumer,
+                                          SharedResourcesAcquirer* sra,
                                           ModuleCallingContext const* mcc) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
@@ -234,6 +242,7 @@ namespace edm {
                                           std::string const& instance,
                                           std::string const& process,
                                           EDConsumerBase const* consumer,
+                                          SharedResourcesAcquirer* sra,
                                           ModuleCallingContext const* mcc) const;
 
     virtual void readFromSource_(ProductHolderBase const& /* phb */, ModuleCallingContext const* /* mcc */) const {}

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -111,6 +111,7 @@ edm::Ref<AppleCollection> ref(refApples, index);
 namespace edm {
 
   class ModuleCallingContext;
+  class SharedResourcesAcquirer;
 
   namespace principal_get_adapter_detail {
     void
@@ -139,6 +140,11 @@ namespace edm {
     void setConsumer(EDConsumerBase const* iConsumer) {
       consumer_ = iConsumer;
     }
+    
+    void setSharedResourcesAcquirer(SharedResourcesAcquirer* iSra) {
+      resourcesAcquirer_ = iSra;
+    }
+
 
     bool isComplete() const;
 
@@ -230,7 +236,7 @@ namespace edm {
     ModuleDescription const& md_;
     
     EDConsumerBase const* consumer_;
-
+    SharedResourcesAcquirer* resourcesAcquirer_;
   };
 
   template <typename PROD>

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -24,6 +24,7 @@ namespace edm {
   class ProductProvenanceRetriever;
   class DelayedReader;
   class ModuleCallingContext;
+  class SharedResourcesAcquirer;
   class Principal;
 
   class ProductHolderBase {
@@ -45,9 +46,11 @@ namespace edm {
       return getProductData();
     }
 
-    ProductData const* resolveProduct(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+    ProductData const* resolveProduct(ResolveStatus& resolveStatus,
+                                      bool skipCurrentProcess,
+                                      SharedResourcesAcquirer* sra,
                                       ModuleCallingContext const* mcc) const {
-      return resolveProduct_(resolveStatus, skipCurrentProcess, mcc);
+      return resolveProduct_(resolveStatus, skipCurrentProcess, sra, mcc);
     }
 
     void resetStatus () {
@@ -171,7 +174,9 @@ namespace edm {
   private:
     virtual ProductData const& getProductData() const = 0;
     virtual ProductData& getProductData() = 0;
-    virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+    virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                               bool skipCurrentProcess,
+                                               SharedResourcesAcquirer* sra,
                                                ModuleCallingContext const* mcc) const = 0;
     virtual void swap_(ProductHolderBase& rhs) = 0;
     virtual bool onDemand_() const = 0;
@@ -223,7 +228,9 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(productIsUnavailable_, other.productIsUnavailable_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                                 bool skipCurrentProcess,
+                                                 SharedResourcesAcquirer* sra,
                                                  ModuleCallingContext const* mcc) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
@@ -310,7 +317,9 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(theStatus_, other.theStatus_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                                 bool skipCurrentProcess,
+                                                 SharedResourcesAcquirer* sra,
                                                  ModuleCallingContext const* mcc) const override;
       virtual void resetStatus_() override {theStatus_ = NotRun;}
       virtual bool onDemand_() const override {return false;}
@@ -338,7 +347,9 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(theStatus_, other.theStatus_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                                 bool skipCurrentProcess,
+                                                 SharedResourcesAcquirer* sra,
                                                  ModuleCallingContext const* mcc) const override;
       virtual void resetStatus_() override {theStatus_ = UnscheduledNotRun;}
       virtual bool onDemand_() const override {return status() == UnscheduledNotRun;}
@@ -366,7 +377,9 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(theStatus_, other.theStatus_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                                 bool skipCurrentProcess,
+                                                 SharedResourcesAcquirer* sra,
                                                  ModuleCallingContext const* mcc) const override;
       virtual void resetStatus_() override {theStatus_ = NotPut;}
       virtual bool onDemand_() const override {return false;}
@@ -390,8 +403,10 @@ namespace edm {
         realProduct_.swap(other.realProduct_);
         std::swap(bd_, other.bd_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
-                                                 ModuleCallingContext const* mcc) const override {return realProduct_.resolveProduct(resolveStatus, skipCurrentProcess, mcc);}
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                                 bool skipCurrentProcess,
+                                                 SharedResourcesAcquirer* sra,
+                                                 ModuleCallingContext const* mcc) const override {return realProduct_.resolveProduct(resolveStatus, skipCurrentProcess, sra, mcc);}
       virtual bool onDemand_() const override {return realProduct_.onDemand();}
       virtual void resetStatus_() override {realProduct_.resetStatus();}
       virtual bool productUnavailable_() const override {return realProduct_.productUnavailable();}
@@ -439,7 +454,9 @@ namespace edm {
     private:
       virtual ProductData const& getProductData() const override;
       virtual ProductData& getProductData() override;
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                                 bool skipCurrentProcess,
+                                                 SharedResourcesAcquirer* sra,
                                                  ModuleCallingContext const* mcc) const override;
       virtual void swap_(ProductHolderBase& rhs) override;
       virtual bool onDemand_() const override;

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -34,6 +34,8 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 namespace edm {
   class ModuleCallingContext;
   class ProducerBase;
+  class SharedResourcesAcquirer;
+  
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
   }
@@ -49,6 +51,9 @@ namespace edm {
       provRecorder_.setConsumer(iConsumer);
     }
     
+    void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
+      provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
+    }
 
     typedef PrincipalGetAdapter Base;
     // AUX functions are defined in RunBase
@@ -176,6 +181,7 @@ namespace edm {
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
     ModuleCallingContext const* moduleCallingContext_;
+    SharedResourcesAcquirer* sharedResourcesAcquirer_;
 
     static const std::string emptyString_;
   };

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -103,6 +103,7 @@ namespace edm {
     virtual bool isComplete_() const override {return complete_;}
 
     virtual bool unscheduledFill(std::string const&,
+                                 SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const*) const override {return false;}
 
     virtual unsigned int transitionIndex_() const override;

--- a/FWCore/Framework/interface/SharedResourcesAcquirer.h
+++ b/FWCore/Framework/interface/SharedResourcesAcquirer.h
@@ -51,7 +51,8 @@ namespace edm {
     /// e.g. when a Event::getByLabel call launches a Producer via unscheduled processing
     template<typename FUNC>
     void temporaryUnlock(FUNC iFunc) {
-      std::shared_ptr<SharedResourcesAcquirer*> guard(this,[](SharedResourcesAcquirer* iThis) {iThis->lock();});
+      auto iThis = this;
+      std::shared_ptr<void> guard(nullptr,[iThis](void* ) {iThis->lock();});
       this->unlock();
       iFunc();
     }

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -38,6 +38,7 @@ namespace edm {
     {
       std::lock_guard<std::mutex> guard(mutex_);
       std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+      e.setSharedResourcesAcquirer(&resourceAcquirer_);
       EventSignalsSentry sentry(act,mcc);
       this->analyze(e, c);
     }

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -187,9 +187,6 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
 
   if(iBranchType == InEvent) {
     itemsToGet(iBranchType, itemsToGetFromEvent_);
-    //Temporary: until we release resources on Event::getBy* calls
-    // we need to prefetch mayConsumes as well
-    itemsMayGet(iBranchType, itemsToGetFromEvent_);
   }
 }
 

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -37,6 +37,7 @@ namespace edm {
       std::lock_guard<std::mutex> guard(mutex_);
       {
         std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+        e.setSharedResourcesAcquirer(&resourceAcquirer_);
         EventSignalsSentry sentry(act,mcc);
         rc = this->filter(e, c);
       }

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -37,6 +37,7 @@ namespace edm {
       std::lock_guard<std::mutex> guard(mutex_);
       {
         std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+        e.setSharedResourcesAcquirer(&resourceAcquirer_);
         EventSignalsSentry sentry(act,mcc);
         this->produce(e, c);
       }

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -17,7 +17,7 @@ namespace edm {
   Event::Event(EventPrincipal& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext) :
       provRecorder_(ep, md),
       aux_(ep.aux()),
-      luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md, moduleCallingContext) : 0),
+      luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md, moduleCallingContext) : nullptr),
       gotBranchIDs_(),
       gotViews_(),
       streamID_(ep.streamID()),
@@ -38,6 +38,13 @@ namespace edm {
     provRecorder_.setConsumer(iConsumer);
     const_cast<LuminosityBlock*>(luminosityBlock_.get())->setConsumer(iConsumer);
   }
+  
+  void
+  Event::setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
+    provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
+    const_cast<LuminosityBlock*>(luminosityBlock_.get())->setSharedResourcesAcquirer(iResourceAcquirer);
+  }
+
 
   EventPrincipal&
   Event::eventPrincipal() {

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -40,6 +40,13 @@ namespace edm {
       const_cast<Run*>(run_.get())->setConsumer(iConsumer);
     }
   }
+  
+  void
+  LuminosityBlock::setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
+    provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
+    const_cast<Run*>(run_.get())->setSharedResourcesAcquirer(iResourceAcquirer);
+  }
+
 
   LuminosityBlockPrincipal const&
   LuminosityBlock::luminosityBlockPrincipal() const {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -471,9 +471,10 @@ namespace edm {
                         TypeID const& typeID,
                         InputTag const& inputTag,
                         EDConsumerBase const* consumer,
+                        SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const {
 
-    ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, mcc);
+    ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, sra, mcc);
     if(result == 0) {
       return BasicHandle(makeHandleExceptionFactory([=]()->std::shared_ptr<cms::Exception> {
         return makeNotFoundException("getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(), inputTag.process());
@@ -489,9 +490,10 @@ namespace edm {
                         std::string const& instance,
                         std::string const& process,
                         EDConsumerBase const* consumer,
+                        SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const {
 
-    ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer, mcc);
+    ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer, sra, mcc);
     if(result == 0) {
       return BasicHandle(makeHandleExceptionFactory([=]()->std::shared_ptr<cms::Exception> {
         return makeNotFoundException("getByLabel", kindOfType, typeID, label, instance, process);
@@ -506,12 +508,13 @@ namespace edm {
                         ProductHolderIndex index,
                         bool skipCurrentProcess,
                         bool& ambiguous,
+                        SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const {
     assert(index !=ProductHolderIndexInvalid);
     std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
     assert(0!=productHolder.get());
     ProductHolderBase::ResolveStatus resolveStatus;
-    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
+    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, sra, mcc);
     if(resolveStatus == ProductHolderBase::Ambiguous) {
       ambiguous = true;
       return BasicHandle();
@@ -529,13 +532,14 @@ namespace edm {
     std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_.at(index);
     assert(0!=productHolder.get());
     ProductHolderBase::ResolveStatus resolveStatus;
-    productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
+    productHolder->resolveProduct(resolveStatus, skipCurrentProcess, nullptr, mcc);
   }
 
   void
   Principal::getManyByType(TypeID const& typeID,
                            BasicHandleVec& results,
                            EDConsumerBase const* consumer,
+                           SharedResourcesAcquirer* sra,
                            ModuleCallingContext const* mcc) const {
 
     assert(results.empty());
@@ -587,7 +591,7 @@ namespace edm {
       if(!matches.isFullyResolved(i)) {
         if(!holders.empty()) {
           // Process the ones with a particular module label and instance
-          findProducts(holders, typeID, results, mcc);
+          findProducts(holders, typeID, results, sra, mcc);
           holders.clear();
         }
       } else {
@@ -598,7 +602,7 @@ namespace edm {
     }
     // Do not miss the last subset of products
     if(!holders.empty()) {
-      findProducts(holders, typeID, results, mcc);
+      findProducts(holders, typeID, results, sra, mcc);
     }
     return;
   }
@@ -607,6 +611,7 @@ namespace edm {
   Principal::findProducts(std::vector<ProductHolderBase const*> const& holders,
                           TypeID const&,
                           BasicHandleVec& results,
+                          SharedResourcesAcquirer* sra,
                           ModuleCallingContext const* mcc) const {
 
     for (auto iter = processHistoryPtr_->rbegin(),
@@ -623,7 +628,7 @@ namespace edm {
           }
 
           ProductHolderBase::ResolveStatus resolveStatus;
-          ProductData const* productData = productHolder->resolveProduct(resolveStatus, false, mcc);
+          ProductData const* productData = productHolder->resolveProduct(resolveStatus, false, sra, mcc);
           if(productData) {
             // Skip product if not available.
             results.emplace_back(*productData);
@@ -638,6 +643,7 @@ namespace edm {
                                 TypeID const& typeID,
                                 InputTag const& inputTag,
                                 EDConsumerBase const* consumer,
+                                SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const {
 
     bool skipCurrentProcess = inputTag.willSkipCurrentProcess();
@@ -678,7 +684,7 @@ namespace edm {
     std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
 
     ProductHolderBase::ResolveStatus resolveStatus;
-    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
+    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, sra, mcc);
     if(resolveStatus == ProductHolderBase::Ambiguous) {
       throwAmbiguousException("findProductByLabel", typeID, inputTag.label(), inputTag.instance(), inputTag.process());
     }
@@ -692,6 +698,7 @@ namespace edm {
                                 std::string const& instance,
                                 std::string const& process,
                                 EDConsumerBase const* consumer,
+                                SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const {
 
     ProductHolderIndex index = productLookup().index(kindOfType,
@@ -719,7 +726,7 @@ namespace edm {
     std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
 
     ProductHolderBase::ResolveStatus resolveStatus;
-    ProductData const* productData = productHolder->resolveProduct(resolveStatus, false, mcc);
+    ProductData const* productData = productHolder->resolveProduct(resolveStatus, false, sra, mcc);
     if(resolveStatus == ProductHolderBase::Ambiguous) {
       throwAmbiguousException("findProductByLabel", typeID, label, instance, process);
     }
@@ -732,6 +739,7 @@ namespace edm {
       findProductByLabel(PRODUCT_TYPE,
                          typeID,
                          tag,
+                         nullptr,
                          nullptr,
                          mcc);
     return productData;
@@ -752,7 +760,7 @@ namespace edm {
     }
     if(getProd) {
       ProductHolderBase::ResolveStatus status;
-      phb->resolveProduct(status,false,mcc);
+      phb->resolveProduct(status,false,nullptr, mcc);
     }
     if(!phb->provenance() || (!phb->product() && !phb->productProvenancePtr())) {
       return OutputHandle();
@@ -770,7 +778,7 @@ namespace edm {
 
     if(phb->onDemand()) {
       ProductHolderBase::ResolveStatus status;
-      if(not phb->resolveProduct(status,false,mcc) ) {
+      if(not phb->resolveProduct(status,false, nullptr, mcc) ) {
         throwProductNotFoundException("getProvenance(onDemand)", errors::ProductNotFound, bid);
       }
     }

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -22,7 +22,8 @@ namespace edm {
     //putProducts_(),
     principal_(pcpl),
     md_(md),
-    consumer_(nullptr)
+    consumer_(nullptr),
+    resourcesAcquirer_(nullptr)
   {
   }
 
@@ -147,7 +148,7 @@ namespace edm {
   PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
                                    InputTag const& tag,
                                    ModuleCallingContext const* mcc) const {
-    return principal_.getByLabel(PRODUCT_TYPE, typeID, tag, consumer_, mcc);
+    return principal_.getByLabel(PRODUCT_TYPE, typeID, tag, consumer_, resourcesAcquirer_, mcc);
   }
 
   BasicHandle
@@ -156,7 +157,7 @@ namespace edm {
   	                           std::string const& instance,
   	                           std::string const& process,
                                    ModuleCallingContext const* mcc) const {
-    return principal_.getByLabel(PRODUCT_TYPE, typeID, label, instance, process, consumer_, mcc);
+    return principal_.getByLabel(PRODUCT_TYPE, typeID, label, instance, process, consumer_, resourcesAcquirer_, mcc);
   }
   
   BasicHandle
@@ -172,7 +173,7 @@ namespace edm {
       throwAmbiguousException(id, token);
     }
     bool ambiguous = false;
-    BasicHandle h = principal_.getByToken(kindOfType, id, index, skipCurrentProcess, ambiguous, mcc);
+    BasicHandle h = principal_.getByToken(kindOfType, id, index, skipCurrentProcess, ambiguous, resourcesAcquirer_, mcc);
     if (ambiguous) {
       // This deals with ambiguities where the process is not specified
       throwAmbiguousException(id, token);
@@ -186,7 +187,7 @@ namespace edm {
   PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
                                                    InputTag const& tag,
                                                    ModuleCallingContext const* mcc) const {
-    return principal_.getByLabel(ELEMENT_TYPE, typeID, tag, consumer_, mcc);
+    return principal_.getByLabel(ELEMENT_TYPE, typeID, tag, consumer_, resourcesAcquirer_, mcc);
   }
 
   BasicHandle
@@ -201,6 +202,7 @@ namespace edm {
                                   instance,
                                   process,
                                   consumer_,
+                                  resourcesAcquirer_,
                                   mcc);
     return h;
   }
@@ -209,7 +211,7 @@ namespace edm {
   PrincipalGetAdapter::getManyByType_(TypeID const& tid,
                                       BasicHandleVec& results,
                                       ModuleCallingContext const* mcc) const {
-    principal_.getManyByType(tid, results, consumer_, mcc);
+    principal_.getManyByType(tid, results, consumer_, resourcesAcquirer_, mcc);
   }
 
   ProcessHistory const&

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -37,6 +37,7 @@ namespace edm {
 
   ProductData const*
   InputProductHolder::resolveProduct_(ResolveStatus& resolveStatus, bool,
+                                      SharedResourcesAcquirer* ,
                                       ModuleCallingContext const* mcc) const {
     if(productWasDeleted()) {
       throwProductDeletedException();
@@ -55,7 +56,9 @@ namespace edm {
   }
 
   ProductData const*
-  ScheduledProductHolder::resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+  ScheduledProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                          bool skipCurrentProcess,
+                                          SharedResourcesAcquirer*,
                                           ModuleCallingContext const*) const {
     if (!skipCurrentProcess) {
       if(productWasDeleted()) {
@@ -71,7 +74,9 @@ namespace edm {
   }
 
   ProductData const*
-  SourceProductHolder::resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+  SourceProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                       bool skipCurrentProcess,
+                                       SharedResourcesAcquirer*,
                                        ModuleCallingContext const*) const {
     if (!skipCurrentProcess) {
       if(productWasDeleted()) {
@@ -89,6 +94,7 @@ namespace edm {
   ProductData const*
   UnscheduledProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
                                             bool skipCurrentProcess,
+                                            SharedResourcesAcquirer* sra,
                                             ModuleCallingContext const* mcc) const {
     if (!skipCurrentProcess) {
       if(productWasDeleted()) {
@@ -98,7 +104,7 @@ namespace edm {
         resolveStatus = ProductFound;
         return &productData_;
       }
-      principal_->unscheduledFill(moduleLabel(), mcc);
+      principal_->unscheduledFill(moduleLabel(), sra, mcc);
       if(product() && product()->isPresent()) {
         resolveStatus = ProductFound;
         return &productData_;
@@ -402,6 +408,7 @@ namespace edm {
 
   ProductData const* NoProcessProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
                                                              bool skipCurrentProcess,
+                                                             SharedResourcesAcquirer* sra,
                                                              ModuleCallingContext const* mcc) const {
     std::vector<unsigned int> const& lookupProcessOrder = principal_->lookupProcessOrder();
     for(unsigned int k : lookupProcessOrder) {
@@ -413,7 +420,7 @@ namespace edm {
       }
       if (matchingHolders_[k] != ProductHolderIndexInvalid) {
         ProductHolderBase const* productHolder = principal_->getProductHolderByIndex(matchingHolders_[k]);
-        ProductData const* pd =  productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
+        ProductData const* pd =  productHolder->resolveProduct(resolveStatus, skipCurrentProcess, sra, mcc);
         if(pd != nullptr) return pd;
       }
     }

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -166,6 +166,7 @@ namespace edm
                                           s_TrigResultsType,
                                           selector.inputTag(),
                                           nullptr,
+                                          nullptr,
                                           mcc);
         handle_t product;
         convert_handle(std::move(h), product);

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -60,6 +60,7 @@ namespace edm {
       {
         std::lock_guard<std::mutex> guard(mutex_);
         std::lock_guard<SharedResourcesAcquirer> guardResources(resourcesAcquirer_);
+        e.setSharedResourcesAcquirer(&resourcesAcquirer_);
         EventSignalsSentry sentry(act,mcc);
         this->analyze(e, c);
       }

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -59,6 +59,7 @@ namespace edm {
         std::lock_guard<std::mutex> guard(mutex_);
         {
           std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
+          e.setSharedResourcesAcquirer(&resourcesAcquirer_);
           EventSignalsSentry sentry(act,mcc);
           returnValue = this->filter(e, c);
         }

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -57,6 +57,7 @@ namespace edm {
         std::lock_guard<std::mutex> guard(mutex_);
         {
           std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
+          e.setSharedResourcesAcquirer(&resourcesAcquirer_);
           EventSignalsSentry sentry(act,mcc);
           this->produce(e, c);
         }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -218,6 +218,11 @@
   <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Utilities"/>
 </bin>
+<bin   name="TestFWCoreFrameworkMayConsumesDeadlock" file="TestDriver.cpp">
+  <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_deadlock_test.sh"/>
+  <use   name="DataFormats/WrappedStdDictionaries"/>
+  <use   name="FWCore/Utilities"/>
+</bin>
 <bin   name="TestFWCoreFrameworkReplace" file="TestDriver.cpp">
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_replace_tests.sh"/>
   <use   name="FWCore/Utilities"/>

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -588,10 +588,10 @@ void testEvent::getByLabel() {
 
   }
 
-  BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",nullptr, nullptr);
+  BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",nullptr, nullptr, nullptr);
   convert_handle(std::move(bh), h);
   CPPUNIT_ASSERT(h->value == 100);
-  BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",nullptr, nullptr));
+  BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",nullptr, nullptr, nullptr));
   CPPUNIT_ASSERT(!bh2.isValid());
 
   std::shared_ptr<Wrapper<edmtest::IntProduct> const> ptr = getProductByTag<edmtest::IntProduct>(*principal_, inputTag, nullptr);

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -233,7 +233,7 @@ void test_ep::failgetbyLabelTest() {
 
   std::string label("this does not exist");
 
-  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(), nullptr, nullptr));
+  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(), nullptr, nullptr, nullptr));
   CPPUNIT_ASSERT(h.failedToGet());
 }
 
@@ -242,7 +242,7 @@ void test_ep::failgetManybyTypeTest() {
   edm::TypeID tid(dummy);
   std::vector<edm::BasicHandle > handles;
 
-  pEvent_->getManyByType(tid, handles, nullptr, nullptr);
+  pEvent_->getManyByType(tid, handles, nullptr, nullptr, nullptr);
   CPPUNIT_ASSERT(handles.empty());
 }
 

--- a/FWCore/Framework/test/run_deadlock_test.sh
+++ b/FWCore/Framework/test/run_deadlock_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${LOCAL_TEST_DIR}/test_mayConsumes_deadlocking_cfg.py
+(cmsRun $F1 ) || die "Failure using $F1" $?
+

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -11,6 +11,7 @@ Toy EDAnalyzers for testing purposes only.
 //
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -86,6 +87,31 @@ namespace edmtest {
         throw cms::Exception("ValueMissMatch")
           << "The value for \"" << moduleLabel_ << "\" is "
           << handle->value << " but it was supposed to be " << value_;
+      }
+    }
+  private:
+    int value_;
+    edm::InputTag moduleLabel_;
+  };
+
+  //--------------------------------------------------------------------
+  //
+  class ConsumingOneSharedResourceAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+  public:
+    ConsumingOneSharedResourceAnalyzer(edm::ParameterSet const& iPSet) :
+    value_(iPSet.getUntrackedParameter<int>("valueMustMatch")),
+    moduleLabel_(iPSet.getUntrackedParameter<edm::InputTag>("moduleLabel")) {
+      mayConsume<IntProduct>(moduleLabel_);
+      usesResource(iPSet.getUntrackedParameter<std::string>("resourceName"));
+    }
+    
+    void analyze(edm::Event const& iEvent, edm::EventSetup const&) {
+      edm::Handle<IntProduct> handle;
+      iEvent.getByLabel(moduleLabel_, handle);
+      if(handle->value != value_) {
+        throw cms::Exception("ValueMissMatch")
+        << "The value for \"" << moduleLabel_ << "\" is "
+        << handle->value << " but it was supposed to be " << value_;
       }
     }
   private:
@@ -199,11 +225,13 @@ namespace edmtest {
 using edmtest::NonAnalyzer;
 using edmtest::IntTestAnalyzer;
 using edmtest::ConsumingStreamAnalyzer;
+using edmtest::ConsumingOneSharedResourceAnalyzer;
 using edmtest::SCSimpleAnalyzer;
 using edmtest::DSVAnalyzer;
 DEFINE_FWK_MODULE(NonAnalyzer);
 DEFINE_FWK_MODULE(IntTestAnalyzer);
 DEFINE_FWK_MODULE(ConsumingStreamAnalyzer);
+DEFINE_FWK_MODULE(ConsumingOneSharedResourceAnalyzer);
 DEFINE_FWK_MODULE(SCSimpleAnalyzer);
 DEFINE_FWK_MODULE(DSVAnalyzer);
 

--- a/FWCore/Framework/test/test_mayConsumes_deadlocking_cfg.py
+++ b/FWCore/Framework/test/test_mayConsumes_deadlocking_cfg.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DEADLOCKTEST")
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20000))
+
+process.a = cms.EDAnalyzer("ConsumingOneSharedResourceAnalyzer", 
+                            valueMustMatch = cms.untracked.int32(1),
+                            moduleLabel = cms.untracked.InputTag("one"),
+                            resourceName = cms.untracked.string("A")
+                            )
+
+process.b = cms.EDAnalyzer("ConsumingOneSharedResourceAnalyzer", 
+                            valueMustMatch = cms.untracked.int32(2),
+                            moduleLabel = cms.untracked.InputTag("two"),
+                            resourceName = cms.untracked.string("B")
+                            )
+
+process.one = cms.EDProducer("IntLegacyProducer",
+                             ivalue = cms.int32(1)
+)
+
+process.two = cms.EDProducer("IntLegacyProducer",
+                             ivalue = cms.int32(2)
+)
+           
+process.options = cms.untracked.PSet(
+                    allowUnscheduled = cms.untracked.bool(True),
+                    numberOfThreads = cms.untracked.uint32(2),
+                    numberOfStreams = cms.untracked.uint32(0)
+)                 
+
+process.p1 = cms.Path(process.a)
+process.p2 = cms.Path(process.b)
+
+process.add_(cms.Service("ZombieKillerService", secondsBetweenChecks = cms.untracked.uint32(10)))

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -98,7 +98,7 @@ namespace edm {
             (*it)->branchDescription().moduleLabel(),
             (*it)->branchDescription().productInstanceName(),
             (*it)->branchDescription().processName(),
-                                          nullptr, mcc);
+                                          nullptr, nullptr, mcc);
             
             /*This doesn't appear to be an error, it just means the Product isn't available, which can be legitimate
             if(!bh.product()) {

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -117,6 +117,7 @@ namespace edm {
                                                     "",
                                                     "",
                                                     nullptr,
+                                                    nullptr,
                                                     nullptr);
     assert(bhandle.isValid());
     Handle<edmtest::UInt64Product> handle;
@@ -131,6 +132,7 @@ namespace edm {
                                                "Thing",
                                                "",
                                                "",
+                                               nullptr,
                                                nullptr,
                                                nullptr).wrapper();
     assert(ep != nullptr);

--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -38,7 +38,7 @@ public:
   template<typename T>
   bool
   getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
-    edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr, mcc_);
+    edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr, nullptr, mcc_);
     convert_handle(std::move(bh), result);
     return result.isValid();
   }


### PR DESCRIPTION
Temporarily release any shared resources when making a `edm::Event::getBy*` if it triggers an unscheduled execution of a module. This is needed to avoid potential deadlocks.
The previous workaround for this problem was to prefetch data even if the data had been marked as 'mayConsume'.
