### PR TITLE
adding schema to db shortcut name

### DIFF
--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -346,8 +346,8 @@ def _getCMSOracleSQLAlchemyConnectionString(database, schema = 'cms_conditions')
 
 
 # Entry point
-def connect(database='pro', init=False, verbose=0):
-    '''Returns a Connection instance to the CMS Condition DB.
+def connect(database='pro', init=False, verbose=0, schema='cms_conditions'):
+    '''Returns a Connection instance to the CMS Condition DB, optionally for a given schema.
 
     See database_help for the description of the database parameter.
 
@@ -358,28 +358,27 @@ def connect(database='pro', init=False, verbose=0):
         2 = In addition, results of the queries (all rows and the column headers).
     '''
 
+
     # Lazy in order to avoid calls to cmsGetFnConnect
     mapping = {
-        'pro':           lambda: _getCMSFrontierSQLAlchemyConnectionString('PromptProd'),
-        'arc':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierArc'),
-        'int':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierInt'),
-        'dev':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', 'cms_conditions_002'),
-        'boost':         lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierProd', 'cms_conditions'),
-        'boostprep':     lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', 'cms_conditions_002'),
+        'pro':           lambda: _getCMSFrontierSQLAlchemyConnectionString('PromptProd', schema),
+        'arc':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierArc', schema),
+        'int':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierInt', schema),
+        'dev':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', schema),
 
-        'orapro':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg'),
-        'oraarc':        lambda: _getCMSOracleSQLAlchemyConnectionString('cmsarc_lb'),
-        'oraint':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_int'),
-        'oradev':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', 'cms_conditions_002'),
-        'oraboost':      lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg'  , 'cms_conditions'),
-        'oraboostprep':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', 'cms_conditions_002'),
+        'orapro':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg', schema),
+        'oraarc':        lambda: _getCMSOracleSQLAlchemyConnectionString('cmsarc_lb', schema),
+        'oraint':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_int', schema),
+        'oradev':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', schema),
 
-        'onlineorapro':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_prod'),
-        'onlineoraint':  lambda: _getCMSOracleSQLAlchemyConnectionString('cmsintr_lb'),
+        'onlineorapro':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_prod', schema),
+        'onlineoraint':  lambda: _getCMSOracleSQLAlchemyConnectionString('cmsintr_lb', schema),
     }
 
     if database in mapping:
         database = mapping[database]()
+
+    logging.debug('connection string set to "%s"' % database)
 
     try:
         url = sqlalchemy.engine.url.make_url(database)

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -240,8 +240,15 @@ def _check_same_object(args):
 
 
 def _connect(db, init, verbose, read_only, force):
+
     logging.debug('Connecting to %s ...', db)
-    connection = conddb.connect(db, init=init, verbose=0 if verbose is None else verbose - 1)
+
+    schema = 'cms_conditions'
+    if ':' in db and '://' not in db: # check if we got a shortcut like "pro:<schema>", if so, disentangle
+       db, schema = db.split(':')
+
+    logging.debug(' ... using db "%s", schema "%s"' % (db, schema) )
+    connection = conddb.connect(db, init=init, schema=schema, verbose=0 if verbose is None else verbose - 1)
 
     if not read_only:
         if connection.is_read_only:
@@ -256,7 +263,7 @@ def _connect(db, init, verbose, read_only, force):
     return connection
 
 
-def connect(args, init=False, read_only=True):
+def connect(args, init=False, read_only=True, schema='cms_conditions'):
     args.force = args.force if 'force' in dir(args) else False
     if 'destdb' in args:
         if args.destdb is None or args.db == args.destdb:


### PR DESCRIPTION
This PR allows to add an optional schema/DB name ('cms_conditions' by default) to the db shortcut name via <shortcut>:<schema> for simple accesses to different DBs (e.g. dev:cms_conditions_002). This PR also resets the default for dev to cms_conditions to be consistent with the DB uploads via the dropbox, and removes the obsolete _boost_ shortcuts.
