### PR TITLE
add triplets using TOB and TIB4  for redundancy in TobTec and PIxelLess seeding steps respectively. reduce chi2-cut in MuonInOut

### DIFF
--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -85,7 +85,7 @@ mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
 
 # SEEDING LAYERS
 mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
-    layerList = cms.vstring('BPix2+BPix3+TIB1'),
+    layerList = cms.vstring('BPix2+BPix3+TIB1', 'BPix1+BPix3+TIB1'),
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -85,7 +85,7 @@ mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
 
 # SEEDING LAYERS
 mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
-    layerList = cms.vstring('BPix2+BPix3+TIB1', 'BPix1+BPix3+TIB1'),
+    layerList = cms.vstring('BPix2+BPix3+TIB1'),
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -32,7 +32,7 @@ muonSeededTrajectoryCleanerBySharedHits = TrackingTools.TrajectoryCleaning.Traje
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
 muonSeededMeasurementEstimatorForInOut = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
     ComponentName = cms.string('muonSeededMeasurementEstimatorForInOut'),
-    MaxChi2 = cms.double(400.0), ## was 30 ## TO BE TUNED
+    MaxChi2 = cms.double(80.0), ## was 30 ## TO BE TUNED
     nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
 )
 muonSeededMeasurementEstimatorForOutIn = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -21,7 +21,7 @@ from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     layerList = cms.vstring(
     #TIB
-    'TIB1+TIB2+MTIB3',
+    'TIB1+TIB2+MTIB3','TIB1+TIB2+MTIB4',
     #TIB+TID
     'TIB1+TIB2+MTID1_pos','TIB1+TIB2+MTID1_neg',
     #TID
@@ -140,7 +140,7 @@ import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorESProducer_cfi
 pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
     ComponentName = cms.string('pixelLessStepChi2Est'),
     nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0),
+    MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -21,7 +21,7 @@ from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
     layerList = cms.vstring(
     #TOB
-    'TOB1+TOB2+MTOB3',
+    'TOB1+TOB2+MTOB3','TOB1+TOB2+MTOB4',
     #TOB+MTEC
     'TOB1+TOB2+MTEC1_pos','TOB1+TOB2+MTEC1_neg',
     ),

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -147,7 +147,7 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 
 tobTecStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     maxLostHits = 0,
-    minimumNumberOfHits = 6,
+    minimumNumberOfHits = 5,
     minPt = 0.1,
     minHitsMinPt = 3
     )
@@ -211,7 +211,7 @@ import TrackingTools.TrackFitters.RungeKuttaFitters_cff
 tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
     ComponentName = 'tobTecStepFitterSmoother',
     EstimateCut = 30,
-    MinNumberOfHits = 8,
+    MinNumberOfHits = 7,
     Fitter = cms.string('tobTecStepRKFitter'),
     Smoother = cms.string('tobTecStepRKSmoother')
     )
@@ -225,7 +225,7 @@ tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
 # Also necessary to specify minimum number of hits after final track fit
 tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectoryFitter.clone(
     ComponentName = cms.string('tobTecStepRKFitter'),
-    minHits = 8
+    minHits = 7
 )
 tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
     ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
@@ -235,7 +235,7 @@ tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
 tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectorySmoother.clone(
     ComponentName = cms.string('tobTecStepRKSmoother'),
     errorRescaling = 10.0,
-    minHits = 8
+    minHits = 7
 )
 tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
     ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),


### PR DESCRIPTION
trying to mitigate inactive feds in TOB L3.
for an extensive description please refer to
https://indico.cern.ch/event/442135/session/1/contribution/18/attachments/1160196/1670021/tob3.pdf

for "ideal" MC results by @makortel 
Plots are here:
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_7_6_0_pre5_tob3/index.html

In the global picture there is ~no effect in efficiency, while fake rate increases by ~0.5-1 % (up to 3 % in barrel)
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_7_6_0_pre5_tob3/ttbar_25ns_ootb/effandfake1.pdf

For tobTecStep itself also an efficiency increase is visible
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_7_6_0_pre5_tob3/ttbar_25ns_tobTecStep/effandfake1.pdf
but it is so small (~0.05 %-unit) that it is not visible in the global picture.

some timing numbers:

```
            760pre5    +tob3    increase
```

reco             11.27      11.32    ~0.4 %
tracking          5.80      5.87        1 %

tobTecStep        0.426     0.463       8 %
*SeedsTripl      0.080     0.096      20 %
*TrackCandidates 0.256     0.276       8 %
*Tracks          0.028     0.028      ~0
(for other parts of tobTecStep the times are ~the same)

All times are real time per event as given by
process.options.wantSummary=True for a single run of 200 events of
TTbar+25ns PU on the same machine. For both cases the reported event
loop real time and CPU time are within <0.5 %, so I think the numbers
are good enough.
