### PR TITLE
Back-port of a set of fixes for the conddb core

### DIFF
--- a/CondCore/CondDB/interface/GTProxy.h
+++ b/CondCore/CondDB/interface/GTProxy.h
@@ -21,7 +21,8 @@ namespace cond {
 
   namespace persistency {
 
-    // required in the "bridge" mode, to be removed with the ORA based code after the transition
+    // required to handle the tag overriding
+    std::string fullyQualifiedTag( const std::string& tag, const std::string& connectionString );
     std::pair<std::string,std::string> parseTag( const std::string& tag );
 
     class SessionImpl;

--- a/CondCore/CondDB/interface/Utils.h
+++ b/CondCore/CondDB/interface/Utils.h
@@ -28,6 +28,24 @@ namespace cond {
       return ret;
     }
 
+    inline std::string currentCMSSWVersion(){
+      std::string version("");
+      const char* envVersion = ::getenv( "CMSSW_VERSION" );
+      if(envVersion){
+        version += envVersion;
+      }
+      return version;
+    }
+
+    inline std::string currentArchitecture(){
+      std::string arch("");
+      const char* archEnv = ::getenv( "SCRAM_ARCH" );
+      if(archEnv){
+        arch += archEnv;
+      }
+      return arch;
+    }
+
   }
 
   namespace persistency {
@@ -65,6 +83,9 @@ namespace cond {
 
     inline std::string convertoToOracleConnection(const std::string & input){
 
+      // leave the connection string unmodified for sqlite
+      if( input.find("sqlite") == 0 || input.find("oracle") == 0) return input;
+
       //static const boost::regex trivial("oracle://(cms_orcon_adg|cms_orcoff_prep)/([_[:alnum:]]+?)");
       static const boost::regex short_frontier("frontier://([[:alnum:]]+?)/([_[:alnum:]]+?)");
       static const boost::regex long_frontier("frontier://((\\([-[:alnum:]]+?=[^\\)]+?\\))+)/([_[:alnum:]]+?)");
@@ -101,7 +122,7 @@ namespace cond {
 	match = true;
       }
 
-      if( !match ) throwException("Connection string can't be converted.","convertoToOracleConnection");
+      if( !match ) throwException("Connection string "+input+" can't be converted to oracle connection.","convertoToOracleConnection");
 
       if( service == "FrontierArc" ){
 	size_t len = account.size()-5;

--- a/CondCore/CondDB/python/CondDB_cfi.py
+++ b/CondCore/CondDB/python/CondDB_cfi.py
@@ -6,7 +6,7 @@ CondDB = cms.PSet(
         authenticationSystem = cms.untracked.int32(0),
         messageLevel = cms.untracked.int32(0),
     ),
-    connect = cms.string('protocol://db/schema'), ##db/schema"
+    connect = cms.string(''), 
     dbFormat = cms.untracked.int32(0)
 )
 

--- a/CondCore/CondDB/src/GTProxy.cc
+++ b/CondCore/CondDB/src/GTProxy.cc
@@ -5,14 +5,19 @@ namespace cond {
 
   namespace persistency {
 
+    std::string fullyQualifiedTag( const std::string& tag, const std::string& connectionString ){
+      if(connectionString.empty()) return tag;
+      return  tag+"@["+connectionString+"]";
+    }
+
     std::pair<std::string,std::string> parseTag( const std::string& tag ){
       std::string pfn("");
       std::string t(tag);
-      size_t pos = tag.rfind('@');
-      if( pos != std::string::npos && tag.size() >= pos+3 ){
-	if( tag[pos+1]=='[' && tag[tag.size()-1]==']' ) {
-	  pfn = tag.substr( pos+2,tag.size()-pos-3 ); 
-	  t = tag.substr( 0, pos );
+      size_t pos = tag.rfind("[");
+      if( pos != std::string::npos && tag.size() >= pos+2 ){
+	if( tag[pos-1]=='@' && tag[tag.size()-1]==']' ) {
+	  pfn = tag.substr( pos+1,tag.size()-pos-2 ); 
+	  t = tag.substr( 0, pos-1 );
 	}
       }
       return std::make_pair( t, pfn );

--- a/CondCore/CondDB/src/Serialization.cc
+++ b/CondCore/CondDB/src/Serialization.cc
@@ -1,135 +1,20 @@
 #include "CondCore/CondDB/interface/Serialization.h"
-#include "CondCore/CondDB/interface/Exception.h"
-#include "CondCore/CondDB/interface/Utils.h"
-#include "FWCore/PluginManager/interface/PluginCapabilities.h"
 //
 #include <sstream>
-// root includes 
-#include "TStreamerInfo.h"
-#include "TClass.h"
-#include "TBufferFile.h"
+#include "boost/version.hpp"
 
-namespace cond {
-
-  // load dictionary when required
-  TClass* lookUpDictionary( const std::type_info& sourceType ){
-    TClass* rc = TClass::GetClass(sourceType);
-    if( !rc ){
-      static std::string const prefix("LCGReflex/");
-      std::string name = demangledName(sourceType);
-      edmplugin::PluginCapabilities::get()->load(prefix + name);
-      rc = TClass::GetClass(sourceType);
-    }
-    return rc;
-  }
+std::string cond::StreamerInfo::techVersion(){
+  return BOOST_LIB_VERSION;
 }
 
-class RootStreamBuffer: public TBufferFile {
-public:
-  RootStreamBuffer():
-    TBufferFile( TBufferFile::kWrite ),
-    m_streamerInfoBuff( TBufferFile::kWrite ){
-  }
-
-  RootStreamBuffer( const std::string& dataSource, const std::string& streamerInfoSource ):
-    TBufferFile( TBufferFile::kRead, dataSource.size(), const_cast<char*>( dataSource.c_str()), kFALSE ),
-    m_streamerInfoBuff( TBufferFile::kRead, streamerInfoSource.size(), const_cast<char*>( streamerInfoSource.c_str()), kFALSE ){
-  }
-
-  void ForceWriteInfo(TVirtualStreamerInfo* sinfo, Bool_t /* force */){
-    m_streamerInfo.Add( sinfo );
-  }
-
-  void TagStreamerInfo(TVirtualStreamerInfo* sinfo){
-    m_streamerInfo.Add( sinfo );
-  }
-
-  void write( const void* obj, const TClass* ptrClass ){
-    m_streamerInfo.Clear();
-    // this will populate the streamerInfo list 'behind the scenes' - calling the TagStreamerInfo method
-    StreamObject(const_cast<void*>(obj), ptrClass);    
-    // serialize the StreamerInfo
-    if(m_streamerInfo.GetEntries() ){
-      m_streamerInfoBuff.WriteObject( &m_streamerInfo );
-    }
-    m_streamerInfo.Clear();
-  }
-
-  void read( void* destinationInstance, const TClass* ptrClass ){
-    // first "load" the available streaminfo(s) 
-    // code imported from TSocket::RecvStreamerInfos
-    TList *list = 0;
-    if(m_streamerInfoBuff.Length()){
-      list = (TList*)m_streamerInfoBuff.ReadObject( TList::Class() );
-      TIter next(list);
-      TStreamerInfo *info;
-      TObjLink *lnk = list->FirstLink();
-      // First call BuildCheck for regular class
-      while (lnk) {
-	info = (TStreamerInfo*)lnk->GetObject();
-	TObject *element = info->GetElements()->UncheckedAt(0);
-	Bool_t isstl = element && strcmp("This",element->GetName())==0;
-	if (!isstl) {
-	  info->BuildCheck();
-	}
-	lnk = lnk->Next();
-      }
-      // Then call BuildCheck for stl class
-      lnk = list->FirstLink();
-      while (lnk) {
-	info = (TStreamerInfo*)lnk->GetObject();
-	TObject *element = info->GetElements()->UncheckedAt(0);
-	Bool_t isstl = element && strcmp("This",element->GetName())==0;
-	if (isstl) {
-	  info->BuildCheck();
-	}
-	lnk = lnk->Next();
-      }
-    }
-    // then read the object data
-    StreamObject(destinationInstance, ptrClass);
-    if( list ) delete list;
-  }
-
-  void copy( std::ostream& destForData, std::ostream& destForStreamerInfo ){
-    destForData.write( static_cast<const char*>(Buffer()),Length() );
-    destForStreamerInfo.write( static_cast<const char*>(m_streamerInfoBuff.Buffer()),m_streamerInfoBuff.Length() );
-  }
-  
-private:
-  TBufferFile m_streamerInfoBuff;
-  TList m_streamerInfo;
-};
-
-cond::RootOutputArchive::RootOutputArchive( std::ostream& dataDest, std::ostream& streamerInfoDest ):
-  m_dataBuffer( dataDest ),
-  m_streamerInfoBuffer( streamerInfoDest ){
-} 
-
-void cond::RootOutputArchive::write( const std::type_info& sourceType, const void* sourceInstance){
-  TClass* r_class = lookUpDictionary( sourceType );
-  if (!r_class) throwException( "No ROOT class registered for \"" + demangledName(sourceType)+"\"", "RootOutputArchive::write");
-  RootStreamBuffer buffer;
-  buffer.InitMap();
-  buffer.write(sourceInstance, r_class);
-  // copy the two streams into the target buffers
-  buffer.copy( m_dataBuffer, m_streamerInfoBuffer );
-}
-
-cond::RootInputArchive::RootInputArchive( std::istream& binaryData, std::istream& binaryStreamerInfo ):
-  m_dataBuffer( std::istreambuf_iterator<char>( binaryData ), std::istreambuf_iterator<char>()),
-  m_streamerInfoBuffer( std::istreambuf_iterator<char>( binaryStreamerInfo ), std::istreambuf_iterator<char>()),
-  m_streamer( new RootStreamBuffer( m_dataBuffer, m_streamerInfoBuffer ) ){
-  m_streamer->InitMap();
-}
-
-cond::RootInputArchive::~RootInputArchive(){
-  delete m_streamer;
-}
-
-void cond::RootInputArchive::read( const std::type_info& destinationType, void* destinationInstance){
-  TClass* r_class = lookUpDictionary( destinationType );
-  if (!r_class) throwException( "No ROOT class registered for \"" + demangledName(destinationType) +"\"","RootInputArchive::read");
-  m_streamer->read( destinationInstance, r_class );
+std::string cond::StreamerInfo::jsonString(){
+  std::stringstream ss;
+  ss<<" {"<<std::endl;
+  ss<<"\""<<CMSSW_VERSION_LABEL<<"\": \""<<currentCMSSWVersion()<<"\","<<std::endl;
+  ss<<"\""<<ARCH_LABEL<<"\": \""<<currentArchitecture()<<"\","<<std::endl;
+  ss<<"\""<<TECH_LABEL<<"\": \""<<TECHNOLOGY<<"\","<<std::endl;
+  ss<<"\""<<TECH_VERSION_LABEL<<"\": \""<<techVersion()<<"\""<<std::endl;
+  ss<<" }"<<std::endl;
+  return ss.str();
 }
 


### PR DESCRIPTION
Fixes back-ported:
- remove of Root based serialization
- addition of CMSSW and boost serialization version information as payload metadata
- improved handling of exception in serialization/deserialization
- fix for condition overriding with toGet: support of '@' characters in sqlite file names (!)
