### PR TITLE
Use cluster index for assignment instead of push_back on resized vectors (75X)

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
@@ -239,9 +239,9 @@ inline void calculateValues(EcalClusterLazyToolsBase* tools_tocast,
     
     if(theseed == pclus ) 
       continue;
-    _clusterRawEnergy.push_back(pclus->energy());
-    _clusterDPhiToSeed.push_back(reco::deltaPhi(pclus->phi(),theseed->phi()));
-    _clusterDEtaToSeed.push_back(pclus->eta() - theseed->eta());
+    _clusterRawEnergy[iclus]  = pclus->energy();
+    _clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
+    _clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
     
     // find cluster with max dR
     if(reco::deltaR(*pclus, *theseed) > maxDR) {


### PR DESCRIPTION
Backport of #11236.
