### PR TITLE
L1 Stage 1 MET fixes

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -130,6 +130,8 @@ namespace l1t {
 	//std::cout << "eta: " << regionEta << " pusub: " << puSub << std::endl;
 
 	int regionEtCorr = std::max(0, regionET - puSub);
+	if(regionET == 1023)
+	  regionEtCorr = 1023; // do not subtract overflow regions
 
 	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > lorentz(0,0,0,0);
 	CaloRegion newSubRegion(*&lorentz, 0, 0, regionEtCorr, regionEta, regionPhi, notCorrectedRegion->hwQual(), notCorrectedRegion->hwEtEm(), notCorrectedRegion->hwEtHad());


### PR DESCRIPTION
The L1 ET sum emulator algorithm requires some changes to the handling of overflow regions to agree with firmware. These changes were tested with Ben Kreis on the firmware side.

The changes are in response to differences between L1 firmware and DQM re-emulation that were found. This will need to be back-ported to 75X and 74X as well.
