### PR TITLE
Fix crash in pat::MET when no Type-I uncertainties are added

### DIFF
--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -205,6 +205,10 @@ MET::findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) c
   
 
   //find uncertainty shift =============================
+
+  if (uncertainties_.empty())
+      return totShift;
+
   if(shift>=MET::METUncertaintySize) throw cms::Exception("Unsupported", "MET uncertainty does not exist");
   if(isSmeared && shift<=MET::JetResDown) shift = (MET::METUncertainty)(MET::METUncertaintySize+shift+1);
 							  


### PR DESCRIPTION
Hello,

This PR fixes a crash I experienced when running on CMSSW 7.4.12 patch4. I manually create a new slimmedMETs using the following code snippet:

``` python
from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
jetToolbox(process, 'ak4', 'ak4CHSJetSequence', 'out', PUMethod='CHS', runOnMC=not isData, miniAOD=True, addPUJetID=False)

from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
process.load('RecoMET.METProducers.PFMET_cfi')

process.pfMet.src = cms.InputTag('packedPFCandidates')
addMETCollection(process, labelName='patPFMet', metSource='pfMet')


process.load('JetMETCorrections.Configuration.JetCorrectors_cff')
from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPfMetType1
from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT1

process.corrPfMetType1 = corrPfMetType1.clone(
        src = 'ak4PFJetsCHS',
        jetCorrLabel = 'ak4PFCHSL1FastL2L3Corrector' if not isData else 'ak4PFCHSL1FastL2L3ResidualCorrector',
        offsetCorrLabel = 'ak4PFCHSL1FastjetCorrector'
    )
    process.pfMetT1 = pfMetT1.clone(
        src = 'pfMet',
        srcCorrections = [cms.InputTag("corrPfMetType1", "type1")]
    )

addMETCollection(process, labelName='patMET', metSource='pfMetT1') # T1 MET

from PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi import slimmedMETs
del slimmedMETs.caloMET

process.slimmedMETs = slimmedMETs.clone()

process.slimmedMETs.src = cms.InputTag("patMET")
process.slimmedMETs.rawVariation = cms.InputTag("patPFMet")
```

I explicitly do not want T1 uncertainties, I'm only interested in T1 met + Raw met.

When trying to access `pat::MET::uncorPt()` the code crash inside the `pat::MET::findMETTotalShift`.

This is because in this particular case, the `uncertainties_` array is empty, because, since there's no Type1 uncertainties, the function `setUncShift` is never called by `PATMETSlimmer`.

~~This PR fixes both issues: first, it ensure that if `uncertainties_` is empty, the code no longer crashed. Second, it fixes `PATMETSlimmer` by making sure `setUncShift` is called not matter the type of uncertainties.~~

This PR changes `pat::MET::findMETTotalShift` to prevent the crash by checking if `uncertainties_` is empty.

If merged, it'll need to be backport to 7.5 and 7.4.

Thanks
