### PR TITLE
adding schema to db shortcut name 

### DIFF
--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -345,29 +345,34 @@ def _getCMSOracleSQLAlchemyConnectionString(database, schema = 'cms_conditions')
 
 
 # Entry point
+
 def make_url(database='pro'):
+
+    schema = 'cms_conditions'  # set the default
+    if ':' in database and '://' not in database: # check if we really got a shortcut like "pro:<schema>" (and not a url like proto://...), if so, disentangle
+       database, schema = database.split(':')
+    logging.debug(' ... using db "%s", schema "%s"' % (database, schema) )
+
     # Lazy in order to avoid calls to cmsGetFnConnect
     mapping = {
-        'pro':           lambda: _getCMSFrontierSQLAlchemyConnectionString('PromptProd'),
-        'arc':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierArc'),
-        'int':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierInt'),
-        'dev':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', 'cms_conditions_002'),
-        'boost':         lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierProd', 'cms_conditions'),
-        'boostprep':     lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', 'cms_conditions_002'),
+        'pro':           lambda: _getCMSFrontierSQLAlchemyConnectionString('PromptProd', schema),
+        'arc':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierArc', schema),
+        'int':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierInt', schema),
+        'dev':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', schema),
 
-        'orapro':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg'),
-        'oraarc':        lambda: _getCMSOracleSQLAlchemyConnectionString('cmsarc_lb'),
-        'oraint':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_int'),
-        'oradev':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', 'cms_conditions_002'),
-        'oraboost':      lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg'  , 'cms_conditions'),
-        'oraboostprep':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', 'cms_conditions_002'),
+        'orapro':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg', schema),
+        'oraarc':        lambda: _getCMSOracleSQLAlchemyConnectionString('cmsarc_lb', schema),
+        'oraint':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_int', schema),
+        'oradev':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', schema),
 
-        'onlineorapro':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_prod'),
-        'onlineoraint':  lambda: _getCMSOracleSQLAlchemyConnectionString('cmsintr_lb'),
+        'onlineorapro':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_prod', schema),
+        'onlineoraint':  lambda: _getCMSOracleSQLAlchemyConnectionString('cmsintr_lb', schema),
     }
 
     if database in mapping:
         database = mapping[database]()
+
+    logging.debug('connection string set to "%s"' % database)
 
     try:
         url = sqlalchemy.engine.url.make_url(database)

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -240,6 +240,9 @@ def _check_same_object(args):
 
 
 def _connect(db, init, verbose, read_only, force):
+
+    logging.debug('Connecting to %s ...', db)
+
     url = conddb.make_url( db )
     pretty_url = url
     if url.drivername == 'oracle+frontier':
@@ -250,6 +253,7 @@ def _connect(db, init, verbose, read_only, force):
     logging.info('Connecting to %s', connTo)
     logging.debug('DB url: %s',url)
     connection = conddb.connect(url, init=init, verbose=0 if verbose is None else verbose - 1)
+
 
     if not read_only:
         if connection.is_read_only:
@@ -269,7 +273,7 @@ def _connect(db, init, verbose, read_only, force):
     return connection
 
 
-def connect(args, init=False, read_only=True):
+def connect(args, init=False, read_only=True, schema='cms_conditions'):
     args.force = args.force if 'force' in dir(args) else False
 
     if 'destdb' in args:


### PR DESCRIPTION
This PR allows to add an optional schema/DB name ('cms_conditions' by default) to the db shortcut name via : for simple accesses to different DBs (e.g. dev:cms_conditions_002). This PR also resets the default for dev to cms_conditions to be consistent with the DB uploads via the dropbox, and removes the obsolete boost shortcuts.

This PR replaces #11449 which did not merge.
