### PR TITLE
CSC Halo filter: adding classes for nex filter

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 ## We don't use "import *" because the cff contains some modules for which the C++ class doesn't exist
 ## and this triggers an error under unscheduled mode
-from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, CSCTightHaloFilter, CSCTightHaloTrkMuUnvetoFilter,CSCTightHalo2015Filter,hcalLaserEventFilter, EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter, primaryVertexFilter 
+from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, hcalLaserEventFilter
+from RecoMET.METFilters.metFilters_cff import EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter
+from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, CSCTightHaloFilter, CSCTightHaloTrkMuUnvetoFilter, CSCTightHalo2015Filter, HcalStripHaloFilter
 from RecoMET.METFilters.metFilters_cff import goodVertices, trackingFailureFilter, trkPOGFilters, manystripclus53X, toomanystripclus53X, logErrorTooManyClusters
 from RecoMET.METFilters.metFilters_cff import metFilters
 
@@ -12,6 +14,7 @@ Flag_HBHENoiseIsoFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseIsoF
 Flag_CSCTightHaloFilter = cms.Path(CSCTightHaloFilter)
 Flag_CSCTightHaloTrkMuUnvetoFilter = cms.Path(CSCTightHaloTrkMuUnvetoFilter)
 Flag_CSCTightHalo2015Filter = cms.Path(CSCTightHalo2015Filter)
+Flag_HcalStripHaloFilter = cms.Path(HcalStripHaloFilter)
 Flag_hcalLaserEventFilter = cms.Path(hcalLaserEventFilter)
 Flag_EcalDeadCellTriggerPrimitiveFilter = cms.Path(EcalDeadCellTriggerPrimitiveFilter)
 Flag_EcalDeadCellBoundaryEnergyFilter = cms.Path(EcalDeadCellBoundaryEnergyFilter)
@@ -30,13 +33,13 @@ Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 Flag_METFilters = cms.Path(metFilters)
 
 #add your new path here!!
-allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
+allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HcalStripHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
                    'ecalLaserCorrFilter','trkPOGFilters','trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
 
        
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
-    for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
+    for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HcalStripHaloFilter','HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(True)))
     for X in 'manystripclus53X', 'toomanystripclus53X', 'logErrorTooManyClusters':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -2,10 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 ## We don't use "import *" because the cff contains some modules for which the C++ class doesn't exist
 ## and this triggers an error under unscheduled mode
-from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, hcalLaserEventFilter
-from RecoMET.METFilters.metFilters_cff import EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter
-from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, CSCTightHaloFilter, HcalStripHaloFilter
-
+from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, CSCTightHaloFilter, CSCTightHaloTrkMuUnvetoFilter,CSCTightHalo2015Filter,hcalLaserEventFilter, EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter, primaryVertexFilter 
 from RecoMET.METFilters.metFilters_cff import goodVertices, trackingFailureFilter, trkPOGFilters, manystripclus53X, toomanystripclus53X, logErrorTooManyClusters
 from RecoMET.METFilters.metFilters_cff import metFilters
 
@@ -13,7 +10,8 @@ from RecoMET.METFilters.metFilters_cff import metFilters
 Flag_HBHENoiseFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseFilter)
 Flag_HBHENoiseIsoFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseIsoFilter)
 Flag_CSCTightHaloFilter = cms.Path(CSCTightHaloFilter)
-Flag_HcalStripHaloFilter = cms.Path(HcalStripHaloFilter)
+Flag_CSCTightHaloTrkMuUnvetoFilter = cms.Path(CSCTightHaloTrkMuUnvetoFilter)
+Flag_CSCTightHalo2015Filter = cms.Path(CSCTightHalo2015Filter)
 Flag_hcalLaserEventFilter = cms.Path(hcalLaserEventFilter)
 Flag_EcalDeadCellTriggerPrimitiveFilter = cms.Path(EcalDeadCellTriggerPrimitiveFilter)
 Flag_EcalDeadCellBoundaryEnergyFilter = cms.Path(EcalDeadCellBoundaryEnergyFilter)
@@ -32,13 +30,13 @@ Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 Flag_METFilters = cms.Path(metFilters)
 
 #add your new path here!!
-allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','HcalStripHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
+allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
                    'ecalLaserCorrFilter','trkPOGFilters','trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
 
        
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
-    for X in 'CSCTightHaloFilter', 'HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer', 'HcalStripHaloFilter':
+    for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(True)))
     for X in 'manystripclus53X', 'toomanystripclus53X', 'logErrorTooManyClusters':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))

--- a/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
@@ -1,0 +1,43 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/METReco/interface/BeamHaloSummary.h"
+
+class CSCTightHalo2015Filter : public edm::EDFilter {
+
+  public:
+
+    explicit CSCTightHalo2015Filter(const edm::ParameterSet & iConfig);
+    ~CSCTightHalo2015Filter() {}
+
+  private:
+
+    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+
+    const bool taggingMode_;
+    edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
+};
+
+CSCTightHalo2015Filter::CSCTightHalo2015Filter(const edm::ParameterSet & iConfig)
+  : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
+  , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
+{
+
+  produces<bool>();
+}
+
+bool CSCTightHalo2015Filter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+
+  edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
+  iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);
+
+  const bool pass = !beamHaloSummary->CSCTightHaloId2015();
+
+  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+
+  return taggingMode_ || !pass;  // return false if it is a beamhalo event
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CSCTightHalo2015Filter);

--- a/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
@@ -1,10 +1,10 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/METReco/interface/BeamHaloSummary.h"
 
-class CSCTightHalo2015Filter : public edm::EDFilter {
+class CSCTightHalo2015Filter : public edm::global::EDFilter<> {
 
   public:
 
@@ -13,7 +13,7 @@ class CSCTightHalo2015Filter : public edm::EDFilter {
 
   private:
 
-    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+  virtual bool filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
     const bool taggingMode_;
     edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
@@ -27,7 +27,7 @@ CSCTightHalo2015Filter::CSCTightHalo2015Filter(const edm::ParameterSet & iConfig
   produces<bool>();
 }
 
-bool CSCTightHalo2015Filter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool CSCTightHalo2015Filter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
   iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);

--- a/RecoMET/METFilters/plugins/CSCTightHaloFilter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHaloFilter.cc
@@ -1,10 +1,10 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/METReco/interface/BeamHaloSummary.h"
 
-class CSCTightHaloFilter : public edm::EDFilter {
+class CSCTightHaloFilter : public edm::global::EDFilter<> {
 
   public:
 
@@ -13,7 +13,7 @@ class CSCTightHaloFilter : public edm::EDFilter {
 
   private:
 
-    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+  virtual bool filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
     const bool taggingMode_;
     edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
@@ -27,7 +27,7 @@ CSCTightHaloFilter::CSCTightHaloFilter(const edm::ParameterSet & iConfig)
   produces<bool>();
 }
 
-bool CSCTightHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool CSCTightHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
   iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);

--- a/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
@@ -1,10 +1,10 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/METReco/interface/BeamHaloSummary.h"
 
-class CSCTightHaloTrkMuUnvetoFilter : public edm::EDFilter {
+class CSCTightHaloTrkMuUnvetoFilter : public edm::global::EDFilter<> {
 
   public:
 
@@ -13,7 +13,7 @@ class CSCTightHaloTrkMuUnvetoFilter : public edm::EDFilter {
 
   private:
 
-    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+  virtual bool filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
     const bool taggingMode_;
     edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
@@ -27,7 +27,7 @@ CSCTightHaloTrkMuUnvetoFilter::CSCTightHaloTrkMuUnvetoFilter(const edm::Paramete
   produces<bool>();
 }
 
-bool CSCTightHaloTrkMuUnvetoFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool CSCTightHaloTrkMuUnvetoFilter::filter(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
   iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);

--- a/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
@@ -1,0 +1,43 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/METReco/interface/BeamHaloSummary.h"
+
+class CSCTightHaloTrkMuUnvetoFilter : public edm::EDFilter {
+
+  public:
+
+    explicit CSCTightHaloTrkMuUnvetoFilter(const edm::ParameterSet & iConfig);
+    ~CSCTightHaloTrkMuUnvetoFilter() {}
+
+  private:
+
+    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+
+    const bool taggingMode_;
+    edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
+};
+
+CSCTightHaloTrkMuUnvetoFilter::CSCTightHaloTrkMuUnvetoFilter(const edm::ParameterSet & iConfig)
+  : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
+  , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
+{
+
+  produces<bool>();
+}
+
+bool CSCTightHaloTrkMuUnvetoFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+
+  edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
+  iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);
+
+  const bool pass = !beamHaloSummary->CSCTightHaloIdTrkMuUnveto();
+
+  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+
+  return taggingMode_ || pass;  // return false if it is a beamhalo event
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CSCTightHaloTrkMuUnvetoFilter);

--- a/RecoMET/METFilters/python/CSCTightHalo2015Filter_cfi.py
+++ b/RecoMET/METFilters/python/CSCTightHalo2015Filter_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+CSCTightHalo2015Filter = cms.EDFilter(
+  "CSCTightHalo2015Filter",
+  taggingMode = cms.bool(False)
+)

--- a/RecoMET/METFilters/python/CSCTightHaloTrkMuUnvetoFilter_cfi.py
+++ b/RecoMET/METFilters/python/CSCTightHaloTrkMuUnvetoFilter_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+CSCTightHaloTrkMuUnvetoFilter = cms.EDFilter(
+  "CSCTightHaloTrkMuUnvetoFilter",
+  taggingMode = cms.bool(False),
+)

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms
+B1;3409;0cimport FWCore.ParameterSet.Config as cms
 
 ## The iso-based HBHE noise filter ___________________________________________||
 from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
@@ -7,8 +7,11 @@ from CommonTools.RecoAlgos.HBHENoiseFilter_cfi import *
 ## The CSC beam halo tight filter ____________________________________________||
 from RecoMET.METFilters.CSCTightHaloFilter_cfi import *
 
-## The hcal problematic strip halo filter ____________________________________________||
-from RecoMET.METFilters.HcalStripHaloFilter_cfi import *
+## The CSC beam halo tight filter ____________________________________________||
+from RecoMET.METFilters.CSCTightHaloTrkMuUnvetoFilter_cfi import *
+
+## The CSC beam halo tight filter ____________________________________________||
+from RecoMET.METFilters.CSCTightHalo2015Filter_cfi import *
 
 ## The HCAL laser filter _____________________________________________________||
 from RecoMET.METFilters.hcalLaserEventFilter_cfi import *
@@ -58,11 +61,12 @@ from RecoMET.METFilters.trackingPOGFilters_cff import *
 metFilters = cms.Sequence(
    HBHENoiseFilterResultProducer *
    HBHENoiseFilter *
-#   HBHENoiseIsoFilter*
-#   HcalStripHaloFilter *
    primaryVertexFilter*
+#   HBHENoiseIsoFilter*
    CSCTightHaloFilter *
 #   hcalLaserEventFilter *
+#  CSCTightHaloTrkMuUnvetoFilter *
+# CSCTightHalo2015Filter *
    EcalDeadCellTriggerPrimitiveFilter* 
 #   *goodVertices * trackingFailureFilter *
    eeBadScFilter

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -1,4 +1,4 @@
-B1;3409;0cimport FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 
 ## The iso-based HBHE noise filter ___________________________________________||
 from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
@@ -12,6 +12,9 @@ from RecoMET.METFilters.CSCTightHaloTrkMuUnvetoFilter_cfi import *
 
 ## The CSC beam halo tight filter ____________________________________________||
 from RecoMET.METFilters.CSCTightHalo2015Filter_cfi import *
+
+## The hcal problematic strip halo filter ____________________________________________||
+from RecoMET.METFilters.HcalStripHaloFilter_cfi import *
 
 ## The HCAL laser filter _____________________________________________________||
 from RecoMET.METFilters.hcalLaserEventFilter_cfi import *
@@ -63,6 +66,7 @@ metFilters = cms.Sequence(
    HBHENoiseFilter *
    primaryVertexFilter*
 #   HBHENoiseIsoFilter*
+#   HcalStripHaloFilter *
    CSCTightHaloFilter *
 #   hcalLaserEventFilter *
 #  CSCTightHaloTrkMuUnvetoFilter *


### PR DESCRIPTION
So far, the results of the two new working points of the filter were only stored as methods in CSCHaloData. 
I have now created two EDFilters for each of them and added them to the list of metFilters. 
I also added them to the lists of flags in MINIAOD. 
Let me know if there's any problem ! 

Thanks a lot, 

Laurent 
