### PR TITLE
Fix PU jet ID config used for MVAmet

### DIFF
--- a/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
@@ -38,6 +38,7 @@ puJetIdForPFMVAMEt = pileupJetIdEvaluator.clone(
             "frac04",
             "frac05"
             ),
+        etaBinnedWeights = cms.bool(False),
         tmvaWeights = cms.string("RecoJets/JetProducers/data/TMVAClassificationCategory_JetID_MET_53X_Dec2012.weights.xml.gz"),
         tmvaMethod = cms.string("JetID"),
         tmvaSpectators = cms.vstring(),


### PR DESCRIPTION
Fixes the problem in the PU jet ID config, to be able to run on the new MiniAOD samples, reported in this thread:
https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3413/1/1.html
