### PR TITLE
cleanup of uninitialized reads reported by valgrind (backport of #11173 )

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -1288,7 +1288,7 @@ namespace cscdqm {
 //     CSCCFEBData * cfebData[N_CFEBs];
 //     CSCCFEBTimeSlice *  timeSlice[N_CFEBs][16];
 //     CSCCFEBDataWord * timeSample[N_CFEBs][16][6][16];
-    int Pedestal[N_CFEBs][6][16];
+    int Pedestal[N_CFEBs][6][16];    memset(Pedestal, 0, sizeof(Pedestal));
     #ifdef __clang__
     std::vector<std::array<std::array<std::pair<int,int>, 6>, 16>> CellPeak(N_CFEBs);
     std::fill(CellPeak.begin(), CellPeak.end(), std::array<std::array<std::pair<int,int>, 6>, 16>{});

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.cc
@@ -381,7 +381,7 @@ void StripClusterFinder::printClusters(void)
  std::cout << "======================================================================" << std::endl;	
    return;
 }
-bool  StripClusterFinder::Sort::operator()(StripClusterFitData a , StripClusterFitData b) const
+bool  StripClusterFinder::Sort::operator()(const StripClusterFitData& a , const StripClusterFitData& b) const
 {return  a.channel_ < b.channel_;}
 
 }

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.h
@@ -30,7 +30,7 @@ class StripClusterFinder {
  public:
   class Sort{
   public:
-    bool  operator()(StripClusterFitData a,StripClusterFitData b) const;
+    bool  operator()(const StripClusterFitData& a, const StripClusterFitData& b) const;
   };
   std::vector<StripCluster> MEStripClusters;
   ClusterLocalMax localMaxTMP;

--- a/DQM/HcalMonitorTasks/src/HcalZDCMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalZDCMonitor.cc
@@ -1,6 +1,9 @@
 #include "DQM/HcalMonitorTasks/interface/HcalZDCMonitor.h"
 
-HcalZDCMonitor::HcalZDCMonitor() {
+HcalZDCMonitor::HcalZDCMonitor() : TotalChannelErrors{}, DeadChannelCounter{}, ColdChannelCounter{},
+				   DeadChannelError{}, HotChannelError{}, DigiErrorCAPID{}, DigiErrorDVER{},
+				   ChannelHasDigiError{}
+{
 }
 HcalZDCMonitor::~HcalZDCMonitor() {
 }

--- a/DQM/Physics/src/B2GDQM.cc
+++ b/DQM/Physics/src/B2GDQM.cc
@@ -123,6 +123,7 @@ B2GDQM::B2GDQM(const edm::ParameterSet& ps) {
           ps.getParameter<std::string>("muonSelect")));
 
   semiE_HadJetPtCut_ = ps.getParameter<double>("semiE_HadJetPtCut");
+  semiE_LepJetPtCut_ = ps.getParameter<double>("semiE_LepJetPtCut");
   semiE_dphiHadCut_ = ps.getParameter<double>("semiE_dphiHadCut");
   semiE_dRMin_ = ps.getParameter<double>("semiE_dRMin");
   semiE_ptRel_ = ps.getParameter<double>("semiE_ptRel");

--- a/DataFormats/JetReco/src/PileupJetIdentifier.cc
+++ b/DataFormats/JetReco/src/PileupJetIdentifier.cc
@@ -1,13 +1,11 @@
 #include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <limits>
+#include <cstring>
 
 // ------------------------------------------------------------------------------------------
 StoredPileupJetIdentifier::StoredPileupJetIdentifier() 
 {
+  memset(this, 0, sizeof(StoredPileupJetIdentifier));
 }
 
 // ------------------------------------------------------------------------------------------
@@ -23,4 +21,5 @@ PileupJetIdentifier::PileupJetIdentifier()
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier::~PileupJetIdentifier() 
 {
+  memset(this, 0, sizeof(PileupJetIdentifier));
 }

--- a/DataFormats/JetReco/src/PileupJetIdentifier.cc
+++ b/DataFormats/JetReco/src/PileupJetIdentifier.cc
@@ -16,10 +16,10 @@ StoredPileupJetIdentifier::~StoredPileupJetIdentifier()
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier::PileupJetIdentifier() 
 {
+  memset(this, 0, sizeof(PileupJetIdentifier));
 }
 
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier::~PileupJetIdentifier() 
 {
-  memset(this, 0, sizeof(PileupJetIdentifier));
 }

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -333,7 +333,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
     for (int i=0; i<31; ++i) esHits.push_back(0);
   } else {
     it = rechits_map.find(strip);
-    if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+    if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
     else esHits.push_back(0);
     //cout<<"center : "<<strip<<" "<<it->second.energy()<<endl;
 
@@ -344,7 +344,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.east();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"east "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
@@ -361,7 +361,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.west();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"west "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
@@ -379,7 +379,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.north();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"north "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
@@ -396,7 +396,7 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
         next = theESNav.south();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it->second.energy() > 1.0e-10 && it != rechits_map.end()) esHits.push_back(it->second.energy());
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
           else esHits.push_back(0);
           //cout<<"south "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {


### PR DESCRIPTION
A fraction of uninitialized value reads reported by valgrind in wflow 4.53 step3 is cleaned up.
The following summary is based on tests in 76X  with #11173 (there is no ZDC monitor change in 74X; otherwise it's the same change as in #11173 )
- PileupJetIdAlgo is buggy and will need to be fixed by JME developers (I will start a separate thread for this). I have just gotten rid of uninitialized reads.
  - confirmed with valgrind as fixed
- B2GDQM was missing initialization of semiE_LepJetPtCut (the default uninitialized value was between zero and any other value; it now becomes 30 GeV as desired in the config). Corresponding plots will change.
  - confirmed with valgrind as fixed
- EcalClusterLazyToolsBase had reads beyond vector size (should be harmless from the logic)
  - confirmed with valgrind as fixed
- patPFMETCorrections changes appear to be cosmetic
  - the invalid read in SmearedJetProducerT calling StringCutObjectSelector still remains
- changes in cscdqm::StripClusterFinder are towards cleaning of uninitialized values in StripClusterFitData::height_
  - cleanup is not confirmed by valgrind

Tested in CMSSW_7_4_X_2015-09-07-1100 /test area sign584/: 
    - short matrix test comparisons show changes in affected plots in DQM
    - reco products monitored with fwlite script are not affected
