### PR TITLE
 cleanup of uninitialized reads reported by valgrind (backport of #11173 )

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -1288,7 +1288,7 @@ namespace cscdqm {
 //     CSCCFEBData * cfebData[N_CFEBs];
 //     CSCCFEBTimeSlice *  timeSlice[N_CFEBs][16];
 //     CSCCFEBDataWord * timeSample[N_CFEBs][16][6][16];
-    int Pedestal[N_CFEBs][6][16];
+    int Pedestal[N_CFEBs][6][16];    memset(Pedestal, 0, sizeof(Pedestal));
     #ifdef __clang__
     std::vector<std::array<std::array<std::pair<int,int>, 6>, 16>> CellPeak(N_CFEBs);
     std::fill(CellPeak.begin(), CellPeak.end(), std::array<std::array<std::pair<int,int>, 6>, 16>{});

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.cc
@@ -381,7 +381,7 @@ void StripClusterFinder::printClusters(void)
  std::cout << "======================================================================" << std::endl;	
    return;
 }
-bool  StripClusterFinder::Sort::operator()(StripClusterFitData a , StripClusterFitData b) const
+bool  StripClusterFinder::Sort::operator()(const StripClusterFitData& a , const StripClusterFitData& b) const
 {return  a.channel_ < b.channel_;}
 
 }

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.h
@@ -30,7 +30,7 @@ class StripClusterFinder {
  public:
   class Sort{
   public:
-    bool  operator()(StripClusterFitData a,StripClusterFitData b) const;
+    bool  operator()(const StripClusterFitData& a, const StripClusterFitData& b) const;
   };
   std::vector<StripCluster> MEStripClusters;
   ClusterLocalMax localMaxTMP;

--- a/DQM/HcalMonitorTasks/src/HcalZDCMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalZDCMonitor.cc
@@ -1,6 +1,9 @@
 #include "DQM/HcalMonitorTasks/interface/HcalZDCMonitor.h"
 
-HcalZDCMonitor::HcalZDCMonitor() {
+HcalZDCMonitor::HcalZDCMonitor() : TotalChannelErrors{}, DeadChannelCounter{}, ColdChannelCounter{},
+				   DeadChannelError{}, HotChannelError{}, DigiErrorCAPID{}, DigiErrorDVER{},
+				   ChannelHasDigiError{}
+{
 }
 HcalZDCMonitor::~HcalZDCMonitor() {
 }
@@ -12,7 +15,7 @@ void HcalZDCMonitor::setup(const edm::ParameterSet & ps, DQMStore::IBooker & ib)
 
 	baseFolder_ = rootFolder_ + "ZDCMonitor_Hcal";
 
-	const edm::ParameterSet psZDC(ps.getParameter<edm::ParameterSet>("zdcMonitorTask"));
+	const edm::ParameterSet& psZDC(ps.getParameter<edm::ParameterSet>("zdcMonitorTask"));
 	NLumiBlocks_           = psZDC.getUntrackedParameter<int>("NLumiBlocks",4000);
 	ChannelWeighting_      = psZDC.getUntrackedParameter<std::vector<double>> ("ZDC_ChannelWeighting");
 	MaxErrorRates_         = psZDC.getUntrackedParameter<std::vector<double>> ("ZDC_AcceptableChannelErrorRates");

--- a/DQM/Physics/src/B2GDQM.cc
+++ b/DQM/Physics/src/B2GDQM.cc
@@ -123,6 +123,7 @@ B2GDQM::B2GDQM(const edm::ParameterSet& ps) {
           ps.getParameter<std::string>("muonSelect")));
 
   semiE_HadJetPtCut_ = ps.getParameter<double>("semiE_HadJetPtCut");
+  semiE_LepJetPtCut_ = ps.getParameter<double>("semiE_LepJetPtCut");
   semiE_dphiHadCut_ = ps.getParameter<double>("semiE_dphiHadCut");
   semiE_dRMin_ = ps.getParameter<double>("semiE_dRMin");
   semiE_ptRel_ = ps.getParameter<double>("semiE_ptRel");

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -3221,11 +3221,11 @@ DQMStore::removeElement(const std::string &dir, const std::string &name, bool wa
 {
   MonitorElement proto(&dir, name);
   MEMap::iterator pos = data_.find(proto);
-  if (pos == data_.end() && warning)
+  if (pos != data_.end())
+    data_.erase(pos);
+  else if (warning)
     std::cout << "DQMStore: WARNING: attempt to remove non-existent"
               << " monitor element '" << name << "' in '" << dir << "'\n";
-  else
-    data_.erase(pos);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/DataFormats/JetReco/src/PileupJetIdentifier.cc
+++ b/DataFormats/JetReco/src/PileupJetIdentifier.cc
@@ -1,13 +1,11 @@
 #include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <limits>
+#include <cstring>
 
 // ------------------------------------------------------------------------------------------
 StoredPileupJetIdentifier::StoredPileupJetIdentifier() 
 {
+  memset(this, 0, sizeof(StoredPileupJetIdentifier));
 }
 
 // ------------------------------------------------------------------------------------------
@@ -23,4 +21,5 @@ PileupJetIdentifier::PileupJetIdentifier()
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier::~PileupJetIdentifier() 
 {
+  memset(this, 0, sizeof(PileupJetIdentifier));
 }

--- a/DataFormats/JetReco/src/PileupJetIdentifier.cc
+++ b/DataFormats/JetReco/src/PileupJetIdentifier.cc
@@ -16,10 +16,10 @@ StoredPileupJetIdentifier::~StoredPileupJetIdentifier()
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier::PileupJetIdentifier() 
 {
+  memset(this, 0, sizeof(PileupJetIdentifier));
 }
 
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier::~PileupJetIdentifier() 
 {
-  memset(this, 0, sizeof(PileupJetIdentifier));
 }

--- a/HLTrigger/HLTanalyzers/interface/HLTrigReport.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTrigReport.h
@@ -12,23 +12,22 @@
  *
  */
 
-#include "DataFormats/Common/interface/TriggerResults.h"
-
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "FWCore/Common/interface/TriggerNames.h"
-#include<vector>
-#include<string>
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include <vector>
+#include <string>
 
 //
 // class declaration
 //
 
-class HLTrigReport : public edm::EDAnalyzer {
+class HLTrigReport : public edm::one::EDAnalyzer<> {
    private:
       enum ReportEvery {
         NEVER       = 0,
@@ -104,10 +103,10 @@ class HLTrigReport : public edm::EDAnalyzer {
       unsigned int refIndex_;                                   // index of the reference path for rate calculation
       double refRate_;                                         // rate of the reference path, the rate of all other paths will be normalized to this
 
-      ReportEvery reportBy_;        // dump report for every never/event/lumi/run/job
-      ReportEvery resetBy_;         // reset counters  every never/event/lumi/run/job
-      ReportEvery serviceBy_;       // call to service every never/event/lumi/run/job
-      HLTConfigProvider hltConfig_; // to get configuration for L1s/Pre
+      const ReportEvery reportBy_;          // dump report for every never/event/lumi/run/job
+      const ReportEvery resetBy_;           // reset counters  every never/event/lumi/run/job
+      const ReportEvery serviceBy_;         // call to service every never/event/lumi/run/job
+      HLTConfigProvider hltConfig_;         // to get configuration for L1s/Pre
 };
 
 #endif //HLTrigReport_h

--- a/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
@@ -48,7 +48,8 @@ HLTrigReport::ReportEvery HLTrigReport::decode(const std::string & value) {
 // constructors and destructor
 //
 HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
-  hlTriggerResults_ (iConfig.getParameter<edm::InputTag> ("HLTriggerResults")),
+  hlTriggerResults_(iConfig.getParameter<edm::InputTag> ("HLTriggerResults")),
+  hlTriggerResultsToken_(consumes<edm::TriggerResults>(hlTriggerResults_)),
   configured_(false),
   nEvents_(0),
   nWasRun_(0),
@@ -81,8 +82,6 @@ HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
   serviceBy_(decode(iConfig.getUntrackedParameter<std::string>("serviceBy", "never")) ),
   hltConfig_()
 {
-  hlTriggerResultsToken_ = consumes<edm::TriggerResults>(hlTriggerResults_);
-
   const edm::ParameterSet customDatasets(iConfig.getUntrackedParameter<edm::ParameterSet>("CustomDatasets", edm::ParameterSet()));
   isCustomDatasets_ = (customDatasets != edm::ParameterSet());
   if (isCustomDatasets_) {

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReport.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReport.h
@@ -23,10 +23,9 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -43,7 +42,7 @@ class L1GtTriggerMenu;
 
 // class declaration
 
-class L1GtTrigReport : public edm::EDAnalyzer
+class L1GtTrigReport : public edm::one::EDAnalyzer<>
 {
 
 public:
@@ -119,19 +118,19 @@ private:
 private:
 
     /// boolean flag to select the input record
-    bool m_useL1GlobalTriggerRecord;
+    const bool m_useL1GlobalTriggerRecord;
 
     /// input tag for GT record (L1 GT DAQ record or L1 GT "lite" record):
-    edm::InputTag m_l1GtRecordInputTag;
+    const edm::InputTag m_l1GtRecordInputTag;
 
-    edm::EDGetTokenT<L1GlobalTriggerRecord> m_l1GtRecordInputToken1;
-    edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtRecordInputToken2;
+    const edm::EDGetTokenT<L1GlobalTriggerRecord> m_l1GtRecordInputToken1;
+    const edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtRecordInputToken2;
 
     /// print verbosity
-    int m_printVerbosity;
+    const int m_printVerbosity;
 
     /// print output
-    int m_printOutput;
+    const int m_printOutput;
 
     /// counters
 
@@ -154,7 +153,7 @@ private:
     typedef std::list<L1GtTrigReportEntry*>::iterator ItEntry;
 
     /// index of physics DAQ partition
-    unsigned int m_physicsDaqPartition;
+    const unsigned int m_physicsDaqPartition;
 
 };
 

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -65,68 +65,68 @@
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReportEntry.h"
 
 // constructor(s)
-L1GtTrigReport::L1GtTrigReport(const edm::ParameterSet& pSet) {
+L1GtTrigReport::L1GtTrigReport(const edm::ParameterSet& pSet) :
+
+    // initialize cached IDs
+
+    //
+    m_l1GtStableParCacheID( 0ULL ),
+
+    m_numberPhysTriggers( 0 ),
+    m_numberTechnicalTriggers( 0 ),
+    m_numberDaqPartitions( 0 ),
+    m_numberDaqPartitionsMax( 0 ),
+
+    //
+    m_l1GtPfAlgoCacheID( 0ULL ),
+    m_l1GtPfTechCacheID( 0ULL ),
+
+    m_l1GtTmAlgoCacheID( 0ULL ),
+    m_l1GtTmTechCacheID( 0ULL ),
+
+    m_l1GtTmVetoAlgoCacheID( 0ULL ),
+    m_l1GtTmVetoTechCacheID( 0ULL ),
+
+    //
+    m_l1GtMenuCacheID( 0ULL ),
 
     // boolean flag to select the input record
     // if true, it will use L1GlobalTriggerRecord
-    m_useL1GlobalTriggerRecord = pSet.getParameter<bool>("UseL1GlobalTriggerRecord");
+    m_useL1GlobalTriggerRecord( pSet.getParameter<bool>("UseL1GlobalTriggerRecord") ),
 
     /// input tag for GT record (L1 GT DAQ record or L1 GT "lite" record):
-    m_l1GtRecordInputTag = pSet.getParameter<edm::InputTag>("L1GtRecordInputTag");
+    m_l1GtRecordInputTag( pSet.getParameter<edm::InputTag>("L1GtRecordInputTag") ),
+    m_l1GtRecordInputToken1( m_useL1GlobalTriggerRecord
+        ? consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag)
+        : edm::EDGetTokenT<L1GlobalTriggerRecord>() ),
+    m_l1GtRecordInputToken2( not m_useL1GlobalTriggerRecord
+        ? consumes<L1GlobalTriggerReadoutRecord>(m_l1GtRecordInputTag)
+        : edm::EDGetTokenT<L1GlobalTriggerReadoutRecord>() ),
 
     // print verbosity
-    m_printVerbosity = pSet.getUntrackedParameter<int>("PrintVerbosity", 2);
+    m_printVerbosity( pSet.getUntrackedParameter<int>("PrintVerbosity", 2) ),
 
     // print output
-    m_printOutput = pSet.getUntrackedParameter<int>("PrintOutput", 3);
+    m_printOutput( pSet.getUntrackedParameter<int>("PrintOutput", 3) ),
 
+    // initialize global counters
+
+    // number of events processed
+    m_totalEvents( 0 ),
+
+    //
+    m_entryList(),
+    m_entryListTechTrig(),
+
+    // set the index of physics DAQ partition TODO input parameter?
+    m_physicsDaqPartition( 0 )
+
+{
     LogDebug("L1GtTrigReport") << "\n  Use L1GlobalTriggerRecord:   " << m_useL1GlobalTriggerRecord
             << "\n   (if false: L1GtTrigReport uses L1GlobalTriggerReadoutRecord.)"
             << "\n  Input tag for L1 GT record:  " << m_l1GtRecordInputTag.label() << " \n"
             << "\n  Print verbosity level:           " << m_printVerbosity << " \n"
             << "\n  Print output:                    " << m_printOutput << " \n" << std::endl;
-
-    // initialize cached IDs
-
-    //
-    m_l1GtStableParCacheID = 0ULL;
-
-    m_numberPhysTriggers = 0;
-    m_numberTechnicalTriggers = 0;
-    m_numberDaqPartitions = 0;
-    m_numberDaqPartitionsMax = 0;
-
-    //
-    m_l1GtPfAlgoCacheID = 0ULL;
-    m_l1GtPfTechCacheID = 0ULL;
-
-    m_l1GtTmAlgoCacheID = 0ULL;
-    m_l1GtTmTechCacheID = 0ULL;
-
-    m_l1GtTmVetoAlgoCacheID = 0ULL;
-    m_l1GtTmVetoTechCacheID = 0ULL;
-
-    //
-    m_l1GtMenuCacheID = 0ULL;
-
-    // initialize global counters
-
-    // number of events processed
-    m_totalEvents = 0;
-
-    //
-    m_entryList.clear();
-    m_entryListTechTrig.clear();
-
-    // set the index of physics DAQ partition TODO input parameter?
-    m_physicsDaqPartition = 0;
-
-    if (m_useL1GlobalTriggerRecord) {
-      m_l1GtRecordInputToken1=consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag);
-    }
-    else{
-      m_l1GtRecordInputToken2=consumes<L1GlobalTriggerReadoutRecord>(m_l1GtRecordInputTag);
-    }
 
 }
 

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -110,7 +110,7 @@ patSmearedJets = cms.EDProducer("SmearedPATJetProducer",
                    #             even though jet energy got smeared by merely 1 GeV
                    #
                    skipJetSelection = cms.string(
-        'jecSetsAvailable & abs(energy - correctedP4("Uncorrected").energy) > (5.*min(energy, correctedP4("Uncorrected").energy))'
+        'jecSetsAvailable && abs(energy - correctedP4("Uncorrected").energy) > (5.*min(energy, correctedP4("Uncorrected").energy))'
         ),
             skipRawJetPtThreshold = cms.double(10.), # GeV
             skipCorrJetPtThreshold = cms.double(1.e-2),

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -333,7 +333,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
     for (int i=0; i<31; ++i) esHits.push_back(0);
   } else {
     it = rechits_map.find(strip);
-    if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+    if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
     else esHits.push_back(0);
     //cout<<"center : "<<strip<<" "<<it->second.energy()<<endl;
 
@@ -344,7 +344,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.east();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"east "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
@@ -361,7 +361,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.west();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"west "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
@@ -379,7 +379,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.north();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"north "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
@@ -396,7 +396,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.south();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"south "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {

--- a/RecoHI/HiTracking/python/hiMultiTrackSelector_cfi.py
+++ b/RecoHI/HiTracking/python/hiMultiTrackSelector_cfi.py
@@ -45,7 +45,10 @@ hiLooseMTS = cms.PSet(
 
     # parameters for cutting on pterror/pt and number of valid hits
     max_relpterr = cms.double(0.2),
-    min_nhits = cms.uint32(8)
+    min_nhits = cms.uint32(8),
+
+    useMVA = cms.bool(False),
+    minMVA = cms.double(-1)
     )
 
 hiTightMTS=hiLooseMTS.clone(
@@ -79,6 +82,9 @@ hiMultiTrackSelector = cms.EDProducer("HIMultiTrackSelector",
                                     useVertices = cms.bool(True),
                                     useVtxError = cms.bool(True),
                                     vertices    = cms.InputTag("hiSelectedVertex"),
+                                    useAnyMVA = cms.bool(False),
+                                    GBRForestLabel = cms.string(''),
+                                    GBRForestVars = cms.vstring(),
                                     trackSelectors = cms.VPSet( hiLooseMTS,
                                                                 hiTightMTS,
                                                                 hiHighpurityMTS)


### PR DESCRIPTION
A fraction of uninitialized value reads reported by valgrind in wflow 4.53 step3 is done.
The following summary is based on tests in 76X  with #11173
- PileupJetIdAlgo is buggy and will need to be fixed by JME developers (I will start a separate thread for this). I have just gotten rid of uninitialized reads.
  - confirmed with valgrind as fixed
- HcalZDCMonitor counters initialized (cleans up occasional NANs in the plots)
  - confirmed with valgrind as fixed
- B2GDQM was missing initialization of semiE_LepJetPtCut (the default uninitialized value was between zero and any other value; it now becomes 30 GeV as desired in the config). Corresponding plots will change.
  - confirmed with valgrind as fixed
- EcalClusterLazyToolsBase had reads beyond vector size (should be harmless from the logic)
  - confirmed with valgrind as fixed
- patPFMETCorrections changes appear to be cosmetic
  - the invalid read in SmearedJetProducerT calling StringCutObjectSelector still remains
- changes in cscdqm::StripClusterFinder are towards cleaning of uninitialized values in StripClusterFitData::height_
  - cleanup is not confirmed by valgrind

Tested in CMSSW_7_5_X_2015-09-06-2300 /test area sign584/: 
    - short matrix test comparisons show changes in affected plots in DQM
    - reco products monitored with fwlite script are not affected
