### PR TITLE
Templated BVertex plugins

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
@@ -8,6 +8,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/BTauReco/interface/ParticleMasses.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -20,55 +22,78 @@
 
 #include <algorithm>
 
-class BtoCharmDecayVertexMerger : public edm::stream::EDProducer<> {
+reco::Candidate::LorentzVector vtxP4(const reco::VertexCompositePtrCandidate & vtx) {
+  reco::Candidate::LorentzVector sum;
+  const std::vector<reco::CandidatePtr> & tracks = vtx.daughterPtrVector();
+
+  for(std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec;
+    vec.SetPx((*track)->px());
+    vec.SetPy((*track)->py());
+    vec.SetPz((*track)->pz());
+    vec.SetM(reco::ParticleMasses::piPlus);
+    sum += vec;
+  }
+  return sum;
+}
+
+template<typename VTX>
+class BtoCharmDecayVertexMergerT : public edm::stream::EDProducer<> {
     public:
-       BtoCharmDecayVertexMerger(const edm::ParameterSet &params);
+       BtoCharmDecayVertexMergerT(const edm::ParameterSet &params);
 
        virtual void produce(edm::Event &event, const edm::EventSetup &es);
 
+       typedef reco::TemplatedSecondaryVertex<VTX> SecondaryVertex;
+
     private:
        edm::EDGetTokenT<reco::VertexCollection>  token_primaryVertex;
-       edm::EDGetTokenT<reco::VertexCollection>  token_secondaryVertex;
+       edm::EDGetTokenT<edm::View<VTX> >         token_secondaryVertex;
        reco::Vertex                              pv;
        // double                                    maxFraction;
        // double                                    minSignificance;
 
-       double minDRForUnique, vecSumIMCUTForUnique, minCosPAtomerge, maxPtreltomerge;
+       double maxDRForUnique, maxvecSumIMCUTForUnique, minCosPAtomerge, maxPtreltomerge;
 
        // a vertex proxy for sorting using stl
-       struct vertexProxy{
-         reco::Vertex vert;
+       struct VertexProxy{
+         VTX vert;
          double invm;
          size_t ntracks;
        };
 
-       // comparison operator for vertexProxy, used in sorting
-       friend bool operator<(vertexProxy v1, vertexProxy v2){
+       // comparison operator for VertexProxy, used in sorting
+       friend bool operator<(VertexProxy v1, VertexProxy v2){
          if(v1.ntracks>2 && v2.ntracks<3) return true;
          if(v1.ntracks<3 && v2.ntracks>2) return false;
          return (v1.invm>v2.invm);
        }
 
-       void resolveBtoDchain(std::vector<vertexProxy>& coll, unsigned int i, unsigned int k);
-       GlobalVector flightDirection(reco::Vertex &pv, reco::Vertex &sv);
+       VertexProxy buildVertexProxy(const VTX & vtx);
+
+       void resolveBtoDchain(std::vector<VertexProxy>& coll, unsigned int i, unsigned int k);
+       GlobalVector flightDirection(const reco::Vertex &v1, const reco::Vertex &v2);
+       GlobalVector flightDirection(const reco::Vertex &v1, const reco::VertexCompositePtrCandidate &v2);
+       GlobalVector flightDirection(const reco::VertexCompositePtrCandidate &v1, const reco::VertexCompositePtrCandidate &v2);
 };
 
 
-
-BtoCharmDecayVertexMerger::BtoCharmDecayVertexMerger(const edm::ParameterSet &params) :
+template<typename VTX>
+BtoCharmDecayVertexMergerT<VTX>::BtoCharmDecayVertexMergerT(const edm::ParameterSet &params) :
        token_primaryVertex(consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"))),
-       token_secondaryVertex(consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("secondaryVertices"))),
-       minDRForUnique(params.getUntrackedParameter<double>("minDRUnique",0.4)),
-       vecSumIMCUTForUnique(params.getUntrackedParameter<double>("minvecSumIMifsmallDRUnique",5.5)),
-       minCosPAtomerge(params.getUntrackedParameter<double>("minCosPAtomerge",0.99)),
-       maxPtreltomerge(params.getUntrackedParameter<double>("maxPtreltomerge",7777.0))
+       token_secondaryVertex(consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("secondaryVertices"))),
+       maxDRForUnique(params.getParameter<double>("maxDRUnique")),
+       maxvecSumIMCUTForUnique(params.getParameter<double>("maxvecSumIMifsmallDRUnique")),
+       minCosPAtomerge(params.getParameter<double>("minCosPAtomerge")),
+       maxPtreltomerge(params.getParameter<double>("maxPtreltomerge"))
        // maxFraction(params.getParameter<double>("maxFraction")),
        // minSignificance(params.getParameter<double>("minSignificance"))
 {
-       produces<reco::VertexCollection>();
+       produces<std::vector<VTX> >();
 }
-//-----------------------
-void BtoCharmDecayVertexMerger::produce(edm::Event &iEvent, const edm::EventSetup &iSetup){
+//------------------------------------
+template<typename VTX>
+void BtoCharmDecayVertexMergerT<VTX>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup){
 
   using namespace reco;
   // PV
@@ -81,17 +106,16 @@ void BtoCharmDecayVertexMerger::produce(edm::Event &iEvent, const edm::EventSetu
   pv = pvc[0];
 
   // get the IVF collection
-  edm::Handle<reco::VertexCollection> secondaryVertices;
+  edm::Handle<edm::View<VTX> > secondaryVertices;
   iEvent.getByToken(token_secondaryVertex, secondaryVertices);
 
 
 
   //loop over vertices,  fill into own collection for sorting
-  std::vector<vertexProxy> vertexProxyColl;
-  for(std::vector<reco::Vertex>::const_iterator sv = secondaryVertices->begin();
+  std::vector<VertexProxy> vertexProxyColl;
+  for(typename edm::View<VTX>::const_iterator sv = secondaryVertices->begin();
       sv != secondaryVertices->end(); ++sv) {
-    vertexProxy vtx = {*sv,(*sv).p4().M(),(*sv).tracksSize()};
-    vertexProxyColl.push_back( vtx );
+    vertexProxyColl.push_back( buildVertexProxy(*sv) );
   }
 
   // sort the vertices by mass and track multiplicity
@@ -99,33 +123,72 @@ void BtoCharmDecayVertexMerger::produce(edm::Event &iEvent, const edm::EventSetu
 
 
   // loop forward over all vertices
-  for(unsigned int iVtx=0; iVtx < vertexProxyColl.size(); iVtx++){
+  for(unsigned int iVtx=0; iVtx < vertexProxyColl.size(); ++iVtx){
 
     // nested loop backwards (in order to start from light masses)
     // check all vertices against each other for B->D chain
-    for(unsigned int kVtx=vertexProxyColl.size()-1; kVtx>iVtx; kVtx--){
+    for(unsigned int kVtx=vertexProxyColl.size()-1; kVtx>iVtx; --kVtx){
       // remove D vertices from the collection and add the tracks to the original one
       resolveBtoDchain(vertexProxyColl, iVtx, kVtx);
     }
   }
 
   // now create new vertex collection and add to event
-  VertexCollection *bvertices = new VertexCollection();
-  for(std::vector<vertexProxy>::iterator it=vertexProxyColl.begin(); it!=vertexProxyColl.end(); it++) bvertices->push_back((*it).vert);
-  std::auto_ptr<VertexCollection> bvertColl(bvertices);
+  std::auto_ptr<std::vector<VTX> > bvertColl(new std::vector<VTX>);
+  for(typename std::vector<VertexProxy>::const_iterator it=vertexProxyColl.begin(); it!=vertexProxyColl.end(); ++it) bvertColl->push_back((*it).vert);
   iEvent.put(bvertColl);
   }
   else{
-    std::auto_ptr<VertexCollection> bvertCollEmpty(new VertexCollection);
+    std::auto_ptr<std::vector<VTX> > bvertCollEmpty(new std::vector<VTX>);
     iEvent.put(bvertCollEmpty);
   }
 }
-
-
 //------------------------------------
-void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll, unsigned int i, unsigned int k){
+template<typename VTX>
+GlobalVector
+BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::Vertex & v1, const reco::Vertex & v2) {
+  return  GlobalVector(v2.x() - v1.x(),
+                       v2.y() - v1.y(),
+                       v2.z() - v1.z());
+}
+
+template<typename VTX>
+GlobalVector
+BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::Vertex & v1, const reco::VertexCompositePtrCandidate & v2) {
+  return  GlobalVector(v2.vertex().x() - v1.x(),
+                       v2.vertex().y() - v1.y(),
+                       v2.vertex().z() - v1.z());
+}
+
+template<typename VTX>
+GlobalVector
+BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::VertexCompositePtrCandidate & v1, const reco::VertexCompositePtrCandidate & v2) {
+  return  GlobalVector(v2.vertex().x() - v1.vertex().x(),
+                       v2.vertex().y() - v1.vertex().y(),
+                       v2.vertex().z() - v1.vertex().z());
+}
+//-------------- template specializations --------------------
+
+// -------------- buildVertexProxy ----------------
+template<>
+BtoCharmDecayVertexMergerT<reco::Vertex>::VertexProxy
+BtoCharmDecayVertexMergerT<reco::Vertex>::buildVertexProxy(const reco::Vertex & vtx) {
+  VertexProxy vtxProxy = {vtx,vtx.p4().M(),vtx.tracksSize()};
+  return vtxProxy;
+}
+
+template<>
+BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::VertexProxy
+BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::buildVertexProxy(const reco::VertexCompositePtrCandidate & vtx) {
+  VertexProxy vtxProxy = {vtx,vtxP4(vtx).M(),vtx.numberOfSourceCandidatePtrs()};
+  return vtxProxy;
+}
+
+// -------------- resolveBtoDchain ----------------
+template<>
+void BtoCharmDecayVertexMergerT<reco::Vertex>::resolveBtoDchain(std::vector<VertexProxy>& coll, unsigned int i, unsigned int k){
   using namespace reco;
-  typedef reco::TemplatedSecondaryVertex<reco::Vertex> SecondaryVertex;
+
   GlobalVector momentum1 = GlobalVector(coll[i].vert.p4().X(), coll[i].vert.p4().Y(), coll[i].vert.p4().Z());
   GlobalVector momentum2 = GlobalVector(coll[k].vert.p4().X(), coll[k].vert.p4().Y(), coll[k].vert.p4().Z());
 
@@ -148,24 +211,25 @@ void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll,
   }
   GlobalVector nearToFar = flightDirection( svNear, svFar);
   GlobalVector pvToNear  = flightDirection( pv, svNear);
+  GlobalVector pvToFar   = flightDirection( pv, svFar);
 
   double cosPA =  nearToFar.dot(momentumFar) / momentumFar.mag()/ nearToFar.mag();
   double cosa  =  pvToNear. dot(momentumFar) / pvToNear.mag()   / momentumFar.mag();
   double ptrel = sqrt(1.0 - cosa*cosa)* momentumFar.mag();
 
-  double vertexDeltaR = Geom::deltaR(flightDirection(pv, sv1), flightDirection(pv, sv2) );
+  double vertexDeltaR = Geom::deltaR(pvToNear, pvToFar);
 
   // create a set of all tracks from both vertices, avoid double counting by using a std::set<>
   std::set<reco::TrackRef> trackrefs;
   // first vertex
-  for(reco::Vertex::trackRef_iterator ti = sv1.tracks_begin(); ti!=sv1.tracks_end(); ti++){
+  for(reco::Vertex::trackRef_iterator ti = sv1.tracks_begin(); ti!=sv1.tracks_end(); ++ti){
     if(sv1.trackWeight(*ti)>0.5){
       reco::TrackRef t = ti->castTo<reco::TrackRef>();
       trackrefs.insert(t);
     }
   }
   // second vertex
-  for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ti++){
+  for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ++ti){
     if(sv2.trackWeight(*ti)>0.5){
       reco::TrackRef t = ti->castTo<reco::TrackRef>();
       trackrefs.insert(t);
@@ -174,20 +238,20 @@ void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll,
 
   // now calculate one LorentzVector from the track momenta
   ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > mother;
-  for(std::set<reco::TrackRef>::const_iterator it = trackrefs.begin(); it!= trackrefs.end(); it++){
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >  temp ( (*it)->px(),(*it)->py(),(*it)->pz(), 0.13957 );
+  for(std::set<reco::TrackRef>::const_iterator it = trackrefs.begin(); it!= trackrefs.end(); ++it){
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >  temp ( (*it)->px(),(*it)->py(),(*it)->pz(), ParticleMasses::piPlus );
     mother += temp;
   }
 
 
   //   check if criteria for merging are fulfilled
-  if(vertexDeltaR<minDRForUnique && mother.M()<vecSumIMCUTForUnique && cosPA>minCosPAtomerge && fabs(ptrel)<maxPtreltomerge ) {
+  if(vertexDeltaR<maxDRForUnique && mother.M()<maxvecSumIMCUTForUnique && cosPA>minCosPAtomerge && std::abs(ptrel)<maxPtreltomerge ) {
 
 
     // add tracks of second vertex which are missing to first vertex
     // loop over the second
     bool bFoundDuplicate=false;
-    for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ti++){
+    for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ++ti){
       reco::Vertex::trackRef_iterator it = find(sv1.tracks_begin(), sv1.tracks_end(), *ti);
       if (it==sv1.tracks_end()) coll[i].vert.add( *ti, sv2.refittedTrack(*ti), sv2.trackWeight(*ti) );
       else bFoundDuplicate=true;
@@ -200,7 +264,7 @@ void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll,
       std::vector<TrackBaseRef > tracks_;
       std::vector<Track> refittedTracks_;
       std::vector<float> weights_;
-      for(reco::Vertex::trackRef_iterator it = coll[i].vert.tracks_begin(); it!=coll[i].vert.tracks_end(); it++) {
+      for(reco::Vertex::trackRef_iterator it = coll[i].vert.tracks_begin(); it!=coll[i].vert.tracks_end(); ++it) {
        tracks_.push_back( *it);
        refittedTracks_.push_back( coll[i].vert.refittedTrack(*it));
        weights_.push_back( coll[i].vert.trackWeight(*it) );
@@ -209,7 +273,7 @@ void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll,
       coll[i].vert.removeTracks();
       std::vector<Track>::iterator it2 = refittedTracks_.begin();
       std::vector<float>::iterator it3 = weights_.begin();
-      for(reco::Vertex::trackRef_iterator it = tracks_.begin(); it!=tracks_.end(); it++, it2++, it3++){
+      for(reco::Vertex::trackRef_iterator it = tracks_.begin(); it!=tracks_.end(); ++it, ++it2, ++it3){
        float weight = *it3;
        float weight2= sv2.trackWeight(*it);
        Track refittedTrackWithLargerWeight = *it2;
@@ -226,17 +290,84 @@ void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll,
   }
 
 }
-//-------------
+
+template<>
+void BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::resolveBtoDchain(std::vector<VertexProxy>& coll, unsigned int i, unsigned int k){
+  using namespace reco;
+
+  Candidate::LorentzVector vtx1P4 = vtxP4(coll[i].vert);
+  Candidate::LorentzVector vtx2P4 = vtxP4(coll[k].vert);
+  GlobalVector momentum1 = GlobalVector(vtx1P4.X(), vtx1P4.Y(), vtx1P4.Z());
+  GlobalVector momentum2 = GlobalVector(vtx2P4.X(), vtx2P4.Y(), vtx2P4.Z());
+
+  SecondaryVertex sv1(pv, coll[i].vert, momentum1 , true);
+  SecondaryVertex sv2(pv, coll[k].vert, momentum2 , true);
 
 
-GlobalVector
-BtoCharmDecayVertexMerger::flightDirection(reco::Vertex &pv, reco::Vertex &sv){
-  GlobalVector res(sv.position().X() - pv.position().X(),
-                    sv.position().Y() - pv.position().Y(),
-                    sv.position().Z() - pv.position().Z());
-  return res;
+  // find out which one is near and far
+  SecondaryVertex svNear = sv1;
+  SecondaryVertex svFar  = sv2;
+  GlobalVector momentumNear  = momentum1;
+  GlobalVector momentumFar   = momentum2;
+
+  // swap if it is the other way around
+  if(sv1.dist3d().value() >= sv2.dist3d().value()){
+    svNear = sv2;
+    svFar = sv1;
+    momentumNear = momentum2;
+    momentumFar = momentum1;
+  }
+  GlobalVector nearToFar = flightDirection( svNear, svFar);
+  GlobalVector pvToNear  = flightDirection( pv, svNear);
+  GlobalVector pvToFar   = flightDirection( pv, svFar);
+
+  double cosPA =  nearToFar.dot(momentumFar) / momentumFar.mag()/ nearToFar.mag();
+  double cosa  =  pvToNear. dot(momentumFar) / pvToNear.mag()   / momentumFar.mag();
+  double ptrel = sqrt(1.0 - cosa*cosa)* momentumFar.mag();
+
+  double vertexDeltaR = Geom::deltaR(pvToNear, pvToFar);
+
+  // create a set of all tracks from both vertices, avoid double counting by using a std::set<>
+  std::set<reco::CandidatePtr> trackrefs;
+  // first vertex
+  for(size_t i=0; i < sv1.numberOfSourceCandidatePtrs(); ++i)
+      trackrefs.insert(sv1.daughterPtr(i));
+  // second vertex
+  for(size_t i=0; i < sv2.numberOfSourceCandidatePtrs(); ++i)
+      trackrefs.insert(sv2.daughterPtr(i));
+
+  // now calculate one LorentzVector from the track momenta
+  Candidate::LorentzVector mother;
+  for(std::set<reco::CandidatePtr>::const_iterator it = trackrefs.begin(); it!= trackrefs.end(); ++it){
+    Candidate::LorentzVector temp ( (*it)->px(),(*it)->py(),(*it)->pz(), ParticleMasses::piPlus );
+    mother += temp;
+  }
+
+  //   check if criteria for merging are fulfilled
+  if(vertexDeltaR<maxDRForUnique && mother.M()<maxvecSumIMCUTForUnique && cosPA>minCosPAtomerge && std::abs(ptrel)<maxPtreltomerge ) {
+
+    // add tracks of second vertex which are missing to first vertex
+    // loop over the second
+    const std::vector<reco::CandidatePtr> & tracks1 = sv1.daughterPtrVector();
+    const std::vector<reco::CandidatePtr> & tracks2 = sv2.daughterPtrVector();
+    for(std::vector<reco::CandidatePtr>::const_iterator ti = tracks2.begin(); ti!=tracks2.end(); ++ti){
+      std::vector<reco::CandidatePtr>::const_iterator it = find(tracks1.begin(), tracks1.end(), *ti);
+      if (it==tracks1.end()) {
+        coll[i].vert.addDaughter( *ti );
+        coll[i].vert.setP4( (*ti)->p4() + coll[i].vert.p4() );
+      }
+    }
+
+    // remove the second vertex from the collection
+    coll.erase( coll.begin() + k  );
+  }
 }
 
 
+// define specific instances of the templated BtoCharmDecayVertexMergerT class
+typedef BtoCharmDecayVertexMergerT<reco::Vertex>                      BtoCharmDecayVertexMerger;
+typedef BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate> CandidateBtoCharmDecayVertexMerger;
 
+// define plugins
 DEFINE_FWK_MODULE(BtoCharmDecayVertexMerger);
+DEFINE_FWK_MODULE(CandidateBtoCharmDecayVertexMerger);

--- a/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 bToCharmDecayVertexMerged = cms.EDProducer("BtoCharmDecayVertexMerger",
       primaryVertices  = cms.InputTag("offlinePrimaryVertices"),
       secondaryVertices = cms.InputTag("inclusiveSecondaryVerticesFiltered"),
-      minDRUnique = cms.untracked.double(0.4),
-      minvecSumIMifsmallDRUnique = cms.untracked.double(5.5),
-      minCosPAtomerge = cms.untracked.double(0.99),
-      maxPtreltomerge = cms.untracked.double(7777.0)
+      maxDRUnique = cms.double(0.4),
+      maxvecSumIMifsmallDRUnique = cms.double(5.5),
+      minCosPAtomerge = cms.double(0.99),
+      maxPtreltomerge = cms.double(7777.0)
 )


### PR DESCRIPTION
This PR templates the BVertexFilter and BtoCharmDecayVertexMerger plugins in order to make them usable in the candidate-based framework

No impact on the standard reconstruction is expected.

@imarches @cvernier 
