### PR TITLE
don't pass puppi NaNs to pseudojet methods

### DIFF
--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -47,7 +47,11 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
         // float nom = sqrt((fRecoParticle.m)*(fRecoParticle.m) + (fRecoParticle.pt)*(fRecoParticle.pt)*(cosh(fRecoParticle.eta))*(cosh(fRecoParticle.eta))) + (fRecoParticle.pt)*sinh(fRecoParticle.eta);//hacked
         // float denom = sqrt((fRecoParticle.m)*(fRecoParticle.m) + (fRecoParticle.pt)*(fRecoParticle.pt));//hacked
         // float rapidity = log(nom/denom);//hacked
-        curPseudoJet.reset_PtYPhiM(fRecoParticle.pt,fRecoParticle.rapidity,fRecoParticle.phi,fRecoParticle.m);//hacked
+	if (edm::isFinite(fRecoParticle.rapidity)){
+	  curPseudoJet.reset_PtYPhiM(fRecoParticle.pt,fRecoParticle.rapidity,fRecoParticle.phi,fRecoParticle.m);//hacked
+	} else {
+	  curPseudoJet.reset_PtYPhiM(0, 99., 0, 0);//skipping may have been a better choice
+	}
         //curPseudoJet.reset_PtYPhiM(fRecoParticle.pt,fRecoParticle.eta,fRecoParticle.phi,fRecoParticle.m);
         int puppi_register = 0;
         if(fRecoParticle.id == 0 or fRecoParticle.charge == 0)  puppi_register = 0; // zero is neutral hadron


### PR DESCRIPTION
fix crash reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1385.html
[and likely similar ones observed with the previous versions in 0T in the past]

tested in CMSSW_7_4_12 with the setup reported in the HN: 
- crash was reproduced (faster with a skip of 2500 events) in the original release
- crash is gone with the fix (the pt=0 and y=99 didn't reappear as an issue downstream)
