### PR TITLE
correctedP4 must return a copy of p4()

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -152,10 +152,10 @@ namespace pat {
       Jet correctedJet(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const;
       /// p4 of the jet corrected up to the given level for the set
       /// of jet energy correction factors, which is currently in use
-      const LorentzVector& correctedP4(const std::string& level, const std::string& flavor="none", const std::string& set="") const { return correctedJet(level, flavor, set).p4(); };
+      const LorentzVector correctedP4(const std::string& level, const std::string& flavor="none", const std::string& set="") const { return correctedJet(level, flavor, set).p4(); };
       /// p4 of the jet corrected up to the given level for the set
       /// of jet energy correction factors, which is currently in use
-      const LorentzVector& correctedP4(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const { return correctedJet(level, flavor, set).p4(); };
+      const LorentzVector correctedP4(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const { return correctedJet(level, flavor, set).p4(); };
 
   private:
       /// index of the set of jec factors with given label; returns -1 if no set


### PR DESCRIPTION
`correctedJet()` returns a new `Jet` object. In `correctedP4()` we
return a reference to p4() on a stack, thus the reference is invalid and
most likely value will be changed with the next few function calls.

```
DataFormats/PatCandidates/interface/Jet.h:155:178: error: function
returns address of local variable [-Werror=return-local-addr]
DataFormats/PatCandidates/interface/Jet.h:158:204: error: function
returns address of local variable [-Werror=return-local-addr]
```

A quick fix (this patch) is to make `correctedP4()` return a copy
instead of a reference.

If `correctedJet()` is on hot path, the new `Jet` object should be
cached and then we could also return a reference in `correctedP4()`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
