### PR TITLE
Bugfix in HLTTauDQMPath affecting L2 plots

### DIFF
--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -575,7 +575,7 @@ void HLTTauDQMPath::getFilterObjects(const trigger::TriggerEvent& triggerEvent, 
 bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& triggerObjects, const HLTTauDQMOfflineObjects& offlineObjects, double dR, std::vector<Object>& matchedTriggerObjects, HLTTauDQMOfflineObjects& matchedOfflineObjects) const {
   bool isL1 = (i==0 && isFirstL1Seed_);
   std::vector<bool> offlineMask;
-  if(filterLevel_[i] == 3 && filterTauN_[i] > 0) {
+  if(filterLevel_[i] > 1 && filterTauN_[i] > 0) {
     int matchedObjects = 0;
     offlineMask.resize(offlineObjects.taus.size());
     std::fill(offlineMask.begin(), offlineMask.end(), true);
@@ -594,7 +594,7 @@ bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& trigger
     if(matchedObjects == 0)
       return false;
   }
-  if(filterLevel_[i] == 3 && filterElectronN_[i] > 0) {
+  if(filterLevel_[i] > 1 && filterElectronN_[i] > 0) {
     int matchedObjects = 0;
     offlineMask.resize(offlineObjects.electrons.size());
     std::fill(offlineMask.begin(), offlineMask.end(), true);
@@ -611,7 +611,7 @@ bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& trigger
     if(matchedObjects < filterElectronN_[i])
       return false;
   }
-  if(filterLevel_[i] == 3 && filterMuonN_[i] > 0) {
+  if(filterLevel_[i] > 1 && filterMuonN_[i] > 0) {
     int matchedObjects = 0;
     offlineMask.resize(offlineObjects.muons.size());
     std::fill(offlineMask.begin(), offlineMask.end(), true);


### PR DESCRIPTION
Same fix as in PR #11483, but now for 75X
