### PR TITLE
Remove -Werror=unused-variable to downgrade errors from CLHEP

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/plugins/BuildFile.xml
@@ -13,7 +13,8 @@
 <use   name="cgal"/>
 <use   name="f77compiler"/>
 
-<Flags CXXFLAGS="-frounding-math -Wno-unknown-pragmas"/>
+<flags CXXFLAGS="-frounding-math -Wno-unknown-pragmas"/>
+<flags REM_CXXFLAGS="-Werror=unused-variable"/>
 <flags   EDM_PLUGIN="1"/>
 <library   file="*.cc,*.f" name="HiJetAlgosPlugins">
 </library>


### PR DESCRIPTION
Currently we receive a number of errors from `SystemOfUnits.h` and
`PhysicalConstants.h` from CLHEP. Due to the way C++ Preprocessor is
implemented for C++ (GCC) we cannot use diagnostic pragmas to silence
them. This might be resolved in future (e.g., GCC 6.1.0) [1]. Until then
this would make sure that unused variables from CLHEP are not triggering
fatal errors.

Note, this also could be resolved by modifying CLHEP and using 'used'
attribute on special variables. This would force compiler to **emit**
them, thus resolving the errors.

[1] https://gcc.gnu.org/ml/gcc-patches/2015-07/msg02414.html

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
