### PR TITLE
multithreading fix for 74x: RecoTrackRefSelector

### DIFF
--- a/CommonTools/RecoAlgos/plugins/RecoTrackRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoTrackRefSelector.cc
@@ -10,12 +10,12 @@
  *
  */
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 //#include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 #include "CommonTools/RecoAlgos/interface/RecoTrackRefSelector.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  typedef ObjectSelector<RecoTrackRefSelector,reco::TrackRefVector> RecoTrackRefSelector;
+  typedef ObjectSelectorStream<RecoTrackRefSelector,reco::TrackRefVector> RecoTrackRefSelector;
   DEFINE_FWK_MODULE(RecoTrackRefSelector);
 }


### PR DESCRIPTION
This is a minimal change to make RecoTrackRefSelector a stream module (i.e. easily back-portable).
