### PR TITLE
Fix in PF reconstruction for the  spike at MET=0.0

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -290,7 +290,7 @@ class PFRecHitQTestHCALThresholdVsDepth : public PFRecHitQTestBase {
 	if (detid.depth() == depths_[i]) {
 	  if (  energy<thresholds_[i])
 	    {
-	      clean=true;
+	      clean=false;
 	      return false;
 	    }
 	  break;

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -352,7 +352,7 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
   pfAlgo_->setPFMuonAndFakeParameters(iConfig);
   
   //Post cleaning of the HF
-  bool postHFCleaning
+  postHFCleaning_
     = iConfig.getParameter<bool>("postHFCleaning");
   double minHFCleaningPt 
     = iConfig.getParameter<double>("minHFCleaningPt");
@@ -368,7 +368,7 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
     = iConfig.getParameter<double>("minDeltaMet");
 
   // Set post HF cleaning muon parameters
-  pfAlgo_->setPostHFCleaningParameters(postHFCleaning,
+  pfAlgo_->setPostHFCleaningParameters(postHFCleaning_,
 				       minHFCleaningPt,
 				       minSignificance,
 				       maxSignificance,
@@ -617,7 +617,9 @@ PFProducer::produce(Event& iEvent,
       hfCopy.push_back( (*hfCleaned)[jhf] );
     }
   }
-  pfAlgo_->checkCleaning( hfCopy );
+
+  if (postHFCleaning_)
+    pfAlgo_->checkCleaning( hfCopy );
 
   // Save recovered HF candidates
   auto_ptr< reco::PFCandidateCollection > 

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.h
@@ -103,6 +103,8 @@ class PFProducer : public edm::stream::EDProducer<> {
   // Take PF cluster calibrations from Global Tag ?
   bool useCalibrationsFromDB_;
 
+
+  bool postHFCleaning_;
   // Name of the calibration functions to read from the database
   // std::vector<std::string> fToRead;
   


### PR DESCRIPTION
This PR contains two bug-fixes:

A) There is a post cleaning algorithm that is deactivated since 62X. This algorithm has two sub-algortihms . One to remove HF candidates from PF if noisy/spikey and one to add HF cleaned hits if they were previously cleaned by DPG but they balance better the MET. 
The second one method: checkCleaning() in PFAlgo was not deactivated. In 25 ns data taking the second one can start adding to PF cleaned out of time hits picking the ones that balance the MET better biasing the MET. This bias would make the MET O(200) MeV

B)There was an additional small bug in the new clustering  that adds hits below threshold to the collection of the cleaned HF hits while in this collection we need only the DPG cleaned hits. The checkCleaning() sequence runs on those very low energy hits and finds a combination   that can bring the MET down from 200 MeV down to 10 MeV or less!

The fix A dominates the spike that is seen only in the data . If we apply only fix B then the met will still peak at 0.0 but at 100 MeV instead of 20 MeV

The fix B has also a small effect of the MC since low energy HF hits can be added back but the energy of those hits is so small that they can only change the Jet/MET by 100 MeV max

Tests were performed with any combination of cleaning and bug fixes. The conclusion is:
+checkCleaning needs to be deactivated since postCleaning is deactivated  
+Fix needed to not add the below threshold hits to the Cleaned collection
## Notes

1.The nature and understanding of the problem implies that the problem will not appear on metNoHF which is the default one for now in CMS 

2.The problem is also at HLT but cannot change efficiency or rate since the change of MET is max 5-10 GeV      - much lower than the HLT thresholds
