### PR TITLE
Backport: update JetMET HLT DQM with new trigger paths

### DIFF
--- a/DQMOffline/Trigger/python/JetMETHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/JetMETHLTOfflineSource_cfi.py
@@ -44,6 +44,7 @@ jetMETHLTOfflineSource = cms.EDAnalyzer(
                                        "HLT_PFJet",
                                        "HLT_PFNoPUJet",
                                        "HLT_DiPFJetAve",
+                                       "HLT_DiCaloJetAve",
                                        "HLT_PFMET",
                                        "HLT_PFchMET",
                                        "HLT_MET",


### PR DESCRIPTION
add DiCaloJetAve-triggers to DQM validation suite (for Zero Tesla datataking)

Backport of 
#11319
