### PR TITLE
Made PFTau const thread-safe

### DIFF
--- a/DataFormats/TauReco/interface/PFTau.h
+++ b/DataFormats/TauReco/interface/PFTau.h
@@ -206,6 +206,12 @@ class PFTau : public BaseTau {
     friend class tau::RecoTauConstructor;
     friend class tau::PFRecoTauEnergyAlgorithmPlugin;
 
+    //These are used by the friends
+    std::vector<RecoTauPiZero>& signalPiZeroCandidatesRestricted();
+    std::vector<RecoTauPiZero>& isolationPiZeroCandidatesRestricted();
+    std::vector<PFRecoTauChargedHadron>& signalTauChargedHadronCandidatesRestricted();
+    std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidatesRestricted();
+
     // check overlap with another candidate
     virtual bool overlap(const Candidate&) const;
 

--- a/DataFormats/TauReco/interface/PFTau.h
+++ b/DataFormats/TauReco/interface/PFTau.h
@@ -9,6 +9,7 @@
  * revised: Tue Aug 31 13:34:40 CEST 2010
  */
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Common/interface/AtomicPtrCache.h"
 #include "DataFormats/TauReco/interface/BaseTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/TauReco/interface/PFTauTagInfo.h"
@@ -127,23 +128,23 @@ class PFTau : public BaseTau {
 
     /// Retrieve the association of signal region gamma candidates into candidate PiZeros
     const std::vector<RecoTauPiZero>& signalPiZeroCandidates() const;
-    void setsignalPiZeroCandidates(const std::vector<RecoTauPiZero>&);
-    void setSignalPiZeroCandidatesRefs(const RecoTauPiZeroRefVector&);
+    void setsignalPiZeroCandidates(std::vector<RecoTauPiZero>);
+    void setSignalPiZeroCandidatesRefs(RecoTauPiZeroRefVector);
 
     /// Retrieve the association of isolation region gamma candidates into candidate PiZeros
     const std::vector<RecoTauPiZero>& isolationPiZeroCandidates() const;
-    void setisolationPiZeroCandidates(const std::vector<RecoTauPiZero>&);
-    void setIsolationPiZeroCandidatesRefs(const RecoTauPiZeroRefVector&);
+    void setisolationPiZeroCandidates(std::vector<RecoTauPiZero>);
+    void setIsolationPiZeroCandidatesRefs(RecoTauPiZeroRefVector);
 
     /// Retrieve the association of signal region PF candidates into candidate PFRecoTauChargedHadrons
     const std::vector<PFRecoTauChargedHadron>& signalTauChargedHadronCandidates() const;
-    void setSignalTauChargedHadronCandidates(const std::vector<PFRecoTauChargedHadron>&);
-    void setSignalTauChargedHadronCandidatesRefs(const PFRecoTauChargedHadronRefVector&);
+    void setSignalTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron>);
+    void setSignalTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector);
 
     /// Retrieve the association of isolation region PF candidates into candidate PFRecoTauChargedHadron
     const std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidates() const;
-    void setIsolationTauChargedHadronCandidates(const std::vector<PFRecoTauChargedHadron>&);
-    void setIsolationTauChargedHadronCandidatesRefs(const PFRecoTauChargedHadronRefVector&);
+    void setIsolationTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron>);
+    void setIsolationTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector);
 
     /// Retrieve the identified hadronic decay mode according to the number of
     /// charged and piZero candidates in the signal cone
@@ -263,12 +264,12 @@ class PFTau : public BaseTau {
     PFRecoTauChargedHadronRefVector isolationTauChargedHadronCandidatesRefs_;
 
     // Association of gamma candidates into PiZeros (transient)
-    mutable std::vector<reco::RecoTauPiZero> signalPiZeroCandidates_;
-    mutable std::vector<reco::RecoTauPiZero> isolationPiZeroCandidates_;
+    edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero>> signalPiZeroCandidates_;
+    edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero>> isolationPiZeroCandidates_;
 
     // Association of PF candidates into PFRecoTauChargedHadrons (transient)
-    mutable std::vector<reco::PFRecoTauChargedHadron> signalTauChargedHadronCandidates_;
-    mutable std::vector<reco::PFRecoTauChargedHadron> isolationTauChargedHadronCandidates_;
+    edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron>> signalTauChargedHadronCandidates_;
+    edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron>> isolationTauChargedHadronCandidates_;
 };
 
 std::ostream & operator<<(std::ostream& out, const PFTau& c);

--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -109,6 +109,14 @@ namespace {
   }
 
   template<typename T>
+  T& makeCacheIfNeeded(edm::AtomicPtrCache<T>& oCache) {
+    if(not oCache.isSet()) {
+      oCache.set(std::move(std::make_unique<T>()));
+    }
+    return *oCache;
+  }
+
+  template<typename T>
   void copyToCache(T&& iFrom, edm::AtomicPtrCache<T>& oCache) {
     oCache.reset();
     oCache.set( std::make_unique<T>(std::move(iFrom)));
@@ -122,14 +130,32 @@ const std::vector<RecoTauPiZero>& PFTau::signalPiZeroCandidates() const {
   return *signalPiZeroCandidates_;
 }
 
+std::vector<RecoTauPiZero>& PFTau::signalPiZeroCandidatesRestricted() {
+  // Check if the signal pi zeros are already filled
+  return makeCacheIfNeeded(signalPiZeroCandidates_);
+}
+
 void PFTau::setsignalPiZeroCandidates(std::vector<RecoTauPiZero> cands) {
    copyToCache(std::move(cands), signalPiZeroCandidates_);
+}
+
+void PFTau::setSignalPiZeroCandidatesRefs(RecoTauPiZeroRefVector cands) {
+  signalPiZeroCandidatesRefs_ = std::move(cands);
 }
 
 const std::vector<RecoTauPiZero>& PFTau::isolationPiZeroCandidates() const {
   // Check if the signal pi zeros are already filled
   setCache(isolationPiZeroCandidatesRefs_, isolationPiZeroCandidates_);
   return *isolationPiZeroCandidates_;
+}
+
+std::vector<RecoTauPiZero>& PFTau::isolationPiZeroCandidatesRestricted() {
+  // Check if the signal pi zeros are already filled
+  return makeCacheIfNeeded(isolationPiZeroCandidates_);
+}
+
+void PFTau::setIsolationPiZeroCandidatesRefs(RecoTauPiZeroRefVector cands) {
+  isolationPiZeroCandidatesRefs_ = std::move(cands);
 }
 
 void PFTau::setisolationPiZeroCandidates(std::vector<RecoTauPiZero> cands) {
@@ -151,6 +177,11 @@ const std::vector<PFRecoTauChargedHadron>& PFTau::signalTauChargedHadronCandidat
   return *signalTauChargedHadronCandidates_;
 }
 
+std::vector<PFRecoTauChargedHadron>& PFTau::signalTauChargedHadronCandidatesRestricted() {
+  // Check if the signal tau charged hadrons are already filled
+  return makeCacheIfNeeded(signalTauChargedHadronCandidates_);
+}
+
 void PFTau::setSignalTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron> cands) {
   copyToCache(std::move(cands), signalTauChargedHadronCandidates_);
 }
@@ -163,6 +194,11 @@ const std::vector<PFRecoTauChargedHadron>& PFTau::isolationTauChargedHadronCandi
   // Check if the isolation tau charged hadrons are already filled
   setCache(isolationTauChargedHadronCandidatesRefs_, isolationTauChargedHadronCandidates_);
   return *isolationTauChargedHadronCandidates_;
+}
+
+std::vector<PFRecoTauChargedHadron>& PFTau::isolationTauChargedHadronCandidatesRestricted() {
+  // Check if the isolation tau charged hadrons are already filled
+  return makeCacheIfNeeded(isolationTauChargedHadronCandidates_);
 }
 
 void PFTau::setIsolationTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron> cands) {

--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -93,43 +93,47 @@ void PFTau::setisolationPFNeutrHadrCands(const std::vector<PFCandidatePtr>& myPa
 const std::vector<PFCandidatePtr>& PFTau::isolationPFGammaCands() const { return selectedIsolationPFGammaCands_; }
 void PFTau::setisolationPFGammaCands(const std::vector<PFCandidatePtr>& myParts)  { selectedIsolationPFGammaCands_ = myParts; }
 
+
+namespace {
+  template<typename T, typename U>
+  void setCache( const T& iFrom, const edm::AtomicPtrCache<U>& oCache) {
+    if ( not oCache.isSet()) {
+      // Fill them from the refs
+      auto temp = std::make_unique<U>();
+      temp->reserve(iFrom.size());
+      for ( auto const& ref: iFrom ) {
+        temp->push_back(*ref);
+      }
+      oCache.set(std::move(temp));
+    }
+  }
+
+  template<typename T>
+  void copyToCache(T&& iFrom, edm::AtomicPtrCache<T>& oCache) {
+    oCache.reset();
+    oCache.set( std::make_unique<T>(std::move(iFrom)));
+  }
+}
+
 // PiZero and decay mode information
 const std::vector<RecoTauPiZero>& PFTau::signalPiZeroCandidates() const {
   // Check if the signal pi zeros are already filled
-  if ( signalPiZeroCandidates_.size() < signalPiZeroCandidatesRefs_.size() ) {
-    // Fill them from the refs
-    for ( size_t i = 0; i < signalPiZeroCandidatesRefs_.size(); ++i ) {
-      signalPiZeroCandidates_.push_back(*signalPiZeroCandidatesRefs_[i]);
-    }
-  }
-  return signalPiZeroCandidates_;
+  setCache(signalPiZeroCandidatesRefs_, signalPiZeroCandidates_);
+  return *signalPiZeroCandidates_;
 }
 
-void PFTau::setsignalPiZeroCandidates(const std::vector<RecoTauPiZero>& cands) {
-   signalPiZeroCandidates_ = cands;
-}
-
-void PFTau::setSignalPiZeroCandidatesRefs(const RecoTauPiZeroRefVector& cands) {
-   signalPiZeroCandidatesRefs_ = cands;
-}
-
-void PFTau::setIsolationPiZeroCandidatesRefs(const RecoTauPiZeroRefVector& cands) {
-   isolationPiZeroCandidatesRefs_ = cands;
+void PFTau::setsignalPiZeroCandidates(std::vector<RecoTauPiZero> cands) {
+   copyToCache(std::move(cands), signalPiZeroCandidates_);
 }
 
 const std::vector<RecoTauPiZero>& PFTau::isolationPiZeroCandidates() const {
   // Check if the signal pi zeros are already filled
-  if ( isolationPiZeroCandidates_.size() < isolationPiZeroCandidatesRefs_.size() ) {
-    // Fill them from the refs
-    for ( size_t i = 0; i < isolationPiZeroCandidatesRefs_.size(); ++i ) {
-      isolationPiZeroCandidates_.push_back(*isolationPiZeroCandidatesRefs_[i]);
-    }
-  }
-  return isolationPiZeroCandidates_;
+  setCache(isolationPiZeroCandidatesRefs_, isolationPiZeroCandidates_);
+  return *isolationPiZeroCandidates_;
 }
 
-void PFTau::setisolationPiZeroCandidates(const std::vector<RecoTauPiZero>& cands) {
-   signalPiZeroCandidates_ = cands;
+void PFTau::setisolationPiZeroCandidates(std::vector<RecoTauPiZero> cands) {
+  copyToCache(std::move(cands), signalPiZeroCandidates_);
 }
 
 // Tau Charged Hadron information
@@ -143,40 +147,30 @@ PFRecoTauChargedHadronRef PFTau::leadTauChargedHadronCandidate() const {
 
 const std::vector<PFRecoTauChargedHadron>& PFTau::signalTauChargedHadronCandidates() const {
   // Check if the signal tau charged hadrons are already filled
-  if ( signalTauChargedHadronCandidates_.size() < signalTauChargedHadronCandidatesRefs_.size() ) {
-    // Fill them from the refs
-    for ( size_t i = 0; i < signalTauChargedHadronCandidatesRefs_.size(); ++i ) {
-      signalTauChargedHadronCandidates_.push_back(*signalTauChargedHadronCandidatesRefs_[i]);
-    }
-  }
-  return signalTauChargedHadronCandidates_;
+  setCache(signalTauChargedHadronCandidatesRefs_, signalTauChargedHadronCandidates_);
+  return *signalTauChargedHadronCandidates_;
 }
 
-void PFTau::setSignalTauChargedHadronCandidates(const std::vector<PFRecoTauChargedHadron>& cands) {
-  signalTauChargedHadronCandidates_ = cands;
+void PFTau::setSignalTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron> cands) {
+  copyToCache(std::move(cands), signalTauChargedHadronCandidates_);
 }
 
-void PFTau::setSignalTauChargedHadronCandidatesRefs(const PFRecoTauChargedHadronRefVector& cands) {
-  signalTauChargedHadronCandidatesRefs_ = cands;
+void PFTau::setSignalTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector cands) {
+  signalTauChargedHadronCandidatesRefs_ = std::move(cands);
 }
 
 const std::vector<PFRecoTauChargedHadron>& PFTau::isolationTauChargedHadronCandidates() const {
   // Check if the isolation tau charged hadrons are already filled
-  if ( isolationTauChargedHadronCandidates_.size() < isolationTauChargedHadronCandidatesRefs_.size() ) {
-    // Fill them from the refs
-    for ( size_t i = 0; i < isolationTauChargedHadronCandidatesRefs_.size(); ++i ) {
-      isolationTauChargedHadronCandidates_.push_back(*isolationTauChargedHadronCandidatesRefs_[i]);
-    }
-  }
-  return isolationTauChargedHadronCandidates_;
+  setCache(isolationTauChargedHadronCandidatesRefs_, isolationTauChargedHadronCandidates_);
+  return *isolationTauChargedHadronCandidates_;
 }
 
-void PFTau::setIsolationTauChargedHadronCandidates(const std::vector<PFRecoTauChargedHadron>& cands) {
-  isolationTauChargedHadronCandidates_ = cands;
+void PFTau::setIsolationTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron> cands) {
+  copyToCache(std::move(cands),isolationTauChargedHadronCandidates_);
 }
 
-void PFTau::setIsolationTauChargedHadronCandidatesRefs(const PFRecoTauChargedHadronRefVector& cands) {
-  isolationTauChargedHadronCandidatesRefs_ = cands;
+void PFTau::setIsolationTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector cands) {
+  isolationTauChargedHadronCandidatesRefs_ = std::move(cands);
 }
 
 PFTau::hadronicDecayMode PFTau::decayMode() const { return decayMode_; }

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -165,7 +165,7 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
 source = "" 
 target="signalPiZeroCandidates_">
 <![CDATA[
-signalPiZeroCandidates_.clear();
+signalPiZeroCandidates_.reset();
 ]]>
 </ioread>
               
@@ -174,7 +174,7 @@ signalPiZeroCandidates_.clear();
 source = "" 
 target="isolationPiZeroCandidates_">
 <![CDATA[
-isolationPiZeroCandidates_.clear();
+isolationPiZeroCandidates_.reset();
 ]]>
 </ioread>
 
@@ -183,7 +183,7 @@ isolationPiZeroCandidates_.clear();
  targetClass="reco::PFTau" 
 source = "" 
 target="signalTauChargedHadronCandidates_">
-<![CDATA[signalTauChargedHadronCandidates_.clear();
+<![CDATA[signalTauChargedHadronCandidates_.reset();
 ]]>                                    
 </ioread>
                                       
@@ -192,7 +192,7 @@ target="signalTauChargedHadronCandidates_">
 source = "" 
 target="isolationTauChargedHadronCandidates_">                                          
 <![CDATA[
-isolationTauChargedHadronCandidates_.clear();                                              
+isolationTauChargedHadronCandidates_.reset();                                              
 ]]>                                                
 </ioread>
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -139,7 +139,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
   unsigned numNonPFCandTracks = 0;
   double nonPFCandTracksSumP = 0.;
   double nonPFCandTracksSumPerr2 = 0.;
-  const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau.signalTauChargedHadronCandidates();
+  const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau.signalTauChargedHadronCandidatesRestricted();
   for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
 	chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
     if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
@@ -221,7 +221,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 	if ( chargedHadron.getNeutralPFCandidates().size() >= 1 ) {
 	  PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
 	  setChargedHadronP4(chargedHadron_modified, scaleFactor);
-	  tau.signalTauChargedHadronCandidates_[iChargedHadron] = chargedHadron_modified;
+	  tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
 	  diffP4 += (chargedHadron.p4() - chargedHadron_modified.p4());
 	}
       }
@@ -272,7 +272,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 	  double chargedHadronPz_modified = scaleFactor*chargedPFCand->pz();
 	  reco::Candidate::LorentzVector chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);	  
 	  chargedHadron_modified.setP4(chargedHadronP4_modified);
-	  tau.signalTauChargedHadronCandidates_[iChargedHadron] = chargedHadron_modified;
+	  tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
 	  diffP4 += (chargedHadron.p4() - chargedHadron_modified.p4());
 	}
       }
@@ -284,7 +284,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
     } else {
       double allTracksSumP = 0.;
       double allTracksSumPerr2 = 0.;
-      const std::vector<PFRecoTauChargedHadron> chargedHadrons = tau.signalTauChargedHadronCandidates();
+      const std::vector<PFRecoTauChargedHadron> chargedHadrons = tau.signalTauChargedHadronCandidatesRestricted();
       for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
 	    chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
 	if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) || chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
@@ -337,7 +337,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 	    if ( verbosity_ ) {
 	      std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy() << " to " << chargedHadron_modified.energy() << std::endl;
 	    }
-	    tau.signalTauChargedHadronCandidates_[iChargedHadron] = chargedHadron_modified;
+	    tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
 	  } else if ( chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) ) {
 	    PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
 	    chargedHadron_modified.neutralPFCandidates_.clear();
@@ -359,7 +359,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 	    if ( verbosity_ ) {
 	      std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy() << " to " << chargedHadron_modified.energy() << std::endl;
 	    }
-	    tau.signalTauChargedHadronCandidates_[iChargedHadron] = chargedHadron_modified;
+	    tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
 	  }
 	}
 	double scaleFactor = allNeutralsSumEn/tau.energy();
@@ -420,7 +420,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 	      if ( verbosity_ ) {
 		std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy() << " to " << chargedHadron_modified.energy() << std::endl;
 	      }
-	      tau.signalTauChargedHadronCandidates_[iChargedHadron] = chargedHadron_modified;
+	      tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
 	    }
 	  }
 	  double scaleFactor = allNeutralsSumEn/tau.energy();

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -101,10 +101,10 @@ void RecoTauConstructor::reserve(Region region, ParticleType type, size_t size){
 void RecoTauConstructor::reserveTauChargedHadron(Region region, size_t size) 
 {
   if ( region == kSignal ) {
-    tau_->signalTauChargedHadronCandidates_.reserve(size);
+    tau_->signalTauChargedHadronCandidatesRestricted().reserve(size);
     tau_->selectedSignalPFChargedHadrCands_.reserve(size);
   } else {
-    tau_->isolationTauChargedHadronCandidates_.reserve(size);
+    tau_->isolationTauChargedHadronCandidatesRestricted().reserve(size);
     tau_->selectedIsolationPFChargedHadrCands_.reserve(size);
   }
 }
@@ -147,10 +147,10 @@ void RecoTauConstructor::addTauChargedHadron(Region region, const PFRecoTauCharg
     LogDebug("TauConstructorAddChH") << "neutral = " << neutral->id() << ":" << neutral->key();
     bool isUnique = true;
     if ( copyGammas_ ) checkOverlap(*neutral, *getSortedCollection(kSignal, kGamma), isUnique);
-    else checkOverlap(*neutral, tau_->signalPiZeroCandidates_, isUnique);
+    else checkOverlap(*neutral, tau_->signalPiZeroCandidatesRestricted(), isUnique);
     if ( region == kIsolation ) {
       if ( copyGammas_ ) checkOverlap(*neutral, *getSortedCollection(kIsolation, kGamma), isUnique);
-      else checkOverlap(*neutral, tau_->isolationPiZeroCandidates_, isUnique);      
+      else checkOverlap(*neutral, tau_->isolationPiZeroCandidatesRestricted(), isUnique);      
     }
     LogDebug("TauConstructorAddChH") << "--> isUnique = " << isUnique;
     if ( isUnique ) neutrals_cleaned.push_back(*neutral);
@@ -161,7 +161,7 @@ void RecoTauConstructor::addTauChargedHadron(Region region, const PFRecoTauCharg
     setChargedHadronP4(chargedHadron_cleaned);
   }
   if ( region == kSignal ) {
-    tau_->signalTauChargedHadronCandidates_.push_back(chargedHadron_cleaned);
+    tau_->signalTauChargedHadronCandidatesRestricted().push_back(chargedHadron_cleaned);
     p4_ += chargedHadron_cleaned.p4();
     if ( chargedHadron_cleaned.getChargedPFCandidate().isNonnull() ) {
       addPFCand(kSignal, kChargedHadron, chargedHadron_cleaned.getChargedPFCandidate(), true);
@@ -173,7 +173,7 @@ void RecoTauConstructor::addTauChargedHadron(Region region, const PFRecoTauCharg
       else if ( (*neutral)->particleId() == reco::PFCandidate::h0    ) addPFCand(kSignal, kNeutralHadron, *neutral, true);
     };
   } else {
-    tau_->isolationTauChargedHadronCandidates_.push_back(chargedHadron_cleaned);
+    tau_->isolationTauChargedHadronCandidatesRestricted().push_back(chargedHadron_cleaned);
     if ( chargedHadron_cleaned.getChargedPFCandidate().isNonnull() ) {
       if      ( chargedHadron_cleaned.getChargedPFCandidate()->particleId() == reco::PFCandidate::h  ) addPFCand(kIsolation, kChargedHadron, chargedHadron_cleaned.getChargedPFCandidate());
       else if ( chargedHadron_cleaned.getChargedPFCandidate()->particleId() == reco::PFCandidate::h0 ) addPFCand(kIsolation, kNeutralHadron, chargedHadron_cleaned.getChargedPFCandidate());
@@ -190,12 +190,12 @@ void RecoTauConstructor::addTauChargedHadron(Region region, const PFRecoTauCharg
 void RecoTauConstructor::reservePiZero(Region region, size_t size) 
 {
   if ( region == kSignal ) {
-    tau_->signalPiZeroCandidates_.reserve(size);
+    tau_->signalPiZeroCandidatesRestricted().reserve(size);
     // If we are building the gammas with the pizeros, resize that
     // vector as well
     if ( copyGammas_ ) reserve(kSignal, kGamma, 2*size);
   } else {
-    tau_->isolationPiZeroCandidates_.reserve(size);
+    tau_->isolationPiZeroCandidatesRestricted().reserve(size);
     if ( copyGammas_ ) reserve(kIsolation, kGamma, 2*size);
   }
 }
@@ -204,7 +204,7 @@ void RecoTauConstructor::addPiZero(Region region, const RecoTauPiZero& piZero)
 {
   LogDebug("TauConstructorAddPi0") << " region = " << region << ": Pt = " << piZero.pt() << ", eta = " << piZero.eta() << ", phi = " << piZero.phi();
   if ( region == kSignal ) {
-    tau_->signalPiZeroCandidates_.push_back(piZero);
+    tau_->signalPiZeroCandidatesRestricted().push_back(piZero);
     // Copy the daughter gammas into the gamma collection if desired
     if ( copyGammas_ ) {
       // If we are using the pizeros to build the gammas, make sure we update
@@ -214,7 +214,7 @@ void RecoTauConstructor::addPiZero(Region region, const RecoTauPiZero& piZero)
           piZero.daughterPtrVector().end());
     }
   } else {
-    tau_->isolationPiZeroCandidates_.push_back(piZero);
+    tau_->isolationPiZeroCandidatesRestricted().push_back(piZero);
     if ( copyGammas_ ) {
       addPFCands(kIsolation, kGamma, piZero.daughterPtrVector().begin(),
           piZero.daughterPtrVector().end());
@@ -279,17 +279,17 @@ template<typename T> bool ptDescendingPtr(const T& a, const T& b) {
 
 void RecoTauConstructor::sortAndCopyIntoTau() {
   // The charged hadrons and pizeros are a special case, as we can sort them in situ
-  std::sort(tau_->signalTauChargedHadronCandidates_.begin(),
-            tau_->signalTauChargedHadronCandidates_.end(),
+  std::sort(tau_->signalTauChargedHadronCandidatesRestricted().begin(),
+            tau_->signalTauChargedHadronCandidatesRestricted().end(),
             ptDescending<PFRecoTauChargedHadron>);
-  std::sort(tau_->isolationTauChargedHadronCandidates_.begin(),
-            tau_->isolationTauChargedHadronCandidates_.end(),
+  std::sort(tau_->isolationTauChargedHadronCandidatesRestricted().begin(),
+            tau_->isolationTauChargedHadronCandidatesRestricted().end(),
             ptDescending<PFRecoTauChargedHadron>);
-  std::sort(tau_->signalPiZeroCandidates_.begin(),
-            tau_->signalPiZeroCandidates_.end(),
+  std::sort(tau_->signalPiZeroCandidatesRestricted().begin(),
+            tau_->signalPiZeroCandidatesRestricted().end(),
             ptDescending<RecoTauPiZero>);
-  std::sort(tau_->isolationPiZeroCandidates_.begin(),
-            tau_->isolationPiZeroCandidates_.end(),
+  std::sort(tau_->isolationPiZeroCandidatesRestricted().begin(),
+            tau_->isolationPiZeroCandidatesRestricted().end(),
             ptDescending<RecoTauPiZero>);
 
   // Sort each of our sortable collections, and copy them into the final
@@ -370,8 +370,8 @@ std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects)
   int charge = 0;
   double leadChargedHadronPt = 0.;
   int leadChargedHadronCharge = 0;
-  for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = tau_->signalTauChargedHadronCandidates_.begin();
-	chargedHadron != tau_->signalTauChargedHadronCandidates_.end(); ++chargedHadron ) {
+  for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = tau_->signalTauChargedHadronCandidatesRestricted().begin();
+	chargedHadron != tau_->signalTauChargedHadronCandidatesRestricted().end(); ++chargedHadron ) {
     if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) || chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
       ++nCharged;
       charge += chargedHadron->charge();


### PR DESCRIPTION
PFTau caches values the first time certain member functions are called.
The caches were changed to use edm::AtomicPtrCache in order to be
thread-safe.
