### PR TITLE
New GTs for 75X: Hcal MC response corrections and other fixes

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '75X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v6',
+    'run2_design'       :   '75X_mcRun2_design_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v5',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v6',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v6',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v5',
     # GlobalTag for Run1 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '75X_mcRun1_design_v4',
+    'run1_design'       :   '75X_mcRun1_design_v5',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '75X_mcRun1_realistic_v4',
+    'run1_mc'           :   '75X_mcRun1_realistic_v5',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v4',
+    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v5',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '75X_mcRun1_pA_v4',
+    'run1_mc_pa'        :   '75X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v5',
+    'run2_design'       :   '75X_mcRun2_design_v6',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v4',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v5',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v4',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v5',
+    'run1_data'         :   '75X_dataRun1_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v5',
+    'run2_data'         :   '75X_dataRun2_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v2',
+    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v1',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes
## Run1 simulation
- Ideal: [75X_mcRun1_design_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_design_v5) : As [75X_mcRun1_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_design_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_design_v4/75X_mcRun1_design_v5):
  - adding BTag conditions as GRBForest payloads;  
  - Hcal response corrections from Data/MC comparison.
- Realistic: [75X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_realistic_v5): As [75X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_realistic_v4/75X_mcRun1_realistic_v5):
  - adding BTag conditions as GRBForest payloads;
  - Hcal response corrections from Data/MC comparison.
- Heavy Ion: [75X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_HeavyIon_v5): As [75X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_HeavyIon_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_HeavyIon_v4/75X_mcRun1_HeavyIon_v5):
  - adding BTag conditions as GRBForest payloads;
  - Hcal response corrections from Data/MC comparison;
  - Adding new Centrality table in `HeavyIonRcd` with label `HFtowersHydjetDrum5`.
- Proton Lead: [75X_mcRun1_pA_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_pA_v5): As [75X_mcRun1_pA_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_pA_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_pA_v4/75X_mcRun1_pA_v5):
  - adding BTag conditions as GRBForest payloads;
  - Hcal response corrections from Data/MC comparison.
## Run1 data
- Offline: [75X_dataRun1_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_v5): As [75X_dataRun1_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_v4]) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun1_v5/75X_dataRun1_v4):
  - adding BTag conditions as GRBForest payloads;
  - adding HF tower description for HeavyIons as new label in HevayIonRcd;
  - updating HCAL channel quality: mark 18 HCAL channels of a particular HPD as bad (0x8002) in the run range 253937 - 255294 due to a mistakenly set low bias voltage.
  - taxonomy change for Muon APE tags 
- HLT: [75X_dataRun1_HLT_frozen_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_HLT_frozen_v3): As [75X_dataRun1_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_HLT_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun1_HLT_frozen_v2/75X_dataRun1_HLT_frozen_v3):
  - taxonomy change for Muon APE tags;
  - taxonomy change for SiStrip back-plane corrections in deconvolution mode;
  - new snapshot time: 2015-09-21 07:47:14.
## Run2 simulation
- Ideal: [75X_mcRun2_design_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_design_v5): As [75X_mcRun2_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_design_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_design_v5/75X_mcRun2_design_v4):
  - adding BTag conditions as GRBForest payloads;
  - new 25ns JEC including PUPPI;
  - Hcal response corrections from Data/MC comparison;
  - Hcal ZS thresholds to simulate HF zero suppresion settings;
  - New 25ns JECs for HLT;
  - New L1 menu for stage1 (v5).
- Startup: [75X_mcRun2_startup_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_startup_v5): As [75X_mcRun2_startup_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_startup_v4/75X_mcRun2_startup_v2):
  - adding BTag conditions as GRBForest payloads;
  - new Pixel dead channel map (from Run2015C);
  - new 50ns JEC including PUPPI;
  - Hcal response corrections from Data/MC comparison;
  - Hcal ZS thresholds to simulate HF zero suppresion settings.
- Asymptotic: [75X_mcRun2_asymptotic_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_asymptotic_v6): As [75X_mcRun2_asymptotic_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_asymptotic_v5) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_asymptotic_v5/75X_mcRun2_asymptotic_v6):
  - adding BTag conditions as GRBForest payloads;
  - new Pixel dead channel map (from Run2015C);
  - new 50ns JEC including PUPPI;
  - Hcal response corrections from Data/MC comparison;
  - Hcal ZS thresholds to simulate HF zero suppresion settings;
  - New 25ns JECs for HLT;
  - New L1 menu for stage1 (v5).
- Heavy Ion: [75X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_HeavyIon_v5): As [75X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_HeavyIon_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_HeavyIon_v4/75X_mcRun2_HeavyIon_v5):
  - adding BTag conditions as GRBForest payloads;
  - new Pixel dead channel map (from Run2015C);
  - new 25ns JEC including PUPPI;
  - Hcal response corrections from Data/MC comparison;
  - Hcal ZS thresholds to simulate HF zero suppresion settings;
  - New 25ns JECs for HLT;
  - New L1 menu for stage1 (v5);
  - Adding new Centrality table in `HeavyIonRcd` with label `HFtowersHydjetDrum5`.
## Run2 data
- Offline: [75X_dataRun2_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_v6): As [75X_dataRun2_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_v5) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun2_v5/75X_dataRun2_v6):
  - adding BTag conditions as GRBForest payloads;
  - adding new Centrality Table for HF tower description for HeavyIons as new label in HevayIonRcd; 
  - updating HCAL channel quality: mark 18 HCAL channels of a particular HPD as bad (0x8002) in the run range 253937 - 255294 due to a mistakenly set low bias voltage;
  - updating JEC for data (25ns-50ns transitions are handled via IOV) including new labels for PUPPI;
  - taxonomy change for Muon APE tags.
- HLT: [75X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HLT_frozen_v3): As [75X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HLT_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun2_HLT_frozen_v2/75X_dataRun2_HLT_frozen_v3):
  - taxonomy change for Muon APE tags; 
  - taxonomy change for SiStrip back plane corrections in deconvolution mode;
  - new snapshot time: 2015-09-21 07:47:14.
