### PR TITLE
multithreading fix for 74x: L1GtTrigReport

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReport.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReport.h
@@ -23,10 +23,9 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -43,7 +42,7 @@ class L1GtTriggerMenu;
 
 // class declaration
 
-class L1GtTrigReport : public edm::EDAnalyzer
+class L1GtTrigReport : public edm::one::EDAnalyzer<>
 {
 
 public:
@@ -119,19 +118,19 @@ private:
 private:
 
     /// boolean flag to select the input record
-    bool m_useL1GlobalTriggerRecord;
+    const bool m_useL1GlobalTriggerRecord;
 
     /// input tag for GT record (L1 GT DAQ record or L1 GT "lite" record):
-    edm::InputTag m_l1GtRecordInputTag;
+    const edm::InputTag m_l1GtRecordInputTag;
 
-    edm::EDGetTokenT<L1GlobalTriggerRecord> m_l1GtRecordInputToken1;
-    edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtRecordInputToken2;
+    const edm::EDGetTokenT<L1GlobalTriggerRecord> m_l1GtRecordInputToken1;
+    const edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtRecordInputToken2;
 
     /// print verbosity
-    int m_printVerbosity;
+    const int m_printVerbosity;
 
     /// print output
-    int m_printOutput;
+    const int m_printOutput;
 
     /// counters
 
@@ -154,7 +153,7 @@ private:
     typedef std::list<L1GtTrigReportEntry*>::iterator ItEntry;
 
     /// index of physics DAQ partition
-    unsigned int m_physicsDaqPartition;
+    const unsigned int m_physicsDaqPartition;
 
 };
 

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -65,68 +65,68 @@
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReportEntry.h"
 
 // constructor(s)
-L1GtTrigReport::L1GtTrigReport(const edm::ParameterSet& pSet) {
+L1GtTrigReport::L1GtTrigReport(const edm::ParameterSet& pSet) :
+
+    // initialize cached IDs
+
+    //
+    m_l1GtStableParCacheID( 0ULL ),
+
+    m_numberPhysTriggers( 0 ),
+    m_numberTechnicalTriggers( 0 ),
+    m_numberDaqPartitions( 0 ),
+    m_numberDaqPartitionsMax( 0 ),
+
+    //
+    m_l1GtPfAlgoCacheID( 0ULL ),
+    m_l1GtPfTechCacheID( 0ULL ),
+
+    m_l1GtTmAlgoCacheID( 0ULL ),
+    m_l1GtTmTechCacheID( 0ULL ),
+
+    m_l1GtTmVetoAlgoCacheID( 0ULL ),
+    m_l1GtTmVetoTechCacheID( 0ULL ),
+
+    //
+    m_l1GtMenuCacheID( 0ULL ),
 
     // boolean flag to select the input record
     // if true, it will use L1GlobalTriggerRecord
-    m_useL1GlobalTriggerRecord = pSet.getParameter<bool>("UseL1GlobalTriggerRecord");
+    m_useL1GlobalTriggerRecord( pSet.getParameter<bool>("UseL1GlobalTriggerRecord") ),
 
     /// input tag for GT record (L1 GT DAQ record or L1 GT "lite" record):
-    m_l1GtRecordInputTag = pSet.getParameter<edm::InputTag>("L1GtRecordInputTag");
+    m_l1GtRecordInputTag( pSet.getParameter<edm::InputTag>("L1GtRecordInputTag") ),
+    m_l1GtRecordInputToken1( m_useL1GlobalTriggerRecord
+        ? consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag)
+        : edm::EDGetTokenT<L1GlobalTriggerRecord>() ),
+    m_l1GtRecordInputToken2( not m_useL1GlobalTriggerRecord
+        ? consumes<L1GlobalTriggerReadoutRecord>(m_l1GtRecordInputTag)
+        : edm::EDGetTokenT<L1GlobalTriggerReadoutRecord>() ),
 
     // print verbosity
-    m_printVerbosity = pSet.getUntrackedParameter<int>("PrintVerbosity", 2);
+    m_printVerbosity( pSet.getUntrackedParameter<int>("PrintVerbosity", 2) ),
 
     // print output
-    m_printOutput = pSet.getUntrackedParameter<int>("PrintOutput", 3);
+    m_printOutput( pSet.getUntrackedParameter<int>("PrintOutput", 3) ),
 
+    // initialize global counters
+
+    // number of events processed
+    m_totalEvents( 0 ),
+
+    //
+    m_entryList(),
+    m_entryListTechTrig(),
+
+    // set the index of physics DAQ partition TODO input parameter?
+    m_physicsDaqPartition( 0 )
+
+{
     LogDebug("L1GtTrigReport") << "\n  Use L1GlobalTriggerRecord:   " << m_useL1GlobalTriggerRecord
             << "\n   (if false: L1GtTrigReport uses L1GlobalTriggerReadoutRecord.)"
             << "\n  Input tag for L1 GT record:  " << m_l1GtRecordInputTag.label() << " \n"
             << "\n  Print verbosity level:           " << m_printVerbosity << " \n"
             << "\n  Print output:                    " << m_printOutput << " \n" << std::endl;
-
-    // initialize cached IDs
-
-    //
-    m_l1GtStableParCacheID = 0ULL;
-
-    m_numberPhysTriggers = 0;
-    m_numberTechnicalTriggers = 0;
-    m_numberDaqPartitions = 0;
-    m_numberDaqPartitionsMax = 0;
-
-    //
-    m_l1GtPfAlgoCacheID = 0ULL;
-    m_l1GtPfTechCacheID = 0ULL;
-
-    m_l1GtTmAlgoCacheID = 0ULL;
-    m_l1GtTmTechCacheID = 0ULL;
-
-    m_l1GtTmVetoAlgoCacheID = 0ULL;
-    m_l1GtTmVetoTechCacheID = 0ULL;
-
-    //
-    m_l1GtMenuCacheID = 0ULL;
-
-    // initialize global counters
-
-    // number of events processed
-    m_totalEvents = 0;
-
-    //
-    m_entryList.clear();
-    m_entryListTechTrig.clear();
-
-    // set the index of physics DAQ partition TODO input parameter?
-    m_physicsDaqPartition = 0;
-
-    if (m_useL1GlobalTriggerRecord) {
-      m_l1GtRecordInputToken1=consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag);
-    }
-    else{
-      m_l1GtRecordInputToken2=consumes<L1GlobalTriggerReadoutRecord>(m_l1GtRecordInputTag);
-    }
 
 }
 


### PR DESCRIPTION
Migrate summary modules
- L1GtTrigReport
  to one::EDAnalyzer. They could be migrated to global::EDAnalyzer, but since we do not run them online it's probably not worth it.
