### PR TITLE
Intrusive 'private' and 'protected' macros (cleanup list)

### DIFF
--- a/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
@@ -9,12 +9,7 @@
 
 #include <vector>
 
-// Make everything public to access all methods
-#define protected public
-#define private public
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
-#undef protected
-#undef private
 
 std::vector<int> vectorDate(const int year, const int month,
 			    const int day, const int hour,

--- a/CondCore/DBCommon/test/testBlobStreaming.cpp
+++ b/CondCore/DBCommon/test/testBlobStreaming.cpp
@@ -1,9 +1,7 @@
 //
 // unit test, include files as they exists only in the plugin...
 //
-#define private public
 #include "CondCore/DBCommon/plugins/BlobStreamingService.cc"
-#undef private
 #include "CondCore/DBCommon/plugins/TBufferBlobStreamingService.cc"
 
 

--- a/CondFormats/Common/test/SmallWORMDict_t.cpp
+++ b/CondFormats/Common/test/SmallWORMDict_t.cpp
@@ -1,7 +1,4 @@
-#define private public
 #include "CondFormats/Common/interface/SmallWORMDict.h"
-#undef private
-
 
 #include <iostream>
 

--- a/CondFormats/Common/test/UpdateStamp_t.cpp
+++ b/CondFormats/Common/test/UpdateStamp_t.cpp
@@ -1,10 +1,6 @@
 #include <cppunit/extensions/HelperMacros.h>
 
-//#include "boost/intrusive_ptr.hpp"
-
-#define private public
 #include "CondFormats/Common/interface/UpdateStamp.h"
-#undef private
 #include "CondFormats/Common/interface/TimeConversions.h"
 
 namespace {

--- a/DataFormats/Common/test/DataFrame_t.cpp
+++ b/DataFormats/Common/test/DataFrame_t.cpp
@@ -1,10 +1,9 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#define private public
 #include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/Common/interface/DataFrameContainer.h"
-#undef private
+
 #include <vector>
 #include <algorithm>
 #include <cstdlib>

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -1,12 +1,10 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#define private public
 #include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/DetSetAlgorithm.h"
 #include "DataFormats/Common/interface/DetSet2RangeMap.h"
-#undef private
 
 #include "FWCore/Utilities/interface/EDMException.h"
 

--- a/DataFormats/Common/test/MapOfVectors_t.cpp
+++ b/DataFormats/Common/test/MapOfVectors_t.cpp
@@ -1,9 +1,7 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#define private public
 #include "DataFormats/Common/interface/MapOfVectors.h"
-#undef private
 
 #include<vector>
 #include<algorithm>

--- a/DataFormats/EcalDigi/test/EcalDigi_t.cpp
+++ b/DataFormats/EcalDigi/test/EcalDigi_t.cpp
@@ -1,11 +1,10 @@
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
 #include <cppunit/extensions/HelperMacros.h>
 
-#define private public
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/Common/interface/DataFrameContainer.h"
-#undef private
+
 #include<vector>
 #include<algorithm>
 #include<boost/function.hpp>

--- a/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
@@ -8,11 +8,7 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -8,11 +8,7 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -8,11 +8,7 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
@@ -8,11 +8,7 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
@@ -8,11 +8,7 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -8,11 +8,7 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/TrackReco/test/testHitPattern.cpp
+++ b/DataFormats/TrackReco/test/testHitPattern.cpp
@@ -1,6 +1,4 @@
-#define private public
 #include "DataFormats/TrackReco/interface/HitPattern.h"
-#undef private
 
 #include <random>
 #include <algorithm>

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -36,10 +36,7 @@ Test of the EventPrincipal class.
 #include <string>
 #include <typeinfo>
 
-//have to do this evil in order to access commit_ member function
-#define private public
 #include "FWCore/Framework/interface/Event.h"
-#undef private
 
 class testEventGetRefBeforePut: public CppUnit::TestFixture {
 CPPUNIT_TEST_SUITE(testEventGetRefBeforePut);

--- a/FWCore/PluginManager/test/cacheparser_t.cc
+++ b/FWCore/PluginManager/test/cacheparser_t.cc
@@ -17,7 +17,6 @@
 #include <sstream>
 
 // user include files
-#define private public
 #include "FWCore/PluginManager/interface/CacheParser.h"
 
 class TestCacheParser : public CppUnit::TestFixture

--- a/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
+++ b/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
@@ -6,11 +6,7 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceWrapper.h"
 #include "FWCore/Utilities/interface/Exception.h"
-
-//NOTE: I need to open a 'back door' so I can test ServiceManager 'inheritance'
-#define private public
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
-#undef private
 
 #include <cstdlib>
 #include <vector>

--- a/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
@@ -5,11 +5,7 @@
  *  Created by Chris Jones on 9/5/05.
  *
  */
-//NOTE: I need to open a 'back door' so I can test ServiceManager 'inheritance'
-#define private public
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
-#undef private
-
 #include "FWCore/ServiceRegistry/interface/ServicesManager.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include <cppunit/extensions/HelperMacros.h>

--- a/FWCore/Utilities/test/EDGetToken_t.cpp
+++ b/FWCore/Utilities/test/EDGetToken_t.cpp
@@ -1,8 +1,4 @@
-// have to do this evil in order to access constructors.
-// This is acceptable only for white box tests like this.
-#define private public
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#undef private
 
 #include <iostream>
 

--- a/FWCore/Utilities/test/RunningAverage_t.cpp
+++ b/FWCore/Utilities/test/RunningAverage_t.cpp
@@ -1,6 +1,4 @@
-#define private public
 #include "FWCore/Utilities/interface/RunningAverage.h"
-#undef private
 
 namespace {
 

--- a/Fireworks/Core/src/FWEveView.cc
+++ b/Fireworks/Core/src/FWEveView.cc
@@ -19,10 +19,8 @@
 
 // user include files
 
-#define private public  //!!! TODO add get/sets for camera zoom and FOV
 #include "TGLOrthoCamera.h"
 #include "TGLPerspectiveCamera.h"
-#undef private
 #include "TGLCameraGuide.h"
 
 #include "TGLEmbeddedViewer.h"
@@ -31,9 +29,7 @@
 #include "TEveElement.h"
 #include "TEveWindow.h"
 #include "TEveScene.h"
-#define protected public  //!!! TODO add get/sets for TEveCalo2D for CellIDs
 #include "TEveCalo.h"
-#undef protected
 #include "TGLOverlay.h"
 
 #include "Fireworks/Core/interface/FWTEveViewer.h"

--- a/Fireworks/Core/src/FWEveViewManager.cc
+++ b/Fireworks/Core/src/FWEveViewManager.cc
@@ -18,12 +18,7 @@
 // user include files
 
 // For optimized redraw of Eve views
-#define protected public
-#define private   public
 #include "TEveManager.h"
-#undef private
-#undef protected
-
 #include "TEveSelection.h"
 #include "TEveScene.h"
 #include "TEveViewer.h"

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -15,10 +15,7 @@
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
-
 #include "Fireworks/Core/interface/FWFileEntry.h"
 #include "Fireworks/Core/interface/FWEventItemsManager.h"
 #include "Fireworks/Core/interface/fwLog.h"

--- a/Fireworks/Core/src/FWRPZView.cc
+++ b/Fireworks/Core/src/FWRPZView.cc
@@ -24,11 +24,7 @@
 #include "TEveProjectionAxes.h"
 #include "TGLabel.h"
 #include "TEveProjectionManager.h"
-
-//!!! FIXME add get/sets for TEveCalo2D for CellIDs
-#define protected public  
 #include "TEveCalo.h"
-#undef protected
 
 // user include files
 #include "Fireworks/Core/interface/FWRPZView.h"

--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -20,9 +20,7 @@
 
 #include "TMath.h"
 #include "TGLIncludes.h"
-#define protected public
 #include "TGLFBO.h"
-#undef protected
 
 #include "Fireworks/Core/interface/FWTEveViewer.h"
 #include "Fireworks/Core/interface/FWTGLViewer.h"

--- a/Fireworks/Core/test/unittest_changemanager.cc
+++ b/Fireworks/Core/test/unittest_changemanager.cc
@@ -19,9 +19,7 @@
 
 // user include files
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 

--- a/Fireworks/Core/test/unittest_modelexpressionselector.cc
+++ b/Fireworks/Core/test/unittest_modelexpressionselector.cc
@@ -19,15 +19,10 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
-
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
-
 #include "Fireworks/Core/interface/FWSelectionManager.h"
 #include "Fireworks/Core/interface/FWModelExpressionSelector.h"
-
 #include "Fireworks/Core/interface/FWItemAccessorBase.h"
 
 //

--- a/Fireworks/Core/test/unittest_selectionmanager.cc
+++ b/Fireworks/Core/test/unittest_selectionmanager.cc
@@ -22,14 +22,9 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
-
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
-
 #include "Fireworks/Core/interface/FWSelectionManager.h"
-
 #include "Fireworks/Core/interface/FWItemAccessorBase.h"
 
 //

--- a/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
@@ -1,8 +1,5 @@
-
-#define protected public
 #include "TGLViewer.h" // access to over-all bounding box
 #include "TEveCalo.h" // workaround for TEveCalo3D bounding box
-#undef protected
 #include "TGLFontManager.h"
 #include "TEveScene.h"
 #include "TEveManager.h"

--- a/Fireworks/Eve/src/EveService.cc
+++ b/Fireworks/Eve/src/EveService.cc
@@ -19,7 +19,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
-#define private public
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TColor.h"

--- a/Fireworks/FWInterface/src/FWFFHelper.cc
+++ b/Fireworks/FWInterface/src/FWFFHelper.cc
@@ -2,7 +2,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
-#define private public
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TColor.h"

--- a/Fireworks/Geometry/plugins/EveDisplayPlugin.cc
+++ b/Fireworks/Geometry/plugins/EveDisplayPlugin.cc
@@ -15,7 +15,6 @@
 //         Created:  Wed Sep 26 08:27:23 EDT 2007
 //
 //
-#define private public // workaround for bug in 5.34.18
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TColor.h"

--- a/Fireworks/Vertices/src/TEveEllipsoidGL.cc
+++ b/Fireworks/Vertices/src/TEveEllipsoidGL.cc
@@ -1,9 +1,6 @@
 #include "Fireworks/Vertices/interface/TEveEllipsoidGL.h"
 
-#define protected public  
 #include "TEveProjections.h" // AMT missing getter for projection center / beam-spot
-#undef protected
-
 #include "Fireworks/Vertices/interface/TEveEllipsoidGL.h"
 #include "Fireworks/Vertices/interface/TEveEllipsoid.h"
 #include "TEveProjectionManager.h"

--- a/MagneticField/Engine/test/testMagneticField.cc
+++ b/MagneticField/Engine/test/testMagneticField.cc
@@ -466,7 +466,6 @@ void testMagneticField::fillFromTable(string inputFile, vector<GlobalPoint>& p, 
 }
 
 
-#define private public
 #include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
 
 // Get the pointer of the volume containing a point

--- a/MagneticField/GeomBuilder/test/stubs/MagGeometryAnalyzer.cc
+++ b/MagneticField/GeomBuilder/test/stubs/MagGeometryAnalyzer.cc
@@ -12,14 +12,9 @@
 #include "MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include "MagneticField/Layers/interface/MagVerbosity.h"
-
-//dirty hack
-#define private public
 #include "MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.h"
 #include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
-#undef public
 
 #include <iostream>
 #include <vector>

--- a/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestBackgroundHandler.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestBackgroundHandler.cc
@@ -11,11 +11,7 @@
 #include <iterator>
 #include <boost/foreach.hpp>
 
-#define private public
-#define protected public
 #include "MuonAnalysis/MomentumScaleCalibration/interface/BackgroundHandler.h"
-#undef private
-#undef protected
 
 #ifndef TestBackgroundHandler_cc
 #define TestBackgroundHandler_cc

--- a/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestCrossSectionHandler.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestCrossSectionHandler.cc
@@ -11,11 +11,7 @@
 #include <iterator>
 #include <boost/foreach.hpp>
 
-#define private public
-#define protected public
 #include "MuonAnalysis/MomentumScaleCalibration/interface/CrossSectionHandler.h"
-#undef private
-#undef protected
 
 #ifndef TestCrossSectionHandler_cc
 #define TestCrossSectionHandler_cc

--- a/PerfTools/Callgrind/test/ProfilerServiceTest.cppunit.cc
+++ b/PerfTools/Callgrind/test/ProfilerServiceTest.cppunit.cc
@@ -1,7 +1,4 @@
-#define private public
 #include "PerfTools/Callgrind/interface/ProfilerService.h"
-#undef private
-
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeHitFilter_t.cpp
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeHitFilter_t.cpp
@@ -1,7 +1,5 @@
 // ClusterShapeHitFilter test
-#define private public
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-#undef private
 
 #include <iostream>
 #include <cassert>

--- a/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_prec.cpp
+++ b/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_prec.cpp
@@ -1,10 +1,7 @@
-#define private public
 #include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc"
-#undef private
 
 #include<iostream>
 #include<string>
-
 
 int main(int n, const char **) {
   if (n<2) return 0; // protect testing

--- a/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_t.cpp
+++ b/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_t.cpp
@@ -1,6 +1,4 @@
-#define private public
 #include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc"
-#undef private
 
 #include <cmath>
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"

--- a/SimG4Core/Geometry/test/PseudoTrap_.cpp
+++ b/SimG4Core/Geometry/test/PseudoTrap_.cpp
@@ -9,7 +9,6 @@
 #include <G4VSolid.hh>
 
 #include <string>
-#define private public
 #include <SimG4Core/Geometry/interface/DDG4SolidConverter.h>
 
 class testPseudoTrap : public CppUnit::TestFixture

--- a/SimG4Core/Geometry/test/TruncTubs_.cpp
+++ b/SimG4Core/Geometry/test/TruncTubs_.cpp
@@ -10,7 +10,6 @@
 
 #include <string>
 
-#define private public
 #include <SimG4Core/Geometry/interface/DDG4SolidConverter.h>
 
 class testTruncTubs : public CppUnit::TestFixture

--- a/TrackingTools/PatternTools/test/ClosestApproachInRPhi_t.cpp
+++ b/TrackingTools/PatternTools/test/ClosestApproachInRPhi_t.cpp
@@ -1,17 +1,8 @@
-#define private public
 #include "TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixHelix.h"
-#undef private
-
-// #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-
-// #include "TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
-
-
 #include "TrackingTools/PatternTools/src/ClosestApproachInRPhi.cc"
-
 
 #include <iostream>
 


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

The files in this PR used such intrusive macros, but removal of them
breaks compilation. Thus additional review and refactoring is required
for droping intrusive macros. This PR acts as a cleanup list.

Most of such things (about 35 out of 45) are used in tests.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
