### PR TITLE
add new 2015 PFJetID, monitor TrackMet and MET Filters, add Ak8 monitoring for MiniAOD

### DIFF
--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -58,6 +58,8 @@
 
 #include "DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h"
 
+#include "DataFormats/BTauReco/interface/CATopJetTagInfo.h"
+
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
@@ -355,6 +357,8 @@ class JetAnalyzer : public DQMEDAnalyzer {
   std::vector<std::string> lowPtJetExpr_;
 
   bool jetCleaningFlag_;
+  bool filljetsubstruc_;
+  double pt_min_boosted_;
 
   bool runcosmics_;
 
@@ -657,6 +661,88 @@ class JetAnalyzer : public DQMEDAnalyzer {
   MonitorElement* meHFEMFracPlus_BXm1Filled;
   MonitorElement* mePtForwardPlus_BXm1Filled;
   MonitorElement* meEta_BXm1Filled;
+
+  //miniaod specific variables, especially for substructure
+  MonitorElement* mSoftDropMass; 
+  MonitorElement* mPrunedMass; 
+  MonitorElement* mTrimmedMass; 
+  MonitorElement* mFilteredMass; 
+  MonitorElement* mtau2_over_tau1; 
+  MonitorElement* mtau3_over_tau2; 
+  MonitorElement* mCATopTag_topMass;
+  MonitorElement* mCATopTag_minMass; 
+  MonitorElement* mCATopTag_nSubJets; 
+
+  MonitorElement* mnSubJetsCMSTopTag; 
+  MonitorElement* mSubJet1_CMSTopTag_pt; 
+  MonitorElement* mSubJet1_CMSTopTag_eta; 
+  MonitorElement* mSubJet1_CMSTopTag_phi; 
+  MonitorElement* mSubJet1_CMSTopTag_mass; 
+  MonitorElement* mSubJet2_CMSTopTag_pt; 
+  MonitorElement* mSubJet2_CMSTopTag_eta; 
+  MonitorElement* mSubJet2_CMSTopTag_phi; 
+  MonitorElement* mSubJet2_CMSTopTag_mass; 
+  MonitorElement* mSubJet3_CMSTopTag_pt; 
+  MonitorElement* mSubJet3_CMSTopTag_eta; 
+  MonitorElement* mSubJet3_CMSTopTag_phi; 
+  MonitorElement* mSubJet3_CMSTopTag_mass; 
+  MonitorElement* mSubJet4_CMSTopTag_pt; 
+  MonitorElement* mSubJet4_CMSTopTag_eta; 
+  MonitorElement* mSubJet4_CMSTopTag_phi; 
+  MonitorElement* mSubJet4_CMSTopTag_mass; 
+
+  MonitorElement* mnSubJetsSoftDrop; 
+  MonitorElement* mSubJet1_SoftDrop_pt; 
+  MonitorElement* mSubJet1_SoftDrop_eta; 
+  MonitorElement* mSubJet1_SoftDrop_phi; 
+  MonitorElement* mSubJet1_SoftDrop_mass; 
+  MonitorElement* mSubJet2_SoftDrop_pt; 
+  MonitorElement* mSubJet2_SoftDrop_eta; 
+  MonitorElement* mSubJet2_SoftDrop_phi; 
+  MonitorElement* mSubJet2_SoftDrop_mass; 
+
+  //miniaod specific variables, especially for substructure for a boosted regime
+  MonitorElement* mSoftDropMass_boosted; 
+  MonitorElement* mPrunedMass_boosted; 
+  MonitorElement* mTrimmedMass_boosted; 
+  MonitorElement* mFilteredMass_boosted; 
+  MonitorElement* mtau2_over_tau1_boosted; 
+  MonitorElement* mtau3_over_tau2_boosted; 
+  MonitorElement* mCATopTag_topMass_boosted;
+  MonitorElement* mCATopTag_minMass_boosted; 
+  MonitorElement* mCATopTag_nSubJets_boosted; 
+
+  MonitorElement* mnSubJetsCMSTopTag_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_mass_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_mass_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_mass_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_mass_boosted; 
+
+  MonitorElement* mnSubJetsSoftDrop_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_pt_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_eta_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_phi_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_mass_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_pt_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_eta_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_phi_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_mass_boosted; 
+
+  //miniaod only variables
+  MonitorElement* mPt_CaloJet;
+  MonitorElement* mEMF_CaloJet;
 
   //now ZJets plots
   MonitorElement*  mDPhiZJet;

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -743,6 +743,10 @@ class JetAnalyzer : public DQMEDAnalyzer {
   //miniaod only variables
   MonitorElement* mPt_CaloJet;
   MonitorElement* mEMF_CaloJet;
+  MonitorElement* mMass_Barrel;
+  MonitorElement* mMass_EndCap;
+  MonitorElement* mMass_Forward;
+
 
   //now ZJets plots
   MonitorElement*  mDPhiZJet;

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -160,6 +160,7 @@ class METAnalyzer : public DQMEDAnalyzer{
   edm::EDGetTokenT<edm::TriggerResults> METFilterMiniAODToken2_;
 
   std::vector<int> miniaodFilterIndex_;
+  int miniaodfilterdec;//if RECO set to 0, if reRECO set to 1, else to -1
 
   edm::InputTag hbheNoiseFilterResultTag_;
   edm::EDGetTokenT<bool>                          hbheNoiseFilterResultToken_;

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -116,8 +116,8 @@ class METAnalyzer : public DQMEDAnalyzer{
   void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
   //  void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
   // Fill MonitorElements
-  void fillMESet(const edm::Event&, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET&, const reco::Candidate::PolarLorentzVector&, std::map<std::string,MonitorElement*>&,std::vector<bool>);
-  void fillMonitorElement(const edm::Event&, std::string, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET& , const reco::Candidate::PolarLorentzVector& ,std::map<std::string,MonitorElement*>&,bool,bool,std::vector<bool>);
+  void fillMESet(const edm::Event&, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET&, const reco::Candidate::PolarLorentzVector&, std::map<std::string,MonitorElement*>&,std::vector<bool>,std::vector<bool>);
+  void fillMonitorElement(const edm::Event&, std::string, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET& , const reco::Candidate::PolarLorentzVector& ,std::map<std::string,MonitorElement*>&,bool,bool,std::vector<bool>,std::vector<bool>);
   void makeRatePlot(std::string, double);
 
 //  bool selectHighPtJetEvent(const edm::Event&);
@@ -143,9 +143,9 @@ class METAnalyzer : public DQMEDAnalyzer{
   edm::InputTag metCollectionLabel_;
   edm::InputTag hcalNoiseRBXCollectionTag_;
   edm::InputTag jetCollectionLabel_;
-  edm::InputTag hbheNoiseFilterResultTag_;
   edm::InputTag vertexTag_;
   edm::InputTag gtTag_;
+
 
   edm::EDGetTokenT<std::vector<reco::Vertex>>     vertexToken_;
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord>  gtToken_;
@@ -154,7 +154,21 @@ class METAnalyzer : public DQMEDAnalyzer{
   edm::EDGetTokenT<pat::JetCollection>        patJetsToken_;
   edm::EDGetTokenT<reco::MuonCollection>         MuonsToken_;
 
+  edm::InputTag METFilterMiniAODLabel_;
+  edm::EDGetTokenT<edm::TriggerResults> METFilterMiniAODToken_;
+  edm::InputTag METFilterMiniAODLabel2_;//needed for RECO and reRECO differntiation
+  edm::EDGetTokenT<edm::TriggerResults> METFilterMiniAODToken2_;
+
+  std::vector<int> miniaodFilterIndex_;
+
+  edm::InputTag hbheNoiseFilterResultTag_;
   edm::EDGetTokenT<bool>                          hbheNoiseFilterResultToken_;
+  edm::InputTag CSCHaloResultTag_;
+  edm::EDGetTokenT<bool>  CSCHaloResultToken_;
+  edm::InputTag EcalDeadCellTriggerTag_;
+  edm::EDGetTokenT<bool>  EcalDeadCellTriggerToken_;
+  edm::InputTag eeBadScFilterTag_;
+  edm::EDGetTokenT<bool>  eeBadScFilterToken_;
 
   edm::EDGetTokenT<pat::METCollection>           patMetToken_; 
   edm::EDGetTokenT<reco::PFMETCollection>         pfMetToken_;
@@ -173,6 +187,7 @@ class METAnalyzer : public DQMEDAnalyzer{
   double ptThreshold_;
 
   HLTConfigProvider hltConfig_;
+  HLTConfigProvider FilterhltConfig_;
   edm::InputTag                         triggerResultsLabel_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
 
@@ -278,6 +293,17 @@ class METAnalyzer : public DQMEDAnalyzer{
   //MonitorElement* hEz;
   MonitorElement* hMETSig;
   MonitorElement* hMET;
+  MonitorElement* hMET_2;
+
+  MonitorElement* hMET_HBHENoiseFilter;
+  MonitorElement* hMET_2_HBHENoiseFilter;
+  MonitorElement* hMET_CSCTightHaloFilter;
+  MonitorElement* hMET_2_CSCTightHaloFilter;
+  MonitorElement* hMET_eeBadScFilter;
+  MonitorElement* hMET_2_eeBadScFilter;
+  MonitorElement* hMET_EcalDeadCellTriggerFilter;
+  MonitorElement* hMET_2_EcalDeadCellTriggerFilter;
+
   MonitorElement* hMETPhi;
   MonitorElement* hSumET;
 

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -164,7 +164,8 @@ class METAnalyzer : public DQMEDAnalyzer{
   edm::InputTag hbheNoiseFilterResultTag_;
   edm::EDGetTokenT<bool>                          hbheNoiseFilterResultToken_;
   edm::InputTag CSCHaloResultTag_;
-  edm::EDGetTokenT<bool>  CSCHaloResultToken_;
+  edm::EDGetTokenT<bool>  CSCHaloResultToken_;//leads to problems running later
+  edm::EDGetTokenT<reco::BeamHaloSummary> BeamHaloSummaryToken_;
   edm::InputTag EcalDeadCellTriggerTag_;
   edm::EDGetTokenT<bool>  EcalDeadCellTriggerToken_;
   edm::InputTag eeBadScFilterTag_;

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -11,7 +11,7 @@ jetDQMAnalyzerSequence = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
 
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 
-jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD)
+jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFCHSCleanedMiniAOD)
 
 jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMAnalyzerIC5CaloHIUncleaned
                                         * jetDQMAnalyzerAkPU3Calo

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -11,6 +11,8 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
     muonsrc = cms.InputTag("muons"),
     l1algoname = cms.string("L1Tech_BPTX_plus_AND_minus.v0"),
     filljetHighLevel =cms.bool(False),
+    fillsubstructure =cms.bool(False),
+    ptMinBoosted = cms.double(400.),
     #
     #
     #
@@ -18,8 +20,7 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
         andOr         = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
-        hltDBKey       = cms.string( 'jetmet_highptjet' ),
-        hltPaths       = cms.vstring( 'HLT_Jet300_v','HLT_Jet300_v6','HLT_Jet300_v7','HLT_Jet300_v8' ), 
+        hltPaths       = cms.vstring( 'HLT_PFJet450_v*'), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -27,8 +28,7 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
         andOr         = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
-        hltDBKey       = cms.string( 'jetmet_lowptjet' ),
-        hltPaths       = cms.vstring( 'HLT_Jet60_v','HLT_Jet60_v6','HLT_Jet60_v7','HLT_Jet60_v8' ), 
+        hltPaths       = cms.vstring( 'HLT_PFJet80_v*'), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -89,7 +89,7 @@ jetDQMAnalyzerAk4CaloCleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     JetCleaningFlag   = cms.untracked.bool(True),
     filljetHighLevel  = cms.bool(False),
     CleaningParameters = cleaningParameters.clone(
-        bypassAllPVChecks = cms.bool(False),
+        bypassAllPVChecks = cms.bool(True),
     ),
     jetAnalysis=jetDQMParameters.clone(
         ptThreshold = cms.double(20.),
@@ -160,6 +160,11 @@ jetDQMAnalyzerAk4PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCleaned.clone(
         ),
     JetType = cms.string('miniaod'),#pf, calo or jpt
     jetsrc = cms.InputTag("slimmedJets"),
+)
+
+jetDQMAnalyzerAk8PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clone(
+    jetsrc = cms.InputTag("slimmedJetsAK8"),
+    fillsubstructure =cms.bool(True),
 )
 
 jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -105,8 +105,8 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
     #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: FIRSTDATA
-    JetIDVersion               = cms.string("FIRSTDATA"),
+    #for PFJets: FIRSTDATA or RUNIISTARTUP (suitable for RECO beyond 7_2_X)
+    JetIDVersion               = cms.string("RUNIISTARTUP"),
     JetType = cms.string('pf'),#pf, calo or jpt
     JetCorrections = cms.InputTag("dqmAk4PFL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJets"),
@@ -136,7 +136,6 @@ jetDQMAnalyzerAk4PFCHSCleaned=jetDQMAnalyzerAk4PFCleaned.clone(
     JetCorrections = cms.InputTag("dqmAk4PFCHSL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJetsCHS"),
     METCollectionLabel     = cms.InputTag("pfMETT1"),
-    #actually done only for PFJets at the moment
     InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorCHSDQM","fullDiscriminant"),
     InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorCHSDQM","cutbasedDiscriminant"),
     InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorCHSDQM","fullId"),

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -14,6 +14,7 @@ jetDQMAnalyzerAk4CaloUncleaned.filljetHighLevel =cms.bool(True)
 caloMetDQMAnalyzer.runcosmics = cms.untracked.bool(True)
 caloMetDQMAnalyzer.onlyCleaned = cms.untracked.bool(False)
 caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
+from RecoMET.METFilters.metFilters_cff  import *
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -17,4 +17,6 @@ caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
 from RecoMET.METFilters.metFilters_cff  import *
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(HBHENoiseFilterResultProducer*HBHENoiseFilter*primaryVertexFilter*
+                                      EcalDeadCellTriggerPrimitiveFilter*eeBadScFilter*
+                                      AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -9,6 +9,7 @@ from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
 
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
+from RecoMET.METFilters.metFilters_cff  import *
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -84,7 +85,7 @@ caloMetDQMAnalyzerMC=caloMetDQMAnalyzer.clone(JetCorrections    = cms.InputTag("
 pfMetDQMAnalyzerMC=pfMetDQMAnalyzer.clone(JetCorrections      = cms.InputTag("dqmAk4PFL1FastL2L3Corrector"))
 pfMetT1DQMAnalyzerMC=pfMetT1DQMAnalyzer.clone(JetCorrections    = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"))
 
-jetMETDQMOfflineSource = cms.Sequence(HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -85,7 +85,8 @@ caloMetDQMAnalyzerMC=caloMetDQMAnalyzer.clone(JetCorrections    = cms.InputTag("
 pfMetDQMAnalyzerMC=pfMetDQMAnalyzer.clone(JetCorrections      = cms.InputTag("dqmAk4PFL1FastL2L3Corrector"))
 pfMetT1DQMAnalyzerMC=pfMetT1DQMAnalyzer.clone(JetCorrections    = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"))
 
-jetMETDQMOfflineSource = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(HBHENoiseFilterResultProducer*HBHENoiseFilter*primaryVertexFilter*
+                                      EcalDeadCellTriggerPrimitiveFilter*eeBadScFilter*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
+#from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
 
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
@@ -8,6 +8,7 @@ from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
 from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
+from RecoMET.METFilters.metFilters_cff  import *
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -79,7 +80,7 @@ pfMETT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
         cms.InputTag('dqmCorrPfMetType1', 'type1')
         ))
 
-jetMETDQMOfflineSource = cms.Sequence(HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(metFilters*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -46,19 +46,19 @@ dqmAk4CaloL2L3ResidualCorrectorChain = cms.Sequence(
 
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3ResidualCorrectorChain,ak4PFL1FastL2L3ResidualCorrector,ak4PFCHSL1FastL2L3Corrector,ak4PFResidualCorrector,ak4PFL3AbsoluteCorrector,ak4PFL2RelativeCorrector,ak4PFL1FastjetCorrector
 
-dqmAk4PFCHSL1FastL2L3Corrector = ak4PFCHSL1FastL2L3Corrector.clone()
-dqmAk4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
-    #ak4CaloL2RelativeCorrector*ak4CaloL3AbsoluteCorrector*ak4CaloResidualCorrector*
-    dqmAk4PFCHSL1FastL2L3Corrector
-)
-
 dqmAk4PFL1FastL2L3ResidualCorrector = ak4PFL1FastL2L3ResidualCorrector.clone()
 dqmAk4PFL1FastL2L3ResidualCorrectorChain = cms.Sequence(
     #ak4PFL1FastjetCorrector*ak4PFL2RelativeCorrector*ak4PFL3AbsoluteCorrector*ak4PFResidualCorrector*
     dqmAk4PFL1FastL2L3ResidualCorrector
 )
 
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3ResidualCorrectorChain,ak4PFCHSL1FastL2L3ResidualCorrector,ak4PFCHSResidualCorrector,ak4PFCHSL3AbsoluteCorrector,ak4PFCHSL2RelativeCorrector,ak4PFCHSL1FastjetCorrector
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3ResidualCorrectorChain,ak4PFCHSL1FastL2L3CorrectorChain,ak4PFCHSL1FastL2L3ResidualCorrector,ak4PFCHSResidualCorrector,ak4PFCHSL3AbsoluteCorrector,ak4PFCHSL2RelativeCorrector,ak4PFCHSL1FastjetCorrector
+
+dqmAk4PFCHSL1FastL2L3Corrector = ak4PFCHSL1FastL2L3Corrector.clone()
+dqmAk4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
+    #ak4CaloL2RelativeCorrector*ak4CaloL3AbsoluteCorrector*ak4CaloResidualCorrector*
+    dqmAk4PFCHSL1FastL2L3Corrector
+)
 
 dqmAk4PFCHSL1FastL2L3ResidualCorrector = ak4PFCHSL1FastL2L3ResidualCorrector.clone()
 dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain = cms.Sequence(
@@ -80,7 +80,9 @@ pfMETT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
         cms.InputTag('dqmCorrPfMetType1', 'type1')
         ))
 
-jetMETDQMOfflineSource = cms.Sequence(metFilters*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(HBHENoiseFilterResultProducer*HBHENoiseFilter*primaryVertexFilter*
+                                      EcalDeadCellTriggerPrimitiveFilter*eeBadScFilter*
+                                      goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/metDQMConfig_cff.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.JetMET.metDQMConfig_cfi import *
 
 #correction for type 1 done in JetMETDQMOfflineSource now
-METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfMetT1DQMAnalyzer)
+METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer)
 
 METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD)
 

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -22,7 +22,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
     
     FolderName = cms.untracked.string("JetMET/MET/"),
 
-    fillMetHighLevel = cms.bool(True),
+    fillMetHighLevel = cms.bool(True),#fills lumi overview plots
 
     fillCandidateMaps = cms.bool(False),
 
@@ -171,7 +171,7 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
         ),
 )
 pfMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzer.clone(
-    fillMetHighLevel = cms.bool(False),
+    fillMetHighLevel = cms.bool(True),#fills only lumisec plots
     fillCandidateMaps = cms.bool(False),
     CleaningParameters = cleaningParameters.clone(
         vertexCollection    = cms.InputTag( "goodOfflinePrimaryVerticesDQMforMiniAOD" ),

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -27,7 +27,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
     fillCandidateMaps = cms.bool(False),
 
     CleaningParameters = cleaningParameters.clone(
-        bypassAllPVChecks = cms.bool(True),#needed for 0T running),
+        bypassAllPVChecks = cms.bool(True),#needed for 0T running
         ),
     METDiagonisticsParameters = multPhiCorr_METDiagnostics,
 
@@ -101,10 +101,10 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
     ) 
     ),
     
-    HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"),
-    #HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResultRun2Loose"),  
+    HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"),                                    
     HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResult"),  
     CSCHaloResultLabel = cms.InputTag("CSCTightHaloFilter"),  
+    BeamHaloSummaryLabel = cms.InputTag("BeamHaloSummary"),
     EcalDeadCellTriggerLabel = cms.InputTag("EcalDeadCellTriggerPrimitiveFilter"), 
     eeBadScFilterLabel = cms.InputTag("eeBadScFilter"), 
 

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -26,10 +26,14 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
 
     fillCandidateMaps = cms.bool(False),
 
-    CleaningParameters = cleaningParameters.clone(),
+    CleaningParameters = cleaningParameters.clone(
+        bypassAllPVChecks = cms.bool(True),#needed for 0T running),
+        ),
     METDiagonisticsParameters = multPhiCorr_METDiagnostics,
 
     TriggerResultsLabel  = cms.InputTag("TriggerResults::HLT"),
+    FilterResultsLabelMiniAOD  = cms.InputTag("TriggerResults::RECO"),
+    FilterResultsLabelMiniAOD2  = cms.InputTag("TriggerResults::reRECO"),
 
     onlyCleaned                = cms.untracked.bool(True),
     runcosmics                 = cms.untracked.bool(False),  
@@ -46,7 +50,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
 #        hltDBKey       = cms.string( 'jetmet_highptjet' ), #overrides hltPaths!
-        hltPaths       = cms.vstring( 'HLT_PFJet400_v*' ), 
+        hltPaths       = cms.vstring( 'HLT_PFJet450_v*' ), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -73,7 +77,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
 #        hltDBKey       = cms.string( 'jetmet_highmet' ),#overrides hltPaths!
-        hltPaths       = cms.vstring( 'HLT_MET400_v*' ), 
+        hltPaths       = cms.vstring( 'HLT_MET250_v*' ), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -91,7 +95,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
 #        hltDBKey       = cms.string( 'jetmet_muon' ),#overrides hltPaths!
-        hltPaths       = cms.vstring( 'HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu24_v*'), 
+        hltPaths       = cms.vstring( 'HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu27_v*'), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ) 
@@ -100,6 +104,9 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
     HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"),
     #HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResultRun2Loose"),  
     HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResult"),  
+    CSCHaloResultLabel = cms.InputTag("CSCTightHaloFilter"),  
+    EcalDeadCellTriggerLabel = cms.InputTag("EcalDeadCellTriggerPrimitiveFilter"), 
+    eeBadScFilterLabel = cms.InputTag("eeBadScFilter"), 
 
 #    HighPtJetThreshold = cms.double(60.),
 #    LowPtJetThreshold  = cms.double(15.),
@@ -130,12 +137,22 @@ pfMetDQMAnalyzer = caloMetDQMAnalyzer.clone(
     fillMetHighLevel = cms.bool(False),
     fillCandidateMaps = cms.bool(True),
     onlyCleaned                = cms.untracked.bool(False),
+    CleaningParameters = cleaningParameters.clone(
+        bypassAllPVChecks = cms.bool(False),
+        ),
     DCSFilter = cms.PSet(
         DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
         #DebugOn = cms.untracked.bool(True),
         Filter = cms.untracked.bool(True)
         ),
 )
+
+pfChMetDQMAnalyzer = pfMetDQMAnalyzer.clone(
+    METCollectionLabel     = cms.InputTag("pfChMet"),
+    fillCandidateMaps = cms.bool(False),
+    onlyCleaned                = cms.untracked.bool(True),
+)
+
 #both CaloMET and type1 MET only cleaned plots are filled
 pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
     METType=cms.untracked.string('pf'),
@@ -145,6 +162,9 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
     JetCorrections = cms.InputTag("dqmAk4PFCHSL1FastL2L3ResidualCorrector"),
     fillMetHighLevel = cms.bool(False),
     fillCandidateMaps = cms.bool(False),
+   CleaningParameters = cleaningParameters.clone(
+        bypassAllPVChecks = cms.bool(False),
+        ),
     DCSFilter = cms.PSet(
         DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
         Filter = cms.untracked.bool(True)

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -151,6 +151,9 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   if(isPFJet_ || isMiniAODJet_){
     if(JetIDVersion_== "FIRSTDATA"){
       pfjetidversion = PFJetIDSelectionFunctor::FIRSTDATA;
+    }
+   if(JetIDVersion_== "RUNIISTARTUP"){
+      pfjetidversion = PFJetIDSelectionFunctor::RUNIISTARTUP;
     }else{
       if (verbose_) std::cout<<"no valid PF JetID version given"<<std::endl;
     }
@@ -2084,12 +2087,6 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if(isMiniAODJet_ && (*patJets)[ijet].isPFJet()){
       pat::strbitset stringbitset=pfjetIDFunctor.getBitTemplate();
       jetpassid = pfjetIDFunctor((*patJets)[ijet],stringbitset);
-      if(fabs ((*patJets)[ijet].eta()>3.0)){
-	jetpassid =false;
-	if((1.-(*patJets)[ijet].neutralHadronEnergyFraction())<0.90 && (*patJets)[ijet].neutralMultiplicity()>10){
-	  jetpassid =true;
-	}
-      }
       if(jetCleaningFlag_){
 	Thiscleaned = jetpassid;
 	JetIDWPU = jetpassid;
@@ -2159,12 +2156,6 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       puidmvaflag=(*puJetIdFlagMva)[pfjetref];
       puidcutflag=(*puJetIdFlag)[pfjetref];
       jetpassid = pfjetIDFunctor((*pfJets)[ijet]);
-      if(fabs ((*pfJets)[ijet].eta()>3.0)){
-	jetpassid =false;
-	if((1.-(*pfJets)[ijet].neutralHadronEnergyFraction())<0.90 && (*pfJets)[ijet].neutralMultiplicity()>10){
-	  jetpassid =true;
-	}
-      }
       if(jetCleaningFlag_){
 	Thiscleaned = jetpassid;
 	//JetIDWPU= (jetpassid && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose ));//until new tuning of PU JetID take that out

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -1259,11 +1259,11 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_mass_boosted", mSubJet4_CMSTopTag_mass_boosted));
 
       mnSubJetsSoftDrop_boosted = ibooker.book1D("nSubJets_SoftDrop_boosted", "nSubJets_SoftDrop_boosted", 10, 0, 10); 
-      mSubJet1_SoftDrop_pt_boosted         = ibooker.book1D("SubJet1_SoftDrop_pt_boosted",   "SubJet1_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_SoftDrop_pt_boosted         = ibooker.book1D("SubJet1_SoftDrop_pt_boosted",   "SubJet1_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
       mSubJet1_SoftDrop_eta_boosted        = ibooker.book1D("SubJet1_SoftDrop_eta_boosted",  "SubJet1_SoftDrop_eta_boosted",               etaBin_, etaMin_, etaMax_);
       mSubJet1_SoftDrop_phi_boosted        = ibooker.book1D("SubJet1_SoftDrop_phi_boosted",  "SubJet1_SoftDrop_phi_boosted",               phiBin_, phiMin_, phiMax_);
       mSubJet1_SoftDrop_mass_boosted       = ibooker.book1D("SubJet1_SoftDrop_mass_boosted", "SubJet1_SoftDrop_mass_boosted", 50, 0, 250); 
-      mSubJet2_SoftDrop_pt_boosted         = ibooker.book1D("SubJet2_SoftDrop_pt_boosted",   "SubJet2_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_SoftDrop_pt_boosted         = ibooker.book1D("SubJet2_SoftDrop_pt_boosted",   "SubJet2_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
       mSubJet2_SoftDrop_eta_boosted        = ibooker.book1D("SubJet2_SoftDrop_eta_boosted",  "SubJet2_SoftDrop_eta_boosted",               etaBin_, etaMin_, etaMax_);
       mSubJet2_SoftDrop_phi_boosted        = ibooker.book1D("SubJet2_SoftDrop_phi_boosted",  "SubJet2_SoftDrop_phi_boosted",               phiBin_, phiMin_, phiMax_);
       mSubJet2_SoftDrop_mass_boosted       = ibooker.book1D("SubJet2_SoftDrop_mass_boosted", "SubJet2_SoftDrop_mass_boosted", 50, 0, 250); 

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -1223,11 +1223,11 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CATopTag_boosted" ,mCATopTag_nSubJets_boosted));
 
       mnSubJetsCMSTopTag_boosted = ibooker.book1D("nSubJets_CMSTopTag_boosted", "nSubJets_CMSTopTag_boosted", 10, 0, 10); 
-      mSubJet1_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet1_CMSTopTag_pt_boosted",   "SubJet1_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet1_CMSTopTag_pt_boosted",   "SubJet1_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
       mSubJet1_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet1_CMSTopTag_eta_boosted",  "SubJet1_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
       mSubJet1_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet1_CMSTopTag_phi_boosted",  "SubJet1_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
       mSubJet1_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet1_CMSTopTag_mass_boosted", "SubJet1_CMSTopTag_mass_boosted", 50, 0, 250); 
-      mSubJet2_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet2_CMSTopTag_pt_boosted",   "SubJet2_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet2_CMSTopTag_pt_boosted",   "SubJet2_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
       mSubJet2_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet2_CMSTopTag_eta_boosted",  "SubJet2_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
       mSubJet2_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet2_CMSTopTag_phi_boosted",  "SubJet2_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
       mSubJet2_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet2_CMSTopTag_mass_boosted", "SubJet2_CMSTopTag_mass_boosted", 50, 0, 250); 

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -454,7 +454,7 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 
     // CaloJet specific
     mHadEnergyInHO          = ibooker.book1D("HadEnergyInHO", "HadEnergyInHO", 50, 0, 20);
-    mHadEnergyInHB          = ibooker.book1D("HadEnergy5InHB", "HadEnergyInHB", 50, 0, 100);
+    mHadEnergyInHB          = ibooker.book1D("HadEnergyInHB", "HadEnergyInHB", 50, 0, 100);
     mHadEnergyInHF          = ibooker.book1D("HadEnergyInHF", "HadEnergyInHF", 50, 0, 100);
     mHadEnergyInHE          = ibooker.book1D("HadEnergyInHE", "HadEnergyInHE", 50, 0, 200);
     mEmEnergyInEB           = ibooker.book1D("EmEnergyInEB", "EmEnergyInEB", 50, 0, 100);

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -151,8 +151,7 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   if(isPFJet_ || isMiniAODJet_){
     if(JetIDVersion_== "FIRSTDATA"){
       pfjetidversion = PFJetIDSelectionFunctor::FIRSTDATA;
-    }
-   if(JetIDVersion_== "RUNIISTARTUP"){
+    }else if(JetIDVersion_== "RUNIISTARTUP"){
       pfjetidversion = PFJetIDSelectionFunctor::RUNIISTARTUP;
     }else{
       if (verbose_) std::cout<<"no valid PF JetID version given"<<std::endl;

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -1117,6 +1117,13 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 
   //
   if(isMiniAODJet_){
+    mMass_Barrel     = ibooker.book1D("JetMass_Barrel", "JetMass_Barrel", 50, 0, 250);
+    mMass_EndCap     = ibooker.book1D("JetMass_EndCap", "JetMass_EndCap", 50, 0, 250);
+    mMass_Forward     = ibooker.book1D("JetMass_Forward", "JetMass_Forward", 50, 0, 250);
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"JetMass_Barrel" , mMass_Barrel ));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"JetMass_EndCap" , mMass_EndCap ));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"JetMass_Forward" , mMass_Forward ));
     if(!filljetsubstruc_){
       //done only for MINIAOD
       mPt_CaloJet      = ibooker.book1D("Pt_CaloJet", "Pt_CaloJet",    ptBin_,  10,  ptMax_);
@@ -2019,10 +2026,6 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if(pass_corrected){
       recoJets.push_back(correctedJet);
     }
-
-    if(!pass_corrected && !pass_uncorrected){
-      continue;
-    }
     bool jetpassid=true;
     bool Thiscleaned=true;
     bool JetIDWPU=true;
@@ -2098,6 +2101,8 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	mConstituents_uncor = map_of_MEs[DirName+"/"+"Constituents_uncor"]; if (mConstituents_uncor && mConstituents_uncor->getRootObject()) if (mConstituents_uncor) mConstituents_uncor->Fill ((*patJets)[ijet].nConstituents());
       }
       if(Thiscleaned && pass_corrected){
+	mPt_CaloJet  = map_of_MEs[DirName+"/"+"Pt_CaloJet"]; if(mPt_CaloJet && mPt_CaloJet->getRootObject()&& (*patJets)[ijet].hasUserFloat("caloJetMap:pt")) mPt_CaloJet->Fill((*patJets)[ijet].userFloat("caloJetMap:pt"));
+	mEMF_CaloJet  = map_of_MEs[DirName+"/"+"EMF_CaloJet"]; if(mEMF_CaloJet && mEMF_CaloJet->getRootObject() && (*patJets)[ijet].hasUserFloat("caloJetMap:emEnergyFraction")) mEMF_CaloJet->Fill((*patJets)[ijet].userFloat("caloJetMap:emEnergyFraction"));
 	if(fabs(correctedJet.eta()) <= 1.3) {
 	  if(correctedJet.pt()<=50.){
 	    mMVAPUJIDDiscriminant_lowPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel"]; if(mMVAPUJIDDiscriminant_lowPt_Barrel && mMVAPUJIDDiscriminant_lowPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))mMVAPUJIDDiscriminant_lowPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); } 
@@ -2108,6 +2113,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	  if(correctedJet.pt()>140.){
 	    mMVAPUJIDDiscriminant_highPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel"]; if(mMVAPUJIDDiscriminant_highPt_Barrel && mMVAPUJIDDiscriminant_highPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_highPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant"));} 
 	  }
+	  mMass_Barrel=map_of_MEs[DirName+"/"+"JetMass_Barrel"]; if(mMass_Barrel && mMass_Barrel->getRootObject())mMass_Barrel->Fill((*patJets)[ijet].mass());
 	  mCHFracVSpT_Barrel = map_of_MEs[DirName+"/"+"CHFracVSpT_Barrel"]; if(mCHFracVSpT_Barrel && mCHFracVSpT_Barrel->getRootObject()) mCHFracVSpT_Barrel->Fill(correctedJet.pt(),(*patJets)[ijet].chargedHadronEnergyFraction());
 	  mNHFracVSpT_Barrel = map_of_MEs[DirName+"/"+"NHFracVSpT_Barrel"];if (mNHFracVSpT_Barrel && mNHFracVSpT_Barrel->getRootObject()) mNHFracVSpT_Barrel->Fill(correctedJet.pt(),(*patJets)[ijet].neutralHadronEnergyFraction());
 	  mPhFracVSpT_Barrel = map_of_MEs[DirName+"/"+"PhFracVSpT_Barrel"];if (mPhFracVSpT_Barrel && mPhFracVSpT_Barrel->getRootObject()) mPhFracVSpT_Barrel->Fill(correctedJet.pt(),(*patJets)[ijet].neutralEmEnergyFraction());
@@ -2121,6 +2127,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	  if(correctedJet.pt()>140.){
 	    mMVAPUJIDDiscriminant_highPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap"]; if(mMVAPUJIDDiscriminant_highPt_EndCap && mMVAPUJIDDiscriminant_highPt_EndCap->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_highPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
 	  }
+	  mMass_EndCap=map_of_MEs[DirName+"/"+"JetMass_EndCap"]; if(mMass_EndCap && mMass_EndCap->getRootObject())mMass_EndCap->Fill((*patJets)[ijet].mass());
 	  mCHFracVSpT_EndCap = map_of_MEs[DirName+"/"+"CHFracVSpT_EndCap"]; if(mCHFracVSpT_EndCap && mCHFracVSpT_EndCap->getRootObject()) mCHFracVSpT_EndCap->Fill(correctedJet.pt(),(*patJets)[ijet].chargedHadronEnergyFraction());
 	  mNHFracVSpT_EndCap = map_of_MEs[DirName+"/"+"NHFracVSpT_EndCap"];if (mNHFracVSpT_EndCap && mNHFracVSpT_EndCap->getRootObject()) mNHFracVSpT_EndCap->Fill(correctedJet.pt(),(*patJets)[ijet].neutralHadronEnergyFraction());
 	  mPhFracVSpT_EndCap = map_of_MEs[DirName+"/"+"PhFracVSpT_EndCap"];if (mPhFracVSpT_EndCap && mPhFracVSpT_EndCap->getRootObject()) mPhFracVSpT_EndCap->Fill(correctedJet.pt(),(*patJets)[ijet].neutralEmEnergyFraction());
@@ -2134,6 +2141,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	  if(correctedJet.pt()>140.){
 	    mMVAPUJIDDiscriminant_highPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward"]; if(mMVAPUJIDDiscriminant_highPt_Forward && mMVAPUJIDDiscriminant_highPt_Forward->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_highPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
 	  }
+	  mMass_Forward=map_of_MEs[DirName+"/"+"JetMass_Forward"]; if(mMass_Forward && mMass_Forward->getRootObject())mMass_Forward->Fill((*patJets)[ijet].mass());
 	  mHFHFracVSpT_Forward = map_of_MEs[DirName+"/"+"HFHFracVSpT_Forward"]; if (mHFHFracVSpT_Forward && mHFHFracVSpT_Forward->getRootObject())    mHFHFracVSpT_Forward->Fill(correctedJet.pt(),(*patJets)[ijet].HFHadronEnergyFraction ());	
 	  mHFEFracVSpT_Forward = map_of_MEs[DirName+"/"+"HFEFracVSpT_Forward"]; if (mHFEFracVSpT_Forward && mHFEFracVSpT_Forward->getRootObject())    mHFEFracVSpT_Forward->Fill (correctedJet.pt(),(*patJets)[ijet].HFEMEnergyFraction ());
 	}

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -74,7 +74,9 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   jetType_ = pSet.getParameter<std::string>("JetType");
   m_l1algoname_ = pSet.getParameter<std::string>("l1algoname");
 
-  fill_jet_high_level_histo=pSet.getParameter<bool>("filljetHighLevel"),
+  fill_jet_high_level_histo=pSet.getParameter<bool>("filljetHighLevel");
+  filljetsubstruc_=pSet.getParameter<bool>("fillsubstructure");
+  pt_min_boosted_=pSet.getParameter<double>("ptMinBoosted");
   
   isCaloJet_ = (std::string("calo")==jetType_);
   //isJPTJet_  = (std::string("jpt") ==jetType_);
@@ -749,26 +751,28 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   }
   //
   if(isMiniAODJet_ || isPFJet_){
-    mMVAPUJIDDiscriminant_lowPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Barrel","MVAPUJIDDiscriminant_lowPt_Barrel",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_lowPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_EndCap","MVAPUJIDDiscriminant_lowPt_EndCap",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_lowPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Forward","MVAPUJIDDiscriminant_lowPt_Forward",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_mediumPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Barrel","MVAPUJIDDiscriminant_mediumPt_Barrel",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_mediumPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_EndCap","MVAPUJIDDiscriminant_mediumPt_EndCap",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_mediumPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Forward","MVAPUJIDDiscriminant_mediumPt_Forward",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_highPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Barrel","MVAPUJIDDiscriminant_highPt_Barrel",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_highPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_EndCap","MVAPUJIDDiscriminant_highPt_EndCap",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_highPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Forward","MVAPUJIDDiscriminant_highPt_Forward",50, -1.00, 1.00);
-
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel",mMVAPUJIDDiscriminant_lowPt_Barrel));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_EndCap",mMVAPUJIDDiscriminant_lowPt_EndCap));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Forward",mMVAPUJIDDiscriminant_lowPt_Forward));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Barrel",mMVAPUJIDDiscriminant_mediumPt_Barrel));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_EndCap",mMVAPUJIDDiscriminant_mediumPt_EndCap));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Forward",mMVAPUJIDDiscriminant_mediumPt_Forward));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel",mMVAPUJIDDiscriminant_highPt_Barrel));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap",mMVAPUJIDDiscriminant_highPt_EndCap));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward",mMVAPUJIDDiscriminant_highPt_Forward));
-
+    
+    if(!filljetsubstruc_){//not available for ak8 -> so just take out
+      mMVAPUJIDDiscriminant_lowPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Barrel","MVAPUJIDDiscriminant_lowPt_Barrel",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_lowPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_EndCap","MVAPUJIDDiscriminant_lowPt_EndCap",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_lowPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Forward","MVAPUJIDDiscriminant_lowPt_Forward",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_mediumPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Barrel","MVAPUJIDDiscriminant_mediumPt_Barrel",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_mediumPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_EndCap","MVAPUJIDDiscriminant_mediumPt_EndCap",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_mediumPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Forward","MVAPUJIDDiscriminant_mediumPt_Forward",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_highPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Barrel","MVAPUJIDDiscriminant_highPt_Barrel",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_highPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_EndCap","MVAPUJIDDiscriminant_highPt_EndCap",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_highPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Forward","MVAPUJIDDiscriminant_highPt_Forward",50, -1.00, 1.00);
+      
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel",mMVAPUJIDDiscriminant_lowPt_Barrel));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_EndCap",mMVAPUJIDDiscriminant_lowPt_EndCap));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Forward",mMVAPUJIDDiscriminant_lowPt_Forward));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Barrel",mMVAPUJIDDiscriminant_mediumPt_Barrel));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_EndCap",mMVAPUJIDDiscriminant_mediumPt_EndCap));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Forward",mMVAPUJIDDiscriminant_mediumPt_Forward));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel",mMVAPUJIDDiscriminant_highPt_Barrel));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap",mMVAPUJIDDiscriminant_highPt_EndCap));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward",mMVAPUJIDDiscriminant_highPt_Forward));
+    }
     mCHFracVSpT_Barrel= ibooker.bookProfile("CHFracVSpT_Barrel","CHFracVSpT_Barrel",ptBin_, ptMin_, ptMax_,0.,1.2);
     mNHFracVSpT_Barrel= ibooker.bookProfile("NHFracVSpT_Barrel","NHFracVSpT_Barrel",ptBin_, ptMin_, ptMax_,0.,1.2);
     mPhFracVSpT_Barrel= ibooker.bookProfile("PhFracVSpT_Barrel","PhFracVSpT_Barrel",ptBin_, ptMin_, ptMax_,0.,1.2);
@@ -1110,6 +1114,173 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"NeutralConstituentsFraction" ,mNeutralFraction));
 
   }
+
+  //
+  if(isMiniAODJet_){
+    if(!filljetsubstruc_){
+      //done only for MINIAOD
+      mPt_CaloJet      = ibooker.book1D("Pt_CaloJet", "Pt_CaloJet",    ptBin_,  10,  ptMax_);
+      mEMF_CaloJet     = ibooker.book1D("EMF_CaloJet", "EMF_CaloJet",  52,   -0.02,    1.02);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"Pt_CaloJet" ,mPt_CaloJet));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"EMF_CaloJet" ,mEMF_CaloJet));
+    }
+    if(filljetsubstruc_){
+      //miniaod specific variables, especially for substructure
+      mSoftDropMass = ibooker.book1D("SoftDropMass", "SoftDropMass", 50, 0, 250);
+      mPrunedMass = ibooker.book1D("PrunedMass", "PrunedMass", 50, 0, 250);
+      mTrimmedMass = ibooker.book1D("TrimmedMass", "TrimmedMass", 50, 0, 250);
+      mFilteredMass = ibooker.book1D("FilteredMass", "FilteredMass", 50, 0, 250);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SoftDropMass" ,mSoftDropMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PrunedMass" ,mPrunedMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"TrimmedMass" ,mTrimmedMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"FilteredMass" ,mFilteredMass));
+
+      mtau2_over_tau1 = ibooker.book1D("tau2_over_tau1", "tau2_over_tau1", 50, 0, 1); 
+      mtau3_over_tau2 = ibooker.book1D("tau3_over_tau2", "tau3_over_tau2", 50, 0, 1); 
+      mCATopTag_topMass = ibooker.book1D("CATopTag_topMass", "CATopTag_topMass", 50, 50, 250);
+      mCATopTag_minMass = ibooker.book1D("CATopTag_minMass", "CATopTag_minMass", 50, 0, 250); 
+      mCATopTag_nSubJets = ibooker.book1D("nSubJets_CATopTag", "nSubJets_CATopTag", 10, 0, 10); 
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau2_over_tau1" ,mtau2_over_tau1));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau3_over_tau2" ,mtau3_over_tau2));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_topMass" ,mCATopTag_topMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_minMass" ,mCATopTag_minMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CATopTag" ,mCATopTag_nSubJets));
+
+      mnSubJetsCMSTopTag = ibooker.book1D("nSubJets_CMSTopTag", "nSubJets_CMSTopTag", 10, 0, 10); 
+      mSubJet1_CMSTopTag_pt         = ibooker.book1D("SubJet1_CMSTopTag_pt",   "SubJet1_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_CMSTopTag_eta        = ibooker.book1D("SubJet1_CMSTopTag_eta",  "SubJet1_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_CMSTopTag_phi        = ibooker.book1D("SubJet1_CMSTopTag_phi",  "SubJet1_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_CMSTopTag_mass       = ibooker.book1D("SubJet1_CMSTopTag_mass", "SubJet1_CMSTopTag_mass", 50, 0, 250); 
+      mSubJet2_CMSTopTag_pt         = ibooker.book1D("SubJet2_CMSTopTag_pt",   "SubJet2_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_CMSTopTag_eta        = ibooker.book1D("SubJet2_CMSTopTag_eta",  "SubJet2_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_CMSTopTag_phi        = ibooker.book1D("SubJet2_CMSTopTag_phi",  "SubJet2_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_CMSTopTag_mass       = ibooker.book1D("SubJet2_CMSTopTag_mass", "SubJet2_CMSTopTag_mass", 50, 0, 250); 
+      mSubJet3_CMSTopTag_pt         = ibooker.book1D("SubJet3_CMSTopTag_pt",   "SubJet3_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet3_CMSTopTag_eta        = ibooker.book1D("SubJet3_CMSTopTag_eta",  "SubJet3_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet3_CMSTopTag_phi        = ibooker.book1D("SubJet3_CMSTopTag_phi",  "SubJet3_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet3_CMSTopTag_mass       = ibooker.book1D("SubJet3_CMSTopTag_mass", "SubJet3_CMSTopTag_mass", 50, 0, 250); 
+      mSubJet4_CMSTopTag_pt         = ibooker.book1D("SubJet4_CMSTopTag_pt",   "SubJet4_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet4_CMSTopTag_eta        = ibooker.book1D("SubJet4_CMSTopTag_eta",  "SubJet4_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet4_CMSTopTag_phi        = ibooker.book1D("SubJet4_CMSTopTag_phi",  "SubJet4_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet4_CMSTopTag_mass       = ibooker.book1D("SubJet4_CMSTopTag_mass", "SubJet4_CMSTopTag_mass", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CMSTopTag" ,mnSubJetsCMSTopTag));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_pt" ,mSubJet1_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_eta" ,mSubJet1_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_phi" ,mSubJet1_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_mass" ,mSubJet1_CMSTopTag_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_pt" ,mSubJet2_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_eta" ,mSubJet2_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_phi" ,mSubJet2_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_mass" ,mSubJet2_CMSTopTag_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_pt" ,mSubJet3_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_eta" ,mSubJet3_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_phi" ,mSubJet3_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_mass" ,mSubJet3_CMSTopTag_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_pt" ,mSubJet4_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_eta" ,mSubJet4_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_phi" ,mSubJet4_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_mass" ,mSubJet4_CMSTopTag_mass));
+
+      mnSubJetsSoftDrop = ibooker.book1D("nSubJets_SoftDrop", "nSubJets_SoftDrop", 10, 0, 10); 
+      mSubJet1_SoftDrop_pt         = ibooker.book1D("SubJet1_SoftDrop_pt",   "SubJet1_SoftDrop_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_SoftDrop_eta        = ibooker.book1D("SubJet1_SoftDrop_eta",  "SubJet1_SoftDrop_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_SoftDrop_phi        = ibooker.book1D("SubJet1_SoftDrop_phi",  "SubJet1_SoftDrop_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_SoftDrop_mass       = ibooker.book1D("SubJet1_SoftDrop_mass", "SubJet1_SoftDrop_mass", 50, 0, 250); 
+      mSubJet2_SoftDrop_pt         = ibooker.book1D("SubJet2_SoftDrop_pt",   "SubJet2_SoftDrop_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_SoftDrop_eta        = ibooker.book1D("SubJet2_SoftDrop_eta",  "SubJet2_SoftDrop_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_SoftDrop_phi        = ibooker.book1D("SubJet2_SoftDrop_phi",  "SubJet2_SoftDrop_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_SoftDrop_mass       = ibooker.book1D("SubJet2_SoftDrop_mass", "SubJet2_SoftDrop_mass", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_SoftDrop" ,mnSubJetsSoftDrop));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_pt" ,mSubJet1_SoftDrop_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_eta" ,mSubJet1_SoftDrop_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_phi" ,mSubJet1_SoftDrop_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_mass" ,mSubJet1_SoftDrop_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_pt" ,mSubJet2_SoftDrop_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_eta" ,mSubJet2_SoftDrop_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_phi" ,mSubJet2_SoftDrop_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_mass" ,mSubJet2_SoftDrop_mass));
+      //miniaod specific variables, especially for substructure for boosted stuff
+      mSoftDropMass_boosted = ibooker.book1D("SoftDropMass_boosted", "SoftDropMass_boosted", 50, 0, 250);
+      mPrunedMass_boosted = ibooker.book1D("PrunedMass_boosted", "PrunedMass_boosted", 50, 0, 250);
+      mTrimmedMass_boosted = ibooker.book1D("TrimmedMass_boosted", "TrimmedMass_boosted", 50, 0, 250);
+      mFilteredMass_boosted = ibooker.book1D("FilteredMass_boosted", "FilteredMass_boosted", 50, 0, 250);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SoftDropMass_boosted" ,mSoftDropMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PrunedMass_boosted" ,mPrunedMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"TrimmedMass_boosted" ,mTrimmedMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"FilteredMass_boosted" ,mFilteredMass_boosted));
+
+      mtau2_over_tau1_boosted = ibooker.book1D("tau2_over_tau1_boosted", "tau2_over_tau1_boosted", 50, 0, 1); 
+      mtau3_over_tau2_boosted = ibooker.book1D("tau3_over_tau2_boosted", "tau3_over_tau2_boosted", 50, 0, 1); 
+      mCATopTag_topMass_boosted = ibooker.book1D("CATopTag_topMass_boosted", "CATopTag_topMass_boosted", 50, 50, 250);
+      mCATopTag_minMass_boosted = ibooker.book1D("CATopTag_minMass_boosted", "CATopTag_minMass_boosted", 50, 0, 250); 
+      mCATopTag_nSubJets_boosted = ibooker.book1D("nSubJets_CATopTag_boosted", "nSubJets_CATopTag_boosted", 10, 0, 10); 
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau2_over_tau1_boosted" ,mtau2_over_tau1_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau3_over_tau2_boosted" ,mtau3_over_tau2_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_topMass_boosted" ,mCATopTag_topMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_minMass_boosted" ,mCATopTag_minMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CATopTag_boosted" ,mCATopTag_nSubJets_boosted));
+
+      mnSubJetsCMSTopTag_boosted = ibooker.book1D("nSubJets_CMSTopTag_boosted", "nSubJets_CMSTopTag_boosted", 10, 0, 10); 
+      mSubJet1_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet1_CMSTopTag_pt_boosted",   "SubJet1_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet1_CMSTopTag_eta_boosted",  "SubJet1_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet1_CMSTopTag_phi_boosted",  "SubJet1_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet1_CMSTopTag_mass_boosted", "SubJet1_CMSTopTag_mass_boosted", 50, 0, 250); 
+      mSubJet2_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet2_CMSTopTag_pt_boosted",   "SubJet2_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet2_CMSTopTag_eta_boosted",  "SubJet2_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet2_CMSTopTag_phi_boosted",  "SubJet2_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet2_CMSTopTag_mass_boosted", "SubJet2_CMSTopTag_mass_boosted", 50, 0, 250); 
+      mSubJet3_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet3_CMSTopTag_pt_boosted",   "SubJet3_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet3_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet3_CMSTopTag_eta_boosted",  "SubJet3_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet3_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet3_CMSTopTag_phi_boosted",  "SubJet3_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet3_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet3_CMSTopTag_mass_boosted", "SubJet3_CMSTopTag_mass_boosted", 50, 0, 250); 
+      mSubJet4_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet4_CMSTopTag_pt_boosted",   "SubJet4_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet4_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet4_CMSTopTag_eta_boosted",  "SubJet4_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet4_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet4_CMSTopTag_phi_boosted",  "SubJet4_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet4_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet4_CMSTopTag_mass_boosted", "SubJet4_CMSTopTag_mass_boosted", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CMSTopTag_boosted", mnSubJetsCMSTopTag_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_pt_boosted", mSubJet1_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_eta_boosted", mSubJet1_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_phi_boosted", mSubJet1_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_mass_boosted", mSubJet1_CMSTopTag_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_pt_boosted", mSubJet2_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_eta_boosted", mSubJet2_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_phi_boosted", mSubJet2_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_mass_boosted", mSubJet2_CMSTopTag_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_pt_boosted", mSubJet3_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_eta_boosted", mSubJet3_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_phi_boosted", mSubJet3_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_mass_boosted", mSubJet3_CMSTopTag_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_pt_boosted", mSubJet4_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_eta_boosted", mSubJet4_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_phi_boosted", mSubJet4_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_mass_boosted", mSubJet4_CMSTopTag_mass_boosted));
+
+      mnSubJetsSoftDrop_boosted = ibooker.book1D("nSubJets_SoftDrop_boosted", "nSubJets_SoftDrop_boosted", 10, 0, 10); 
+      mSubJet1_SoftDrop_pt_boosted         = ibooker.book1D("SubJet1_SoftDrop_pt_boosted",   "SubJet1_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_SoftDrop_eta_boosted        = ibooker.book1D("SubJet1_SoftDrop_eta_boosted",  "SubJet1_SoftDrop_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_SoftDrop_phi_boosted        = ibooker.book1D("SubJet1_SoftDrop_phi_boosted",  "SubJet1_SoftDrop_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_SoftDrop_mass_boosted       = ibooker.book1D("SubJet1_SoftDrop_mass_boosted", "SubJet1_SoftDrop_mass_boosted", 50, 0, 250); 
+      mSubJet2_SoftDrop_pt_boosted         = ibooker.book1D("SubJet2_SoftDrop_pt_boosted",   "SubJet2_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_SoftDrop_eta_boosted        = ibooker.book1D("SubJet2_SoftDrop_eta_boosted",  "SubJet2_SoftDrop_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_SoftDrop_phi_boosted        = ibooker.book1D("SubJet2_SoftDrop_phi_boosted",  "SubJet2_SoftDrop_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_SoftDrop_mass_boosted       = ibooker.book1D("SubJet2_SoftDrop_mass_boosted", "SubJet2_SoftDrop_mass_boosted", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_SoftDrop_boosted", mnSubJetsSoftDrop_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_pt_boosted", mSubJet1_SoftDrop_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_eta_boosted", mSubJet1_SoftDrop_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_phi_boosted", mSubJet1_SoftDrop_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_mass_boosted", mSubJet1_SoftDrop_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_pt_boosted", mSubJet2_SoftDrop_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_eta_boosted", mSubJet2_SoftDrop_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_phi_boosted", mSubJet2_SoftDrop_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_mass_boosted", mSubJet2_SoftDrop_mass_boosted));
+
+    }
+  }
+
 
   if(jetCleaningFlag_){
     //so far we have only one additional selection -> implement to make it expandable
@@ -1910,6 +2081,12 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if(isMiniAODJet_ && (*patJets)[ijet].isPFJet()){
       pat::strbitset stringbitset=pfjetIDFunctor.getBitTemplate();
       jetpassid = pfjetIDFunctor((*patJets)[ijet],stringbitset);
+      if(fabs ((*patJets)[ijet].eta()>3.0)){
+	jetpassid =false;
+	if((1.-(*patJets)[ijet].neutralHadronEnergyFraction())<0.90 && (*patJets)[ijet].neutralMultiplicity()>10){
+	  jetpassid =true;
+	}
+      }
       if(jetCleaningFlag_){
 	Thiscleaned = jetpassid;
 	JetIDWPU = jetpassid;
@@ -1974,12 +2151,15 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       puidmvaflag=(*puJetIdFlagMva)[pfjetref];
       puidcutflag=(*puJetIdFlag)[pfjetref];
       jetpassid = pfjetIDFunctor((*pfJets)[ijet]);
-      if((*pfJets)[ijet].muonEnergyFraction()>0.8){
+      if(fabs ((*pfJets)[ijet].eta()>3.0)){
 	jetpassid =false;
+	if((1.-(*pfJets)[ijet].neutralHadronEnergyFraction())<0.90 && (*pfJets)[ijet].neutralMultiplicity()>10){
+	  jetpassid =true;
+	}
       }
       if(jetCleaningFlag_){
 	Thiscleaned = jetpassid;
-	JetIDWPU= (jetpassid && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose ));
+	//JetIDWPU= (jetpassid && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose ));//until new tuning of PU JetID take that out
       }
       if(Thiscleaned && pass_uncorrected){
 	mPt_uncor = map_of_MEs[DirName+"/"+"Pt_uncor"]; if (mPt_uncor && mPt_uncor->getRootObject())  mPt_uncor->Fill ((*pfJets)[ijet].pt());
@@ -2433,6 +2613,124 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	mJetEnergyCorr = map_of_MEs[DirName+"/"+"JetEnergyCorr"]; if(mJetEnergyCorr && mJetEnergyCorr->getRootObject()) mJetEnergyCorr->Fill(1./(*patJets)[ijet].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSEta = map_of_MEs[DirName+"/"+"JetEnergyCorrVSEta"]; if(mJetEnergyCorrVSEta && mJetEnergyCorrVSEta->getRootObject())mJetEnergyCorrVSEta->Fill(correctedJet.eta(),1./(*patJets)[ijet].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSPt = map_of_MEs[DirName+"/"+"JetEnergyCorrVSPt"]; if(mJetEnergyCorrVSPt && mJetEnergyCorrVSPt->getRootObject()) mJetEnergyCorrVSPt->Fill(correctedJet.pt(),1./(*patJets)[ijet].jecFactor("Uncorrected"));
+	if(filljetsubstruc_){
+	  //miniaod specific variables, especially for substructure
+	  mSoftDropMass = map_of_MEs[DirName+"/"+"SoftDropMass"];if(mSoftDropMass && mSoftDropMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSSoftDropMass")) mSoftDropMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSSoftDropMass"));
+	  mPrunedMass = map_of_MEs[DirName+"/"+"PrunedMass"];if(mPrunedMass && mPrunedMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSPrunedMass")) mPrunedMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSPrunedMass"));
+	  mTrimmedMass = map_of_MEs[DirName+"/"+"TrimmedMass"];if(mTrimmedMass && mTrimmedMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSTrimmedMass")) mTrimmedMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSTrimmedMass"));
+	  mFilteredMass = map_of_MEs[DirName+"/"+"FilteredMass"];if(mFilteredMass && mFilteredMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSFilteredMass")) mFilteredMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSFilteredMass"));
+	  mtau2_over_tau1 = map_of_MEs[DirName+"/"+"tau2_over_tau1"]; if(mtau2_over_tau1 && mtau2_over_tau1->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau1") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2")))mtau2_over_tau1->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau2")/(*patJets)[ijet].userFloat("NjettinessAK8:tau1"));
+	  mtau3_over_tau2 = map_of_MEs[DirName+"/"+"tau3_over_tau2"]; if(mtau3_over_tau2 && mtau3_over_tau2->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau3")))mtau3_over_tau2->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau3")/(*patJets)[ijet].userFloat("NjettinessAK8:tau2"));
+	  if((*patJets)[ijet].hasTagInfo("caTop")){
+	    reco::CATopJetTagInfo const * tagInfo=  dynamic_cast<reco::CATopJetTagInfo const *>((*patJets)[ijet].tagInfo("caTop"));
+	    if ( tagInfo != 0 ) {
+	      mCATopTag_topMass = map_of_MEs[DirName+"/"+"CATopTag_topMass"];if(mCATopTag_topMass && mCATopTag_topMass->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_topMass->Fill(tagInfo->properties().topMass);
+	      mCATopTag_minMass = map_of_MEs[DirName+"/"+"CATopTag_minMass"];if(mCATopTag_minMass && mCATopTag_minMass->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_minMass->Fill(tagInfo->properties().minMass);
+	      mCATopTag_nSubJets = map_of_MEs[DirName+"/"+"nSubJets_CATopTag"];if(mCATopTag_nSubJets && mCATopTag_nSubJets->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_nSubJets->Fill(tagInfo->properties().nSubJets);
+	    }
+	  }
+	  if((*patJets)[ijet].hasSubjets("CMSTopTag")){
+	    mnSubJetsCMSTopTag=map_of_MEs[DirName+"/"+"nSubJets_CMSTopTag"]; if(mnSubJetsCMSTopTag && mnSubJetsCMSTopTag->getRootObject()) mnSubJetsCMSTopTag->Fill((*patJets)[ijet].subjets("CMSTopTag").size());
+	  }
+	  if((*patJets)[ijet].hasSubjets("CMSTopTag") && (*patJets)[ijet].subjets("CMSTopTag").size()>0){
+	    mSubJet1_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_pt"]; if(mSubJet1_CMSTopTag_pt && mSubJet1_CMSTopTag_pt->getRootObject()) mSubJet1_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->pt());
+	    mSubJet1_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_eta"]; if(mSubJet1_CMSTopTag_eta && mSubJet1_CMSTopTag_eta->getRootObject()) mSubJet1_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->eta());
+	    mSubJet1_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_phi"]; if(mSubJet1_CMSTopTag_phi && mSubJet1_CMSTopTag_phi->getRootObject()) mSubJet1_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->phi());
+	    mSubJet1_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_mass"]; if(mSubJet1_CMSTopTag_mass && mSubJet1_CMSTopTag_mass->getRootObject()) mSubJet1_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->mass());
+	    if((*patJets)[ijet].subjets("CMSTopTag").size()>1){
+	      mSubJet2_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_pt"]; if(mSubJet2_CMSTopTag_pt && mSubJet2_CMSTopTag_pt->getRootObject()) mSubJet2_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->pt());
+	      mSubJet2_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_eta"]; if(mSubJet2_CMSTopTag_eta && mSubJet2_CMSTopTag_eta->getRootObject()) mSubJet2_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->eta());
+	      mSubJet2_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_phi"]; if(mSubJet2_CMSTopTag_phi && mSubJet2_CMSTopTag_phi->getRootObject()) mSubJet2_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->phi());
+	      mSubJet2_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_mass"]; if(mSubJet2_CMSTopTag_mass && mSubJet2_CMSTopTag_mass->getRootObject()) mSubJet2_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->mass());
+	      if((*patJets)[ijet].subjets("CMSTopTag").size()>2){
+		mSubJet3_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_pt"]; if(mSubJet3_CMSTopTag_pt && mSubJet3_CMSTopTag_pt->getRootObject()) mSubJet3_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->pt());
+		mSubJet3_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_eta"]; if(mSubJet3_CMSTopTag_eta && mSubJet3_CMSTopTag_eta->getRootObject()) mSubJet3_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->eta());
+		mSubJet3_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_phi"]; if(mSubJet3_CMSTopTag_phi && mSubJet3_CMSTopTag_phi->getRootObject()) mSubJet3_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->phi());
+		mSubJet3_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_mass"]; if(mSubJet3_CMSTopTag_mass && mSubJet3_CMSTopTag_mass->getRootObject()) mSubJet3_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->mass());
+		if((*patJets)[ijet].subjets("CMSTopTag").size()>3){
+		  mSubJet4_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_pt"]; if(mSubJet4_CMSTopTag_pt && mSubJet4_CMSTopTag_pt->getRootObject()) mSubJet4_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->pt());
+		  mSubJet4_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_eta"]; if(mSubJet4_CMSTopTag_eta && mSubJet4_CMSTopTag_eta->getRootObject()) mSubJet4_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->eta());
+		  mSubJet4_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_phi"]; if(mSubJet4_CMSTopTag_phi && mSubJet4_CMSTopTag_phi->getRootObject()) mSubJet4_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->phi());
+		  mSubJet4_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_mass"]; if(mSubJet4_CMSTopTag_mass && mSubJet4_CMSTopTag_mass->getRootObject()) mSubJet4_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->mass());
+		}
+	      }
+	    }
+	  }//CMS top tag filling
+	  if((*patJets)[ijet].hasSubjets("SoftDrop")){
+	    mnSubJetsSoftDrop=map_of_MEs[DirName+"/"+"nSubJets_SoftDrop"]; if(mnSubJetsSoftDrop && mnSubJetsSoftDrop->getRootObject()) mnSubJetsSoftDrop->Fill((*patJets)[ijet].subjets("SoftDrop").size());
+	  }
+	  if((*patJets)[ijet].hasSubjets("SoftDrop") && (*patJets)[ijet].subjets("SoftDrop").size()>0){
+	    mSubJet1_SoftDrop_pt=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_pt"]; if(mSubJet1_SoftDrop_pt && mSubJet1_SoftDrop_pt->getRootObject()) mSubJet1_SoftDrop_pt->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->pt());
+	    mSubJet1_SoftDrop_eta=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_eta"]; if(mSubJet1_SoftDrop_eta && mSubJet1_SoftDrop_eta->getRootObject()) mSubJet1_SoftDrop_eta->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->eta());
+	    mSubJet1_SoftDrop_phi=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_phi"]; if(mSubJet1_SoftDrop_phi && mSubJet1_SoftDrop_phi->getRootObject()) mSubJet1_SoftDrop_phi->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->phi());
+	    mSubJet1_SoftDrop_mass=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_mass"]; if(mSubJet1_SoftDrop_mass && mSubJet1_SoftDrop_mass->getRootObject()) mSubJet1_SoftDrop_mass->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->mass());
+	    if((*patJets)[ijet].subjets("SoftDrop").size()>1){
+	      mSubJet2_SoftDrop_pt=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_pt"]; if(mSubJet2_SoftDrop_pt && mSubJet2_SoftDrop_pt->getRootObject()) mSubJet2_SoftDrop_pt->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->pt());
+	      mSubJet2_SoftDrop_eta=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_eta"]; if(mSubJet2_SoftDrop_eta && mSubJet2_SoftDrop_eta->getRootObject()) mSubJet2_SoftDrop_eta->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->eta());
+	      mSubJet2_SoftDrop_phi=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_phi"]; if(mSubJet2_SoftDrop_phi && mSubJet2_SoftDrop_phi->getRootObject()) mSubJet2_SoftDrop_phi->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->phi());
+	      mSubJet2_SoftDrop_mass=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_mass"]; if(mSubJet2_SoftDrop_mass && mSubJet2_SoftDrop_mass->getRootObject()) mSubJet2_SoftDrop_mass->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->mass());
+	    }
+	  }//soft drop jets
+	  if((*patJets)[ijet].pt()>pt_min_boosted_){
+	    //miniaod specific variables, especially for boosted substructure
+	    mSoftDropMass_boosted = map_of_MEs[DirName+"/"+"SoftDropMass_boosted"];if(mSoftDropMass_boosted && mSoftDropMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSSoftDropMass")) mSoftDropMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSSoftDropMass"));
+	    mPrunedMass_boosted = map_of_MEs[DirName+"/"+"PrunedMass_boosted"];if(mPrunedMass_boosted && mPrunedMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSPrunedMass")) mPrunedMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSPrunedMass"));
+	    mTrimmedMass_boosted = map_of_MEs[DirName+"/"+"TrimmedMass_boosted"];if(mTrimmedMass_boosted && mTrimmedMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSTrimmedMass")) mTrimmedMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSTrimmedMass"));
+	    mFilteredMass_boosted = map_of_MEs[DirName+"/"+"FilteredMass_boosted"];if(mFilteredMass_boosted && mFilteredMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSFilteredMass")) mFilteredMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSFilteredMass"));
+	    mtau2_over_tau1_boosted = map_of_MEs[DirName+"/"+"tau2_over_tau1_boosted"]; if(mtau2_over_tau1_boosted && mtau2_over_tau1_boosted->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau1") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2")))mtau2_over_tau1_boosted->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau2")/(*patJets)[ijet].userFloat("NjettinessAK8:tau1"));
+	    mtau3_over_tau2_boosted = map_of_MEs[DirName+"/"+"tau3_over_tau2_boosted"]; if(mtau3_over_tau2_boosted && mtau3_over_tau2_boosted->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau3")))mtau3_over_tau2_boosted->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau3")/(*patJets)[ijet].userFloat("NjettinessAK8:tau2"));
+	    if((*patJets)[ijet].hasTagInfo("caTop")){
+	      reco::CATopJetTagInfo const * tagInfo_boosted =  dynamic_cast<reco::CATopJetTagInfo const *>((*patJets)[ijet].tagInfo("caTop"));
+	      if ( tagInfo_boosted  != 0 ) {
+		mCATopTag_topMass_boosted = map_of_MEs[DirName+"/"+"CATopTag_topMass_boosted"];if(mCATopTag_topMass_boosted && mCATopTag_topMass_boosted->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_topMass_boosted->Fill(tagInfo_boosted->properties().topMass);
+		mCATopTag_minMass_boosted = map_of_MEs[DirName+"/"+"CATopTag_minMass_boosted"];if(mCATopTag_minMass_boosted && mCATopTag_minMass_boosted->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_minMass_boosted->Fill(tagInfo_boosted->properties().minMass);
+		mCATopTag_nSubJets_boosted = map_of_MEs[DirName+"/"+"nSubJets_CATopTag_boosted"];if(mCATopTag_nSubJets_boosted && mCATopTag_nSubJets_boosted->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_nSubJets_boosted->Fill(tagInfo_boosted->properties().nSubJets);
+	      }
+	    }
+	    if((*patJets)[ijet].hasSubjets("CMSTopTag")){
+	      mnSubJetsCMSTopTag_boosted=map_of_MEs[DirName+"/"+"nSubJets_CMSTopTag_boosted"]; if(mnSubJetsCMSTopTag_boosted && mnSubJetsCMSTopTag_boosted->getRootObject()) mnSubJetsCMSTopTag_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag").size());
+	    }
+	    if((*patJets)[ijet].hasSubjets("CMSTopTag") && (*patJets)[ijet].subjets("CMSTopTag").size()>0){
+	      mSubJet1_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_pt_boosted"]; if(mSubJet1_CMSTopTag_pt_boosted && mSubJet1_CMSTopTag_pt_boosted->getRootObject()) mSubJet1_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->pt());
+	      mSubJet1_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_eta_boosted"]; if(mSubJet1_CMSTopTag_eta_boosted && mSubJet1_CMSTopTag_eta_boosted->getRootObject()) mSubJet1_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->eta());
+	      mSubJet1_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_phi_boosted"]; if(mSubJet1_CMSTopTag_phi_boosted && mSubJet1_CMSTopTag_phi_boosted->getRootObject()) mSubJet1_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->phi());
+	      mSubJet1_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_mass_boosted"]; if(mSubJet1_CMSTopTag_mass_boosted && mSubJet1_CMSTopTag_mass_boosted->getRootObject()) mSubJet1_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->mass());
+	      if((*patJets)[ijet].subjets("CMSTopTag").size()>1){
+		mSubJet2_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_pt_boosted"]; if(mSubJet2_CMSTopTag_pt_boosted && mSubJet2_CMSTopTag_pt_boosted->getRootObject()) mSubJet2_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->pt());
+		mSubJet2_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_eta_boosted"]; if(mSubJet2_CMSTopTag_eta_boosted && mSubJet2_CMSTopTag_eta_boosted->getRootObject()) mSubJet2_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->eta());
+		mSubJet2_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_phi_boosted"]; if(mSubJet2_CMSTopTag_phi_boosted && mSubJet2_CMSTopTag_phi_boosted->getRootObject()) mSubJet2_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->phi());
+		mSubJet2_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_mass_boosted"]; if(mSubJet2_CMSTopTag_mass_boosted && mSubJet2_CMSTopTag_mass_boosted->getRootObject()) mSubJet2_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->mass());
+		if((*patJets)[ijet].subjets("CMSTopTag").size()>2){
+		  mSubJet3_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_pt_boosted"]; if(mSubJet3_CMSTopTag_pt_boosted && mSubJet3_CMSTopTag_pt_boosted->getRootObject()) mSubJet3_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->pt());
+		  mSubJet3_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_eta_boosted"]; if(mSubJet3_CMSTopTag_eta_boosted && mSubJet3_CMSTopTag_eta_boosted->getRootObject()) mSubJet3_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->eta());
+		  mSubJet3_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_phi_boosted"]; if(mSubJet3_CMSTopTag_phi_boosted && mSubJet3_CMSTopTag_phi_boosted->getRootObject()) mSubJet3_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->phi());
+		  mSubJet3_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_mass_boosted"]; if(mSubJet3_CMSTopTag_mass_boosted && mSubJet3_CMSTopTag_mass_boosted->getRootObject()) mSubJet3_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->mass());
+		  if((*patJets)[ijet].subjets("CMSTopTag").size()>3){
+		    mSubJet4_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_pt_boosted"]; if(mSubJet4_CMSTopTag_pt_boosted && mSubJet4_CMSTopTag_pt_boosted->getRootObject()) mSubJet4_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->pt());
+		    mSubJet4_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_eta_boosted"]; if(mSubJet4_CMSTopTag_eta_boosted && mSubJet4_CMSTopTag_eta_boosted->getRootObject()) mSubJet4_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->eta());
+		    mSubJet4_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_phi_boosted"]; if(mSubJet4_CMSTopTag_phi_boosted && mSubJet4_CMSTopTag_phi_boosted->getRootObject()) mSubJet4_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->phi());
+		    mSubJet4_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_mass_boosted"]; if(mSubJet4_CMSTopTag_mass_boosted && mSubJet4_CMSTopTag_mass_boosted->getRootObject()) mSubJet4_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->mass());
+		  }
+		}
+	      }
+	    }
+	    if((*patJets)[ijet].hasSubjets("SoftDrop")){
+	      mnSubJetsSoftDrop_boosted=map_of_MEs[DirName+"/"+"nSubJets_SoftDrop_boosted"]; if(mnSubJetsSoftDrop_boosted && mnSubJetsSoftDrop_boosted->getRootObject()) mnSubJetsSoftDrop_boosted->Fill((*patJets)[ijet].subjets("SoftDrop").size());
+	    }
+	    if((*patJets)[ijet].hasSubjets("SoftDrop") && (*patJets)[ijet].subjets("SoftDrop").size()>0){
+	      mSubJet1_SoftDrop_pt_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_pt_boosted"]; if(mSubJet1_SoftDrop_pt_boosted && mSubJet1_SoftDrop_pt_boosted->getRootObject()) mSubJet1_SoftDrop_pt_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->pt());
+	      mSubJet1_SoftDrop_eta_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_eta_boosted"]; if(mSubJet1_SoftDrop_eta_boosted && mSubJet1_SoftDrop_eta_boosted->getRootObject()) mSubJet1_SoftDrop_eta_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->eta());
+	      mSubJet1_SoftDrop_phi_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_phi_boosted"]; if(mSubJet1_SoftDrop_phi_boosted && mSubJet1_SoftDrop_phi_boosted->getRootObject()) mSubJet1_SoftDrop_phi_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->phi());
+	      mSubJet1_SoftDrop_mass_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_mass_boosted"]; if(mSubJet1_SoftDrop_mass_boosted && mSubJet1_SoftDrop_mass_boosted->getRootObject()) mSubJet1_SoftDrop_mass_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->mass());
+	      if((*patJets)[ijet].subjets("SoftDrop").size()>1){
+		mSubJet2_SoftDrop_pt_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_pt_boosted"]; if(mSubJet2_SoftDrop_pt_boosted && mSubJet2_SoftDrop_pt_boosted->getRootObject()) mSubJet2_SoftDrop_pt_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->pt());
+		mSubJet2_SoftDrop_eta_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_eta_boosted"]; if(mSubJet2_SoftDrop_eta_boosted && mSubJet2_SoftDrop_eta_boosted->getRootObject()) mSubJet2_SoftDrop_eta_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->eta());
+		mSubJet2_SoftDrop_phi_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_phi_boosted"]; if(mSubJet2_SoftDrop_phi_boosted && mSubJet2_SoftDrop_phi_boosted->getRootObject()) mSubJet2_SoftDrop_phi_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->phi());
+		mSubJet2_SoftDrop_mass_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_mass_boosted"]; if(mSubJet2_SoftDrop_mass_boosted && mSubJet2_SoftDrop_mass_boosted->getRootObject()) mSubJet2_SoftDrop_mass_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->mass());
+	      }
+	    }
+	  }//substructure filling for boosted
+	}//substructure filling	  
       }
       // --- Event passed the low pt jet trigger
       if (jetLoPass_ == 1) {	  

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -45,6 +45,8 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   m_l1algoname_ = pSet.getParameter<std::string>("l1algoname");
   m_bitAlgTechTrig_=-1;
 
+  miniaodfilterdec=-1;
+
   LSBegin_     = pSet.getParameter<int>("LSBegin");
   LSEnd_       = pSet.getParameter<int>("LSEnd");
  // Smallest track pt
@@ -993,7 +995,8 @@ void METAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
   }
   if(isMiniAODMet_){
     bool changed_filter=true;
-    if (FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel_.process(),changed_filter)){	
+    if (FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel_.process(),changed_filter)){
+      miniaodfilterdec=0;
       std::vector<int>initializeFilter(4,-1);
       miniaodFilterIndex_=initializeFilter; 
       for(unsigned int i=0;i<FilterhltConfig_.size();i++){
@@ -1016,6 +1019,7 @@ void METAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 	}
       }
     }else if(FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel2_.process(),changed_filter)){
+      miniaodfilterdec=1;
       std::vector<int>initializeFilter(4,-1);
       miniaodFilterIndex_=initializeFilter; 
       for(unsigned int i=0;i<FilterhltConfig_.size();i++){
@@ -1576,22 +1580,24 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }
   }else{
     edm::Handle<edm::TriggerResults> metFilterResults;
-    iEvent.getByToken(METFilterMiniAODToken_, metFilterResults);
-
-    if(metFilterResults.isValid()){
-      if(miniaodFilterIndex_[0]!=-1){
-	filter_decisions[0] = metFilterResults->accept(miniaodFilterIndex_[0]);
+    if(miniaodfilterdec==0){
+      iEvent.getByToken(METFilterMiniAODToken_, metFilterResults);
+      
+      if(metFilterResults.isValid()){
+	if(miniaodFilterIndex_[0]!=-1){
+	  filter_decisions[0] = metFilterResults->accept(miniaodFilterIndex_[0]);
+	}
+	if(miniaodFilterIndex_[1]!=-1){
+	  filter_decisions[1] = metFilterResults->accept(miniaodFilterIndex_[1]);
+	}
+	if(miniaodFilterIndex_[2]!=-1){
+	  filter_decisions[2] = metFilterResults->accept(miniaodFilterIndex_[2]);
+	}
+	if(miniaodFilterIndex_[3]!=-1){
+	  filter_decisions[3] = metFilterResults->accept(miniaodFilterIndex_[3]);
+	}
       }
-      if(miniaodFilterIndex_[1]!=-1){
-	filter_decisions[1] = metFilterResults->accept(miniaodFilterIndex_[1]);
-      }
-      if(miniaodFilterIndex_[2]!=-1){
-	filter_decisions[2] = metFilterResults->accept(miniaodFilterIndex_[2]);
-      }
-      if(miniaodFilterIndex_[3]!=-1){
-	filter_decisions[3] = metFilterResults->accept(miniaodFilterIndex_[3]);
-      }
-    }else{
+    }else if (miniaodfilterdec==1){
       iEvent.getByToken(METFilterMiniAODToken2_, metFilterResults);
       if(metFilterResults.isValid()){
 	if(miniaodFilterIndex_[0]!=-1){

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -76,7 +76,7 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   }
   if(isPFMet_ || isMiniAODMet_){
     pflowToken_ = consumes<std::vector<reco::PFCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
-    pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::FIRSTDATA, PFJetIDSelectionFunctor::LOOSE);
+    pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::RUNIISTARTUP, PFJetIDSelectionFunctor::LOOSE);
   }
   MuonsToken_ = consumes<reco::MuonCollection>(pSet.getParameter<edm::InputTag>       ("muonsrc"));
 

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -1594,10 +1594,10 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }
   }
 
-  bool HBHENoiseFilterResult=filter_decisions[0];//setup for RECO and MINIAOD
+  bool HBHENoiseFilterResultFlag=filter_decisions[0];//setup for RECO and MINIAOD
   // ==========================================================
   // HCAL Noise filter
-  bool bHBHENoiseFilter = HBHENoiseFilterResult;
+  bool bHBHENoiseFilter = HBHENoiseFilterResultFlag;
 
   // DCS Filter
   bool bDCSFilter = (bypassAllDCSChecks_ || DCSFilter_->filter(iEvent, iSetup));
@@ -1946,7 +1946,7 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
 	    if(c.eta()>(-3.0)&& c.eta()<(-1.479)){
 	      px_PhotonsEndcapMinus-=c.px();
 	      py_PhotonsEndcapMinus-=c.py();
-	      pt_sum_PhF_Endcap_plus+=c.et();
+	      pt_sum_PhF_Endcap_minus+=c.et();
 	    }else if(c.eta()>=(-1.479)&& c.eta()<=1.479){
 	      px_PhotonsBarrel-=c.px();
 	      py_PhotonsBarrel-=c.py();
@@ -1954,7 +1954,7 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
 	    }else if(c.eta()>1.479 && c.eta()<3.0){
 	      px_PhotonsEndcapPlus-=c.px();
 	      py_PhotonsEndcapPlus-=c.py();
-	      pt_sum_PhF_Endcap_minus+=c.et();
+	      pt_sum_PhF_Endcap_plus+=c.et();
 	    }
 	  }
 	  if(c.particleId()==6){//HFHadrons
@@ -2466,7 +2466,7 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
       if (meHFHadronEtFraction_profile      && meHFHadronEtFraction_profile     ->getRootObject()) meHFHadronEtFraction_profile     ->Fill(numPV_, patmet.Type6EtFraction());
       if (meHFEMEtFraction_profile          && meHFEMEtFraction_profile         ->getRootObject()) meHFEMEtFraction_profile         ->Fill(numPV_, patmet.Type7EtFraction());
 
-     mePhotonEt        = map_of_MEs[DirName + "/PfPhotonEt"];
+      mePhotonEt        = map_of_MEs[DirName + "/PfPhotonEt"];
       meNeutralHadronEt = map_of_MEs[DirName + "/PfNeutralHadronEt"];
       meChargedHadronEt = map_of_MEs[DirName + "/PfChargedHadronEt"];
       meHFHadronEt      = map_of_MEs[DirName + "/PfHFHadronEt"];

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -1575,9 +1575,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       if (verbose_) std::cout << "METAnalyzer: EcalDeadCellTriggerFilterResultHandle" << std::endl;
     }
     filter_decisions[3]= *EcalDeadCellTriggerFilterResultHandle;
-    if(filter_decisions[0]==false){
-      std::cout<<"HBHENoiseFilter failed "<<filter_decisions[0]<<"/"<<*HBHENoiseFilterResultHandle<<"/"<<(!BeamHaloSummaryHandle->CSCTightHaloId())<<"/"<<*eeBadScFilterResultHandle<<"/"<<*EcalDeadCellTriggerFilterResultHandle<<std::endl;
-    }
   }else{
     edm::Handle<edm::TriggerResults> metFilterResults;
     if(miniaodfilterdec==0){

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -130,6 +130,18 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
 
   hbheNoiseFilterResultTag_    = parameters.getParameter<edm::InputTag>("HBHENoiseFilterResultLabel");
   hbheNoiseFilterResultToken_=consumes<bool>(hbheNoiseFilterResultTag_);
+  CSCHaloResultTag_= parameters.getParameter<edm::InputTag>("CSCHaloResultLabel");
+  CSCHaloResultToken_=consumes<bool>(CSCHaloResultTag_);
+  EcalDeadCellTriggerTag_= parameters.getParameter<edm::InputTag>("EcalDeadCellTriggerLabel");
+  EcalDeadCellTriggerToken_=consumes<bool>(EcalDeadCellTriggerTag_);
+  eeBadScFilterTag_= parameters.getParameter<edm::InputTag>("eeBadScFilterLabel");
+  eeBadScFilterToken_=consumes<bool>(eeBadScFilterTag_);
+
+  METFilterMiniAODLabel_=parameters.getParameter<edm::InputTag>("FilterResultsLabelMiniAOD");
+  METFilterMiniAODToken_=consumes<edm::TriggerResults>(METFilterMiniAODLabel_);
+
+  METFilterMiniAODLabel2_=parameters.getParameter<edm::InputTag>("FilterResultsLabelMiniAOD2");
+  METFilterMiniAODToken2_=consumes<edm::TriggerResults>(METFilterMiniAODLabel2_);
 
   // 
   nbinsPV_ = parameters.getParameter<int>("pVBin");
@@ -200,12 +212,12 @@ void METAnalyzer::bookMESet(std::string DirName, DQMStore::IBooker & ibooker, st
   if (DirName.find("Cleaned")!=std::string::npos) {
     fillPFCandidatePlots=true;
     bookMonitorElement(DirName,ibooker,map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,fillZPlots);
-    for (unsigned int i = 0; i<triggerFolderEventFlag_.size(); i++) {
-      fillPFCandidatePlots=false;
-      if (triggerFolderEventFlag_[i]->on()) {
-        bookMonitorElement(DirName+"/"+triggerFolderLabels_[i],ibooker,map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,fillZPlots);
-      }
-    }
+    //for (unsigned int i = 0; i<triggerFolderEventFlag_.size(); i++) {
+    //fillPFCandidatePlots=false;
+    //if (triggerFolderEventFlag_[i]->on()) {
+    //  bookMonitorElement(DirName+"/"+triggerFolderLabels_[i],ibooker,map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,fillZPlots);
+    //}
+    //}
   }else if (DirName.find("ZJets")!=std::string::npos) {
     fillPFCandidatePlots=false;
     fillZPlots=true;
@@ -287,15 +299,17 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
     hMEx        = ibooker.book1D("MEx",        "MEx",        200, -500,  500);
     hMEy        = ibooker.book1D("MEy",        "MEy",        200, -500,  500);
     hMET        = ibooker.book1D("MET",        "MET",        200,    0, 1000);
+    hMET_2      = ibooker.book1D("MET_2",      "MET Range 2",200,    0, 2000);
     hSumET      = ibooker.book1D("SumET",      "SumET",      400,    0, 4000);
     hMETSig     = ibooker.book1D("METSig",     "METSig",      51,    0,   51);
     hMETPhi     = ibooker.book1D("METPhi",     "METPhi",      60, -M_PI,  M_PI);
-    hMET_logx   = ibooker.book1D("MET_logx",   "MET_logx",    40,   -1,    7);
-    hSumET_logx = ibooker.book1D("SumET_logx", "SumET_logx",  40,   -1,    7);
+    hMET_logx   = ibooker.book1D("MET_logx",   "MET_logx",    40,   -1,    9);
+    hSumET_logx = ibooker.book1D("SumET_logx", "SumET_logx",  40,   -1,    9);
     
     hMEx       ->setAxisTitle("MEx [GeV]",        1);
     hMEy       ->setAxisTitle("MEy [GeV]",        1);
     hMET       ->setAxisTitle("MET [GeV]",        1);
+    hMET_2     ->setAxisTitle("MET [GeV]",        1);
     hSumET     ->setAxisTitle("SumET [GeV]",      1);
     hMETSig    ->setAxisTitle("METSig",       1);
     hMETPhi    ->setAxisTitle("METPhi [rad]",     1);
@@ -306,11 +320,30 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MEx",hMEx));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MEy",hMEy));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET",hMET));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2",hMET_2));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SumET",hSumET));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METSig",hMETSig));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhi",hMETPhi));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_logx",hMET_logx));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SumET_logx",hSumET_logx));
+
+    hMET_HBHENoiseFilter        = ibooker.book1D("MET_HBHENoiseFilter",        "MET_HBHENoiseFiltered",        200,    0, 1000);
+    hMET_2_HBHENoiseFilter      = ibooker.book1D("MET_2_HBHENoiseFilter",      "MET_HBHENoiseFiltered Range 2",200,    0, 2000);
+    hMET_CSCTightHaloFilter    = ibooker.book1D("MET_CSCTightHaloFilter",        "MET_CSCTightHaloFiltered",        200,    0, 1000);
+    hMET_2_CSCTightHaloFilter     = ibooker.book1D("MET_2_CSCTightHaloFilter",      "MET_CSCTightHaloFiltered Range 2",200,    0, 2000);
+    hMET_eeBadScFilter    = ibooker.book1D("MET_eeBadScFilter",        "MET_eeBadScFiltered",        200,    0, 1000);
+    hMET_2_eeBadScFilter     = ibooker.book1D("MET_2_eeBadScFilter",      "MET_eeBadScFiltered Range 2",200,    0, 2000);
+    hMET_EcalDeadCellTriggerFilter    = ibooker.book1D("MET_EcalDeadCellTriggerFilter",        "MET_EcalDeadCellTriggerFiltered",        200,    0, 1000);
+    hMET_2_EcalDeadCellTriggerFilter     = ibooker.book1D("MET_2_EcalDeadCellTriggerFilter",      "MET_EcalDeadCellTriggerFiltered Range 2",200,    0, 2000);
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_HBHENoiseFilter",hMET_HBHENoiseFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_HBHENoiseFilter",hMET_2_HBHENoiseFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_CSCTightHaloFilter",hMET_CSCTightHaloFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_CSCTightHaloFilter",hMET_2_CSCTightHaloFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_eeBadScFilter",hMET_eeBadScFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_eeBadScFilter",hMET_2_eeBadScFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_EcalDeadCellTriggerFilter",hMET_EcalDeadCellTriggerFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_EcalDeadCellTriggerFilter",hMET_2_EcalDeadCellTriggerFilter));
     
     // Book NPV profiles --> would some of these profiles be interesting for other MET types too
     //----------------------------------------------------------------------------
@@ -702,39 +735,6 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
 	map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhiHFEGammasPlus"                ,meMETPhiHFEGammasPlus));
 	map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhiHFEGammasMinus"               ,meMETPhiHFEGammasMinus));
       }
-      mePhotonEt                = ibooker.book1D("PfPhotonEt",                "photonEt()",                50, 0, 1000);
-      meNeutralHadronEt         = ibooker.book1D("PfNeutralHadronEt",         "neutralHadronEt()",         50, 0, 1000);
-      meElectronEt              = ibooker.book1D("PfElectronEt",              "electronEt()",              50, 0, 100);
-      meChargedHadronEt         = ibooker.book1D("PfChargedHadronEt",         "chargedHadronEt()",         50, 0, 1000);
-      meMuonEt                  = ibooker.book1D("PfMuonEt",                  "muonEt()",                  50, 0, 100);
-      meHFHadronEt              = ibooker.book1D("PfHFHadronEt",              "HFHadronEt()",              50, 0, 1000);
-      meHFEMEt                  = ibooker.book1D("PfHFEMEt",                  "HFEMEt()",                  50, 0, 1000);
-
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt"               ,mePhotonEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt"        ,meNeutralHadronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfElectronEt"             ,meElectronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt"        ,meChargedHadronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfMuonEt"                 ,meMuonEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt"             ,meHFHadronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt"                 ,meHFEMEt));
-      
-      mePhotonEt_profile                = ibooker.bookProfile("PfPhotonEt_profile",                "photonEt()",                nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meNeutralHadronEt_profile         = ibooker.bookProfile("PfNeutralHadronEt_profile",         "neutralHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meChargedHadronEt_profile         = ibooker.bookProfile("PfChargedHadronEt_profile",         "chargedHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meHFHadronEt_profile              = ibooker.bookProfile("PfHFHadronEt_profile",              "HFHadronEt()",              nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meHFEMEt_profile                  = ibooker.bookProfile("PfHFEMEt_profile",                  "HFEMEt()",                  nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      
-      mePhotonEt_profile               ->setAxisTitle("nvtx", 1);
-      meNeutralHadronEt_profile        ->setAxisTitle("nvtx", 1);
-      meChargedHadronEt_profile        ->setAxisTitle("nvtx", 1);
-      meHFHadronEt_profile             ->setAxisTitle("nvtx", 1);
-      meHFEMEt_profile                 ->setAxisTitle("nvtx", 1);
-      
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt_profile"                ,mePhotonEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt_profile"         ,meNeutralHadronEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt_profile"         ,meChargedHadronEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt_profile"              ,meHFHadronEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt_profile"                  ,meHFEMEt_profile));
       
       if(fillPFCandPlots && fillCandidateMap_histos){
 	if(!etaMinPFCand_.empty()){
@@ -880,6 +880,40 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEtFraction_profile" ,meChargedHadronEtFraction_profile));
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEtFraction_profile"      ,meHFHadronEtFraction_profile));
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEtFraction_profile"          ,meHFEMEtFraction_profile));
+
+      mePhotonEt                = ibooker.book1D("PfPhotonEt",                "photonEt()",                50, 0, 1000);
+      meNeutralHadronEt         = ibooker.book1D("PfNeutralHadronEt",         "neutralHadronEt()",         50, 0, 1000);
+      meElectronEt              = ibooker.book1D("PfElectronEt",              "electronEt()",              50, 0, 100);
+      meChargedHadronEt         = ibooker.book1D("PfChargedHadronEt",         "chargedHadronEt()",         50, 0, 2000);
+      meMuonEt                  = ibooker.book1D("PfMuonEt",                  "muonEt()",                  50, 0, 100);
+      meHFHadronEt              = ibooker.book1D("PfHFHadronEt",              "HFHadronEt()",              50, 0, 2000);
+      meHFEMEt                  = ibooker.book1D("PfHFEMEt",                  "HFEMEt()",                  50, 0, 1000);
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt"               ,mePhotonEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt"        ,meNeutralHadronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfElectronEt"             ,meElectronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt"        ,meChargedHadronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfMuonEt"                 ,meMuonEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt"             ,meHFHadronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt"                 ,meHFEMEt));
+      
+      mePhotonEt_profile                = ibooker.bookProfile("PfPhotonEt_profile",                "photonEt()",                nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meNeutralHadronEt_profile         = ibooker.bookProfile("PfNeutralHadronEt_profile",         "neutralHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meChargedHadronEt_profile         = ibooker.bookProfile("PfChargedHadronEt_profile",         "chargedHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meHFHadronEt_profile              = ibooker.bookProfile("PfHFHadronEt_profile",              "HFHadronEt()",              nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meHFEMEt_profile                  = ibooker.bookProfile("PfHFEMEt_profile",                  "HFEMEt()",                  nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      
+      mePhotonEt_profile               ->setAxisTitle("nvtx", 1);
+      meNeutralHadronEt_profile        ->setAxisTitle("nvtx", 1);
+      meChargedHadronEt_profile        ->setAxisTitle("nvtx", 1);
+      meHFHadronEt_profile             ->setAxisTitle("nvtx", 1);
+      meHFEMEt_profile                 ->setAxisTitle("nvtx", 1);
+      
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt_profile"                ,mePhotonEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt_profile"         ,meNeutralHadronEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt_profile"         ,meChargedHadronEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt_profile"              ,meHFHadronEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt_profile"                  ,meHFEMEt_profile));
     }
     
     if (isCaloMet_){
@@ -956,6 +990,57 @@ void METAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
       }
     }
   }
+  if(isMiniAODMet_){
+    bool changed_filter=true;
+    if (FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel_.process(),changed_filter)){	
+      std::vector<int>initializeFilter(4,-1);
+      miniaodFilterIndex_=initializeFilter; 
+      for(unsigned int i=0;i<FilterhltConfig_.size();i++){
+	std::string search=FilterhltConfig_.triggerName(i).substr(5);//actual label of filter, the first 5 items are Flag_
+	std::size_t found=hbheNoiseFilterResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[0]=i;
+	}
+	found=CSCHaloResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[1]=i;
+	}
+	found=eeBadScFilterTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[2]=i;
+	}
+	found=EcalDeadCellTriggerTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[3]=i;
+	}
+      }
+    }else if(FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel2_.process(),changed_filter)){
+      std::vector<int>initializeFilter(4,-1);
+      miniaodFilterIndex_=initializeFilter; 
+      for(unsigned int i=0;i<FilterhltConfig_.size();i++){
+	std::string search=FilterhltConfig_.triggerName(i).substr(5);//actual label of filter, the first 5 items are Flag_
+	std::size_t found=hbheNoiseFilterResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[0]=i;
+	}
+	found=CSCHaloResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[1]=i;
+	}
+	found=eeBadScFilterTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[2]=i;
+	}
+	found=EcalDeadCellTriggerTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[3]=i;
+	}
+      }
+    }else{
+      std::cout<<"nothing found with both RECO and reRECO label"<<std::endl;
+    }
+  }
+
 }
 
 // ***********************************************************
@@ -1094,10 +1179,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       triggerFolderDecisions_[pos] = fd;
     }
     allTriggerDecisions_.clear();
-    for (unsigned int i=0;i<allTriggerNames_.size();++i)  {
-      allTriggerDecisions_.push_back((*triggerResults).accept(i)); 
-      //std::cout<<"TR "<<(*triggerResults).size()<<" "<<(*triggerResults).accept(i)<<" "<<allTriggerNames_[i]<<std::endl;
-    }
   }
 
   // ==========================================================
@@ -1169,17 +1250,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
   // ==========================================================
   //
-
-  edm::Handle<bool> HBHENoiseFilterResultHandle;
-  bool HBHENoiseFilterResult=true;
-  if(!isMiniAODMet_){//not checked for MiniAOD
-    iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
-    if (!HBHENoiseFilterResultHandle.isValid()) {
-      LogDebug("") << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
-      if (verbose_) std::cout << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
-    }
-    HBHENoiseFilterResult = *HBHENoiseFilterResultHandle;
-  }
   // ==========================================================
   bool bJetID = false;
   bool bDiJetID = false;
@@ -1345,10 +1415,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }
   }
   // ==========================================================
-  // HCAL Noise filter
-
-  bool bHBHENoiseFilter = HBHENoiseFilterResult;
-  // ==========================================================
   //Vertex information
   Handle<VertexCollection> vertexHandle;
   iEvent.getByToken(vertexToken_, vertexHandle);
@@ -1462,6 +1528,77 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     trigger_flag[3]=true;
   }
 
+  std::vector<bool>filter_decisions(4,false);
+  if(!isMiniAODMet_){//not checked for MiniAOD -> for miniaod decision filled as "triggerResults" bool
+    edm::Handle<bool> HBHENoiseFilterResultHandle;
+    iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
+    if (!HBHENoiseFilterResultHandle.isValid()) {
+      LogDebug("") << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
+    }
+    filter_decisions[0]= *HBHENoiseFilterResultHandle;
+    edm::Handle<bool> CSCTightHaloFilterResultHandle;
+    iEvent.getByToken(CSCHaloResultToken_, CSCTightHaloFilterResultHandle);
+    if (!CSCTightHaloFilterResultHandle.isValid()) {
+      LogDebug("") << "METAnalyzer: Could not find CSCTightHaloFilterResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: CSCTightHaloFilterResultHandle" << std::endl;
+    }
+    filter_decisions[1]= *CSCTightHaloFilterResultHandle;
+    edm::Handle<bool> eeBadScFilterResultHandle;
+    iEvent.getByToken(eeBadScFilterToken_, eeBadScFilterResultHandle);
+    if (!eeBadScFilterResultHandle.isValid()) {
+      LogDebug("") << "METAnalyzer: Could not find eeBadScFilterResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: eeBadScFilterResultHandle" << std::endl;
+    }
+    filter_decisions[2]= *eeBadScFilterResultHandle;
+    edm::Handle<bool> EcalDeadCellTriggerFilterResultHandle;
+    iEvent.getByToken(EcalDeadCellTriggerToken_, EcalDeadCellTriggerFilterResultHandle);
+    if (!EcalDeadCellTriggerFilterResultHandle.isValid()) {
+      LogDebug("") << "METAnalyzer: Could not find EcalDeadCellTriggerFilterResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: EcalDeadCellTriggerFilterResultHandle" << std::endl;
+    }
+    filter_decisions[3]= *EcalDeadCellTriggerFilterResultHandle;
+  }else{
+    edm::Handle<edm::TriggerResults> metFilterResults;
+    iEvent.getByToken(METFilterMiniAODToken_, metFilterResults);
+
+    if(metFilterResults.isValid()){
+      if(miniaodFilterIndex_[0]!=-1){
+	filter_decisions[0] = metFilterResults->accept(miniaodFilterIndex_[0]);
+      }
+      if(miniaodFilterIndex_[1]!=-1){
+	filter_decisions[1] = metFilterResults->accept(miniaodFilterIndex_[1]);
+      }
+      if(miniaodFilterIndex_[2]!=-1){
+	filter_decisions[2] = metFilterResults->accept(miniaodFilterIndex_[2]);
+      }
+      if(miniaodFilterIndex_[3]!=-1){
+	filter_decisions[3] = metFilterResults->accept(miniaodFilterIndex_[3]);
+      }
+    }else{
+      iEvent.getByToken(METFilterMiniAODToken2_, metFilterResults);
+      if(metFilterResults.isValid()){
+	if(miniaodFilterIndex_[0]!=-1){
+	  filter_decisions[0] = metFilterResults->accept(miniaodFilterIndex_[0]);
+	}
+	if(miniaodFilterIndex_[1]!=-1){
+	  filter_decisions[1] = metFilterResults->accept(miniaodFilterIndex_[1]);
+	}
+	if(miniaodFilterIndex_[2]!=-1){
+	  filter_decisions[2] = metFilterResults->accept(miniaodFilterIndex_[2]);
+	}
+	if(miniaodFilterIndex_[3]!=-1){
+	  filter_decisions[3] = metFilterResults->accept(miniaodFilterIndex_[3]);
+	}
+      }
+    }
+  }
+
+  bool HBHENoiseFilterResult=filter_decisions[0];//setup for RECO and MINIAOD
+  // ==========================================================
+  // HCAL Noise filter
+  bool bHBHENoiseFilter = HBHENoiseFilterResult;
+
   // DCS Filter
   bool bDCSFilter = (bypassAllDCSChecks_ || DCSFilter_->filter(iEvent, iSetup));
   // ==========================================================
@@ -1471,20 +1608,20 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
        ic != folderNames_.end(); ic++){
     bool pass_selection = false;
     if ((*ic=="Uncleaned")  &&(isCaloMet_ || bPrimaryVertex)){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet, *pfmet,*calomet,zCand, map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet, *pfmet,*calomet,zCand, map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection =true;
     }
     //take two lines out for first check
     if ((*ic=="Cleaned")    &&bDCSFilter&&bHBHENoiseFilter&&bPrimaryVertex&&bJetID){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection=true;
     }
     if ((*ic=="DiJet" )     &&bDCSFilter&&bHBHENoiseFilter&& bPrimaryVertex&& bDiJetID){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection=true;
     }
     if ((*ic=="ZJets" )     &&bDCSFilter&&bHBHENoiseFilter&& bPrimaryVertex&& bZJets){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection=true;
     }
     if(pass_selection && isPFMet_){
@@ -1497,28 +1634,28 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
 // ***********************************************************
 void METAnalyzer::fillMESet(const edm::Event& iEvent, std::string DirName,
-			    const reco::MET& met, const pat::MET& patmet, const reco::PFMET& pfmet, const reco::CaloMET& calomet,const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs, std::vector<bool>techTriggerCase)
+			    const reco::MET& met, const pat::MET& patmet, const reco::PFMET& pfmet, const reco::CaloMET& calomet,const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs, std::vector<bool>techTriggerCase, std::vector<bool>METFilterDecision)
 {
   bool bLumiSecPlot=fill_met_high_level_histo;
   bool fillPFCandidatePlots=false;
   if (DirName.find("Cleaned")!=std::string::npos) {
     fillPFCandidatePlots=true;
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
     for (unsigned int i = 0; i<triggerFolderLabels_.size(); i++) {
       fillPFCandidatePlots=false;
       if (triggerFolderDecisions_[i]){  
-	fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+	fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
       }
     }
   }else if (DirName.find("DiJet")!=std::string::npos) {
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
     for (unsigned int i = 0; i<triggerFolderLabels_.size(); i++) {
-      if (triggerFolderDecisions_[i])  fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+      if (triggerFolderDecisions_[i])  fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
     }
   }else if (DirName.find("ZJets")!=std::string::npos) {
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
   }else{
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
   }
   
 
@@ -1527,7 +1664,7 @@ void METAnalyzer::fillMESet(const edm::Event& iEvent, std::string DirName,
 // ***********************************************************
 void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirName,
 					 std::string subFolderName,
-				     const reco::MET& met,const pat::MET & patmet, const reco::PFMET & pfmet, const reco::CaloMET &calomet, const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs,bool bLumiSecPlot, bool fillPFCandidatePlots,std::vector<bool> techTriggerCase)
+				     const reco::MET& met,const pat::MET & patmet, const reco::PFMET & pfmet, const reco::CaloMET &calomet, const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs,bool bLumiSecPlot, bool fillPFCandidatePlots,std::vector<bool> techTriggerCase,std::vector<bool> METFilterDecision)
 {
   bool do_only_Z_histograms=false;
   if(DirName.find("ZJets")!=std::string::npos) {//do Z plots only
@@ -1613,9 +1750,37 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
     }
     
     
-    hMEx    = map_of_MEs[DirName+"/"+"MEx"];     if (hMEx           && hMEx->getRootObject())    hMEx          ->Fill(MEx);
+    hMEx    = map_of_MEs[DirName+"/"+"MEx"];     if (hMEx           && hMEx->getRootObject())     hMEx          ->Fill(MEx);
     hMEy    = map_of_MEs[DirName+"/"+"MEy"];     if (hMEy           && hMEy->getRootObject())     hMEy          ->Fill(MEy);
     hMET    = map_of_MEs[DirName+"/"+"MET"];     if (hMET           && hMET->getRootObject())     hMET          ->Fill(MET);
+    hMET_2  = map_of_MEs[DirName+"/"+"MET_2"];   if (hMET_2         && hMET_2->getRootObject())   hMET_2        ->Fill(MET);
+
+    bool HBHENoiseFilterResult=true;
+    bool CSCTightHaloFilterResult=true;
+    bool eeBadScFilterResult=true;
+    bool EcalDeadCellTriggerFilterResult=true;
+    HBHENoiseFilterResult = METFilterDecision[0];
+    if(HBHENoiseFilterResult){
+      hMET_HBHENoiseFilter    = map_of_MEs[DirName+"/"+"MET_HBHENoiseFilter"];     if (hMET_HBHENoiseFilter           && hMET_HBHENoiseFilter->getRootObject())     hMET_HBHENoiseFilter          ->Fill(MET);
+      hMET_2_HBHENoiseFilter  = map_of_MEs[DirName+"/"+"MET_2_HBHENoiseFilter"];   if (hMET_2_HBHENoiseFilter         && hMET_2_HBHENoiseFilter->getRootObject())   hMET_2_HBHENoiseFilter        ->Fill(MET);
+    }
+    CSCTightHaloFilterResult =  METFilterDecision[1];
+    if(CSCTightHaloFilterResult){
+      hMET_CSCTightHaloFilter    = map_of_MEs[DirName+"/"+"MET_CSCTightHaloFilter"];     if (hMET_CSCTightHaloFilter           && hMET_CSCTightHaloFilter->getRootObject())     hMET_CSCTightHaloFilter          ->Fill(MET);
+      hMET_2_CSCTightHaloFilter  = map_of_MEs[DirName+"/"+"MET_2_CSCTightHaloFilter"];   if (hMET_2_CSCTightHaloFilter         && hMET_2_CSCTightHaloFilter->getRootObject())   hMET_2_CSCTightHaloFilter        ->Fill(MET);
+    }
+    eeBadScFilterResult =  METFilterDecision[2];
+    if(eeBadScFilterResult){
+      hMET_eeBadScFilter    = map_of_MEs[DirName+"/"+"MET_eeBadScFilter"];     if (hMET_eeBadScFilter           && hMET_eeBadScFilter->getRootObject())     hMET_eeBadScFilter          ->Fill(MET);
+      hMET_2_eeBadScFilter  = map_of_MEs[DirName+"/"+"MET_2_eeBadScFilter"];   if (hMET_2_eeBadScFilter         && hMET_2_eeBadScFilter->getRootObject())   hMET_2_eeBadScFilter        ->Fill(MET);
+    }
+    EcalDeadCellTriggerFilterResult =  METFilterDecision[3];
+    if(EcalDeadCellTriggerFilterResult){
+      hMET_EcalDeadCellTriggerFilter    = map_of_MEs[DirName+"/"+"MET_EcalDeadCellTriggerFilter"];     if (hMET_EcalDeadCellTriggerFilter           && hMET_EcalDeadCellTriggerFilter->getRootObject())     hMET_EcalDeadCellTriggerFilter          ->Fill(MET);
+      hMET_2_EcalDeadCellTriggerFilter  = map_of_MEs[DirName+"/"+"MET_2_EcalDeadCellTriggerFilter"];   if (hMET_2_EcalDeadCellTriggerFilter         && hMET_2_EcalDeadCellTriggerFilter->getRootObject())   hMET_2_EcalDeadCellTriggerFilter        ->Fill(MET);
+    }
+
+
     hMETPhi = map_of_MEs[DirName+"/"+"METPhi"];  if (hMETPhi        && hMETPhi->getRootObject())  hMETPhi       ->Fill(METPhi);
     hSumET  = map_of_MEs[DirName+"/"+"SumET"];   if (hSumET         && hSumET->getRootObject())   hSumET        ->Fill(SumET);
     hMETSig = map_of_MEs[DirName+"/"+"METSig"];  if (hMETSig        && hMETSig->getRootObject())  hMETSig       ->Fill(METSig);
@@ -2300,6 +2465,35 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
       if (meChargedHadronEtFraction_profile && meChargedHadronEtFraction_profile->getRootObject()) meChargedHadronEtFraction_profile->Fill(numPV_, patmet.ChargedHadEtFraction());
       if (meHFHadronEtFraction_profile      && meHFHadronEtFraction_profile     ->getRootObject()) meHFHadronEtFraction_profile     ->Fill(numPV_, patmet.Type6EtFraction());
       if (meHFEMEtFraction_profile          && meHFEMEtFraction_profile         ->getRootObject()) meHFEMEtFraction_profile         ->Fill(numPV_, patmet.Type7EtFraction());
+
+     mePhotonEt        = map_of_MEs[DirName + "/PfPhotonEt"];
+      meNeutralHadronEt = map_of_MEs[DirName + "/PfNeutralHadronEt"];
+      meChargedHadronEt = map_of_MEs[DirName + "/PfChargedHadronEt"];
+      meHFHadronEt      = map_of_MEs[DirName + "/PfHFHadronEt"];
+      meHFEMEt          = map_of_MEs[DirName + "/PfHFEMEt"];
+      meMuonEt          = map_of_MEs[DirName + "/PfMuonEt"];
+      meElectronEt      = map_of_MEs[DirName + "/PfElectronEt"];
+
+      if (mePhotonEt        && mePhotonEt       ->getRootObject()) mePhotonEt       ->Fill(patmet.NeutralEMFraction()*patmet.sumEt());
+      if (meNeutralHadronEt && meNeutralHadronEt->getRootObject()) meNeutralHadronEt->Fill(patmet.NeutralHadEtFraction()*patmet.sumEt());
+      if (meChargedHadronEt && meChargedHadronEt->getRootObject()) meChargedHadronEt->Fill(patmet.ChargedHadEtFraction()*patmet.sumEt());
+      if (meHFHadronEt      && meHFHadronEt     ->getRootObject()) meHFHadronEt     ->Fill(patmet.Type6EtFraction()*patmet.sumEt());//HFHadrons
+      if (meHFEMEt          && meHFEMEt         ->getRootObject()) meHFEMEt         ->Fill(patmet.Type7EtFraction()*patmet.sumEt());
+      if (meMuonEt          && meMuonEt         ->getRootObject()) meMuonEt         ->Fill(patmet.MuonEtFraction()*patmet.sumEt());
+      if (meElectronEt      && meElectronEt     ->getRootObject()) meElectronEt     ->Fill(patmet.ChargedEMEtFraction()*patmet.sumEt());
+
+      //NPV profiles     
+      mePhotonEt_profile        = map_of_MEs[DirName + "/PfPhotonEt_profile"];
+      meNeutralHadronEt_profile = map_of_MEs[DirName + "/PfNeutralHadronEt_profile"];
+      meChargedHadronEt_profile = map_of_MEs[DirName + "/PfChargedHadronEt_profile"];
+      meHFHadronEt_profile      = map_of_MEs[DirName + "/PfHFHadronEt_profile"];
+      meHFEMEt_profile          = map_of_MEs[DirName + "/PfHFEMEt_profile"];
+      
+      if (mePhotonEt_profile        && mePhotonEt_profile       ->getRootObject()) mePhotonEt_profile       ->Fill(numPV_, patmet.NeutralEMFraction()*patmet.sumEt());
+      if (meNeutralHadronEt_profile && meNeutralHadronEt_profile->getRootObject()) meNeutralHadronEt_profile->Fill(numPV_, patmet.NeutralHadEtFraction()*patmet.sumEt());
+      if (meChargedHadronEt_profile && meChargedHadronEt_profile->getRootObject()) meChargedHadronEt_profile->Fill(numPV_, patmet.ChargedHadEtFraction()*patmet.sumEt());
+      if (meHFHadronEt_profile      && meHFHadronEt_profile     ->getRootObject()) meHFHadronEt_profile     ->Fill(numPV_, patmet.Type6EtFraction()*patmet.sumEt());
+      if (meHFEMEt_profile          && meHFEMEt_profile         ->getRootObject()) meHFEMEt_profile         ->Fill(numPV_, patmet.Type7EtFraction()*patmet.sumEt());
     }
 
     if (isCaloMet_){

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -12,7 +12,7 @@ process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
 #for data in 720pre7
-process.GlobalTag.globaltag ='GR_R_74_V12A'
+process.GlobalTag.globaltag ='74X_dataRun2_v2'
 
 # check # of bins
 process.load("DQMServices.Components.DQMStoreStats_cfi")
@@ -21,11 +21,57 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/06947E9F-204A-E511-B627-02163E0137BA.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/18D18896-204A-E511-B82D-02163E01190D.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/260A1195-204A-E511-8627-02163E014125.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/6A03E597-204A-E511-B2EA-02163E01418B.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/7086989C-204A-E511-B943-02163E013409.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/7CA25D9B-204A-E511-BF7A-02163E011955.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/823FA0A1-204A-E511-887F-02163E01453E.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/AA29DAA0-204A-E511-83FD-02163E0136D5.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/BA4041A9-204A-E511-937D-02163E011E1D.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/BE8974AB-204A-E511-9AB8-02163E01266D.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/C42C66A7-204A-E511-A53D-02163E01448C.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/F2098695-204A-E511-85CE-02163E014657.root',
+       #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/F60BE6A7-204A-E511-AF26-02163E0146B3.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/00088BD6-813C-E511-B574-0025905964BC.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0253073D-7F3C-E511-BC5B-0026189438F7.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/04CACE3D-7F3C-E511-B0E8-002618943925.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/04E0F04B-7F3C-E511-A19D-002590593876.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/060DFA85-803C-E511-9E12-0025905A60F4.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0862E1A9-823C-E511-AF36-0025905A6088.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0AD74E86-803C-E511-A715-0025905B85AA.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0C2164D3-813C-E511-8594-0025905A48F0.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0C487CE9-813C-E511-9D45-0025905A610A.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0E0CAFDB-7D3C-E511-B7A1-0025905B855C.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0E657740-7F3C-E511-8F5E-003048FFD770.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/10288AE2-7D3C-E511-922D-0025905B85D6.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/10474781-853C-E511-9685-0025905A60F8.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/105B72DC-7C3C-E511-9C63-0026189438F3.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/12322589-803C-E511-9010-0025905A60F4.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/127639DA-813C-E511-BF5D-002618943874.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/144D2FEC-7D3C-E511-92C6-003048FFD720.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/160D4B46-7D3C-E511-89E8-0025905B860E.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/16467F99-803C-E511-9EA4-003048FFCC18.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/164A1983-803C-E511-B28F-0025905A6110.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/16717A4C-7F3C-E511-BCFB-003048FFD760.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/18641BAD-7E3C-E511-970C-0025905A609A.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/18798CEC-813C-E511-B01F-0025905A6138.root'
        #'/store/relval/CMSSW_7_4_6_patch1/RelValProdTTbar_13/MINIAODSIM/MCRUN2_74_V9_unsch-v1/00000/28F53E5E-321D-E511-AEF1-0026189438F7.root',
        #'/store/relval/CMSSW_7_4_6_patch1/RelValProdTTbar_13/MINIAODSIM/MCRUN2_74_V9_unsch-v1/00000/4236E25F-321D-E511-92B6-0026189438B0.root' 
+       #'/store/relval/CMSSW_7_4_8_patch1/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_74_V11_mulTrh-v1/00000/3E8E7CFC-503C-E511-B57E-0025905A60A6.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_74_V11_mulTrh-v1/00000/DA8BC5FB-503C-E511-AD75-0025905A48D8.root' 
        #'/store/relval/CMSSW_7_4_3_patch1/JetHT/RECO/GR_R_74_V12A_unsch_RelVal_jet2012D-v1/00000/00648F9F-9D06-E511-A11C-0026189438C9.root',
        #'/store/relval/CMSSW_7_4_3_patch1/JetHT/RECO/GR_R_74_V12A_unsch_RelVal_jet2012D-v1/00000/026D63AD-A606-E511-B290-00261894386B.root',
-       '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/28CBB168-411A-E511-B2A2-002618943869.root'
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/5CEA33B7-873C-E511-BE51-0025905A60DA.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/8226D0B8-873C-E511-ACD3-0025905B85AE.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/924546B9-873C-E511-9B90-0025905B8576.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/A2937EB9-873C-E511-BA25-0025905B8598.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/AA4690B5-873C-E511-B398-0025905A60A8.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/BA0637B7-873C-E511-AE94-0025905A60B2.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/C6DC17B8-873C-E511-B34C-0025905A6084.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/CA8E9CB9-873C-E511-A795-0025905B8598.root',
+       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/F44521B8-873C-E511-8C81-0025905B85F6.root' 
        ] );
 
 
@@ -60,11 +106,12 @@ process.dqmSaver.workflow = Workflow
 
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 
-process.p = cms.Path(                    #process.dump*
-                     #process.jetMETDQMOfflineSourceMiniAOD*
+process.p = cms.Path(
+                     process.jetMETDQMOfflineSourceMiniAOD*
                      #for cosmic data and MC
                      #process.jetMETDQMOfflineSourceCosmic*
                      #for Data and MC pp and HI
-                     process.jetMETDQMOfflineSource*
+                     #process.jetMETDQMOfflineSource*
+#                     process.dump*
                      process.dqmSaver
                      )

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -12,7 +12,7 @@ process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
 #for data in 720pre7
-process.GlobalTag.globaltag ='74X_dataRun2_v2'
+process.GlobalTag.globaltag ='74X_dataRun2_Prompt_v3'
 
 # check # of bins
 process.load("DQMServices.Components.DQMStoreStats_cfi")
@@ -21,24 +21,13 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0C806DA1-A127-E511-B9B2-02163E012601.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0C8D29B7-9A27-E511-A7F2-02163E013770.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0E183999-9E27-E511-BB8F-02163E012183.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0E3D3941-9A27-E511-809E-02163E012183.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0ED47BB7-9A27-E511-BA69-02163E012704.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/10176B03-9D27-E511-9D8B-02163E012595.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/104F51D7-9B27-E511-A02A-02163E01387D.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/1246E41C-9827-E511-8CD1-02163E011836.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/126A46B1-9627-E511-9691-02163E012BD2.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/12EBF600-9D27-E511-AF26-02163E0143AA.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/140C43DE-A027-E511-AA82-02163E0133B5.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/149CC210-9627-E511-BD0F-02163E011D23.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/163CE7FB-9827-E511-8257-02163E0133F9.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/16579E06-9E27-E511-BB3D-02163E01267F.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/16718FEC-A227-E511-8696-02163E012A7F.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/183354BC-9A27-E511-AFF8-02163E0133AD.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/18B6E10D-9827-E511-9F24-02163E013901.root',
-       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/18EFD43F-9E27-E511-8134-02163E013576.root'
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/251/00000/00597BBF-8027-E511-8D9F-02163E014376.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/251/00000/008D4935-8127-E511-BD12-02163E0127DF.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/251/00000/00B58C93-8527-E511-9127-02163E014553.root'
+       #'/store/backfill/1/data/Tier0_Test_SUPERBUNNIES_vocms047/JetHT/MINIAOD/PromptReco-v91/000/251/251/00000/6C03D331-3858-E511-9B7C-02163E017135.root',
+       #'/store/backfill/1/data/Tier0_Test_SUPERBUNNIES_vocms047/JetHT/MINIAOD/PromptReco-v91/000/251/251/00000/9C949F3F-3858-E511-B785-02163E013750.root',
+       #'/store/backfill/1/data/Tier0_Test_SUPERBUNNIES_vocms047/JetHT/MINIAOD/PromptReco-v91/000/251/251/00000/AAEAE841-3858-E511-A66E-02163E011989.root',
+       #'/store/backfill/1/data/Tier0_Test_SUPERBUNNIES_vocms047/JetHT/MINIAOD/PromptReco-v91/000/251/251/00000/DEFB433D-3858-E511-A1C1-02163E0119B3.root' 
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/06947E9F-204A-E511-B627-02163E0137BA.root',
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/18D18896-204A-E511-B82D-02163E01190D.root',
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/260A1195-204A-E511-8627-02163E014125.root',
@@ -100,7 +89,7 @@ process.p = cms.Path(
                      #for cosmic data and MC
                      #process.jetMETDQMOfflineSourceCosmic*
                      #for Data and MC pp and HI
-                     #process.dump*
                      process.jetMETDQMOfflineSource*
+                     #process.dump*
                      process.dqmSaver
                      )

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -21,6 +21,24 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0C806DA1-A127-E511-B9B2-02163E012601.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0C8D29B7-9A27-E511-A7F2-02163E013770.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0E183999-9E27-E511-BB8F-02163E012183.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0E3D3941-9A27-E511-809E-02163E012183.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/0ED47BB7-9A27-E511-BA69-02163E012704.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/10176B03-9D27-E511-9D8B-02163E012595.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/104F51D7-9B27-E511-A02A-02163E01387D.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/1246E41C-9827-E511-8CD1-02163E011836.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/126A46B1-9627-E511-9691-02163E012BD2.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/12EBF600-9D27-E511-AF26-02163E0143AA.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/140C43DE-A027-E511-AA82-02163E0133B5.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/149CC210-9627-E511-BD0F-02163E011D23.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/163CE7FB-9827-E511-8257-02163E0133F9.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/16579E06-9E27-E511-BB3D-02163E01267F.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/16718FEC-A227-E511-8696-02163E012A7F.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/183354BC-9A27-E511-AFF8-02163E0133AD.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/18B6E10D-9827-E511-9F24-02163E013901.root',
+       '/store/data/Run2015B/JetHT/RECO/PromptReco-v1/000/251/252/00000/18EFD43F-9E27-E511-8134-02163E013576.root'
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/06947E9F-204A-E511-B627-02163E0137BA.root',
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/18D18896-204A-E511-B82D-02163E01190D.root',
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/260A1195-204A-E511-8627-02163E014125.root',
@@ -34,44 +52,15 @@ readFiles.extend( [
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/C42C66A7-204A-E511-A53D-02163E01448C.root',
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/F2098695-204A-E511-85CE-02163E014657.root',
        #'/store/data/Run2015C/JetHT/MINIAOD/PromptReco-v1/000/254/790/00000/F60BE6A7-204A-E511-AF26-02163E0146B3.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/00088BD6-813C-E511-B574-0025905964BC.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0253073D-7F3C-E511-BC5B-0026189438F7.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/04CACE3D-7F3C-E511-B0E8-002618943925.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/04E0F04B-7F3C-E511-A19D-002590593876.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/060DFA85-803C-E511-9E12-0025905A60F4.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0862E1A9-823C-E511-AF36-0025905A6088.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0AD74E86-803C-E511-A715-0025905B85AA.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0C2164D3-813C-E511-8594-0025905A48F0.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0C487CE9-813C-E511-9D45-0025905A610A.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0E0CAFDB-7D3C-E511-B7A1-0025905B855C.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/0E657740-7F3C-E511-8F5E-003048FFD770.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/10288AE2-7D3C-E511-922D-0025905B85D6.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/10474781-853C-E511-9685-0025905A60F8.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/105B72DC-7C3C-E511-9C63-0026189438F3.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/12322589-803C-E511-9010-0025905A60F4.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/127639DA-813C-E511-BF5D-002618943874.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/144D2FEC-7D3C-E511-92C6-003048FFD720.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/160D4B46-7D3C-E511-89E8-0025905B860E.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/16467F99-803C-E511-9EA4-003048FFCC18.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/164A1983-803C-E511-B28F-0025905A6110.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/16717A4C-7F3C-E511-BCFB-003048FFD760.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/18641BAD-7E3C-E511-970C-0025905A609A.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/RECO/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/18798CEC-813C-E511-B01F-0025905A6138.root'
-       #'/store/relval/CMSSW_7_4_6_patch1/RelValProdTTbar_13/MINIAODSIM/MCRUN2_74_V9_unsch-v1/00000/28F53E5E-321D-E511-AEF1-0026189438F7.root',
-       #'/store/relval/CMSSW_7_4_6_patch1/RelValProdTTbar_13/MINIAODSIM/MCRUN2_74_V9_unsch-v1/00000/4236E25F-321D-E511-92B6-0026189438B0.root' 
-       #'/store/relval/CMSSW_7_4_8_patch1/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_74_V11_mulTrh-v1/00000/3E8E7CFC-503C-E511-B57E-0025905A60A6.root',
-       #'/store/relval/CMSSW_7_4_8_patch1/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_74_V11_mulTrh-v1/00000/DA8BC5FB-503C-E511-AD75-0025905A48D8.root' 
-       #'/store/relval/CMSSW_7_4_3_patch1/JetHT/RECO/GR_R_74_V12A_unsch_RelVal_jet2012D-v1/00000/00648F9F-9D06-E511-A11C-0026189438C9.root',
-       #'/store/relval/CMSSW_7_4_3_patch1/JetHT/RECO/GR_R_74_V12A_unsch_RelVal_jet2012D-v1/00000/026D63AD-A606-E511-B290-00261894386B.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/5CEA33B7-873C-E511-BE51-0025905A60DA.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/8226D0B8-873C-E511-ACD3-0025905B85AE.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/924546B9-873C-E511-9B90-0025905B8576.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/A2937EB9-873C-E511-BA25-0025905B8598.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/AA4690B5-873C-E511-B398-0025905A60A8.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/BA0637B7-873C-E511-AE94-0025905A60B2.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/C6DC17B8-873C-E511-B34C-0025905A6084.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/CA8E9CB9-873C-E511-A795-0025905B8598.root',
-       '/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/F44521B8-873C-E511-8C81-0025905B85F6.root' 
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/5CEA33B7-873C-E511-BE51-0025905A60DA.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/8226D0B8-873C-E511-ACD3-0025905B85AE.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/924546B9-873C-E511-9B90-0025905B8576.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/A2937EB9-873C-E511-BA25-0025905B8598.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/AA4690B5-873C-E511-B398-0025905A60A8.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/BA0637B7-873C-E511-AE94-0025905A60B2.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/C6DC17B8-873C-E511-B34C-0025905A6084.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/CA8E9CB9-873C-E511-A795-0025905B8598.root',
+       #'/store/relval/CMSSW_7_4_8_patch1/JetHT/MINIAOD/GR_H_V57A_mulTrh_RelVal_jet2012D-v1/00000/F44521B8-873C-E511-8C81-0025905B85F6.root' 
        ] );
 
 
@@ -107,11 +96,11 @@ process.dqmSaver.workflow = Workflow
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 
 process.p = cms.Path(
-                     process.jetMETDQMOfflineSourceMiniAOD*
+                     #process.jetMETDQMOfflineSourceMiniAOD*
                      #for cosmic data and MC
                      #process.jetMETDQMOfflineSourceCosmic*
                      #for Data and MC pp and HI
-                     #process.jetMETDQMOfflineSource*
-#                     process.dump*
+                     #process.dump*
+                     process.jetMETDQMOfflineSource*
                      process.dqmSaver
                      )

--- a/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 
 pfJetIDSelector = cms.PSet(
-        version = cms.string('FIRSTDATA'),
+        version = cms.string('RUNIISTARTUP'),
         quality = cms.string('LOOSE')
     )

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -14,18 +14,26 @@ from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT0pc,pfMetT0pcT1,pf
 from JetMETCorrections.Type1MET.correctionTermsPfMetType0PFCandidate_cff import *
 from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPfMetType1
 
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3CorrectorChain,ak4PFL1FastL2L3Corrector,ak4PFL3AbsoluteCorrector,ak4PFL2RelativeCorrector,ak4PFL1FastjetCorrector
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3ResidualCorrectorChain,ak4PFCHSL1FastL2L3CorrectorChain,ak4PFCHSL1FastL2L3ResidualCorrector,ak4PFCHSResidualCorrector,ak4PFCHSL1FastL2L3Corrector,ak4PFCHSL3AbsoluteCorrector,ak4PFCHSL2RelativeCorrector,ak4PFCHSL1FastjetCorrector
 
-newAK4PFL1FastL2L3Corrector = ak4PFL1FastL2L3Corrector.clone()
-newAK4PFL1FastL2L3CorrectorChain = cms.Sequence(
+newAK4PFCHSL1FastL2L3Corrector = ak4PFCHSL1FastL2L3Corrector.clone()
+newAK4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
     #ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * 
-    newAK4PFL1FastL2L3Corrector
+    newAK4PFCHSL1FastL2L3Corrector
     )
 
-metPreValidSeq=cms.Sequence(ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector)
+newAK4PFCHSL1FastL2L3ResidualCorrector = ak4PFCHSL1FastL2L3ResidualCorrector.clone()
+newAK4PFCHSL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+    #ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * 
+    newAK4PFCHSL1FastL2L3ResidualCorrector
+    )
+
+metPreValidSeq=cms.Sequence(ak4PFCHSL1FastjetCorrector * ak4PFCHSL2RelativeCorrector * ak4PFCHSL3AbsoluteCorrector * ak4PFCHSResidualCorrector)
 
 
-valCorrPfMetType1=corrPfMetType1.clone(jetCorrLabel = cms.InputTag('newAK4PFL1FastL2L3Corrector'))
+valCorrPfMetType1=corrPfMetType1.clone(jetCorrLabel = cms.InputTag('newAK4PFCHSL1FastL2L3Corrector'),
+                                       jetCorrLabelRes = cms.InputTag('newAK4PFCHSL1FastL2L3ResidualCorrector')
+                                       )
 
 PfMetT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
         cms.InputTag('valCorrPfMetType1', 'type1')
@@ -42,7 +50,8 @@ METRelValSequence = cms.Sequence(
     pfMetAnalyzer*
     genMetTrueAnalyzer*
     correctionTermsPfMetType0PFCandidateForValidation*
-    newAK4PFL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3ResidualCorrectorChain*
     valCorrPfMetType1*
     pfMetT0pc*
     PfMetT1*
@@ -58,7 +67,8 @@ METValidation = cms.Sequence(
     pfMetAnalyzer*
     genMetTrueAnalyzer*
     correctionTermsPfMetType0PFCandidateForValidation*
-    newAK4PFL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3ResidualCorrectorChain*
     valCorrPfMetType1*
     pfMetT0pc*
     PfMetT1*

--- a/Validation/RecoMET/test/sequence_validation_cfg.py
+++ b/Validation/RecoMET/test/sequence_validation_cfg.py
@@ -11,7 +11,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = 'MCRUN2_74_V9'
+process.GlobalTag.globaltag = '74X_mcRun2_asymptotic_v2'
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
@@ -28,19 +28,15 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
-        #'/store/relval/CMSSW_7_4_6_patch1/RelValProdTTbar_13/MINIAODSIM/MCRUN2_74_V9_unsch-v1/00000/28F53E5E-321D-E511-AEF1-0026189438F7.root',
-       #'/store/relval/CMSSW_7_4_6_patch1/RelValProdTTbar_13/MINIAODSIM/MCRUN2_74_V9_unsch-v1/00000/4236E25F-321D-E511-92B6-0026189438B0.root'
-       #for RECO
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/403FA79E-251A-E511-B21A-0025905B855C.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/623B1740-551A-E511-8A61-0025905A60CA.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/6AEC1D6D-361A-E511-8AFF-0025905938A8.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/801ABCFB-5B1A-E511-BB68-0025905A4964.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/9429572C-221A-E511-8613-0025905A6064.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/B6B7C7EA-1E1B-E511-8472-0025905B8576.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/D6833B78-3C1A-E511-9D9B-0026189438B5.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/DA508AF0-4E1A-E511-A655-0025905A60E0.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/F479010F-491A-E511-98F9-0025905938B4.root',
-       '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/F837DA4C-561B-E511-BB00-0025905A6138.root' 
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/006F3660-4B5E-E511-B8FD-0025905B8596.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/1E34D76A-7B5E-E511-AD5E-0025905A6138.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/22EF90FD-4C5E-E511-952A-0025905B8590.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/62258A2B-7D5E-E511-985C-0025905A6094.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/6A040A44-495E-E511-82C4-0025905A605E.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/70101C9E-4D5E-E511-AC66-0025905B855C.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/7467606A-4B5E-E511-8606-00261894390E.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/AE731747-495E-E511-AA22-0025905B8576.root',
+       '/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/D0F8E44D-505E-E511-BFF0-002618943809.root'
 ] );
 
 process.load('Configuration/StandardSequences/EDMtoMEAtJobEnd_cff')


### PR DESCRIPTION
implement new recommendations for PFJetID, add monitoring on TrackMET, monitor MET Filter performance for RECO and MINIAOD. Since MET filters are stored in a triggerResult object in MINIAOD, consider two cases: one for data prompt RECO and one for reRECO workflows.

Extend jet monitoring on MINIAOD to AK8 jets and substructure information.
