### PR TITLE
Fix MeasurementTrackerEvent configuration of some TrackingRegionProducers

### DIFF
--- a/FastSimulation/HighLevelTrigger/python/HLTFastRecoForTau_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastRecoForTau_cff.py
@@ -14,7 +14,8 @@ hltRegionalPixelTracks.RegionFactoryPSet.RegionPSet = cms.PSet(
     deltaEtaRegion = cms.double( 0.5 ),
     deltaPhiRegion = cms.double( 0.5 ),
     TrkSrc = cms.InputTag( "hltL3Muons" ),
-    UseVtxTks = cms.bool( False )
+    UseVtxTks = cms.bool( False ),
+    howToUseMeasurementTracker = cms.string("Never"),
 )
 
 hltPixelTracksReg = FastSimulation.Tracking.HLTPixelTracksProducer_cfi.hltPixelTracks.clone()

--- a/FastSimulation/HighLevelTrigger/python/HLTFastRecoForTau_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastRecoForTau_cff.py
@@ -37,7 +37,8 @@ hltPixelTracksReg.RegionFactoryPSet.RegionPSet = cms.PSet(
         deltaPhi = cms.double( 0.5 ),
         nSigmaZVertex = cms.double( 3.0 ),
         zErrorVertex = cms.double( 0.2 ),
-        nSigmaZBeamSpot = cms.double( 4.0 )
+        nSigmaZBeamSpot = cms.double( 4.0 ),
+        whereToUseMeasurementTracker = cms.string("Never"),
 )
 
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -138,7 +138,7 @@ def customiseFor10911(process):
 # Fix MeasurementTrackerEvent configuration in several TrackingRegionProducers (PR 11183)
 def customiseFor11183(process):
     def useMTEName(componentName):
-        if componentName == "CandidateSeededTrackingRegionsProducer":
+        if componentName in ["CandidateSeededTrackingRegionsProducer", "TrackingRegionsFromBeamSpotAndL2Tau"]:
             return "whereToUseMeasurementTracker"
         return "howToUseMeasurementTracker"
 

--- a/HLTrigger/HLTanalyzers/python/OpenHLT_Tau_cff.py
+++ b/HLTrigger/HLTanalyzers/python/OpenHLT_Tau_cff.py
@@ -202,7 +202,8 @@ openhltL25TauPixelSeeds = cms.EDProducer( "SeedGeneratorFromRegionHitsEDProducer
         originHalfLength = cms.double( 0.2 ),
         precise = cms.bool( True ),
         JetSrc = cms.InputTag( 'openhltL2TauJets' ),
-        vertexSrc = cms.InputTag( "hltPixelVertices" )
+        vertexSrc = cms.InputTag( "hltPixelVertices" ),
+        howToUseMeasurementTracker = cms.string("Never"),
       )
     ),
     OrderedHitsFactoryPSet = cms.PSet( 

--- a/HLTrigger/btau/src/L3MumuTrackingRegion.h
+++ b/HLTrigger/btau/src/L3MumuTrackingRegion.h
@@ -43,19 +43,9 @@ public:
     else{
       m_searchOpt = false;
     }
-    m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
-    if (regionPSet.exists("measurementTrackerName")){
-      // FIXME: when next time altering the configuration of this
-      // class, please change the types of the following parameters:
-      // - howToUseMeasurementTracker to at least int32 or to a string
-      //   corresponding to the UseMeasurementTracker enumeration
-      // - measurementTrackerName to InputTag
-      if (regionPSet.exists("howToUseMeasurementTracker")){
-	m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(regionPSet.getParameter<double>("howToUseMeasurementTracker"));
-      }
-      if(m_howToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
-        theMeasurementTrackerToken = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<std::string>("measurementTrackerName"));
-      }
+    m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(regionPSet.getParameter<std::string>("howToUseMeasurementTracker"));
+    if(m_howToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+      theMeasurementTrackerToken = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<edm::InputTag>("measurementTrackerName"));
     }
   }   
 

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -66,8 +66,8 @@ hiJetCoreRegionalStepSeeds.RegionFactoryPSet = cms.PSet(
         deltaEtaRegion = cms.double( 0.30 ), 
         JetSrc = cms.InputTag( "hiJetsForCoreTracking" ),
         vertexSrc = cms.InputTag( "hiFirstStepGoodPrimaryVertices" ),
-        measurementTrackerName = cms.string( "MeasurementTrackerEvent" ),
-        howToUseMeasurementTracker = cms.double( -1.0 )
+        measurementTrackerName = cms.InputTag( "MeasurementTrackerEvent" ),
+        howToUseMeasurementTracker = cms.string( "Never" )
       )
 )
 hiJetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'hiJetCoreRegionalStepSeedLayers'

--- a/RecoTauTag/HLTProducers/python/CandidateSeededTrackingRegionsProducer_cff.py
+++ b/RecoTauTag/HLTProducers/python/CandidateSeededTrackingRegionsProducer_cff.py
@@ -21,7 +21,10 @@ SeededTrackingRegionsFromBeamSpotFixedZLength = cms.PSet(
         
         nSigmaZVertex = cms.double( 3. ),
         zErrorVetex = cms.double( 0.2 ),
-        nSigmaZBeamSpot = cms.double( 4. )
+        nSigmaZBeamSpot = cms.double( 4. ),
+
+        whereToUseMeasurementTracker = cms.string("ForSiStrips"),
+        measurementTrackerName = cms.InputTag( "REPLACE" ),
     )
 )
 

--- a/RecoTauTag/HLTProducers/python/TauRegionalPixelSeedGenerator_cfi.py
+++ b/RecoTauTag/HLTProducers/python/TauRegionalPixelSeedGenerator_cfi.py
@@ -19,7 +19,9 @@ tauRegionalPixelSeedGenerator = cms.EDProducer("SeedGeneratorFromRegionHitsEDPro
             ptMin = cms.double(5.0),
             JetSrc = cms.InputTag("icone5Tau1"),
             originZPos = cms.double(0.0),
-            vertexSrc = cms.InputTag("pixelVertices")
+            vertexSrc = cms.InputTag("pixelVertices"),
+            howToUseMeasurementTracker = cms.string("ForSiStrips"),
+            measurementTrackerName = cms.InputTag("MeasurementTrackerEvent"),
         )
     ),
     TTRHBuilder = cms.string('WithTrackAngle')

--- a/RecoTauTag/HLTProducers/python/TrackingRegionsFromBeamSpotAndL2Tau_cfi.py
+++ b/RecoTauTag/HLTProducers/python/TrackingRegionsFromBeamSpotAndL2Tau_cfi.py
@@ -12,7 +12,8 @@ TrackingRegionsFromBeamSpotAndL2TauBlock = cms.PSet(
         JetMaxEta = cms.double( 2.1 ),
         JetMaxN = cms.int32( 10 ),
         beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
-        precise = cms.bool( True )
+        precise = cms.bool( True ),
+        whereToUseMeasurementTracker = cms.string("Never"),
     )
 )
 

--- a/RecoTauTag/HLTProducers/src/CandidateSeededTrackingRegionsProducer.h
+++ b/RecoTauTag/HLTProducers/src/CandidateSeededTrackingRegionsProducer.h
@@ -78,18 +78,9 @@ public:
     m_deltaEta         = regPSet.getParameter<double>("deltaEta");
     m_deltaPhi         = regPSet.getParameter<double>("deltaPhi");
     m_precise          = regPSet.getParameter<bool>("precise");
-    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
-    if (regPSet.exists("measurementTrackerName"))
-    {
-      // FIXME: when next time altering the configuration of this
-      // class, please change the types of the following parameters:
-      // - whereToUseMeasurementTracker to at least int32 or to a string
-      //   corresponding to the UseMeasurementTracker enumeration
-      // - measurementTrackerName to InputTag
-      if (regPSet.exists("whereToUseMeasurementTracker"))
-        m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(regPSet.getParameter<double>("whereToUseMeasurementTracker"));
-      if(m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever)
-        token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regPSet.getParameter<std::string>("measurementTrackerName"));
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(regPSet.getParameter<std::string>("whereToUseMeasurementTracker"));
+    if(m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+      token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regPSet.getParameter<edm::InputTag>("measurementTrackerName"));
     }
     m_searchOpt = false;
     if (regPSet.exists("searchOpt")) m_searchOpt = regPSet.getParameter<bool>("searchOpt");

--- a/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
+++ b/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
@@ -52,19 +52,9 @@ class TauRegionalPixelSeedGenerator : public TrackingRegionProducer {
       else{
 	m_searchOpt = false;
       }
-      m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
-      if (regionPSet.exists("measurementTrackerName")){
-        // FIXME: when next time altering the configuration of this
-        // class, please change the types of the following parameters:
-        // - howToUseMeasurementTracker to at least int32 or to a string
-        //   corresponding to the UseMeasurementTracker enumeration
-        // - measurementTrackerName to InputTag
-	if (regionPSet.exists("howToUseMeasurementTracker")){
-	  m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(regionPSet.getParameter<double>("howToUseMeasurementTracker"));
-	}
-        if(m_howToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
-          token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<std::string>("measurementTrackerName"));
-        }
+      m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(regionPSet.getParameter<std::string>("howToUseMeasurementTracker"));
+      if(m_howToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+        token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<std::string>("measurementTrackerName"));
       }
     }
   

--- a/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
+++ b/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
@@ -48,18 +48,9 @@ public:
     if (regionPSet.exists("searchOpt")) m_searchOpt = regionPSet.getParameter<bool>("searchOpt");
     else                                m_searchOpt = false;
 
-    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
-    if (regionPSet.exists("measurementTrackerName"))
-    {
-      // FIXME: when next time altering the configuration of this
-      // class, please change the types of the following parameters:
-      // - whereToUseMeasurementTracker to at least int32 or to a string
-      //   corresponding to the UseMeasurementTracker enumeration
-      // - measurementTrackerName to InputTag
-      if (regionPSet.exists("whereToUseMeasurementTracker"))
-        m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(regionPSet.getParameter<double>("whereToUseMeasurementTracker"));
-      if(m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever)
-        token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<std::string>("measurementTrackerName"));
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(regionPSet.getParameter<std::string>("whereToUseMeasurementTracker"));
+    if(m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+      token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<edm::InputTag>("measurementTrackerName"));
     }
   }
   

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -64,7 +64,7 @@ jetCoreRegionalStepSeeds.RegionFactoryPSet = cms.PSet(
 #       JetSrc = cms.InputTag( "ak5CaloJets" ),
         vertexSrc = cms.InputTag( "firstStepGoodPrimaryVertices" ),
         measurementTrackerName = cms.string( "MeasurementTrackerEvent" ),
-        howToUseMeasurementTracker = cms.double( -1.0 )
+        howToUseMeasurementTracker = cms.string( "Never" )
       )
 )
 jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'jetCoreRegionalStepSeedLayers'

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -46,6 +46,8 @@ public:
     return UseMeasurementTracker::kNever;
   }
 
+  static UseMeasurementTracker stringToUseMeasurementTracker(const std::string& name);
+
   RectangularEtaPhiTrackingRegion(RectangularEtaPhiTrackingRegion const & rh) :
     TrackingRegion(rh),
     theEtaRange(rh.theEtaRange),

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -82,18 +82,9 @@ public:
     m_deltaEta         = regPSet.getParameter<double>("deltaEta");
     m_deltaPhi         = regPSet.getParameter<double>("deltaPhi");
     m_precise          = regPSet.getParameter<bool>("precise");
-    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
-    if (regPSet.exists("measurementTrackerName"))
-    {
-      // FIXME: when next time altering the configuration of this
-      // class, please change the types of the following parameters:
-      // - whereToUseMeasurementTracker to at least int32 or to a string
-      //   corresponding to the UseMeasurementTracker enumeration
-      // - measurementTrackerName to InputTag
-      if (regPSet.exists("whereToUseMeasurementTracker"))
-        m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(regPSet.getParameter<double>("whereToUseMeasurementTracker"));
-      if(m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever)
-        token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regPSet.getParameter<std::string>("measurementTrackerName"));
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(regPSet.getParameter<std::string>("whereToUseMeasurementTracker"));
+    if(m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+      token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regPSet.getParameter<edm::InputTag>("measurementTrackerName"));
     }
     m_searchOpt = false;
     if (regPSet.exists("searchOpt")) m_searchOpt = regPSet.getParameter<bool>("searchOpt");

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -35,6 +35,8 @@
 
 
 #include<iostream>
+#include <algorithm>
+#include <cctype>
 
 template <class T> T sqr( T t) {return t*t;}
 
@@ -42,6 +44,18 @@ template <class T> T sqr( T t) {return t*t;}
 using namespace PixelRecoUtilities;
 using namespace std;
 using namespace ctfseeding; 
+
+RectangularEtaPhiTrackingRegion::UseMeasurementTracker RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(const std::string& name) {
+  std::string tmp = name;
+  std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+  if(tmp == "never")
+    return UseMeasurementTracker::kNever;
+  if(tmp == "forsistrips")
+    return UseMeasurementTracker::kForSiStrips;
+  if(tmp == "always")
+    return UseMeasurementTracker::kAlways;
+  throw cms::Exception("Configuration") << "Got invalid string '" << name << "', valid values are 'Never', 'ForSiStrips', 'Always' (case insensitive)";
+}
 
 void RectangularEtaPhiTrackingRegion:: initEtaRange( const GlobalVector & dir, const Margin& margin) {
   float eta = dir.eta();

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -38,7 +38,9 @@
 #include <algorithm>
 #include <cctype>
 
+namespace {
 template <class T> T sqr( T t) {return t*t;}
+}
 
 
 using namespace PixelRecoUtilities;


### PR DESCRIPTION
This PR addresses the segfault reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1562.html
and supersedes the first attempt #11155.

These TrackingRegionProducers have inconsistent default configuration for the use of MeasurementTrackerEvent. They set the usage mode to `kForSiStrips`, but do not read MTE, leading to a segfault if anybody uses these for strip hits (the case in the HN thread). In all current uses in the release, the default configuration is used only for pixel hits (i.e. MTE is not used).

Following the FIXME items added in #3105, the parameters `howToUseMeasurementTracker`/`whereToUseMeasurementTracker` and `measurementTrackerName` are made mandatory (latter only if the former is not `kNever`), and their types are changed to `string` and `InputTag`, respectively. The default mode is kept as `kForSiStrips` and the `measurementTrackerName` is set to some value (so in the HN case the user would get ProductNotFound exception in case of error instead of segfault), except for TrackingRegionsFromBeamSpotAndL2Tau, whose default mode is changed to `kNever` (there was only one use in the release, and it was clearly pixel-only, so this way we can avoid guessing the proper value for `measurementTrackerName`).

All uses of these TrackingRegionProducers are supposed to be migrated to the new configuration (i.e something missing is an error).

Tested in CMSSW_7_6_X_2015-09-06-2300 (with full matrix), no changes expected in results.
