### PR TITLE
VID fix & core unit tests + Regression ValueMap Producer code cleanup. (76X)

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
@@ -174,9 +174,9 @@ namespace {
       
         if(theseed == pclus ) 
           continue;
-        _clusterRawEnergy.push_back(pclus->energy());
-        _clusterDPhiToSeed.push_back(reco::deltaPhi(pclus->phi(),theseed->phi()));
-        _clusterDEtaToSeed.push_back(pclus->eta() - theseed->eta());
+        _clusterRawEnergy[iclus]  = pclus->energy();
+        _clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
+        _clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
         
         // find cluster with max dR
         if(reco::deltaR(*pclus, *theseed) > maxDR) {

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
@@ -20,32 +20,190 @@
 
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 namespace {
-  constexpr char sigmaIEtaIPhi_[] = "sigmaIEtaIPhi";
-  constexpr char eMax_[] = "eMax";
-  constexpr char e2nd_[] = "e2nd";
-  constexpr char eTop_[] = "eTop";
-  constexpr char eBottom_[] = "eBottom";
-  constexpr char eLeft_[] = "eLeft";
-  constexpr char eRight_[] = "eRight";
-  constexpr char clusterMaxDR_[] = "clusterMaxDR";
-  constexpr char clusterMaxDRDPhi_[] = "clusterMaxDRDPhi";
-  constexpr char clusterMaxDRDEta_[] = "clusterMaxDRDEta";
-  constexpr char clusterMaxDRRawEnergy_[] = "clusterMaxDRRawEnergy";
-  constexpr char clusterRawEnergy0_[] = "clusterRawEnergy0";
-  constexpr char clusterRawEnergy1_[] = "clusterRawEnergy1";
-  constexpr char clusterRawEnergy2_[] = "clusterRawEnergy2";
-  constexpr char clusterDPhiToSeed0_[] = "clusterDPhiToSeed0";
-  constexpr char clusterDPhiToSeed1_[] = "clusterDPhiToSeed1";
-  constexpr char clusterDPhiToSeed2_[] = "clusterDPhiToSeed2";
-  constexpr char clusterDEtaToSeed0_[] = "clusterDEtaToSeed0";
-  constexpr char clusterDEtaToSeed1_[] = "clusterDEtaToSeed1";
-  constexpr char clusterDEtaToSeed2_[] = "clusterDEtaToSeed2";
-  constexpr char eleIPhi_[]    = "iPhi";
-  constexpr char eleIEta_[]    = "iEta";
-  constexpr char eleCryPhi_[]  = "cryPhi";
-  constexpr char eleCryEta_[]  = "cryEta";
+  enum reg_float_vars { k_sigmaIEtaIPhi = 0,
+                        k_eMax,
+                        k_e2nd,
+                        k_eTop,
+                        k_eBottom,
+                        k_eLeft,
+                        k_eRight,
+                        k_clusterMaxDR,
+                        k_clusterMaxDRDPhi,
+                        k_clusterMaxDRDEta,
+                        k_clusterMaxDRRawEnergy,
+                        k_clusterRawEnergy0,
+                        k_clusterRawEnergy1,
+                        k_clusterRawEnergy2,
+                        k_clusterDPhiToSeed0,
+                        k_clusterDPhiToSeed1,
+                        k_clusterDPhiToSeed2,
+                        k_clusterDEtaToSeed0,
+                        k_clusterDEtaToSeed1,
+                        k_clusterDEtaToSeed2,
+                        k_cryPhi,
+                        k_cryEta,
+                        k_NFloatVars             };
+  
+  enum reg_int_vars { k_iPhi = 0,
+                      k_iEta,
+                      k_NIntVars     };
+
+  static const std::vector<std::string> float_var_names( { "sigmaIEtaIPhi",
+                                                            "eMax",
+                                                            "e2nd",
+                                                            "eTop",
+                                                            "eBottom",
+                                                            "eLeft",
+                                                            "eRight",
+                                                            "clusterMaxDR",
+                                                            "clusterMaxDRDPhi",
+                                                            "clusterMaxDRDEta",
+                                                            "clusterMaxDRRawEnergy",
+                                                            "clusterRawEnergy0",
+                                                            "clusterRawEnergy1",
+                                                            "clusterRawEnergy2",
+                                                            "clusterDPhiToSeed0",
+                                                            "clusterDPhiToSeed1",
+                                                            "clusterDPhiToSeed2",
+                                                            "clusterDEtaToSeed0",
+                                                            "clusterDEtaToSeed1",
+                                                            "clusterDEtaToSeed2",
+                                                            "cryPhi",
+                                                            "cryEta"                 } );
+  
+  static const std::vector<std::string> integer_var_names( { "iPhi", "iEta" } );  
+  
+  inline void set_map_val( const reg_float_vars index, const float value,
+                           std::unordered_map<std::string,float>& map) {
+    map[float_var_names[index]] = value;
+  }
+  inline void set_map_val( const reg_int_vars index, const int value,
+                           std::unordered_map<std::string,int>& map) {
+    map[integer_var_names[index]] = value;
+  }
+
+  template<typename T>
+  inline void check_map(const std::unordered_map<std::string,T>& map, unsigned exp_size) {
+    if( map.size() != exp_size ) {
+      throw cms::Exception("ElectronRegressionWeirdConfig")
+        << "variable map size: " << map.size() 
+        << " not equal to expected size: " << exp_size << " !"
+        << " The regression variable calculation code definitely has a bug, fix it!";
+    }
+  }
+
+  template<typename LazyTools>
+  void calculateValues(EcalClusterLazyToolsBase* tools_tocast,
+                       const edm::Ptr<reco::GsfElectron>& iEle,
+                       const edm::EventSetup& iSetup,
+                       std::unordered_map<std::string,float>& float_vars,
+                       std::unordered_map<std::string,int>& int_vars ) {
+    LazyTools* tools = static_cast<LazyTools*>(tools_tocast);
+    
+    const auto& the_sc  = iEle->superCluster();
+    const auto& theseed = the_sc->seed();
+    
+    const int numberOfClusters =  the_sc->clusters().size();
+    const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
+    
+    std::vector<float> vCov = tools->localCovariances( *theseed );
+    
+    const float eMax = tools->eMax( *theseed );
+    const float e2nd = tools->e2nd( *theseed );
+    const float eTop = tools->eTop( *theseed );
+    const float eLeft = tools->eLeft( *theseed );
+    const float eRight = tools->eRight( *theseed );
+    const float eBottom = tools->eBottom( *theseed );
+    
+    float dummy;
+    int iPhi;
+    int iEta;
+    float cryPhi;
+    float cryEta;
+    EcalClusterLocal _ecalLocal;
+    if (iEle->isEB()) 
+      _ecalLocal.localCoordsEB(*theseed, iSetup, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
+    else 
+      _ecalLocal.localCoordsEE(*theseed, iSetup, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
+    
+    double see = (isnan(vCov[0]) ? 0. : sqrt(vCov[0]));
+    double spp = (isnan(vCov[2]) ? 0. : sqrt(vCov[2]));
+    double sep;    
+    if (see*spp > 0)
+      sep = vCov[1] / (see * spp);
+    else if (vCov[1] > 0)
+      sep = 1.0;
+    else
+      sep = -1.0;
+    
+    set_map_val(k_sigmaIEtaIPhi,sep,float_vars);
+    set_map_val(k_eMax,eMax,float_vars);
+    set_map_val(k_e2nd,e2nd,float_vars);
+    set_map_val(k_eTop,eTop,float_vars);
+    set_map_val(k_eBottom,eBottom,float_vars);
+    set_map_val(k_eLeft,eLeft,float_vars);
+    set_map_val(k_eRight,eRight,float_vars);
+    set_map_val(k_cryPhi,cryPhi,float_vars);
+    set_map_val(k_cryEta,cryEta,float_vars);
+
+    set_map_val(k_iPhi,iPhi,int_vars);
+    set_map_val(k_iEta,iEta,int_vars);
+    
+    std::vector<float> _clusterRawEnergy;
+    _clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
+    std::vector<float> _clusterDEtaToSeed;
+    _clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
+    std::vector<float> _clusterDPhiToSeed;
+    _clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
+    float _clusterMaxDR     = 999.;
+    float _clusterMaxDRDPhi = 999.;
+    float _clusterMaxDRDEta = 999.;
+    float _clusterMaxDRRawEnergy = 0.;
+    
+    size_t iclus = 0;
+    float maxDR = 0;
+    edm::Ptr<reco::CaloCluster> pclus;
+    if( !missing_clusters ) {
+      // loop over all clusters that aren't the seed  
+      auto clusend = the_sc->clustersEnd();
+      for( auto clus = the_sc->clustersBegin(); clus != clusend; ++clus ) {
+        pclus = *clus;
+      
+        if(theseed == pclus ) 
+          continue;
+        _clusterRawEnergy.push_back(pclus->energy());
+        _clusterDPhiToSeed.push_back(reco::deltaPhi(pclus->phi(),theseed->phi()));
+        _clusterDEtaToSeed.push_back(pclus->eta() - theseed->eta());
+        
+        // find cluster with max dR
+        if(reco::deltaR(*pclus, *theseed) > maxDR) {
+          maxDR = reco::deltaR(*pclus, *theseed);
+          _clusterMaxDR = maxDR;
+          _clusterMaxDRDPhi = _clusterDPhiToSeed[iclus];
+          _clusterMaxDRDEta = _clusterDEtaToSeed[iclus];
+          _clusterMaxDRRawEnergy = _clusterRawEnergy[iclus];
+        }      
+        ++iclus;
+      }
+    }
+    
+    set_map_val(k_clusterMaxDR,_clusterMaxDR,float_vars);
+    set_map_val(k_clusterMaxDRDPhi,_clusterMaxDRDPhi,float_vars);
+    set_map_val(k_clusterMaxDRDEta,_clusterMaxDRDEta,float_vars);
+    set_map_val(k_clusterMaxDRRawEnergy,_clusterMaxDRRawEnergy,float_vars);
+    set_map_val(k_clusterRawEnergy0,_clusterRawEnergy[0],float_vars); 
+    set_map_val(k_clusterRawEnergy1,_clusterRawEnergy[1],float_vars); 
+    set_map_val(k_clusterRawEnergy2,_clusterRawEnergy[2],float_vars); 
+    set_map_val(k_clusterDPhiToSeed0,_clusterDPhiToSeed[0],float_vars);
+    set_map_val(k_clusterDPhiToSeed1,_clusterDPhiToSeed[1],float_vars);
+    set_map_val(k_clusterDPhiToSeed2,_clusterDPhiToSeed[2],float_vars);
+    set_map_val(k_clusterDEtaToSeed0,_clusterDEtaToSeed[0],float_vars);
+    set_map_val(k_clusterDEtaToSeed1,_clusterDEtaToSeed[1],float_vars);
+    set_map_val(k_clusterDEtaToSeed2,_clusterDEtaToSeed[2],float_vars);
+  }
 }
 
 class ElectronRegressionValueMapProducer : public edm::stream::EDProducer<> {
@@ -61,15 +219,11 @@ class ElectronRegressionValueMapProducer : public edm::stream::EDProducer<> {
   
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
+  template<typename T>
   void writeValueMap(edm::Event &iEvent,
 		     const edm::Handle<edm::View<reco::GsfElectron> > & handle,
-		     const std::vector<float> & values,
-		     const std::string    & label) const ;
-
-  void writeValueMap(edm::Event &iEvent,
-		     const edm::Handle<edm::View<reco::GsfElectron> > & handle,
-		     const std::vector<int> & values,
-		     const std::string    & label) const ;
+		     const std::vector<T> & values,
+		     const std::string    & label) const ;  
 
   std::unique_ptr<EcalClusterLazyToolsBase> lazyTools;
 
@@ -112,164 +266,16 @@ ElectronRegressionValueMapProducer::ElectronRegressionValueMapProducer(const edm
   src_        = mayConsume<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>("src"));
   srcMiniAOD_ = mayConsume<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>("srcMiniAOD"));
 
-  produces<edm::ValueMap<float> >(sigmaIEtaIPhi_); 
-  produces<edm::ValueMap<float> >(eMax_);
-  produces<edm::ValueMap<float> >(e2nd_);
-  produces<edm::ValueMap<float> >(eTop_);
-  produces<edm::ValueMap<float> >(eBottom_);
-  produces<edm::ValueMap<float> >(eLeft_);
-  produces<edm::ValueMap<float> >(eRight_);
-  produces<edm::ValueMap<float> >(clusterMaxDR_);
-  produces<edm::ValueMap<float> >(clusterMaxDRDPhi_);
-  produces<edm::ValueMap<float> >(clusterMaxDRDEta_);
-  produces<edm::ValueMap<float> >(clusterMaxDRRawEnergy_);
-  produces<edm::ValueMap<float> >(clusterRawEnergy0_); 
-  produces<edm::ValueMap<float> >(clusterRawEnergy1_); 
-  produces<edm::ValueMap<float> >(clusterRawEnergy2_); 
-  produces<edm::ValueMap<float> >(clusterDPhiToSeed0_);
-  produces<edm::ValueMap<float> >(clusterDPhiToSeed1_);
-  produces<edm::ValueMap<float> >(clusterDPhiToSeed2_);
-  produces<edm::ValueMap<float> >(clusterDEtaToSeed0_);
-  produces<edm::ValueMap<float> >(clusterDEtaToSeed1_);
-  produces<edm::ValueMap<float> >(clusterDEtaToSeed2_);
-  produces<edm::ValueMap<int> >(eleIPhi_);
-  produces<edm::ValueMap<int> >(eleIEta_);
-  produces<edm::ValueMap<float> >(eleCryPhi_);
-  produces<edm::ValueMap<float> >(eleCryEta_);
+  for( const std::string& name : float_var_names ) {
+    produces<edm::ValueMap<float> >(name);
+  }
+
+  for( const std::string& name : integer_var_names ) {
+    produces<edm::ValueMap<int> >(name);
+  }  
 }
 
 ElectronRegressionValueMapProducer::~ElectronRegressionValueMapProducer() {
-}
-
-template<typename LazyTools>
-inline void calculateValues(EcalClusterLazyToolsBase* tools_tocast,
-                            const edm::Ptr<reco::GsfElectron>& iEle,
-                            const edm::EventSetup& iSetup,
-                            std::vector<float>& vsigmaIEtaIPhi,
-                            std::vector<float>& veMax,
-                            std::vector<float>& ve2nd,
-                            std::vector<float>& veTop,
-                            std::vector<float>& veBottom,
-                            std::vector<float>& veLeft,
-                            std::vector<float>& veRight,
-                            std::vector<float>& vclusterMaxDR,
-                            std::vector<float>& vclusterMaxDRDPhi,
-                            std::vector<float>& vclusterMaxDRDEta,
-                            std::vector<float>& vclusterMaxDRRawEnergy,
-                            std::vector<float>& vclusterRawEnergy0, 
-                            std::vector<float>& vclusterRawEnergy1, 
-                            std::vector<float>& vclusterRawEnergy2, 
-                            std::vector<float>& vclusterDPhiToSeed0,
-                            std::vector<float>& vclusterDPhiToSeed1,
-                            std::vector<float>& vclusterDPhiToSeed2,
-                            std::vector<float>& vclusterDEtaToSeed0,
-                            std::vector<float>& vclusterDEtaToSeed1,
-                            std::vector<float>& vclusterDEtaToSeed2,
-                            std::vector<int>& veleIPhi,
-                            std::vector<int>& veleIEta,
-                            std::vector<float>& veleCryPhi,
-                            std::vector<float>& veleCryEta) {
-  LazyTools* tools = static_cast<LazyTools*>(tools_tocast);
-  
-  const auto& the_sc  = iEle->superCluster();
-  const auto& theseed = the_sc->seed();
-  
-  const int numberOfClusters =  the_sc->clusters().size();
-  const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
-  
-  std::vector<float> vCov = tools->localCovariances( *theseed );
-  
-  const float eMax = tools->eMax( *theseed );
-  const float e2nd = tools->e2nd( *theseed );
-  const float eTop = tools->eTop( *theseed );
-  const float eLeft = tools->eLeft( *theseed );
-  const float eRight = tools->eRight( *theseed );
-  const float eBottom = tools->eBottom( *theseed );
-  
-  float dummy;
-  int iPhi;
-  int iEta;
-  float cryPhi;
-  float cryEta;
-  EcalClusterLocal _ecalLocal;
-  if (iEle->isEB()) 
-    _ecalLocal.localCoordsEB(*theseed, iSetup, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
-  else 
-    _ecalLocal.localCoordsEE(*theseed, iSetup, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
-  
-  double see = (isnan(vCov[0]) ? 0. : sqrt(vCov[0]));
-  double spp = (isnan(vCov[2]) ? 0. : sqrt(vCov[2]));
-  double sep;    
-  if (see*spp > 0)
-    sep = vCov[1] / (see * spp);
-  else if (vCov[1] > 0)
-    sep = 1.0;
-  else
-    sep = -1.0;
-  
-  vsigmaIEtaIPhi.push_back(sep);
-  veMax.push_back(eMax);
-  ve2nd.push_back(e2nd);
-  veTop.push_back(eTop);
-  veBottom.push_back(eBottom);
-  veLeft.push_back(eLeft);
-  veRight.push_back(eRight);
-  veleIPhi.push_back(iPhi);
-  veleIEta.push_back(iEta);
-  veleCryPhi.push_back(cryPhi);
-  veleCryEta.push_back(cryEta);
-    
-  std::vector<float> _clusterRawEnergy;
-  _clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
-  std::vector<float> _clusterDEtaToSeed;
-  _clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
-  std::vector<float> _clusterDPhiToSeed;
-  _clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
-  float _clusterMaxDR     = 999.;
-  float _clusterMaxDRDPhi = 999.;
-  float _clusterMaxDRDEta = 999.;
-  float _clusterMaxDRRawEnergy = 0.;
-  
-  size_t iclus = 0;
-  float maxDR = 0;
-  edm::Ptr<reco::CaloCluster> pclus;
-  if( !missing_clusters ) {
-    // loop over all clusters that aren't the seed  
-    auto clusend = the_sc->clustersEnd();
-    for( auto clus = the_sc->clustersBegin(); clus != clusend; ++clus ) {
-      pclus = *clus;
-      
-      if(theseed == pclus ) 
-        continue;
-      _clusterRawEnergy.push_back(pclus->energy());
-      _clusterDPhiToSeed.push_back(reco::deltaPhi(pclus->phi(),theseed->phi()));
-      _clusterDEtaToSeed.push_back(pclus->eta() - theseed->eta());
-      
-      // find cluster with max dR
-      if(reco::deltaR(*pclus, *theseed) > maxDR) {
-        maxDR = reco::deltaR(*pclus, *theseed);
-        _clusterMaxDR = maxDR;
-        _clusterMaxDRDPhi = _clusterDPhiToSeed[iclus];
-        _clusterMaxDRDEta = _clusterDEtaToSeed[iclus];
-        _clusterMaxDRRawEnergy = _clusterRawEnergy[iclus];
-      }      
-      ++iclus;
-    }
-  }
-  
-  vclusterMaxDR.push_back(_clusterMaxDR);
-  vclusterMaxDRDPhi.push_back(_clusterMaxDRDPhi);
-  vclusterMaxDRDEta.push_back(_clusterMaxDRDEta);
-  vclusterMaxDRRawEnergy.push_back(_clusterMaxDRRawEnergy);
-  vclusterRawEnergy0.push_back(_clusterRawEnergy[0]); 
-  vclusterRawEnergy1.push_back(_clusterRawEnergy[1]); 
-  vclusterRawEnergy2.push_back(_clusterRawEnergy[2]); 
-  vclusterDPhiToSeed0.push_back(_clusterDPhiToSeed[0]);
-  vclusterDPhiToSeed1.push_back(_clusterDPhiToSeed[1]);
-  vclusterDPhiToSeed2.push_back(_clusterDPhiToSeed[2]);
-  vclusterDEtaToSeed0.push_back(_clusterDEtaToSeed[0]);
-  vclusterDEtaToSeed1.push_back(_clusterDEtaToSeed[1]);
-  vclusterDEtaToSeed2.push_back(_clusterDEtaToSeed[2]);
 }
 
 void ElectronRegressionValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -310,30 +316,11 @@ void ElectronRegressionValueMapProducer::produce(edm::Event& iEvent, const edm::
                                                        ebrh, eerh, esrh );
   }
 
-  std::vector<float> sigmaIEtaIPhi;
-  std::vector<float> eMax;
-  std::vector<float> e2nd;
-  std::vector<float> eTop;
-  std::vector<float> eBottom;
-  std::vector<float> eLeft;
-  std::vector<float> eRight;
-  std::vector<float> clusterMaxDR;
-  std::vector<float> clusterMaxDRDPhi;
-  std::vector<float> clusterMaxDRDEta;
-  std::vector<float> clusterMaxDRRawEnergy;
-  std::vector<float> clusterRawEnergy0; 
-  std::vector<float> clusterRawEnergy1; 
-  std::vector<float> clusterRawEnergy2; 
-  std::vector<float> clusterDPhiToSeed0;
-  std::vector<float> clusterDPhiToSeed1;
-  std::vector<float> clusterDPhiToSeed2;
-  std::vector<float> clusterDEtaToSeed0;
-  std::vector<float> clusterDEtaToSeed1;
-  std::vector<float> clusterDEtaToSeed2;
-  std::vector<int> eleIPhi;
-  std::vector<int> eleIEta;
-  std::vector<float> eleCryPhi;
-  std::vector<float> eleCryEta;
+  std::vector<std::vector<float> > float_vars(k_NFloatVars);
+  std::vector<std::vector<int> > int_vars(k_NIntVars);
+  
+  std::unordered_map<std::string,float> float_vars_map;
+  std::unordered_map<std::string,int> int_vars_map;
 
   // reco::GsfElectron::superCluster() is virtual so we can exploit polymorphism
   for (size_t i = 0; i < src->size(); ++i){
@@ -343,111 +330,51 @@ void ElectronRegressionValueMapProducer::produce(edm::Event& iEvent, const edm::
       calculateValues<noZS::EcalClusterLazyTools>(lazyTools.get(),
                                                   iEle,
                                                   iSetup,
-                                                  sigmaIEtaIPhi,
-                                                  eMax,
-                                                  e2nd,
-                                                  eTop,
-                                                  eBottom,
-                                                  eLeft,
-                                                  eRight,
-                                                  clusterMaxDR,
-                                                  clusterMaxDRDPhi,
-                                                  clusterMaxDRDEta,
-                                                  clusterMaxDRRawEnergy,
-                                                  clusterRawEnergy0, 
-                                                  clusterRawEnergy1, 
-                                                  clusterRawEnergy2, 
-                                                  clusterDPhiToSeed0,
-                                                  clusterDPhiToSeed1,
-                                                  clusterDPhiToSeed2,
-                                                  clusterDEtaToSeed0,
-                                                  clusterDEtaToSeed1,
-                                                  clusterDEtaToSeed2,
-                                                  eleIPhi,
-                                                  eleIEta,
-                                                  eleCryPhi,
-                                                  eleCryEta);
+                                                  float_vars_map,
+                                                  int_vars_map);
     } else {
       calculateValues<EcalClusterLazyTools>(lazyTools.get(),
                                             iEle,
                                             iSetup,
-                                            sigmaIEtaIPhi,
-                                            eMax,
-                                            e2nd,
-                                            eTop,
-                                            eBottom,
-                                            eLeft,
-                                            eRight,
-                                            clusterMaxDR,
-                                            clusterMaxDRDPhi,
-                                            clusterMaxDRDEta,
-                                            clusterMaxDRRawEnergy,
-                                            clusterRawEnergy0, 
-                                            clusterRawEnergy1, 
-                                            clusterRawEnergy2, 
-                                            clusterDPhiToSeed0,
-                                            clusterDPhiToSeed1,
-                                            clusterDPhiToSeed2,
-                                            clusterDEtaToSeed0,
-                                            clusterDEtaToSeed1,
-                                            clusterDEtaToSeed2,
-                                            eleIPhi,
-                                            eleIEta,
-                                            eleCryPhi,
-                                            eleCryEta);
+                                            float_vars_map,
+                                            int_vars_map);
+    }
+
+    check_map(float_vars_map, k_NFloatVars);
+    check_map(int_vars_map, k_NIntVars);
+    
+    for( unsigned i = 0; i < float_vars.size(); ++i ) {
+      float_vars[i].emplace_back(float_vars_map.at(float_var_names[i]));
+    }
+
+    for( unsigned i = 0; i < int_vars.size(); ++i ) {
+      int_vars[i].emplace_back(int_vars_map.at(integer_var_names[i]));
     }
   }
   
-  writeValueMap(iEvent, src, sigmaIEtaIPhi, sigmaIEtaIPhi_);  
-  writeValueMap(iEvent, src, eMax      ,eMax_);
-  writeValueMap(iEvent, src, e2nd	 ,e2nd_);
-  writeValueMap(iEvent, src, eTop	 ,eTop_);
-  writeValueMap(iEvent, src, eBottom	 ,eBottom_);
-  writeValueMap(iEvent, src, eLeft     ,eLeft_);
-  writeValueMap(iEvent, src, eRight	 ,eRight_);
-  writeValueMap(iEvent, src, clusterMaxDR,	   clusterMaxDR_);	  
-  writeValueMap(iEvent, src, clusterMaxDRDPhi,	   clusterMaxDRDPhi_);	  
-  writeValueMap(iEvent, src, clusterMaxDRDEta,	   clusterMaxDRDEta_);	  
-  writeValueMap(iEvent, src, clusterMaxDRRawEnergy,clusterMaxDRRawEnergy_);
-  writeValueMap(iEvent, src, clusterRawEnergy0,    clusterRawEnergy0_);   
-  writeValueMap(iEvent, src, clusterRawEnergy1,    clusterRawEnergy1_);   
-  writeValueMap(iEvent, src, clusterRawEnergy2,    clusterRawEnergy2_);   
-  writeValueMap(iEvent, src, clusterDPhiToSeed0,   clusterDPhiToSeed0_);  
-  writeValueMap(iEvent, src, clusterDPhiToSeed1,   clusterDPhiToSeed1_);  
-  writeValueMap(iEvent, src, clusterDPhiToSeed2,   clusterDPhiToSeed2_);  
-  writeValueMap(iEvent, src, clusterDEtaToSeed0,   clusterDEtaToSeed0_);  
-  writeValueMap(iEvent, src, clusterDEtaToSeed1,   clusterDEtaToSeed1_);  
-  writeValueMap(iEvent, src, clusterDEtaToSeed2,   clusterDEtaToSeed2_);  
-  writeValueMap(iEvent, src, eleIPhi		 ,eleIPhi_);
-  writeValueMap(iEvent, src, eleIEta		 ,eleIEta_);
-  writeValueMap(iEvent, src, eleCryPhi		 ,eleCryPhi_);
-  writeValueMap(iEvent, src, eleCryEta           ,eleCryEta_);
+  for( unsigned i = 0; i < float_vars.size(); ++i ) {
+    writeValueMap(iEvent, src, float_vars[i], float_var_names[i]);
+  }
+  
+  for( unsigned i = 0; i < int_vars.size(); ++i ) {
+    writeValueMap(iEvent, src, int_vars[i], integer_var_names[i]);
+  }
+  
   lazyTools.reset();
 }
 
+template<typename T>
 void ElectronRegressionValueMapProducer::writeValueMap(edm::Event &iEvent,
-					     const edm::Handle<edm::View<reco::GsfElectron> > & handle,
-					     const std::vector<float> & values,
-					     const std::string    & label) const 
+                                                       const edm::Handle<edm::View<reco::GsfElectron> > & handle,
+                                                       const std::vector<T> & values,
+                                                       const std::string    & label) const 
 {
   using namespace edm; 
   using namespace std;
-  auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
-  edm::ValueMap<float>::Filler filler(*valMap);
-  filler.insert(handle, values.begin(), values.end());
-  filler.fill();
-  iEvent.put(valMap, label);
-}
+  typedef ValueMap<T> TValueMap;
 
-void ElectronRegressionValueMapProducer::writeValueMap(edm::Event &iEvent,
-					     const edm::Handle<edm::View<reco::GsfElectron> > & handle,
-					     const std::vector<int> & values,
-					     const std::string    & label) const 
-{
-  using namespace edm; 
-  using namespace std;
-  auto_ptr<ValueMap<int> > valMap(new ValueMap<int>());
-  edm::ValueMap<int>::Filler filler(*valMap);
+  auto_ptr<TValueMap> valMap(new TValueMap());
+  typename TValueMap::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
   iEvent.put(valMap, label);

--- a/RecoEgamma/ElectronIdentification/test/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/test/BuildFile.xml
@@ -6,10 +6,19 @@
 <use   name="CondFormats/EgammaObjects"/>
 <use   name="DataFormats/EgammaCandidates"/>
 <use   name="DataFormats/EcalRecHit"/>
+<use   name="CommonTools/UtilAlgos"/>
 <use   name="root"/>
 <use   name="rootcore"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="RecoEgamma/ElectronIdentification"/>
+
 <library name="RecoEgammaElectronIdentificationVIDExample" file="VIDUsageExample.cc">
    <flags   EDM_PLUGIN="1"/>
 </library>
+
+<environment>
+  <bin   file="runtestRecoEgammaElectronIdentification.cpp">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash RecoEgamma/ElectronIdentification/test runtests.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/RecoEgamma/ElectronIdentification/test/runElectron_VID.py
+++ b/RecoEgamma/ElectronIdentification/test/runElectron_VID.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("TestElectrons")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+# NOTE: the pick the right global tag!
+#    for PHYS14 scenario PU4bx50 : global tag is ???
+#    for PHYS14 scenario PU20bx25: global tag is PHYS14_25_V1
+#  as a rule, find the global tag in the DAS under the Configs for given dataset
+#process.GlobalTag.globaltag = 'PHYS14_25_V1::All'
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+#
+# Define input data to read
+#
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+
+inputFilesAOD = cms.untracked.vstring(
+    # AOD test files from /store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/3ADB5D32-DD4F-E511-AC01-002618943811.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/54B6CF34-DD4F-E511-9629-002590596490.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/8043D96A-6C4F-E511-81E7-003048FFD736.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/8E554BD2-6D4F-E511-BFD2-0025905A60DE.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/98EB5C3F-6D4F-E511-910B-0025905A6056.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/9C8CF66A-6C4F-E511-BD02-00259059391E.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/D015FB85-6C4F-E511-88FE-002618943902.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/D873CC62-6C4F-E511-ABBA-0025905B855E.root'
+    )    
+
+inputFilesMiniAOD = cms.untracked.vstring(
+    # MiniAOD test files from /store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v1-v1
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/BE21962F-DD4F-E511-B681-002354EF3BDF.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValZEE_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/D2B5E032-DD4F-E511-96A4-0025905A610C.root'
+    )
+
+# Set up input/output depending on the format
+# You can list here either AOD or miniAOD files, but not both types mixed
+#
+
+print sys.argv[2]
+useAOD = bool(int(sys.argv[2]))
+
+if useAOD == True :
+    inputFiles = inputFilesAOD
+    outputFile = "electron_ntuple.root"
+    print("AOD input files are used")
+else :
+    inputFiles = inputFilesMiniAOD
+    outputFile = "electron_ntuple_mini.root"
+    print("MiniAOD input files are used")
+process.source = cms.Source ("PoolSource", fileNames = inputFiles )                             
+
+#
+# Set up electron ID (VID framework)
+#
+
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+# turn on VID producer, indicate data format  to be
+# DataFormat.AOD or DataFormat.MiniAOD, as appropriate 
+if useAOD == True :
+    dataFormat = DataFormat.AOD
+else :
+    dataFormat = DataFormat.MiniAOD
+
+switchOnVIDElectronIdProducer(process, dataFormat)
+
+# define which IDs we want to produce
+my_id_modules = [sys.argv[3]]
+
+#add them to the VID producer
+for idmod in my_id_modules:
+    setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+
+# Make sure to add the ID sequence upstream from the user analysis module
+process.p = cms.Path(process.egmGsfElectronIDSequence)

--- a/RecoEgamma/ElectronIdentification/test/runtestRecoEgammaElectronIdentification.cpp
+++ b/RecoEgamma/ElectronIdentification/test/runtestRecoEgammaElectronIdentification.cpp
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/RecoEgamma/ElectronIdentification/test/runtests.sh
+++ b/RecoEgamma/ElectronIdentification/test/runtests.sh
@@ -1,0 +1,15 @@
+function die { echo $1: status $2 ;  exit $2; }
+
+ids_to_test=(
+"RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V2_cff"
+"RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff"
+"RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_50ns_V1_cff"
+"RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff"
+"RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff"
+)
+
+for id_set in "${ids_to_test[@]}"; do
+    echo Checking: $id_set
+    cmsRun ${LOCAL_TEST_DIR}/runElectron_VID.py 1 $id_set || die "Failure using runElectron_VID.py on AOD $id_set" $?
+    cmsRun ${LOCAL_TEST_DIR}/runElectron_VID.py 0 $id_set || die "Failure using runElectron_VID.py on MiniAOD $id_set" $?
+done

--- a/RecoEgamma/PhotonIdentification/test/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <bin   file="runtestRecoEgammaPhotonIdentification.cpp">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash RecoEgamma/PhotonIdentification/test runtests.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/RecoEgamma/PhotonIdentification/test/runPhoton_VID.py
+++ b/RecoEgamma/PhotonIdentification/test/runPhoton_VID.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("TestPhotons")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+# NOTE: the pick the right global tag!
+#    for PHYS14 scenario PU4bx50 : global tag is ???
+#    for PHYS14 scenario PU20bx25: global tag is PHYS14_25_V1
+#  as a rule, find the global tag in the DAS under the Configs for given dataset
+#process.GlobalTag.globaltag = 'PHYS14_25_V1::All'
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+#
+# Define input data to read
+#
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+
+inputFilesAOD = cms.untracked.vstring(
+    # AOD test files from /store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/0E37A324-714F-E511-B658-003048FFD770.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/18C42D26-714F-E511-90A9-0025905B855C.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/2448F11B-734F-E511-99C8-0025905A608E.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/3A648F28-E64F-E511-9291-0026189438E1.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/5211471B-724F-E511-9B00-0025905A613C.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/8C6C961C-734F-E511-92F5-003048FF9AC6.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/BC2BE168-E74F-E511-B126-0025905A60B0.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/BEA93A19-724F-E511-B0C0-0025905A60F4.root'
+    )    
+
+inputFilesMiniAOD = cms.untracked.vstring(
+    # MiniAOD test files from /store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/14954967-E74F-E511-BEF2-0026189438EF.root',
+    '/store/relval/CMSSW_7_6_0_pre4/RelValH130GGgluonfusion_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/2061DB66-E74F-E511-9531-0026189438DB.root'
+    )
+
+# Set up input/output depending on the format
+# You can list here either AOD or miniAOD files, but not both types mixed
+#
+
+print sys.argv[2]
+useAOD = bool(int(sys.argv[2]))
+
+if useAOD == True :
+    inputFiles = inputFilesAOD
+    outputFile = "photon_ntuple.root"
+    print("AOD input files are used")
+else :
+    inputFiles = inputFilesMiniAOD
+    outputFile = "photon_ntuple_mini.root"
+    print("MiniAOD input files are used")
+process.source = cms.Source ("PoolSource", fileNames = inputFiles )
+
+#
+# Set up electron ID (VID framework)
+#
+
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+# turn on VID producer, indicate data format  to be
+# DataFormat.AOD or DataFormat.MiniAOD, as appropriate 
+if useAOD == True :
+    dataFormat = DataFormat.AOD
+else :
+    dataFormat = DataFormat.MiniAOD
+
+switchOnVIDPhotonIdProducer(process, dataFormat)
+
+# define which IDs we want to produce
+my_id_modules = [sys.argv[3]]
+
+#add them to the VID producer
+for idmod in my_id_modules:
+    setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
+
+# Make sure to add the ID sequence upstream from the user analysis module
+process.p = cms.Path(process.egmPhotonIDSequence)

--- a/RecoEgamma/PhotonIdentification/test/runtestRecoEgammaPhotonIdentification.cpp
+++ b/RecoEgamma/PhotonIdentification/test/runtestRecoEgammaPhotonIdentification.cpp
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/RecoEgamma/PhotonIdentification/test/runtests.sh
+++ b/RecoEgamma/PhotonIdentification/test/runtests.sh
@@ -1,0 +1,14 @@
+function die { echo $1: status $2 ;  exit $2; }
+
+ids_to_test=(
+"RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_PHYS14_PU20bx25_V2_cff"
+"RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_50ns_V1_cff"
+"RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V2_cff"
+"RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_50ns_nonTrig_V2_cff"
+)
+
+for id_set in "${ids_to_test[@]}"; do
+    echo Checking: $id_set
+    cmsRun ${LOCAL_TEST_DIR}/runPhoton_VID.py 1 $id_set || die "Failure using runPhoton_VID.py on AOD $id_set" $?
+    cmsRun ${LOCAL_TEST_DIR}/runPhoton_VID.py 0 $id_set || die "Failure using runPhoton_VID.py on MiniAOD $id_set" $?
+done


### PR DESCRIPTION
Addresses some recent issues (and fixes one) for maintaining out-of-the-box functionality for VID.
Particularly that VID doesn't run on top of MiniAOD right now, after this PR it does.

There are now unit tests that ensure Electron/Photon VID runs on MiniAOD and AOD out of the box.
This will help ensure problems like the one above are not encountered again.

Fixes a small bug in the calculation of regression input values.

Vectors started with size at least three, then push_back was used to assign instead of the index.

Small changes expected to MiniAOD electron energy.
