### PR TITLE
HeavyIon: Add E/p cut to electrons and extend event content for electron collections.

### DIFF
--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -21,7 +21,8 @@ photonIsolationHIProducerGED = photonIsolationHIProducer.clone(photonProducer=cm
 #These are set for consistency w/ HiElectronSequence, but these cuts need to be studied
 gedGsfElectronsTmp.maxHOverEBarrel = cms.double(0.25)
 gedGsfElectronsTmp.maxHOverEEndcaps = cms.double(0.25)
-
+gedGsfElectronsTmp.maxEOverPBarrel = cms.double(2.)
+gedGsfElectronsTmp.maxEOverPEndcaps = cms.double(2.)
 
 from RecoParticleFlow.Configuration.RecoParticleFlow_cff import *
 

--- a/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
@@ -12,7 +12,9 @@ RecoHiEgammaFEVT = cms.PSet(
     "keep recoGsfElectrons_*_*_*",
     'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*',
     'keep recoPhotons_gedPhotonsTmp_*_*',
-    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*'
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*',
+    'keep recoElectronSeeds_ecalDrivenElectronSeeds_*_*',
+    'keep recoTrackExtras_electronGsfTracks_*_*'
     )
     )
 
@@ -28,7 +30,9 @@ RecoHiEgammaRECO = cms.PSet(
     "keep recoGsfElectrons_*_*_*",
     'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*',
     'keep recoPhotons_gedPhotonsTmp_*_*',
-    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*'
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*',
+    'keep recoElectronSeeds_ecalDrivenElectronSeeds_*_*',
+     'keep recoTrackExtras_electronGsfTracks_*_*'
     )
     )
 
@@ -40,6 +44,8 @@ RecoHiEgammaAOD = cms.PSet(
     'keep recoSuperClusters_correctedIslandEndcapSuperClusters_*_*',
     'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*',
     'keep recoPhotons_gedPhotonsTmp_*_*',
-    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*'
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*',
+    'keep recoElectronSeeds_ecalDrivenElectronSeeds_*_*',
+    'keep recoTrackExtras_electronGsfTracks_*_*'
     )
     )


### PR DESCRIPTION
This PR adds an E/p cut of <2 to the Heavy Ion electron reconstructions chain. The reason for this cut is to remove fake jets which arise from low-pt (very-curved) tracks attached to high pt ecal clusters. Theses "electrons" are then included in jets, but since the track is very curved the ecal cluster is not actually inside the jet.
Please see motivation slides here:
https://twiki.cern.ch/twiki/pub/CMS/PhotonAnalyses2015/20150825_fakerate.pdf
Additional documentation can be provided on request.

Additionally, this PR includes two additions to the Heavy Ion Event Content for electron-related quantities.

This PR should not affect pp workflows in any way.
Matrices 5.1 and 140.53 worked locally for me.

This will also be backported to 7_5_X.

This PR supersedes @doanhien PRs #11193 and #11191, both of those should be closed.
