### PR TITLE
Make ROOT5 checksums known to ROOT6

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -278,10 +278,11 @@
   </class>
 
   <class name="pat::PackedCandidate" ClassVersion="22">
+    <version ClassVersion="23" checksum="559934341"/>
     <version ClassVersion="22" checksum="691064527"/>
     <version ClassVersion="21" checksum="1075665714"/>
     <version ClassVersion="20" checksum="2078702780"/>
-    <version ClassVersion="19" checksum="359155190"/>    
+    <version ClassVersion="19" checksum="359155190"/>
     <version ClassVersion="18" checksum="4275117305"/>
     <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   
   <class name="reco::PFTau" ClassVersion="19">
+   <version ClassVersion="20" checksum="3395041825"/>
    <version ClassVersion="19" checksum="4003955973"/>
    <version ClassVersion="18" checksum="1318776182"/>
    <version ClassVersion="17" checksum="1523260402"/>
@@ -267,6 +268,7 @@ isolationTauChargedHadronCandidates_.clear();
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
 
   <class name="reco::RecoTauPiZero" ClassVersion="14">
+   <version ClassVersion="15" checksum="4070597512"/>
    <version ClassVersion="14" checksum="3535311745"/>
    <version ClassVersion="13" checksum="3687187514"/>
    <version ClassVersion="12" checksum="453348937"/>


### PR DESCRIPTION
Some class checksums for ROOT5 have changed, causing build problems in CMSSW_7_4_ROOT5_X.
This PR simply makes the new ROOT5 checksums visible in the ROOT6 release, CMSSW_7_4_X.
PR #11211 will fix the build problems in 7_4_ROOT5_X.
