### PR TITLE
Change default MeasurementTrackerEvent mode to kNever in several TrackingRegionProducers

### DIFF
--- a/HLTrigger/btau/src/L3MumuTrackingRegion.h
+++ b/HLTrigger/btau/src/L3MumuTrackingRegion.h
@@ -43,7 +43,7 @@ public:
     else{
       m_searchOpt = false;
     }
-    m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
+    m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever;
     if (regionPSet.exists("measurementTrackerName")){
       // FIXME: when next time altering the configuration of this
       // class, please change the types of the following parameters:

--- a/RecoTauTag/HLTProducers/src/CandidateSeededTrackingRegionsProducer.h
+++ b/RecoTauTag/HLTProducers/src/CandidateSeededTrackingRegionsProducer.h
@@ -78,7 +78,7 @@ public:
     m_deltaEta         = regPSet.getParameter<double>("deltaEta");
     m_deltaPhi         = regPSet.getParameter<double>("deltaPhi");
     m_precise          = regPSet.getParameter<bool>("precise");
-    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever;
     if (regPSet.exists("measurementTrackerName"))
     {
       // FIXME: when next time altering the configuration of this

--- a/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
+++ b/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
@@ -52,7 +52,7 @@ class TauRegionalPixelSeedGenerator : public TrackingRegionProducer {
       else{
 	m_searchOpt = false;
       }
-      m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
+      m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever;
       if (regionPSet.exists("measurementTrackerName")){
         // FIXME: when next time altering the configuration of this
         // class, please change the types of the following parameters:

--- a/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
+++ b/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
@@ -48,7 +48,7 @@ public:
     if (regionPSet.exists("searchOpt")) m_searchOpt = regionPSet.getParameter<bool>("searchOpt");
     else                                m_searchOpt = false;
 
-    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever;
     if (regionPSet.exists("measurementTrackerName"))
     {
       // FIXME: when next time altering the configuration of this

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -82,7 +82,7 @@ public:
     m_deltaEta         = regPSet.getParameter<double>("deltaEta");
     m_deltaPhi         = regPSet.getParameter<double>("deltaPhi");
     m_precise          = regPSet.getParameter<bool>("precise");
-    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever;
     if (regPSet.exists("measurementTrackerName"))
     {
       // FIXME: when next time altering the configuration of this


### PR DESCRIPTION
This PR fixes the segfault reported in
https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1562.html

The problem in the reported case was that TauRegionalPixelSeedGenerator by default sets the MeasurementTrackerEvent usage mode to `kForSiStrips`, but does not read the MTE from the event, leading to a segfault in RectangularEtaPhiTrackingRegion if any hits from strips are read. Since MTE is not read by default, the only sensible default value for MTE usage mode is `kNever`. Apparently I missed these in #3105, where the default value of RectangularEtaPhiTrackingRegion itself was set to `kNever`. In hits PR also the other TrackingRegionProducers having `kForSiStrips` default (those who do not read MTE by default) are changed to use `kNever` mode by default (PointSeededTrackingRegionsProducer seems to have appeared since #3105).

In all current uses (e.g. in HLT) where these TrackingRegionProducers are uset with the default MTE usage mode, only pixel hits are read (without MTE) and the bug is not triggered. The case in reported in the HN was probably the first use of any of these TrackingRegionProducers with strip hits (otherwise we should have got segfault report earlier).

Tested in 760pre2, no changes expected in results.
