### PR TITLE
multithreading fix for 74x: HLTrigReport

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/HLTrigReport.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTrigReport.h
@@ -12,23 +12,22 @@
  *
  */
 
-#include "DataFormats/Common/interface/TriggerResults.h"
-
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "FWCore/Common/interface/TriggerNames.h"
-#include<vector>
-#include<string>
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include <vector>
+#include <string>
 
 //
 // class declaration
 //
 
-class HLTrigReport : public edm::EDAnalyzer {
+class HLTrigReport : public edm::one::EDAnalyzer<> {
    private:
       enum ReportEvery {
         NEVER       = 0,
@@ -104,10 +103,10 @@ class HLTrigReport : public edm::EDAnalyzer {
       unsigned int refIndex_;                                   // index of the reference path for rate calculation
       double refRate_;                                         // rate of the reference path, the rate of all other paths will be normalized to this
 
-      ReportEvery reportBy_;        // dump report for every never/event/lumi/run/job
-      ReportEvery resetBy_;         // reset counters  every never/event/lumi/run/job
-      ReportEvery serviceBy_;       // call to service every never/event/lumi/run/job
-      HLTConfigProvider hltConfig_; // to get configuration for L1s/Pre
+      const ReportEvery reportBy_;          // dump report for every never/event/lumi/run/job
+      const ReportEvery resetBy_;           // reset counters  every never/event/lumi/run/job
+      const ReportEvery serviceBy_;         // call to service every never/event/lumi/run/job
+      HLTConfigProvider hltConfig_;         // to get configuration for L1s/Pre
 };
 
 #endif //HLTrigReport_h

--- a/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
@@ -48,7 +48,8 @@ HLTrigReport::ReportEvery HLTrigReport::decode(const std::string & value) {
 // constructors and destructor
 //
 HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
-  hlTriggerResults_ (iConfig.getParameter<edm::InputTag> ("HLTriggerResults")),
+  hlTriggerResults_(iConfig.getParameter<edm::InputTag> ("HLTriggerResults")),
+  hlTriggerResultsToken_(consumes<edm::TriggerResults>(hlTriggerResults_)),
   configured_(false),
   nEvents_(0),
   nWasRun_(0),
@@ -81,8 +82,6 @@ HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
   serviceBy_(decode(iConfig.getUntrackedParameter<std::string>("serviceBy", "never")) ),
   hltConfig_()
 {
-  hlTriggerResultsToken_ = consumes<edm::TriggerResults>(hlTriggerResults_);
-
   const edm::ParameterSet customDatasets(iConfig.getUntrackedParameter<edm::ParameterSet>("CustomDatasets", edm::ParameterSet()));
   isCustomDatasets_ = (customDatasets != edm::ParameterSet());
   if (isCustomDatasets_) {


### PR DESCRIPTION
Migrate summary modules
- HLTrigReport
  to one::EDAnalyzer. They could be migrated to global::EDAnalyzer, but since we do not run them online it's probably not worth it.
