### PR TITLE
Add combMVA to DQM (cherry-picking PR #10529)

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -102,6 +102,11 @@ bTagCommonBlock = cms.PSet(
             folder = cms.string("CSVv2")
         ),
         cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("pfCombinedMVABJetTags"),
+            folder = cms.string("combMVA")
+        ),
+        cms.PSet(
             bTagSoftLeptonAnalysisBlock,
             label = cms.InputTag("softPFMuonBJetTags"),
             folder = cms.string("SMT")


### PR DESCRIPTION
This is a backport from 7_6_X (PR #10529) to add combMVA to the DQM.
