### PR TITLE
Add combMVAV2 to DQM common configuration

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -107,6 +107,11 @@ bTagCommonBlock = cms.PSet(
             folder = cms.string("combMVA")
         ),
         cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("pfCombinedMVAV2BJetTags"),
+            folder = cms.string("combMVAV2")
+        ),
+        cms.PSet(
             bTagSoftLeptonAnalysisBlock,
             label = cms.InputTag("softPFMuonBJetTags"),
             folder = cms.string("SMT")


### PR DESCRIPTION
This PR adds combMVAV2 to the DQMOffline. Because the bTagGenericAnalysisBlock config
is used only a python configuration has to be modified.

I run several tests (FullSim, Data and FastSim) with the runTheMatrix.py script and everything
seem to work as expected.

This changes have to be backported to 75X and 74X as soon as possible.
