### PR TITLE
74x Fireworks: fix problem with muon global  track propagation 

### DIFF
--- a/Fireworks/Muons/src/FWMuonBuilder.cc
+++ b/Fireworks/Muons/src/FWMuonBuilder.cc
@@ -200,7 +200,6 @@ TEveTrack* prepareMuonTrackWithExtraPoints(const reco::Track& track,
          trk->AddPathMark( TEvePathMark( TEvePathMark::kDaughter, extraPoints[i] ) );
    }
    trk->AddPathMark( TEvePathMark( TEvePathMark::kDecay, extraPoints.back() ) );
-   trk->PrintPathMarks();
    return trk;
 }
 
@@ -312,7 +311,6 @@ FWMuonBuilder::buildMuon( FWProxyBuilderBase* pb,
          trk = prepareMuonTrackWithExtraPoints(*( muon->globalTrack()),pb->context().getMuonTrackPropagator(), extraPoints); 
 
       trk->MakeTrack();
-      trk->Print("all");
       trk->SetLineWidth(m_lineWidth);
       pb->setupAddElement( trk, tList );
       return;

--- a/Fireworks/Muons/src/FWMuonBuilder.cc
+++ b/Fireworks/Muons/src/FWMuonBuilder.cc
@@ -179,6 +179,32 @@ buggyMuon( const reco::Muon* muon,
    return false;
 }
 
+TEveTrack* prepareMuonTrackWithExtraPoints(const reco::Track& track,
+              TEveTrackPropagator* propagator,
+              const std::vector<TEveVector>& extraPoints )
+{
+   TEveRecTrack t;
+   t.fBeta = 1.;
+   t.fSign = track.charge();
+   t.fV.Set(track.vx(), track.vy(), track.vz());
+   t.fP.Set(track.px(), track.py(), track.pz());
+   //  t.fSign = muon->charge();
+   //  t.fV.Set(muon->vx(), muon->vy(), muon->vz());
+   //  t.fP.Set(muon->px(), muon->py(), muon->pz());
+   TEveTrack* trk = new TEveTrack( &t, propagator );
+   size_t n = extraPoints.size();
+
+   if (n > 1) {
+      int lastDaughter = n-2;
+      for (int i = 0; i <= lastDaughter; ++i)
+         trk->AddPathMark( TEvePathMark( TEvePathMark::kDaughter, extraPoints[i] ) );
+   }
+   trk->AddPathMark( TEvePathMark( TEvePathMark::kDecay, extraPoints.back() ) );
+   trk->PrintPathMarks();
+   return trk;
+}
+
+
 }
 
 //
@@ -279,10 +305,14 @@ FWMuonBuilder::buildMuon( FWProxyBuilderBase* pb,
 					    muon->outerTrack()->outerPosition().y(),
 					    muon->outerTrack()->outerPosition().z()));
       }
-      TEveTrack* trk = fireworks::prepareTrack( *( muon->globalTrack()),
-						pb->context().getMuonTrackPropagator(),
-						extraPoints );
+      TEveTrack* trk = 0;
+      if (extraPoints.empty())
+         trk = fireworks::prepareTrack( *( muon->globalTrack()),pb->context().getMuonTrackPropagator());
+      else
+         trk = prepareMuonTrackWithExtraPoints(*( muon->globalTrack()),pb->context().getMuonTrackPropagator(), extraPoints); 
+
       trk->MakeTrack();
+      trk->Print("all");
       trk->SetLineWidth(m_lineWidth);
       pb->setupAddElement( trk, tList );
       return;

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -74,7 +74,7 @@ prepareTrack( const reco::Track& track,
               TEveTrackPropagator* propagator,
               const std::vector<TEveVector>& extraRefPoints )
 {
-   // To make use of all available information, we have to order states
+   // To make use of all available ation, we have to order states
    // properly first. Propagator should take care of y=0 transition.
 
    std::vector<State> refStates;

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -74,7 +74,7 @@ prepareTrack( const reco::Track& track,
               TEveTrackPropagator* propagator,
               const std::vector<TEveVector>& extraRefPoints )
 {
-   // To make use of all available ation, we have to order states
+   // To make use of all available information, we have to order states
    // properly first. Propagator should take care of y=0 transition.
 
    std::vector<State> refStates;


### PR DESCRIPTION
<img width="994" alt="d58e30e2-629e-11e5-8654-fe4bb7c1f970" src="https://cloud.githubusercontent.com/assets/2516492/10085726/974b19aa-62bf-11e5-860b-034cfa1442db.png">

Path marks from moun inner/outer track position and the last two path mark from muon->globalTrack():
 innerTrack()->innerPosition() (-3.77266,-1.91869,5.69689)https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Fireworks/Muons/src/FWMuonBuilder.cc#L266
 moun innerTrack()->outerPosition() (-87.8516,-1.73888,263.885) https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Fireworks/Muons/src/FWMuonBuilder.cc#L269
 moun outerTrack()->innerPosition() (-112.689,29.4957,585.348)https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Fireworks/Muons/src/FWMuonBuilder.cc#L275
 moun outerTrack()->outerPosition() (-149.12,45.3741,839.739)https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Fireworks/Muons/src/FWMuonBuilder.cc#L279

 fireworks::prepareTrack track.innerOk (-3.77311,-1.9179,5.69697) https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Fireworks/Tracks/interface/TrackUtils.h#L54
 fireworks::prepareTrack track.outerOk (-129.255,35.7668,614.673)https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Fireworks/Tracks/interface/TrackUtils.h#L95

Yuu can see that there 4 reference path from muon inner and outer track position. Before that the globalMuon extra points are added, which resolves in the following path mark order:
TEveTrack 'TEveRecTrackT<float>', number of path marks 6, label -1
  Reference  p: -0.696788 -0.354075 2.260245 Vertex: -3.773114e+00 -1.917895e+00 5.696975e+00 0 Extra:0.000000 0.000000 0.000000
  Reference  p: -0.058421 0.029470 0.185701 Vertex: -1.292555e+02 3.576676e+01 6.146726e+02 0 Extra:0.000000 0.000000 0.000000
  Daughter   p: 0.000000 0.000000 0.000000 Vertex: -3.772659e+00 -1.918688e+00 5.696890e+00 0 Extra:0.000000 0.000000 0.000000
  Daughter   p: 0.000000 0.000000 0.000000 Vertex: -8.785159e+01 -1.738879e+00 2.638853e+02 0 Extra:0.000000 0.000000 0.000000
  Daughter   p: 0.000000 0.000000 0.000000 Vertex: -1.126888e+02 2.949574e+01 5.853483e+02 0 Extra:0.000000 0.000000 0.000000
  Decay      p: 0.000000 0.000000 0.000000 Vertex: -1.491195e+02 4.537413e+01 8.397385e+02 0 Extra:0.000000 0.000000 0.000000
