### PR TITLE
Adding fastjet shape correction for analysis in 74x

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -492,6 +492,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       bge_rho_grid->set_particles(fjInputs_);
       subtractor = unique_ptr<fastjet::Subtractor>( new fastjet::Subtractor(  bge_rho_grid.get()) );
       subtractor->set_use_rho_m();
+      subtractor->use_common_bge_for_rho_and_rhom(true);
     }
 
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -35,6 +35,8 @@
 #include "fastjet/tools/MassDropTagger.hh"
 #include "fastjet/contrib/SoftDrop.hh"
 #include "fastjet/tools/JetMedianBackgroundEstimator.hh"
+#include "fastjet/tools/GridMedianBackgroundEstimator.hh"
+#include "fastjet/tools/Subtractor.hh"
 #include "fastjet/contrib/ConstituentSubtractor.hh"
 #include "RecoJets/JetAlgorithms/interface/CMSBoostedTauSeedingAlgorithm.h"
 
@@ -65,6 +67,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     useKtPruning_(false),
     useConstituentSubtraction_(false),
     useSoftDrop_(false),
+    correctShape_(false),
     muCut_(-1.0),
     yCut_(-1.0),
     rFilt_(-1.0),
@@ -76,7 +79,9 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     csRho_EtaMax_(-1.0),
     csRParam_(-1.0),
     beta_(-1.0),
-    R0_(-1.0)
+    R0_(-1.0),
+    gridMaxRapidity_(-1.0), // For fixed-grid rho
+    gridSpacing_(-1.0)  // For fixed-grid rho
 {
 
   if ( iConfig.exists("UseOnlyVertexTracks") )
@@ -212,6 +217,13 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
       R0_ = iConfig.getParameter<double>("R0");
     }
 
+  }
+
+  if ( iConfig.exists("correctShape") ) {
+    correctShape_ = iConfig.getParameter<bool>("correctShape");
+    gridMaxRapidity_ = iConfig.getParameter<double>("gridMaxRapidity");
+    gridSpacing_ = iConfig.getParameter<double>("gridSpacing");
+    useExplicitGhosts_ = true;
   }
 
   input_chrefcand_token_ = consumes<edm::View<reco::RecoChargedRefCandidate> >(src_);
@@ -473,6 +485,15 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       transformers.push_back( transformer_ptr(sd) );
     }
 
+    unique_ptr<fastjet::Subtractor> subtractor;
+    unique_ptr<fastjet::GridMedianBackgroundEstimator> bge_rho_grid;
+    if ( correctShape_ ) {
+      bge_rho_grid = unique_ptr<fastjet::GridMedianBackgroundEstimator> (new  fastjet::GridMedianBackgroundEstimator(gridMaxRapidity_, gridSpacing_) );
+      bge_rho_grid->set_particles(fjInputs_);
+      subtractor = unique_ptr<fastjet::Subtractor>( new fastjet::Subtractor(  bge_rho_grid.get()) );
+      subtractor->set_use_rho_m();
+    }
+
 
     for ( std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(),
 	    ijetEnd = tempJets.end(); ijet != ijetEnd; ++ijet ) {
@@ -486,6 +507,10 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
 	} else {
 	  passed=false;
 	}
+      }
+
+      if ( correctShape_ ) {
+	transformedJet = (*subtractor)(transformedJet);
       }
 
       if ( passed ) {

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -492,7 +492,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       bge_rho_grid->set_particles(fjInputs_);
       subtractor = unique_ptr<fastjet::Subtractor>( new fastjet::Subtractor(  bge_rho_grid.get()) );
       subtractor->set_use_rho_m();
-      subtractor->use_common_bge_for_rho_and_rhom(true);
+      //subtractor->use_common_bge_for_rho_and_rhom(true);
     }
 
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -84,6 +84,7 @@ protected:
   bool useKtPruning_;         /// Use Kt clustering algorithm for pruning (default is Cambridge/Aachen)
   bool useConstituentSubtraction_; /// constituent subtraction technique
   bool useSoftDrop_;          /// Soft drop
+  bool correctShape_;         /// Correct the shape of the jets
   double muCut_;              /// for mass-drop tagging, m0/mjet (m0 = mass of highest mass subjet)
   double yCut_;               /// for mass-drop tagging, symmetry cut: min(pt1^2,pt2^2) * dR(1,2) / mjet > ycut
   double rFilt_;              /// for filtering, trimming: dR scale of sub-clustering
@@ -97,6 +98,8 @@ protected:
   double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
   double beta_;               /// for soft drop : beta (angular exponent)
   double R0_;                 /// for soft drop : R0 (angular distance normalization - should be set to jet radius in most cases)
+  double gridMaxRapidity_;    /// for shape subtraction, get the fixed-grid rho
+  double gridSpacing_;        /// for shape subtraction, get the grid spacing
 
 
   double subjetPtMin_;        /// for CMSBoostedTauSeedingAlgorithm : subjet pt min


### PR DESCRIPTION
Here is a fastjet "rho-based" shape correction for future analysis releases in 74x. 
Currently this is completely disabled by default. Some advances in fastjet contrib
are forthcoming to make this much faster than it currently is. Until then,
this should remain disabled except for expert usage in analyses. 
