### PR TITLE
Fix sigmaIetaIphi for photon regression

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -585,7 +585,8 @@ void EGExtraInfoModifierFromDB::modifyObject(pat::Photon& pho) const {
   eval[9] = reco::deltaPhi(theseed->phi(),sc->position().Phi());
   eval[10] = pho.seedEnergy()/sc->rawEnergy();
   eval[11] = pho.e3x3()/pho.e5x5();
-  eval[12] = pho.sigmaIetaIeta();
+  const float sieie = pho.sigmaIetaIeta();
+  eval[12] = sieie;
 
   float sipip=0, sieip=0, e2x5Max=0, e2x5Left=0, e2x5Right=0, e2x5Top=0, e2x5Bottom=0;
   assignValue(ptr, ph_conf.tag_float_token_map.find(std::string("sigmaIetaIphi"))->second.second, pho_vmaps, sieip);
@@ -597,7 +598,7 @@ void EGExtraInfoModifierFromDB::modifyObject(pat::Photon& pho) const {
   assignValue(ptr, ph_conf.tag_float_token_map.find(std::string("e2x5Bottom"))->second.second, pho_vmaps, e2x5Bottom);
   
   eval[13] = sipip;
-  eval[14] = sieip;
+  eval[14] = sieip/(sieie*sipip);
   eval[15] = pho.maxEnergyXtal()/pho.e5x5();
   eval[16] = pho.e2nd()/pho.e5x5();
   eval[17] = pho.eTop()/pho.e5x5();


### PR DESCRIPTION
Greetings.

Found another bug in the photon regression, mostly coming from a very misleading set of RelVals with the base name `H130GGgluonfusion`.

Since it appeared that the new regressions were adjusting the scale to 130 GeV, the regressions appeared to be doing the right thing (centering better the Hgg peak). However, it is not the case and the actual Higgs mass in these samples is now 125 GeV with pythia 8. It had been assumed the photon scale was rather off due to old regressions, but it was really the gen settings.

After finding this out we rather quickly traced down the problem to an improperly calculated shower shape (sigmaIetaIphi needs to be normalized by sigmaIetaIeta*sigmaIphiIphi for the regressions).

@matteosan1 will upload higher-stats validation tomorrow.

@gpetruc @bendavid 

(red is fixed regressions, blue is original energy, before faulty regressions)
<img width="696" alt="screen shot 2015-09-21 at 22 42 20" src="https://cloud.githubusercontent.com/assets/1068089/10006608/d62f3bf4-60be-11e5-96bd-3ebc9e7914b5.png">
