### PR TITLE
Disabling the reclustering in the MET correction and uncertainty tool (76X)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
+++ b/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
@@ -1,0 +1,63 @@
+#include "PhysicsTools/PatAlgos/plugins/RecoMETExtractor.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <memory>
+
+using namespace pat;
+
+RecoMETExtractor::RecoMETExtractor(const edm::ParameterSet& iConfig) {
+
+  edm::InputTag metIT = iConfig.getParameter<edm::InputTag>("metSource");
+  metSrcToken_ = consumes<pat::METCollection>(metIT);
+  
+  std::string corLevel = iConfig.getParameter<std::string>("correctionLevel");
+
+  //all possible met flavors
+  if(corLevel=="raw")           { corLevel_=pat::MET::Raw;}
+  else if(corLevel=="type1")         { corLevel_=pat::MET::Type1;}
+  else if(corLevel=="type01")        { corLevel_=pat::MET::Type01;}
+  else if(corLevel=="typeXY")        { corLevel_=pat::MET::TypeXY;}
+  else if(corLevel=="type1XY")       { corLevel_=pat::MET::Type1XY;}
+  else if(corLevel=="type01XY")      { corLevel_=pat::MET::Type01XY;}
+  else if(corLevel=="type1Smear")    { corLevel_=pat::MET::Type1Smear;}
+  else if(corLevel=="type01Smear")   { corLevel_=pat::MET::Type01Smear;}
+  else if(corLevel=="type1SmearXY")  { corLevel_=pat::MET::Type1SmearXY;}
+  else if(corLevel=="type01SmearXY") { corLevel_=pat::MET::Type01SmearXY;}
+  else if(corLevel=="rawCalo")       { corLevel_=pat::MET::RawCalo;}
+  else {
+    //throw exception
+
+  }
+
+  // produces vector of recoMet
+  produces<std::vector<reco::MET> >();
+}
+
+
+RecoMETExtractor::~RecoMETExtractor() {
+
+}
+
+
+void RecoMETExtractor::produce(edm::StreamID streamID, edm::Event & iEvent,
+			       const edm::EventSetup & iSetup) const {
+
+  edm::Handle<std::vector<pat::MET> >  src;
+  iEvent.getByToken(metSrcToken_, src);
+  if(src->size()==0) edm::LogError("RecoMETExtractor::produce") << "input reco MET collection is empty" ;
+
+  std::vector<reco::MET> *metCol = new std::vector<reco::MET>();
+  
+  reco::MET met(src->front().corP4(corLevel_), src->front().vertex() );
+  metCol->push_back( met );
+  
+  std::auto_ptr<std::vector<reco::MET> > recoMETs(metCol);
+  iEvent.put(recoMETs);
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(RecoMETExtractor);

--- a/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.h
+++ b/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.h
@@ -1,0 +1,47 @@
+#ifndef PhysicsTools_PatAlgos_RecoMETExtractor_h
+#define PhysicsTools_PatAlgos_RecoMETExtractor_h
+
+/**
+  \class    pat::RecoMETExtractor RecoMETExtractor.h "PhysicsTools/PatAlgos/interface/RecoMETExtractor.h"
+  \brief    Retrieves the recoMET from a pat::MET
+
+   The RecoMETExtractor produces the analysis-level pat::MET starting from
+   a collection of objects of METType.
+
+  \author   Matthieu Marionneau
+  \version  $Id: RecoMETExtractor.h,v 1.0 2015/07/22 mmarionn Exp $
+*/
+
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/METReco/interface/MET.h"
+
+namespace pat {
+
+  class RecoMETExtractor : public edm::global::EDProducer<> {
+
+    public:
+
+    explicit RecoMETExtractor(const edm::ParameterSet& iConfig);
+    ~RecoMETExtractor();
+
+    virtual void produce(edm::StreamID streamID, edm::Event & iEvent,
+			 const edm::EventSetup & iSetup) const;
+
+  private:
+
+    edm::EDGetTokenT<std::vector<pat::MET> > metSrcToken_;
+    
+    pat::MET::METCorrectionLevel corLevel_;
+
+  };
+
+}
+
+#endif

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -107,7 +107,7 @@ def miniAOD_customizeCommon(process):
                                      )
     runMetCorAndUncForMiniAODProduction(process,
                                         pfCandColl=cms.InputTag("noHFCands"),
-                                        recomputeMET=True, #needed for HF removal
+                                        recoMetFromPFCs=True, #needed for HF removal
                                         postfix="NoHF"
                                         )
     process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')

--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -27,7 +27,7 @@ process.maxEvents = cms.untracked.PSet(
 
 #configurable options =======================================================================
 runOnData=False #data/MC switch
-usePrivateSQlite=True #use external JECs (sqlite file)
+usePrivateSQlite=False #use external JECs (sqlite file)
 useHFCandidates=False #create an additionnal NoHF slimmed MET collection if the option is set to false
 applyResiduals=True #application of residual corrections. Have to be set to True once the 13 TeV residual corrections are available. False to be kept meanwhile. Can be kept to False later for private tests or for analysis checks and developments (not the official recommendation!).
 #===================================================================
@@ -45,8 +45,8 @@ if runOnData:
   process.GlobalTag.globaltag = autoCond['run2_data']
   #process.GlobalTag.globaltag = '75X_dataRun1_v2' #'74X_dataRun2_Prompt_v1'
 else:
-  #process.GlobalTag.globaltag = 'MCRUN2_74_v9'
-  process.GlobalTag.globaltag = autoCond['run2_mc']
+  process.GlobalTag.globaltag = 'MCRUN2_75_V5'
+ # process.GlobalTag.globaltag = autoCond['run2_mc']
  # process.GlobalTag = GlobaTag(GlobalTag, 'auto:run2_mc', '')
 
 if usePrivateSQlite:
@@ -85,7 +85,8 @@ if runOnData:
 else:
   #75X file : root://eoscms.cern.ch//store/relval/CMSSW_7_5_0/RelValTTbar_13/MINIAODSIM/75X_mcRun2_asymptotic_v1-v1/00000/92A928E7-842A-E511-87CC-0025905A60E0.root
   #74X file : root://eoscms.cern.ch//store/mc/RunIISpring15DR74/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v2/60000/001C7571-0511-E511-9B8E-549F35AE4FAF.root
-  fname = 'root://eoscms.cern.ch//store/mc/RunIISpring15DR74/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v2/60000/001C7571-0511-E511-9B8E-549F35AE4FAF.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_7_5_3/RelValZEE_13/MINIAODSIM/75X_mcRun2_asymptotic_v5-v1/00000/F8C5D3F4-A861-E511-BA41-002618943906.root'
+  
 # Define the input source
 process.source = cms.Source("PoolSource", 
     fileNames = cms.untracked.vstring([ fname ])
@@ -117,6 +118,8 @@ if not useHFCandidates:
     runMetCorAndUncFromMiniAOD(process,
                                isData=runOnData,
                                pfCandColl=cms.InputTag("noHFCands"),
+                               reclusterJets=True, #needed for NoHF
+                               recoMetFromPFCs=True, #needed for NoHF
                                postfix="NoHF"
                                )
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -230,9 +230,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.setParameter('reclusterJets',True)
         
         #miniAOD
-        if onMiniAOD:
-            self.setParameter('reclusterJets',True)
-            self.setParameter('recoMetFromPFCs',True)
+        #if onMiniAOD:
+           # self.setParameter('reclusterJets',True)
+           # self.setParameter('recoMetFromPFCs',True)
             
         self.apply(process)
         
@@ -279,26 +279,30 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                          patMetModuleSequence,
                                          postfix)
             reclusterJets = True
+        elif onMiniAOD: #raw MET extraction if running on miniAODs
+            self.extractMET(process, "raw", patMetModuleSequence, postfix)
+
 
         #default MET production
         self.produceMET(process, metType,patMetModuleSequence, postfix)
         
-        #preparation to run over miniAOD (met reproduction) 
-        #-> could be extracted from the slimmedMET for a gain in CPU performances
-        if onMiniAOD:
-            reclusterJets = True
-            self.miniAODConfiguration(process, 
-                                      pfCandCollection,
-                                      patMetModuleSequence,
-                                      repro74X,
-                                      postfix
-                                      )
             
         #jet AK4 reclustering if needed for JECs
         if reclusterJets:
             jetCollection = self.ak4JetReclustering(process, pfCandCollection, 
                                                     patMetModuleSequence, postfix)
-            
+
+        #preparation to run over miniAOD (met reproduction) 
+        if onMiniAOD:
+           # reclusterJets = True
+            self.miniAODConfiguration(process, 
+                                      pfCandCollection,
+                                      jetCollectionUnskimmed,
+                                      patMetModuleSequence,
+                                      repro74X,
+                                      postfix
+                                      )        
+
         #jet ES configuration and jet cleaning
         #self.jetConfiguration()
         self.jetCleaning(process, autoJetCleaning, postfix)
@@ -1165,7 +1169,39 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 setattr(process, 'patMETs'+postfix, getattr(process,'patMETs' ).clone() )
                 getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
 
+
+    def extractMET(self, process, correctionLevel, patMetModuleSequence, postfix):
+        pfMet = cms.EDProducer("RecoMETExtractor",
+                               metSource= cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess()),
+                               correctionLevel = cms.string(correctionLevel)
+                               )
+        if(correctionLevel=="raw"):#dummy fix
+            setattr(process,"pfMet"+postfix ,pfMet)
+            patMetModuleSequence += getattr(process, "pfMet"+postfix)
+        else:
+            setattr(process,"met"+correctionLevel+postfix ,pfMet)
+            patMetModuleSequence += getattr(process, "met"+correctionLevel+postfix)
+
+
+    def updateJECs(self,process,jetCollection, patMetModuleSequence, postfix):
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetCorrFactorsUpdated
+        patJetCorrFactorsReapplyJEC = patJetCorrFactorsUpdated.clone(
+            src = jetCollection,
+            levels = ['L1FastJet', 
+                      'L2Relative', 
+                      'L3Absolute'],
+            payload = 'AK4PFchs' ) # always CHS from miniAODs
         
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetsUpdated
+        patJetsReapplyJEC = patJetsUpdated.clone(
+            jetSource = cms.InputTag("slimmedJets"),
+            jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"))
+            )
+        
+        setattr(process,"patJetCorrFactorsReapplyJEC",patJetCorrFactorsReapplyJEC)
+        setattr(process,"patJets",patJetsReapplyJEC.clone())
+        patMetModuleSequence += getattr(process,"patJetCorrFactorsReapplyJEC")
+        patMetModuleSequence += getattr(process,"patJets")
 
 
     def ak4JetReclustering(self,process, pfCandCollection, patMetModuleSequence, postfix):
@@ -1228,28 +1264,30 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process,"patJetCorrFactors"+postfix).src=cms.InputTag(jetColName)
             getattr(process,"patJetCorrFactors"+postfix).primaryVertices= cms.InputTag("offlineSlimmedPrimaryVertices")
 
-            #if self._parameters["reclusterJets"].value:
-                
          
         return cms.InputTag("selectedPatJets"+postfix)
         
 
-    def miniAODConfiguration(self, process, pfCandCollection, patMetModuleSequence, repro74X, postfix ):
+    def miniAODConfiguration(self, process, pfCandCollection, jetCollection, patMetModuleSequence, repro74X, postfix ):
         
         if self._parameters["metType"].value == "PF": # not hasattr(process, "pfMet"+postfix)
             
-            #getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, "patPFMet"+postfix).addGenMET  = False
             if not self._parameters["runOnData"].value:
                 getattr(process, "patPFMet"+postfix).addGenMET  = True
                 process.genMetExtractor = cms.EDProducer("GenMETExtractor",
-                                                         metSource= cms.InputTag("slimmedMETs","","PAT")
+                                                         metSource= cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess())
                                                          )
                 patMetModuleSequence += getattr(process, "genMetExtractor")
                 getattr(process, "patPFMet"+postfix).genMETSource = cms.InputTag("genMetExtractor")
      
             if hasattr(process, "patPFMetTxyCorr"+postfix):
                 getattr(process, "patPFMetTxyCorr"+postfix).vertexCollection = cms.InputTag("offlineSlimmedPrimaryVertices")
+
+            #handling jets when no reclustering is done
+            if not self._parameters["reclusterJets"].value:
+                self.updateJECs(process, jetCollection, patMetModuleSequence, postfix)
+
 
         #MM: FIXME MVA
         #if hasattr(process, "pfMVAMet"):
@@ -1281,14 +1319,22 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process,"slimmedMETs"+postfix).tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxy"+postfix)
 
             getattr(process,"slimmedMETs"+postfix).runningOnMiniAOD = True
-            getattr(process,"slimmedMETs"+postfix).t01Variation = cms.InputTag("slimmedMETs","","PAT")
+            getattr(process,"slimmedMETs"+postfix).t01Variation = cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess())
          
+            #extractor for caloMET === temporary for the beginning of the data taking
+            self.extractMET(process,"calo",patMetModuleSequence,postfix)
+            from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+            addMETCollection(process,
+                             labelName = "patCaloMet",
+                             metSource = "metcalo")
+            getattr(process,"patCaloMet").addGenMET = False
+
             #smearing and type0 variations not yet supported in reprocessing
             del getattr(process,"slimmedMETs"+postfix).t1SmearedVarsAndUncs
             del getattr(process,"slimmedMETs"+postfix).tXYUncForT01
             del getattr(process,"slimmedMETs"+postfix).tXYUncForT1Smear
             del getattr(process,"slimmedMETs"+postfix).tXYUncForT01Smear
-            del getattr(process,"slimmedMETs"+postfix).caloMET
+            #del getattr(process,"slimmedMETs"+postfix).caloMET
 
             if repro74X:
                 del getattr(process,"slimmedMETs"+postfix).t01Variation
@@ -1463,7 +1509,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
 
 # miniAOD reproduction ===========================
 def runMetCorAndUncFromMiniAOD(process, metType="PF",
-                               jetCollUnskimmed="patJets",
+                               jetCollUnskimmed="slimmedJets",
                                jetColl="selectedPatJets",
                                photonColl="slimmedPhotons",
                                electronColl="slimmedElectrons",
@@ -1488,6 +1534,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       produceIntermediateCorrections=False,
                                       addToPatDefaultSequence=False,
                                       jetCollection=jetColl,
+                                      jetCollectionUnskimmed=jetCollUnskimmed,
                                       electronCollection=electronColl,
                                       muonCollection=muonColl,
                                       tauCollection=tauColl,
@@ -1511,6 +1558,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       produceIntermediateCorrections=True,
                                       addToPatDefaultSequence=False,
                                       jetCollection=jetColl,
+                                      jetCollectionUnskimmed=jetCollUnskimmed,
                                       electronCollection=electronColl,
                                       muonCollection=muonColl,
                                       tauCollection=tauColl,

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -223,10 +223,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if recoMetFromPFCs: 
             self.setParameter('reclusterJets',True)
         
-        #miniAOD
-        #if onMiniAOD:
-           # self.setParameter('reclusterJets',True)
-           # self.setParameter('recoMetFromPFCs',True)
+        #jet collection overloading for automatic jet reclustering
+        if reclusterJets:
+            self.setParameter('jetCollection',cms.InputTag('selectedPatJets'))
+            self.setParameter('jetCollectionUnSkimmed',cms.InputTag('patJets'))
             
         self.apply(process)
         
@@ -296,7 +296,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                       )        
 
         #jet ES configuration and jet cleaning
-        #self.jetConfiguration()
         self.jetCleaning(process, autoJetCleaning, postfix)
         
 
@@ -1431,7 +1430,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                         pfCandColl = "particleFlow",
                                         jetCleaning="LepClean",
                                         jecUnFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
-                                        recomputeMET=False,
+                                        recoMetFromPFCs=False,
                                         postfix=""):
 
     runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
@@ -1451,7 +1450,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       autoJetCleaning=jetCleaning,
                                       jecUncertaintyFile=jecUnFile,
-                                      recoMetFromPFCs=recomputeMET,
+                                      recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix
                                       )
     
@@ -1470,7 +1469,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       autoJetCleaning=jetCleaning,
                                       jecUncertaintyFile=jecUnFile,
-                                      recoMetFromPFCs=recomputeMET,
+                                      recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix
                                       )
     
@@ -1489,7 +1488,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       autoJetCleaning=jetCleaning,
                                       jecUncertaintyFile=jecUnFile,
-                                      recoMetFromPFCs=recomputeMET,
+                                      recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix,
                                       )
 
@@ -1509,6 +1508,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                jetCleaning="LepClean",
                                isData=False,
                                jetConfig=False,
+                               reclusterJets=False,
+                               recoMetFromPFCs=False,
                                jetCorLabelL3=cms.InputTag('ak4PFCHSL1FastL2L3Corrector'),
                                jetCorLabelRes=cms.InputTag('ak4PFCHSL1FastL2L3ResidualCorrector'),
                                jecUncFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
@@ -1531,6 +1532,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       runOnData=isData,
                                       onMiniAOD=True,
+                                      reclusterJets=reclusterJets,
+                                      recoMetFromPFCs=recoMetFromPFCs,
                                       autoJetCleaning=jetCleaning,
                                       manualJetConfig=jetConfig,
                                       jetFlavor=jetFlav,
@@ -1555,6 +1558,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       runOnData=isData,
                                       onMiniAOD=True,
+                                      reclusterJets=reclusterJets,
+                                      recoMetFromPFCs=recoMetFromPFCs,
                                       autoJetCleaning=jetCleaning,
                                       manualJetConfig=jetConfig,
                                       jetFlavor=jetFlav,

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -77,8 +77,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Switch for data/MC processing", Type=bool)
         self.addParameter(self._defaultParameters, 'onMiniAOD', False,
                           "Switch on miniAOD configuration", Type=bool)
-        self.addParameter(self._defaultParameters, 'repro74X', False,
-                          "option for 74X miniAOD re-processing", Type=bool)          
         self.addParameter(self._defaultParameters, 'postfix', '',
                           "Technical parameter to identify the resulting sequence and its modules (allows multiple calls in a job)", Type=str)
         self._parameters = copy.deepcopy(self._defaultParameters)
@@ -115,7 +113,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                  CHS                     =None,
                  runOnData               =None,
                  onMiniAOD               =None,
-                 repro74X                =None,
                  postfix                 =None):
         electronCollection = self.initializeInputTag(electronCollection, 'electronCollection')
         photonCollection = self.initializeInputTag(photonCollection, 'photonCollection')
@@ -178,8 +175,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             runOnData = self._defaultParameters['runOnData'].value
         if onMiniAOD is None :
             onMiniAOD = self._defaultParameters['onMiniAOD'].value
-        if repro74X is None :
-            repro74X = self._defaultParameters['repro74X'].value
         if postfix is None :
             postfix = self._defaultParameters['postfix'].value
 
@@ -208,7 +203,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('recoMetFromPFCs',recoMetFromPFCs),
         self.setParameter('runOnData',runOnData),
         self.setParameter('onMiniAOD',onMiniAOD),
-        self.setParameter('repro74X',repro74X),
         self.setParameter('postfix',postfix),
 
         #if mva MET, autoswitch to std jets
@@ -261,7 +255,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         recoMetFromPFCs         = self._parameters['recoMetFromPFCs'].value
         reclusterJets           = self._parameters['reclusterJets'].value
         onMiniAOD               = self._parameters['onMiniAOD'].value
-        repro74X                = self._parameters['repro74X'].value
         postfix                 = self._parameters['postfix'].value
         
         #prepare jet configuration
@@ -299,7 +292,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                       pfCandCollection,
                                       jetCollectionUnskimmed,
                                       patMetModuleSequence,
-                                      repro74X,
                                       postfix
                                       )        
 
@@ -1268,7 +1260,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         return cms.InputTag("selectedPatJets"+postfix)
         
 
-    def miniAODConfiguration(self, process, pfCandCollection, jetCollection, patMetModuleSequence, repro74X, postfix ):
+    def miniAODConfiguration(self, process, pfCandCollection, jetCollection, patMetModuleSequence, postfix ):
         
         if self._parameters["metType"].value == "PF": # not hasattr(process, "pfMet"+postfix)
             
@@ -1335,9 +1327,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             del getattr(process,"slimmedMETs"+postfix).tXYUncForT1Smear
             del getattr(process,"slimmedMETs"+postfix).tXYUncForT01Smear
             #del getattr(process,"slimmedMETs"+postfix).caloMET
-
-            if repro74X:
-                del getattr(process,"slimmedMETs"+postfix).t01Variation
 
 
     def jetConfiguration(self):


### PR DESCRIPTION
Same as #11490 , (full description in #11489) for 76X.
