### PR TITLE
Make ROOT5 checksums known in ROOT6 (7_5_X)

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -25,6 +25,7 @@
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
   <class name="reco::GsfTrack" ClassVersion="17">
+   <version ClassVersion="18" checksum="1193413886"/>
    <version ClassVersion="17" checksum="2463004588"/>
    <version ClassVersion="16" checksum="4129402716"/>
    <version ClassVersion="15" checksum="2494468278"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   
   <class name="reco::PFTau" ClassVersion="19">
+   <version ClassVersion="20" checksum="3395041825"/>
    <version ClassVersion="19" checksum="4003955973"/>
    <version ClassVersion="18" checksum="1318776182"/>
    <version ClassVersion="17" checksum="1523260402"/>
@@ -267,6 +268,7 @@ isolationTauChargedHadronCandidates_.clear();
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
 
   <class name="reco::RecoTauPiZero" ClassVersion="14">
+   <version ClassVersion="15" checksum="4070597512"/>
    <version ClassVersion="14" checksum="3535311745"/>
    <version ClassVersion="13" checksum="3687187514"/>
    <version ClassVersion="12" checksum="453348937"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -8,6 +8,7 @@
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
   <class name="reco::TrackBase" ClassVersion="17">
+   <version ClassVersion="18" checksum="1935215297"/>
    <version ClassVersion="17" checksum="1774167599"/>
    <version ClassVersion="16" checksum="3673246687"/>
    <version ClassVersion="15" checksum="1802760569"/>
@@ -356,6 +357,7 @@
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
   <class name="reco::Track" ClassVersion="17">
+   <version ClassVersion="18" checksum="3235158110"/>
    <version ClassVersion="17" checksum="3387867292"/>
    <version ClassVersion="16" checksum="697987788"/>
    <version ClassVersion="15" checksum="3694119510"/>


### PR DESCRIPTION
This PR makes new checksums for ROOT5 available in this ROOT6 release.
Totally technical.
