### PR TITLE
Avoid unnecessary locks in ROOT function GetBaseClassOffset()

### DIFF
--- a/DataFormats/Common/interface/RefHolderBase.h
+++ b/DataFormats/Common/interface/RefHolderBase.h
@@ -5,8 +5,7 @@
  *
  */
 #include <memory>
-
-#include "FWCore/Utilities/interface/TypeWithDict.h"
+#include <typeinfo>
 
 namespace edm {
   class ProductID;
@@ -52,7 +51,7 @@ namespace edm {
       // and cast it to the type specified by toType.
       // Return 0 if the real type is not toType nor a subclass of
       // toType.
-      virtual void const* pointerToType(TypeWithDict const& toType) const = 0;
+      virtual void const* pointerToType(std::type_info const& toType) const = 0;
     };
 
     //------------------------------------------------------------------
@@ -67,8 +66,7 @@ namespace edm {
     T const*
     RefHolderBase::getPtr() const
     {
-      static const TypeWithDict s_type(typeid(T));
-      return static_cast<T const*>(pointerToType(s_type));
+      return static_cast<T const*>(pointerToType(typeid(T)));
     }
 
   }

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -4,10 +4,11 @@
 
 #include "DataFormats/Common/interface/RefHolderBase.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/OffsetToBase.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <memory>
+#include <typeinfo>
 
 namespace edm {
   namespace reftobase {
@@ -44,7 +45,7 @@ namespace edm {
       //Needed for ROOT storage
       CMS_CLASS_VERSION(10)
     private:
-      virtual void const* pointerToType(TypeWithDict const& iToType) const GCC11_OVERRIDE;
+      virtual void const* pointerToType(std::type_info const& iToType) const GCC11_OVERRIDE;
       REF ref_;
     };
 
@@ -133,12 +134,12 @@ namespace edm {
 
     template <class REF>
     void const* 
-    RefHolder<REF>::pointerToType(TypeWithDict const& iToType) const 
-    {
+    RefHolder<REF>::pointerToType(std::type_info const& iToType) const {
       typedef typename REF::value_type contained_type;
-      static TypeWithDict const s_type(typeid(contained_type));
-    
-      return iToType.pointerToBaseType(ref_.get(), s_type);
+      if(iToType == typeid(contained_type)) {
+        return ref_.get();
+      }
+      return pointerToBase(iToType, ref_.get());
     }
   } // namespace reftobase
 }

--- a/DataFormats/Common/interface/fillPtrVector.h
+++ b/DataFormats/Common/interface/fillPtrVector.h
@@ -23,7 +23,7 @@
 // user include files
 #include "DataFormats/Common/interface/FillView.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/OffsetToBase.h"
 
 #include "DataFormats/Common/interface/fwd_fillPtrVector.h"
 
@@ -56,8 +56,6 @@ namespace edm {
           oPtr.push_back(address);
         }
       } else {
-        static TypeWithDict const s_type(typeid(element_type));
-
         for(std::vector<unsigned long>::const_iterator itIndex = iIndicies.begin(),
             itEnd = iIndicies.end();
             itIndex != itEnd;
@@ -65,8 +63,8 @@ namespace edm {
           iter it = coll.begin();
           std::advance(it, *itIndex);
           element_type const* address = GetProduct<product_type>::address(it);
-          void const* ptr = TypeWithDict(iToType).pointerToBaseType(address, s_type);
-          if(0 != ptr) {
+          void const* ptr = pointerToBase(iToType,address);
+          if(nullptr != ptr) {
             oPtr.push_back(ptr);
           } else {
             Exception::throwThis(errors::LogicError,

--- a/DataFormats/Common/interface/setPtr.h
+++ b/DataFormats/Common/interface/setPtr.h
@@ -22,7 +22,7 @@
 #include "DataFormats/Common/interface/FillView.h"
 #include "DataFormats/Common/interface/fwd_setPtr.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/OffsetToBase.h"
 
 // system include files
 #include <typeinfo>
@@ -45,18 +45,16 @@ namespace edm {
       if(iToType == typeid(element_type)) {
         iter it = coll.begin();
         std::advance(it,iIndex);
-        element_type const* address = GetProduct<product_type>::address( it );
+        element_type const* address = GetProduct<product_type>::address(it);
         oPtr = address;
       } else {
-        static TypeWithDict const s_type(TypeWithDict(typeid(element_type)));
-
         iter it = coll.begin();
         std::advance(it,iIndex);
-        element_type const* address = GetProduct<product_type>::address( it );
+        element_type const* address = GetProduct<product_type>::address(it);
 
-        oPtr = TypeWithDict(iToType).pointerToBaseType(address, s_type);
+        oPtr = pointerToBase(iToType,address);
 
-        if(0 == oPtr) {
+        if(nullptr == oPtr) {
           Exception::throwThis(errors::LogicError,
             "TypeConversionError"
              "edm::Ptr<> : unable to convert type ",

--- a/DataFormats/Common/test/testOwnVector.cc
+++ b/DataFormats/Common/test/testOwnVector.cc
@@ -1,8 +1,8 @@
 #include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
+#include <cstring>
 #include <iterator>
 #include <iostream>
-#include <string.h>
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 

--- a/DataFormats/Common/test/testOwnVector.cc
+++ b/DataFormats/Common/test/testOwnVector.cc
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <iterator>
 #include <iostream>
+#include <string.h>
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 

--- a/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
+++ b/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
@@ -1,5 +1,6 @@
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "DataFormats/Common/interface/RefProd.h"
+#include <cstring>
 
 pat::PackedTriggerPrescales::PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> & handle) :
     prescaleValues_(), 

--- a/FWCore/Utilities/interface/OffsetToBase.h
+++ b/FWCore/Utilities/interface/OffsetToBase.h
@@ -10,16 +10,17 @@
  * A specialization would look something like this
  * (in YourClass.h"
  *
- * #include "FWCore/Utilities/interface/OffsetToBase.h 
+ * #include "FWCore/Utilities/interface/OffsetToBase.h"
  * namespace edm {
  *   template<>
  *   class OffsetToBase<YourClass> {
  *     public OffsetToBase() {}
  *     size_t offsetToBase(std::type_info const& baseTypeInfo) const {
- *       YourClass object;
- *       void const* objectPtr = &object;
+ *       int const dummy = 0;
+ *       YourClass const* object = reinterpret_cast<YourClass const*>(&dummy);
+ *       void const* objectPtr = object;
  *       if(baseTypeInfo == typeid(BaseClass1)) {
- *          BaseClass1 const* base = &object;
+ *          BaseClass1 const* base = object;
  *          void const* basePtr = base;
  *          return static_cast<char const*>(basePtr) - static_cast<char const*>(objectPtr);
  *       }

--- a/FWCore/Utilities/interface/OffsetToBase.h
+++ b/FWCore/Utilities/interface/OffsetToBase.h
@@ -1,0 +1,55 @@
+#ifndef FWCore_Utilities_OffsetToBase_h
+#define FWCore_Utilities_OffsetToBase_h
+#include <typeinfo>
+
+/*
+ * For any class used in Views, RefToBase, or Ptr,
+ * class template OffsetToBase must be specialized for any class
+ * with multiple inheritance (i.e. with non-zero offset to
+ * at least one base class).
+ * A specialization would look something like this
+ * (in YourClass.h"
+ *
+ * #include "FWCore/Utilities/interface/OffsetToBase.h 
+ * namespace edm {
+ *   template<>
+ *   class OffsetToBase<YourClass> {
+ *     public OffsetToBase() {}
+ *     size_t offsetToBase(std::type_info const& baseTypeInfo) const {
+ *       YourClass object;
+ *       void const* objectPtr = &object;
+ *       if(baseTypeInfo == typeid(BaseClass1)) {
+ *          BaseClass1 const* base = &object;
+ *          void const* basePtr = base;
+ *          return static_cast<char const*>(basePtr) - static_cast<char const*>(objectPtr);
+ *       }
+ *       if(baseTypeInfo == typeid(BaseClass2)) {
+ *          ...
+ *       }
+ *       etc.
+ *     }
+ *   };
+ * }
+ *
+*/
+
+
+namespace edm {
+  template<typename T>
+  class OffsetToBase {
+  public:
+    OffsetToBase() {} 
+    size_t offsetToBase(std::type_info const& baseTypeInfo) const {
+      return 0;
+    }
+  };
+
+  template<typename T>
+  void const* pointerToBase(std::type_info const& baseTypeInfo, T const* address) {
+    OffsetToBase<T> offsetToBase;
+    int offset = offsetToBase.offsetToBase(baseTypeInfo);
+    void const* ptr = address;
+    return static_cast<char const*>(ptr) + offset;
+  }
+}
+#endif

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -8,6 +8,7 @@
 
 
 #include <iostream>
+#include <unordered_set>
 
 template<typename P>
 class MCTruthHelper {


### PR DESCRIPTION
The ROOT function GetBaseClassOffset() does locking that seriously hurts threading efficiency, especially in analysis jobs using pat::. In the vast majority of the cases (in fact in all cases so far observed), the actual offset to the base class object from the derived class object was 0.
This PR replaces  GetBaseClassOffset() with a call to a function of a class template  that returns 0 by default. In cases where the actual offset is non-zero, the class can be specialized to return the proper value. In cases where the true offset is non-zero, and the class has not been properly specialized, a segfault should result, which will be noticed.
