### PR TITLE
Use anonymous namespace to avoid duplicate symbols

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
@@ -100,10 +100,12 @@ EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf) :
   ele_idx = pho_idx = 0;
 }
 
-inline void get_product(const edm::Event& evt,
-                        const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
-                        std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
-  if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+namespace {
+  inline void get_product(const edm::Event& evt,
+                          const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
+    if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+  }
 }
 
 void EGPfIsolationModifierFromValueMaps::
@@ -152,8 +154,10 @@ void EGPfIsolationModifierFromValueMaps::
 setEventContent(const edm::EventSetup& evs) {
 }
 
-template<typename T, typename U, typename V>
-inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+namespace {
+  template<typename T, typename U, typename V>
+  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+}
 
 void EGPfIsolationModifierFromValueMaps::
 setConsumes(edm::ConsumesCollector& sumes) {
@@ -178,12 +182,14 @@ setConsumes(edm::ConsumesCollector& sumes) {
   }   
 }
 
-template<typename T, typename U, typename V>
-inline void assignValue(const T& ptr, const U& input_map, const std::string& name, const V& map, float& value) {
-  auto itr = input_map.find(name);
-  if( itr == input_map.end() ) return;
-  const auto& tok = std::get<1>(itr->second);
-  if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+namespace {
+  template<typename T, typename U, typename V>
+  inline void assignValue(const T& ptr, const U& input_map, const std::string& name, const V& map, float& value) {
+    auto itr = input_map.find(name);
+    if( itr == input_map.end() ) return;
+    const auto& tok = std::get<1>(itr->second);
+    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+  }
 }
 
 void EGPfIsolationModifierFromValueMaps::


### PR DESCRIPTION
Bug fix. Totally technical.
In RecoEgamma/EgammaTools/plugins, there were free function templates in different files that had the same signature. These were violations of the ODR (one definition rule).
The reason this problem had not yet been seen before is that the function templates in question are declared "inline". However, "inline" is only a suggestion to the compiler. When compiled in debug mode (-O0), in-lining was apparently turned off. This did not cause a link error, as function templates are not instantiated until run time. However, it caused the wrong function to be called in several cases, causing relvals 4.53, 135.4, and 1330.0 to fail.
This problem was previously fixed in CMSSW_7_5_X with PR #11069. However, since #11069 was
merged, another file was introduced into 7_5_X that has the same issue. This new PR makes the same fix to the in-line template free functions in this new file by nesting them inside an anonymous namespace.
