### PR TITLE
Add HaloTowerStrip to dictionary

### DIFF
--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -172,6 +172,7 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
+  <class name="HaloTowerStrip"/>
   <class name="std::vector<HaloTowerStrip>"/>
   <class name="edm::Wrapper<std::vector<HaloTowerStrip> >"/>
 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -172,7 +172,9 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
-  <class name="HaloTowerStrip"/>
+  <class name="HaloTowerStrip" ClassVersion="2">
+   <version ClassVersion="2" checksum="665188928"/>
+  </class>
   <class name="std::vector<HaloTowerStrip>"/>
   <class name="edm::Wrapper<std::vector<HaloTowerStrip> >"/>
 


### PR DESCRIPTION
This is a fix for https://github.com/cms-sw/cmssw/pull/10934/ failing `runTheMatrix.py -l 1102 -i all` as the HaloTowerStrip class didn't have a dictionary entry (only the vector)
