### PR TITLE
Make version numbers consistent with 7_4_X

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -278,7 +278,9 @@
   </class>
 
   <class name="pat::PackedCandidate" ClassVersion="21">
-    <version ClassVersion="23" checksum="663492232"/>
+    <version ClassVersion="24" checksum="663492232"/>
+    <version ClassVersion="23" checksum="559934341"/>
+    <version ClassVersion="22" checksum="691064527"/>
     <version ClassVersion="21" checksum="1075665714"/>
     <version ClassVersion="20" checksum="2078702780"/>
     <version ClassVersion="19" checksum="359155190"/>


### PR DESCRIPTION
The ROOT class version numbers for class pat::PackedCandidate have recently  become inconsistent between 7_4_X and 7_5_X, in that version 23 is used for different checksums in the two releases.
Fortunately, the version actually used in 7_5_X (version 21) is consistent, so no harm has yet been done. Nonetheless, to prevent possible severe problems in the future, this PR makes the class versions in 7_5_X consistent with 7_4_X.
Since this is purely technical, it should be expedited.
