### PR TITLE
HLtriggerOffline/Higgs path update

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -335,6 +335,7 @@ for type in plot_types:
             efficiency_strings.append(efficiency_string(obj,type,trig))
 
 efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 
 hltHiggsPostMSSMHbb = hltHiggsPostProcessor.clone()
 hltHiggsPostMSSMHbb.subDirs = ['HLT/Higgs/MSSMHbb']

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -211,16 +211,15 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
      Htaunu = cms.PSet(
         hltPathsToCheck = cms.vstring(
-            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v",
-            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v",
-            # monitoring triggers for efficiency measurement
-            "HLT_LooseIsoPFTau50_Trk30_eta2p1_v",
-            "HLT_IsoMu16_eta2p1_CaloMET30_LooseIsoPFTau50_Trk30_eta2p1_v",
-            "HLT_IsoMu16_eta2p1_CaloMET30_v",
-            
-            # new menu, not updated?
             "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_JetIdCleaned_v",
-            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_JetIdCleaned_v"
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_JetIdCleaned_v",
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_v",
+            
+            # frozen menu paths
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v",
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v",            
+            "HLT_IsoMu16_eta2p1_CaloMET30_LooseIsoPFTau50_Trk30_eta2p1_v",
+            "HLT_IsoMu16_eta2p1_CaloMET30_v"
             ),
         recPFTauLabel   = cms.string("hpsPFTauProducer"),
         recCaloMETLabel = cms.string("caloMet"),

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -349,7 +349,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_Ele27_eta2p1_WPLoose_Gsf_v",
             "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v",
             
-            # frozen menu paths (already in dqm)
+            # frozen menu paths
             "HLT_Ele27_WP85_Gsf_v",
             "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v"
             ),
@@ -381,6 +381,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     WHToENuBB  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
             "HLT_Ele27_WPLoose_Gsf_WHbbBoost_v",
+            "HLT_Ele23_WPLoose_Gsf_WHbbBoost_v"
             ),
         recElecLabel   = cms.string("gedGsfElectrons"),
         recJetLabel  = cms.string("ak4PFJetsCHS"),

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -143,7 +143,6 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v",
             "HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v",
             "HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v",
-            "HLT_TripleMu_12_10_5_1PairDZ_v",
             "HLT_TripleMu_12_10_5_v"
         ),
         recMuonLabel  = cms.string("muons"),
@@ -154,19 +153,28 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     Hgg = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_Diphoton10_10_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass10_ForMC_v",
             "HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v",
-            "HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelSeedMatch_Mass70_v",
             "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v",
             "HLT_Diphoton30_18_Solid_R9Id_AND_IsoCaloId_AND_HE_R9Id_Mass55_v",
-            "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v"
+            "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v",
+            
+            # frozen menu paths
+            "HLT_Diphoton44_28_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P1_R9Id50b80e_v",
+            "HLT_Diphoton30_18_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_Mass95_v",
+            "HLT_Diphoton28_14_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_Mass50_Eta_1p5_v",
+            "HLT_Diphoton30_18_R9Id85_AND_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_Solid_Mass30_v",
+            "HLT_Diphoton30_18_R9Id85_AND_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_PV_v",
+            "HLT_Diphoton30_18_R9Id85_AND_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_DoublePV_v"
         ),
         recPhotonLabel  = cms.string("photons"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(2), 
         ),
+    # seperate directory because it needs a different relval    
     HggControlPaths = cms.PSet( 
         hltPathsToCheck = cms.vstring(
+            "HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelSeedMatch_Mass70_v",
+            # frozen menu paths
             "HLT_Diphoton30_18_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_PixelSeed_Mass70_v"
         ),
         recPhotonLabel  = cms.string("photons"),
@@ -180,7 +188,11 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_Mu17_Mu8_SameSign_DZ_v",
             "HLT_Mu20_Mu10_v",
             "HLT_Mu20_Mu10_DZ_v",
-            "HLT_Mu20_Mu10_SameSign_DZ_v"
+            "HLT_Mu20_Mu10_SameSign_DZ_v",
+            
+            # frozen menu paths
+            "HLT_Mu17_Mu8_SameSign_v",
+            "HLT_Mu17_Mu8_SameSign_DPhi_v"
         ),
         recMuonLabel  = cms.string("muons"),
         # -- Analysis specific cuts
@@ -199,14 +211,16 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
      Htaunu = cms.PSet(
         hltPathsToCheck = cms.vstring(
-#            "HLT_LooseIsoPFTau35_Trk20_Prong1_MET70_v",
-#            "HLT_LooseIsoPFTau35_Trk20_Prong1_MET75_v",
             "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v",
             "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v",
             # monitoring triggers for efficiency measurement
             "HLT_LooseIsoPFTau50_Trk30_eta2p1_v",
             "HLT_IsoMu16_eta2p1_CaloMET30_LooseIsoPFTau50_Trk30_eta2p1_v",
-            "HLT_IsoMu16_eta2p1_CaloMET30_v"
+            "HLT_IsoMu16_eta2p1_CaloMET30_v",
+            
+            # new menu, not updated?
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_JetIdCleaned_v",
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_JetIdCleaned_v"
             ),
         recPFTauLabel   = cms.string("hpsPFTauProducer"),
         recCaloMETLabel = cms.string("caloMet"),
@@ -223,12 +237,8 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     H2tau  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            #"HLT_Ele22_eta2p1_WP90Rho_LooseIsoPFTau20_v",#?
-            #"HLT_Ele22_eta2p1_WP90Rho_Gsf_LooseIsoPFTau20_v",
-            #"HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20_v",
             "HLT_IsoMu17_eta2p1_LooseIsoPFTau20_v",
             "HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v",
-            #"HLT_IsoMu24_eta2p1_IterTrk02_LooseIsoPFTau20_v",
             "HLT_IsoMu17_eta2p1_LooseIsoPFTau20_SingleL1_v",
             "HLT_IsoMu17_eta2p1_MediumIsoPFTau40_Trk1_eta2p1_Reg_v",
             "HLT_IsoMu17_eta2p1_v",
@@ -243,14 +253,12 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_Ele22_eta2p1_WPTight_Gsf_v",
             "HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf_v",
             "HLT_IsoMu24_eta2p1_LooseIsoPFTau20_v",
-            "HLT_IsoMu24_eta2p1_IterTrk02_v",
             "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
             "HLT_Ele22_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_v",
             "HLT_Ele27_eta2p1_WPLoose_Gsf_v",
             "HLT_Ele27_eta2p1_WPTight_Gsf_v",
             "HLT_Ele32_eta2p1_WPLoose_Gsf_v",
             "HLT_Ele32_eta2p1_WPTight_Gsf_v",
-            "HLT_Ele17_Ele8_Gsf_v"
             ),
         recPFTauLabel  = cms.string("hpsPFTauProducer"),
         recMuonLabel   = cms.string("muons"),
@@ -300,6 +308,14 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_PFMET110_PFMHT110_IDTight_v",
             "HLT_PFMET100_PFMHT100_IDTight_v",
             "HLT_PFMET90_PFMHT90_IDTight_v",
+            
+            # frozen menu paths
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v",
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_v"
+            "HLT_PFMET120_PFMHT120_IDLoose_v",
+            "HLT_PFMET110_PFMHT110_IDLoose_v",
+            "HLT_PFMET100_PFMHT100_IDLoose_v",
+            "HLT_PFMET90_PFMHT90_IDLoose_v",
             ),
         Jet_recCut   = cms.string("pt > 10 && abs(eta) < 2.6"),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
@@ -315,6 +331,12 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_DoubleJet90_Double30_DoubleBTagCSV0p67_v",
             "HLT_QuadJet45_TripleBTagCSV0p67_v",
             "HLT_QuadJet45_DoubleBTagCSV0p67_v",
+            
+            # frozen menu paths
+            "HLT_DoubleJet90_Double30_TripleCSV0p5_v",
+            "HLT_DoubleJet90_Double30_DoubleCSV0p5_v",
+            "HLT_QuadJet45_TripleCSV0p5_v",
+            "HLT_QuadJet45_DoubleCSV0p5_v"
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
@@ -324,10 +346,12 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     TTHbbej  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_Ele27_WP85_Gsf_v",
-            "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v",
             "HLT_Ele27_eta2p1_WPLoose_Gsf_v",
-            "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v"
+            "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v",
+            
+            # frozen menu paths (already in dqm)
+            "HLT_Ele27_WP85_Gsf_v",
+            "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v"
             ),
         recElecLabel   = cms.string("gedGsfElectrons"),
         #recJetLabel  = cms.string("ak4PFJetsCHS"),
@@ -343,6 +367,10 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_PFHT400_SixJet30_BTagCSV0p55_2PFBTagCSV0p72_v",
             "HLT_PFHT450_SixJet40_v",
             "HLT_PFHT400_SixJet30_v",
+            
+            # frozen menu paths
+            "HLT_PFHT450_SixJet40_PFBTagCSV_v",
+            "HLT_PFHT400_SixJet30_BTagCSV0p5_2PFBTagCSV_v"
             ),
         #recElecLabel   = cms.string("gedGsfElectrons"),
         recJetLabel  = cms.string("ak4PFJetsCHS"),

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -746,12 +746,18 @@ const std::vector<unsigned int> HLTHiggsSubAnalysis::getObjectsType(const std::s
         {
             if( (objtriggernames[i] == EVTColContainer::PFJET && TString(hltPath).Contains("WHbbBoost") ) ||   // fix for HLT_Ele27_WPLoose_Gsf_WHbbBoost_v
                 (objtriggernames[i] == EVTColContainer::PFJET && TString(hltPath).Contains("CSV") ) ||   // fix for ZnnHbb PFJET            
-                (objtriggernames[i] == EVTColContainer::PFMET && TString(hltPath).Contains("MHT")) )        // fix for ZnnHbb PFMET
-                objsType.insert(objtriggernames[i]);
-            else if (objtriggernames[i] == EVTColContainer::PHOTON && TString(hltPath).Contains("Diphoton") ) objsType.insert(objtriggernames[i]);    //case of the New Diphoton paths
+                (objtriggernames[i] == EVTColContainer::PFMET && TString(hltPath).Contains("MHT")) ||        // fix for ZnnHbb PFMET
+                (objtriggernames[i] == EVTColContainer::PHOTON && TString(hltPath).Contains("Diphoton")) ) 
+            {
+                    objsType.insert(objtriggernames[i]);    //case of the New Diphoton paths
+            }
            continue;
         }
-        if( objtriggernames[i] == EVTColContainer::CALOMET && (TString(hltPath).Contains("PFMET") || TString(hltPath).Contains("MHT") ) ) continue; // fix for PFMET
+        if( ( objtriggernames[i] == EVTColContainer::CALOMET && (TString(hltPath).Contains("PFMET") || TString(hltPath).Contains("MHT") ) ) || // fix for PFMET
+        (objtriggernames[i] == EVTColContainer::PFJET && TString(hltPath).Contains("JetIdCleaned")) ) // fix for Htaunu
+        {
+            continue;
+        }
 
         objsType.insert(objtriggernames[i]);
     }


### PR DESCRIPTION
This PR contains an update of the paths that have to be monitored in the HLT Higgs dqm.

More specifically:
- The paths from the frozen menu are added back as was requested by the TSG
- Old paths that were not used any more are removed
- Paths are updated for the Htaunu analysis and a fix is included in the code which was causing an error for these paths
- A new path for WHToENuBB is included
- The summary plots are added for MSSMHbb
