### PR TITLE
Fix Build problems due to ROOT issues

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -78,9 +78,9 @@ namespace pat {
 
 
       // ---- methods for uncorrected MET ----
-      float uncorrectedPt() const;
-      float uncorrectedPhi() const;
-      float uncorrectedSumEt() const;
+      //float uncorrectedPt() const;
+      //float uncorrectedPhi() const;
+      //float uncorrectedSumEt() const;
 
       // ---- methods to know what the pat::MET was constructed from ----
       /// True if this pat::MET was made from a reco::CaloMET

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -271,7 +271,12 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="17">
+  <class name="pat::PackedCandidate" ClassVersion="23">
+    <version ClassVersion="23" checksum="559934341"/>
+    <version ClassVersion="22" checksum="691064527"/>
+    <version ClassVersion="21" checksum="1075665714"/>
+    <version ClassVersion="20" checksum="2078702780"/>
+    <version ClassVersion="19" checksum="359155190"/>
     <version ClassVersion="18" checksum="4275117305"/>
     <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,8 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="17">
+  <class name="reco::PFTau" ClassVersion="20">
+   <version ClassVersion="20" checksum="3395041825"/>
+   <version ClassVersion="19" checksum="4003955973"/>
    <version ClassVersion="18" checksum="1318776182"/>
    <version ClassVersion="17" checksum="1523260402"/>
     <version ClassVersion="16" checksum="2695990650"/>
@@ -265,7 +267,9 @@ isolationTauChargedHadronCandidates_.clear();
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauDecayMode> > >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
 
-  <class name="reco::RecoTauPiZero" ClassVersion="12">
+  <class name="reco::RecoTauPiZero" ClassVersion="15">
+   <version ClassVersion="15" checksum="4070597512"/>
+   <version ClassVersion="14" checksum="3535311745"/>
    <version ClassVersion="13" checksum="3687187514"/>
    <version ClassVersion="12" checksum="453348937"/>
    <version ClassVersion="11" checksum="2458276705"/>


### PR DESCRIPTION
This PR does the following:
1) It fixes the fatal build errors in CMSSW_7_4_ROOT5_X due to changed ROOT checksums for ROOT5.
2) It makes several new ROOT6 checksums from CMSSW_7_4_X visible in CMSSW_7_4_ROOT5_X.
3) It fixes the fatal build error due to declarations of undefined functions in DataFormats/PatCandidates/interface/MET.h. While declaring an undefined function is legal in C++, it is fatal to the build of a ROOT5 dictionary for the class.
Note:  The corresponding PR for this in CMSSW_7_4_X is #11210.
Please merge this in a timely manner so CMSSW_7_4_ROOT5_X will be usable.
