### PR TITLE
Lowering SeverityLevel of HFDigiTime and HBHEFlatNoise flags for 25ns data

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -60,8 +60,13 @@ def customiseDataRun2Common(process):
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common(process)
 
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",8)
+    HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",8)
+
     from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
     process=customiseL1RecoForStage1(process)
+
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.StandardSequences.Reconstruction_cff import *
+import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 from RecoTracker.Configuration.customiseForRunI import customiseForRunI
 #gone with the fact that there is no difference between production and development sequence
 #def customiseCommon(process):
@@ -60,7 +62,6 @@ def customiseDataRun2Common(process):
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common(process)
 
-    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
     HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",8)
     HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",8)
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Reconstruction_cff import *
+from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 from RecoTracker.Configuration.customiseForRunI import customiseForRunI
 #gone with the fact that there is no difference between production and development sequence

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
-import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 from RecoTracker.Configuration.customiseForRunI import customiseForRunI
 #gone with the fact that there is no difference between production and development sequence
 #def customiseCommon(process):
@@ -62,8 +60,9 @@ def customiseDataRun2Common(process):
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common(process)
 
-    HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",8)
-    HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",8)
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
 
     from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
     process=customiseL1RecoForStage1(process)

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -16,25 +16,7 @@ for qTest in particleFlowRecHitHF.producers[0].qualityTests:
         qTest.cleaningThresholds.append(30.)
         qTest.flags.append('HFDigi')
              
-particleFlowRecHitHF.producers[0].qualityTests.append(
-    cms.PSet(
-        name = cms.string("PFRecHitQTestHCALTimeVsDepth"),
-        cuts = cms.VPSet(
-            cms.PSet(
-                depth = cms.int32(1),
-                threshold = cms.double(30.),
-                minTime   = cms.double(-5.),
-                maxTime   = cms.double(+5.),
-            ),
-            cms.PSet(
-                depth = cms.int32(2),
-                threshold = cms.double(30.),
-                minTime   = cms.double(-5.),
-                maxTime   = cms.double(+5.),
-            ) 
-        )
-    )
-)
+
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)


### PR DESCRIPTION
Follow up of discussion at CMS RECO meeting on Thu.24 Sep.
https://indico.cern.ch/event/447792/
Halil's slides
https://indico.cern.ch/event/447792/session/4/contribution/24/attachments/1159916/1669575/Talk_Sep24_2015.pdf 

If OK, will be backported to 75X 
NB: needs corresponding changes in HLT configs
