### PR TITLE
Disable LTO in BigProducts for any architecture

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -19,10 +19,8 @@
 <use name="SimDataFormats/ValidationFormats"/>
 <use name="geant4static"/>
 <flags DROP_DEP="geant4core"/>
-<architecture name="slc[6|7]_amd64_gcc49">
-  # hack needed to avoid undefined variable in CLHEP.
-  <flags REM_CXXFLAGS="-Werror=unused-variable"/>
-  # disable LTO in BigLibs, as it seems to clash with debugging symbols with gcc 4.9.x
-  <flags REM_BIGOBJ_CXXFLAGS="-flto"/>
-  <flags BIGOBJ_CXXFLAGS="-fno-lto"/>
-</architecture>
+<!-- Hack needed to avoid undefined variable in CLHEP -->
+<flags REM_CXXFLAGS="-Werror=unused-variable"/>
+<!-- Disable LTO in BigLibs, as it seems to clash with debugging symbols with gcc 4.9.X -->
+<flags REM_BIGOBJ_CXXFLAGS="-flto"/>
+<flags BIGOBJ_CXXFLAGS="-fno-lto"/>


### PR DESCRIPTION
The same applies to any Linux distribution, to any GCC starting with the
current production compiler and any architecture. Thus remove
architecture specific guards.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
