### PR TITLE
Stacktrace handler revisited

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
+#include <thread>
 #include <sys/wait.h>
 #include <sstream>
 #include <string.h>
@@ -185,14 +186,14 @@ namespace {
 
   extern "C" {
 
-    static int full_cerr_write(const char *text)
+    static int full_write(int fd, const char *text)
     {
       const char *buffer = text;
       size_t count = strlen(text);
       ssize_t written = 0;
       while (count)
       {
-        written = write(2, buffer, count);
+        written = write(fd, buffer, count);
         if (written == -1) 
         {
           if (errno == EINTR) {continue;}
@@ -202,6 +203,30 @@ namespace {
         buffer += written;
       }
       return 0;
+    }
+
+    static int full_read(int fd, char *inbuf, size_t len)
+    {
+      char *buf = inbuf;
+      size_t count = len;
+      ssize_t complete = 0;
+      while (count)
+      {
+        complete = read(fd, buf, count);
+        if (complete == -1)
+        {
+          if (errno == EINTR) {continue;}
+          else {return -errno;}
+        }
+        count -= complete;
+        buf += complete;
+      }
+      return 0;
+    }
+
+    static int full_cerr_write(const char *text)
+    {
+      return full_write(2, text);
     }
 
     void sig_dostack_then_abort(int sig, siginfo_t*, void*) {
@@ -224,6 +249,109 @@ namespace {
       full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n"
         "NOTE:The first few functions on the stack are artifacts of processing the signal and can be ignored\n\n");
 
+      edm::service::InitRootHandlers::stacktraceFromThread();
+
+      full_cerr_write("\nA fatal system signal has occurred: ");
+      full_cerr_write(signalname);
+      full_cerr_write("\n");
+
+      // For these three known cases, re-raise the signal so get the correct
+      // exit code.
+      if ((sig == SIGILL) || (sig == SIGSEGV) || (sig == SIGBUS))
+      {
+        signal(sig, SIG_DFL);
+        raise(sig);
+      }
+      else
+      {
+        ::abort();
+      }
+    }
+    
+    void sig_abort(int sig, siginfo_t*, void*) {
+      ::abort();
+    }
+  }
+}  // end of unnamed namespace
+
+namespace edm {
+  namespace service {
+
+    /*
+     * We've run into issues where GDB fails to print the thread which calls clone().
+     * To avoid this problem, we have an alternate approach below where the signal handler
+     * only reads/writes to a dedicated thread via pipes.  The helper thread does the clone()
+     * invocation; we don't care if that thread is missing from the traceback in this case.
+     */
+    static void cmssw_stacktrace_fork();
+
+    void InitRootHandlers::stacktraceHelperThread()
+    {
+      int toParent = childToParent_[1];
+      int fromParent = parentToChild_[0];
+      char buf[2]; buf[1] = '\0';
+      while(true)
+      {
+        int result = full_read(fromParent, buf, 1);
+        if (result < 0)
+        {
+          close(toParent);
+          full_cerr_write("\n\nTraceback helper thread failed to read from parent: ");
+          full_cerr_write(strerror(-result));
+          full_cerr_write("\n");
+          ::abort();
+        }
+        if (buf[0] == '1')
+        {
+          cmssw_stacktrace_fork();
+          full_write(toParent, buf);
+        }
+        else if (buf[0] == '2')
+        {
+          // We have just finished forking.  Reload the file descriptors for thread
+          // communication.
+          close(toParent);
+          close(fromParent);
+          toParent = childToParent_[1];
+          fromParent = parentToChild_[0];
+        }
+        else if (buf[0] == '3')
+        {
+          break;
+        }
+        else
+        {
+          close(toParent);
+          full_cerr_write("\n\nTraceback helper thread got unknown command from parent: ");
+          full_cerr_write(buf);
+          full_cerr_write("\n");
+          ::abort();
+        }
+      }
+    }
+
+    void InitRootHandlers::stacktraceFromThread()
+    {
+      int result = full_write(parentToChild_[1], "1");
+      if (result < 0)
+      {
+        full_cerr_write("\n\nAttempt to request stacktrace failed: ");
+        full_cerr_write(strerror(-result));
+        full_cerr_write("\n");
+        return;
+      }
+      char buf[2]; buf[1] = '\0';
+      if ((result = full_read(childToParent_[0], buf, 1)) < 0)
+      {
+        full_cerr_write("\n\nWaiting for stacktrace completion failed: ");
+        full_cerr_write(strerror(-result));
+        full_cerr_write("\n");
+        return;
+      }
+    }
+
+    void cmssw_stacktrace_fork()
+    {
       char child_stack[4*1024];
       char *child_stack_ptr = child_stack + 4*1024;
         // On Linux, we currently use jemalloc.  This registers pthread_atfork handlers; these
@@ -250,29 +378,7 @@ namespace {
           full_cerr_write("(Failed to wait on stack dump output.)\n");
         }
       }
-
-      full_cerr_write("\nA fatal system signal has occurred: ");
-      full_cerr_write(signalname);
-      full_cerr_write("\n");
-
-      // For these three known cases, re-raise the signal so get the correct
-      // exit code.
-      if ((sig == SIGILL) || (sig == SIGSEGV) || (sig == SIGBUS))
-      {
-        signal(sig, SIG_DFL);
-        raise(sig);
-      }
-      ::abort();
     }
-    
-    void sig_abort(int sig, siginfo_t*, void*) {
-      ::abort();
-    }
-  }
-}  // end of unnamed namespace
-
-namespace edm {
-  namespace service {
 
     int cmssw_stacktrace(void * /*arg*/)
     {
@@ -286,6 +392,9 @@ namespace edm {
     static char dashC[] = "-c";
     char InitRootHandlers::pidString_[InitRootHandlers::pidStringLength_] = {};
     char * const InitRootHandlers::pstackArgv_[] = {pstackName, dashC, InitRootHandlers::pidString_, nullptr};
+    int InitRootHandlers::parentToChild_[2] = {-1, -1};
+    int InitRootHandlers::childToParent_[2] = {-1, -1};
+    std::unique_ptr<std::thread> InitRootHandlers::helperThread_;
 
     InitRootHandlers::InitRootHandlers (ParameterSet const& pset, ActivityRegistry& iReg)
       : RootHandlers(),
@@ -437,6 +546,50 @@ namespace edm {
         sstr << "Unable to pre-allocate stacktrace handler information";
         edm::Exception except(edm::errors::OtherCMS, sstr.str());
         throw except;
+      }
+
+        // Initialize read/write pipes for child thread.
+      int must_reload_child = parentToChild_[1];
+
+      int child_to_parent_pipe[2];
+      if (-1 == pipe2(child_to_parent_pipe, O_CLOEXEC))
+      {
+        std::ostringstream sstr;
+        sstr << "Failed to create child-to-parent pipes (errno=" << errno << "): " << strerror(errno);
+        edm::Exception except(edm::errors::OtherCMS, sstr.str());
+        throw except;
+      }
+
+      int parent_to_child_pipe[2];
+      if (-1 == pipe2(parent_to_child_pipe, O_CLOEXEC))
+      {
+        std::ostringstream sstr;
+        sstr << "Failed to create child-to-parent pipes (errno=" << errno << "): " << strerror(errno);
+        edm::Exception except(edm::errors::OtherCMS, sstr.str());
+        throw except;
+      }
+
+      close(childToParent_[0]);
+      childToParent_[0] = child_to_parent_pipe[0];
+      childToParent_[1] = child_to_parent_pipe[1];
+      parentToChild_[0] = parent_to_child_pipe[0];
+      parentToChild_[1] = parent_to_child_pipe[1];
+      if (must_reload_child >= 0)
+      {
+        int result = full_write(must_reload_child, "2");
+        if (result < 0)
+        {
+          std::ostringstream sstr;
+          sstr << "Failed to notify traceback thread to reload its file descriptors (errno=" << -result << "): " << strerror(-result);
+          edm::Exception except(edm::errors::OtherCMS, sstr.str());
+          throw except;
+        }
+      }
+      close(must_reload_child);
+
+      if (!helperThread_)
+      {
+        helperThread_.reset(new std::thread(stacktraceHelperThread));
       }
     }
 

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -590,6 +590,7 @@ namespace edm {
       if (!helperThread_)
       {
         helperThread_.reset(new std::thread(stacktraceHelperThread));
+        helperThread_->detach();
       }
     }
 

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -4,6 +4,10 @@
 #include <memory>
 #include "FWCore/Utilities/interface/RootHandlers.h"
 
+namespace std {
+  class thread;
+}
+
 namespace edm {
   class ConfigurationDescriptions;
   class ParameterSet;
@@ -19,6 +23,7 @@ namespace edm {
       virtual ~InitRootHandlers();
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void stacktraceFromThread();
 
     private:
       static char *const *getPstackArgv();
@@ -29,10 +34,14 @@ namespace edm {
 
       void cachePidInfoHandler(unsigned int, unsigned int) {cachePidInfo();}
       void cachePidInfo();
+      static void stacktraceHelperThread();
 
       static const int pidStringLength_ = 200;
       static char pidString_[pidStringLength_];
       static char * const pstackArgv_[];
+      static int parentToChild_[2];
+      static int childToParent_[2];
+      static std::unique_ptr<std::thread> helperThread_;
       bool unloadSigHandler_;
       bool resetErrHandler_;
       bool loadAllDictionaries_;


### PR DESCRIPTION
This is the second version of the improved stacktrace.  The first version had improper handling around forked processes (the helper thread would communicate with the wrong process).
- Ran unit tests in FWCore/Modules successfully (these failed in the first round).
- Verified stack traces are printed appropriately on SIGSEGV.
- Verified detached thread causes no problem for the non-failure case.
- Managed to send a SIGSEGV while one thread was holding the jemalloc lock; process did not deadlock.
