### PR TITLE
HcalTopology HT size initialization fix

### DIFF
--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -36,6 +36,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode, int maxDepthHB, int maxD
   HESize_(kHESizePreLS1),
   HOSize_(kHOSizePreLS1),
   HFSize_(kHFSizePreLS1),
+  HTSize_(kHTSizePreLS1),
   numberOfShapes_(( mode==HcalTopologyMode::SLHC ) ? 500 : 87 ) {
 
   if (mode_==HcalTopologyMode::LHC) {
@@ -44,12 +45,16 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode, int maxDepthHB, int maxD
     HESize_= kHESizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_= kHOSizePreLS1; // ieta * iphi * 2
     HFSize_= kHFSizePreLS1; // phi * eta * depth * pm 
+    HTSize_= kHTSizePreLS1; // NB: will need an need update,
+                            // once full HF granularity is set 
+
   } else if (mode_==HcalTopologyMode::SLHC) { // need to know more eventually
     HBSize_= maxDepthHB*16*72*2;
     HESize_= maxDepthHE*(29-16+1)*72*2;
     HOSize_= 15*72*2; // ieta * iphi * 2
     HFSize_= 72*13*2*2; // phi * eta * depth * pm 
-
+    HTSize_= kHTSizePreLS1; // NB: will need an update, 
+                            // once full HF granularity is set 
     topoVersion_=10;
   }
     


### PR DESCRIPTION
This initialization has been lost in CVS->GIT translation and has been only added to 62X_SLHCx series...
runTheMatrix.py -s --useInput all    - finished successfully 
