### PR TITLE
Permanently enabling method 3

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -43,9 +43,6 @@ public:
   HcalSimpleRecAlgo(bool correctForTimeslew, 
 		    bool correctForContainment, float fixedPhaseNs);
 
-  /** Simple constructor for PMT-based detectors */
-  HcalSimpleRecAlgo();
-
   void beginRun(edm::EventSetup const & es);
   void endRun();
 
@@ -80,17 +77,17 @@ public:
   HcalCalibRecHit reconstruct(const HcalCalibDataFrame& digi,  int first, int toadd, const HcalCoder& coder, const HcalCalibrations& calibs) const;
 
   void setpuCorrMethod(int method){ 
-    puCorrMethod_ = method; if( puCorrMethod_ == 2 ) psFitOOTpuCorr_ = std::auto_ptr<PulseShapeFitOOTPileupCorrection>(new PulseShapeFitOOTPileupCorrection());
-    if( puCorrMethod_ == 3) hltOOTpuCorr_ = std::auto_ptr<HcalDeterministicFit>(new HcalDeterministicFit());
+    puCorrMethod_ = method;
+    if( puCorrMethod_ == 2 )
+        psFitOOTpuCorr_ = std::auto_ptr<PulseShapeFitOOTPileupCorrection>(new PulseShapeFitOOTPileupCorrection());
   }
+
   void setpuCorrParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,bool iUnConstrainedFit,bool iApplyTimeSlew,
 		       double iTS4Min, double iTS4Max, double iPulseJitter,double iTimeMean,double iTimeSig,double iPedMean,double iPedSig,
 		       double iNoise,double iTMin,double iTMax,
 		       double its3Chi2,double its4Chi2,double its345Chi2,double iChargeThreshold, int iFitTimes); 
   void setMeth3Params(int iPedSubMethod, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3);
                
-  std::auto_ptr<PedestalSub> pedSubFxn_= std::auto_ptr<PedestalSub>(new PedestalSub());
-  
 private:
   bool correctForTimeslew_;
   bool correctForPulse_;
@@ -111,8 +108,13 @@ private:
 
   std::auto_ptr<PulseShapeFitOOTPileupCorrection> psFitOOTpuCorr_;
   
+  std::auto_ptr<PedestalSub> pedSubFxn_;
+
   // S.Brandt Feb19 : Add a pointer to the HLT algo
   std::auto_ptr<HcalDeterministicFit> hltOOTpuCorr_;
+
+  // Speed up the code a little bit by not allocating a vector every time
+  mutable std::vector<double> vectorBuffer_;
 };
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -112,9 +112,6 @@ private:
 
   // S.Brandt Feb19 : Add a pointer to the HLT algo
   std::auto_ptr<HcalDeterministicFit> hltOOTpuCorr_;
-
-  // Speed up the code a little bit by not allocating a vector every time
-  mutable std::vector<double> vectorBuffer_;
 };
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -317,7 +317,7 @@ namespace HcalSimpleRecAlgoImpl {
 		     const HcalTimeSlew::BiasSetting slewFlavor,
                      const int runnum, const bool useLeak,
                      const AbsOOTPileupCorrection* pileupCorrection,
-                     const BunchXParameter* bxInfo, const unsigned lenInfo, const int puCorrMethod, const PulseShapeFitOOTPileupCorrection * psFitOOTpuCorr, HcalDeterministicFit * hltOOTpuCorr, PedestalSub * hltPedSub /* whatever don't know what to do with the pointer...*/, std::vector<double>& buffer)// const on end
+                     const BunchXParameter* bxInfo, const unsigned lenInfo, const int puCorrMethod, const PulseShapeFitOOTPileupCorrection * psFitOOTpuCorr, HcalDeterministicFit * hltOOTpuCorr, PedestalSub * hltPedSub /* whatever don't know what to do with the pointer...*/)// const on end
   {
     double fc_ampl =0, ampl =0, uncorr_ampl =0, m3_ampl =0, maxA = -1.e300;
     int nRead = 0, maxI = -1;
@@ -354,7 +354,7 @@ namespace HcalSimpleRecAlgoImpl {
 
     // Note that uncorr_ampl is always set from outside of method 2!
     if( puCorrMethod == 2 ){
-      buffer.clear();
+      std::vector<double> correctedOutput;
 
       CaloSamples cs;
       coder.adc2fC(digi,cs);
@@ -363,16 +363,16 @@ namespace HcalSimpleRecAlgoImpl {
         const int capid = digi[ip].capid();
         capidvec.push_back(capid);
       }
-      psFitOOTpuCorr->apply(cs, capidvec, calibs, buffer);
-      if( buffer.back() == 0 && buffer.size() >1 ){
-	time = buffer[1]; ampl = buffer[0];
+      psFitOOTpuCorr->apply(cs, capidvec, calibs, correctedOutput);
+      if( correctedOutput.back() == 0 && correctedOutput.size() >1 ){
+	time = correctedOutput[1]; ampl = correctedOutput[0];
       }
     }
     
     // S. Brandt - Feb 19th : Adding Section for HLT
     // Run "Method 3" all the time.
     {
-      buffer.clear();
+      std::vector<double> hltCorrOutput;
 
       CaloSamples cs;
       coder.adc2fC(digi,cs);
@@ -381,11 +381,11 @@ namespace HcalSimpleRecAlgoImpl {
         const int capid = digi[ip].capid();
         capidvec.push_back(capid);
       }
-      hltOOTpuCorr->apply(cs, capidvec, calibs, digi, buffer);
-      if( buffer.size() > 1 ){
-        m3_ampl = buffer[0];
+      hltOOTpuCorr->apply(cs, capidvec, calibs, digi, hltCorrOutput);
+      if( hltCorrOutput.size() > 1 ){
+        m3_ampl = hltCorrOutput[0];
         if (puCorrMethod == 3) {
-	  time = buffer[1]; ampl = buffer[0];
+	  time = hltCorrOutput[1]; ampl = hltCorrOutput[0];
         }
       }
     }
@@ -423,7 +423,7 @@ namespace HcalSimpleRecAlgoImpl {
 			 const HcalTimeSlew::BiasSetting slewFlavor,
 			 const int runnum, const bool useLeak,
 			 const AbsOOTPileupCorrection* pileupCorrection,
-			 const BunchXParameter* bxInfo, const unsigned lenInfo, const int puCorrMethod, const PulseShapeFitOOTPileupCorrection * psFitOOTpuCorr, HcalDeterministicFit * hltOOTpuCorr, PedestalSub * hltPedSub, std::vector<double>& buffer)// const on end
+			 const BunchXParameter* bxInfo, const unsigned lenInfo, const int puCorrMethod, const PulseShapeFitOOTPileupCorrection * psFitOOTpuCorr, HcalDeterministicFit * hltOOTpuCorr, PedestalSub * hltPedSub)// const on end
   {
     double fc_ampl =0, ampl =0, uncorr_ampl =0, m3_ampl =0, maxA = -1.e300;
     int nRead = 0, maxI = -1;
@@ -461,7 +461,7 @@ namespace HcalSimpleRecAlgoImpl {
     
     // Note that uncorr_ampl is always set from outside of method 2!
     if( puCorrMethod == 2 ){
-      buffer.clear();
+      std::vector<double> correctedOutput;
 
       CaloSamples cs;
       coder.adc2fC(digi,cs);
@@ -470,17 +470,17 @@ namespace HcalSimpleRecAlgoImpl {
 	const int capid = digi[ip].capid();
 	capidvec.push_back(capid);
       }
-      psFitOOTpuCorr->apply(cs, capidvec, calibs, buffer);
-      if( buffer.back() == 0 && buffer.size() >1 ){
-	time = buffer[1]; ampl = buffer[0]; 
-	useTriple = buffer[4];
+      psFitOOTpuCorr->apply(cs, capidvec, calibs, correctedOutput);
+      if( correctedOutput.back() == 0 && correctedOutput.size() >1 ){
+	time = correctedOutput[1]; ampl = correctedOutput[0]; 
+	useTriple = correctedOutput[4];
       }
     }
     
     // S. Brandt - Feb 19th : Adding Section for HLT
     // Run "Method 3" all the time.
     {
-      buffer.clear();
+      std::vector<double> hltCorrOutput;
 
       CaloSamples cs;
       coder.adc2fC(digi,cs);
@@ -489,11 +489,11 @@ namespace HcalSimpleRecAlgoImpl {
 	const int capid = digi[ip].capid();
 	capidvec.push_back(capid);
       }
-      hltOOTpuCorr->apply(cs, capidvec, calibs, digi, buffer);
-      if (buffer.size() > 1) {
-        m3_ampl = buffer[0];
+      hltOOTpuCorr->apply(cs, capidvec, calibs, digi, hltCorrOutput);
+      if (hltCorrOutput.size() > 1) {
+        m3_ampl = hltCorrOutput[0];
         if (puCorrMethod == 3) {
-	  time = buffer[1]; ampl = buffer[0];
+	  time = hltCorrOutput[1]; ampl = hltCorrOutput[0];
         }
       }
     }
@@ -536,7 +536,7 @@ HBHERecHit HcalSimpleRecAlgo::reconstruct(const HBHEDataFrame& digi, int first, 
 							       HcalTimeSlew::Medium,
                                                                runnum_, setLeakCorrection_,
                                                                hbhePileupCorr_.get(),
-                                                               bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get(),vectorBuffer_);
+                                                               bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get());
 }
 
 
@@ -546,7 +546,7 @@ HORecHit HcalSimpleRecAlgo::reconstruct(const HODataFrame& digi, int first, int 
 							   pulseCorr_->get(digi.id(), toadd, phaseNS_),
 							   HcalTimeSlew::Slow,
                                                            runnum_, false, hoPileupCorr_.get(),
-                                                           bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get(),vectorBuffer_);
+                                                           bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get());
 }
 
 
@@ -556,7 +556,7 @@ HcalCalibRecHit HcalSimpleRecAlgo::reconstruct(const HcalCalibDataFrame& digi, i
 									 pulseCorr_->get(digi.id(), toadd, phaseNS_),
 									 HcalTimeSlew::Fast,
                                                                          runnum_, false, 0,
-                                                                         bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get(),vectorBuffer_);
+                                                                         bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get());
 }
 
 
@@ -566,7 +566,7 @@ HBHERecHit HcalSimpleRecAlgo::reconstructHBHEUpgrade(const HcalUpgradeDataFrame&
                                                                                    pulseCorr_->get(digi.id(), toadd, phaseNS_),
                                                                                    HcalTimeSlew::Medium, 0, false,
                                                                                    hbhePileupCorr_.get(),
-                                                                                   bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get(),vectorBuffer_);
+                                                                                   bunchCrossingInfo_, lenBunchCrossingInfo_, puCorrMethod_, psFitOOTpuCorr_.get(),/*hlt*/hltOOTpuCorr_.get(),pedSubFxn_.get());
   HcalTDCReco tdcReco;
   tdcReco.reconstruct(digi, result);
   return result;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -163,12 +163,12 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
     produces<HBHERecHitCollection>();
   } else if (!strcasecmp(subd.c_str(),"HO")) {
     subdet_=HcalOuter;
-    setPileupCorrection_ = &HcalSimpleRecAlgo::setHOPileupCorrection;
+    // setPileupCorrection_ = &HcalSimpleRecAlgo::setHOPileupCorrection;
     setPileupCorrection_ = 0;
     produces<HORecHitCollection>();
   } else if (!strcasecmp(subd.c_str(),"HF")) {
     subdet_=HcalForward;
-    setPileupCorrection_ = &HcalSimpleRecAlgo::setHFPileupCorrection;
+    // setPileupCorrection_ = &HcalSimpleRecAlgo::setHFPileupCorrection;
     setPileupCorrection_ = 0;
     digiTimeFromDB_=conf.getParameter<bool>("digiTimeFromDB");
 

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -47,7 +47,7 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
   mcOOTCorrectionCategory_("MC"),
   setPileupCorrection_(0),
   paramTS(0),
-  puCorrMethod_(conf.existsAs<int>("puCorrMethod") ? conf.getParameter<int>("puCorrMethod") : 0),
+  puCorrMethod_(conf.getParameter<int>("puCorrMethod")),
   cntprtCorrMethod_(0),
   first_(true)
 
@@ -270,16 +270,13 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
                           conf.getParameter<int>   ("fitTimes")
 			  );
   }
-  if(puCorrMethod_ == 3) {
-    reco_.setMeth3Params(
-              conf.getParameter<int>     ("pedestalSubtractionType"),
-              conf.getParameter<double>  ("pedestalUpperLimit"),
-              conf.getParameter<int>     ("timeSlewParsType"),
-              conf.getParameter<std::vector<double> >("timeSlewPars"),
-              conf.getParameter<double>  ("respCorrM3")
-              );
-  }
-
+  reco_.setMeth3Params(
+            conf.getParameter<int>     ("pedestalSubtractionType"),
+            conf.getParameter<double>  ("pedestalUpperLimit"),
+            conf.getParameter<int>     ("timeSlewParsType"),
+            conf.getParameter<std::vector<double> >("timeSlewPars"),
+            conf.getParameter<double>  ("respCorrM3")
+            );
 }
 
 void HcalHitReconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
Permanently enabling "Method 3" in HcalSimpleRecAlgo.

Some trivial cleanup of HcalSimpleRecAlgo (e.g., removed unused default constructor, added a buffer vector of doubles so that this vector does not have to be reallocated for every digi, etc).

Require proper initialization of "Method 3" in the HcalHitReconstructor module.
