### PR TITLE
Finally fix segfault!

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -117,8 +117,10 @@ private:
   struct SummaryContainer{
     SummaryContainer() : sumXResiduals_(), summaryXResiduals_(), 
 			 sumNormXResiduals_(), summaryNormXResiduals_(),
-			 sumYResiduals_(), summaryYResiduals_() ,
-			 sumNormYResiduals_(), summaryNormYResiduals_() {}
+			 sumYResiduals_(), summaryYResiduals_(),
+			 sumNormYResiduals_(), summaryNormYResiduals_(),
+			 sumResXvsXProfile_(), sumResXvsYProfile_(),
+			 sumResYvsXProfile_(), sumResYvsYProfile_() {}
     
     TH1* sumXResiduals_;
     TH1* summaryXResiduals_;
@@ -128,6 +130,11 @@ private:
     TH1* summaryYResiduals_;
     TH1* sumNormYResiduals_;
     TH1* summaryNormYResiduals_;
+
+    TH1* sumResXvsXProfile_;
+    TH1* sumResXvsYProfile_;
+    TH1* sumResYvsXProfile_;
+    TH1* sumResYvsYProfile_;
   };
   
   
@@ -1281,6 +1288,15 @@ TrackerOfflineValidation::collateSummaryHists( DirectoryWrapper& tfd, const Alig
 	vLevelProfiles[iComp].sumNormXResiduals_->Add(vProfiles[n].sumNormXResiduals_);
 	if (hY)     hY->Add(vProfiles[n].sumYResiduals_);         // only if existing
 	if (hNormY) hNormY->Add(vProfiles[n].sumNormYResiduals_); // dito (pxl, stripYResiduals_)
+
+        TH1 *pXX = vLevelProfiles[iComp].sumResXvsXProfile_;
+        TH1 *pXY = vLevelProfiles[iComp].sumResXvsYProfile_;
+        TH1 *pYX = vLevelProfiles[iComp].sumResYvsXProfile_;
+        TH1 *pYY = vLevelProfiles[iComp].sumResYvsYProfile_;
+	if (pXX) pXX->Add(vProfiles[n].sumResXvsXProfile_);
+	if (pXY) pXY->Add(vProfiles[n].sumResXvsYProfile_);
+	if (pYX) pYX->Add(vProfiles[n].sumResYvsXProfile_);
+	if (pYY) pYY->Add(vProfiles[n].sumResYvsYProfile_);
       }
       if(dqmMode_)continue;  // No fits in dqmMode
       //add fit values to stat box
@@ -1386,6 +1402,19 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
   sumContainer.sumNormXResiduals_ = tfd.make<TH1F>(Form("h_NormXprime_%s_%d",aliTypeName,i), 
 						   sumTitle + xTitHists.NormResXprimeHisto->GetXaxis()->GetTitle(),
 						   nbins, xmin, xmax);
+
+  if ( moduleLevelProfiles_ ) {
+    this->getBinning(aliDetId.subdetId(), XResidualProfile, nbins, xmin, xmax);
+    sumContainer.sumResXvsXProfile_ = tfd.make<TProfile>(Form("p_resXX_%s_%d",aliTypeName,i), 
+							 sumTitle + xTitHists.ResXvsXProfile->GetXaxis()->GetTitle(),
+							 nbins, xmin, xmax);
+    sumContainer.sumResXvsXProfile_->Sumw2();
+    sumContainer.sumResXvsYProfile_ = tfd.make<TProfile>(Form("p_resXY_%s_%d",aliTypeName,i), 
+							 sumTitle + xTitHists.ResXvsYProfile->GetXaxis()->GetTitle(),
+							 nbins, xmin, xmax);
+    sumContainer.sumResXvsYProfile_->Sumw2();
+  }
+
   if (bookResidY) {
     this->getBinning(aliDetId.subdetId(), YprimeResidual, nbins, xmin, xmax);
     sumContainer.sumYResiduals_ = tfd.make<TH1F>(Form("h_Yprime_%s_%d",aliTypeName,i), 
@@ -1396,6 +1425,18 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
     sumContainer.sumNormYResiduals_ = tfd.make<TH1F>(Form("h_NormYprime_%s_%d",aliTypeName,i), 
 						     sumTitle + xTitHists.NormResYprimeHisto->GetXaxis()->GetTitle(),
 						     nbins, xmin, xmax);
+
+    if ( moduleLevelProfiles_ ) {
+      this->getBinning(aliDetId.subdetId(), YResidualProfile, nbins, xmin, xmax);
+      sumContainer.sumResYvsXProfile_ = tfd.make<TProfile>(Form("p_resYX_%s_%d",aliTypeName,i), 
+							   sumTitle + xTitHists.ResYvsXProfile->GetXaxis()->GetTitle(),
+							   nbins, xmin, xmax);
+      sumContainer.sumResYvsXProfile_->Sumw2();
+      sumContainer.sumResYvsYProfile_ = tfd.make<TProfile>(Form("p_resYY_%s_%d",aliTypeName,i), 
+							   sumTitle + xTitHists.ResYvsYProfile->GetXaxis()->GetTitle(),
+							   nbins, xmin, xmax);
+      sumContainer.sumResYvsYProfile_->Sumw2();
+    }
   }
   
   // If we are at the lowest level, we already sum up and fill the summary.
@@ -1408,9 +1449,17 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
       this->summarizeBinInContainer(k+1, detid.subdetId() ,sumContainer, histStruct );
       sumContainer.sumXResiduals_->Add(histStruct.ResXprimeHisto);
       sumContainer.sumNormXResiduals_->Add(histStruct.NormResXprimeHisto);
+      if ( moduleLevelProfiles_ ) {
+        sumContainer.sumResXvsXProfile_->Add(histStruct.ResXvsXProfile);
+        sumContainer.sumResXvsYProfile_->Add(histStruct.ResXvsYProfile);
+      }
       if( this->isPixel(detid.subdetId()) || stripYResiduals_ ) {
       	sumContainer.sumYResiduals_->Add(histStruct.ResYprimeHisto);
       	sumContainer.sumNormYResiduals_->Add(histStruct.NormResYprimeHisto);
+        if ( moduleLevelProfiles_ ) {
+          sumContainer.sumResYvsXProfile_->Add(histStruct.ResYvsXProfile);
+          sumContainer.sumResYvsYProfile_->Add(histStruct.ResYvsYProfile);
+        }
       }
     }
   } else if( subtype == align::AlignableDet && subcompSize > 1) { // fixed: was aliSize before
@@ -1422,9 +1471,17 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
 	this->summarizeBinInContainer(2*k+j+1, detid.subdetId() ,sumContainer, histStruct );
 	sumContainer.sumXResiduals_->Add( histStruct.ResXprimeHisto);
 	sumContainer.sumNormXResiduals_->Add( histStruct.NormResXprimeHisto);
+        if ( moduleLevelProfiles_ ) {
+          sumContainer.sumResXvsXProfile_->Add(histStruct.ResXvsXProfile);
+          sumContainer.sumResXvsYProfile_->Add(histStruct.ResXvsYProfile);
+        }
 	if( this->isPixel(detid.subdetId()) || stripYResiduals_ ) {
 	  sumContainer.sumYResiduals_->Add( histStruct.ResYprimeHisto);
 	  sumContainer.sumNormYResiduals_->Add( histStruct.NormResYprimeHisto);
+          if ( moduleLevelProfiles_ ) {
+            sumContainer.sumResYvsXProfile_->Add(histStruct.ResYvsXProfile);
+            sumContainer.sumResYvsYProfile_->Add(histStruct.ResYvsYProfile);
+          }
 	}
       }
     }

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -22,6 +22,7 @@
 #include <map>
 #include <sstream>
 #include <math.h>
+#include <tuple>
 #include <utility>
 #include <vector>
 #include <iostream>
@@ -80,7 +81,7 @@ public:
   explicit TrackerOfflineValidation(const edm::ParameterSet&);
   ~TrackerOfflineValidation();
   
-  enum HistogrammType { XResidual, NormXResidual, 
+  enum HistogramType { XResidual, NormXResidual, 
 			YResidual, /*NormYResidual, */
 			XprimeResidual, NormXprimeResidual, 
 			YprimeResidual, NormYprimeResidual,
@@ -113,7 +114,7 @@ private:
     TH1* LocalY;
   };
   
-  // container struct to organize collection of histogramms during endJob
+  // container struct to organize collection of histograms during endJob
   struct SummaryContainer{
     SummaryContainer() : sumXResiduals_(), summaryXResiduals_(), 
 			 sumNormXResiduals_(), summaryNormXResiduals_(),
@@ -209,8 +210,9 @@ private:
   void bookDirHists(DirectoryWrapper& tfd, const Alignable& ali, const TrackerTopology* tTopo);
   void bookHists(DirectoryWrapper& tfd, const Alignable& ali, const TrackerTopology* tTopo, align::StructureType type, int i); 
  
-  void collateSummaryHists( DirectoryWrapper& tfd, const Alignable& ali, int i, 
+  void prepareSummaryHists( DirectoryWrapper& tfd, const Alignable& ali,
 			    std::vector<TrackerOfflineValidation::SummaryContainer>& vLevelProfiles);
+  void collateSummaryHists();
   
   void setUpTreeMembers(const std::map<int, TrackerOfflineValidation::ModuleHistos>& moduleHist_,
 		const TrackerGeometry& tkgeom, const TrackerTopology* tTopo);
@@ -236,7 +238,7 @@ private:
   TProfile* bookTProfile(bool isTransient, DirectoryWrapper& tfd, const char* histName, const char* histTitle, 
 			 int nBinsX, double lowX, double highX, double lowY, double highY);
 
-  void getBinning(uint32_t subDetId, TrackerOfflineValidation::HistogrammType residualtype, 
+  void getBinning(uint32_t subDetId, TrackerOfflineValidation::HistogramType residualtype, 
 		  int& nBinsX, double& lowerBoundX, double& upperBoundX);
 
   void summarizeBinInContainer(int bin, SummaryContainer& targetContainer, 
@@ -288,7 +290,19 @@ private:
 
   std::map<int,TkOffTreeVariables> mTreeMembers_;
 
-  const edm::EventSetup* lastSetup_;
+  //There are two types of summary histograms.  The first contains, for each component, a bin per subcomponent.
+  //These are filled through summarizeBinInContainer().  The second type is just the sum of the lower level histograms.
+  //Prepare the filling of both types at the beginning, when the tracker topology is available through the eventsetup.
+  //They are not actually filled until the end, but at that time eventsetup is no longer accessible.
+
+  //To fill the summary hists, directly store the arguments of summarizeBinInContainer() (two forms of the function)
+  //At the end, call the function (LowestLevel first).
+  std::vector<std::tuple<int,SummaryContainer*,SummaryContainer*> > summaryHistStructure_;
+  std::vector<std::tuple<int,uint32_t,SummaryContainer*,ModuleHistos*> > summaryHistStructureLowestLevel_;
+  //To fill the sum hists, just store pairs of TH1*.  At the end, first->Add(second).
+  std::vector<std::pair<TH1*,TH1*> > sumHistStructure_;
+  //sum hists are fit at the end using fitResiduals()
+  std::vector<TH1*> toFit_;
 
   TrackerValidationVariables avalidator_;
 };
@@ -372,7 +386,6 @@ TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iCon
     useOverflowForRMS_(parSet_.getParameter<bool>("useOverflowForRMS")),
     dqmMode_(parSet_.getParameter<bool>("useInDqmMode")),
     moduleDirectory_(parSet_.getParameter<std::string>("moduleDirectoryInOutput")),
-    lastSetup_(nullptr),
     avalidator_(iConfig, consumesCollector())
 {
 }
@@ -416,21 +429,24 @@ TrackerOfflineValidation::checkBookHists(const edm::EventSetup& es)
 					     << "Out of these "<<newBareTkGeomPtr->detUnitIds().size()
 					     <<" are detUnits";
     
-    // Book Histogramms for global track quantities
+    // Book histograms for global track quantities
     std::string globDir("GlobalTrackVariables");
     DirectoryWrapper trackglobal(globDir,moduleDirectory_,dqmMode_);
     this->bookGlobalHists(trackglobal);
     
-    // recursively book histogramms on lowest level
+    // recursively book histograms on lowest level
     DirectoryWrapper tfdw("",moduleDirectory_,dqmMode_);
     this->bookDirHists(tfdw, aliTracker, tTopo);
+    // and prepare the higher level histograms
+    std::vector<TrackerOfflineValidation::SummaryContainer> vTrackerprofiles;
+    this->prepareSummaryHists(tfdw, (aliTracker), vTrackerprofiles);
 
-    setUpTreeMembers(mPxbResiduals_, newBareTkGeomPtr, tTopo);
-    setUpTreeMembers(mPxeResiduals_, newBareTkGeomPtr, tTopo);
-    setUpTreeMembers(mTibResiduals_, newBareTkGeomPtr, tTopo);
-    setUpTreeMembers(mTidResiduals_, newBareTkGeomPtr, tTopo);
-    setUpTreeMembers(mTobResiduals_, newBareTkGeomPtr, tTopo);
-    setUpTreeMembers(mTecResiduals_, newBareTkGeomPtr, tTopo);
+    setUpTreeMembers(mPxbResiduals_, *newBareTkGeomPtr, tTopo);
+    setUpTreeMembers(mPxeResiduals_, *newBareTkGeomPtr, tTopo);
+    setUpTreeMembers(mTibResiduals_, *newBareTkGeomPtr, tTopo);
+    setUpTreeMembers(mTidResiduals_, *newBareTkGeomPtr, tTopo);
+    setUpTreeMembers(mTobResiduals_, *newBareTkGeomPtr, tTopo);
+    setUpTreeMembers(mTecResiduals_, *newBareTkGeomPtr, tTopo);
   }
   else { // histograms booked, but changed TrackerGeometry?
     edm::LogWarning("GeometryChange") << "@SUB=checkBookHists"
@@ -657,7 +673,7 @@ TrackerOfflineValidation::bookHists(DirectoryWrapper& tfd, const Alignable& ali,
   if (type == align::AlignableDetUnit )subtype = type;
   else if( this->isDetOrDetUnit(ali.alignableObjectId()) ) subtype = ali.alignableObjectId();
   
-  // construct histogramm title and name
+  // construct histogram title and name
   std::stringstream histoname, histotitle, normhistoname, normhistotitle, 
     yhistoname, yhistotitle,
     xprimehistoname, xprimehistotitle, normxprimehistoname, normxprimehistotitle,
@@ -867,7 +883,7 @@ bool TrackerOfflineValidation::isDetOrDetUnit(align::StructureType type)
 
 void 
 TrackerOfflineValidation::getBinning(uint32_t subDetId, 
-				     TrackerOfflineValidation::HistogrammType residualType, 
+				     TrackerOfflineValidation::HistogramType residualType, 
 				     int& nBinsX, double& lowerBoundX, double& upperBoundX)
 {
   // determine if 
@@ -1225,28 +1241,19 @@ TrackerOfflineValidation::endJob()
 {
 
   if (!tkGeom_.product()) return;
-
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  lastSetup_->get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
-  AlignableTracker aliTracker(&(*tkGeom_), tTopo);
   
   static const int kappadiffindex = this->GetIndex(vTrackHistos_,"h_diff_curvature");
   vTrackHistos_[kappadiffindex]->Add(vTrackHistos_[this->GetIndex(vTrackHistos_,"h_curvature_neg")],
 				     vTrackHistos_[this->GetIndex(vTrackHistos_,"h_curvature_pos")],-1,1);
  
   // Collate Information for Subdetectors
-  // create summary histogramms recursively
-  std::vector<TrackerOfflineValidation::SummaryContainer> vTrackerprofiles;
-  DirectoryWrapper f("",moduleDirectory_,dqmMode_);
-  this->collateSummaryHists(f,(aliTracker), 0, vTrackerprofiles);
-  
+  // create summary histograms recursively
+  this->collateSummaryHists();
+
   if (dqmMode_) return;
   // Should be excluded in dqmMode, since TTree is not usable
   // In dqmMode tree operations are are sourced out to the additional module TrackerOfflineValidationSummary
-  
+
   edm::Service<TFileService> fs;
   TTree *tree = fs->make<TTree>("TkOffVal","TkOffVal");
  
@@ -1255,7 +1262,7 @@ TrackerOfflineValidation::endJob()
   // This works because we have a dictionary for 'TkOffTreeVariables'
   // (see src/classes_def.xml and src/classes.h):
   tree->Branch("TkOffTreeVariables", &treeMemPtr); // address of pointer!
- 
+
   this->fillTree(*tree, mPxbResiduals_);
   this->fillTree(*tree, mPxeResiduals_);
   this->fillTree(*tree, mTibResiduals_);
@@ -1268,7 +1275,7 @@ TrackerOfflineValidation::endJob()
 
 
 void
-TrackerOfflineValidation::collateSummaryHists( DirectoryWrapper& tfd, const Alignable& ali, int i, 
+TrackerOfflineValidation::prepareSummaryHists( DirectoryWrapper& tfd, const Alignable& ali,
 					       std::vector<TrackerOfflineValidation::SummaryContainer>& vLevelProfiles)
 {
   std::vector<Alignable*> alivec(ali.components());
@@ -1288,37 +1295,64 @@ TrackerOfflineValidation::collateSummaryHists( DirectoryWrapper& tfd, const Alig
     if(  !(this->isDetOrDetUnit( (alivec)[iComp]->alignableObjectId()) )
 	 || (alivec)[0]->components().size() > 1 ) {
       DirectoryWrapper f(tfd,dirname.str(),moduleDirectory_,dqmMode_);
-      this->collateSummaryHists( f, *(alivec)[iComp], i, vProfiles);
+      this->prepareSummaryHists( f, *(alivec)[iComp], vProfiles);
       vLevelProfiles.push_back(this->bookSummaryHists(tfd, *(alivec[iComp]), ali.alignableObjectId(), iComp+1));
+      TH1 *hX = vLevelProfiles[iComp].sumXResiduals_;
+      TH1 *hNormX = vLevelProfiles[iComp].sumNormXResiduals_;
       TH1 *hY = vLevelProfiles[iComp].sumYResiduals_;
       TH1 *hNormY = vLevelProfiles[iComp].sumNormYResiduals_;
+      TH1 *pXX = vLevelProfiles[iComp].sumResXvsXProfile_;
+      TH1 *pXY = vLevelProfiles[iComp].sumResXvsYProfile_;
+      TH1 *pYX = vLevelProfiles[iComp].sumResYvsXProfile_;
+      TH1 *pYY = vLevelProfiles[iComp].sumResYvsYProfile_;
       for(uint n = 0; n < vProfiles.size(); ++n) {
-	this->summarizeBinInContainer(n+1, vLevelProfiles[iComp], vProfiles[n] );
-	vLevelProfiles[iComp].sumXResiduals_->Add(vProfiles[n].sumXResiduals_);
-	vLevelProfiles[iComp].sumNormXResiduals_->Add(vProfiles[n].sumNormXResiduals_);
-	if (hY)     hY->Add(vProfiles[n].sumYResiduals_);         // only if existing
-	if (hNormY) hNormY->Add(vProfiles[n].sumNormYResiduals_); // dito (pxl, stripYResiduals_)
-
-        TH1 *pXX = vLevelProfiles[iComp].sumResXvsXProfile_;
-        TH1 *pXY = vLevelProfiles[iComp].sumResXvsYProfile_;
-        TH1 *pYX = vLevelProfiles[iComp].sumResYvsXProfile_;
-        TH1 *pYY = vLevelProfiles[iComp].sumResYvsYProfile_;
-	if (pXX) pXX->Add(vProfiles[n].sumResXvsXProfile_);
-	if (pXY) pXY->Add(vProfiles[n].sumResXvsYProfile_);
-	if (pYX) pYX->Add(vProfiles[n].sumResYvsXProfile_);
-	if (pYY) pYY->Add(vProfiles[n].sumResYvsYProfile_);
+        summaryHistStructure_.emplace_back(n+1, &vLevelProfiles[iComp], &vProfiles[n]);
+	            sumHistStructure_.emplace_back(hX,     vProfiles[n].sumXResiduals_);
+	            sumHistStructure_.emplace_back(hNormX, vProfiles[n].sumNormXResiduals_);
+	if (hY)     sumHistStructure_.emplace_back(hY,     vProfiles[n].sumYResiduals_);         // only if existing
+	if (hNormY) sumHistStructure_.emplace_back(hNormY, vProfiles[n].sumNormYResiduals_);     // ditto (pxl, stripYResiduals_)
+	if (pXX)    sumHistStructure_.emplace_back(pXX,    vProfiles[n].sumResXvsXProfile_);
+	if (pXY)    sumHistStructure_.emplace_back(pXY,    vProfiles[n].sumResXvsYProfile_);
+	if (pYX)    sumHistStructure_.emplace_back(pYX,    vProfiles[n].sumResYvsXProfile_);
+	if (pYY)    sumHistStructure_.emplace_back(pYY,    vProfiles[n].sumResYvsYProfile_);
       }
       if(dqmMode_)continue;  // No fits in dqmMode
       //add fit values to stat box
-      this->fitResiduals(vLevelProfiles[iComp].sumXResiduals_);
-      this->fitResiduals(vLevelProfiles[iComp].sumNormXResiduals_);
-      if (hY)     this->fitResiduals(hY);     // only if existing (pixel or stripYResiduals_)
-      if (hNormY) this->fitResiduals(hNormY); // dito
+      toFit_.push_back(vLevelProfiles[iComp].sumXResiduals_);
+      toFit_.push_back(vLevelProfiles[iComp].sumNormXResiduals_);
+      if (hY)     toFit_.push_back(hY);     // only if existing (pixel or stripYResiduals_)
+      if (hNormY) toFit_.push_back(hNormY); // ditto
     } else {
       // nothing to be done for det or detunits
       continue;
     }
   }
+}
+
+void
+TrackerOfflineValidation::collateSummaryHists()
+{
+    for (std::vector<std::tuple<int,uint32_t,SummaryContainer*,ModuleHistos*> >::const_iterator it = summaryHistStructureLowestLevel_.begin();
+           it != summaryHistStructureLowestLevel_.end();
+           ++it)
+        //note that the last 2 arguments are dereferenced
+        summarizeBinInContainer(std::get<0>(*it), std::get<1>(*it), *std::get<2>(*it), *std::get<3>(*it));
+
+    for (std::vector<std::tuple<int,SummaryContainer*,SummaryContainer*> >::const_iterator it = summaryHistStructure_.begin();
+           it != summaryHistStructure_.end();
+           ++it)
+        //note that the last 2 arguments are dereferenced
+        summarizeBinInContainer(std::get<0>(*it), *std::get<1>(*it), *std::get<2>(*it));
+
+    for (std::vector<std::pair<TH1*,TH1*> >::const_iterator it = sumHistStructure_.begin();
+           it != sumHistStructure_.end();
+           ++it)
+        it->first->Add(it->second);
+
+    for (std::vector<TH1*>::const_iterator it = toFit_.begin();
+           it != toFit_.end();
+           ++it)
+        fitResiduals(*it);
 }
 
 
@@ -1391,7 +1425,7 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
 
   } else {
     edm::LogError("TrackerOfflineValidation") << "@SUB=TrackerOfflineValidation::bookSummaryHists" 
-					      << "No summary histogramm for hierarchy level " 
+					      << "No summary histogram for hierarchy level " 
 					      << aliTypeName << " in subdet " << aliDetId.subdetId();
   }
 
@@ -1456,19 +1490,19 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
     for(uint k = 0; k < aliSize; ++k) {
       DetId detid = ali.components()[k]->id();
       ModuleHistos &histStruct = this->getHistStructFromMap(detid);
-      this->summarizeBinInContainer(k+1, detid.subdetId() ,sumContainer, histStruct );
-      sumContainer.sumXResiduals_->Add(histStruct.ResXprimeHisto);
-      sumContainer.sumNormXResiduals_->Add(histStruct.NormResXprimeHisto);
+      summaryHistStructureLowestLevel_.emplace_back(k+1, detid.subdetId(), &sumContainer, &histStruct);
+      sumHistStructure_.emplace_back(sumContainer.sumXResiduals_, histStruct.ResXprimeHisto);
+      sumHistStructure_.emplace_back(sumContainer.sumNormXResiduals_, histStruct.NormResXprimeHisto);
       if ( moduleLevelProfiles_ ) {
-        sumContainer.sumResXvsXProfile_->Add(histStruct.ResXvsXProfile);
-        sumContainer.sumResXvsYProfile_->Add(histStruct.ResXvsYProfile);
+        sumHistStructure_.emplace_back(sumContainer.sumResXvsXProfile_, histStruct.ResXvsXProfile);
+        sumHistStructure_.emplace_back(sumContainer.sumResXvsYProfile_, histStruct.ResXvsYProfile);
       }
       if( this->isPixel(detid.subdetId()) || stripYResiduals_ ) {
-      	sumContainer.sumYResiduals_->Add(histStruct.ResYprimeHisto);
-      	sumContainer.sumNormYResiduals_->Add(histStruct.NormResYprimeHisto);
+      	sumHistStructure_.emplace_back(sumContainer.sumYResiduals_, histStruct.ResYprimeHisto);
+      	sumHistStructure_.emplace_back(sumContainer.sumNormYResiduals_, histStruct.NormResYprimeHisto);
         if ( moduleLevelProfiles_ ) {
-          sumContainer.sumResYvsXProfile_->Add(histStruct.ResYvsXProfile);
-          sumContainer.sumResYvsYProfile_->Add(histStruct.ResYvsYProfile);
+          sumHistStructure_.emplace_back(sumContainer.sumResYvsXProfile_, histStruct.ResYvsXProfile);
+          sumHistStructure_.emplace_back(sumContainer.sumResYvsYProfile_, histStruct.ResYvsYProfile);
         }
       }
     }
@@ -1478,19 +1512,19 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
       for(uint j = 0; j < subcompSize; ++j) { // assumes all have same size (as binning does)
 	DetId detid = ali.components()[k]->components()[j]->id();
 	ModuleHistos &histStruct = this->getHistStructFromMap(detid);	
-	this->summarizeBinInContainer(2*k+j+1, detid.subdetId() ,sumContainer, histStruct );
-	sumContainer.sumXResiduals_->Add( histStruct.ResXprimeHisto);
-	sumContainer.sumNormXResiduals_->Add( histStruct.NormResXprimeHisto);
+	summaryHistStructureLowestLevel_.emplace_back(2*k+j+1, detid.subdetId(), &sumContainer, &histStruct );
+	sumHistStructure_.emplace_back(sumContainer.sumXResiduals_,  histStruct.ResXprimeHisto);
+	sumHistStructure_.emplace_back(sumContainer.sumNormXResiduals_,  histStruct.NormResXprimeHisto);
         if ( moduleLevelProfiles_ ) {
-          sumContainer.sumResXvsXProfile_->Add(histStruct.ResXvsXProfile);
-          sumContainer.sumResXvsYProfile_->Add(histStruct.ResXvsYProfile);
+          sumHistStructure_.emplace_back(sumContainer.sumResXvsXProfile_, histStruct.ResXvsXProfile);
+          sumHistStructure_.emplace_back(sumContainer.sumResXvsYProfile_, histStruct.ResXvsYProfile);
         }
 	if( this->isPixel(detid.subdetId()) || stripYResiduals_ ) {
-	  sumContainer.sumYResiduals_->Add( histStruct.ResYprimeHisto);
-	  sumContainer.sumNormYResiduals_->Add( histStruct.NormResYprimeHisto);
+	  sumHistStructure_.emplace_back(sumContainer.sumYResiduals_,  histStruct.ResYprimeHisto);
+	  sumHistStructure_.emplace_back(sumContainer.sumNormYResiduals_,  histStruct.NormResYprimeHisto);
           if ( moduleLevelProfiles_ ) {
-            sumContainer.sumResYvsXProfile_->Add(histStruct.ResYvsXProfile);
-            sumContainer.sumResYvsYProfile_->Add(histStruct.ResYvsYProfile);
+            sumHistStructure_.emplace_back(sumContainer.sumResYvsXProfile_, histStruct.ResYvsXProfile);
+            sumHistStructure_.emplace_back(sumContainer.sumResYvsYProfile_, histStruct.ResYvsYProfile);
           }
 	}
       }
@@ -1537,7 +1571,7 @@ TrackerOfflineValidation::setUpTreeMembers(const std::map<int, TrackerOfflineVal
 
   for(std::map<int, TrackerOfflineValidation::ModuleHistos>::const_iterator it = moduleHist_.begin(), 
 	itEnd= moduleHist_.end(); it != itEnd;++it ) { 
-    TkOffTreeVariables &treeMem = mTreeMembers[it->first];
+    TkOffTreeVariables &treeMem = mTreeMembers_[it->first];
 
     //variables concerning the tracker components/hierarchy levels
     DetId detId_ = it->first;
@@ -1643,6 +1677,7 @@ TrackerOfflineValidation::setUpTreeMembers(const std::map<int, TrackerOfflineVal
     if(dR>=0.)treeMem.rDirection = 1; else treeMem.rDirection = -1;
     if(dPhi>=0.)treeMem.phiDirection = 1; else treeMem.phiDirection = -1;
     if(dZ>=0.)treeMem.zDirection = 1; else treeMem.zDirection = -1;
+  }
 }
 
 void
@@ -1651,7 +1686,7 @@ TrackerOfflineValidation::fillTree(TTree& tree,
 {
   for(std::map<int, TrackerOfflineValidation::ModuleHistos>::const_iterator it = moduleHist_.begin(),
 	itEnd= moduleHist_.end(); it != itEnd;++it ) {
-    TkOffTreeVariables &treeMem = mTreeMembers[it->first];
+    TkOffTreeVariables &treeMem = mTreeMembers_[it->first];
 
     //mean and RMS values (extracted from histograms(Xprime on module level)
     treeMem.entries = static_cast<UInt_t>(it->second.ResXprimeHisto->GetEntries());

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -216,7 +216,7 @@ private:
   
   void setUpTreeMembers(const std::map<int, TrackerOfflineValidation::ModuleHistos>& moduleHist_,
 		const TrackerGeometry& tkgeom, const TrackerTopology* tTopo);
-  void fillTree(TTree& tree, const std::map<int, TrackerOfflineValidation::ModuleHistos>& moduleHist_);
+  void fillTree(TTree& tree, TkOffTreeVariables &treeMem, const std::map<int, TrackerOfflineValidation::ModuleHistos>& moduleHist_);
   
   TrackerOfflineValidation::SummaryContainer bookSummaryHists(DirectoryWrapper& tfd, 
 							      const Alignable& ali, 
@@ -1261,12 +1261,12 @@ TrackerOfflineValidation::endJob()
   // (see src/classes_def.xml and src/classes.h):
   tree->Branch("TkOffTreeVariables", &treeMemPtr); // address of pointer!
 
-  this->fillTree(*tree, mPxbResiduals_);
-  this->fillTree(*tree, mPxeResiduals_);
-  this->fillTree(*tree, mTibResiduals_);
-  this->fillTree(*tree, mTidResiduals_);
-  this->fillTree(*tree, mTobResiduals_);
-  this->fillTree(*tree, mTecResiduals_);
+  this->fillTree(*tree, *treeMemPtr, mPxbResiduals_);
+  this->fillTree(*tree, *treeMemPtr, mPxeResiduals_);
+  this->fillTree(*tree, *treeMemPtr, mTibResiduals_);
+  this->fillTree(*tree, *treeMemPtr, mTidResiduals_);
+  this->fillTree(*tree, *treeMemPtr, mTobResiduals_);
+  this->fillTree(*tree, *treeMemPtr, mTecResiduals_);
 
   delete treeMemPtr; treeMemPtr = 0;
 }
@@ -1330,15 +1330,15 @@ TrackerOfflineValidation::prepareSummaryHists( DirectoryWrapper& tfd, const Alig
 void
 TrackerOfflineValidation::collateSummaryHists()
 {
-    for (std::vector<std::tuple<int,TH1*,TH1*> >::const_iterator it = summaryBins_.begin();
-           it != summaryBins_.end();
-           ++it)
-        setSummaryBin(std::get<0>(*it), std::get<1>(*it), std::get<2>(*it));
-
     for (std::vector<std::pair<TH1*,TH1*> >::const_iterator it = sumHistStructure_.begin();
            it != sumHistStructure_.end();
            ++it)
         it->first->Add(it->second);
+
+    for (std::vector<std::tuple<int,TH1*,TH1*> >::const_iterator it = summaryBins_.begin();
+           it != summaryBins_.end();
+           ++it)
+        setSummaryBin(std::get<0>(*it), std::get<1>(*it), std::get<2>(*it));
 
     for (std::vector<TH1*>::const_iterator it = toFit_.begin();
            it != toFit_.end();
@@ -1672,12 +1672,12 @@ TrackerOfflineValidation::setUpTreeMembers(const std::map<int, TrackerOfflineVal
 }
 
 void
-TrackerOfflineValidation::fillTree(TTree& tree,
+TrackerOfflineValidation::fillTree(TTree& tree, TkOffTreeVariables &treeMem,
 				   const std::map<int, TrackerOfflineValidation::ModuleHistos>& moduleHist_)
 {
   for(std::map<int, TrackerOfflineValidation::ModuleHistos>::const_iterator it = moduleHist_.begin(),
 	itEnd= moduleHist_.end(); it != itEnd;++it ) {
-    TkOffTreeVariables &treeMem = mTreeMembers_[it->first];
+    treeMem = mTreeMembers_[it->first];
 
     //mean and RMS values (extracted from histograms(Xprime on module level)
     treeMem.entries = static_cast<UInt_t>(it->second.ResXprimeHisto->GetEntries());

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -291,14 +291,13 @@ private:
   std::map<int,TkOffTreeVariables> mTreeMembers_;
 
   //There are two types of summary histograms.  The first contains, for each component, a bin per subcomponent.
-  //These are filled through summarizeBinInContainer().  The second type is just the sum of the lower level histograms.
+  //These are set up through summarizeBinInContainer().  The second type is just the sum of the lower level histograms.
   //Prepare the filling of both types at the beginning, when the tracker topology is available through the eventsetup.
   //They are not actually filled until the end, but at that time eventsetup is no longer accessible.
 
-  //To fill the summary hists, directly store the arguments of summarizeBinInContainer() (two forms of the function)
-  //At the end, call the function (LowestLevel first).
-  std::vector<std::tuple<int,SummaryContainer*,SummaryContainer*> > summaryHistStructure_;
-  std::vector<std::tuple<int,uint32_t,SummaryContainer*,ModuleHistos*> > summaryHistStructureLowestLevel_;
+  //To fill the summary hists, store the arguments of setSummaryBin()
+  //At the end, call the function
+  std::vector<std::tuple<int,TH1*,TH1*> > summaryBins_;
   //To fill the sum hists, just store pairs of TH1*.  At the end, first->Add(second).
   std::vector<std::pair<TH1*,TH1*> > sumHistStructure_;
   //sum hists are fit at the end using fitResiduals()
@@ -950,11 +949,11 @@ void
 TrackerOfflineValidation::summarizeBinInContainer( int bin, SummaryContainer& targetContainer, 
 						   SummaryContainer& sourceContainer)
 {
-  this->setSummaryBin(bin, targetContainer.summaryXResiduals_, sourceContainer.sumXResiduals_);
-  this->setSummaryBin(bin, targetContainer.summaryNormXResiduals_, sourceContainer.sumNormXResiduals_);
+  summaryBins_.emplace_back(bin, targetContainer.summaryXResiduals_, sourceContainer.sumXResiduals_);
+  summaryBins_.emplace_back(bin, targetContainer.summaryNormXResiduals_, sourceContainer.sumNormXResiduals_);
   // If no y-residual hists, just returns:
-  this->setSummaryBin(bin, targetContainer.summaryYResiduals_, sourceContainer.sumYResiduals_);
-  this->setSummaryBin(bin, targetContainer.summaryNormYResiduals_, sourceContainer.sumNormYResiduals_);
+  summaryBins_.emplace_back(bin, targetContainer.summaryYResiduals_, sourceContainer.sumYResiduals_);
+  summaryBins_.emplace_back(bin, targetContainer.summaryNormYResiduals_, sourceContainer.sumNormYResiduals_);
 }
 
 
@@ -964,11 +963,11 @@ TrackerOfflineValidation::summarizeBinInContainer( int bin, uint32_t subDetId,
 						   ModuleHistos& sourceContainer)
 {
   // takes two summary Containers and sets summaryBins for all histograms
-  this->setSummaryBin(bin, targetContainer.summaryXResiduals_, sourceContainer.ResXprimeHisto);
-  this->setSummaryBin(bin, targetContainer.summaryNormXResiduals_, sourceContainer.NormResXprimeHisto);
+  summaryBins_.emplace_back(bin, targetContainer.summaryXResiduals_, sourceContainer.ResXprimeHisto);
+  summaryBins_.emplace_back(bin, targetContainer.summaryNormXResiduals_, sourceContainer.NormResXprimeHisto);
   if( this->isPixel(subDetId) || stripYResiduals_ ) {
-    this->setSummaryBin(bin, targetContainer.summaryYResiduals_, sourceContainer.ResYprimeHisto);
-    this->setSummaryBin(bin, targetContainer.summaryNormYResiduals_, sourceContainer.NormResYprimeHisto);
+    summaryBins_.emplace_back(bin, targetContainer.summaryYResiduals_, sourceContainer.ResYprimeHisto);
+    summaryBins_.emplace_back(bin, targetContainer.summaryNormYResiduals_, sourceContainer.NormResYprimeHisto);
   }
 }
 
@@ -1239,7 +1238,6 @@ TrackerOfflineValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 void 
 TrackerOfflineValidation::endJob()
 {
-
   if (!tkGeom_.product()) return;
   
   static const int kappadiffindex = this->GetIndex(vTrackHistos_,"h_diff_curvature");
@@ -1306,7 +1304,7 @@ TrackerOfflineValidation::prepareSummaryHists( DirectoryWrapper& tfd, const Alig
       TH1 *pYX = vLevelProfiles[iComp].sumResYvsXProfile_;
       TH1 *pYY = vLevelProfiles[iComp].sumResYvsYProfile_;
       for(uint n = 0; n < vProfiles.size(); ++n) {
-        summaryHistStructure_.emplace_back(n+1, &vLevelProfiles[iComp], &vProfiles[n]);
+        this->summarizeBinInContainer(n+1, vLevelProfiles[iComp], vProfiles[n]);
 	            sumHistStructure_.emplace_back(hX,     vProfiles[n].sumXResiduals_);
 	            sumHistStructure_.emplace_back(hNormX, vProfiles[n].sumNormXResiduals_);
 	if (hY)     sumHistStructure_.emplace_back(hY,     vProfiles[n].sumYResiduals_);         // only if existing
@@ -1332,17 +1330,10 @@ TrackerOfflineValidation::prepareSummaryHists( DirectoryWrapper& tfd, const Alig
 void
 TrackerOfflineValidation::collateSummaryHists()
 {
-    for (std::vector<std::tuple<int,uint32_t,SummaryContainer*,ModuleHistos*> >::const_iterator it = summaryHistStructureLowestLevel_.begin();
-           it != summaryHistStructureLowestLevel_.end();
+    for (std::vector<std::tuple<int,TH1*,TH1*> >::const_iterator it = summaryBins_.begin();
+           it != summaryBins_.end();
            ++it)
-        //note that the last 2 arguments are dereferenced
-        summarizeBinInContainer(std::get<0>(*it), std::get<1>(*it), *std::get<2>(*it), *std::get<3>(*it));
-
-    for (std::vector<std::tuple<int,SummaryContainer*,SummaryContainer*> >::const_iterator it = summaryHistStructure_.begin();
-           it != summaryHistStructure_.end();
-           ++it)
-        //note that the last 2 arguments are dereferenced
-        summarizeBinInContainer(std::get<0>(*it), *std::get<1>(*it), *std::get<2>(*it));
+        setSummaryBin(std::get<0>(*it), std::get<1>(*it), std::get<2>(*it));
 
     for (std::vector<std::pair<TH1*,TH1*> >::const_iterator it = sumHistStructure_.begin();
            it != sumHistStructure_.end();
@@ -1490,7 +1481,7 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
     for(uint k = 0; k < aliSize; ++k) {
       DetId detid = ali.components()[k]->id();
       ModuleHistos &histStruct = this->getHistStructFromMap(detid);
-      summaryHistStructureLowestLevel_.emplace_back(k+1, detid.subdetId(), &sumContainer, &histStruct);
+      this->summarizeBinInContainer(k+1, detid.subdetId(), sumContainer, histStruct);
       sumHistStructure_.emplace_back(sumContainer.sumXResiduals_, histStruct.ResXprimeHisto);
       sumHistStructure_.emplace_back(sumContainer.sumNormXResiduals_, histStruct.NormResXprimeHisto);
       if ( moduleLevelProfiles_ ) {
@@ -1512,7 +1503,7 @@ TrackerOfflineValidation::bookSummaryHists(DirectoryWrapper& tfd, const Alignabl
       for(uint j = 0; j < subcompSize; ++j) { // assumes all have same size (as binning does)
 	DetId detid = ali.components()[k]->components()[j]->id();
 	ModuleHistos &histStruct = this->getHistStructFromMap(detid);	
-	summaryHistStructureLowestLevel_.emplace_back(2*k+j+1, detid.subdetId(), &sumContainer, &histStruct );
+	this->summarizeBinInContainer(2*k+j+1, detid.subdetId(), sumContainer, histStruct );
 	sumHistStructure_.emplace_back(sumContainer.sumXResiduals_,  histStruct.ResXprimeHisto);
 	sumHistStructure_.emplace_back(sumContainer.sumNormXResiduals_,  histStruct.NormResXprimeHisto);
         if ( moduleLevelProfiles_ ) {


### PR DESCRIPTION
See details here: #6085

This fixes the segfault, and I think it addresses everyone's concerns there.  Please let me know if not.

The summary histograms and the tree are filled in the endJob, as before, because they require the lower level histograms to be completely filled first, and it would be inefficient to reset every run.  However, the structure (e.g. which histograms summarize which other histograms), which comes from the tracker topology, is set up at the beginning.  In my tests I find identical output to setting the lastSetup variable.

This is orthogonal to #11022 except for one commit, which is rebased here to avoid conflicts.
