### PR TITLE
change wrong input tag back to pMinRBXRechitR45EnergyFraction

### DIFF
--- a/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
@@ -136,7 +136,7 @@ HcalNoiseAlgo::HcalNoiseAlgo(const edm::ParameterSet& iConfig)
      pMinRBXRechitR45Fraction_ = iConfig.getParameter<double>("pMinRBXRechitR45Fraction");
   else
      pMinRBXRechitR45Fraction_ = 0;
-  if(iConfig.existsAs<double>("pMinRechitR45EnergyFraction"))
+  if(iConfig.existsAs<double>("pMinRBXRechitR45EnergyFraction"))
      pMinRBXRechitR45EnergyFraction_ = iConfig.getParameter<double>("pMinRBXRechitR45EnergyFraction");
   else
      pMinRBXRechitR45EnergyFraction_ = 0;


### PR DESCRIPTION
Hi,

The input tag in the IF condition is different from that used in the statement following IF. They should be both "pMinRBXRechitR45EnergyFraction", as set by the config file:
https://github.com/cms-sw/cmssw/blob/CMSSW_7_6_X/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py#L36

The consequence caused by this inconsistency is that HcalNoiseAlgo::isProblematic(...) function will always returns true:https://github.com/cms-sw/cmssw/blob/CMSSW_7_6_X/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc#L203

Thus in the RECO step, the RecoMET/METProducers/src/HcalNoiseInfoProducer.cc will regard all RBXs as problematic and store them in the event. This will affect our analysis  since we just want to reach RBXs that are either problematic or of highest energy.

Maybe it's too late to get this code changed in the current reconstruction, it will be helpful if it's fixed in future reReco of data.

Thanks
