### PR TITLE
Return back modifications which can work only with Geant4 10.1

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -55,6 +55,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         Resolution = cms.untracked.int32(10000),
         RegionFlag = cms.untracked.bool(True),  # if true - selection by G4Region name
         gdmlFlag = cms.untracked.bool(True),  # if true - dump gdml file
+        PVname = cms.vstring(''),
+        LVname = cms.vstring(''),
         NodeNames = cms.vstring('World')
     ),
     G4Commands = cms.vstring(),

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -191,7 +191,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   // geometry dump
   if("" != m_WriteFile) {
-    G4GDMLParser gdml;
+    G4GDMLParser gdml(new G4GDMLReadStructure(), new CMSGDMLWriteStructure());
     gdml.Write(m_WriteFile, m_world->GetWorldVolume(), true);
   }
 


### PR DESCRIPTION
Recent modification valid only for Geant4 10.1 are taken out in order to be able to return Geant4 10.0 into 7_6_X.

Recent extensions to Geant4 geometry overlap checks are added (these are not affecting production).
