### PR TITLE
add protection for rare infinite loop in ecal multifit (76X)

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
@@ -300,7 +300,7 @@ bool PulseChiSqSNNLS::NNLS() {
   aTbvec = invcovp.transpose()*_covdecomp.matrixL().solve(_sampvec);  
   
   int iter = 0;
-  Index idxwmax;
+  Index idxwmax = 0;
   double wmax = 0.0;
   //work = PulseVector::zeros();
   while (true) {    
@@ -311,10 +311,12 @@ bool PulseChiSqSNNLS::NNLS() {
       const unsigned int nActive = npulse - _nP;
       
       updatework = aTbvec - aTamat*_ampvec;      
+      Index idxwmaxprev = idxwmax;
+      double wmaxprev = wmax;
       wmax = updatework.tail(nActive).maxCoeff(&idxwmax);
       
       //convergence
-      if (wmax<1e-11) break;
+      if (wmax<1e-11 || (idxwmax==idxwmaxprev && wmax==wmaxprev)) break;
       
       //unconstrain parameter
       Index idxp = _nP + idxwmax;


### PR DESCRIPTION
This protects against a rare infinite loop observed to occur when updating ecal pulse shape templates to those derived from 2015 low pileup data.

Should have zero effect on MC (or data with existing db conditions)

Will be backported to 74x and 75x asap as well.  (And in fact this change is needed both for HLT and prompt reco before updated multifit pulse conditions can safely be deployed)

@emanueledimarco @lgray
