### PR TITLE
remove rct parameters hardcode from 74X

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
@@ -5,8 +5,8 @@ from L1Trigger.L1TCalorimeter.caloStage1Params_cfi import *
 # HCAL TP hack
 from L1Trigger.L1TCalorimeter.L1TRerunHCALTP_FromRaw_cff import *
 
-### CCLA include latest RCT calibrations from UCT
-from L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff import *
+#now taken from GT:
+#from L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff import *
 
 from Configuration.StandardSequences.RawToDigi_Data_cff import ecalDigis
 


### PR DESCRIPTION
This should have been removed long ago... only noticing now because hard-coded values were in sync with latest tables in DB.
