### PR TITLE
Misc. streams related fixes

### DIFF
--- a/CondFormats/SiStripObjects/src/SiStripLatency.cc
+++ b/CondFormats/SiStripObjects/src/SiStripLatency.cc
@@ -16,7 +16,7 @@ bool SiStripLatency::put( const uint32_t detId, const uint16_t apv, const uint16
     error << "of the writing of this class was 47017836 as defined in CalibTracker/SiStripCommon/data/SiStripDetInfo.dat." << std::endl;
     error << "If the maximum value has changed a revision of this calss is needed, possibly changing the detIdAndApv value from" << std::endl;
     error << "from uint32_t to uint64_t." << std::endl;
-    edm::LogError("SiStripLatency::put") << error;
+    edm::LogError("SiStripLatency::put") << error.str();
     throw cms::Exception("InsertFailure");
   }
 

--- a/DQM/HcalMonitorClient/interface/HcalHistoUtils.h
+++ b/DQM/HcalMonitorClient/interface/HcalHistoUtils.h
@@ -229,15 +229,15 @@ myHist* getAnyHisto(myHist* hist,
   
   if (!me) 
     {
-      if (verb) std::cout <<"SORRY, COULD NOT FIND HISTOGRAM NAMED ["<< title.str().c_str()<<"]"<<std::endl;
+      if (verb) std::cout <<"SORRY, COULD NOT FIND HISTOGRAM NAMED ["<< title.str()<<"]"<<std::endl;
       return NULL; // ME not found
     } // if (!me)
 
   if (verb) 
-    std::cout << "Found '" << title.str().c_str() << "'" << std::endl;
+    std::cout << "Found '" << title.str() << "'" << std::endl;
 
   if (clone)
-    clonehisto<<"ME "<<name.c_str(); // set clone histogram name
+    clonehisto<<"ME "<<name; // set clone histogram name
 
   /* As of 25 April 2008, there are 5 histogram types associated with 
      Monitor Elements (TH1F, TH2F, TH3F, TProfile, and TProfile2D).
@@ -298,7 +298,7 @@ myHist* getAnyHisto(myHist* hist,
     {
       if (verb) 
 	{
-	  std::cout <<"Don't know how to access histogram '"<<title;
+	  std::cout <<"Don't know how to access histogram '"<<title.str();
 	  std::cout<<"' of type '"<<histtype<<"'"<<std::endl;
 	}
       return NULL;

--- a/EventFilter/Utilities/src/FileIO.cc
+++ b/EventFilter/Utilities/src/FileIO.cc
@@ -43,6 +43,6 @@ bool FileIO::readStringFromFile(std::string const& filename, std::string& conten
 bool FileIO::fileExists(std::string const& path)
 {
   std::ifstream ifile(path.c_str());
-  return ifile;
+  return !ifile.fail();
 }
 

--- a/L1Trigger/CSCTrackFinder/plugins/CSCTFanalyzer.cc
+++ b/L1Trigger/CSCTrackFinder/plugins/CSCTFanalyzer.cc
@@ -109,7 +109,7 @@ void CSCTFanalyzer::analyze(edm::Event const& e, edm::EventSetup const& es){
 				//int dtSector =(stub->sector()-1)*2 + stub->subsector()-1;
 				//int dtEndcap = stub->endcap()-1;
 				std::cout<<"   DT data: tbin="<<stub->BX()<<" (CSC) sector="<<stub->sector()<<" (CSC) subsector="<<stub->subsector()<<" station="<<stub->station()<<" endcap="<<stub->endcap()
-					<<" phi="<<stub->phiPacked()<<" phiBend="<<stub->getBend()<<" quality="<<stub->getQuality()<<" id="<<stub->getMPCLink()<<" mb_bxn="<<stub->cscid()<<std::cout;
+					<<" phi="<<stub->phiPacked()<<" phiBend="<<stub->getBend()<<" quality="<<stub->getQuality()<<" id="<<stub->getMPCLink()<<" mb_bxn="<<stub->cscid()<<std::endl;
 			}
 
 		} else edm::LogInfo("CSCTFAnalyzer")<<"  No valid CSCTriggerContainer<csctf::TrackStub> products found";

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
@@ -103,7 +103,7 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent,
     GenJet jet( sumVisMom, vertex, specific, constituents);
 
     if (charge != (*iTau)->charge() )
-      std::cout<<" charge of Tau: " << (*iTau) << " not equal to charge of sum of charge of all descendents. " << std::cout;
+      std::cout<<" charge of Tau: " << (*iTau) << " not equal to charge of sum of charge of all descendents. " << std::endl;
 
     jet.setCharge(charge);
     pOutVisTaus->push_back( jet );

--- a/Validation/Geometry/BuildFile.xml
+++ b/Validation/Geometry/BuildFile.xml
@@ -12,3 +12,9 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="DQMServices/Core"/>
 <flags   EDM_PLUGIN="1"/>
+<!--
+     There is no way to avoid these in C++ until possibly GCC 6.1.0
+     Diagnostic pragmas would not work due to the way C++ pre-processor is implemented
+     RFC PATCH: https://gcc.gnu.org/ml/gcc-patches/2015-07/msg02414.html
+-->
+<flags REM_CXXFLAGS="-Werror=unused-variable"/>

--- a/Validation/Geometry/src/MaterialBudgetCategorizer.cc
+++ b/Validation/Geometry/src/MaterialBudgetCategorizer.cc
@@ -131,9 +131,9 @@ void MaterialBudgetCategorizer::buildCategoryMap(std::string theMaterialFileName
   //  const G4MaterialTable* matTable = G4Material::GetMaterialTable();
   //  G4int matSize = matTable->size();
   
-  std::ifstream theMaterialFile(theMaterialFileName.c_str());
+  std::ifstream theMaterialFile(theMaterialFileName);
   if (!theMaterialFile) 
-    cms::Exception("LogicError") <<" File not found " << theMaterialFile;
+    cms::Exception("LogicError") <<" File not found " << theMaterialFileName;
   
   // fill everything as "other"
   float sup,sen,cab,col,ele,oth,air;


### PR DESCRIPTION
GCC 5.2.0 does not allow piping output stream into output stream, e.g.,
`std::cout << std::cout`. There is no more impilicit conversion to `void *`
since C++11.

`std::cout` does not directly support `std::basic_stringstream` as
argument, but because `std::basic_stringstream` inherits `std::basic_ios`
and it supports operator `void*` (until C++11) one could have pushed it
to `std::cout`. That is wrong, because `operator void*() const` does not
provide string content of `std::basic_stringstream`. Instead use `str()`
method to get a string copy of `std::basic_stringstream` content.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
