### PR TITLE
add missing break statement to final protection for multifit infinite loops

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
@@ -322,6 +322,7 @@ bool PulseChiSqSNNLS::NNLS() {
       //worst case protection
       if (iter>=500) {
         edm::LogWarning("PulseChiSqSNNLS::NNLS()") << "Max Iterations reached at iter " << iter <<  std::endl;
+        break;
       }
       
       //unconstrain parameter


### PR DESCRIPTION
addendum to https://github.com/cms-sw/cmssw/pull/11368
