### PR TITLE
Fix incorrect checksums in CMSSW_7_5_ROOT5_X

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,7 +24,9 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="16">
+  <class name="reco::GsfTrack" ClassVersion="18">
+   <version ClassVersion="18" checksum="1193413886"/>
+   <version ClassVersion="17" checksum="2463004588"/>
    <version ClassVersion="16" checksum="4129402716"/>
    <version ClassVersion="15" checksum="2494468278"/>
    <version ClassVersion="14" checksum="3085391575"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -271,7 +271,11 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="19">
+  <class name="pat::PackedCandidate" ClassVersion="24">
+    <version ClassVersion="24" checksum="663492232"/>
+    <version ClassVersion="23" checksum="559934341"/>
+    <version ClassVersion="22" checksum="691064527"/>
+    <version ClassVersion="21" checksum="1075665714"/>
     <version ClassVersion="20" checksum="2078702780"/>
     <version ClassVersion="19" checksum="359155190"/>
     <version ClassVersion="18" checksum="4275117305"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,8 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="17">
+  <class name="reco::PFTau" ClassVersion="20">
+   <version ClassVersion="20" checksum="3395041825"/>
+   <version ClassVersion="19" checksum="4003955973"/>
    <version ClassVersion="18" checksum="1318776182"/>
    <version ClassVersion="17" checksum="1523260402"/>
     <version ClassVersion="16" checksum="2695990650"/>
@@ -265,7 +267,9 @@ isolationTauChargedHadronCandidates_.clear();
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauDecayMode> > >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
 
-  <class name="reco::RecoTauPiZero" ClassVersion="12">
+  <class name="reco::RecoTauPiZero" ClassVersion="15">
+   <version ClassVersion="15" checksum="4070597512"/>
+   <version ClassVersion="14" checksum="3535311745"/>
    <version ClassVersion="13" checksum="3687187514"/>
    <version ClassVersion="12" checksum="453348937"/>
    <version ClassVersion="11" checksum="2458276705"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -5,14 +5,16 @@
       <version ClassVersion="11" checksum="1621684703"/>
   </class>
 
-  <class name="reco::TrackBase" ClassVersion="16">
+  <class name="reco::TrackBase" ClassVersion="18">
+   <version ClassVersion="18" checksum="1935215297"/>
+   <version ClassVersion="17" checksum="1774167599"/>
    <version ClassVersion="16" checksum="3673246687"/>
    <version ClassVersion="15" checksum="1802760569"/>
    <version ClassVersion="14" checksum="3929365050"/>
    <version ClassVersion="13" checksum="1244921154"/>
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
-   
+
    <version ClassVersion="12" checksum="2704717983"/>
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
@@ -364,7 +366,9 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="16">
+  <class name="reco::Track" ClassVersion="18">
+   <version ClassVersion="18" checksum="3235158110"/>
+   <version ClassVersion="17" checksum="3387867292"/>
    <version ClassVersion="16" checksum="697987788"/>
    <version ClassVersion="15" checksum="3694119510"/>
    <version ClassVersion="14" checksum="4228121071"/>


### PR DESCRIPTION
This PR does two things:
1) Updates the incorrect ROOT5 checksums causing build errors in CMSSW_7_5_ROOT5_X.
2) Makes new checksums for ROOT6 known to the ROOT5 release.
Purely technical. Please expedite.
There is a related PR in 7_5_X, #11299
