### PR TITLE
 avoid empty FED occupancy plot in offline Pixel DQM

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -51,7 +51,6 @@ SiPixelDigiSource.bladeOn = True
 SiPixelDigiSource.diskOn = True
 SiPixelDigiSource.ringOn = False
 SiPixelDigiSource.bigEventSize = 2600
-SiPixelDigiSource.isOffline = True
 #Cluster
 SiPixelClusterSource.modOn = False
 SiPixelClusterSource.twoDimOn = False

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -56,6 +56,9 @@
        virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
        virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
+       virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+       virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
        virtual void buildStructure(edm::EventSetup const&);
        virtual void bookMEs(DQMStore::IBooker &, const edm::EventSetup& iSetup);
 
@@ -188,7 +191,6 @@
        
        int bigEventSize;
        bool isUpgrade;
-       bool isOffline;
        bool firstRun;
        
        std::string I_name[1856];

--- a/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
+++ b/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
@@ -23,7 +23,6 @@ SiPixelDigiSource = cms.EDAnalyzer("SiPixelDigiSource",
     ringOn = cms.untracked.bool(False),
     bladeOn = cms.untracked.bool(False),
     diskOn = cms.untracked.bool(False),
-    isOffline = cms.untracked.bool(False),
     bigEventSize = cms.untracked.int32(1000)
 )
 

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -64,7 +64,6 @@ SiPixelDigiSource::SiPixelDigiSource(const edm::ParameterSet& iConfig) :
   diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ),
   bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",1000) ), 
   isUpgrade( conf_.getUntrackedParameter<bool>("isUpgrade",false) ),
-  isOffline( conf_.getUntrackedParameter<bool>("isOffline",false) ),
   noOfLayers(0),
   noOfDisks(0)
 {
@@ -96,6 +95,64 @@ SiPixelDigiSource::~SiPixelDigiSource()
    // (e.g. close files, deallocate resources etc.)
   LogInfo ("PixelDQM") << "SiPixelDigiSource::~SiPixelDigiSource: Destructor"<<endl;
 }
+
+
+void 
+SiPixelDigiSource::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+  //std::cout << "New luminosity block!!" << std::endl;
+
+ if(modOn && nLumiSecs%10==0){
+    if(averageDigiOccupancy){
+      nBPIXDigis = 0; 
+      nFPIXDigis = 0;
+      for(int i=0; i!=40; i++) nDigisPerFed[i]=0;
+    }
+  }
+  if(!modOn){
+    if(averageDigiOccupancy){
+      nBPIXDigis = 0; 
+      nFPIXDigis = 0;
+      for(int i=0; i!=40; i++) nDigisPerFed[i]=0;
+    }
+  }
+
+}
+
+void 
+SiPixelDigiSource::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+  nLumiSecs++;
+
+  float averageBPIXFed = float(nBPIXDigis)/32.;
+  float averageFPIXFed = float(nFPIXDigis)/8.;
+
+  if(averageDigiOccupancy){
+    
+      for(int i=0; i!=40; i++){
+
+	float averageOcc = 0.;
+	if(i<32){
+	  if(averageBPIXFed>0.) averageOcc = nDigisPerFed[i]/averageBPIXFed;
+	}else{
+	  if(averageFPIXFed>0.) averageOcc = nDigisPerFed[i]/averageFPIXFed;
+	}
+	std::cout << averageOcc << std::endl;
+	if (!modOn){
+	  float entry=(averageDigiOccupancy->getBinContent(i+1) * (nLumiSecs-1) + averageOcc)/nLumiSecs; //this is the mean of the actual value + the bin entry already present in the histo, that is what we want in Offline GUI
+	  averageDigiOccupancy->setBinContent(i+1,entry);
+	}        
+
+	if (modOn && nLumiSecs%10==0){
+	  averageDigiOccupancy->setBinContent(i+1,averageOcc); // "modOn" basically mean Online DQM, in this case fill histos with actual value of digi fraction per fed for each ten lumisections
+	  if (avgfedDigiOccvsLumi){
+	  avgfedDigiOccvsLumi->setBinContent(int(nLumiSecs/10), i+1, averageOcc); //fill with the mean over ten the 10 lumisections, previous code was filling this histo only with last event of each 10th lumisection
+	}//endif meX5
+      }//endif modOn
+    }
+  }
+}
+
 
 
 void SiPixelDigiSource::dqmBeginRun(const edm::Run& r, const edm::EventSetup& iSetup){
@@ -198,7 +255,8 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
   int lumiSection = (int)iEvent.luminosityBlock();
   int nEventDigis = 0; int nActiveModules = 0;
   
-  if(modOn && !isOffline){
+  /*
+  if(modOn){
     if(averageDigiOccupancy && lumiSection%8==0){
       averageDigiOccupancy->Reset();
       nBPIXDigis = 0; 
@@ -206,7 +264,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
       for(int i=0; i!=40; i++) nDigisPerFed[i]=0;
     }
   }
-  if(!modOn && !isOffline){
+  if(!modOn){
     if(averageDigiOccupancy && lumiSection%1==0){
       averageDigiOccupancy->Reset();
       nBPIXDigis = 0; 
@@ -214,7 +272,8 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
       for(int i=0; i!=40; i++) nDigisPerFed[i]=0;
     }
   }
-  
+  */
+
   std::map<uint32_t,SiPixelDigiModule*>::iterator struct_iter;
   for(int i=0; i!=192; i++) numberOfDigis[i]=0;
   for(int i=0; i!=1152; i++) nDigisPerChan[i]=0;  
@@ -228,6 +287,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
 						       bladeOn, diskOn, ringOn, 
 						       twoDimOn, reducedSet, twoDimModOn, twoDimOnlyLayDisk,
 						       nDigisA, nDigisB, isUpgrade);
+    
     if (modOn && twoDimOnlyLayDisk && lumiSection%10 == 0) (*struct_iter).second->resetRocMap();
 
     bool barrel = DetId((*struct_iter).first).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
@@ -450,6 +510,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
         }
       }//endif(Endcap && isUpgrade)
     } // endif any digis in this module
+
     if (twoDimOnlyLayDisk && lumiSection%10 > 2){
       std::pair<int,int> tempPair = (*struct_iter).second->getZeroLoEffROCs();
       if (barrel){
@@ -537,6 +598,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
   }
   
   // Actual digi occupancy in a FED compared to average digi occupancy per FED
+  /*
   if(averageDigiOccupancy){
 
     for(int i=0; i!=40; i++){
@@ -559,7 +621,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
       }//endif modOn
     }
   }
-  
+  */
   // slow down...
   if(slowDown) usleep(10000);
   
@@ -689,7 +751,7 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker, const edm::EventSet
   averageDigiOccupancy->setLumiFlag();
   if(modOn){
     char title4[80]; sprintf(title4, "FED Digi Occupancy (NDigis/<NDigis>) vs LumiSections;Lumi Section;FED");
-    avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title4, 400,0., 3200., 40, -0.5, 39.5);
+    avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title4, 320,0., 3200., 40, -0.5, 39.5);
   }  
   std::map<uint32_t,SiPixelDigiModule*>::iterator struct_iter;
  


### PR DESCRIPTION
Revision of a precedent PR with cleaner way to fill histos lumi by lumi
