### PR TITLE
Resolve issues with std::basic_ios and std::basic_stringstream usage

### DIFF
--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
@@ -417,8 +417,8 @@ void EcalSimRawData::genTccOut(string basename, int iEvent,
 	<< setfill(' ') << getExt();
       ofstream dccF(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
       
-      if(!dccF){
-	cout << "Warning: failed to create or open file " << s << ".\n";
+      if(dccF.fail()){
+	cout << "Warning: failed to create or open file " << s.str() << ".\n";
 	return;
       }
       

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
@@ -205,7 +205,7 @@ void EcalSimRawData::genFeData(string basename, int iEvent,
 	<< setfill(' ') << ext;
       ofstream f(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
 
-      if(!f) return;
+      if(f.fail()) return;
 
 
       if(writeMode_==ascii){
@@ -283,7 +283,7 @@ void EcalSimRawData::genSrData(string basename, int iEvent,
 	<< setfill(' ') << getExt();
       ofstream f(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
       
-      if(!f) throw cms::Exception(string("Cannot create/open file ")
+      if(f.fail()) throw cms::Exception(string("Cannot create/open file ")
 				  + s.str() + ".");
       
       int iWord = 0;
@@ -353,7 +353,7 @@ void EcalSimRawData::genTccIn(string basename, int iEvent,
 	<< setfill(' ') << ext;
       ofstream fe2tcc(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
 
-      if(!fe2tcc) throw cms::Exception(string("Failed to create file ")
+      if(fe2tcc.fail()) throw cms::Exception(string("Failed to create file ")
 				       + s.str() + ".");
       
       int memPos = iEvent-1;

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
@@ -41,14 +41,16 @@ struct GzInputStream
    }
   ~GzInputStream()
    { gzclose(gzf) ; }
-  operator void*()
-   { return ((eof==true)?((void*)0):iss) ; }
+  explicit operator bool() const
+  {
+    return ((eof == true) ? false : iss.fail());
+  }
  } ;
 
 template <typename T>
 GzInputStream & operator>>( GzInputStream & gis, T & var )
  {
-  while ((gis)&&(!(gis.iss>>var)))
+  while ((bool)gis && !(gis.iss >> var))
    { gis.readLine() ; }
   return gis ;
  }

--- a/SimG4CMS/FP420/plugins/BuildFile.xml
+++ b/SimG4CMS/FP420/plugins/BuildFile.xml
@@ -1,4 +1,10 @@
 <use   name="SimG4CMS/FP420"/>
 <library   file="*.cc" name="SimG4CMSFP420Plugins">
   <flags   EDM_PLUGIN="1"/>
+  <!--
+       There is no way to avoid these in C++ until possibly GCC 6.1.0
+       Diagnostic pragmas would not work due to the way C++ pre-processor is implemented
+       RFC PATCH: https://gcc.gnu.org/ml/gcc-patches/2015-07/msg02414.html
+  -->
+  <flags REM_CXXFLAGS="-Werror=unused-variable"/>
 </library>

--- a/SimG4CMS/FP420/plugins/FP420Test.cc
+++ b/SimG4CMS/FP420/plugins/FP420Test.cc
@@ -148,8 +148,7 @@ FP420Test::~FP420Test() {
         // Write histograms to file
         TheHistManager->WriteToFile(fOutputFile,fRecreateFile);
   if (verbosity > 0) {
-    std::cout << std::endl << "FP420Test Destructor  -------->  End of FP420Test : "
-      << std::cout << std::endl; 
+    std::cout << std::endl << "FP420Test Destructor  -------->  End of FP420Test : " << std::endl;
   }
 
   std::cout<<"FP420Test: End of process"<<std::endl;

--- a/SimG4CMS/Forward/BuildFile.xml
+++ b/SimG4CMS/Forward/BuildFile.xml
@@ -19,3 +19,9 @@
 <export>
   <lib   name="1"/>
 </export>
+<!--
+     There is no way to avoid these in C++ until possibly GCC 6.1.0
+     Diagnostic pragmas would not work due to the way C++ pre-processor is implemented
+     RFC PATCH: https://gcc.gnu.org/ml/gcc-patches/2015-07/msg02414.html
+-->
+<flags REM_CXXFLAGS="-Werror=unused-variable"/>

--- a/SimG4CMS/Forward/plugins/BuildFile.xml
+++ b/SimG4CMS/Forward/plugins/BuildFile.xml
@@ -19,4 +19,10 @@
 <use   name="rootmath"/>
 <library   file="*.cc" name="SimG4CMSForwardPlugins">
   <flags   EDM_PLUGIN="1"/>
+  <!--
+       There is no way to avoid these in C++ until possibly GCC 6.1.0
+       Diagnostic pragmas would not work due to the way C++ pre-processor is implemented
+       RFC PATCH: https://gcc.gnu.org/ml/gcc-patches/2015-07/msg02414.html
+  -->
+  <flags REM_CXXFLAGS="-Werror=unused-variable"/>
 </library>

--- a/SimG4CMS/Forward/src/BscTest.cc
+++ b/SimG4CMS/Forward/src/BscTest.cc
@@ -101,8 +101,7 @@ BscTest::~BscTest() {
   // Write histograms to file
   TheHistManager->WriteToFile(fOutputFile,fRecreateFile);
   if (verbosity > 0) {
-    std::cout << std::endl << "BscTest Destructor  -------->  End of BscTest : "
-	      << std::cout << std::endl; 
+    std::cout << std::endl << "BscTest Destructor  -------->  End of BscTest : " << std::endl;
   }
 
   std::cout<<"BscTest: End of process"<<std::endl;

--- a/SimMuon/CSCDigitizer/src/CSCGasCollisions.cc
+++ b/SimMuon/CSCDigitizer/src/CSCGasCollisions.cc
@@ -113,7 +113,7 @@ void CSCGasCollisions::readCollisionTable() {
 
   ifstream & fin = *f1();
 
-  if (fin == 0) {
+  if (fin.fail()) {
     string errorMessage = "Cannot open input file " + path + colliFile;
     edm::LogError("CSCGasCollisions") << errorMessage;
     throw cms::Exception(errorMessage);


### PR DESCRIPTION
`std::cout` does not directly support `std::basic_stringstream` as
argument, but because `std::basic_stringstream` inherits `std::basic_ios`
and it supports `operator void*` (until C++11) one could have pushed it
to `std::cout`. That is wrong, because `operator void*() const` does not
provide string content of `std::basic_stringstream`. Instead use `str()`
method to get a string copy of `std::basic_stringstream` content.

Instead of using `operator void*() const;` to check if stream is
good/bad. You have to use `explicit operator bool() const` in C++11 or
above or directly use `fail()` method.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
