### PR TITLE
Use iorule to remove mutables from CandKinResolution

### DIFF
--- a/DataFormats/PatCandidates/interface/CandKinResolution.h
+++ b/DataFormats/PatCandidates/interface/CandKinResolution.h
@@ -72,12 +72,11 @@ namespace pat {
 
         /// Returns the number of free parameters in this parametrization
         uint32_t dimension() const { 
-            return (static_cast<uint32_t>(parametrization_) & 0x0F);
+            return dimensionFrom(parametrization_);
         }
 
         /// Returns the full covariance matrix
         const AlgebraicSymMatrix44 & covariance()  const { 
-            if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
             return covmatrix_; 
         }
 
@@ -121,6 +120,13 @@ namespace pat {
         /// Resolution on pz, given the 4-momentum of the associated Candidate
 	double resolPz(const LorentzVector &p4) const ;
 
+        static int dimensionFrom(Parametrization parametrization) {
+          return (static_cast<uint32_t>(parametrization) & 0x0F);
+        }
+
+        static void fillMatrixFrom( Parametrization parametrization, const std::vector<Scalar>& covariances,
+                                    AlgebraicSymMatrix44& covmatrix);
+
      private:
         // persistent 
         /// Parametrization code
@@ -132,16 +138,13 @@ namespace pat {
 
         // transient
 
-        /// Did we make the Matrix from the vector?
-        mutable bool       hasMatrix_;
-    
         /// Transient copy of the full 4x4 covariance matrix
-        mutable AlgebraicSymMatrix44 covmatrix_;
+        AlgebraicSymMatrix44 covmatrix_;
 
         //methods
 
         /// Fill matrix from vector
-        void fillMatrix() const ; // const: the matrix is mutable
+        void fillMatrix() ;
 
         /// Fill vectoor from matrix
         void fillVector() ;

--- a/DataFormats/PatCandidates/src/CandKinResolution.cc
+++ b/DataFormats/PatCandidates/src/CandKinResolution.cc
@@ -7,7 +7,7 @@ pat::CandKinResolution::CandKinResolution() :
     parametrization_(Invalid), 
     covariances_(),
     constraints_(),
-    hasMatrix_(false), covmatrix_() 
+    covmatrix_() 
 { 
 }
 
@@ -15,7 +15,6 @@ pat::CandKinResolution::CandKinResolution(Parametrization parametrization, const
     parametrization_(parametrization),
     covariances_(covariances), 
     constraints_(constraints),
-    hasMatrix_(true),
     covmatrix_()
 {
     fillMatrix();
@@ -25,7 +24,6 @@ pat::CandKinResolution::CandKinResolution(Parametrization parametrization, const
     parametrization_(parametrization),
     covariances_(), 
     constraints_(constraints),
-    hasMatrix_(true),
     covmatrix_(covariance)
 {
     fillVector();
@@ -39,62 +37,50 @@ pat::CandKinResolution::~CandKinResolution() {
 
 double pat::CandKinResolution::resolEta(const pat::CandKinResolution::LorentzVector &p4)   const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolEta(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolTheta(const pat::CandKinResolution::LorentzVector &p4) const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolTheta(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolPhi(const pat::CandKinResolution::LorentzVector &p4)   const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolPhi(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolE(const pat::CandKinResolution::LorentzVector &p4)     const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolE(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolEt(const pat::CandKinResolution::LorentzVector &p4)    const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolEt(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolM(const pat::CandKinResolution::LorentzVector &p4)     const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolM(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolP(const pat::CandKinResolution::LorentzVector &p4)     const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolP(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolPt(const pat::CandKinResolution::LorentzVector &p4)    const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolPt(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolPInv(const pat::CandKinResolution::LorentzVector &p4)  const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolPInv(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolPx(const pat::CandKinResolution::LorentzVector &p4)    const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolPx(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolPy(const pat::CandKinResolution::LorentzVector &p4)    const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolPy(parametrization_, covmatrix_, p4);
 }
 double pat::CandKinResolution::resolPz(const pat::CandKinResolution::LorentzVector &p4)    const
 {
-    if (!hasMatrix_) { fillMatrix(); hasMatrix_ = true; }
     return pat::helper::ResolutionHelper::getResolPz(parametrization_, covmatrix_, p4);
 }
 
@@ -106,18 +92,27 @@ void pat::CandKinResolution::fillVector() {
         covariances_.insert(covariances_.end(), covmatrix_.begin(), covmatrix_.end());
     }
 }
-void pat::CandKinResolution::fillMatrix() const { 
-    if (dimension() == 3) {
-        if (covariances_.size() == 3) {
-            for (int i = 0; i < 3; ++i) covmatrix_(i,i) = covariances_[i];
+
+void pat::CandKinResolution::fillMatrixFrom(Parametrization parametrization, 
+                                            const std::vector<Scalar>& covariances,
+                                            AlgebraicSymMatrix44& covmatrix) { 
+    int dimension = dimensionFrom(parametrization);
+    if (dimension == 3) {
+        if (covariances.size() == 3) {
+            for (int i = 0; i < 3; ++i) covmatrix(i,i) = covariances[i];
         } else {
-            covmatrix_.Place_at(AlgebraicSymMatrix33(covariances_.begin(), covariances_.end()), 0, 0);
+            covmatrix.Place_at(AlgebraicSymMatrix33(covariances.begin(), covariances.end()), 0, 0);
         }
-    } else if (dimension() == 4) {
-        if (covariances_.size() == 4) {
-            for (int i = 0; i < 4; ++i) covmatrix_(i,i) = covariances_[i];
+    } else if (dimension == 4) {
+        if (covariances.size() == 4) {
+            for (int i = 0; i < 4; ++i) covmatrix(i,i) = covariances[i];
         } else {
-            covmatrix_ = AlgebraicSymMatrix44(covariances_.begin(), covariances_.end());
+            covmatrix = AlgebraicSymMatrix44(covariances.begin(), covariances.end());
         }
     }
+}
+
+
+void pat::CandKinResolution::fillMatrix() { 
+    fillMatrixFrom(parametrization_, covariances_, covmatrix_);
 }

--- a/DataFormats/PatCandidates/src/classes_def_other.xml
+++ b/DataFormats/PatCandidates/src/classes_def_other.xml
@@ -51,13 +51,12 @@
   <class name="pat::CandKinResolution"  ClassVersion="13">
    <version ClassVersion="13" checksum="1576481716"/>
    <field name="covmatrix_" transient="true"/>
-   <field name="hasMatrix_" transient="true"/>
    <version ClassVersion="12" checksum="811710989"/>
    <version ClassVersion="11" checksum="3628324235"/>
    <version ClassVersion="10" checksum="932672721"/>
   </class>
-  <ioread sourceClass="pat::CandKinResolution" targetClass="pat::CandKinResolution" version="[1-]" source="" target="hasMatrix_">
-  <![CDATA[hasMatrix_ = false;]]>
+  <ioread sourceClass="pat::CandKinResolution" targetClass="pat::CandKinResolution" version="[1-]" source="pat::CandKinResolution::Parametrization parametrization_; std::vector<pat::CandKinResolution::Scalar> covariances_" target="covmatrix_">
+  <![CDATA[pat::CandKinResolution::fillMatrixFrom(onfile.parametrization_, onfile.covariances_,covmatrix_);]]>
   </ioread>
   <class name="std::vector<pat::CandKinResolution>" />
   <class name="pat::CandKinResolutionValueMap" />


### PR DESCRIPTION
Previously, CandKinResolution would on the first request for the
covariance matrix fill the matrix. This was done since the matrix
is a transient member. This delayed filling is difficult to do in
a thread safe manner. Therefore the matrix is now filled when reading
back from the file via a ROOT iorule.
