### PR TITLE
pick ecal fraction of 0 for a candidate with trackMomentum 0

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1475,7 +1475,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	  // Skip muons
 	  if ( (*pfCandidates_)[tmpi[ic]].particleId() == reco::PFCandidate::mu ) continue; 
 
-	  double fraction = (*pfCandidates_)[tmpi[ic]].trackRef()->p()/trackMomentum;
+	  double fraction = trackMomentum > 0 ? (*pfCandidates_)[tmpi[ic]].trackRef()->p()/trackMomentum : 0;
 	  double ecalCal = bNeutralProduced ? 
 	    (calibEcal-neutralEnergy*slopeEcal)*fraction : calibEcal*fraction;
 	  double ecalRaw = totalEcal*fraction;


### PR DESCRIPTION
This is a follow up to investigation of origins of the NaN PFCandidate that leads to a crash in 
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1385.html

Here, the ecal raw energy was set to infinity, while the momentum is still OK.
Then later in the PFCandConnector, in the process of updating the momentum to account for nuclear interations, the candidate momentum is updated based on the calorimeter energy values. That's the point where the final candidate momentum turns to a NaN.

@bachtis please check if fraction=0 makes sense in this case.
If confirmed, I'd run more tests and propagate to 75X/76X.
