### PR TITLE
Resolve issues with std::basic_stringstream usage

### DIFF
--- a/DQMOffline/Trigger/src/EgHLTTrigCodes.cc
+++ b/DQMOffline/Trigger/src/EgHLTTrigCodes.cc
@@ -91,6 +91,6 @@ void TrigCodes::printCodes()
   std::ostringstream msg;
   msg <<" trig bits defined: "<<std::endl;
   for(size_t i=0;i<codeDefs_.size();i++) msg <<" key : "<<codeDefs_[i].first<<" bit "<<codeDefs_[i].second<<std::endl;
-  edm::LogInfo("TrigCodes") <<msg;
+  edm::LogInfo("TrigCodes") << msg.str();
  
 }

--- a/DataFormats/PatCandidates/src/JetCorrFactors.cc
+++ b/DataFormats/PatCandidates/src/JetCorrFactors.cc
@@ -112,8 +112,7 @@ JetCorrFactors::print() const
   edm::LogInfo message( "JetCorrFactors" );
   for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor){
     unsigned int corrFactorIdx=corrFactor-jec_.begin();
-    std::stringstream idx; idx << corrFactorIdx;
-    message << std::setw(3) << idx << "  " << corrFactor->first;
+    message << std::setw(3) << corrFactorIdx << "  " << corrFactor->first;
     if( flavorDependent(*corrFactor) ){
       for(std::vector<float>::const_iterator flavor=corrFactor->second.begin(); flavor!=corrFactor->second.end(); ++flavor){
 	unsigned int flavorIdx=flavor-corrFactor->second.begin();

--- a/DataFormats/PatCandidates/src/TauJetCorrFactors.cc
+++ b/DataFormats/PatCandidates/src/TauJetCorrFactors.cc
@@ -66,9 +66,7 @@ TauJetCorrFactors::print() const
   for ( std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); 
 	corrFactor != jec_.end(); ++corrFactor ) {
     unsigned int corrFactorIdx = corrFactor-jec_.begin();
-    std::stringstream idx; 
-    idx << corrFactorIdx;
-    message << std::setw(3) << idx << "  " << corrFactor->first;
+    message << std::setw(3) << corrFactorIdx << "  " << corrFactor->first;
     message << std::setw(10) << correction (corrFactor-jec_.begin()); 
     message << "\n";
   }

--- a/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
@@ -2189,7 +2189,7 @@ void EcalSelectiveReadoutValidation::selectFedsForLog(){
   buf <<  "\nOnly DCCs from this list will be considered for error logging\n";
   srpAlgoErrorLog_ << buf.str();
   srApplicationErrorLog_<<  buf.str();
-  LogInfo("EcalSrValid") << buf;
+  LogInfo("EcalSrValid") << buf.str();
 }
 
 


### PR DESCRIPTION
There is no `operator<<` overload taking two
`std::basic_ostringstream<char>`. It used to work before C++11 because
`std::basic_ios` provided `operator void*() const`. It never provided
the content of `std::basic_stringstream`. Instead use `str()`
method to get a string copy of `std::basic_stringstream` content.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
