### PR TITLE
CSC Beam Halo filter update

### DIFF
--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -17,9 +17,6 @@
 #include "DataFormats/METReco/interface/HcalHaloData.h" 
 #include "DataFormats/METReco/interface/GlobalHaloData.h" 
 
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
-
 namespace reco {
   class BeamHaloInfoProducer;
   
@@ -42,6 +39,8 @@ namespace reco {
 
     const bool CSCLooseHaloId() const { return CSCHaloReport.size() ? CSCHaloReport[0] : false ; }
     const bool CSCTightHaloId() const { return CSCHaloReport.size() > 1 ? CSCHaloReport[1] : false ; }
+    const bool CSCTightHaloIdTrkMuUnveto() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false ; }
+    const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 5 ? CSCHaloReport[5] : false ; }
     
     const bool GlobalLooseHaloId() const { return GlobalHaloReport.size() ? GlobalHaloReport[0] : false ; }
     const bool GlobalTightHaloId() const { return GlobalHaloReport.size() > 1 ? GlobalHaloReport[1] : false ; }
@@ -72,10 +71,10 @@ namespace reco {
 
     std::vector<int>& GetGlobaliPhiSuspects() { return GlobaliPhiSuspects ;}
     const std::vector<int>& GetGlobaliPhiSuspects() const { return GlobaliPhiSuspects ;}
-
+    
     std::vector<HaloTowerStrip>& getProblematicStrips() { return problematicStrips ;}
     const std::vector<HaloTowerStrip>& getProblematicStrips() const { return problematicStrips ;}
-
+    
   private: 
     std::vector<char>  HcalHaloReport;
     std::vector<char>  EcalHaloReport;
@@ -87,7 +86,7 @@ namespace reco {
     std::vector<int>  GlobaliPhiSuspects;
 
     std::vector<HaloTowerStrip> problematicStrips;
-
+    
   };
   
 }

--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -17,6 +17,9 @@
 #include "DataFormats/METReco/interface/HcalHaloData.h" 
 #include "DataFormats/METReco/interface/GlobalHaloData.h" 
 
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
+
 namespace reco {
   class BeamHaloInfoProducer;
   

--- a/DataFormats/METReco/interface/CSCHaloData.h
+++ b/DataFormats/METReco/interface/CSCHaloData.h
@@ -31,7 +31,9 @@ namespace reco {
 
     // Number of HaloTriggers in +/- endcap
     int NumberOfHaloTriggers (HaloData::Endcap z= HaloData::both) const ;
+    int NumberOfHaloTriggers_TrkMuUnVeto (HaloData::Endcap z= HaloData::both) const ;
     int NHaloTriggers(HaloData::Endcap z = HaloData::both ) const { return NumberOfHaloTriggers(z);}
+
     // Number of Halo Tracks in +/-  endcap
     int NumberOfHaloTracks(HaloData::Endcap z= HaloData::both) const ;
     int NHaloTracks(HaloData::Endcap z = HaloData::both) const { return NumberOfHaloTracks(z) ;}
@@ -53,7 +55,12 @@ namespace reco {
     // MLR
     short int NFlatHaloSegments() const{ return nFlatHaloSegments; }
     bool GetSegmentsInBothEndcaps() const{ return segments_in_both_endcaps; }
+    bool GetSegmentIsCaloMatched() const{ return segmentiscalomatched; }
     // End MLR
+    short int NFlatHaloSegments_TrkMuUnVeto() const{ return nFlatHaloSegments_TrkMuUnVeto; }
+    bool GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() const{ return segments_in_both_endcaps_loose_TrkMuUnVeto;}
+    bool GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() const{ return segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;}
+
 
     // Get Reference to the Tracks
     edm::RefVector<reco::TrackCollection>& GetTracks(){return TheTrackRefs;}
@@ -61,7 +68,7 @@ namespace reco {
     
     // Set Number of Halo Triggers
     void SetNumberOfHaloTriggers(int PlusZ,  int MinusZ ){ nTriggers_PlusZ =PlusZ; nTriggers_MinusZ = MinusZ ;}
-
+    void SetNumberOfHaloTriggers_TrkMuUnVeto(int PlusZ,  int MinusZ ){ nTriggers_PlusZ_TrkMuUnVeto =PlusZ; nTriggers_MinusZ_TrkMuUnVeto = MinusZ ;}
     // Set number of chamber-level triggers with non-collision timing
     void SetNOutOfTimeTriggers(short int PlusZ,short int MinusZ){ nOutOfTimeTriggers_PlusZ = PlusZ ; nOutOfTimeTriggers_MinusZ = MinusZ;}
     // Set number of CSCRecHits with non-collision timing
@@ -85,6 +92,11 @@ namespace reco {
     void SetNFlatHaloSegments(short int nSegments) {nFlatHaloSegments = nSegments;}
     void SetSegmentsBothEndcaps(bool b) { segments_in_both_endcaps = b; }
     // End MLR
+    void SetNFlatHaloSegments_TrkMuUnVeto(short int nSegments) {nFlatHaloSegments_TrkMuUnVeto = nSegments;}
+    void SetSegmentsBothEndcaps_Loose_TrkMuUnVeto(bool b) { segments_in_both_endcaps_loose_TrkMuUnVeto = b; }
+    void SetSegmentsBothEndcaps_Loose_dTcut_TrkMuUnVeto(bool b) { segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto = b; }
+    void SetSegmentIsCaloMatched(bool b) { segmentiscalomatched = b; }
+
   private:
     edm::RefVector<reco::TrackCollection> TheTrackRefs;
 
@@ -92,7 +104,8 @@ namespace reco {
     std::vector<GlobalPoint> TheGlobalPositions;
     int nTriggers_PlusZ;
     int nTriggers_MinusZ;
-
+    int nTriggers_PlusZ_TrkMuUnVeto;
+    int nTriggers_MinusZ_TrkMuUnVeto;
     // CSC halo trigger reported by the HLT
     bool HLTAccept;
    
@@ -117,7 +130,10 @@ namespace reco {
     short int nFlatHaloSegments;
     bool segments_in_both_endcaps;
     // end MLR
-
+    short int nFlatHaloSegments_TrkMuUnVeto;
+    bool segments_in_both_endcaps_loose_TrkMuUnVeto;
+    bool segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;
+    bool segmentiscalomatched ;
   };
 
 

--- a/DataFormats/METReco/src/BeamHaloSummary.cc
+++ b/DataFormats/METReco/src/BeamHaloSummary.cc
@@ -11,7 +11,7 @@ using namespace reco;
 
 BeamHaloSummary::BeamHaloSummary()
 {
-  for( unsigned int i = 0 ; i < 4 ; i++ )
+  for( unsigned int i = 0 ; i < 6 ; i++ )
     {
       CSCHaloReport.push_back(0);
       if( i < 2 )

--- a/DataFormats/METReco/src/CSCHaloData.cc
+++ b/DataFormats/METReco/src/CSCHaloData.cc
@@ -39,6 +39,19 @@ int CSCHaloData::NumberOfHaloTriggers(HaloData::Endcap z) const
     return nTriggers_MinusZ + nTriggers_PlusZ;
 }
 
+
+
+int CSCHaloData::NumberOfHaloTriggers_TrkMuUnVeto(HaloData::Endcap z) const
+{
+  if( z == HaloData::plus )
+    return nTriggers_PlusZ_TrkMuUnVeto;
+  else if( z == HaloData::minus )
+    return nTriggers_MinusZ_TrkMuUnVeto;
+  else
+    return nTriggers_MinusZ_TrkMuUnVeto + nTriggers_PlusZ_TrkMuUnVeto;
+}
+
+
 short int CSCHaloData::NumberOfOutOfTimeTriggers(HaloData::Endcap z ) const
 {
   if( z == HaloData::plus  ) 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -175,7 +175,8 @@
   <class name="std::vector<HaloTowerStrip>"/>
   <class name="edm::Wrapper<std::vector<HaloTowerStrip> >"/>
 
-  <class name="reco::CSCHaloData" ClassVersion="10">
+  <class name="reco::CSCHaloData" ClassVersion="11">
+   <version ClassVersion="11" checksum="1723373351"/>
    <version ClassVersion="10" checksum="3522217120"/>
   </class>
   <class name="edm::Wrapper<reco::CSCHaloData>"/>

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -164,7 +164,9 @@
   </class>
   <class name="edm::Wrapper<reco::EcalHaloData>"/>
 
-  <class name="reco::HcalHaloData" ClassVersion="11">
+  <class name="reco::HcalHaloData" ClassVersion="13">
+   <version ClassVersion="13" checksum="3305429659"/>
+   <version ClassVersion="12" checksum="3928363167"/>
    <version ClassVersion="10" checksum="3928363167"/>
    <version ClassVersion="11" checksum="3305429659"/>
   </class>
@@ -183,7 +185,9 @@
   </class>
   <class name="edm::Wrapper<reco::GlobalHaloData>"/>
 
-  <class name="reco::BeamHaloSummary" ClassVersion="11">
+  <class name="reco::BeamHaloSummary" ClassVersion="13">
+   <version ClassVersion="13" checksum="146570384"/>
+   <version ClassVersion="12" checksum="1514181401"/>
    <version ClassVersion="10" checksum="1514181401"/>
    <version ClassVersion="11" checksum="146570384"/>
   </class>

--- a/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CSCHaloAlgo.h
@@ -37,11 +37,14 @@
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/L1CSCTrackFinder/interface/L1CSCTrackCollection.h"
 #include "DataFormats/L1CSCTrackFinder/interface/L1CSCStatusDigiCollection.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutRecord.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/MuonDetId/interface/CSCIndexer.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
@@ -56,12 +59,14 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCChamber.h"
 #include "Geometry/CSCGeometry/interface/CSCLayer.h"
 #include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -77,6 +82,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Framework/interface/Event.h"
 
+
 namespace edm {
   class TriggerNames;
 }
@@ -90,9 +96,11 @@ class CSCHaloAlgo {
 			      const edm::Handle<reco::MuonTimeExtraMap> TheCSCTimeMap,
 			      edm::Handle<reco::MuonCollection>& TheMuons, edm::Handle<CSCSegmentCollection>& TheCSCSegments, 
 			      edm::Handle<CSCRecHit2DCollection>& TheCSCRecHits,edm::Handle < L1MuGMTReadoutCollection >& TheL1GMTReadout,
+			      edm::Handle<HBHERecHitCollection>& hbhehits,edm::Handle<EcalRecHitCollection>& ecalebhits,
+			      edm::Handle<EcalRecHitCollection>& ecaleehits,
 			      edm::Handle<edm::TriggerResults>& TheHLTResults, const edm::TriggerNames * triggerNames, 
 			      const edm::Handle<CSCALCTDigiCollection>& TheALCTs, MuonSegmentMatcher *TheMatcher,
-			      const edm::Event &TheEvent);
+			      const edm::Event &TheEvent, const edm::EventSetup &TheEventSetup);
 
   std::vector<edm::InputTag> vIT_HLTBit;
 
@@ -140,6 +148,17 @@ class CSCHaloAlgo {
   float max_segment_phi_diff;
   float max_segment_theta;
   // End MLR
+  float  et_thresh_rh_hbhe, dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe, dr_highthresh_segvsrh_hbhe, dt_lowthresh_segvsrh_hbhe;
+  float  et_thresh_rh_eb, dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb, dr_highthresh_segvsrh_eb, dt_lowthresh_segvsrh_eb;
+  float  et_thresh_rh_ee, dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee, dr_highthresh_segvsrh_ee, dt_lowthresh_segvsrh_ee;
+
+  
+  
+  const CaloGeometry *geo;
+  math::XYZPoint getPosition(const DetId &id, reco::Vertex::Point vtx);
+  bool HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float iZ, float iR, float iT, float iPhi);
+  bool ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float iZ, float iR, float iT, float iPhi );
+
 };
 
 #endif

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -1,3 +1,4 @@
+
 #include "RecoMET/METAlgorithms/interface/CSCHaloAlgo.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 /*
@@ -32,6 +33,33 @@ CSCHaloAlgo::CSCHaloAlgo()
   matching_dphi_threshold = 0.18; //radians
   matching_deta_threshold = 0.4;
   matching_dwire_threshold = 5.;
+
+
+  et_thresh_rh_hbhe=10; //GeV
+  et_thresh_rh_ee=10; 
+  et_thresh_rh_eb=10; 
+
+  dphi_thresh_segvsrh_hbhe=0.05; //radians
+  dphi_thresh_segvsrh_eb=0.05;
+  dphi_thresh_segvsrh_ee=0.05; 
+
+  dr_lowthresh_segvsrh_hbhe=-25; //cm
+  dr_lowthresh_segvsrh_eb=-25; 
+  dr_lowthresh_segvsrh_ee=-25;
+
+  dr_highthresh_segvsrh_hbhe=25; //cm
+  dr_highthresh_segvsrh_eb=25; 
+  dr_highthresh_segvsrh_ee=25;
+
+  dt_lowthresh_segvsrh_hbhe=0;//ns
+  dt_lowthresh_segvsrh_eb=0;
+  dt_lowthresh_segvsrh_ee=0;
+
+
+  geo = 0;
+
+
+  
 }
 
 reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
@@ -41,14 +69,29 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 					 edm::Handle<CSCSegmentCollection>& TheCSCSegments, 
 					 edm::Handle<CSCRecHit2DCollection>& TheCSCRecHits,
 					 edm::Handle < L1MuGMTReadoutCollection >& TheL1GMTReadout,
+					 edm::Handle<HBHERecHitCollection>& hbhehits,
+					 edm::Handle<EcalRecHitCollection>& ecalebhits,
+					 edm::Handle<EcalRecHitCollection>& ecaleehits,
 					 edm::Handle<edm::TriggerResults>& TheHLTResults,
 					 const edm::TriggerNames * triggerNames, 
 					 const edm::Handle<CSCALCTDigiCollection>& TheALCTs,
 					 MuonSegmentMatcher *TheMatcher,  
-					 const edm::Event& TheEvent)
+					 const edm::Event& TheEvent,
+					 const edm::EventSetup& TheSetup)
 {
   reco::CSCHaloData TheCSCHaloData;
   int imucount=0;
+  
+  bool calomatched =false;
+  if(!geo){
+    edm::ESHandle<CaloGeometry> pGeo;
+    TheSetup.get<CaloGeometryRecord>().get(pGeo);
+    geo = pGeo.product();
+  }
+  bool trkmuunvetoisdefault = false; //Pb with low pt tracker muons that veto good csc segments/halo triggers. 
+  //Test to "unveto" low pt trk muons. 
+  //For now, we just recalculate everything without the veto and add an extra set of variables to the class CSCHaloData. 
+  //If this is satisfactory, these variables can become the default ones by setting trkmuunvetoisdefault to true. 
   if( TheCosmicMuons.isValid() )
     {
       short int n_tracks_small_beta=0;
@@ -80,14 +123,14 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	      const GlobalPoint TheGlobalPosition = TheSurface.toGlobal(TheLocalPosition);
 
 	      float z = TheGlobalPosition.z();
-	      if( TMath::Abs(z) < innermost_global_z )
+	      if( abs(z) < innermost_global_z )
 		{
-		  innermost_global_z = TMath::Abs(z);
+		  innermost_global_z = abs(z);
 		  InnerMostGlobalPosition = GlobalPoint( TheGlobalPosition);
 		}
-	      if( TMath::Abs(z) > outermost_global_z )
+	      if( abs(z) > outermost_global_z )
 		{
-		  outermost_global_z = TMath::Abs(z);
+		  outermost_global_z = abs(z);
 		  OuterMostGlobalPosition = GlobalPoint( TheGlobalPosition );
 		}
 	      nCSCHits ++;
@@ -109,14 +152,14 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	      const GlobalPoint TheGlobalPosition = TheCSCChamber->toGlobal(TheLocalPosition);
 	      float z = TheGlobalPosition.z();
 	      int TheEndcap = TheCSCDetId.endcap();
-	      if( TMath::Abs(z) < innermost_seg_z[TheEndcap-1] )
+	      if( abs(z) < innermost_seg_z[TheEndcap-1] )
 		{
-		  innermost_seg_z[TheEndcap-1] = TMath::Abs(z);
+		  innermost_seg_z[TheEndcap-1] = abs(z);
 		  InnerSegmentTime[TheEndcap-1] = (*segment)->time();
 		}
-	      if( TMath::Abs(z) > outermost_seg_z[TheEndcap-1] )
+	      if( abs(z) > outermost_seg_z[TheEndcap-1] )
 		{
-		  outermost_seg_z[TheEndcap-1] = TMath::Abs(z);
+		  outermost_seg_z[TheEndcap-1] = abs(z);
 		  OuterSegmentTime[TheEndcap-1] = (*segment)->time();
 		}
 	    }
@@ -143,8 +186,8 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	  //Its a CSC Track,store it if it passes halo selection 
 	  StoreTrack = true;	  
 
-	  float deta = TMath::Abs( OuterMostGlobalPosition.eta() - InnerMostGlobalPosition.eta() );
-	  float dphi = TMath::ACos( TMath::Cos( OuterMostGlobalPosition.phi() - InnerMostGlobalPosition.phi() ) ) ;
+	  float deta = abs( OuterMostGlobalPosition.eta() - InnerMostGlobalPosition.eta() );
+	  float dphi = abs(deltaPhi( OuterMostGlobalPosition.phi() , InnerMostGlobalPosition.phi() )) ;
 	  float theta = Track->outerMomentum().theta();
 	  float innermost_x = InnerMostGlobalPosition.x() ;
 	  float innermost_y = InnerMostGlobalPosition.y();
@@ -259,6 +302,9 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
        int icsc = 0;
        int PlusZ = 0 ;
        int MinusZ = 0 ;
+       int PlusZ_alt = 0 ;
+       int MinusZ_alt = 0 ;
+
        // Check to see if CSC BeamHalo trigger is tripped
        for (igmtrr = gmt_records.begin (); igmtrr != gmt_records.end (); igmtrr++)
 	 {
@@ -275,16 +321,20 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		      halophi = halophi > TMath::Pi() ? halophi - 2.*TMath::Pi() : halophi;
 		      float haloeta = iter1->etaValue();
 		      bool HaloIsGood = true;
+		      bool HaloIsGood_alt = true;
 		      // Check if halo trigger is faked by any collision muons
 		      if( TheMuons.isValid() )
 			{
 			  float dphi = 9999.;
 			  float deta = 9999.;
-			  for( reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu != TheMuons->end() && HaloIsGood ; mu++ )
+			  for( reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu != TheMuons->end()  && (HaloIsGood ||!trkmuunvetoisdefault) ; mu++ )
 			    {
 			      // Don't match with SA-only muons
+			      bool lowpttrackmu =false;
 			      if( mu->isStandAloneMuon() && !mu->isTrackerMuon() && !mu->isGlobalMuon() )  continue;
-			      
+			      if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3 && trkmuunvetoisdefault) continue;
+			      if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3 ) lowpttrackmu = true;
+
 			      /*
 			      if(!mu->isTrackerMuon())
 				{
@@ -292,7 +342,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 				    {
 				      //make sure that this SA muon is not actually a halo-like muon
 				      float theta =  mu->outerTrack()->outerMomentum().theta();
-				      float deta = TMath::Abs(mu->outerTrack()->outerPosition().eta() - mu->outerTrack()->innerPosition().eta());
+				      float deta = abs(mu->outerTrack()->outerPosition().eta() - mu->outerTrack()->innerPosition().eta());
 				      if( theta < min_outer_theta || theta > max_outer_theta )  //halo-like
 					continue;
 				      else if ( deta > deta_threshold ) //halo-like
@@ -323,21 +373,30 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 					  float phi_ = TheGlobalPosition.phi();
 					  float eta_ = TheGlobalPosition.eta();
 					  
-					  deta = deta < TMath::Abs( eta_ - haloeta ) ? deta : TMath::Abs( eta_ - haloeta );
-					  dphi = dphi < TMath::ACos(TMath::Cos(phi_ - halophi)) ? dphi : TMath::ACos(TMath::Cos(phi_ - halophi));
+					  deta = deta < abs( eta_ - haloeta ) ? deta : abs( eta_ - haloeta );
+					  dphi = dphi < abs(deltaPhi(phi_, halophi)) ? dphi : abs(deltaPhi(phi_, halophi));
 					}
 				    }
 				}
-			      if ( dphi < matching_dphi_threshold && deta < matching_deta_threshold) 
+			      if ( dphi < matching_dphi_threshold && deta < matching_deta_threshold){ 
 				HaloIsGood = false; // i.e., collision muon likely faked halo trigger
+				if(!lowpttrackmu)HaloIsGood_alt   = false;
+			      }
 			    }
 			}
-		      if( !HaloIsGood ) 
-			continue;
-		      if( (*iter1).etaValue() > 0 )
-			PlusZ++;
-		      else
-			MinusZ++;
+		      if( HaloIsGood ){ 
+			if( (*iter1).etaValue() > 0 )
+			  PlusZ++;
+			else
+			  MinusZ++;
+		      }
+		      if( HaloIsGood_alt ){
+			if( (*iter1).etaValue() > 0 )
+                          PlusZ_alt++;
+                        else
+                          MinusZ_alt++;
+                      }
+
 		    }
 		  else
 		    icsc++;
@@ -345,6 +404,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	     }
 	 }
        TheCSCHaloData.SetNumberOfHaloTriggers(PlusZ, MinusZ);
+       TheCSCHaloData.SetNumberOfHaloTriggers_TrkMuUnVeto(PlusZ_alt, MinusZ_alt);
      }
    else
      {
@@ -387,8 +447,9 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		       //Check if there are any collision muons with hits in the vicinity of the digi
 		       for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && DigiIsGood ; mu++ )
 			 {
+			   
 			   if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon() ) continue;
-
+			   if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3 &&trkmuunvetoisdefault) continue;
 			   const std::vector<MuonChamberMatch> chambers = mu->matches();
 			   for(std::vector<MuonChamberMatch>::const_iterator iChamber = chambers.begin();
 			       iChamber != chambers.end(); iChamber ++ )
@@ -407,7 +468,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 				       if( iHit->cscDetId().ring() != digi_ring ) continue;
 				       if( iHit->cscDetId().chamber() != digi_chamber ) continue;
 				       int hit_wire = iHit->hitWire();
-				       dwire = dwire < TMath::Abs(hit_wire - digi_wire)? dwire : TMath::Abs(hit_wire - digi_wire );
+				       dwire = dwire < abs(hit_wire - digi_wire)? dwire : abs(hit_wire - digi_wire );
 				     }
 				 }
 			     }
@@ -497,6 +558,14 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
    bool plus_endcap = false;
    bool minus_endcap = false;
    bool both_endcaps = false;
+   bool both_endcaps_loose = false;
+   //   bool both_endcaps_dtcut = false;
+
+   short int maxNSegments_alt = 0;
+   bool both_endcaps_alt = false;
+   bool both_endcaps_loose_alt = false;
+   bool both_endcaps_loose_dtcut_alt = false;
+
    //float r = 0., phi = 0.;
    if (TheCSCSegments.isValid()) {
      for(CSCSegmentCollection::const_iterator iSegment = TheCSCSegments->begin();
@@ -504,13 +573,18 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
          iSegment++) {
 
        CSCDetId iCscDetID = iSegment->cscDetId();
-       bool SegmentIsGood=true;
+       bool Segment1IsGood=true;
+       bool Segment1IsGood_alt=true;
+
        //avoid segments from collision muons
        if( TheMuons.isValid() )
 	 {
-	   for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && SegmentIsGood ; mu++ )
+	   for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && (Segment1IsGood||!trkmuunvetoisdefault)   ; mu++ )
 	     {
+	       bool  lowpttrackmu=false;
 	       if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon() ) continue;
+	       if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon()&&trkmuunvetoisdefault) continue;
+	       if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3) lowpttrackmu=true;
 	       const std::vector<MuonChamberMatch> chambers = mu->matches();
 	       for(std::vector<MuonChamberMatch>::const_iterator kChamber = chambers.begin();
 		   kChamber != chambers.end(); kChamber ++ )
@@ -524,14 +598,15 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		       
 		       if( kCscDetID == iCscDetID ) 
 			 {
-			   SegmentIsGood = false;
+			   Segment1IsGood = false;
+			   if(!lowpttrackmu) Segment1IsGood_alt=false;
 			 }
 		     }
 		 }
 	     }
 	 }
-       if(!SegmentIsGood) continue;
-
+       if(!Segment1IsGood&&!Segment1IsGood_alt) continue;
+       
        // Get local direction vector; if direction runs parallel to beamline,
        // count this segment as beam halo candidate.
        LocalPoint iLocalPosition = iSegment->localPosition();
@@ -545,14 +620,26 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
        
        float iPhi = iGlobalPosition.phi();
        float iR =  TMath::Sqrt(iGlobalPosition.x()*iGlobalPosition.x() + iGlobalPosition.y()*iGlobalPosition.y());
-       short int nSegs = 0;
+       float iZ = iGlobalPosition.z();
+       float iT = iSegment->time();
+       //       if(abs(iZ)<650&& TheEvent.id().run()< 251737) iT-= 25; 
+       //Calo matching:
 
+       bool hbhematched = HCALSegmentMatching(hbhehits,et_thresh_rh_hbhe,dphi_thresh_segvsrh_hbhe,dr_lowthresh_segvsrh_hbhe,dr_highthresh_segvsrh_hbhe,dt_lowthresh_segvsrh_hbhe,iZ,iR,iT,iPhi);
+       bool ebmatched = ECALSegmentMatching(ecalebhits,et_thresh_rh_eb,dphi_thresh_segvsrh_eb,dr_lowthresh_segvsrh_eb,dr_highthresh_segvsrh_eb,dt_lowthresh_segvsrh_eb,iZ,iR,iT,iPhi);
+       bool eematched = ECALSegmentMatching(ecaleehits,et_thresh_rh_ee,dphi_thresh_segvsrh_ee,dr_lowthresh_segvsrh_ee,dr_highthresh_segvsrh_ee,dt_lowthresh_segvsrh_ee,iZ,iR,iT,iPhi); 
+       calomatched = calomatched? true: (hbhematched|| ebmatched|| eematched);
+
+
+       short int nSegs = 0;
+       short int nSegs_alt = 0;
        // Changed to loop over all Segments (so N^2) to catch as many segments as possible.
        for (CSCSegmentCollection::const_iterator jSegment = TheCSCSegments->begin();
          jSegment != TheCSCSegments->end();
          jSegment++) {
 	 if (jSegment == iSegment) continue;
-	 SegmentIsGood=true;
+	 bool Segment2IsGood = true;
+	 bool Segment2IsGood_alt = true;
 	 LocalPoint jLocalPosition = jSegment->localPosition();
 	 LocalVector jLocalDirection = jSegment->localDirection();
 	 CSCDetId jCscDetID = jSegment->cscDetId();
@@ -561,14 +648,19 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 float jTheta = jGlobalDirection.theta();
 	 float jPhi = jGlobalPosition.phi();
 	 float jR =  TMath::Sqrt(jGlobalPosition.x()*jGlobalPosition.x() + jGlobalPosition.y()*jGlobalPosition.y());
-
-	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= max_segment_phi_diff 
-	     && TMath::Abs(jR - iR) <= max_segment_r_diff 
+	 float jZ = jGlobalPosition.z() ;
+	 float jT = jSegment->time();
+	 //	 if(abs(jZ)<650&& TheEvent.id().run() < 251737)jT-= 25;
+	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= 0.2//max_segment_phi_diff 
+	     //&& abs(jR - iR) <= max_segment_r_diff 
+	     && (abs(jR - iR) <= max_segment_r_diff || (abs(jR - iR)<0.03*abs(jZ - iZ) &&  jZ*iZ<0) )
 	     && (jTheta < max_segment_theta || jTheta > TMath::Pi() - max_segment_theta)) {
 	   //// Check if Segment matches to a colision muon
 	   if( TheMuons.isValid() ) {
-	     for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end() && SegmentIsGood ; mu++ ) {
+	     for(reco::MuonCollection::const_iterator mu = TheMuons->begin(); mu!= TheMuons->end()  && (Segment2IsGood||!trkmuunvetoisdefault) ; mu++ ) {
+	       bool  lowpttrackmu=false;
 	       if( !mu->isTrackerMuon() && !mu->isGlobalMuon() && mu->isStandAloneMuon() ) continue;
+	       if( !mu->isGlobalMuon() &&  mu->isTrackerMuon() &&  mu->pt()<3) lowpttrackmu= true;
 	       const std::vector<MuonChamberMatch> chambers = mu->matches();
 	       for(std::vector<MuonChamberMatch>::const_iterator kChamber = chambers.begin();
 		   kChamber != chambers.end(); kChamber ++ ) {
@@ -579,21 +671,37 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 		   CSCDetId kCscDetID = cscSegRef->cscDetId();
 		   
 		   if( kCscDetID == jCscDetID ) {
-		     SegmentIsGood = false;
+		     Segment2IsGood = false;
+		     if(!lowpttrackmu) Segment2IsGood_alt=false;
 		   }
 		 }
 	       }
 	     }
 	   }   
-	   if(SegmentIsGood) {
+	   if(Segment1IsGood && Segment2IsGood) {
 	     nSegs++;
 	     minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
 	     plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
+	     //	     if( abs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )<0.05 && abs(jT-iT)/sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) )>0.02 && minus_endcap&&plus_endcap ) both_endcaps_dtcut =true;
 	   }
+	   if(Segment1IsGood_alt && Segment2IsGood_alt) {
+             nSegs_alt++;
+             minus_endcap = iGlobalPosition.z() < 0 || jGlobalPosition.z() < 0;
+             plus_endcap = iGlobalPosition.z() > 0 || jGlobalPosition.z() > 0;
+             if( abs(jT-iT)<0.05*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && abs(jT-iT)> 0.02*sqrt( (jR-iR)*(jR-iR)+(jZ-iZ)*(jZ-iZ) ) && minus_endcap&&plus_endcap ) both_endcaps_loose_dtcut_alt =true;
+           }
+	   
 	 }
        }
        // Correct the fact that the way nSegs counts will always be short by 1
        if (nSegs > 0) nSegs++;
+       
+       // The opposite endcaps segments do not need to belong to the longest chain. 
+       if (nSegs > 0) both_endcaps_loose =  both_endcaps_loose ? both_endcaps_loose : minus_endcap && plus_endcap;
+       if (nSegs_alt > 0) nSegs_alt++;
+       if (nSegs_alt > 0) both_endcaps_loose_alt =  both_endcaps_loose_alt ? both_endcaps_loose_alt : minus_endcap && plus_endcap;
+
+       //       if (nSegs > 0) both_endcaps_dt20ns = both_endcaps_dt20ns ? both_endcaps_dt20ns : minus_endcap && plus_endcap &&dt20ns;
        if (nSegs > maxNSegments) {
 	 // Use value of r, phi to collect halo CSCSegments for examining timing (not coded yet...)
 	 //r = iR;
@@ -601,12 +709,64 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 maxNSegments = nSegs;
 	 both_endcaps = both_endcaps ? both_endcaps : minus_endcap && plus_endcap;
        }
+      
+       if (nSegs_alt > maxNSegments_alt) {
+       	 maxNSegments_alt = nSegs_alt;
+         both_endcaps_alt = both_endcaps_alt ? both_endcaps_alt : minus_endcap && plus_endcap;
+       }
+ 
      }
    }
    TheCSCHaloData.SetNFlatHaloSegments(maxNSegments);
    TheCSCHaloData.SetSegmentsBothEndcaps(both_endcaps);
-   // End MLR
+   TheCSCHaloData.SetNFlatHaloSegments_TrkMuUnVeto(maxNSegments_alt);
+   TheCSCHaloData.SetSegmentsBothEndcaps_Loose_TrkMuUnVeto(both_endcaps_loose_alt);
+   TheCSCHaloData.SetSegmentsBothEndcaps_Loose_dTcut_TrkMuUnVeto(both_endcaps_loose_dtcut_alt);
+   TheCSCHaloData.SetSegmentIsCaloMatched(calomatched);
 
    return TheCSCHaloData;
 }
 
+math::XYZPoint CSCHaloAlgo::getPosition(const DetId &id, reco::Vertex::Point vtx){
+
+  const GlobalPoint& pos=geo->getPosition(id);
+  math::XYZPoint posV(pos.x() - vtx.x(),pos.y() - vtx.y(),pos.z() - vtx.z());
+  return posV;
+}
+
+
+bool CSCHaloAlgo::HCALSegmentMatching(edm::Handle<HBHERecHitCollection>& rechitcoll, float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh , float iZ, float iR, float iT, float iPhi){
+  reco::Vertex::Point vtx(0,0,0);
+  for(size_t ihit = 0; ihit< rechitcoll->size(); ++ ihit){
+    const HBHERecHit & rechit = (*rechitcoll)[ ihit ];
+    math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+    double rhet = rechit.energy()/cosh(rhpos.eta());
+    double dphi_rhseg = abs(deltaPhi(rhpos.phi(),iPhi));
+    double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+    double dtcorr_rhseg = rechit.time()- abs(rhpos.z()-iZ)/30- iT; 
+    if(rhet> et_thresh_rh&&
+       dphi_rhseg < dphi_thresh_segvsrh &&
+       dr_rhseg < dr_highthresh_segvsrh && dr_rhseg> dr_lowthresh_segvsrh && //careful: asymmetric cut might not be the most appropriate thing 
+       dtcorr_rhseg> dt_lowthresh_segvsrh
+      ) return true; 
+  }
+  return false;
+}
+
+bool CSCHaloAlgo::ECALSegmentMatching(edm::Handle<EcalRecHitCollection>& rechitcoll,  float et_thresh_rh, float dphi_thresh_segvsrh, float dr_lowthresh_segvsrh, float dr_highthresh_segvsrh, float dt_lowthresh_segvsrh, float iZ, float iR, float iT, float iPhi ){
+  reco::Vertex::Point vtx(0,0,0);
+  for(size_t ihit = 0; ihit<rechitcoll->size(); ++ ihit){
+    const EcalRecHit & rechit = (*rechitcoll)[ ihit ];
+    math::XYZPoint rhpos = getPosition(rechit.id(),vtx);
+    double rhet = rechit.energy()/cosh(rhpos.eta());
+    double dphi_rhseg = abs(deltaPhi(rhpos.phi(),iPhi));
+    double dr_rhseg = sqrt(rhpos.x()*rhpos.x()+rhpos.y()*rhpos.y()) - iR;
+    double dtcorr_rhseg = rechit.time()- abs(rhpos.z()-iZ)/30- iT; 
+    if(rhet> et_thresh_rh&&
+       dphi_rhseg < dphi_thresh_segvsrh &&
+       dr_rhseg < dr_highthresh_segvsrh && dr_rhseg> dr_lowthresh_segvsrh && //careful: asymmetric cut might not be the most appropriate thing 
+       dtcorr_rhseg> dt_lowthresh_segvsrh
+       ) return true; 
+  }
+  return false;
+}

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -651,7 +651,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	 float jZ = jGlobalPosition.z() ;
 	 float jT = jSegment->time();
 	 //	 if(abs(jZ)<650&& TheEvent.id().run() < 251737)jT-= 25;
-	 if (TMath::ACos(TMath::Cos(jPhi - iPhi)) <= 0.2//max_segment_phi_diff 
+	 if ( abs(deltaPhi(jPhi , iPhi)) <= 0.2//max_segment_phi_diff 
 	     //&& abs(jR - iR) <= max_segment_r_diff 
 	     && (abs(jR - iR) <= max_segment_r_diff || (abs(jR - iR)<0.03*abs(jZ - iZ) &&  jZ*iZ<0) )
 	     && (jTheta < max_segment_theta || jTheta > TMath::Pi() - max_segment_theta)) {

--- a/RecoMET/METProducers/interface/CSCHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/CSCHaloDataProducer.h
@@ -154,6 +154,11 @@ class CSCHaloDataProducer : public edm::stream::EDProducer<> {
     //RecHit Level
     edm::InputTag IT_CSCRecHit;
 
+    //Calo rechits                                                                                                                               
+    edm::InputTag IT_HBHErh;
+    edm::InputTag IT_ECALBrh;
+    edm::InputTag IT_ECALErh;
+
     //Higher Level Reco
     edm::InputTag IT_CosmicMuon;
     edm::InputTag IT_CSCSegment;
@@ -166,6 +171,9 @@ class CSCHaloDataProducer : public edm::stream::EDProducer<> {
     edm::EDGetTokenT<reco::MuonCollection> muon_token_;
     edm::EDGetTokenT<CSCSegmentCollection> cscsegment_token_;
     edm::EDGetTokenT<CSCRecHit2DCollection> cscrechit_token_;
+    edm::EDGetTokenT<HBHERecHitCollection> hbhereco_token_;
+    edm::EDGetTokenT<EcalRecHitCollection> EcalRecHitsEB_token_;
+    edm::EDGetTokenT<EcalRecHitCollection> EcalRecHitsEE_token_;
     edm::EDGetTokenT<CSCALCTDigiCollection> cscalct_token_;
     edm::EDGetTokenT<L1MuGMTReadoutCollection> l1mugmtro_token_;
     edm::EDGetTokenT<edm::TriggerResults> hltresult_token_;

--- a/RecoMET/METProducers/python/CSCHaloData_cfi.py
+++ b/RecoMET/METProducers/python/CSCHaloData_cfi.py
@@ -24,6 +24,11 @@ CSCHaloData = cms.EDProducer("CSCHaloDataProducer",
                              # RecHit Level
                              CSCRecHitLabel = cms.InputTag("csc2DRecHits"),
                              
+                             # Calo rec hits
+                             HBHErhLabel = cms.InputTag("hbhereco"),
+                             ECALBrhLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+                             ECALErhLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+                             
                              # Higher Level Reco
                              CSCSegmentLabel= cms.InputTag("cscSegments"),
                              CosmicMuonLabel= cms.InputTag("muonsFromCosmics"),

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -96,6 +96,23 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
       (CSCData.NumberOfHaloTracks() && CSCData.NumberOfOutOfTimeTriggers() ) )
     TheBeamHaloSummary->GetCSCHaloReport()[3] = 1;
 
+  //CSCTight Id for 2015
+  if( (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NumberOfHaloTracks()) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTriggers_TrkMuUnVeto() ) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTracks() ) ||
+      CSCData.GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() ||
+      (CSCData.NTracksSmalldT() && CSCData.NumberOfHaloTracks() ) ||
+      (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() || CSCData.NumberOfHaloTracks()) ))
+    TheBeamHaloSummary->GetCSCHaloReport()[4] = 1;
+
+  //Update
+  if(  (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NFlatHaloSegments_TrkMuUnVeto() ) ||
+       CSCData.GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() ||
+       CSCData.GetSegmentIsCaloMatched()
+       )
+    TheBeamHaloSummary->GetCSCHaloReport()[5] = 1;
+
+
 
   //Ecal Specific Halo Data
   Handle<EcalHaloData> TheEcalHaloData;

--- a/RecoMET/METProducers/src/CSCHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/CSCHaloDataProducer.cc
@@ -25,6 +25,10 @@ CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
   //RecHit Level
   IT_CSCRecHit   = iConfig.getParameter<edm::InputTag>("CSCRecHitLabel");
 
+  //Calo RecHit
+  IT_HBHErh = iConfig.getParameter<edm::InputTag>("HBHErhLabel");
+  IT_ECALBrh= iConfig.getParameter<edm::InputTag>("ECALBrhLabel");
+  IT_ECALErh= iConfig.getParameter<edm::InputTag>("ECALErhLabel");
   //Higher Level Reco 
   IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");  
   IT_CosmicMuon = iConfig.getParameter<edm::InputTag>("CosmicMuonLabel"); 
@@ -67,6 +71,9 @@ CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
   cscrechit_token_  = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
   cscalct_token_    = consumes<CSCALCTDigiCollection>(IT_ALCT);
   l1mugmtro_token_  = consumes<L1MuGMTReadoutCollection>(IT_L1MuGMTReadout);
+  hbhereco_token_   = consumes<HBHERecHitCollection>(IT_HBHErh);
+  EcalRecHitsEB_token_ = consumes<EcalRecHitCollection>(IT_ECALBrh);
+  EcalRecHitsEE_token_ = consumes<EcalRecHitCollection>(IT_ECALErh);
   hltresult_token_  = consumes<edm::TriggerResults>(IT_HLTResult);
 
   produces<CSCHaloData>();
@@ -113,6 +120,14 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel (IT_ALCT, TheALCTs);
   iEvent.getByToken(cscalct_token_, TheALCTs);
 
+  //Calo rec hits
+  Handle<HBHERecHitCollection> hbhehits;
+  iEvent.getByToken(hbhereco_token_,hbhehits);
+  Handle<EcalRecHitCollection> ecalebhits;
+  iEvent.getByToken(EcalRecHitsEB_token_, ecalebhits);
+  Handle<EcalRecHitCollection> ecaleehits;
+  iEvent.getByToken(EcalRecHitsEE_token_,ecaleehits);
+  
   //Get HLT Results                                                                                                                                                       
   edm::Handle<edm::TriggerResults> TheHLTResults;
   //  iEvent.getByLabel( IT_HLTResult , TheHLTResults);
@@ -123,7 +138,7 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
     triggerNames = &iEvent.triggerNames(*TheHLTResults);
   }
 
-  std::auto_ptr<CSCHaloData> TheCSCData(new CSCHaloData( CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent) ) );
+  std::auto_ptr<CSCHaloData> TheCSCData(new CSCHaloData( CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, hbhehits,ecalebhits,ecaleehits,TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent, iSetup) ) );
   // Put it in the event                                                                                                                                                
   iEvent.put(TheCSCData);
   return;


### PR DESCRIPTION
Hi,

This PR is a copy of the PR made for 74X and 75X: 

https://github.com/cms-sw/cmssw/pull/11136
https://github.com/cms-sw/cmssw/pull/11137

-Pairs of segments in opposite endcaps are now matched with a dr/dz condition (rather than dr previously) 
-The dphi condition to match segment has been tightened from 0.35 to 0.2.
-New flat CSC segment matching added (the old one remains the default for now): unvetoing CSC segments associated to tracker muons with pt < 3 gev 
-Optional dt matching of opposite endcaps segments 
-Testing a CSC segment/calorechit matching. 
-Two new working points added in BeamHaloSummary.

The changes on the current filter only affect the counting of the flat segments, especially for opposite endcaps.

The current distribution of the two variables entering the current filter (longest chain of flat segments and opposite endcaps segments found) is shown on S15 here (left plots):
https://indico.cern.ch/event/438533/contribution/1/attachments/1139775/1632303/beamhalo.pdf

I have also added various methods to the CSCHaloData class. Two new filters were added to BeamHaloSummary but are not used anywhere so far. So all the changes, except the two mentioned above should not break anything and the size of the updated classes should not be dramatically modified.
