### PR TITLE
Freeing INI file buffer after writing the file is finished (74X)

### DIFF
--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -111,6 +111,8 @@ namespace edm {
     start();
     std::auto_ptr<InitMsgBuilder>  init_message = serializeRegistry();
     doOutputHeader(*init_message);
+    serializeDataBuffer_.header_buf_.clear();
+    serializeDataBuffer_.header_buf_.shrink_to_fit();
   }
 
   void


### PR DESCRIPTION
Modification to free INI buffer after writing out the INI file. This frees approx 100 MB/process with full 3.8T HLT menu, as seen in this plot:
![free_ini_buffer_effect](https://cloud.githubusercontent.com/assets/5859622/10073594/5b515ecc-62ca-11e5-81dd-77becadb1111.png)
