### PR TITLE
Removal of intrusive 'private' and 'protected' macros

### DIFF
--- a/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripDelay.cc
+++ b/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripDelay.cc
@@ -12,11 +12,7 @@
 #include <boost/foreach.hpp>
 #include <cassert>
 
-#define private public
-#define protected public
 #include "CalibFormats/SiStripObjects/interface/SiStripDelay.h"
-#undef private
-#undef protected
 
 #ifndef TestSiStripDelay_cc
 #define TestSiStripDelay_cc

--- a/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
+++ b/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
@@ -11,11 +11,7 @@
 #include <iterator>
 #include <boost/foreach.hpp>
 
-#define private public
-#define protected public
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-#undef private
-#undef protected
 
 #ifndef TestSiStripGain_cc
 #define TestSiStripGain_cc

--- a/CondFormats/SiStripObjects/test/UnitTests/TestSiStripBaseDelay.cc
+++ b/CondFormats/SiStripObjects/test/UnitTests/TestSiStripBaseDelay.cc
@@ -7,11 +7,7 @@
 #include <cppunit/TextTestProgressListener.h>
 #include <cppunit/CompilerOutputter.h>
 
-#define protected public
-#define private public
 #include "CondFormats/SiStripObjects/interface/SiStripBaseDelay.h"
-#undef protected
-#undef private
 
 class TestSiStripBaseDelay : public CppUnit::TestFixture
 {

--- a/CondFormats/SiStripObjects/test/UnitTests/TestSiStripConfObject.cc
+++ b/CondFormats/SiStripObjects/test/UnitTests/TestSiStripConfObject.cc
@@ -7,11 +7,7 @@
 #include <cppunit/TextTestProgressListener.h>
 #include <cppunit/CompilerOutputter.h>
 
-#define protected public
-#define private public
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
-#undef protected
-#undef private
 
 class TestSiStripConfObject : public CppUnit::TestFixture
 {

--- a/DataFormats/Common/test/testMultiAssociation.cc
+++ b/DataFormats/Common/test/testMultiAssociation.cc
@@ -16,9 +16,6 @@
 #include <iterator>
 #include <memory>
 
-// If you really want to test the inners of MultiAssociation, recompile after commenting
-// out this define
-//#define private public // so that we can get the inners of MultiAssociation
 #include "DataFormats/Common/interface/MultiAssociation.h"
 
 namespace {

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -13,11 +13,8 @@ Test of the EventProcessor class.
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
-//I need to open a 'back door' in order to test the functionality
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
-#define private public
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#undef private
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Presence.h"
 

--- a/FWCore/PluginManager/test/pluginfactory_t.cc
+++ b/FWCore/PluginManager/test/pluginfactory_t.cc
@@ -20,7 +20,6 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 
-#define private public
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
 class TestPluginFactory : public CppUnit::TestFixture

--- a/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
+++ b/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
@@ -6,10 +6,7 @@
  *
  */
 
-//need to open a 'back door' to be able to setup the ServiceRegistry
-#define private public
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#undef private
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/test/stubs/DummyService.h"
 

--- a/Fireworks/Core/interface/FWFileEntry.h
+++ b/Fireworks/Core/interface/FWFileEntry.h
@@ -14,9 +14,7 @@
 
 // user include files
 // MT -- to get auxBranch
-#define private public
 #include "DataFormats/FWLite/interface/Event.h"
-#undef private
 #include "Fireworks/Core/interface/FWEventSelector.h"
 #include "Fireworks/Core/interface/FWTEventList.h"
 #include "Fireworks/Core/interface/FWConfigurable.h"

--- a/Fireworks/Core/test/unittest_eventitemsmanager.cc
+++ b/Fireworks/Core/test/unittest_eventitemsmanager.cc
@@ -19,14 +19,10 @@
 // user include files
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
-
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
 #include "Fireworks/Core/interface/FWSelectionManager.h"
 #include "Fireworks/Core/interface/FWColorManager.h"
-
 #include "Fireworks/Core/interface/FWEventItemsManager.h"
 #include "Fireworks/Core/interface/FWConfiguration.h"
 

--- a/Fireworks/Core/test/unittest_modelfilter.cc
+++ b/Fireworks/Core/test/unittest_modelfilter.cc
@@ -18,15 +18,10 @@
 // user include files
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
-
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
 #include "Fireworks/Core/interface/FWSelectionManager.h"
-
 #include "Fireworks/Core/interface/FWItemAccessorBase.h"
-
 #include "Fireworks/Core/interface/FWModelFilter.h"
 
 //

--- a/Fireworks/Macros/eve_filter.cc
+++ b/Fireworks/Macros/eve_filter.cc
@@ -4,10 +4,7 @@
 #include <iomanip>
 #include <utility>
 
-#define private public
 #include "TPRegexp.h"
-#undef private
-
 #include "TEveManager.h"
 #include "TEveScene.h"
 #include "TEveElement.h"

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
@@ -1,7 +1,4 @@
-
-#define protected public
 #include "TEveBoxSet.h"
-#undef protected
 #include "TEveTrack.h"
 #include "TEveTrackPropagator.h"
 #include "TEveCompound.h"

--- a/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestMuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestMuScleFitUtils.cc
@@ -1,13 +1,6 @@
 #include <iostream>
 
-// Trick to expose all the class to be tested
-// ------------------------------------------
-#define protected public
-#define private public
 #include "MuonAnalysis/MomentumScaleCalibration/interface/MuScleFitUtils.h"
-#undef protected
-#undef private
-// ------------------------------------------
 
 int main()
 {


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in `sstream`.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
