### PR TITLE
Fix naming for fwLite VID in 74X

### DIFF
--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -24,10 +24,10 @@ egamma_modifications = cms.VPSet(
                                           phoFull5x5E2x2          = cms.InputTag('photonIDValueMapProducer:phoFull5x5E2x2'),
                                           phoFull5x5E2x5Max       = cms.InputTag('photonIDValueMapProducer:phoFull5x5E2x5Max'),
                                           phoESEffSigmaRR         = cms.InputTag('photonIDValueMapProducer:phoESEffSigmaRR'),
-                                          chargedHadronIso         = cms.InputTag('photonIDValueMapProducer:phoChargedIsolation'),
-                                          neutralHadronIsolation   = cms.InputTag('photonIDValueMapProducer:phoNeutralHadronIsolation'),
-                                          photonIso                = cms.InputTag('photonIDValueMapProducer:phoPhotonIsolation'),
-                                          chargedHadronIsoWrongVtx = cms.InputTag('photonIDValueMapProducer:phoWorstChargedIsolation')
+                                          phoChargedIsolation         = cms.InputTag('photonIDValueMapProducer:phoChargedIsolation'),
+                                          phoNeutralHadronIsolation   = cms.InputTag('photonIDValueMapProducer:phoNeutralHadronIsolation'),
+                                          phoPhotonIsolation          = cms.InputTag('photonIDValueMapProducer:phoPhotonIsolation'),
+                                          phoWorstChargedIsolation    = cms.InputTag('photonIDValueMapProducer:phoWorstChargedIsolation')
                                           )
               ),
     cms.PSet( modifierName    = cms.string('EGExtraInfoModifierFromIntValueMaps'),


### PR DESCRIPTION
Fixes an issue with the naming of embedded objects for VID usage in FWLite.

To be clear: this PR changes the content of photons in MiniAOD during its creation. It is necessary for reMiniAOD campaign, need a release by Wednesday. 

This can be patched at analysis level, but requires reconfiguration of the code and makes user recipes much more complicated.

It is included in regression/VID PRs for 76X/75X.
