### PR TITLE
Marked DataProxy as thread safe

### DIFF
--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -88,7 +88,7 @@ namespace edm {
          DataProxy const& operator=(DataProxy const&); // stop default
 
          // ---------- member data --------------------------------
-         mutable void const* cache_; //protected by a global mutex
+         [[cms::thread_safe]] mutable void const* cache_; //protected by a global mutex
          mutable std::atomic<bool> cacheIsValid_;
          mutable std::atomic<bool> nonTransientAccessRequested_;
          ComponentDescription const* description_;


### PR DESCRIPTION
The static analyzer was picking up DataProxy as being thread-safe. Applied the appropriate annotation to tell the analyzer the mutable was safe because it is protected by a mutex shared by all EventSetup components.
