### PR TITLE
Fix premature end of run in DAQ (74X)

### DIFF
--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -876,7 +876,7 @@ void FedRawDataInputSource::readSupervisor()
 
     //look for a new file
     std::string nextFile;
-    uint32_t ls;
+    uint32_t ls=0;
     uint32_t fileSize;
 
     uint32_t monLS=1;
@@ -895,6 +895,7 @@ void FedRawDataInputSource::readSupervisor()
      
       uint64_t thisLockWaitTimeUs=0.;
       status = daqDirector_->updateFuLock(ls,nextFile,fileSize,thisLockWaitTimeUs);
+      if (currentLumiSection!=ls && status==evf::EvFDaqDirector::runEnded) status=evf::EvFDaqDirector::noFile;
 
       //monitoring of lock wait time
       if (thisLockWaitTimeUs>0.)
@@ -913,6 +914,7 @@ void FedRawDataInputSource::readSupervisor()
         usleep(100000);
         //now all files should have appeared in ramdisk, check again if any raw files were left behind
         status = daqDirector_->updateFuLock(ls,nextFile,fileSize,thisLockWaitTimeUs);
+        if (currentLumiSection!=ls && status==evf::EvFDaqDirector::runEnded) status=evf::EvFDaqDirector::noFile;
       }
 
       if ( status == evf::EvFDaqDirector::runEnded) {


### PR DESCRIPTION
In case of multiple pending lumisections in builder unit (ramdisk), recently forced behavior is to cycle the framework through each LS (previously source was skipping to the last one having raw data that needs to be processed). This change uncovered a loophole in logic allowing run to end prematurely if end of run file (written by BU) is in ramdisk, and there are still at least two empty lumisections followed by a LS with some raw data to process.
Fix is to allow the run to be closed only if no new files/lumisections have been discovered by source after EoR file has already been written to the input directory.
