### PR TITLE
Cache pointer to function created by cling

### DIFF
--- a/DataFormats/HLTReco/src/classes.h
+++ b/DataFormats/HLTReco/src/classes.h
@@ -1,3 +1,4 @@
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "DataFormats/HLTReco/interface/ModuleTiming.h"
 #include "DataFormats/HLTReco/interface/HLTPerformanceInfo.h"
 #include "DataFormats/HLTReco/interface/TriggerObject.h"

--- a/FWCore/Utilities/interface/FunctionWithDict.h
+++ b/FWCore/Utilities/interface/FunctionWithDict.h
@@ -11,6 +11,7 @@ FunctionWithDict:  A holder for a class member function
 
 #include "TMethod.h"
 #include "TMethodArg.h"
+#include "TInterpreter.h"
 
 #include <cassert>
 #include <cstdlib>
@@ -26,6 +27,8 @@ class TypeWithDict;
 class FunctionWithDict {
 private:
   TMethod* function_;
+  TInterpreter::CallFuncIFacePtr_t funcptr_;
+
 public:
   FunctionWithDict();
   explicit FunctionWithDict(TMethod*);


### PR DESCRIPTION
VTune showed that the previous way of calling into cling was causing
the ROOT internal mutex to be taken for each call. Philippe Canal
devised a way to access the cling generated function pointer directly
which avoids the locks.

This change required an update to ROOT 6.02 in order to work. That change is now in CMSSW_7_6.
