### PR TITLE
Adding new 25/50ns JECs for miniAOD

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -10,21 +10,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '74X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '74X_mcRun2_design_v1',
+    'run2_design'       :   '74X_mcRun2_design_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '74X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '74X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '74X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '74X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '74X_dataRun1_v1',
+    'run1_data'         :   '74X_dataRun1_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '74X_dataRun2_v1',
+    'run2_data'         :   '74X_dataRun2_v2',
     # GlobalTag for Run1 HLT
-    'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v1',
+    'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v2',
     # GlobalTag for Run2 HLT
-    'run2_hlt'          :   '74X_dataRun2_HLT_frozen_v1',
+    'run2_hlt'          :   '74X_dataRun2_HLT_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes
## Run1 data
- Offline: [74X_dataRun1_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v2): As [74X_dataRun1_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_v1/74X_dataRun1_v2):
  - Changing HCAL channel quality to v6.00 in [253937 - 254150) and [254151 - 255294) IOVs
- HLT: [74X_dataRun1_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_HLT_frozen_v2): As [74X_dataRun1_HLT_frozen_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_HLT_frozen_v2/74X_dataRun1_HLT_frozen_v1):
  - Taxonomy change of `EcalClusterLocalContCorrParameters` tag
  - Taxonomy change of `SiStripBackPlaneCorrectionRcd` tag
  - Adding label `full` for `HcalElectronicsMapRcd`
  - Adding negative energy filter payload
  - new snapshot time: 2015-09-07 16:20:18,000000 
## Run2 simulation
- Ideal: [74X_mcRun2_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_design_v2): As [74X_mcRun2_design_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_design_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_design_v1/74X_mcRun2_design_v2):
  - Introducing new 25ns JECs, (including PUPPI labels)
  - Introducing new 25ns HLT JECs
- Startup: [74X_mcRun2_startup_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_startup_v2): As [74X_mcRun2_startup_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_startup_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_startup_v1/74X_mcRun2_startup_v2):
  - Introducing new 50ns JECs, (including PUPPI labels)
- Asymptotic: [74X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_asymptotic_v2): As [74X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_asymptotic_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_asymptotic_v1/74X_mcRun2_asymptotic_v2):
  - Introducing new 25ns JECs, (including PUPPI labels)
  - Introducing new 25ns HLT JECs
- Heavy Ion: [74X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_HeavyIon_v2): As [74X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_HeavyIon_v1/74X_mcRun2_HeavyIon_v2):
  - Introducing new 25ns JECs, (including PUPPI labels)
  - Introducing new 25ns HLT JECs
## Run2 data
- Offline: [74X_dataRun2_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v2): As [74X_dataRun2_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_v1/74X_dataRun2_v2):
  - Introducing new 25/50ns JECs, (including PUPPI labels) with IOV handling for the bunch-spacing
  - Changing HCAL channel quality to v6.00 in [253937 - 254150) and [254151 - 255294) IOVs
- HLT: [74X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_HLT_frozen_v1): As [74X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_HLT_frozen_v1/74X_dataRun2_HLT_frozen_v2):
  - Taxonomy change of `SiStripBackPlaneCorrectionRcd` tag
  - new snapshot time: 2015-09-07 16:20:18,000000
