### PR TITLE
Resolve issues with streams (getline(), stream to void *, etc)

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -1029,7 +1029,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
     AlgebraicSymMatrix55 Cml(tsosMuon.localError().matrix() + extrapolationT.localError().matrix());
     bool ierrLoc = !m.Invert();
     if (ierrLoc && debug_ && info) { 
-      std::cout<< " ==== Error inverting Local covariance matrix ==== "<<std::cout;
+      std::cout<< " ==== Error inverting Local covariance matrix ==== "<<std::endl;
       continue;}
     double chi_Loc = ROOT::Math::Similarity(Vml,m);
     if(debug_)
@@ -1802,7 +1802,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
     AlgebraicSymMatrix55 Cml(tsosMuon.localError().matrix() + extrapolationT.localError().matrix());
     bool ierrLoc = !m.Invert();
     if (ierrLoc && debug_ && info) { 
-      std::cout<< " ==== Error inverting Local covariance matrix ==== "<<std::cout;
+      std::cout<< " ==== Error inverting Local covariance matrix ==== "<<std::endl;
       continue;}
     double chi_Loc = ROOT::Math::Similarity(Vml,m);
     if(debug_)

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcalEmap.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcalEmap.cc
@@ -37,7 +37,7 @@ int HcalEmap::read_map( std::string filename )
   else{
     std::cout << "File with the electronic map opened successfully: " << filename << std::endl;
   }
-  while ( getline( inFile, _row ) > 0 ){
+  while (getline( inFile, _row )) {
     HcalEmapRow aRow;
     char fpga[32];
     char subdet[32];

--- a/CalibFormats/SiStripObjects/src/SiStripDelay.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDelay.cc
@@ -96,8 +96,8 @@ bool SiStripDelay::makeDelay()
 	delays_[*detIdIt] += (*it)->delay(*detIdIt)*sumSign;
       }
       else {
-	std::cout << "makeDelay: Warning, detId = " << *detIdIt << " not present, summing to 0..." << std::cout;
-	std::cout << "This means that the two baseDelay tags have different detIds. PLEASE, CHECK THAT THIS IS EXPECTED." << std::cout;
+	std::cout << "makeDelay: Warning, detId = " << *detIdIt << " not present, summing to 0..." << std::endl;
+	std::cout << "This means that the two baseDelay tags have different detIds. PLEASE, CHECK THAT THIS IS EXPECTED." << std::endl;
 	delays_[*detIdIt] = (*it)->delay(*detIdIt)*sumSign;
       }
     }

--- a/Calibration/Tools/interface/matrixSaver.h
+++ b/Calibration/Tools/interface/matrixSaver.h
@@ -32,7 +32,7 @@ public:
   int saveMatrixVector (std::string outputFileName, 
                        const std::vector<CLHEP::HepGenMatrix*> &saveMe) ;
 
-  int touch (std::string inputFileName) ;
+  bool touch (std::string inputFileName) ;
 
   CLHEP::HepGenMatrix* getMatrix (std::string inputFileName) ;
   

--- a/Calibration/Tools/src/matrixSaver.cc
+++ b/Calibration/Tools/src/matrixSaver.cc
@@ -83,7 +83,7 @@ matrixSaver::saveMatrixVector (std::string filename,
      typedef std::vector<CLHEP::HepGenMatrix*>::const_iterator const_iterator ;
      // open the output file
      std::fstream outputFile (filename.c_str (), std::ios::out) ;
-     assert (outputFile != NULL) ;
+     assert(outputFile.fail() == false) ;
 
      // save the number of elements of the vector
      outputFile << saveMe.size ()	
@@ -134,11 +134,10 @@ operator>> (std::istream& input, CLHEP::HepGenMatrix &matrix)
   return input ;
 }
 
-
-int matrixSaver::touch (std::string inputFileName)
+bool matrixSaver::touch (std::string inputFileName)
 {
    std::fstream inputFile (inputFileName.c_str (), std::ios::in) ;
-   return (inputFile != NULL) ;
+   return !inputFile.fail();
 }
 
 
@@ -148,8 +147,8 @@ matrixSaver::getMatrix (std::string inputFileName)
 {
      //PG open the output file
      std::fstream inputFile (inputFileName.c_str (), std::ios::in) ;
-     if (inputFile == NULL) std::cerr << "file: " << inputFileName << std::endl ;
-     assert (inputFile != NULL) ;
+     if (inputFile.fail()) std::cerr << "file: " << inputFileName << std::endl ;
+     assert(inputFile.fail() == false);
 
      //PG get the matrix dimensions
      int numRow = 0 ;
@@ -175,7 +174,7 @@ matrixSaver::getMatrixVector (std::string inputFileName)
 {
      // open the output file
      std::fstream inputFile (inputFileName.c_str (), std::ios::in) ;
-     assert (inputFile != NULL) ;
+     assert(inputFile.fail() == false);
 
      // get the vector length
      int numElem = 0 ;
@@ -219,7 +218,7 @@ matrixSaver::getConcreteMatrixVector (std::string inputFileName)
 {
      // open the output file
      std::fstream inputFile (inputFileName.c_str (), std::ios::in) ;
-     assert (inputFile != NULL) ;
+     assert(inputFile.fail() == false);
 
      // get the vector length
      int numElem = 0 ;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalChannelIterator.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalChannelIterator.cc
@@ -48,7 +48,7 @@ int HcalChannelIterator::addListFromLmapAscii(std::string filename){
   else{
     std::cout << "File with the logical map opened successfully: " << filename << std::endl;
   }
-  while ( getline( inFile, _row ) > 0 ){
+  while (getline( inFile, _row )) {
     //#   side    eta    phi   dphi  depth    det
     int _num, _side, _eta, _phi, _dphi, _depth;
     char subdetbuf[32];

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalChannelQualityXml.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalChannelQualityXml.cc
@@ -301,7 +301,7 @@ int HcalChannelQualityXml::readStatusWordFromStdin(std::string base){
   _cq.status  = 0;
   _cq.comment = "filled from an ASCII stream";
   geomid_cq.clear();
-  while ( getline( std::cin, _row ) > 0 ){
+  while (getline( std::cin, _row )) {
     //#(empty) eta phi dep det value DetId(optional)
     int _eta, _phi, _dep, _value;
     char _det[32];

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -228,7 +228,7 @@ HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename, int _type )
     }
 
     bool first_lut_entry = true;
-    while ( getline( infile, buf ) > 0 ){
+    while (getline( infile, buf )) {
       buf_vec = HcalQIEManager::splitString( buf );
       for (unsigned int i = 0; i < buf_vec.size(); i++){
 	if (first_lut_entry){

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalQIEManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalQIEManager.cc
@@ -65,7 +65,7 @@ std::map<HcalChannelId,HcalQIECaps> & HcalQIEManager::getQIETableFromFile( std::
 
   if ( infile . is_open() ){
     std::cout << "File is open" << std::endl;
-    while ( getline( infile, buf ) > 0 ){
+    while (getline( infile, buf )) {
       std::vector<std::string> _line = splitString( buf );
 
       HcalChannelId _id;
@@ -151,7 +151,7 @@ void HcalQIEManager::getTableFromDb( std::string query_file, std::string output_
 	else{
 	  std::cout << "Query file opened successfully: " << query_file << std::endl;
 	}
-	while ( getline( inFile, buf ) > 0 ){
+	while (getline( inFile, buf )) {
 	  query . append(buf);
 	  query . append("\n");
 	}
@@ -302,7 +302,7 @@ int HcalQIEManager::getHfQieTable( std::string input_file, std::string output_fi
     std::cout << "File is open" << std::endl;
     getline( infile, buf );
     std::cout << "Table legend: " << std::endl << buf << std::endl;
-    while ( getline( infile, buf ) > 0 ){
+    while (getline( infile, buf )) {
       std::vector<std::string> _line = splitString( buf );
       if ( _line . size() != 17){
 	cout << "Table line is malformed, not clear what to do... exiting." << std::endl;

--- a/CaloOnlineTools/HcalOnlineDb/src/LMap.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/LMap.cc
@@ -77,7 +77,7 @@ int LMap::impl::read( std::string map_file, std::string type )
       std::cout << "File with the logical map opened successfully: " << map_file << std::endl;
       std::cout << "Type: " << type << std::endl;
     }
-  while ( getline( inFile, _row ) > 0 )
+  while (getline( inFile, _row ))
     {
       LMapRow aRow;
       char det[32];
@@ -266,7 +266,7 @@ int EMap::read_map( std::string filename )
   else{
     std::cout << "File with the electronic map opened successfully: " << filename << std::endl;
   }
-  while ( getline( inFile, _row ) > 0 ){
+  while (getline( inFile, _row )) {
     EMapRow aRow;
     char fpga[32];
     char subdet[32];

--- a/CaloOnlineTools/HcalOnlineDb/test/xmlTools.cc
+++ b/CaloOnlineTools/HcalOnlineDb/test/xmlTools.cc
@@ -1566,7 +1566,7 @@ int hardware( void )
 
   if ( infile . is_open() ){
   std::cout << "File is open" << std::endl;
-    while ( getline( infile, buf ) > 0 )
+    while (getline( infile, buf ))
       {
 	vector<std::string> _line = splitString( buf );
 	//std::cout << _line . size() << std::endl;


### PR DESCRIPTION
GCC 5.2.0 does not allow piping output stream into output stream, e.g.,
`std::cout << std::cout`. There is no more impilicit conversion to `void
*` since C++11.

`std::getline()` returns `std::basic_istream` and implicit conversion to
`void *` does not happen. Since C++11 you can use any function returning
references to streams as loop conditions. This is because `explicit
operator bool() const` was introduced since C++11.

To validate stream status you need to use `operator!`, `fail()`,
`eof()`, `bad()` and friends from `std::basic_ios`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
