### PR TITLE
update PFJetID for RunII, add ak8 MiniAOD monitoring, adopt ak4CHS JEC for type1 MET

### DIFF
--- a/DQMOffline/JetMET/interface/DataCertificationJetMET.h
+++ b/DQMOffline/JetMET/interface/DataCertificationJetMET.h
@@ -49,6 +49,7 @@ class DataCertificationJetMET : public DQMEDHarvester {
    std::string jetAlgo;
 
    edm::InputTag inputMETLabelRECO_;
+   edm::InputTag inputMETLabelRECOUncleaned_;
    edm::InputTag inputMETLabelMiniAOD_;
    edm::InputTag inputJetLabelRECO_;
    edm::InputTag inputJetLabelMiniAOD_;
@@ -82,6 +83,16 @@ class DataCertificationJetMET : public DQMEDHarvester {
 
    bool jetTests[5][2];  //one for each type of jet certification/test type
    bool metTests[5][2];  //one for each type of met certification/test type
+
+  //MET: filter efficiencies, started from uncleaned directories
+   MonitorElement* mMET_EffHBHENoiseFilter;
+   MonitorElement* mMET_EffCSCTightHaloFilter;
+   MonitorElement* mMET_EffeeBadScFilter;
+   MonitorElement* mMET_EffEcalDeadCellTriggerFilter;
+   MonitorElement* mMET_EffEcalDeadCellBoundaryFilter;
+   MonitorElement* mMET_EffHBHEIsoNoiseFilter;
+   MonitorElement* mMET_EffCSCTightHalo2015Filter;
+   MonitorElement* mMET_EffHcalStripHaloFilter;
 
    //MET: RECO vs MiniAOD histos
    MonitorElement* mMET_MiniAOD_over_Reco;

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -58,6 +58,8 @@
 
 #include "DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h"
 
+#include "DataFormats/BTauReco/interface/CATopJetTagInfo.h"
+
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
@@ -355,6 +357,8 @@ class JetAnalyzer : public DQMEDAnalyzer {
   std::vector<std::string> lowPtJetExpr_;
 
   bool jetCleaningFlag_;
+  bool filljetsubstruc_;
+  double pt_min_boosted_;
 
   bool runcosmics_;
 
@@ -657,6 +661,91 @@ class JetAnalyzer : public DQMEDAnalyzer {
   MonitorElement* meHFEMFracPlus_BXm1Filled;
   MonitorElement* mePtForwardPlus_BXm1Filled;
   MonitorElement* meEta_BXm1Filled;
+
+  //miniaod specific variables, especially for substructure
+  MonitorElement* mSoftDropMass; 
+  MonitorElement* mPrunedMass; 
+  MonitorElement* mTrimmedMass; 
+  MonitorElement* mFilteredMass; 
+  MonitorElement* mtau2_over_tau1; 
+  MonitorElement* mtau3_over_tau2; 
+  MonitorElement* mCATopTag_topMass;
+  MonitorElement* mCATopTag_minMass; 
+  MonitorElement* mCATopTag_nSubJets; 
+
+  MonitorElement* mnSubJetsCMSTopTag; 
+  MonitorElement* mSubJet1_CMSTopTag_pt; 
+  MonitorElement* mSubJet1_CMSTopTag_eta; 
+  MonitorElement* mSubJet1_CMSTopTag_phi; 
+  MonitorElement* mSubJet1_CMSTopTag_mass; 
+  MonitorElement* mSubJet2_CMSTopTag_pt; 
+  MonitorElement* mSubJet2_CMSTopTag_eta; 
+  MonitorElement* mSubJet2_CMSTopTag_phi; 
+  MonitorElement* mSubJet2_CMSTopTag_mass; 
+  MonitorElement* mSubJet3_CMSTopTag_pt; 
+  MonitorElement* mSubJet3_CMSTopTag_eta; 
+  MonitorElement* mSubJet3_CMSTopTag_phi; 
+  MonitorElement* mSubJet3_CMSTopTag_mass; 
+  MonitorElement* mSubJet4_CMSTopTag_pt; 
+  MonitorElement* mSubJet4_CMSTopTag_eta; 
+  MonitorElement* mSubJet4_CMSTopTag_phi; 
+  MonitorElement* mSubJet4_CMSTopTag_mass; 
+
+  MonitorElement* mnSubJetsSoftDrop; 
+  MonitorElement* mSubJet1_SoftDrop_pt; 
+  MonitorElement* mSubJet1_SoftDrop_eta; 
+  MonitorElement* mSubJet1_SoftDrop_phi; 
+  MonitorElement* mSubJet1_SoftDrop_mass; 
+  MonitorElement* mSubJet2_SoftDrop_pt; 
+  MonitorElement* mSubJet2_SoftDrop_eta; 
+  MonitorElement* mSubJet2_SoftDrop_phi; 
+  MonitorElement* mSubJet2_SoftDrop_mass; 
+
+  //miniaod specific variables, especially for substructure for a boosted regime
+  MonitorElement* mSoftDropMass_boosted; 
+  MonitorElement* mPrunedMass_boosted; 
+  MonitorElement* mTrimmedMass_boosted; 
+  MonitorElement* mFilteredMass_boosted; 
+  MonitorElement* mtau2_over_tau1_boosted; 
+  MonitorElement* mtau3_over_tau2_boosted; 
+  MonitorElement* mCATopTag_topMass_boosted;
+  MonitorElement* mCATopTag_minMass_boosted; 
+  MonitorElement* mCATopTag_nSubJets_boosted; 
+
+  MonitorElement* mnSubJetsCMSTopTag_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet1_CMSTopTag_mass_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet2_CMSTopTag_mass_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet3_CMSTopTag_mass_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_pt_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_eta_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_phi_boosted; 
+  MonitorElement* mSubJet4_CMSTopTag_mass_boosted; 
+
+  MonitorElement* mnSubJetsSoftDrop_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_pt_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_eta_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_phi_boosted; 
+  MonitorElement* mSubJet1_SoftDrop_mass_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_pt_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_eta_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_phi_boosted; 
+  MonitorElement* mSubJet2_SoftDrop_mass_boosted; 
+
+  //miniaod only variables
+  MonitorElement* mPt_CaloJet;
+  MonitorElement* mEMF_CaloJet;
+  MonitorElement* mMass_Barrel;
+  MonitorElement* mMass_EndCap;
+  MonitorElement* mMass_Forward;
 
   //now ZJets plots
   MonitorElement*  mDPhiZJet;

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -581,7 +581,7 @@ class JetAnalyzer : public DQMEDAnalyzer {
 
   JetMETDQMDCSFilter * DCSFilterForJetMonitoring_;
   JetMETDQMDCSFilter * DCSFilterForDCSMonitoring_;
-
+  /*
   MonitorElement* mePhFracBarrel_BXm2BXm1Empty;
   MonitorElement* meNHFracBarrel_BXm2BXm1Empty;
   MonitorElement* meCHFracBarrel_BXm2BXm1Empty;
@@ -601,7 +601,7 @@ class JetAnalyzer : public DQMEDAnalyzer {
   MonitorElement* meHFEMFracPlus_BXm2BXm1Empty;
   MonitorElement* mePtForwardPlus_BXm2BXm1Empty;
   MonitorElement* meEta_BXm2BXm1Empty;
-
+  */
   MonitorElement* mePhFracBarrel_BXm1Empty;
   MonitorElement* meNHFracBarrel_BXm1Empty;
   MonitorElement* meCHFracBarrel_BXm1Empty;
@@ -621,7 +621,7 @@ class JetAnalyzer : public DQMEDAnalyzer {
   MonitorElement* meHFEMFracPlus_BXm1Empty;
   MonitorElement* mePtForwardPlus_BXm1Empty;
   MonitorElement* meEta_BXm1Empty;
-
+  /*
   MonitorElement* mePhFracBarrel_BXm2BXm1Filled;
   MonitorElement* meNHFracBarrel_BXm2BXm1Filled;
   MonitorElement* meCHFracBarrel_BXm2BXm1Filled;
@@ -641,7 +641,7 @@ class JetAnalyzer : public DQMEDAnalyzer {
   MonitorElement* meHFEMFracPlus_BXm2BXm1Filled;
   MonitorElement* mePtForwardPlus_BXm2BXm1Filled;
   MonitorElement* meEta_BXm2BXm1Filled;
-
+  */
   MonitorElement* mePhFracBarrel_BXm1Filled;
   MonitorElement* meNHFracBarrel_BXm1Filled;
   MonitorElement* meCHFracBarrel_BXm1Filled;

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -116,8 +116,8 @@ class METAnalyzer : public DQMEDAnalyzer{
   void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
   //  void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
   // Fill MonitorElements
-  void fillMESet(const edm::Event&, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET&, const reco::Candidate::PolarLorentzVector&, std::map<std::string,MonitorElement*>&,std::vector<bool>);
-  void fillMonitorElement(const edm::Event&, std::string, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET& , const reco::Candidate::PolarLorentzVector& ,std::map<std::string,MonitorElement*>&,bool,bool,std::vector<bool>);
+  void fillMESet(const edm::Event&, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET&, const reco::Candidate::PolarLorentzVector&, std::map<std::string,MonitorElement*>&,std::vector<bool>,std::vector<bool>);
+  void fillMonitorElement(const edm::Event&, std::string, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET& , const reco::Candidate::PolarLorentzVector& ,std::map<std::string,MonitorElement*>&,bool,bool,std::vector<bool>,std::vector<bool>);
   void makeRatePlot(std::string, double);
 
 //  bool selectHighPtJetEvent(const edm::Event&);
@@ -143,7 +143,6 @@ class METAnalyzer : public DQMEDAnalyzer{
   edm::InputTag metCollectionLabel_;
   edm::InputTag hcalNoiseRBXCollectionTag_;
   edm::InputTag jetCollectionLabel_;
-  edm::InputTag hbheNoiseFilterResultTag_;
   edm::InputTag vertexTag_;
   edm::InputTag gtTag_;
 
@@ -154,7 +153,23 @@ class METAnalyzer : public DQMEDAnalyzer{
   edm::EDGetTokenT<pat::JetCollection>        patJetsToken_;
   edm::EDGetTokenT<reco::MuonCollection>         MuonsToken_;
 
+  edm::InputTag METFilterMiniAODLabel_;
+  edm::EDGetTokenT<edm::TriggerResults> METFilterMiniAODToken_;
+  edm::InputTag METFilterMiniAODLabel2_;//needed for RECO and reRECO differntiation
+  edm::EDGetTokenT<edm::TriggerResults> METFilterMiniAODToken2_;
+
+  std::vector<int> miniaodFilterIndex_;
+  int miniaodfilterdec;//if RECO set to 0, if reRECO set to 1, else to -1
+
+  edm::InputTag hbheNoiseFilterResultTag_;
   edm::EDGetTokenT<bool>                          hbheNoiseFilterResultToken_;
+  edm::InputTag CSCHaloResultTag_;
+  edm::EDGetTokenT<bool>  CSCHaloResultToken_;//leads to problems running later
+  edm::EDGetTokenT<reco::BeamHaloSummary> BeamHaloSummaryToken_;
+  edm::InputTag EcalDeadCellTriggerTag_;
+  edm::EDGetTokenT<bool>  EcalDeadCellTriggerToken_;
+  edm::InputTag eeBadScFilterTag_;
+  edm::EDGetTokenT<bool>  eeBadScFilterToken_;
 
   edm::EDGetTokenT<pat::METCollection>           patMetToken_; 
   edm::EDGetTokenT<reco::PFMETCollection>         pfMetToken_;
@@ -173,6 +188,7 @@ class METAnalyzer : public DQMEDAnalyzer{
   double ptThreshold_;
 
   HLTConfigProvider hltConfig_;
+  HLTConfigProvider FilterhltConfig_;
   edm::InputTag                         triggerResultsLabel_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
 
@@ -278,6 +294,17 @@ class METAnalyzer : public DQMEDAnalyzer{
   //MonitorElement* hEz;
   MonitorElement* hMETSig;
   MonitorElement* hMET;
+  MonitorElement* hMET_2;
+
+  MonitorElement* hMET_HBHENoiseFilter;
+  MonitorElement* hMET_2_HBHENoiseFilter;
+  MonitorElement* hMET_CSCTightHaloFilter;
+  MonitorElement* hMET_2_CSCTightHaloFilter;
+  MonitorElement* hMET_eeBadScFilter;
+  MonitorElement* hMET_2_eeBadScFilter;
+  MonitorElement* hMET_EcalDeadCellTriggerFilter;
+  MonitorElement* hMET_2_EcalDeadCellTriggerFilter;
+
   MonitorElement* hMETPhi;
   MonitorElement* hSumET;
 

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -163,16 +163,21 @@ class METAnalyzer : public DQMEDAnalyzer{
   int miniaodfilterdec;//if RECO set to 0, if reRECO set to 1, else to -1
 
   edm::InputTag hbheNoiseFilterResultTag_;
-  edm::EDGetTokenT<bool>                          hbheNoiseFilterResultToken_;
+  edm::EDGetTokenT<bool>    hbheNoiseFilterResultToken_;
+  edm::InputTag hbheNoiseIsoFilterResultTag_;
   edm::EDGetTokenT<bool>    hbheIsoNoiseFilterResultToken_;
   edm::InputTag CSCHaloResultTag_;
   edm::EDGetTokenT<bool>  CSCHaloResultToken_;
+  edm::InputTag CSCHalo2015ResultTag_;
   edm::EDGetTokenT<bool>  CSCHalo2015ResultToken_;
-  edm::EDGetTokenT<reco::BeamHaloSummary> BeamHaloSummaryToken_;
   edm::InputTag EcalDeadCellTriggerTag_;
   edm::EDGetTokenT<bool>  EcalDeadCellTriggerToken_;
   edm::InputTag eeBadScFilterTag_;
   edm::EDGetTokenT<bool>  eeBadScFilterToken_;
+  edm::InputTag EcalDeadCellBoundaryTag_;
+  edm::EDGetTokenT<bool>  EcalDeadCellBoundaryToken_;
+  edm::InputTag HcalStripHaloTag_;
+  edm::EDGetTokenT<bool>  HcalStripHaloToken_;
 
   edm::EDGetTokenT<pat::METCollection>           patMetToken_; 
   edm::EDGetTokenT<reco::PFMETCollection>         pfMetToken_;
@@ -199,6 +204,9 @@ class METAnalyzer : public DQMEDAnalyzer{
 //  std::vector<std::string > HLTPathsJetMBByName_;
   std::vector<std::string > allTriggerNames_;
   std::vector< int > allTriggerDecisions_;
+
+  std::string HBHENoiseStringMiniAOD;
+  std::string HBHEIsoNoiseStringMiniAOD;
 
   edm::EDGetTokenT<reco::JetCorrector> jetCorrectorToken_;
 
@@ -298,21 +306,15 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* hMETSig;
   MonitorElement* hMET;
   MonitorElement* hMET_2;
-
+ 
   MonitorElement* hMET_HBHENoiseFilter;
-  MonitorElement* hMET_2_HBHENoiseFilter;
   MonitorElement* hMET_CSCTightHaloFilter;
-  MonitorElement* hMET_2_CSCTightHaloFilter;
   MonitorElement* hMET_eeBadScFilter;
-  MonitorElement* hMET_2_eeBadScFilter;
   MonitorElement* hMET_EcalDeadCellTriggerFilter;
-  MonitorElement* hMET_2_EcalDeadCellTriggerFilter;
-  //only for non miniaod workflows
+  MonitorElement* hMET_EcalDeadCellBoundaryFilter;
   MonitorElement* hMET_HBHEIsoNoiseFilter;
-  MonitorElement* hMET_2_HBHEIsoNoiseFilter;
   MonitorElement* hMET_CSCTightHalo2015Filter;
-  MonitorElement* hMET_2_CSCTightHalo2015Filter;
-
+  MonitorElement* hMET_HcalStripHaloFilter;
 
   MonitorElement* hMETPhi;
   MonitorElement* hSumET;
@@ -368,7 +370,8 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* meHFHadronEt;
   MonitorElement* meHFEMEtFraction;
   MonitorElement* meHFEMEt;
- //MEs where we fill if the previous two bunches are empty (25 ns bunch spacing)
+  //MEs where we fill if the previous two bunches are empty (25 ns bunch spacing)
+  /*
   MonitorElement* mePhotonEtFraction_BXm2BXm1Empty;
   MonitorElement* meNeutralHadronEtFraction_BXm2BXm1Empty;
   MonitorElement* meChargedHadronEtFraction_BXm2BXm1Empty;
@@ -388,7 +391,7 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* meMETPhiHFHadronsMinus_BXm2BXm1Empty;
   MonitorElement* meMETPhiHFEGammasPlus_BXm2BXm1Empty;
   MonitorElement* meMETPhiHFEGammasMinus_BXm2BXm1Empty;
-
+  */
   //MEs where we fill if the previous bunch is empty (25 ns bunch spacing)
   MonitorElement* mePhotonEtFraction_BXm1Empty;
   MonitorElement* meNeutralHadronEtFraction_BXm1Empty;
@@ -432,27 +435,28 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* meMETPhiHFEGammasMinus_BXm1Filled;
 
   //MEs where we fill if two previous bunches are filled (25 ns bunch spacing)
+  /*
   MonitorElement* meChargedHadronEtFraction_BXm2BXm1Filled;
   MonitorElement* mePhotonEtFraction_BXm2BXm1Filled;
   MonitorElement* meNeutralHadronEtFraction_BXm2BXm1Filled;
   MonitorElement* meMET_BXm2BXm1Filled;
   MonitorElement* meSumET_BXm2BXm1Filled;
-
+  */
   MonitorElement* meCHF_Barrel;
   MonitorElement* meCHF_EndcapPlus;
   MonitorElement* meCHF_EndcapMinus;
   MonitorElement* meCHF_Barrel_BXm1Empty;
   MonitorElement* meCHF_EndcapPlus_BXm1Empty;
   MonitorElement* meCHF_EndcapMinus_BXm1Empty;
-  MonitorElement* meCHF_Barrel_BXm2BXm1Empty;
-  MonitorElement* meCHF_EndcapPlus_BXm2BXm1Empty;
-  MonitorElement* meCHF_EndcapMinus_BXm2BXm1Empty;
+  //MonitorElement* meCHF_Barrel_BXm2BXm1Empty;
+  //MonitorElement* meCHF_EndcapPlus_BXm2BXm1Empty;
+  //MonitorElement* meCHF_EndcapMinus_BXm2BXm1Empty;
   MonitorElement* meCHF_Barrel_BXm1Filled;
   MonitorElement* meCHF_EndcapPlus_BXm1Filled;
   MonitorElement* meCHF_EndcapMinus_BXm1Filled;
-  MonitorElement* meCHF_Barrel_BXm2BXm1Filled;
-  MonitorElement* meCHF_EndcapPlus_BXm2BXm1Filled;
-  MonitorElement* meCHF_EndcapMinus_BXm2BXm1Filled;
+  //MonitorElement* meCHF_Barrel_BXm2BXm1Filled;
+  //MonitorElement* meCHF_EndcapPlus_BXm2BXm1Filled;
+  //MonitorElement* meCHF_EndcapMinus_BXm2BXm1Filled;
 
   MonitorElement* meNHF_Barrel;
   MonitorElement* meNHF_EndcapPlus;
@@ -460,15 +464,15 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* meNHF_Barrel_BXm1Empty;
   MonitorElement* meNHF_EndcapPlus_BXm1Empty;
   MonitorElement* meNHF_EndcapMinus_BXm1Empty;
-  MonitorElement* meNHF_Barrel_BXm2BXm1Empty;
-  MonitorElement* meNHF_EndcapPlus_BXm2BXm1Empty;
-  MonitorElement* meNHF_EndcapMinus_BXm2BXm1Empty;
+  //MonitorElement* meNHF_Barrel_BXm2BXm1Empty;
+  //MonitorElement* meNHF_EndcapPlus_BXm2BXm1Empty;
+  //MonitorElement* meNHF_EndcapMinus_BXm2BXm1Empty;
   MonitorElement* meNHF_Barrel_BXm1Filled;
   MonitorElement* meNHF_EndcapPlus_BXm1Filled;
   MonitorElement* meNHF_EndcapMinus_BXm1Filled;
-  MonitorElement* meNHF_Barrel_BXm2BXm1Filled;
-  MonitorElement* meNHF_EndcapPlus_BXm2BXm1Filled;
-  MonitorElement* meNHF_EndcapMinus_BXm2BXm1Filled;
+  //MonitorElement* meNHF_Barrel_BXm2BXm1Filled;
+  //MonitorElement* meNHF_EndcapPlus_BXm2BXm1Filled;
+  //MonitorElement* meNHF_EndcapMinus_BXm2BXm1Filled;
 
   MonitorElement* mePhF_Barrel;
   MonitorElement* mePhF_EndcapPlus;
@@ -476,38 +480,38 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* mePhF_Barrel_BXm1Empty;
   MonitorElement* mePhF_EndcapPlus_BXm1Empty;
   MonitorElement* mePhF_EndcapMinus_BXm1Empty;
-  MonitorElement* mePhF_Barrel_BXm2BXm1Empty;
-  MonitorElement* mePhF_EndcapPlus_BXm2BXm1Empty;
-  MonitorElement* mePhF_EndcapMinus_BXm2BXm1Empty;
+  //MonitorElement* mePhF_Barrel_BXm2BXm1Empty;
+  //MonitorElement* mePhF_EndcapPlus_BXm2BXm1Empty;
+  //MonitorElement* mePhF_EndcapMinus_BXm2BXm1Empty;
   MonitorElement* mePhF_Barrel_BXm1Filled;
   MonitorElement* mePhF_EndcapPlus_BXm1Filled;
   MonitorElement* mePhF_EndcapMinus_BXm1Filled;
-  MonitorElement* mePhF_Barrel_BXm2BXm1Filled;
-  MonitorElement* mePhF_EndcapPlus_BXm2BXm1Filled;
-  MonitorElement* mePhF_EndcapMinus_BXm2BXm1Filled;
+  //MonitorElement* mePhF_Barrel_BXm2BXm1Filled;
+  //MonitorElement* mePhF_EndcapPlus_BXm2BXm1Filled;
+  //MonitorElement* mePhF_EndcapMinus_BXm2BXm1Filled;
 
   MonitorElement* meHFHadF_Plus;
   MonitorElement* meHFHadF_Minus;
   MonitorElement* meHFHadF_Plus_BXm1Empty;
   MonitorElement* meHFHadF_Minus_BXm1Empty;
-  MonitorElement* meHFHadF_Plus_BXm2BXm1Empty;
-  MonitorElement* meHFHadF_Minus_BXm2BXm1Empty;
+  //MonitorElement* meHFHadF_Plus_BXm2BXm1Empty;
+  //MonitorElement* meHFHadF_Minus_BXm2BXm1Empty;
   MonitorElement* meHFHadF_Plus_BXm1Filled;
   MonitorElement* meHFHadF_Minus_BXm1Filled;
-  MonitorElement* meHFHadF_Plus_BXm2BXm1Filled;
-  MonitorElement* meHFHadF_Minus_BXm2BXm1Filled;
+  //MonitorElement* meHFHadF_Plus_BXm2BXm1Filled;
+  //MonitorElement* meHFHadF_Minus_BXm2BXm1Filled;
 
   MonitorElement* meHFEMF_Plus;
   MonitorElement* meHFEMF_Minus;
   MonitorElement* meHFEMF_Plus_BXm1Empty;
   MonitorElement* meHFEMF_Minus_BXm1Empty;
-  MonitorElement* meHFEMF_Plus_BXm2BXm1Empty;
-  MonitorElement* meHFEMF_Minus_BXm2BXm1Empty;
+  //MonitorElement* meHFEMF_Plus_BXm2BXm1Empty;
+  //MonitorElement* meHFEMF_Minus_BXm2BXm1Empty;
   MonitorElement* meHFEMF_Plus_BXm1Filled;
   MonitorElement* meHFEMF_Minus_BXm1Filled;
-  MonitorElement* meHFEMF_Plus_BXm2BXm1Filled;
-  MonitorElement* meHFEMF_Minus_BXm2BXm1Filled;
-
+  //MonitorElement* meHFEMF_Plus_BXm2BXm1Filled;
+  //MonitorElement* meHFEMF_Minus_BXm2BXm1Filled;
+  /*
   MonitorElement* meMETPhiChargedHadronsBarrel_BXm2BXm1Filled;
   MonitorElement* meMETPhiChargedHadronsEndcapPlus_BXm2BXm1Filled;
   MonitorElement* meMETPhiChargedHadronsEndcapMinus_BXm2BXm1Filled;
@@ -521,7 +525,7 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* meMETPhiHFHadronsMinus_BXm2BXm1Filled;
   MonitorElement* meMETPhiHFEGammasPlus_BXm2BXm1Filled;
   MonitorElement* meMETPhiHFEGammasMinus_BXm2BXm1Filled;
-
+  */
   double ptMinCand_;
 
   // Smallest raw HCAL energy linked to the track

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -83,6 +83,7 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include <map>
 #include <string>
@@ -163,8 +164,10 @@ class METAnalyzer : public DQMEDAnalyzer{
 
   edm::InputTag hbheNoiseFilterResultTag_;
   edm::EDGetTokenT<bool>                          hbheNoiseFilterResultToken_;
+  edm::EDGetTokenT<bool>    hbheIsoNoiseFilterResultToken_;
   edm::InputTag CSCHaloResultTag_;
-  edm::EDGetTokenT<bool>  CSCHaloResultToken_;//leads to problems running later
+  edm::EDGetTokenT<bool>  CSCHaloResultToken_;
+  edm::EDGetTokenT<bool>  CSCHalo2015ResultToken_;
   edm::EDGetTokenT<reco::BeamHaloSummary> BeamHaloSummaryToken_;
   edm::InputTag EcalDeadCellTriggerTag_;
   edm::EDGetTokenT<bool>  EcalDeadCellTriggerToken_;
@@ -304,6 +307,12 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* hMET_2_eeBadScFilter;
   MonitorElement* hMET_EcalDeadCellTriggerFilter;
   MonitorElement* hMET_2_EcalDeadCellTriggerFilter;
+  //only for non miniaod workflows
+  MonitorElement* hMET_HBHEIsoNoiseFilter;
+  MonitorElement* hMET_2_HBHEIsoNoiseFilter;
+  MonitorElement* hMET_CSCTightHalo2015Filter;
+  MonitorElement* hMET_2_CSCTightHalo2015Filter;
+
 
   MonitorElement* hMETPhi;
   MonitorElement* hSumET;
@@ -532,6 +541,8 @@ class METAnalyzer : public DQMEDAnalyzer{
   //PFcandidate maps
   std::vector<MonitorElement* > profilePFCand_x_,profilePFCand_y_,occupancyPFCand_,ptPFCand_,multiplicityPFCand_;
   std::vector<std::string> profilePFCand_x_name_,profilePFCand_y_name_,occupancyPFCand_name_,ptPFCand_name_,multiplicityPFCand_name_;
+  std::vector<MonitorElement* > occupancyPFCand_puppiNolepWeight_,ptPFCand_puppiNolepWeight_;
+  std::vector<std::string> occupancyPFCand_name_puppiNolepWeight_,ptPFCand_name_puppiNolepWeight_;
   std::vector<double> etaMinPFCand_, etaMaxPFCand_, MExPFCand_, MEyPFCand_;
   std::vector<int> typePFCand_, nbinsPFCand_, countsPFCand_, etaNBinsPFCand_;
 
@@ -550,6 +561,7 @@ class METAnalyzer : public DQMEDAnalyzer{
   MonitorElement* meMETPhiHFEGammasMinus;
  
   edm::EDGetTokenT<std::vector<reco::PFCandidate> > pflowToken_;
+  edm::EDGetTokenT<std::vector<pat::PackedCandidate> > pflowPackedToken_;
 
   // NPV profiles --> 
   //----------------------------------------------------------------------------

--- a/DQMOffline/JetMET/python/dataCertificationJetMET_cfi.py
+++ b/DQMOffline/JetMET/python/dataCertificationJetMET_cfi.py
@@ -27,6 +27,9 @@ dataCertificationJetMET = cms.EDAnalyzer('DataCertificationJetMET',
                               jetAlgo        = cms.untracked.string("ak4"),
                               folderName     = cms.untracked.string("JetMET/EventInfo"),  
                               METTypeRECO    = cms.InputTag("pfMETT1"),
+                              #for the uncleaned directory the flag needs to be set accordingly in
+                              #metDQMConfig_cfi.py
+                              METTypeRECOUncleaned = cms.InputTag("pfMet"),
                               METTypeMiniAOD = cms.InputTag("slimmedMETs"),
                               JetTypeRECO    = cms.InputTag("ak4PFJetsCHS"),
                               JetTypeMiniAOD = cms.InputTag("slimmedJets"),

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -11,7 +11,7 @@ jetDQMAnalyzerSequence = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
 
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 
-jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFCHSCleanedMiniAOD)
+jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFCHSCleanedMiniAOD*jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD)
 
 jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMAnalyzerIC5CaloHIUncleaned
                                         * jetDQMMatchAkPu3CaloAkVs3Calo

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -11,7 +11,7 @@ jetDQMAnalyzerSequence = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
 
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 
-jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD)
+jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFCHSCleanedMiniAOD)
 
 jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMAnalyzerIC5CaloHIUncleaned
                                         * jetDQMMatchAkPu3CaloAkVs3Calo

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -166,6 +166,11 @@ jetDQMAnalyzerAk8PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clone(
     fillsubstructure =cms.bool(True),
 )
 
+jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clone(
+    JetType = cms.string('miniaod'),#pf, calo or jpt
+    jetsrc = cms.InputTag("slimmedJetsPuppi"),
+)
+
 jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     filljetHighLevel =cms.bool(True),
     CleaningParameters = cleaningParameters.clone(

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -11,6 +11,8 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
     muonsrc = cms.InputTag("muons"),
     l1algoname = cms.string("L1Tech_BPTX_plus_AND_minus.v0"),
     filljetHighLevel =cms.bool(False),
+    fillsubstructure =cms.bool(False),
+    ptMinBoosted = cms.double(400.),
     #
     #
     #
@@ -18,8 +20,7 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
         andOr         = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
-        hltDBKey       = cms.string( 'jetmet_highptjet' ),
-        hltPaths       = cms.vstring( 'HLT_Jet300_v','HLT_Jet300_v6','HLT_Jet300_v7','HLT_Jet300_v8' ), 
+        hltPaths       = cms.vstring( 'HLT_PFJet450_v*'), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -27,8 +28,7 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
         andOr         = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
-        hltDBKey       = cms.string( 'jetmet_lowptjet' ),
-        hltPaths       = cms.vstring( 'HLT_Jet60_v','HLT_Jet60_v6','HLT_Jet60_v7','HLT_Jet60_v8' ), 
+        hltPaths       = cms.vstring( 'HLT_PFJet80_v*'), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -89,7 +89,7 @@ jetDQMAnalyzerAk4CaloCleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     JetCleaningFlag   = cms.untracked.bool(True),
     filljetHighLevel  = cms.bool(False),
     CleaningParameters = cleaningParameters.clone(
-        bypassAllPVChecks = cms.bool(False),
+        bypassAllPVChecks = cms.bool(True),
     ),
     jetAnalysis=jetDQMParameters.clone(
         ptThreshold = cms.double(20.),
@@ -105,14 +105,12 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
     #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: FIRSTDATA
-    JetIDVersion               = cms.string("FIRSTDATA"),
+    #for PFJets: FIRSTDATA or RUNIISTARTUP (suitable for RECO beyond 7_2_X)
+    JetIDVersion               = cms.string("RUNIISTARTUP"),
     JetType = cms.string('pf'),#pf, calo or jpt
     JetCorrections = cms.InputTag("dqmAk4PFL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJets"),
     METCollectionLabel     = cms.InputTag("pfMet"),
-    #JetCorrections = cms.InputTag("ak4PFCHSL1FastL2L3Corrector"),
-    #jetsrc = cms.InputTag("ak4PFJetsCHS"),
     filljetHighLevel  = cms.bool(False),
     DCSFilterForJetMonitoring = cms.PSet(
       DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
@@ -138,7 +136,6 @@ jetDQMAnalyzerAk4PFCHSCleaned=jetDQMAnalyzerAk4PFCleaned.clone(
     JetCorrections = cms.InputTag("dqmAk4PFCHSL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJetsCHS"),
     METCollectionLabel     = cms.InputTag("pfMETT1"),
-    #actually done only for PFJets at the moment
     InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorCHSDQM","fullDiscriminant"),
     InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorCHSDQM","cutbasedDiscriminant"),
     InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorCHSDQM","fullId"),
@@ -162,6 +159,11 @@ jetDQMAnalyzerAk4PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCleaned.clone(
         ),
     JetType = cms.string('miniaod'),#pf, calo or jpt
     jetsrc = cms.InputTag("slimmedJets"),
+)
+
+jetDQMAnalyzerAk8PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clone(
+    jetsrc = cms.InputTag("slimmedJetsAK8"),
+    fillsubstructure =cms.bool(True),
 )
 
 jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -28,4 +28,4 @@ caloMetDQMAnalyzer.onlyCleaned = cms.untracked.bool(False)
 caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics**HBHENoiseFilterResultProducer*HBHENoiseFilterResultProducer*CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQMMETDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -3,7 +3,20 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
 from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
-from RecoMET.METFilters.metFilters_cff  import *
+from RecoMET.METFilters.metFilters_cff import*
+
+HcalStripHaloFilterDQM=HcalStripHaloFilter.clone(
+    taggingMode = cms.bool(True))
+CSCTightHaloFilterDQM=CSCTightHaloFilter.clone(
+    taggingMode = cms.bool(True))
+CSCTightHalo2015FilterDQM=CSCTightHalo2015Filter.clone(
+    taggingMode = cms.bool(True))
+eeBadScFilterDQM=eeBadScFilter.clone(
+    taggingMode = cms.bool(True))
+EcalDeadCellTriggerPrimitiveFilterDQM=EcalDeadCellTriggerPrimitiveFilter.clone(
+    taggingMode = cms.bool(True))
+EcalDeadCellBoundaryEnergyFilterDQM=EcalDeadCellBoundaryEnergyFilter.clone(
+    taggingMode = cms.bool(True)) 
 
 # empty string: no correction applied
 jetDQMAnalyzerAk4CaloUncleaned.runcosmics = cms.untracked.bool(True)
@@ -15,4 +28,4 @@ caloMetDQMAnalyzer.onlyCleaned = cms.untracked.bool(False)
 caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics**HBHENoiseFilterResultProducer*HBHENoiseFilterResultProducer*CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQMMETDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -15,4 +15,4 @@ caloMetDQMAnalyzer.onlyCleaned = cms.untracked.bool(False)
 caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(metFilters*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
-
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
 from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
@@ -17,4 +15,4 @@ caloMetDQMAnalyzer.onlyCleaned = cms.untracked.bool(False)
 caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(metFilters*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceCosmic_cff.py
@@ -5,6 +5,7 @@ from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
 from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
+from RecoMET.METFilters.metFilters_cff  import *
 
 # empty string: no correction applied
 jetDQMAnalyzerAk4CaloUncleaned.runcosmics = cms.untracked.bool(True)
@@ -16,4 +17,4 @@ caloMetDQMAnalyzer.onlyCleaned = cms.untracked.bool(False)
 caloMetDQMAnalyzer.JetCorrections = cms.InputTag("")
 
 
-jetMETDQMOfflineSourceCosmic = cms.Sequence(HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)
+jetMETDQMOfflineSourceCosmic = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*AnalyzeSUSYDQM*jetDQMAnalyzerSequenceCosmics*METDQMAnalyzerSequenceCosmics)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -6,9 +6,9 @@ from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
 from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
 from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
-
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
+from RecoMET.METFilters.metFilters_cff  import *
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -85,12 +85,13 @@ caloMetDQMAnalyzerMC=caloMetDQMAnalyzer.clone(JetCorrections    = cms.InputTag("
 pfMetDQMAnalyzerMC=pfMetDQMAnalyzer.clone(JetCorrections      = cms.InputTag("dqmAk4PFL1FastL2L3Corrector"))
 pfMetT1DQMAnalyzerMC=pfMetT1DQMAnalyzer.clone(JetCorrections    = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"))
 
-jetMETDQMOfflineSource = cms.Sequence(HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3CorrectorChain*dqmAk4PFL1FastL2L3CorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
                                       dqmCorrPfMetType1*pfMETT1*
-                                      jetDQMAnalyzerSequence*METDQMAnalyzerSequence)
+                                      jetDQMAnalyzerAk4CaloCleanedMC*jetDQMAnalyzerAk4PFUncleanedMC*jetDQMAnalyzerAk4PFCleanedMC*jetDQMAnalyzerAk4PFCHSCleanedMC*
+                                      caloMetDQMAnalyzerMC*pfMetDQMAnalyzerMC*pfMetT1DQMAnalyzerMC)
 
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD*jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -83,13 +83,13 @@ caloMetDQMAnalyzerMC=caloMetDQMAnalyzer.clone(JetCorrections    = cms.InputTag("
 pfMetDQMAnalyzerMC=pfMetDQMAnalyzer.clone(JetCorrections      = cms.InputTag("dqmAk4PFL1FastL2L3Corrector"))
 pfMetT1DQMAnalyzerMC=pfMetT1DQMAnalyzer.clone(JetCorrections    = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"))
 
-jetMETDQMOfflineSource = cms.Sequence(metFilters*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3CorrectorChain*dqmAk4PFL1FastL2L3CorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
                                       dqmCorrPfMetType1*pfMETT1*
                                       jetDQMAnalyzerAk4CaloCleanedMC*jetDQMAnalyzerAk4PFUncleanedMC*jetDQMAnalyzerAk4PFCleanedMC*jetDQMAnalyzerAk4PFCHSCleanedMC*
-                                      caloMetDQMAnalyzerMC*pfMetDQMAnalyzerMC*pfMetT1DQMAnalyzerMC)
+                                      HBHENoiseFilterResultProducer*caloMetDQMAnalyzerMC*pfMetDQMAnalyzerMC*pfMetT1DQMAnalyzerMC)
 
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD*jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
-
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
 from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
@@ -85,7 +83,7 @@ caloMetDQMAnalyzerMC=caloMetDQMAnalyzer.clone(JetCorrections    = cms.InputTag("
 pfMetDQMAnalyzerMC=pfMetDQMAnalyzer.clone(JetCorrections      = cms.InputTag("dqmAk4PFL1FastL2L3Corrector"))
 pfMetT1DQMAnalyzerMC=pfMetT1DQMAnalyzer.clone(JetCorrections    = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"))
 
-jetMETDQMOfflineSource = cms.Sequence(metFilters*HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(metFilters*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -6,8 +6,20 @@ from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
 from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
-from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import*
+from RecoMET.METFilters.metFilters_cff import*
 
+HcalStripHaloFilterDQM=HcalStripHaloFilter.clone(
+    taggingMode = cms.bool(True))
+CSCTightHaloFilterDQM=CSCTightHaloFilter.clone(
+    taggingMode = cms.bool(True))
+CSCTightHalo2015FilterDQM=CSCTightHalo2015Filter.clone(
+    taggingMode = cms.bool(True))
+eeBadScFilterDQM=eeBadScFilter.clone(
+    taggingMode = cms.bool(True))
+EcalDeadCellTriggerPrimitiveFilterDQM=EcalDeadCellTriggerPrimitiveFilter.clone(
+    taggingMode = cms.bool(True))
+EcalDeadCellBoundaryEnergyFilterDQM=EcalDeadCellBoundaryEnergyFilter.clone(
+    taggingMode = cms.bool(True)) 
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -92,9 +104,8 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
-                                      goodOfflinePrimaryVerticesDQM*
-                                      jetDQMAnalyzerSequence*
-                                      HBHENoiseFilterResultProducer*
-                                      dqmCorrPfMetType1*pfMETT1*
-                                      METDQMAnalyzerSequence)
+                                      goodOfflinePrimaryVerticesDQM*                                                                            
+                                      dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*HBHENoiseFilterResultProducer*
+                                      CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQM
+                                      *METDQMAnalyzerSequence)
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD*jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -8,6 +8,14 @@ from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
 from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
+from RecoMET.METFilters.metFilters_cff  import *
+
+
+#from RecoMET.METFilters.CSCTightHaloFilter_cfi import *
+#from RecoMET.METFilters.eeBadScFilter_cfi import *
+#from RecoMET.METFilters.EcalDeadCellTriggerPrimitiveFilter_cfi import *
+#from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
+#from RecoMET.METFilters.primaryVertexFilter_cfi import *
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -70,6 +78,8 @@ dqmAk4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
     dqmAk4PFCHSL1FastL2L3Corrector
 )
 
+HBHENoiseFilterResultProducerDQM=HBHENoiseFilterResultProducer.clone()
+
 jetPreDQMSeq=cms.Sequence(ak4CaloL2RelativeCorrector*ak4CaloL3AbsoluteCorrector*ak4CaloResidualCorrector*
                           ak4PFL1FastjetCorrector*ak4PFL2RelativeCorrector*ak4PFL3AbsoluteCorrector*ak4PFResidualCorrector*
                           ak4PFCHSL1FastjetCorrector*ak4PFCHSL2RelativeCorrector*ak4PFCHSL3AbsoluteCorrector*ak4PFCHSResidualCorrector)
@@ -85,7 +95,10 @@ pfMETT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
         cms.InputTag('dqmCorrPfMetType1', 'type1')
         ))
 
-jetMETDQMOfflineSource = cms.Sequence(HBHENoiseFilterResultProducer*goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(#HBHENoiseFilterResultProducerDQM*primaryVertexFilter*
+                                      #CSCTightHaloFilter*EcalDeadCellTriggerPrimitiveFilter*eeBadScFilter* 
+                                      metFilters*
+                                      goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
-
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
 from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
@@ -9,13 +7,6 @@ from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
 from RecoMET.METFilters.metFilters_cff  import *
-
-
-#from RecoMET.METFilters.CSCTightHaloFilter_cfi import *
-#from RecoMET.METFilters.eeBadScFilter_cfi import *
-#from RecoMET.METFilters.EcalDeadCellTriggerPrimitiveFilter_cfi import *
-#from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import *
-#from RecoMET.METFilters.primaryVertexFilter_cfi import *
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -95,9 +86,7 @@ pfMETT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
         cms.InputTag('dqmCorrPfMetType1', 'type1')
         ))
 
-jetMETDQMOfflineSource = cms.Sequence(#HBHENoiseFilterResultProducerDQM*primaryVertexFilter*
-                                      #CSCTightHaloFilter*EcalDeadCellTriggerPrimitiveFilter*eeBadScFilter* 
-                                      metFilters*
+jetMETDQMOfflineSource = cms.Sequence(metFilters*
                                       goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -6,7 +6,8 @@ from DQMOffline.JetMET.SUSYDQMAnalyzer_cfi  import *
 from DQMOffline.JetMET.goodOfflinePrimaryVerticesDQM_cfi import *
 from RecoJets.JetProducers.PileupJetID_cfi  import *
 from RecoJets.JetProducers.QGTagger_cfi  import *
-from RecoMET.METFilters.metFilters_cff  import *
+from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import*
+
 
 pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
     jets = cms.InputTag("ak4PFJets"),
@@ -86,12 +87,14 @@ pfMETT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
         cms.InputTag('dqmCorrPfMetType1', 'type1')
         ))
 
-jetMETDQMOfflineSource = cms.Sequence(metFilters*
-                                      goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
+                                      goodOfflinePrimaryVerticesDQM*
+                                      jetDQMAnalyzerSequence*
+                                      HBHENoiseFilterResultProducer*
                                       dqmCorrPfMetType1*pfMETT1*
-                                      jetDQMAnalyzerSequence*METDQMAnalyzerSequence)
+                                      METDQMAnalyzerSequence)
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD*jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -105,7 +105,7 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
                                       goodOfflinePrimaryVerticesDQM*                                                                            
-                                      dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*HBHENoiseFilterResultProducer*
+                                      dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
                                       CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQM
                                       *METDQMAnalyzerSequence)
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD*jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD)

--- a/DQMOffline/JetMET/python/metDQMConfig_cff.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cff.py
@@ -5,7 +5,7 @@ from DQMOffline.JetMET.metDQMConfig_cfi import *
 #correction for type 1 done in JetMETDQMOfflineSource now
 METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer)
 
-METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD)
+METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD*pfPuppiMetDQMAnalyzerMiniAOD)
 
 METDQMAnalyzerSequenceCosmics = cms.Sequence(caloMetDQMAnalyzer)
 

--- a/DQMOffline/JetMET/python/metDQMConfig_cff.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.JetMET.metDQMConfig_cfi import *
 
 #correction for type 1 done in JetMETDQMOfflineSource now
-METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfMetT1DQMAnalyzer)
+METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer)
 
 METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD)
 

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -22,14 +22,18 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
     
     FolderName = cms.untracked.string("JetMET/MET/"),
 
-    fillMetHighLevel = cms.bool(True),
+    fillMetHighLevel = cms.bool(True),#fills lumi overview plots
 
     fillCandidateMaps = cms.bool(False),
 
-    CleaningParameters = cleaningParameters.clone(),
+    CleaningParameters = cleaningParameters.clone(       
+        bypassAllPVChecks = cms.bool(True),#needed for 0T running
+        ),
     METDiagonisticsParameters = multPhiCorr_METDiagnostics,
 
     TriggerResultsLabel  = cms.InputTag("TriggerResults::HLT"),
+    FilterResultsLabelMiniAOD  = cms.InputTag("TriggerResults::RECO"),
+    FilterResultsLabelMiniAOD2  = cms.InputTag("TriggerResults::reRECO"),
 
     onlyCleaned                = cms.untracked.bool(True),
     runcosmics                 = cms.untracked.bool(False),  
@@ -46,7 +50,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
 #        hltDBKey       = cms.string( 'jetmet_highptjet' ), #overrides hltPaths!
-        hltPaths       = cms.vstring( 'HLT_PFJet400_v*' ), 
+        hltPaths       = cms.vstring( 'HLT_PFJet450_v*' ), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -73,7 +77,7 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
 #        hltDBKey       = cms.string( 'jetmet_highmet' ),#overrides hltPaths!
-        hltPaths       = cms.vstring( 'HLT_MET400_v*' ), 
+        hltPaths       = cms.vstring( 'HLT_MET250_v*' ), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
@@ -91,15 +95,18 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
 #        hltDBKey       = cms.string( 'jetmet_muon' ),#overrides hltPaths!
-        hltPaths       = cms.vstring( 'HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu24_v*'), 
+        hltPaths       = cms.vstring( 'HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu27_v*'), 
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ) 
     ),
     
-    HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"),
-    #HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResultRun2Loose"),  
+    HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"), 
     HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResult"),  
+    BeamHaloSummaryLabel = cms.InputTag("BeamHaloSummary"),
+    CSCHaloResultLabel = cms.InputTag("CSCTightHaloFilter"), 
+    EcalDeadCellTriggerLabel = cms.InputTag("EcalDeadCellTriggerPrimitiveFilter"), 
+    eeBadScFilterLabel = cms.InputTag("eeBadScFilter"), 
 
 #    HighPtJetThreshold = cms.double(60.),
 #    LowPtJetThreshold  = cms.double(15.),
@@ -127,6 +134,9 @@ pfMetDQMAnalyzer = caloMetDQMAnalyzer.clone(
     srcPFlow = cms.InputTag('particleFlow', ''),
     JetCollectionLabel  = cms.InputTag("ak4PFJets"),
     JetCorrections = cms.InputTag("dqmAk4PFL1FastL2L3ResidualCorrector"),
+    CleaningParameters = cleaningParameters.clone(       
+        bypassAllPVChecks = cms.bool(False),
+        ),
     fillMetHighLevel = cms.bool(False),
     fillCandidateMaps = cms.bool(True),
     onlyCleaned                = cms.untracked.bool(False),
@@ -136,6 +146,14 @@ pfMetDQMAnalyzer = caloMetDQMAnalyzer.clone(
         Filter = cms.untracked.bool(True)
         ),
 )
+pfChMetDQMAnalyzer = pfMetDQMAnalyzer.clone(
+     METCollectionLabel     = cms.InputTag("pfChMet"),
+     fillCandidateMaps = cms.bool(False),
+     onlyCleaned                = cms.untracked.bool(True),
+ )
+
+
+
 #both CaloMET and type1 MET only cleaned plots are filled
 pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
     METType=cms.untracked.string('pf'),
@@ -143,6 +161,9 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
     srcPFlow = cms.InputTag('particleFlow', ''),
     JetCollectionLabel  = cms.InputTag("ak4PFJetsCHS"),
     JetCorrections = cms.InputTag("dqmAk4PFCHSL1FastL2L3ResidualCorrector"),
+    CleaningParameters = cleaningParameters.clone(       
+        bypassAllPVChecks = cms.bool(False),
+        ),
     fillMetHighLevel = cms.bool(False),
     fillCandidateMaps = cms.bool(False),
     DCSFilter = cms.PSet(
@@ -151,7 +172,7 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
         ),
 )
 pfMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzer.clone(
-    fillMetHighLevel = cms.bool(False),
+    fillMetHighLevel = cms.bool(True),#fills only lumisec plots
     fillCandidateMaps = cms.bool(False),
     CleaningParameters = cleaningParameters.clone(
         vertexCollection    = cms.InputTag( "goodOfflinePrimaryVerticesDQMforMiniAOD" ),

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -101,19 +101,19 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
         errorReplyHlt  = cms.bool( False ),
     ) 
     ),
-    
-    HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"), 
-    HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResult"),  
-    HBHEIsoNoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHEIsoNoiseFilterResult"), # not yet in miniaod
-    BeamHaloSummaryLabel = cms.InputTag("BeamHaloSummary"),
-    CSCHaloResultLabel = cms.InputTag("CSCTightHaloFilter"), 
-    CSCHalo2015ResultLabel = cms.InputTag("CSCTightHalo2015Filter"), 
-    EcalDeadCellTriggerLabel = cms.InputTag("EcalDeadCellTriggerPrimitiveFilter"), 
-    eeBadScFilterLabel = cms.InputTag("eeBadScFilter"), 
+ 
+    HBHENoiseLabelMiniAOD = cms.string("Flag_HBHENoiseFilter"),
+    HBHEIsoNoiseLabelMiniAOD = cms.string("Flag_HBHEIsoNoiseFilter"),
 
-#    HighPtJetThreshold = cms.double(60.),
-#    LowPtJetThreshold  = cms.double(15.),
-#    HighMETThreshold   = cms.double(110.),
+    HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"), 
+    HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResult"),
+    HBHENoiseIsoFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHEIsoNoiseFilterResult"),
+    CSCHaloResultLabel = cms.InputTag("CSCTightHaloFilterDQM"), 
+    CSCHalo2015ResultLabel = cms.InputTag("CSCTightHalo2015FilterDQM"), 
+    EcalDeadCellTriggerPrimitiveFilterLabel = cms.InputTag("EcalDeadCellTriggerPrimitiveFilterDQM"), 
+    EcalDeadCellBoundaryEnergyFilterLabel = cms.InputTag("EcalDeadCellBoundaryEnergyFilterDQM"), 
+    eeBadScFilterLabel = cms.InputTag("eeBadScFilterDQM"), 
+    HcalStripHaloFilterLabel = cms.InputTag("HcalStripHaloFilterDQM"),
 
     #if changed here, change certification module input in same manner and injetDQMconfig
     pVBin       = cms.int32(100),
@@ -142,6 +142,8 @@ pfMetDQMAnalyzer = caloMetDQMAnalyzer.clone(
         ),
     fillMetHighLevel = cms.bool(False),
     fillCandidateMaps = cms.bool(True),
+    # if this flag is changed, the METTypeRECOUncleaned flag in dataCertificationJetMET_cfi.py
+    #has to be updated (by a string not pointing to an existing directory)
     onlyCleaned                = cms.untracked.bool(False),
     DCSFilter = cms.PSet(
         DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
@@ -188,7 +190,7 @@ pfMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzer.clone(
     JetCorrections = cms.InputTag(""),#not called, since corrected by default
 )
 pfPuppiMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzerMiniAOD.clone(
-    fillMetHighLevel = cms.bool(True),#fills only lumisec plots
+    fillMetHighLevel = cms.bool(False),#fills only lumisec plots
     fillCandidateMaps = cms.bool(True),
     METType=cms.untracked.string('miniaod'),
     METCollectionLabel     = cms.InputTag("slimmedMETsPuppi"),

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.JetMET.jetMETDQMCleanup_cff import *
 from DQMOffline.JetMET.metDiagnosticParameterSet_cfi import *
+from DQMOffline.JetMET.metDiagnosticParameterSetMiniAOD_cfi import *
 
 #jet corrector defined in jetMETDQMOfflineSource python file
 
@@ -103,8 +104,10 @@ caloMetDQMAnalyzer = cms.EDAnalyzer("METAnalyzer",
     
     HcalNoiseRBXCollection     = cms.InputTag("hcalnoise"), 
     HBHENoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHENoiseFilterResult"),  
+    HBHEIsoNoiseFilterResultLabel = cms.InputTag("HBHENoiseFilterResultProducer", "HBHEIsoNoiseFilterResult"), # not yet in miniaod
     BeamHaloSummaryLabel = cms.InputTag("BeamHaloSummary"),
     CSCHaloResultLabel = cms.InputTag("CSCTightHaloFilter"), 
+    CSCHalo2015ResultLabel = cms.InputTag("CSCTightHalo2015Filter"), 
     EcalDeadCellTriggerLabel = cms.InputTag("EcalDeadCellTriggerPrimitiveFilter"), 
     eeBadScFilterLabel = cms.InputTag("eeBadScFilter"), 
 
@@ -174,11 +177,21 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
 pfMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzer.clone(
     fillMetHighLevel = cms.bool(True),#fills only lumisec plots
     fillCandidateMaps = cms.bool(False),
+    srcPFlow = cms.InputTag('packedPFCandidates', ''),
+    METDiagonisticsParameters = multPhiCorr_METDiagnosticsMiniAOD,
     CleaningParameters = cleaningParameters.clone(
         vertexCollection    = cms.InputTag( "goodOfflinePrimaryVerticesDQMforMiniAOD" ),
         ),
     METType=cms.untracked.string('miniaod'),
     METCollectionLabel     = cms.InputTag("slimmedMETs"),
     JetCollectionLabel  = cms.InputTag("slimmedJets"),
+    JetCorrections = cms.InputTag(""),#not called, since corrected by default
+)
+pfPuppiMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzerMiniAOD.clone(
+    fillMetHighLevel = cms.bool(True),#fills only lumisec plots
+    fillCandidateMaps = cms.bool(True),
+    METType=cms.untracked.string('miniaod'),
+    METCollectionLabel     = cms.InputTag("slimmedMETsPuppi"),
+    JetCollectionLabel  = cms.InputTag("slimmedJetsPuppi"),
     JetCorrections = cms.InputTag(""),#not called, since corrected by default
 )

--- a/DQMOffline/JetMET/python/metDiagnosticParameterSetMiniAOD_cfi.py
+++ b/DQMOffline/JetMET/python/metDiagnosticParameterSetMiniAOD_cfi.py
@@ -1,11 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 import math
 
-
-multPhiCorr_METDiagnostics = cms.VPSet(
+multPhiCorr_METDiagnosticsMiniAOD = cms.VPSet(
     cms.PSet(
         name=cms.string("h"),
-        type=cms.int32(1),
+        type=cms.int32(211),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(7500),
@@ -18,7 +17,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     cms.PSet(
         name=cms.string("h0Barrel"),
-        type=cms.int32(5),
+        type=cms.int32(130),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(250),
@@ -31,7 +30,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     #cms.PSet(
         #name=cms.string("h0EndcapPlus"),
-        #type=cms.int32(5),
+        #type=cms.int32(130),
         #nbins=cms.double(250),
         #nMin=cms.int32(0),
         #nMax=cms.int32(250),
@@ -44,7 +43,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         #),
     cms.PSet(
         name=cms.string("h0Endcap"),
-        type=cms.int32(5),
+        type=cms.int32(130),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(250),
@@ -57,11 +56,11 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     cms.PSet(
         name=cms.string("gammaBarrel"),
-        type=cms.int32(4),
+        type=cms.int32(22),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(2500),
-        etaNBins=cms.int32(75),
+        etaNBins=cms.int32(170),
         etaMin=cms.double(-1.479),
         etaMax=cms.double(1.479),
         phiNBins=cms.int32(120),
@@ -70,7 +69,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     #cms.PSet(
         #name=cms.string("gammaEndcapPlus"),
-        #type=cms.int32(4),
+        #type=cms.int32(22),
         #nbins=cms.double(125),
         #nMin=cms.int32(0),
         #nMax=cms.int32(750),
@@ -83,7 +82,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         #),
     cms.PSet(
         name=cms.string("gammaEndcap"),
-        type=cms.int32(4),
+        type=cms.int32(22),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(750),
@@ -96,7 +95,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     #cms.PSet(
         #name=cms.string("gammaForwardPlus"),
-        #type=cms.int32(4),
+        #type=cms.int32(22),
         #nbins=cms.double(50),
         #nMin=cms.int32(0),
         #nMax=cms.int32(50),
@@ -109,7 +108,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         #),
     cms.PSet(
         name=cms.string("gammaForward"),
-        type=cms.int32(4),
+        type=cms.int32(22),
         nbins=cms.double(50),
         nMin=cms.int32(0),
         nMax=cms.int32(50),
@@ -122,7 +121,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     cms.PSet(
         name=cms.string("e"),
-        type=cms.int32(2),
+        type=cms.int32(11),
         nbins=cms.double(50),
         nMin=cms.int32(0),
         nMax=cms.int32(50),
@@ -135,7 +134,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     cms.PSet(
         name=cms.string("mu"),
-        type=cms.int32(3),
+        type=cms.int32(13),
         nbins=cms.double(50),
         nMin=cms.int32(0),
         nMax=cms.int32(50),
@@ -148,7 +147,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     cms.PSet(
         name=cms.string("hHF"),
-        type=cms.int32(6),
+        type=cms.int32(1),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(1250),
@@ -161,7 +160,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     #cms.PSet(
         #name=cms.string("hHFPlus"),
-        #type=cms.int32(6),
+        #type=cms.int32(1),
         #nbins=cms.double(125),
         #nMin=cms.int32(0),
         #nMax=cms.int32(1250),
@@ -174,7 +173,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         #),
     cms.PSet(
         name=cms.string("egammaHF"),
-        type=cms.int32(7),
+        type=cms.int32(2),
         nbins=cms.double(125),
         nMin=cms.int32(0),
         nMax=cms.int32(1250),
@@ -187,7 +186,7 @@ multPhiCorr_METDiagnostics = cms.VPSet(
         ),
     #cms.PSet(
         #name=cms.string("egammaHFPlus"),
-        #type=cms.int32(7),
+        #type=cms.int32(2),
         #nbins=cms.double(125),
         #nMin=cms.int32(0),
         #nMax=cms.int32(1250),

--- a/DQMOffline/JetMET/src/DataCertificationJetMET.cc
+++ b/DQMOffline/JetMET/src/DataCertificationJetMET.cc
@@ -19,6 +19,7 @@ DataCertificationJetMET::DataCertificationJetMET(const edm::ParameterSet& iConfi
 {
   // now do what ever initialization is needed
   inputMETLabelRECO_=iConfig.getParameter<edm::InputTag>("METTypeRECO");
+  inputMETLabelRECOUncleaned_=iConfig.getParameter<edm::InputTag>("METTypeRECOUncleaned");
   inputMETLabelMiniAOD_=iConfig.getParameter<edm::InputTag>("METTypeMiniAOD");
   inputJetLabelRECO_=iConfig.getParameter<edm::InputTag>("JetTypeRECO");
   inputJetLabelMiniAOD_=iConfig.getParameter<edm::InputTag>("JetTypeMiniAOD");
@@ -93,6 +94,89 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
     ibook_.setCurrentFolder(subDirVecMET[i]);  
     if((subDirVecMET[i]+"/Cleaned")==(RunDirMET+inputMETLabelRECO_.label()+"/Cleaned")){
       found_METreco_dir=true;
+    }
+    if( ((subDirVecMET[i]+"/Uncleaned")==(RunDirMET+inputMETLabelRECOUncleaned_.label()+"/Uncleaned")) || ((subDirVecMET[i]+"/Uncleaned")==(RunDirMET+inputMETLabelMiniAOD_.label()+"/Uncleaned"))){
+      //check filters in uncleaned directory
+      std::string rundirMET_reco="";
+      if((subDirVecMET[i]+"/Uncleaned")==(RunDirMET+inputMETLabelRECOUncleaned_.label()+"/Uncleaned")){
+	rundirMET_reco = RunDirMET+inputMETLabelRECOUncleaned_.label()+"/Uncleaned";
+      }else{
+	rundirMET_reco = RunDirMET+inputMETLabelMiniAOD_.label()+"/Uncleaned";
+      }
+      MonitorElement* mMET_Reco=iget_.get(rundirMET_reco+"/"+"MET");
+      MonitorElement* mMET_Reco_HBHENoiseFilter=iget_.get(rundirMET_reco+"/"+"MET_HBHENoiseFilter");
+      MonitorElement* mMET_Reco_CSCTightHaloFilter=iget_.get(rundirMET_reco+"/"+"MET_CSCTightHaloFilter");
+      MonitorElement* mMET_Reco_eeBadScFilter=iget_.get(rundirMET_reco+"/"+"MET_eeBadScFilter");
+      MonitorElement* mMET_Reco_HBHEIsoNoiseFilter=iget_.get(rundirMET_reco+"/"+"MET_HBHEIsoNoiseFilter");
+      MonitorElement* mMET_Reco_CSCTightHalo2015Filter=iget_.get(rundirMET_reco+"/"+"MET_CSCTightHalo2015Filter");
+      MonitorElement* mMET_Reco_EcalDeadCellTriggerFilter=iget_.get(rundirMET_reco+"/"+"MET_EcalDeadCellTriggerFilter");
+      MonitorElement* mMET_Reco_EcalDeadCellBoundaryFilter=iget_.get(rundirMET_reco+"/"+"MET_EcalDeadCellBoundaryFilter");
+      MonitorElement* mMET_Reco_HcalStripHaloFilter=iget_.get(rundirMET_reco+"/"+"MET_HcalStripHaloFilter");
+      ibook_.setCurrentFolder(rundirMET_reco);
+      mMET_EffHBHENoiseFilter=ibook_.book1D("MET_EffHBHENoiseFilter",(TH1F*)mMET_Reco_HBHENoiseFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffHBHENoiseFilter->setBinContent(i,mMET_Reco_HBHENoiseFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffHBHENoiseFilter->setBinContent(i,0);
+	}
+      }
+      mMET_EffCSCTightHaloFilter=ibook_.book1D("MET_EffCSCTightHaloFilter",(TH1F*)mMET_Reco_CSCTightHaloFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffCSCTightHaloFilter->setBinContent(i,mMET_Reco_CSCTightHaloFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffCSCTightHaloFilter->setBinContent(i,0);
+	}
+      }
+      mMET_EffeeBadScFilter=ibook_.book1D("MET_EffeeBadScFilter",(TH1F*)mMET_Reco_eeBadScFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffeeBadScFilter->setBinContent(i,mMET_Reco_eeBadScFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffeeBadScFilter->setBinContent(i,0);
+	}
+      }
+      mMET_EffHBHEIsoNoiseFilter=ibook_.book1D("MET_EffHBHEIsoNoiseFilter",(TH1F*)mMET_Reco_HBHEIsoNoiseFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffHBHEIsoNoiseFilter->setBinContent(i,mMET_Reco_HBHEIsoNoiseFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffHBHEIsoNoiseFilter->setBinContent(i,0);
+	}
+      }
+      mMET_EffCSCTightHalo2015Filter=ibook_.book1D("MET_EffCSCTightHalo2015Filter",(TH1F*)mMET_Reco_CSCTightHalo2015Filter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffCSCTightHalo2015Filter->setBinContent(i,mMET_Reco_CSCTightHalo2015Filter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffCSCTightHalo2015Filter->setBinContent(i,0);
+	}
+      }
+      mMET_EffEcalDeadCellTriggerFilter=ibook_.book1D("MET_EffEcalDeadCellTriggerFilter",(TH1F*)mMET_Reco_EcalDeadCellTriggerFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffEcalDeadCellTriggerFilter->setBinContent(i,mMET_Reco_EcalDeadCellTriggerFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffEcalDeadCellTriggerFilter->setBinContent(i,0);
+	}
+      }
+      mMET_EffEcalDeadCellBoundaryFilter=ibook_.book1D("MET_EffEcalDeadCellBoundaryFilter",(TH1F*)mMET_Reco_EcalDeadCellBoundaryFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffEcalDeadCellBoundaryFilter->setBinContent(i,mMET_Reco_EcalDeadCellBoundaryFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffEcalDeadCellBoundaryFilter->setBinContent(i,0);
+	}
+      }
+      mMET_EffHcalStripHaloFilter=ibook_.book1D("MET_EffHcalStripHaloFilter",(TH1F*)mMET_Reco_HcalStripHaloFilter->getRootObject());
+      for(int i=0;i<=(mMET_Reco->getNbinsX()+1);i++){
+	if(mMET_Reco->getBinContent(i)!=0){
+	  mMET_EffHcalStripHaloFilter->setBinContent(i,mMET_Reco_HcalStripHaloFilter->getBinContent(i)/mMET_Reco->getBinContent(i));
+	}else{
+	  mMET_EffHcalStripHaloFilter->setBinContent(i,0);
+	}
+      }
     }
     if((subDirVecMET[i]+"/Cleaned")==(RunDirMET+inputMETLabelMiniAOD_.label()+"/Cleaned")){
       found_METminiaod_dir=true;

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -845,7 +845,7 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PhEn_highPt_EndCap" ,mPhEn_highPt_EndCap));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"ElEn_highPt_EndCap" ,mElEn_highPt_EndCap));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MuEn_highPt_EndCap" ,mMuEn_highPt_EndCap));
-
+    /*
     //now get handle on OOT PU
     mePhFracBarrel_BXm2BXm1Empty          = ibooker.book1D("PhFracBarrel_BXm2BXm1Empty",        "PHFrac prev empty 2 bunches (Barrel)",         50, 0,    1);
     mePhFracBarrel_BXm2BXm1Filled        = ibooker.book1D("PhFracBarrel_BXm2BXm1Filled",      "PHFrac prev filled 2 bunches (Barrel)",         50, 0,    1);
@@ -924,7 +924,7 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PtForwardMinus_BXm2BXm1Filled"  ,mePtForwardMinus_BXm2BXm1Filled));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"Eta_BXm2BXm1Empty"  ,meEta_BXm2BXm1Empty));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"Eta_BXm2BXm1Filled",meEta_BXm2BXm1Filled));
- 
+    */
     mePhFracBarrel_BXm1Empty          = ibooker.book1D("PhFracBarrel_BXm1Empty",        "PHFrac prev empty 1 bunch (Barrel)",         50, 0,    1);
     mePhFracBarrel_BXm1Filled        = ibooker.book1D("PhFracBarrel_BXm1Filled",      "PHFrac prev filled 1 bunch (Barrel)",         50, 0,    1);
     meNHFracBarrel_BXm1Empty   = ibooker.book1D("NHFracBarrel_BXm1Empty",   "NHFrac prev empty 1 bunch (Barrel)",         50, 0,    1);
@@ -1807,7 +1807,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if (verbose_) std::cout << "JetAnalyzer: Could not find GT readout record product" << std::endl;
   }
 
-  bool techTriggerResultBxE = false;
+  //bool techTriggerResultBxE = false;
   bool techTriggerResultBxF = false;
   bool techTriggerResultBx0 = false;
 
@@ -1816,7 +1816,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if (verbose_) std::cout << "CaloMETAnalyzer: Could not find GT readout record product" << std::endl;
   }else{
     // trigger results before mask for BxInEvent -2 (E), -1 (F), 0 (L1A), 1, 2 
-    const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBxE = gtReadoutRecord->technicalTriggerWord(-2);
+    //const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBxE = gtReadoutRecord->technicalTriggerWord(-2);
     const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBxF = gtReadoutRecord->technicalTriggerWord(-1);
     const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBx0 = gtReadoutRecord->technicalTriggerWord();
     //const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBxG = gtReadoutRecord->technicalTriggerWord(1);
@@ -1824,7 +1824,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if (m_bitAlgTechTrig_ > -1 && technicalTriggerWordBeforeMaskBx0.size() > 0) {
       techTriggerResultBx0 = technicalTriggerWordBeforeMaskBx0.at(m_bitAlgTechTrig_);
       if(techTriggerResultBx0!=0){
-	techTriggerResultBxE = technicalTriggerWordBeforeMaskBxE.at(m_bitAlgTechTrig_);
+	//techTriggerResultBxE = technicalTriggerWordBeforeMaskBxE.at(m_bitAlgTechTrig_);
 	techTriggerResultBxF = technicalTriggerWordBeforeMaskBxF.at(m_bitAlgTechTrig_);
       }	
     }
@@ -2397,6 +2397,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	  }
 	}
 	//OOT plots
+	/*
 	if(techTriggerResultBx0 && techTriggerResultBxE && techTriggerResultBxF){
 	  meEta_BXm2BXm1Filled    = map_of_MEs[DirName+"/"+"Eta_BXm2BXm1Filled"];     if (  meEta_BXm2BXm1Filled  && meEta_BXm2BXm1Filled ->getRootObject())  meEta_BXm2BXm1Filled  ->Fill((*pfJets)[ijet].eta());
 	  if(fabs(correctedJet.eta()) <= 1.3) {
@@ -2423,7 +2424,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	    meHFHFracPlus_BXm2BXm1Filled    = map_of_MEs[DirName+"/"+"HFHFracPlus_BXm2BXm1Filled"];     if (  meHFHFracPlus_BXm2BXm1Filled  && meHFHFracPlus_BXm2BXm1Filled ->getRootObject())  meHFHFracPlus_BXm2BXm1Filled  ->Fill((*pfJets)[ijet].HFHadronEnergyFraction());
 	    meHFEMFracPlus_BXm2BXm1Filled    = map_of_MEs[DirName+"/"+"HFEMFracPlus_BXm2BXm1Filled"];     if (  meHFEMFracPlus_BXm2BXm1Filled  && meHFEMFracPlus_BXm2BXm1Filled ->getRootObject())  meHFEMFracPlus_BXm2BXm1Filled  ->Fill((*pfJets)[ijet].HFEMEnergyFraction());
 	  }
-	}
+	  }*/
 	if(techTriggerResultBx0 && techTriggerResultBxF){
 	  meEta_BXm1Filled    = map_of_MEs[DirName+"/"+"Eta_BXm1Filled"];     if (  meEta_BXm1Filled  && meEta_BXm1Filled ->getRootObject())  meEta_BXm1Filled  ->Fill((*pfJets)[ijet].eta());
 	  if(fabs(correctedJet.eta()) <= 1.3) {
@@ -2450,7 +2451,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	    meHFHFracPlus_BXm1Filled    = map_of_MEs[DirName+"/"+"HFHFracPlus_BXm1Filled"];     if (  meHFHFracPlus_BXm1Filled  && meHFHFracPlus_BXm1Filled ->getRootObject())  meHFHFracPlus_BXm1Filled  ->Fill((*pfJets)[ijet].HFHadronEnergyFraction());
 	    meHFEMFracPlus_BXm1Filled    = map_of_MEs[DirName+"/"+"HFEMFracPlus_BXm1Filled"];     if (  meHFEMFracPlus_BXm1Filled  && meHFEMFracPlus_BXm1Filled ->getRootObject())  meHFEMFracPlus_BXm1Filled  ->Fill((*pfJets)[ijet].HFEMEnergyFraction());
 	  }
-	}
+	}/*
 	if(techTriggerResultBx0 && !techTriggerResultBxE && !techTriggerResultBxF){
 	  meEta_BXm2BXm1Empty    = map_of_MEs[DirName+"/"+"Eta_BXm2BXm1Empty"];     if (  meEta_BXm2BXm1Empty  && meEta_BXm2BXm1Empty ->getRootObject())  meEta_BXm2BXm1Empty  ->Fill((*pfJets)[ijet].eta());
 	  if(fabs(correctedJet.eta()) <= 1.3) {
@@ -2477,7 +2478,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	    meHFHFracPlus_BXm2BXm1Empty    = map_of_MEs[DirName+"/"+"HFHFracPlus_BXm2BXm1Empty"];     if (  meHFHFracPlus_BXm2BXm1Empty  && meHFHFracPlus_BXm2BXm1Empty ->getRootObject())  meHFHFracPlus_BXm2BXm1Empty  ->Fill((*pfJets)[ijet].HFHadronEnergyFraction());
 	    meHFEMFracPlus_BXm2BXm1Empty    = map_of_MEs[DirName+"/"+"HFEMFracPlus_BXm2BXm1Empty"];     if (  meHFEMFracPlus_BXm2BXm1Empty  && meHFEMFracPlus_BXm2BXm1Empty ->getRootObject())  meHFEMFracPlus_BXm2BXm1Empty  ->Fill((*pfJets)[ijet].HFEMEnergyFraction());
 	  }
-	}
+	  }*/
 	if(techTriggerResultBx0 && !techTriggerResultBxF){
 	  meEta_BXm1Empty    = map_of_MEs[DirName+"/"+"Eta_BXm1Empty"];     if (  meEta_BXm1Empty  && meEta_BXm1Empty ->getRootObject())  meEta_BXm1Empty  ->Fill((*pfJets)[ijet].eta());
 	  if(fabs(correctedJet.eta()) <= 1.3) {

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -75,6 +75,8 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   m_l1algoname_ = pSet.getParameter<std::string>("l1algoname");
 
   fill_jet_high_level_histo=pSet.getParameter<bool>("filljetHighLevel"),
+  filljetsubstruc_=pSet.getParameter<bool>("fillsubstructure");
+  pt_min_boosted_=pSet.getParameter<double>("ptMinBoosted");
   
   isCaloJet_ = (std::string("calo")==jetType_);
   //isJPTJet_  = (std::string("jpt") ==jetType_);
@@ -146,6 +148,8 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   if(isPFJet_ || isMiniAODJet_){
     if(JetIDVersion_== "FIRSTDATA"){
       pfjetidversion = PFJetIDSelectionFunctor::FIRSTDATA;
+    }else if(JetIDVersion_== "RUNIISTARTUP"){
+      pfjetidversion = PFJetIDSelectionFunctor::RUNIISTARTUP;
     }else{
       if (verbose_) std::cout<<"no valid PF JetID version given"<<std::endl;
     }
@@ -449,7 +453,7 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 
     // CaloJet specific
     mHadEnergyInHO          = ibooker.book1D("HadEnergyInHO", "HadEnergyInHO", 50, 0, 20);
-    mHadEnergyInHB          = ibooker.book1D("HadEnergy5InHB", "HadEnergyInHB", 50, 0, 100);
+    mHadEnergyInHB          = ibooker.book1D("HadEnergyInHB", "HadEnergyInHB", 50, 0, 100);
     mHadEnergyInHF          = ibooker.book1D("HadEnergyInHF", "HadEnergyInHF", 50, 0, 100);
     mHadEnergyInHE          = ibooker.book1D("HadEnergyInHE", "HadEnergyInHE", 50, 0, 200);
     mEmEnergyInEB           = ibooker.book1D("EmEnergyInEB", "EmEnergyInEB", 50, 0, 100);
@@ -746,26 +750,28 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   }
   //
   if(isMiniAODJet_ || isPFJet_){
-    mMVAPUJIDDiscriminant_lowPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Barrel","MVAPUJIDDiscriminant_lowPt_Barrel",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_lowPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_EndCap","MVAPUJIDDiscriminant_lowPt_EndCap",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_lowPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Forward","MVAPUJIDDiscriminant_lowPt_Forward",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_mediumPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Barrel","MVAPUJIDDiscriminant_mediumPt_Barrel",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_mediumPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_EndCap","MVAPUJIDDiscriminant_mediumPt_EndCap",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_mediumPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Forward","MVAPUJIDDiscriminant_mediumPt_Forward",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_highPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Barrel","MVAPUJIDDiscriminant_highPt_Barrel",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_highPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_EndCap","MVAPUJIDDiscriminant_highPt_EndCap",50, -1.00, 1.00);
-    mMVAPUJIDDiscriminant_highPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Forward","MVAPUJIDDiscriminant_highPt_Forward",50, -1.00, 1.00);
-
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel",mMVAPUJIDDiscriminant_lowPt_Barrel));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_EndCap",mMVAPUJIDDiscriminant_lowPt_EndCap));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Forward",mMVAPUJIDDiscriminant_lowPt_Forward));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Barrel",mMVAPUJIDDiscriminant_mediumPt_Barrel));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_EndCap",mMVAPUJIDDiscriminant_mediumPt_EndCap));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Forward",mMVAPUJIDDiscriminant_mediumPt_Forward));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel",mMVAPUJIDDiscriminant_highPt_Barrel));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap",mMVAPUJIDDiscriminant_highPt_EndCap));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward",mMVAPUJIDDiscriminant_highPt_Forward));
-
+    
+    if(!filljetsubstruc_){//not available for ak8 -> so just take out
+      mMVAPUJIDDiscriminant_lowPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Barrel","MVAPUJIDDiscriminant_lowPt_Barrel",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_lowPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_EndCap","MVAPUJIDDiscriminant_lowPt_EndCap",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_lowPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_lowPt_Forward","MVAPUJIDDiscriminant_lowPt_Forward",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_mediumPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Barrel","MVAPUJIDDiscriminant_mediumPt_Barrel",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_mediumPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_EndCap","MVAPUJIDDiscriminant_mediumPt_EndCap",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_mediumPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_mediumPt_Forward","MVAPUJIDDiscriminant_mediumPt_Forward",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_highPt_Barrel   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Barrel","MVAPUJIDDiscriminant_highPt_Barrel",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_highPt_EndCap   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_EndCap","MVAPUJIDDiscriminant_highPt_EndCap",50, -1.00, 1.00);
+      mMVAPUJIDDiscriminant_highPt_Forward   = ibooker.book1D("MVAPUJIDDiscriminant_highPt_Forward","MVAPUJIDDiscriminant_highPt_Forward",50, -1.00, 1.00);
+      
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel",mMVAPUJIDDiscriminant_lowPt_Barrel));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_EndCap",mMVAPUJIDDiscriminant_lowPt_EndCap));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Forward",mMVAPUJIDDiscriminant_lowPt_Forward));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Barrel",mMVAPUJIDDiscriminant_mediumPt_Barrel));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_EndCap",mMVAPUJIDDiscriminant_mediumPt_EndCap));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Forward",mMVAPUJIDDiscriminant_mediumPt_Forward));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel",mMVAPUJIDDiscriminant_highPt_Barrel));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap",mMVAPUJIDDiscriminant_highPt_EndCap));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward",mMVAPUJIDDiscriminant_highPt_Forward));
+    }
     mCHFracVSpT_Barrel= ibooker.bookProfile("CHFracVSpT_Barrel","CHFracVSpT_Barrel",ptBin_, ptMin_, ptMax_,0.,1.2);
     mNHFracVSpT_Barrel= ibooker.bookProfile("NHFracVSpT_Barrel","NHFracVSpT_Barrel",ptBin_, ptMin_, ptMax_,0.,1.2);
     mPhFracVSpT_Barrel= ibooker.bookProfile("PhFracVSpT_Barrel","PhFracVSpT_Barrel",ptBin_, ptMin_, ptMax_,0.,1.2);
@@ -1107,6 +1113,180 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"NeutralConstituentsFraction" ,mNeutralFraction));
 
   }
+
+  //
+  if(isMiniAODJet_){
+    mMass_Barrel     = ibooker.book1D("JetMass_Barrel", "JetMass_Barrel", 50, 0, 250);
+    mMass_EndCap     = ibooker.book1D("JetMass_EndCap", "JetMass_EndCap", 50, 0, 250);
+    mMass_Forward     = ibooker.book1D("JetMass_Forward", "JetMass_Forward", 50, 0, 250);
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"JetMass_Barrel" , mMass_Barrel ));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"JetMass_EndCap" , mMass_EndCap ));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"JetMass_Forward" , mMass_Forward ));
+    if(!filljetsubstruc_){
+      //done only for MINIAOD
+      mPt_CaloJet      = ibooker.book1D("Pt_CaloJet", "Pt_CaloJet",    ptBin_,  10,  ptMax_);
+      mEMF_CaloJet     = ibooker.book1D("EMF_CaloJet", "EMF_CaloJet",  52,   -0.02,    1.02);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"Pt_CaloJet" ,mPt_CaloJet));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"EMF_CaloJet" ,mEMF_CaloJet));
+    }
+    if(filljetsubstruc_){
+      //miniaod specific variables, especially for substructure
+      mSoftDropMass = ibooker.book1D("SoftDropMass", "SoftDropMass", 50, 0, 250);
+      mPrunedMass = ibooker.book1D("PrunedMass", "PrunedMass", 50, 0, 250);
+      mTrimmedMass = ibooker.book1D("TrimmedMass", "TrimmedMass", 50, 0, 250);
+      mFilteredMass = ibooker.book1D("FilteredMass", "FilteredMass", 50, 0, 250);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SoftDropMass" ,mSoftDropMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PrunedMass" ,mPrunedMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"TrimmedMass" ,mTrimmedMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"FilteredMass" ,mFilteredMass));
+
+      mtau2_over_tau1 = ibooker.book1D("tau2_over_tau1", "tau2_over_tau1", 50, 0, 1); 
+      mtau3_over_tau2 = ibooker.book1D("tau3_over_tau2", "tau3_over_tau2", 50, 0, 1); 
+      mCATopTag_topMass = ibooker.book1D("CATopTag_topMass", "CATopTag_topMass", 50, 50, 250);
+      mCATopTag_minMass = ibooker.book1D("CATopTag_minMass", "CATopTag_minMass", 50, 0, 250); 
+      mCATopTag_nSubJets = ibooker.book1D("nSubJets_CATopTag", "nSubJets_CATopTag", 10, 0, 10); 
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau2_over_tau1" ,mtau2_over_tau1));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau3_over_tau2" ,mtau3_over_tau2));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_topMass" ,mCATopTag_topMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_minMass" ,mCATopTag_minMass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CATopTag" ,mCATopTag_nSubJets));
+
+      mnSubJetsCMSTopTag = ibooker.book1D("nSubJets_CMSTopTag", "nSubJets_CMSTopTag", 10, 0, 10); 
+      mSubJet1_CMSTopTag_pt         = ibooker.book1D("SubJet1_CMSTopTag_pt",   "SubJet1_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_CMSTopTag_eta        = ibooker.book1D("SubJet1_CMSTopTag_eta",  "SubJet1_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_CMSTopTag_phi        = ibooker.book1D("SubJet1_CMSTopTag_phi",  "SubJet1_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_CMSTopTag_mass       = ibooker.book1D("SubJet1_CMSTopTag_mass", "SubJet1_CMSTopTag_mass", 50, 0, 250); 
+      mSubJet2_CMSTopTag_pt         = ibooker.book1D("SubJet2_CMSTopTag_pt",   "SubJet2_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_CMSTopTag_eta        = ibooker.book1D("SubJet2_CMSTopTag_eta",  "SubJet2_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_CMSTopTag_phi        = ibooker.book1D("SubJet2_CMSTopTag_phi",  "SubJet2_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_CMSTopTag_mass       = ibooker.book1D("SubJet2_CMSTopTag_mass", "SubJet2_CMSTopTag_mass", 50, 0, 250); 
+      mSubJet3_CMSTopTag_pt         = ibooker.book1D("SubJet3_CMSTopTag_pt",   "SubJet3_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet3_CMSTopTag_eta        = ibooker.book1D("SubJet3_CMSTopTag_eta",  "SubJet3_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet3_CMSTopTag_phi        = ibooker.book1D("SubJet3_CMSTopTag_phi",  "SubJet3_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet3_CMSTopTag_mass       = ibooker.book1D("SubJet3_CMSTopTag_mass", "SubJet3_CMSTopTag_mass", 50, 0, 250); 
+      mSubJet4_CMSTopTag_pt         = ibooker.book1D("SubJet4_CMSTopTag_pt",   "SubJet4_CMSTopTag_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet4_CMSTopTag_eta        = ibooker.book1D("SubJet4_CMSTopTag_eta",  "SubJet4_CMSTopTag_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet4_CMSTopTag_phi        = ibooker.book1D("SubJet4_CMSTopTag_phi",  "SubJet4_CMSTopTag_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet4_CMSTopTag_mass       = ibooker.book1D("SubJet4_CMSTopTag_mass", "SubJet4_CMSTopTag_mass", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CMSTopTag" ,mnSubJetsCMSTopTag));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_pt" ,mSubJet1_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_eta" ,mSubJet1_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_phi" ,mSubJet1_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_mass" ,mSubJet1_CMSTopTag_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_pt" ,mSubJet2_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_eta" ,mSubJet2_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_phi" ,mSubJet2_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_mass" ,mSubJet2_CMSTopTag_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_pt" ,mSubJet3_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_eta" ,mSubJet3_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_phi" ,mSubJet3_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_mass" ,mSubJet3_CMSTopTag_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_pt" ,mSubJet4_CMSTopTag_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_eta" ,mSubJet4_CMSTopTag_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_phi" ,mSubJet4_CMSTopTag_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_mass" ,mSubJet4_CMSTopTag_mass));
+
+      mnSubJetsSoftDrop = ibooker.book1D("nSubJets_SoftDrop", "nSubJets_SoftDrop", 10, 0, 10); 
+      mSubJet1_SoftDrop_pt         = ibooker.book1D("SubJet1_SoftDrop_pt",   "SubJet1_SoftDrop_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet1_SoftDrop_eta        = ibooker.book1D("SubJet1_SoftDrop_eta",  "SubJet1_SoftDrop_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_SoftDrop_phi        = ibooker.book1D("SubJet1_SoftDrop_phi",  "SubJet1_SoftDrop_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_SoftDrop_mass       = ibooker.book1D("SubJet1_SoftDrop_mass", "SubJet1_SoftDrop_mass", 50, 0, 250); 
+      mSubJet2_SoftDrop_pt         = ibooker.book1D("SubJet2_SoftDrop_pt",   "SubJet2_SoftDrop_pt",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet2_SoftDrop_eta        = ibooker.book1D("SubJet2_SoftDrop_eta",  "SubJet2_SoftDrop_eta",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_SoftDrop_phi        = ibooker.book1D("SubJet2_SoftDrop_phi",  "SubJet2_SoftDrop_phi",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_SoftDrop_mass       = ibooker.book1D("SubJet2_SoftDrop_mass", "SubJet2_SoftDrop_mass", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_SoftDrop" ,mnSubJetsSoftDrop));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_pt" ,mSubJet1_SoftDrop_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_eta" ,mSubJet1_SoftDrop_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_phi" ,mSubJet1_SoftDrop_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_mass" ,mSubJet1_SoftDrop_mass));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_pt" ,mSubJet2_SoftDrop_pt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_eta" ,mSubJet2_SoftDrop_eta));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_phi" ,mSubJet2_SoftDrop_phi));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_mass" ,mSubJet2_SoftDrop_mass));
+      //miniaod specific variables, especially for substructure for boosted stuff
+      mSoftDropMass_boosted = ibooker.book1D("SoftDropMass_boosted", "SoftDropMass_boosted", 50, 0, 250);
+      mPrunedMass_boosted = ibooker.book1D("PrunedMass_boosted", "PrunedMass_boosted", 50, 0, 250);
+      mTrimmedMass_boosted = ibooker.book1D("TrimmedMass_boosted", "TrimmedMass_boosted", 50, 0, 250);
+      mFilteredMass_boosted = ibooker.book1D("FilteredMass_boosted", "FilteredMass_boosted", 50, 0, 250);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SoftDropMass_boosted" ,mSoftDropMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PrunedMass_boosted" ,mPrunedMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"TrimmedMass_boosted" ,mTrimmedMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"FilteredMass_boosted" ,mFilteredMass_boosted));
+
+      mtau2_over_tau1_boosted = ibooker.book1D("tau2_over_tau1_boosted", "tau2_over_tau1_boosted", 50, 0, 1); 
+      mtau3_over_tau2_boosted = ibooker.book1D("tau3_over_tau2_boosted", "tau3_over_tau2_boosted", 50, 0, 1); 
+      mCATopTag_topMass_boosted = ibooker.book1D("CATopTag_topMass_boosted", "CATopTag_topMass_boosted", 50, 50, 250);
+      mCATopTag_minMass_boosted = ibooker.book1D("CATopTag_minMass_boosted", "CATopTag_minMass_boosted", 50, 0, 250); 
+      mCATopTag_nSubJets_boosted = ibooker.book1D("nSubJets_CATopTag_boosted", "nSubJets_CATopTag_boosted", 10, 0, 10); 
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau2_over_tau1_boosted" ,mtau2_over_tau1_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"tau3_over_tau2_boosted" ,mtau3_over_tau2_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_topMass_boosted" ,mCATopTag_topMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"CATopTag_minMass_boosted" ,mCATopTag_minMass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CATopTag_boosted" ,mCATopTag_nSubJets_boosted));
+
+      mnSubJetsCMSTopTag_boosted = ibooker.book1D("nSubJets_CMSTopTag_boosted", "nSubJets_CMSTopTag_boosted", 10, 0, 10); 
+      mSubJet1_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet1_CMSTopTag_pt_boosted",   "SubJet1_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
+      mSubJet1_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet1_CMSTopTag_eta_boosted",  "SubJet1_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet1_CMSTopTag_phi_boosted",  "SubJet1_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet1_CMSTopTag_mass_boosted", "SubJet1_CMSTopTag_mass_boosted", 50, 0, 250); 
+      mSubJet2_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet2_CMSTopTag_pt_boosted",   "SubJet2_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
+      mSubJet2_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet2_CMSTopTag_eta_boosted",  "SubJet2_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet2_CMSTopTag_phi_boosted",  "SubJet2_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet2_CMSTopTag_mass_boosted", "SubJet2_CMSTopTag_mass_boosted", 50, 0, 250); 
+      mSubJet3_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet3_CMSTopTag_pt_boosted",   "SubJet3_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet3_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet3_CMSTopTag_eta_boosted",  "SubJet3_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet3_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet3_CMSTopTag_phi_boosted",  "SubJet3_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet3_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet3_CMSTopTag_mass_boosted", "SubJet3_CMSTopTag_mass_boosted", 50, 0, 250); 
+      mSubJet4_CMSTopTag_pt_boosted         = ibooker.book1D("SubJet4_CMSTopTag_pt_boosted",   "SubJet4_CMSTopTag_pt_boosted",                ptBin_,  ptMin_,  ptMax_);
+      mSubJet4_CMSTopTag_eta_boosted        = ibooker.book1D("SubJet4_CMSTopTag_eta_boosted",  "SubJet4_CMSTopTag_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet4_CMSTopTag_phi_boosted        = ibooker.book1D("SubJet4_CMSTopTag_phi_boosted",  "SubJet4_CMSTopTag_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet4_CMSTopTag_mass_boosted       = ibooker.book1D("SubJet4_CMSTopTag_mass_boosted", "SubJet4_CMSTopTag_mass_boosted", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_CMSTopTag_boosted", mnSubJetsCMSTopTag_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_pt_boosted", mSubJet1_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_eta_boosted", mSubJet1_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_phi_boosted", mSubJet1_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_CMSTopTag_mass_boosted", mSubJet1_CMSTopTag_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_pt_boosted", mSubJet2_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_eta_boosted", mSubJet2_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_phi_boosted", mSubJet2_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_CMSTopTag_mass_boosted", mSubJet2_CMSTopTag_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_pt_boosted", mSubJet3_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_eta_boosted", mSubJet3_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_phi_boosted", mSubJet3_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet3_CMSTopTag_mass_boosted", mSubJet3_CMSTopTag_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_pt_boosted", mSubJet4_CMSTopTag_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_eta_boosted", mSubJet4_CMSTopTag_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_phi_boosted", mSubJet4_CMSTopTag_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet4_CMSTopTag_mass_boosted", mSubJet4_CMSTopTag_mass_boosted));
+
+      mnSubJetsSoftDrop_boosted = ibooker.book1D("nSubJets_SoftDrop_boosted", "nSubJets_SoftDrop_boosted", 10, 0, 10); 
+      mSubJet1_SoftDrop_pt_boosted         = ibooker.book1D("SubJet1_SoftDrop_pt_boosted",   "SubJet1_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
+      mSubJet1_SoftDrop_eta_boosted        = ibooker.book1D("SubJet1_SoftDrop_eta_boosted",  "SubJet1_SoftDrop_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet1_SoftDrop_phi_boosted        = ibooker.book1D("SubJet1_SoftDrop_phi_boosted",  "SubJet1_SoftDrop_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet1_SoftDrop_mass_boosted       = ibooker.book1D("SubJet1_SoftDrop_mass_boosted", "SubJet1_SoftDrop_mass_boosted", 50, 0, 250); 
+      mSubJet2_SoftDrop_pt_boosted         = ibooker.book1D("SubJet2_SoftDrop_pt_boosted",   "SubJet2_SoftDrop_pt_boosted",                ptBin_,  ptMin_,  2*ptMax_);
+      mSubJet2_SoftDrop_eta_boosted        = ibooker.book1D("SubJet2_SoftDrop_eta_boosted",  "SubJet2_SoftDrop_eta_boosted",               etaBin_, etaMin_, etaMax_);
+      mSubJet2_SoftDrop_phi_boosted        = ibooker.book1D("SubJet2_SoftDrop_phi_boosted",  "SubJet2_SoftDrop_phi_boosted",               phiBin_, phiMin_, phiMax_);
+      mSubJet2_SoftDrop_mass_boosted       = ibooker.book1D("SubJet2_SoftDrop_mass_boosted", "SubJet2_SoftDrop_mass_boosted", 50, 0, 250); 
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"nSubJets_SoftDrop_boosted", mnSubJetsSoftDrop_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_pt_boosted", mSubJet1_SoftDrop_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_eta_boosted", mSubJet1_SoftDrop_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_phi_boosted", mSubJet1_SoftDrop_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet1_SoftDrop_mass_boosted", mSubJet1_SoftDrop_mass_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_pt_boosted", mSubJet2_SoftDrop_pt_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_eta_boosted", mSubJet2_SoftDrop_eta_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_phi_boosted", mSubJet2_SoftDrop_phi_boosted));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SubJet2_SoftDrop_mass_boosted", mSubJet2_SoftDrop_mass_boosted));
+
+    }
+  }
+
 
   if(jetCleaningFlag_){
     //so far we have only one additional selection -> implement to make it expandable
@@ -1914,42 +2094,47 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	mConstituents_uncor = map_of_MEs[DirName+"/"+"Constituents_uncor"]; if (mConstituents_uncor && mConstituents_uncor->getRootObject()) if (mConstituents_uncor) mConstituents_uncor->Fill ((*patJets)[ijet].nConstituents());
       }
       if(Thiscleaned && pass_corrected){
+	mPt_CaloJet  = map_of_MEs[DirName+"/"+"Pt_CaloJet"]; if(mPt_CaloJet && mPt_CaloJet->getRootObject()&& (*patJets)[ijet].hasUserFloat("caloJetMap:pt")) mPt_CaloJet->Fill((*patJets)[ijet].userFloat("caloJetMap:pt"));
+	mEMF_CaloJet  = map_of_MEs[DirName+"/"+"EMF_CaloJet"]; if(mEMF_CaloJet && mEMF_CaloJet->getRootObject() && (*patJets)[ijet].hasUserFloat("caloJetMap:emEnergyFraction")) mEMF_CaloJet->Fill((*patJets)[ijet].userFloat("caloJetMap:emEnergyFraction"));
 	if(fabs(correctedJet.eta()) <= 1.3) {
 	  if(correctedJet.pt()<=50.){
-	    mMVAPUJIDDiscriminant_lowPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel"]; if(mMVAPUJIDDiscriminant_lowPt_Barrel && mMVAPUJIDDiscriminant_lowPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_lowPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant"));}
+	    mMVAPUJIDDiscriminant_lowPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Barrel"]; if(mMVAPUJIDDiscriminant_lowPt_Barrel && mMVAPUJIDDiscriminant_lowPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_lowPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); } 
 	  }
 	  if (correctedJet.pt()>50. && correctedJet.pt()<=140.) {
-	    mMVAPUJIDDiscriminant_mediumPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Barrel"]; if(mMVAPUJIDDiscriminant_mediumPt_Barrel && mMVAPUJIDDiscriminant_mediumPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_mediumPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
+	    mMVAPUJIDDiscriminant_mediumPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Barrel"]; if(mMVAPUJIDDiscriminant_mediumPt_Barrel && mMVAPUJIDDiscriminant_mediumPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_mediumPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
 	  }
 	  if(correctedJet.pt()>140.){
-	    mMVAPUJIDDiscriminant_highPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel"]; if(mMVAPUJIDDiscriminant_highPt_Barrel && mMVAPUJIDDiscriminant_highPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_highPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
+	    mMVAPUJIDDiscriminant_highPt_Barrel=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_Barrel"]; if(mMVAPUJIDDiscriminant_highPt_Barrel && mMVAPUJIDDiscriminant_highPt_Barrel->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_highPt_Barrel->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
 	  }
+	  mMass_Barrel=map_of_MEs[DirName+"/"+"JetMass_Barrel"]; if(mMass_Barrel && mMass_Barrel->getRootObject())mMass_Barrel->Fill((*patJets)[ijet].mass());
 	  mCHFracVSpT_Barrel = map_of_MEs[DirName+"/"+"CHFracVSpT_Barrel"]; if(mCHFracVSpT_Barrel && mCHFracVSpT_Barrel->getRootObject()) mCHFracVSpT_Barrel->Fill(correctedJet.pt(),(*patJets)[ijet].chargedHadronEnergyFraction());
 	  mNHFracVSpT_Barrel = map_of_MEs[DirName+"/"+"NHFracVSpT_Barrel"];if (mNHFracVSpT_Barrel && mNHFracVSpT_Barrel->getRootObject()) mNHFracVSpT_Barrel->Fill(correctedJet.pt(),(*patJets)[ijet].neutralHadronEnergyFraction());
 	  mPhFracVSpT_Barrel = map_of_MEs[DirName+"/"+"PhFracVSpT_Barrel"];if (mPhFracVSpT_Barrel && mPhFracVSpT_Barrel->getRootObject()) mPhFracVSpT_Barrel->Fill(correctedJet.pt(),(*patJets)[ijet].neutralEmEnergyFraction());
 	}else if(fabs(correctedJet.eta()) <= 3) {
 	  if(correctedJet.pt()<=50.){
-	    mMVAPUJIDDiscriminant_lowPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_EndCap"]; if(mMVAPUJIDDiscriminant_lowPt_EndCap && mMVAPUJIDDiscriminant_lowPt_EndCap->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_lowPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); } 
+	    mMVAPUJIDDiscriminant_lowPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_EndCap"]; if(mMVAPUJIDDiscriminant_lowPt_EndCap && mMVAPUJIDDiscriminant_lowPt_EndCap->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_lowPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); } 
 	  }
 	  if (correctedJet.pt()>50. && correctedJet.pt()<=140.) {
-	    mMVAPUJIDDiscriminant_mediumPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_EndCap"]; if(mMVAPUJIDDiscriminant_mediumPt_EndCap && mMVAPUJIDDiscriminant_mediumPt_EndCap->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_mediumPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
+	    mMVAPUJIDDiscriminant_mediumPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_EndCap"]; if(mMVAPUJIDDiscriminant_mediumPt_EndCap && mMVAPUJIDDiscriminant_mediumPt_EndCap->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_mediumPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
 	  }
 	  if(correctedJet.pt()>140.){
-	    mMVAPUJIDDiscriminant_highPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap"];{if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) if(mMVAPUJIDDiscriminant_highPt_EndCap && mMVAPUJIDDiscriminant_highPt_EndCap->getRootObject()) mMVAPUJIDDiscriminant_highPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
+	    mMVAPUJIDDiscriminant_highPt_EndCap=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_EndCap"]; if(mMVAPUJIDDiscriminant_highPt_EndCap && mMVAPUJIDDiscriminant_highPt_EndCap->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_highPt_EndCap->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
 	  }
+	  mMass_EndCap=map_of_MEs[DirName+"/"+"JetMass_EndCap"]; if(mMass_EndCap && mMass_EndCap->getRootObject())mMass_EndCap->Fill((*patJets)[ijet].mass());
 	  mCHFracVSpT_EndCap = map_of_MEs[DirName+"/"+"CHFracVSpT_EndCap"]; if(mCHFracVSpT_EndCap && mCHFracVSpT_EndCap->getRootObject()) mCHFracVSpT_EndCap->Fill(correctedJet.pt(),(*patJets)[ijet].chargedHadronEnergyFraction());
 	  mNHFracVSpT_EndCap = map_of_MEs[DirName+"/"+"NHFracVSpT_EndCap"];if (mNHFracVSpT_EndCap && mNHFracVSpT_EndCap->getRootObject()) mNHFracVSpT_EndCap->Fill(correctedJet.pt(),(*patJets)[ijet].neutralHadronEnergyFraction());
 	  mPhFracVSpT_EndCap = map_of_MEs[DirName+"/"+"PhFracVSpT_EndCap"];if (mPhFracVSpT_EndCap && mPhFracVSpT_EndCap->getRootObject()) mPhFracVSpT_EndCap->Fill(correctedJet.pt(),(*patJets)[ijet].neutralEmEnergyFraction());
 	}else if(fabs(correctedJet.eta()) <= 5) {
 	  if(correctedJet.pt()<=50.){
-	    mMVAPUJIDDiscriminant_lowPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Forward"]; if(mMVAPUJIDDiscriminant_lowPt_Forward && mMVAPUJIDDiscriminant_lowPt_Forward->getRootObject()) {if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))mMVAPUJIDDiscriminant_lowPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); } 
+	    mMVAPUJIDDiscriminant_lowPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_lowPt_Forward"]; if(mMVAPUJIDDiscriminant_lowPt_Forward && mMVAPUJIDDiscriminant_lowPt_Forward->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_lowPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); } 
 	  }
 	  if (correctedJet.pt()>50. && correctedJet.pt()<=140.) {
-	    mMVAPUJIDDiscriminant_mediumPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Forward"]; if(mMVAPUJIDDiscriminant_mediumPt_Forward && mMVAPUJIDDiscriminant_mediumPt_Forward->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) mMVAPUJIDDiscriminant_mediumPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
+	    mMVAPUJIDDiscriminant_mediumPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_mediumPt_Forward"]; if(mMVAPUJIDDiscriminant_mediumPt_Forward && mMVAPUJIDDiscriminant_mediumPt_Forward->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_mediumPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant"));} 
 	  }
 	  if(correctedJet.pt()>140.){
-	    mMVAPUJIDDiscriminant_highPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward"];{if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant")) if(mMVAPUJIDDiscriminant_highPt_Forward && mMVAPUJIDDiscriminant_highPt_Forward->getRootObject()) mMVAPUJIDDiscriminant_highPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant")); }
+	    mMVAPUJIDDiscriminant_highPt_Forward=map_of_MEs[DirName+"/"+"MVAPUJIDDiscriminant_highPt_Forward"]; if(mMVAPUJIDDiscriminant_highPt_Forward && mMVAPUJIDDiscriminant_highPt_Forward->getRootObject()){if((*patJets)[ijet].hasUserFloat("pileupJetId:fullDiscriminant"))  mMVAPUJIDDiscriminant_highPt_Forward->Fill( (*patJets)[ijet].userFloat("pileupJetId:fullDiscriminant"));} 
 	  }
+	  mMass_Forward=map_of_MEs[DirName+"/"+"JetMass_Forward"]; if(mMass_Forward && mMass_Forward->getRootObject())mMass_Forward->Fill((*patJets)[ijet].mass());
 	  mHFHFracVSpT_Forward = map_of_MEs[DirName+"/"+"HFHFracVSpT_Forward"]; if (mHFHFracVSpT_Forward && mHFHFracVSpT_Forward->getRootObject())    mHFHFracVSpT_Forward->Fill(correctedJet.pt(),(*patJets)[ijet].HFHadronEnergyFraction ());	
 	  mHFEFracVSpT_Forward = map_of_MEs[DirName+"/"+"HFEFracVSpT_Forward"]; if (mHFEFracVSpT_Forward && mHFEFracVSpT_Forward->getRootObject())    mHFEFracVSpT_Forward->Fill (correctedJet.pt(),(*patJets)[ijet].HFEMEnergyFraction ());
 	}
@@ -1966,22 +2151,9 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       puidmvaflag=(*puJetIdFlagMva)[pfjetref];
       puidcutflag=(*puJetIdFlag)[pfjetref];
       jetpassid = pfjetIDFunctor((*pfJets)[ijet]);
-      if((*pfJets)[ijet].muonEnergyFraction()>0.8){
-	jetpassid =false;
-      }
-      //int QGmulti=-1;
-      //float QGLikelihood=-10;
-      //float QGptD=-10;
-      //float QGaxis2=-10;
-      //if(fill_CHS_histos){
-      //QGmulti=(*qgMultiplicity)[pfjetref];
-      //QGLikelihood=(*qgLikelihood)[pfjetref];
-      //QGptD=(*qgptD)[pfjetref];
-      //QGaxis2=(*qgaxis2)[pfjetref];
-      //}
       if(jetCleaningFlag_){
 	Thiscleaned = jetpassid;
-	JetIDWPU= (jetpassid && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose ));
+	//JetIDWPU= (jetpassid && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose ));
       }
       if(Thiscleaned && pass_uncorrected){
 	mPt_uncor = map_of_MEs[DirName+"/"+"Pt_uncor"]; if (mPt_uncor && mPt_uncor->getRootObject())  mPt_uncor->Fill ((*pfJets)[ijet].pt());
@@ -2435,6 +2607,124 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	mJetEnergyCorr = map_of_MEs[DirName+"/"+"JetEnergyCorr"]; if(mJetEnergyCorr && mJetEnergyCorr->getRootObject()) mJetEnergyCorr->Fill(1./(*patJets)[ijet].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSEta = map_of_MEs[DirName+"/"+"JetEnergyCorrVSEta"]; if(mJetEnergyCorrVSEta && mJetEnergyCorrVSEta->getRootObject())mJetEnergyCorrVSEta->Fill(correctedJet.eta(),1./(*patJets)[ijet].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSPt = map_of_MEs[DirName+"/"+"JetEnergyCorrVSPt"]; if(mJetEnergyCorrVSPt && mJetEnergyCorrVSPt->getRootObject()) mJetEnergyCorrVSPt->Fill(correctedJet.pt(),1./(*patJets)[ijet].jecFactor("Uncorrected"));
+	if(filljetsubstruc_){
+	  //miniaod specific variables, especially for substructure
+	  mSoftDropMass = map_of_MEs[DirName+"/"+"SoftDropMass"];if(mSoftDropMass && mSoftDropMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSSoftDropMass")) mSoftDropMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSSoftDropMass"));
+	  mPrunedMass = map_of_MEs[DirName+"/"+"PrunedMass"];if(mPrunedMass && mPrunedMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSPrunedMass")) mPrunedMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSPrunedMass"));
+	  mTrimmedMass = map_of_MEs[DirName+"/"+"TrimmedMass"];if(mTrimmedMass && mTrimmedMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSTrimmedMass")) mTrimmedMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSTrimmedMass"));
+	  mFilteredMass = map_of_MEs[DirName+"/"+"FilteredMass"];if(mFilteredMass && mFilteredMass->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSFilteredMass")) mFilteredMass->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSFilteredMass"));
+	  mtau2_over_tau1 = map_of_MEs[DirName+"/"+"tau2_over_tau1"]; if(mtau2_over_tau1 && mtau2_over_tau1->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau1") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2")))mtau2_over_tau1->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau2")/(*patJets)[ijet].userFloat("NjettinessAK8:tau1"));
+	  mtau3_over_tau2 = map_of_MEs[DirName+"/"+"tau3_over_tau2"]; if(mtau3_over_tau2 && mtau3_over_tau2->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau3")))mtau3_over_tau2->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau3")/(*patJets)[ijet].userFloat("NjettinessAK8:tau2"));
+	  if((*patJets)[ijet].hasTagInfo("caTop")){
+	    reco::CATopJetTagInfo const * tagInfo=  dynamic_cast<reco::CATopJetTagInfo const *>((*patJets)[ijet].tagInfo("caTop"));
+	    if ( tagInfo != 0 ) {
+	      mCATopTag_topMass = map_of_MEs[DirName+"/"+"CATopTag_topMass"];if(mCATopTag_topMass && mCATopTag_topMass->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_topMass->Fill(tagInfo->properties().topMass);
+	      mCATopTag_minMass = map_of_MEs[DirName+"/"+"CATopTag_minMass"];if(mCATopTag_minMass && mCATopTag_minMass->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_minMass->Fill(tagInfo->properties().minMass);
+	      mCATopTag_nSubJets = map_of_MEs[DirName+"/"+"nSubJets_CATopTag"];if(mCATopTag_nSubJets && mCATopTag_nSubJets->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_nSubJets->Fill(tagInfo->properties().nSubJets);
+	    }
+	  }
+	  if((*patJets)[ijet].hasSubjets("CMSTopTag")){
+	    mnSubJetsCMSTopTag=map_of_MEs[DirName+"/"+"nSubJets_CMSTopTag"]; if(mnSubJetsCMSTopTag && mnSubJetsCMSTopTag->getRootObject()) mnSubJetsCMSTopTag->Fill((*patJets)[ijet].subjets("CMSTopTag").size());
+	  }
+	  if((*patJets)[ijet].hasSubjets("CMSTopTag") && (*patJets)[ijet].subjets("CMSTopTag").size()>0){
+	    mSubJet1_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_pt"]; if(mSubJet1_CMSTopTag_pt && mSubJet1_CMSTopTag_pt->getRootObject()) mSubJet1_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->pt());
+	    mSubJet1_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_eta"]; if(mSubJet1_CMSTopTag_eta && mSubJet1_CMSTopTag_eta->getRootObject()) mSubJet1_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->eta());
+	    mSubJet1_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_phi"]; if(mSubJet1_CMSTopTag_phi && mSubJet1_CMSTopTag_phi->getRootObject()) mSubJet1_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->phi());
+	    mSubJet1_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_mass"]; if(mSubJet1_CMSTopTag_mass && mSubJet1_CMSTopTag_mass->getRootObject()) mSubJet1_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->mass());
+	    if((*patJets)[ijet].subjets("CMSTopTag").size()>1){
+	      mSubJet2_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_pt"]; if(mSubJet2_CMSTopTag_pt && mSubJet2_CMSTopTag_pt->getRootObject()) mSubJet2_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->pt());
+	      mSubJet2_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_eta"]; if(mSubJet2_CMSTopTag_eta && mSubJet2_CMSTopTag_eta->getRootObject()) mSubJet2_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->eta());
+	      mSubJet2_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_phi"]; if(mSubJet2_CMSTopTag_phi && mSubJet2_CMSTopTag_phi->getRootObject()) mSubJet2_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->phi());
+	      mSubJet2_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_mass"]; if(mSubJet2_CMSTopTag_mass && mSubJet2_CMSTopTag_mass->getRootObject()) mSubJet2_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->mass());
+	      if((*patJets)[ijet].subjets("CMSTopTag").size()>2){
+		mSubJet3_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_pt"]; if(mSubJet3_CMSTopTag_pt && mSubJet3_CMSTopTag_pt->getRootObject()) mSubJet3_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->pt());
+		mSubJet3_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_eta"]; if(mSubJet3_CMSTopTag_eta && mSubJet3_CMSTopTag_eta->getRootObject()) mSubJet3_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->eta());
+		mSubJet3_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_phi"]; if(mSubJet3_CMSTopTag_phi && mSubJet3_CMSTopTag_phi->getRootObject()) mSubJet3_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->phi());
+		mSubJet3_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_mass"]; if(mSubJet3_CMSTopTag_mass && mSubJet3_CMSTopTag_mass->getRootObject()) mSubJet3_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->mass());
+		if((*patJets)[ijet].subjets("CMSTopTag").size()>3){
+		  mSubJet4_CMSTopTag_pt=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_pt"]; if(mSubJet4_CMSTopTag_pt && mSubJet4_CMSTopTag_pt->getRootObject()) mSubJet4_CMSTopTag_pt->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->pt());
+		  mSubJet4_CMSTopTag_eta=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_eta"]; if(mSubJet4_CMSTopTag_eta && mSubJet4_CMSTopTag_eta->getRootObject()) mSubJet4_CMSTopTag_eta->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->eta());
+		  mSubJet4_CMSTopTag_phi=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_phi"]; if(mSubJet4_CMSTopTag_phi && mSubJet4_CMSTopTag_phi->getRootObject()) mSubJet4_CMSTopTag_phi->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->phi());
+		  mSubJet4_CMSTopTag_mass=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_mass"]; if(mSubJet4_CMSTopTag_mass && mSubJet4_CMSTopTag_mass->getRootObject()) mSubJet4_CMSTopTag_mass->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->mass());
+		}
+	      }
+	    }
+	  }//CMS top tag filling
+	  if((*patJets)[ijet].hasSubjets("SoftDrop")){
+	    mnSubJetsSoftDrop=map_of_MEs[DirName+"/"+"nSubJets_SoftDrop"]; if(mnSubJetsSoftDrop && mnSubJetsSoftDrop->getRootObject()) mnSubJetsSoftDrop->Fill((*patJets)[ijet].subjets("SoftDrop").size());
+	  }
+	  if((*patJets)[ijet].hasSubjets("SoftDrop") && (*patJets)[ijet].subjets("SoftDrop").size()>0){
+	    mSubJet1_SoftDrop_pt=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_pt"]; if(mSubJet1_SoftDrop_pt && mSubJet1_SoftDrop_pt->getRootObject()) mSubJet1_SoftDrop_pt->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->pt());
+	    mSubJet1_SoftDrop_eta=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_eta"]; if(mSubJet1_SoftDrop_eta && mSubJet1_SoftDrop_eta->getRootObject()) mSubJet1_SoftDrop_eta->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->eta());
+	    mSubJet1_SoftDrop_phi=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_phi"]; if(mSubJet1_SoftDrop_phi && mSubJet1_SoftDrop_phi->getRootObject()) mSubJet1_SoftDrop_phi->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->phi());
+	    mSubJet1_SoftDrop_mass=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_mass"]; if(mSubJet1_SoftDrop_mass && mSubJet1_SoftDrop_mass->getRootObject()) mSubJet1_SoftDrop_mass->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->mass());
+	    if((*patJets)[ijet].subjets("SoftDrop").size()>1){
+	      mSubJet2_SoftDrop_pt=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_pt"]; if(mSubJet2_SoftDrop_pt && mSubJet2_SoftDrop_pt->getRootObject()) mSubJet2_SoftDrop_pt->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->pt());
+	      mSubJet2_SoftDrop_eta=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_eta"]; if(mSubJet2_SoftDrop_eta && mSubJet2_SoftDrop_eta->getRootObject()) mSubJet2_SoftDrop_eta->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->eta());
+	      mSubJet2_SoftDrop_phi=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_phi"]; if(mSubJet2_SoftDrop_phi && mSubJet2_SoftDrop_phi->getRootObject()) mSubJet2_SoftDrop_phi->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->phi());
+	      mSubJet2_SoftDrop_mass=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_mass"]; if(mSubJet2_SoftDrop_mass && mSubJet2_SoftDrop_mass->getRootObject()) mSubJet2_SoftDrop_mass->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->mass());
+	    }
+	  }//soft drop jets
+	  if((*patJets)[ijet].pt()>pt_min_boosted_){
+	    //miniaod specific variables, especially for boosted substructure
+	    mSoftDropMass_boosted = map_of_MEs[DirName+"/"+"SoftDropMass_boosted"];if(mSoftDropMass_boosted && mSoftDropMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSSoftDropMass")) mSoftDropMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSSoftDropMass"));
+	    mPrunedMass_boosted = map_of_MEs[DirName+"/"+"PrunedMass_boosted"];if(mPrunedMass_boosted && mPrunedMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSPrunedMass")) mPrunedMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSPrunedMass"));
+	    mTrimmedMass_boosted = map_of_MEs[DirName+"/"+"TrimmedMass_boosted"];if(mTrimmedMass_boosted && mTrimmedMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSTrimmedMass")) mTrimmedMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSTrimmedMass"));
+	    mFilteredMass_boosted = map_of_MEs[DirName+"/"+"FilteredMass_boosted"];if(mFilteredMass_boosted && mFilteredMass_boosted->getRootObject() && (*patJets)[ijet].hasUserFloat("ak8PFJetsCHSFilteredMass")) mFilteredMass_boosted->Fill((*patJets)[ijet].userFloat("ak8PFJetsCHSFilteredMass"));
+	    mtau2_over_tau1_boosted = map_of_MEs[DirName+"/"+"tau2_over_tau1_boosted"]; if(mtau2_over_tau1_boosted && mtau2_over_tau1_boosted->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau1") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2")))mtau2_over_tau1_boosted->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau2")/(*patJets)[ijet].userFloat("NjettinessAK8:tau1"));
+	    mtau3_over_tau2_boosted = map_of_MEs[DirName+"/"+"tau3_over_tau2_boosted"]; if(mtau3_over_tau2_boosted && mtau3_over_tau2_boosted->getRootObject() && ((*patJets)[ijet].hasUserFloat("NjettinessAK8:tau2") && (*patJets)[ijet].hasUserFloat("NjettinessAK8:tau3")))mtau3_over_tau2_boosted->Fill((*patJets)[ijet].userFloat("NjettinessAK8:tau3")/(*patJets)[ijet].userFloat("NjettinessAK8:tau2"));
+	    if((*patJets)[ijet].hasTagInfo("caTop")){
+	      reco::CATopJetTagInfo const * tagInfo_boosted =  dynamic_cast<reco::CATopJetTagInfo const *>((*patJets)[ijet].tagInfo("caTop"));
+	      if ( tagInfo_boosted  != 0 ) {
+		mCATopTag_topMass_boosted = map_of_MEs[DirName+"/"+"CATopTag_topMass_boosted"];if(mCATopTag_topMass_boosted && mCATopTag_topMass_boosted->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_topMass_boosted->Fill(tagInfo_boosted->properties().topMass);
+		mCATopTag_minMass_boosted = map_of_MEs[DirName+"/"+"CATopTag_minMass_boosted"];if(mCATopTag_minMass_boosted && mCATopTag_minMass_boosted->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_minMass_boosted->Fill(tagInfo_boosted->properties().minMass);
+		mCATopTag_nSubJets_boosted = map_of_MEs[DirName+"/"+"nSubJets_CATopTag_boosted"];if(mCATopTag_nSubJets_boosted && mCATopTag_nSubJets_boosted->getRootObject() && (*patJets)[ijet].hasTagInfo("caTop")) mCATopTag_nSubJets_boosted->Fill(tagInfo_boosted->properties().nSubJets);
+	      }
+	    }
+	    if((*patJets)[ijet].hasSubjets("CMSTopTag")){
+	      mnSubJetsCMSTopTag_boosted=map_of_MEs[DirName+"/"+"nSubJets_CMSTopTag_boosted"]; if(mnSubJetsCMSTopTag_boosted && mnSubJetsCMSTopTag_boosted->getRootObject()) mnSubJetsCMSTopTag_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag").size());
+	    }
+	    if((*patJets)[ijet].hasSubjets("CMSTopTag") && (*patJets)[ijet].subjets("CMSTopTag").size()>0){
+	      mSubJet1_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_pt_boosted"]; if(mSubJet1_CMSTopTag_pt_boosted && mSubJet1_CMSTopTag_pt_boosted->getRootObject()) mSubJet1_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->pt());
+	      mSubJet1_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_eta_boosted"]; if(mSubJet1_CMSTopTag_eta_boosted && mSubJet1_CMSTopTag_eta_boosted->getRootObject()) mSubJet1_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->eta());
+	      mSubJet1_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_phi_boosted"]; if(mSubJet1_CMSTopTag_phi_boosted && mSubJet1_CMSTopTag_phi_boosted->getRootObject()) mSubJet1_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->phi());
+	      mSubJet1_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet1_CMSTopTag_mass_boosted"]; if(mSubJet1_CMSTopTag_mass_boosted && mSubJet1_CMSTopTag_mass_boosted->getRootObject()) mSubJet1_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[0]->mass());
+	      if((*patJets)[ijet].subjets("CMSTopTag").size()>1){
+		mSubJet2_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_pt_boosted"]; if(mSubJet2_CMSTopTag_pt_boosted && mSubJet2_CMSTopTag_pt_boosted->getRootObject()) mSubJet2_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->pt());
+		mSubJet2_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_eta_boosted"]; if(mSubJet2_CMSTopTag_eta_boosted && mSubJet2_CMSTopTag_eta_boosted->getRootObject()) mSubJet2_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->eta());
+		mSubJet2_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_phi_boosted"]; if(mSubJet2_CMSTopTag_phi_boosted && mSubJet2_CMSTopTag_phi_boosted->getRootObject()) mSubJet2_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->phi());
+		mSubJet2_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet2_CMSTopTag_mass_boosted"]; if(mSubJet2_CMSTopTag_mass_boosted && mSubJet2_CMSTopTag_mass_boosted->getRootObject()) mSubJet2_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[1]->mass());
+		if((*patJets)[ijet].subjets("CMSTopTag").size()>2){
+		  mSubJet3_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_pt_boosted"]; if(mSubJet3_CMSTopTag_pt_boosted && mSubJet3_CMSTopTag_pt_boosted->getRootObject()) mSubJet3_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->pt());
+		  mSubJet3_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_eta_boosted"]; if(mSubJet3_CMSTopTag_eta_boosted && mSubJet3_CMSTopTag_eta_boosted->getRootObject()) mSubJet3_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->eta());
+		  mSubJet3_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_phi_boosted"]; if(mSubJet3_CMSTopTag_phi_boosted && mSubJet3_CMSTopTag_phi_boosted->getRootObject()) mSubJet3_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->phi());
+		  mSubJet3_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet3_CMSTopTag_mass_boosted"]; if(mSubJet3_CMSTopTag_mass_boosted && mSubJet3_CMSTopTag_mass_boosted->getRootObject()) mSubJet3_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[2]->mass());
+		  if((*patJets)[ijet].subjets("CMSTopTag").size()>3){
+		    mSubJet4_CMSTopTag_pt_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_pt_boosted"]; if(mSubJet4_CMSTopTag_pt_boosted && mSubJet4_CMSTopTag_pt_boosted->getRootObject()) mSubJet4_CMSTopTag_pt_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->pt());
+		    mSubJet4_CMSTopTag_eta_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_eta_boosted"]; if(mSubJet4_CMSTopTag_eta_boosted && mSubJet4_CMSTopTag_eta_boosted->getRootObject()) mSubJet4_CMSTopTag_eta_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->eta());
+		    mSubJet4_CMSTopTag_phi_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_phi_boosted"]; if(mSubJet4_CMSTopTag_phi_boosted && mSubJet4_CMSTopTag_phi_boosted->getRootObject()) mSubJet4_CMSTopTag_phi_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->phi());
+		    mSubJet4_CMSTopTag_mass_boosted=map_of_MEs[DirName+"/"+"SubJet4_CMSTopTag_mass_boosted"]; if(mSubJet4_CMSTopTag_mass_boosted && mSubJet4_CMSTopTag_mass_boosted->getRootObject()) mSubJet4_CMSTopTag_mass_boosted->Fill((*patJets)[ijet].subjets("CMSTopTag")[3]->mass());
+		  }
+		}
+	      }
+	    }
+	    if((*patJets)[ijet].hasSubjets("SoftDrop")){
+	      mnSubJetsSoftDrop_boosted=map_of_MEs[DirName+"/"+"nSubJets_SoftDrop_boosted"]; if(mnSubJetsSoftDrop_boosted && mnSubJetsSoftDrop_boosted->getRootObject()) mnSubJetsSoftDrop_boosted->Fill((*patJets)[ijet].subjets("SoftDrop").size());
+	    }
+	    if((*patJets)[ijet].hasSubjets("SoftDrop") && (*patJets)[ijet].subjets("SoftDrop").size()>0){
+	      mSubJet1_SoftDrop_pt_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_pt_boosted"]; if(mSubJet1_SoftDrop_pt_boosted && mSubJet1_SoftDrop_pt_boosted->getRootObject()) mSubJet1_SoftDrop_pt_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->pt());
+	      mSubJet1_SoftDrop_eta_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_eta_boosted"]; if(mSubJet1_SoftDrop_eta_boosted && mSubJet1_SoftDrop_eta_boosted->getRootObject()) mSubJet1_SoftDrop_eta_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->eta());
+	      mSubJet1_SoftDrop_phi_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_phi_boosted"]; if(mSubJet1_SoftDrop_phi_boosted && mSubJet1_SoftDrop_phi_boosted->getRootObject()) mSubJet1_SoftDrop_phi_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->phi());
+	      mSubJet1_SoftDrop_mass_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_mass_boosted"]; if(mSubJet1_SoftDrop_mass_boosted && mSubJet1_SoftDrop_mass_boosted->getRootObject()) mSubJet1_SoftDrop_mass_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[0]->mass());
+	      if((*patJets)[ijet].subjets("SoftDrop").size()>1){
+		mSubJet2_SoftDrop_pt_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_pt_boosted"]; if(mSubJet2_SoftDrop_pt_boosted && mSubJet2_SoftDrop_pt_boosted->getRootObject()) mSubJet2_SoftDrop_pt_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->pt());
+		mSubJet2_SoftDrop_eta_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_eta_boosted"]; if(mSubJet2_SoftDrop_eta_boosted && mSubJet2_SoftDrop_eta_boosted->getRootObject()) mSubJet2_SoftDrop_eta_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->eta());
+		mSubJet2_SoftDrop_phi_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_phi_boosted"]; if(mSubJet2_SoftDrop_phi_boosted && mSubJet2_SoftDrop_phi_boosted->getRootObject()) mSubJet2_SoftDrop_phi_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->phi());
+		mSubJet2_SoftDrop_mass_boosted=map_of_MEs[DirName+"/"+"SubJet2_SoftDrop_mass_boosted"]; if(mSubJet2_SoftDrop_mass_boosted && mSubJet2_SoftDrop_mass_boosted->getRootObject()) mSubJet2_SoftDrop_mass_boosted->Fill((*patJets)[ijet].subjets("SoftDrop")[1]->mass());
+	      }
+	    }
+	  }//substructure filling for boosted
+	}//substructure filling	  
       }
       // --- Event passed the low pt jet trigger
       if (jetLoPass_ == 1) {	  

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -77,8 +77,13 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
     jetID_ValueMapToken_= consumes< edm::ValueMap<reco::JetID> >(inputJetIDValueMap);
     jetIDFunctorLoose=JetIDSelectionFunctor(JetIDSelectionFunctor::PURE09, JetIDSelectionFunctor::LOOSE);
   }
-  if(isPFMet_ || isMiniAODMet_){
-    pflowToken_ = consumes<std::vector<reco::PFCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
+
+  if(isPFMet_){
+   pflowToken_ = consumes<std::vector<reco::PFCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
+   pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::RUNIISTARTUP, PFJetIDSelectionFunctor::LOOSE);
+  }
+  if(isMiniAODMet_){
+    pflowPackedToken_ = consumes<std::vector<pat::PackedCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
     pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::RUNIISTARTUP, PFJetIDSelectionFunctor::LOOSE);
   }
   MuonsToken_ = consumes<reco::MuonCollection>(pSet.getParameter<edm::InputTag>       ("muonsrc"));
@@ -132,9 +137,12 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   if (isMiniAODMet_)   patJetsToken_ = consumes<pat::JetCollection>(jetCollectionLabel_);
 
   hbheNoiseFilterResultTag_    = parameters.getParameter<edm::InputTag>("HBHENoiseFilterResultLabel");
+  hbheIsoNoiseFilterResultToken_ =consumes<bool> (parameters.getParameter<edm::InputTag>("HBHEIsoNoiseFilterResultLabel"));
   hbheNoiseFilterResultToken_=consumes<bool>(hbheNoiseFilterResultTag_);
+  BeamHaloSummaryToken_=consumes<reco::BeamHaloSummary>(parameters.getParameter<edm::InputTag>("BeamHaloSummaryLabel"));
   CSCHaloResultTag_= parameters.getParameter<edm::InputTag>("CSCHaloResultLabel");
   CSCHaloResultToken_=consumes<bool>(CSCHaloResultTag_);
+  CSCHalo2015ResultToken_=consumes<bool> (parameters.getParameter<edm::InputTag>("CSCHalo2015ResultLabel"));
   EcalDeadCellTriggerTag_= parameters.getParameter<edm::InputTag>("EcalDeadCellTriggerLabel");
   EcalDeadCellTriggerToken_=consumes<bool>(EcalDeadCellTriggerTag_);
   eeBadScFilterTag_= parameters.getParameter<edm::InputTag>("eeBadScFilterLabel");
@@ -195,7 +203,9 @@ void METAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     }
     folderNames_.push_back("Cleaned");
     folderNames_.push_back("DiJet");
-    folderNames_.push_back("ZJets");
+    if(!isMiniAODMet_){
+      folderNames_.push_back("ZJets");
+    }
   }
   for (std::vector<std::string>::const_iterator ic = folderNames_.begin();
        ic != folderNames_.end(); ic++){
@@ -237,54 +247,54 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
 
   ibooker.setCurrentFolder(DirName);
   if(fillZPlots){
-  if(isCaloMet_){
-    meZJets_u_par   = ibooker.book1D("u_parallel_Z_inc",        "u_parallel_Z_inc",        50, -1000., 75);
-  }else{
-    meZJets_u_par   = ibooker.book1D("u_parallel_Z_inc",        "u_parallel_Z_inc",        50, -800., 75);
+    if(isCaloMet_){
+      meZJets_u_par   = ibooker.book1D("u_parallel_Z_inc",        "u_parallel_Z_inc",        50, -1000., 75);
+    }else{
+      meZJets_u_par   = ibooker.book1D("u_parallel_Z_inc",        "u_parallel_Z_inc",        50, -800., 75);
+    }
+    meZJets_u_par_ZPt_0_15   = ibooker.book1D("u_parallel_ZPt_0_15",        "u_parallel_ZPt_0_15",        50, -100,  75);
+    meZJets_u_par_ZPt_15_30   = ibooker.book1D("u_parallel_ZPt_15_30",        "u_parallel_ZPt_15_30",        50, -100,  50);
+    meZJets_u_par_ZPt_30_55   = ibooker.book1D("u_parallel_ZPt_30_55",        "u_parallel_ZPt_30_55",        50, -175,  50);
+    meZJets_u_par_ZPt_55_75   = ibooker.book1D("u_parallel_ZPt_55_75",        "u_parallel_ZPt_55_75",        50, -175,  0);
+    meZJets_u_par_ZPt_75_150   = ibooker.book1D("u_parallel_ZPt_75_150",        "u_parallel_ZPt_75_150",        50, -300,  0);
+    if(isCaloMet_){
+      meZJets_u_par_ZPt_150_290   = ibooker.book1D("u_parallel_ZPt_150_290",        "u_parallel_ZPt_150_290",        50, -750,  -100);
+    }else{
+      meZJets_u_par_ZPt_150_290   = ibooker.book1D("u_parallel_ZPt_150_290",        "u_parallel_ZPt_150_290",        50, -450,  -50);
+    }
+    if(isCaloMet_){
+      meZJets_u_par_ZPt_290   = ibooker.book1D("u_parallel_ZPt_290",        "u_parallel_ZPt_290",        50, -1000.,  -350.);
+    }else{
+      meZJets_u_par_ZPt_290   = ibooker.book1D("u_parallel_ZPt_290",        "u_parallel_ZPt_290",        50, -750.,  -150.);
+    }
+    meZJets_u_perp   = ibooker.book1D("u_perp_Z_inc",        "u_perp_Z_inc",        50, -85., 85.);
+    meZJets_u_perp_ZPt_0_15   = ibooker.book1D("u_perp_ZPt_0_15",        "u_perp_ZPt_0_15",        50, -85., 85.);
+    meZJets_u_perp_ZPt_15_30   = ibooker.book1D("u_perp_ZPt_15_30",        "u_perp_ZPt_15_30",        50, -85., 85.);
+    meZJets_u_perp_ZPt_30_55   = ibooker.book1D("u_perp_ZPt_30_55",        "u_perp_ZPt_30_55",        50, -85., 85.);
+    meZJets_u_perp_ZPt_55_75   = ibooker.book1D("u_perp_ZPt_55_75",        "u_perp_ZPt_55_75",        50, -85., 85.);
+    meZJets_u_perp_ZPt_75_150   = ibooker.book1D("u_perp_ZPt_75_150",        "u_perp_ZPt_75_150",        50, -85., 85.);
+    meZJets_u_perp_ZPt_150_290   = ibooker.book1D("u_perp_ZPt_150_290",        "u_perp_ZPt_150_290",        50, -85., 85.);
+    meZJets_u_perp_ZPt_290   = ibooker.book1D("u_perp_ZPt_290",        "u_perp_ZPt_290",        50, -85., 85.);
+    
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_Z_inc",meZJets_u_par));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_0_15",meZJets_u_par_ZPt_0_15));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_15_30",meZJets_u_par_ZPt_15_30));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_30_55",meZJets_u_par_ZPt_30_55));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_55_75",meZJets_u_par_ZPt_55_75));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_75_150",meZJets_u_par_ZPt_75_150));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_150_290",meZJets_u_par_ZPt_150_290));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_290",meZJets_u_par_ZPt_290));
+    
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_Z_inc",meZJets_u_perp));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_0_15",meZJets_u_perp_ZPt_0_15));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_15_30",meZJets_u_perp_ZPt_15_30));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_30_55",meZJets_u_perp_ZPt_30_55));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_55_75",meZJets_u_perp_ZPt_55_75));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_75_150",meZJets_u_perp_ZPt_75_150));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_150_290",meZJets_u_perp_ZPt_150_290));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_290",meZJets_u_perp_ZPt_290));
   }
-   meZJets_u_par_ZPt_0_15   = ibooker.book1D("u_parallel_ZPt_0_15",        "u_parallel_ZPt_0_15",        50, -100,  75);
-   meZJets_u_par_ZPt_15_30   = ibooker.book1D("u_parallel_ZPt_15_30",        "u_parallel_ZPt_15_30",        50, -100,  50);
-   meZJets_u_par_ZPt_30_55   = ibooker.book1D("u_parallel_ZPt_30_55",        "u_parallel_ZPt_30_55",        50, -175,  50);
-   meZJets_u_par_ZPt_55_75   = ibooker.book1D("u_parallel_ZPt_55_75",        "u_parallel_ZPt_55_75",        50, -175,  0);
-   meZJets_u_par_ZPt_75_150   = ibooker.book1D("u_parallel_ZPt_75_150",        "u_parallel_ZPt_75_150",        50, -300,  0);
-   if(isCaloMet_){
-     meZJets_u_par_ZPt_150_290   = ibooker.book1D("u_parallel_ZPt_150_290",        "u_parallel_ZPt_150_290",        50, -750,  -100);
-   }else{
-     meZJets_u_par_ZPt_150_290   = ibooker.book1D("u_parallel_ZPt_150_290",        "u_parallel_ZPt_150_290",        50, -450,  -50);
-   }
-  if(isCaloMet_){
-    meZJets_u_par_ZPt_290   = ibooker.book1D("u_parallel_ZPt_290",        "u_parallel_ZPt_290",        50, -1000.,  -350.);
-  }else{
-    meZJets_u_par_ZPt_290   = ibooker.book1D("u_parallel_ZPt_290",        "u_parallel_ZPt_290",        50, -750.,  -150.);
-  }
-   meZJets_u_perp   = ibooker.book1D("u_perp_Z_inc",        "u_perp_Z_inc",        50, -85., 85.);
-   meZJets_u_perp_ZPt_0_15   = ibooker.book1D("u_perp_ZPt_0_15",        "u_perp_ZPt_0_15",        50, -85., 85.);
-   meZJets_u_perp_ZPt_15_30   = ibooker.book1D("u_perp_ZPt_15_30",        "u_perp_ZPt_15_30",        50, -85., 85.);
-   meZJets_u_perp_ZPt_30_55   = ibooker.book1D("u_perp_ZPt_30_55",        "u_perp_ZPt_30_55",        50, -85., 85.);
-   meZJets_u_perp_ZPt_55_75   = ibooker.book1D("u_perp_ZPt_55_75",        "u_perp_ZPt_55_75",        50, -85., 85.);
-   meZJets_u_perp_ZPt_75_150   = ibooker.book1D("u_perp_ZPt_75_150",        "u_perp_ZPt_75_150",        50, -85., 85.);
-   meZJets_u_perp_ZPt_150_290   = ibooker.book1D("u_perp_ZPt_150_290",        "u_perp_ZPt_150_290",        50, -85., 85.);
-   meZJets_u_perp_ZPt_290   = ibooker.book1D("u_perp_ZPt_290",        "u_perp_ZPt_290",        50, -85., 85.);
-
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_Z_inc",meZJets_u_par));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_0_15",meZJets_u_par_ZPt_0_15));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_15_30",meZJets_u_par_ZPt_15_30));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_30_55",meZJets_u_par_ZPt_30_55));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_55_75",meZJets_u_par_ZPt_55_75));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_75_150",meZJets_u_par_ZPt_75_150));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_150_290",meZJets_u_par_ZPt_150_290));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_parallel_ZPt_290",meZJets_u_par_ZPt_290));
-
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_Z_inc",meZJets_u_perp));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_0_15",meZJets_u_perp_ZPt_0_15));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_15_30",meZJets_u_perp_ZPt_15_30));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_30_55",meZJets_u_perp_ZPt_30_55));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_55_75",meZJets_u_perp_ZPt_55_75));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_75_150",meZJets_u_perp_ZPt_75_150));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_150_290",meZJets_u_perp_ZPt_150_290));
-   map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"u_perp_ZPt_290",meZJets_u_perp_ZPt_290));
-  }
-
+  
   if(!fillZPlots){
     hTrigger    = ibooker.book1D("triggerResults", "triggerResults", 500, 0, 500); 
     for (unsigned int i = 0; i<allTriggerNames_.size();i++){ 
@@ -334,19 +344,32 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
     hMET_2_HBHENoiseFilter      = ibooker.book1D("MET_2_HBHENoiseFilter",      "MET_HBHENoiseFiltered Range 2",200,    0, 2000);
     hMET_CSCTightHaloFilter    = ibooker.book1D("MET_CSCTightHaloFilter",        "MET_CSCTightHaloFiltered",        200,    0, 1000);
     hMET_2_CSCTightHaloFilter     = ibooker.book1D("MET_2_CSCTightHaloFilter",      "MET_CSCTightHaloFiltered Range 2",200,    0, 2000);
-    hMET_eeBadScFilter    = ibooker.book1D("MET_eeBadScFilter",        "MET_eeBadScFiltered",        200,    0, 1000);
-    hMET_2_eeBadScFilter     = ibooker.book1D("MET_2_eeBadScFilter",      "MET_eeBadScFiltered Range 2",200,    0, 2000);
-    hMET_EcalDeadCellTriggerFilter    = ibooker.book1D("MET_EcalDeadCellTriggerFilter",        "MET_EcalDeadCellTriggerFiltered",        200,    0, 1000);
-    hMET_2_EcalDeadCellTriggerFilter     = ibooker.book1D("MET_2_EcalDeadCellTriggerFilter",      "MET_EcalDeadCellTriggerFiltered Range 2",200,    0, 2000);
-
+    if(isMiniAODMet_){
+      hMET_eeBadScFilter    = ibooker.book1D("MET_eeBadScFilter",        "MET_eeBadScFiltered",        200,    0, 1000);
+      hMET_2_eeBadScFilter     = ibooker.book1D("MET_2_eeBadScFilter",      "MET_eeBadScFiltered Range 2",200,    0, 2000);
+      hMET_EcalDeadCellTriggerFilter    = ibooker.book1D("MET_EcalDeadCellTriggerFilter",        "MET_EcalDeadCellTriggerFiltered",        200,    0, 1000);
+      hMET_2_EcalDeadCellTriggerFilter     = ibooker.book1D("MET_2_EcalDeadCellTriggerFilter",      "MET_EcalDeadCellTriggerFiltered Range 2",200,    0, 2000);
+    }
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_HBHENoiseFilter",hMET_HBHENoiseFilter));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_HBHENoiseFilter",hMET_2_HBHENoiseFilter));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_CSCTightHaloFilter",hMET_CSCTightHaloFilter));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_CSCTightHaloFilter",hMET_2_CSCTightHaloFilter));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_eeBadScFilter",hMET_eeBadScFilter));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_eeBadScFilter",hMET_2_eeBadScFilter));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_EcalDeadCellTriggerFilter",hMET_EcalDeadCellTriggerFilter));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_EcalDeadCellTriggerFilter",hMET_2_EcalDeadCellTriggerFilter));
+    if(isMiniAODMet_){//default filters available as boolean
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_eeBadScFilter",hMET_eeBadScFilter));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_eeBadScFilter",hMET_2_eeBadScFilter));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_EcalDeadCellTriggerFilter",hMET_EcalDeadCellTriggerFilter));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_EcalDeadCellTriggerFilter",hMET_2_EcalDeadCellTriggerFilter));
+    }
+    if(!isMiniAODMet_){
+      hMET_CSCTightHalo2015Filter    = ibooker.book1D("MET_CSCTightHalo2015Filter",        "MET_CSCTightHalo2015Filtered",        200,    0, 1000);
+      hMET_2_CSCTightHalo2015Filter  = ibooker.book1D("MET_2_CSCTightHalo2015Filter",      "MET_CSCTightHalo2015Filtered Range 2",200,    0, 2000);
+      hMET_HBHEIsoNoiseFilter        = ibooker.book1D("MET_HBHEIsoNoiseFilter",        "MET_HBHEIsoNoiseFiltered",        200,    0, 1000);
+      hMET_2_HBHEIsoNoiseFilter      = ibooker.book1D("MET_2_HBHEIsoNoiseFilter",      "MET_HBHEIsoNoiseFiltered Range 2",200,    0, 2000);
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_HBHEIsoNoiseFilter",hMET_HBHEIsoNoiseFilter));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_HBHEIsoNoiseFilter",hMET_2_HBHEIsoNoiseFilter));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_CSCTightHalo2015Filter",hMET_CSCTightHalo2015Filter));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_CSCTightHalo2015Filter",hMET_2_CSCTightHalo2015Filter));
+    }
     
     // Book NPV profiles --> would some of these profiles be interesting for other MET types too
     //----------------------------------------------------------------------------
@@ -852,6 +875,84 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
 	mProfileIsoPFChHad_HadPtEndcap=ibooker.book2D("IsoPfChHad_HadPt_endcap",hist_tempPt_HCAL);
 	map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"IsoPfChHad_HadPt_endcap"        ,mProfileIsoPFChHad_HadPtEndcap));
       }	
+    }
+    if(isMiniAODMet_){
+      if(fillPFCandPlots && fillCandidateMap_histos){//first bool internal checks for subdirectory filling, second bool given in cfg file, checks that we fill maps only in one module in total
+	if(!etaMinPFCand_.empty()){
+	  etaMinPFCand_.clear();
+	  etaMaxPFCand_.clear();
+	  typePFCand_.clear();
+	  nbinsPFCand_.clear();
+	  countsPFCand_.clear();
+	  profilePFCand_x_.clear();
+	  profilePFCand_y_.clear();
+	  occupancyPFCand_.clear();
+	  ptPFCand_.clear();
+	  occupancyPFCand_.clear();
+	  ptPFCand_.clear();
+	  occupancyPFCand_name_puppiNolepWeight_.clear();
+	  ptPFCand_name_puppiNolepWeight_.clear();
+	  occupancyPFCand_name_puppiNolepWeight_.clear();
+	  ptPFCand_name_puppiNolepWeight_.clear();
+	  multiplicityPFCand_name_.clear();
+	}
+	for (std::vector<edm::ParameterSet>::const_iterator v = diagnosticsParameters_.begin(); v!=diagnosticsParameters_.end(); v++) {
+	  int etaNBinsPFCand = v->getParameter<int>("etaNBins");
+	  double etaMinPFCand = v->getParameter<double>("etaMin");
+	  double etaMaxPFCand = v->getParameter<double>("etaMax");
+	  int phiNBinsPFCand = v->getParameter<int>("phiNBins");
+	  double phiMinPFCand = v->getParameter<double>("phiMin");
+	  double phiMaxPFCand = v->getParameter<double>("phiMax");
+	  int nbinsPFCand = v->getParameter<double>("nbins");
+	  
+	  // etaNBins_.push_back(etaNBins);
+	  etaMinPFCand_.push_back(etaMinPFCand);
+	  etaMaxPFCand_.push_back(etaMaxPFCand);
+	  nbinsPFCand_.push_back(nbinsPFCand);
+	  typePFCand_.push_back(v->getParameter<int>("type"));
+	  countsPFCand_.push_back(0);
+	  MExPFCand_.push_back(0.);
+	  MEyPFCand_.push_back(0.);
+	  	  
+	  //push back names first, we need to create histograms with the name and fill it for endcap plots later
+	  occupancyPFCand_name_.push_back(std::string(v->getParameter<std::string>("name")).append("_occupancy_").c_str());
+	  ptPFCand_name_.push_back(std::string(v->getParameter<std::string>("name")).append("_pt_").c_str());
+	  //push back names first, we need to create histograms with the name and fill it for endcap plots later
+	  occupancyPFCand_name_puppiNolepWeight_.push_back(std::string(v->getParameter<std::string>("name")).append("_occupancy_puppiNolepWeight_").c_str());	  
+	  ptPFCand_name_puppiNolepWeight_.push_back(std::string(v->getParameter<std::string>("name")).append("_pt_puppiNolepWeight_").c_str());
+	  //special booking for endcap plots, merge plots for eminus and eplus into one plot, using variable binning
+	  //barrel plots have eta-boundaries on minus and plus side
+	  //parameters start on minus side
+	  if(etaMinPFCand*etaMaxPFCand<0){//barrel plots, plot only in barrel region
+	      occupancyPFCand_.push_back(ibooker.book2D(std::string(v->getParameter<std::string>("name")).append("_occupancy_").c_str(),std::string(v->getParameter<std::string>("name"))+"occupancy", etaNBinsPFCand, etaMinPFCand, etaMaxPFCand, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand));
+	    ptPFCand_.push_back(ibooker.book2D(std::string(v->getParameter<std::string>("name")).append("_pt_").c_str(),std::string(v->getParameter<std::string>("name"))+"pt", etaNBinsPFCand, etaMinPFCand, etaMaxPFCand, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand));
+	      occupancyPFCand_puppiNolepWeight_.push_back(ibooker.book2D(std::string(v->getParameter<std::string>("name")).append("_occupancy_puppiNolepWeight_").c_str(),std::string(v->getParameter<std::string>("name"))+"occupancy_puppiNolepWeight", etaNBinsPFCand, etaMinPFCand, etaMaxPFCand, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand));
+	    ptPFCand_puppiNolepWeight_.push_back(ibooker.book2D(std::string(v->getParameter<std::string>("name")).append("_pt_puppiNolepWeight_").c_str(),std::string(v->getParameter<std::string>("name"))+"pt_puppiNolepWeight", etaNBinsPFCand, etaMinPFCand, etaMaxPFCand, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand));
+	  }else{//endcap or forward plots, 
+	    const int nbins_eta_endcap=2*(etaNBinsPFCand+1);
+	    double eta_limits_endcap[nbins_eta_endcap];
+	    for(int i=0;i<nbins_eta_endcap;i++){
+	      if(i<(etaNBinsPFCand+1)){
+		eta_limits_endcap[i]=etaMinPFCand+i*(etaMaxPFCand-etaMinPFCand)/(double)etaNBinsPFCand;
+	      }else{
+		eta_limits_endcap[i]= -etaMaxPFCand +(i- (etaNBinsPFCand+1) )*(etaMaxPFCand-etaMinPFCand)/(double)etaNBinsPFCand;
+	      }
+	    }
+	    TH2F* hist_temp_occup = new TH2F((occupancyPFCand_name_[occupancyPFCand_name_.size()-1]).c_str(),"occupancy",nbins_eta_endcap-1, eta_limits_endcap, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand);
+	    occupancyPFCand_.push_back(ibooker.book2D(occupancyPFCand_name_[occupancyPFCand_name_.size()-1],hist_temp_occup));
+	    TH2F* hist_temp_pt = new TH2F((ptPFCand_name_[ptPFCand_name_.size()-1]).c_str(),"pt",nbins_eta_endcap-1, eta_limits_endcap, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand);
+	    ptPFCand_.push_back(ibooker.book2D(ptPFCand_name_[ptPFCand_name_.size()-1], hist_temp_pt));
+	    TH2F* hist_temp_occup_puppiNolepWeight = new TH2F((occupancyPFCand_name_puppiNolepWeight_[occupancyPFCand_name_puppiNolepWeight_.size()-1]).c_str(),"occupancy_puppiNolepWeight",nbins_eta_endcap-1, eta_limits_endcap, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand);
+	    occupancyPFCand_puppiNolepWeight_.push_back(ibooker.book2D(occupancyPFCand_name_puppiNolepWeight_[occupancyPFCand_name_puppiNolepWeight_.size()-1],hist_temp_occup_puppiNolepWeight));
+	    TH2F* hist_temp_pt_puppiNolepWeight = new TH2F((ptPFCand_name_puppiNolepWeight_[ptPFCand_name_puppiNolepWeight_.size()-1]).c_str(),"pt_puppiNolepWeight",nbins_eta_endcap-1, eta_limits_endcap, phiNBinsPFCand, phiMinPFCand, phiMaxPFCand);
+	    ptPFCand_puppiNolepWeight_.push_back(ibooker.book2D(ptPFCand_name_puppiNolepWeight_[ptPFCand_name_puppiNolepWeight_.size()-1], hist_temp_pt_puppiNolepWeight));
+	  } 
+	  map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+ occupancyPFCand_name_puppiNolepWeight_[occupancyPFCand_name_puppiNolepWeight_.size()-1], occupancyPFCand_puppiNolepWeight_[occupancyPFCand_puppiNolepWeight_.size()-1]));
+	  map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+ ptPFCand_name_puppiNolepWeight_[ptPFCand_name_puppiNolepWeight_.size()-1], ptPFCand_puppiNolepWeight_[ptPFCand_puppiNolepWeight_.size()-1]));
+	  map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+ occupancyPFCand_name_[occupancyPFCand_name_.size()-1], occupancyPFCand_[occupancyPFCand_.size()-1]));
+	  map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+ ptPFCand_name_[ptPFCand_name_.size()-1], ptPFCand_[ptPFCand_.size()-1]));
+	}
+      }   
     }
     
     if(isPFMet_ || isMiniAODMet_){
@@ -1536,8 +1637,9 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     trigger_flag[3]=true;
   }
 
-  std::vector<bool>filter_decisions(4,false);
+  std::vector<bool>filter_decisions(6,false);//for RECO include 1 new filter (HBHEIsoNoise) and 1 2015 update for CSCHalo
   if(!isMiniAODMet_){//not checked for MiniAOD -> for miniaod decision filled as "triggerResults" bool
+    
     edm::Handle<bool> HBHENoiseFilterResultHandle;
     iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
     if (!HBHENoiseFilterResultHandle.isValid()) {
@@ -1545,27 +1647,52 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       if (verbose_) std::cout << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
     }
     filter_decisions[0]= *HBHENoiseFilterResultHandle;
-    edm::Handle<bool> CSCTightHaloFilterResultHandle;
-    iEvent.getByToken(CSCHaloResultToken_, CSCTightHaloFilterResultHandle);
-    if (!CSCTightHaloFilterResultHandle.isValid()) {
-      LogDebug("") << "METAnalyzer: Could not find CSCTightHaloFilterResultHandle" << std::endl;
-      if (verbose_) std::cout << "METAnalyzer: CSCTightHaloFilterResultHandle" << std::endl;
+    edm::Handle<reco::BeamHaloSummary> BeamHaloResultHandle;
+    iEvent.getByToken(BeamHaloSummaryToken_, BeamHaloResultHandle);
+    //the other filters would be applied already at running level and applied at the same time
+    //thus the efficiency would be falsely assumed to be 100 %
+    //so far no resultProducer is available, thus at the moment not monitored in RECO
+    //edm::Handle<bool> CSCTightHaloFilterResultHandle;
+    //iEvent.getByToken(CSCHaloResultToken_, CSCTightHaloFilterResultHandle);
+    //if (!CSCTightHaloFilterResultHandle.isValid()) {
+    //LogDebug("") << "METAnalyzer: Could not find CSCTightHaloFilterResultHandle" << std::endl;
+    //if (verbose_) std::cout << "METAnalyzer: CSCTightHaloFilterResultHandle" << std::endl;
+    //}
+    //filter_decisions[1]= *CSCTightHaloFilterResultHandle;
+    if (!BeamHaloResultHandle.isValid()) {
+      LogDebug("") << "METAnalyzer: Could not find BeamHaloResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: BeamHaloResultHandle" << std::endl;
     }
-    filter_decisions[1]= *CSCTightHaloFilterResultHandle;
-    edm::Handle<bool> eeBadScFilterResultHandle;
-    iEvent.getByToken(eeBadScFilterToken_, eeBadScFilterResultHandle);
-    if (!eeBadScFilterResultHandle.isValid()) {
-      LogDebug("") << "METAnalyzer: Could not find eeBadScFilterResultHandle" << std::endl;
-      if (verbose_) std::cout << "METAnalyzer: eeBadScFilterResultHandle" << std::endl;
+    filter_decisions[1]= !BeamHaloResultHandle->CSCTightHaloId();
+    //edm::Handle<bool> eeBadScFilterResultHandle;
+    //iEvent.getByToken(eeBadScFilterToken_, eeBadScFilterResultHandle);
+    //if (!eeBadScFilterResultHandle.isValid()) {
+    //LogDebug("") << "METAnalyzer: Could not find eeBadScFilterResultHandle" << std::endl;
+    //if (verbose_) std::cout << "METAnalyzer: eeBadScFilterResultHandle" << std::endl;
+    //}
+    //filter_decisions[2]= *eeBadScFilterResultHandle;
+    //edm::Handle<bool> EcalDeadCellTriggerFilterResultHandle;
+    //iEvent.getByToken(EcalDeadCellTriggerToken_, EcalDeadCellTriggerFilterResultHandle);
+    //if (!EcalDeadCellTriggerFilterResultHandle.isValid()) {
+    //LogDebug("") << "METAnalyzer: Could not find EcalDeadCellTriggerFilterResultHandle" << std::endl;
+    //if (verbose_) std::cout << "METAnalyzer: EcalDeadCellTriggerFilterResultHandle" << std::endl;
+    //}
+    //filter_decisions[3]= *EcalDeadCellTriggerFilterResultHandle;
+    edm::Handle<bool> HBHEIsoNoiseFilterResultHandle;
+    iEvent.getByToken(hbheIsoNoiseFilterResultToken_, HBHEIsoNoiseFilterResultHandle);
+    if (!HBHEIsoNoiseFilterResultHandle.isValid()) {
+      LogDebug("") << "METAnalyzer: Could not find HBHEIsoNoiseFilterResult" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: Could not find HBHEIsoNoiseFilterResult" << std::endl;
     }
-    filter_decisions[2]= *eeBadScFilterResultHandle;
-    edm::Handle<bool> EcalDeadCellTriggerFilterResultHandle;
-    iEvent.getByToken(EcalDeadCellTriggerToken_, EcalDeadCellTriggerFilterResultHandle);
-    if (!EcalDeadCellTriggerFilterResultHandle.isValid()) {
-      LogDebug("") << "METAnalyzer: Could not find EcalDeadCellTriggerFilterResultHandle" << std::endl;
-      if (verbose_) std::cout << "METAnalyzer: EcalDeadCellTriggerFilterResultHandle" << std::endl;
-    }
-    filter_decisions[3]= *EcalDeadCellTriggerFilterResultHandle;
+    filter_decisions[4]= *HBHEIsoNoiseFilterResultHandle;
+    //edm::Handle<bool> CSCTightHalo2015FilterResultHandle;
+    //iEvent.getByToken(CSCHalo2015ResultToken_, CSCTightHalo2015FilterResultHandle);
+    //if (!CSCTightHalo2015FilterResultHandle.isValid()) {
+    //LogDebug("") << "METAnalyzer: Could not find CSCTightHalo2015FilterResultHandle" << std::endl;
+    //if (verbose_) std::cout << "METAnalyzer: CSCTightHalo2015FilterResultHandle" << std::endl;
+    //}
+    //filter_decisions[5]= *CSCTightHalo2015FilterResultHandle;
+    filter_decisions[5]= !BeamHaloResultHandle->CSCTightHaloId2015();
   }else{
     edm::Handle<edm::TriggerResults> metFilterResults;
     iEvent.getByToken(METFilterMiniAODToken_, metFilterResults);
@@ -1763,10 +1890,12 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
     hMET    = map_of_MEs[DirName+"/"+"MET"];     if (hMET           && hMET->getRootObject())     hMET          ->Fill(MET);
     hMET_2  = map_of_MEs[DirName+"/"+"MET_2"];   if (hMET_2         && hMET_2->getRootObject())   hMET_2        ->Fill(MET);
 
-    bool HBHENoiseFilterResult=true;
-    bool CSCTightHaloFilterResult=true;
-    bool eeBadScFilterResult=true;
-    bool EcalDeadCellTriggerFilterResult=true;
+    bool HBHENoiseFilterResult=false;
+    bool CSCTightHaloFilterResult=false;
+    bool eeBadScFilterResult=false;
+    bool EcalDeadCellTriggerFilterResult=false;
+    bool HBHEIsoNoiseFilterResult=false;
+    bool CSCTightHalo2015FilterResult=false;
     HBHENoiseFilterResult = METFilterDecision[0];
     if(HBHENoiseFilterResult){
       hMET_HBHENoiseFilter    = map_of_MEs[DirName+"/"+"MET_HBHENoiseFilter"];     if (hMET_HBHENoiseFilter           && hMET_HBHENoiseFilter->getRootObject())     hMET_HBHENoiseFilter          ->Fill(MET);
@@ -1787,7 +1916,18 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
       hMET_EcalDeadCellTriggerFilter    = map_of_MEs[DirName+"/"+"MET_EcalDeadCellTriggerFilter"];     if (hMET_EcalDeadCellTriggerFilter           && hMET_EcalDeadCellTriggerFilter->getRootObject())     hMET_EcalDeadCellTriggerFilter          ->Fill(MET);
       hMET_2_EcalDeadCellTriggerFilter  = map_of_MEs[DirName+"/"+"MET_2_EcalDeadCellTriggerFilter"];   if (hMET_2_EcalDeadCellTriggerFilter         && hMET_2_EcalDeadCellTriggerFilter->getRootObject())   hMET_2_EcalDeadCellTriggerFilter        ->Fill(MET);
     }
-
+    if(!isMiniAODMet_){//not in MINIAOD yet
+      HBHEIsoNoiseFilterResult = METFilterDecision[4];
+      if(HBHEIsoNoiseFilterResult){
+	hMET_HBHEIsoNoiseFilter    = map_of_MEs[DirName+"/"+"MET_HBHEIsoNoiseFilter"];     if (hMET_HBHEIsoNoiseFilter           && hMET_HBHEIsoNoiseFilter->getRootObject())     hMET_HBHEIsoNoiseFilter          ->Fill(MET);
+	hMET_2_HBHEIsoNoiseFilter  = map_of_MEs[DirName+"/"+"MET_2_HBHEIsoNoiseFilter"];   if (hMET_2_HBHEIsoNoiseFilter         && hMET_2_HBHEIsoNoiseFilter->getRootObject())   hMET_2_HBHEIsoNoiseFilter        ->Fill(MET);
+      }
+      CSCTightHalo2015FilterResult =  METFilterDecision[5];
+      if(CSCTightHalo2015FilterResult){
+	hMET_CSCTightHalo2015Filter    = map_of_MEs[DirName+"/"+"MET_CSCTightHalo2015Filter"];     if (hMET_CSCTightHalo2015Filter           && hMET_CSCTightHalo2015Filter->getRootObject())     hMET_CSCTightHalo2015Filter          ->Fill(MET);
+	hMET_2_CSCTightHalo2015Filter  = map_of_MEs[DirName+"/"+"MET_2_CSCTightHalo2015Filter"];   if (hMET_2_CSCTightHalo2015Filter         && hMET_2_CSCTightHalo2015Filter->getRootObject())   hMET_2_CSCTightHalo2015Filter        ->Fill(MET);
+      }
+    }
 
     hMETPhi = map_of_MEs[DirName+"/"+"METPhi"];  if (hMETPhi        && hMETPhi->getRootObject())  hMETPhi       ->Fill(METPhi);
     hSumET  = map_of_MEs[DirName+"/"+"SumET"];   if (hSumET         && hSumET->getRootObject())   hSumET        ->Fill(SumET);
@@ -1861,6 +2001,32 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
       //} 
     }
 
+    if(isMiniAODMet_){
+      if(fillPFCandidatePlots && fillCandidateMap_histos){
+	// typedef std::vector<reco::PFCandidate> pfCand;
+	edm::Handle<std::vector<pat::PackedCandidate> > packedParticleFlow;
+	iEvent.getByToken(pflowPackedToken_, packedParticleFlow);
+	//11, 13, 22 for el/mu/gamma, 211 chargedHadron, 130 neutralHadrons, 1 and 2 hadHF and EGammaHF
+	for (unsigned int i = 0; i < packedParticleFlow->size(); i++) {
+	  const pat::PackedCandidate& c = packedParticleFlow->at(i);
+	  for (unsigned int j=0; j<typePFCand_.size(); j++) {
+	    if (fabs(c.pdgId())==typePFCand_[j]) {
+	      //second check for endcap, if inside barrel Max and Min symmetric around 0
+	      if ( ((c.eta()>etaMinPFCand_[j]) && (c.eta()<etaMaxPFCand_[j])) || ((c.eta()> (-etaMaxPFCand_[j])) && (c.eta()< (-etaMinPFCand_[j]))) ){
+		ptPFCand_[j]   = map_of_MEs[DirName + "/"+ptPFCand_name_[j]];
+		if ( ptPFCand_[j]       && ptPFCand_[j]->getRootObject()) ptPFCand_[j]->Fill(c.eta(), c.phi(), c.pt()*c.puppiWeight());
+		occupancyPFCand_[j]   = map_of_MEs[DirName + "/"+occupancyPFCand_name_[j]];
+		if ( occupancyPFCand_[j]       && occupancyPFCand_[j]->getRootObject()) occupancyPFCand_[j]->Fill(c.eta(), c.phi()),c.puppiWeight();
+		ptPFCand_puppiNolepWeight_[j]   = map_of_MEs[DirName + "/"+ptPFCand_name_puppiNolepWeight_[j]];
+		if ( ptPFCand_puppiNolepWeight_[j]       && ptPFCand_puppiNolepWeight_[j]->getRootObject()) ptPFCand_puppiNolepWeight_[j]->Fill(c.eta(), c.phi(), c.pt()*c.puppiWeightNoLep());
+		occupancyPFCand_puppiNolepWeight_[j]   = map_of_MEs[DirName + "/"+occupancyPFCand_name_puppiNolepWeight_[j]];
+		if ( occupancyPFCand_puppiNolepWeight_[j]       && occupancyPFCand_puppiNolepWeight_[j]->getRootObject()) occupancyPFCand_puppiNolepWeight_[j]->Fill(c.eta(), c.phi()),c.puppiWeightNoLep();
+	      }
+	    }
+	  }
+	}
+      }
+    }
     if(isPFMet_){
 
       if(fillPFCandidatePlots && fillCandidateMap_histos){
@@ -1887,7 +2053,6 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
 	float pt_sum_HFH_minus=0;
 	float pt_sum_HFE_plus=0;
 	float pt_sum_HFE_minus=0;
-
 
 	float px_chargedHadronsBarrel=0;
 	float py_chargedHadronsBarrel=0;

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -1541,7 +1541,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     edm::Handle<bool> HBHENoiseFilterResultHandle;
     iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
     if (!HBHENoiseFilterResultHandle.isValid()) {
-     std::cout<<"wrong1"<<std::endl;
       LogDebug("") << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
       if (verbose_) std::cout << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
     }
@@ -1549,38 +1548,24 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     edm::Handle<bool> CSCTightHaloFilterResultHandle;
     iEvent.getByToken(CSCHaloResultToken_, CSCTightHaloFilterResultHandle);
     if (!CSCTightHaloFilterResultHandle.isValid()) {
-     std::cout<<"wrong2"<<std::endl;
       LogDebug("") << "METAnalyzer: Could not find CSCTightHaloFilterResultHandle" << std::endl;
       if (verbose_) std::cout << "METAnalyzer: CSCTightHaloFilterResultHandle" << std::endl;
-    }
-    if(*CSCTightHaloFilterResultHandle==false){
-      std::cout<<"filter is false CSC"<<std::endl;
-    }else{
-      //std::cout<<"filter is passed CSC"<<(*CSCTightHaloFilterResultHandle)<<std::endl;
     }
     filter_decisions[1]= *CSCTightHaloFilterResultHandle;
     edm::Handle<bool> eeBadScFilterResultHandle;
     iEvent.getByToken(eeBadScFilterToken_, eeBadScFilterResultHandle);
     if (!eeBadScFilterResultHandle.isValid()) {
-     std::cout<<"wrong3"<<std::endl;
       LogDebug("") << "METAnalyzer: Could not find eeBadScFilterResultHandle" << std::endl;
       if (verbose_) std::cout << "METAnalyzer: eeBadScFilterResultHandle" << std::endl;
     }
     filter_decisions[2]= *eeBadScFilterResultHandle;
-    if(*eeBadScFilterResultHandle==false){
-      std::cout<<"filter is false eebadsc"<<std::endl;
-    }
     edm::Handle<bool> EcalDeadCellTriggerFilterResultHandle;
     iEvent.getByToken(EcalDeadCellTriggerToken_, EcalDeadCellTriggerFilterResultHandle);
     if (!EcalDeadCellTriggerFilterResultHandle.isValid()) {
-      std::cout<<"wrong4"<<std::endl;
       LogDebug("") << "METAnalyzer: Could not find EcalDeadCellTriggerFilterResultHandle" << std::endl;
       if (verbose_) std::cout << "METAnalyzer: EcalDeadCellTriggerFilterResultHandle" << std::endl;
     }
     filter_decisions[3]= *EcalDeadCellTriggerFilterResultHandle;
-    if(*EcalDeadCellTriggerFilterResultHandle==false){
-      std::cout<<"filter is false ecalD"<<std::endl;
-    }
   }else{
     edm::Handle<edm::TriggerResults> metFilterResults;
     iEvent.getByToken(METFilterMiniAODToken_, metFilterResults);

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -45,6 +45,9 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   m_l1algoname_ = pSet.getParameter<std::string>("l1algoname");
   m_bitAlgTechTrig_=-1;
 
+  miniaodfilterdec=-1;
+   
+
   LSBegin_     = pSet.getParameter<int>("LSBegin");
   LSEnd_       = pSet.getParameter<int>("LSEnd");
  // Smallest track pt
@@ -76,7 +79,7 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   }
   if(isPFMet_ || isMiniAODMet_){
     pflowToken_ = consumes<std::vector<reco::PFCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
-    pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::FIRSTDATA, PFJetIDSelectionFunctor::LOOSE);
+    pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::RUNIISTARTUP, PFJetIDSelectionFunctor::LOOSE);
   }
   MuonsToken_ = consumes<reco::MuonCollection>(pSet.getParameter<edm::InputTag>       ("muonsrc"));
 
@@ -130,6 +133,18 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
 
   hbheNoiseFilterResultTag_    = parameters.getParameter<edm::InputTag>("HBHENoiseFilterResultLabel");
   hbheNoiseFilterResultToken_=consumes<bool>(hbheNoiseFilterResultTag_);
+  CSCHaloResultTag_= parameters.getParameter<edm::InputTag>("CSCHaloResultLabel");
+  CSCHaloResultToken_=consumes<bool>(CSCHaloResultTag_);
+  EcalDeadCellTriggerTag_= parameters.getParameter<edm::InputTag>("EcalDeadCellTriggerLabel");
+  EcalDeadCellTriggerToken_=consumes<bool>(EcalDeadCellTriggerTag_);
+  eeBadScFilterTag_= parameters.getParameter<edm::InputTag>("eeBadScFilterLabel");
+  eeBadScFilterToken_=consumes<bool>(eeBadScFilterTag_);
+
+  METFilterMiniAODLabel_=parameters.getParameter<edm::InputTag>("FilterResultsLabelMiniAOD");
+  METFilterMiniAODToken_=consumes<edm::TriggerResults>(METFilterMiniAODLabel_);
+
+  METFilterMiniAODLabel2_=parameters.getParameter<edm::InputTag>("FilterResultsLabelMiniAOD2");
+  METFilterMiniAODToken2_=consumes<edm::TriggerResults>(METFilterMiniAODLabel2_);
 
   // 
   nbinsPV_ = parameters.getParameter<int>("pVBin");
@@ -200,12 +215,12 @@ void METAnalyzer::bookMESet(std::string DirName, DQMStore::IBooker & ibooker, st
   if (DirName.find("Cleaned")!=std::string::npos) {
     fillPFCandidatePlots=true;
     bookMonitorElement(DirName,ibooker,map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,fillZPlots);
-    for (unsigned int i = 0; i<triggerFolderEventFlag_.size(); i++) {
-      fillPFCandidatePlots=false;
-      if (triggerFolderEventFlag_[i]->on()) {
-        bookMonitorElement(DirName+"/"+triggerFolderLabels_[i],ibooker,map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,fillZPlots);
-      }
-    }
+    //for (unsigned int i = 0; i<triggerFolderEventFlag_.size(); i++) {
+    //fillPFCandidatePlots=false;
+      //if (triggerFolderEventFlag_[i]->on()) {
+      //bookMonitorElement(DirName+"/"+triggerFolderLabels_[i],ibooker,map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,fillZPlots);
+      //}
+    //}
   }else if (DirName.find("ZJets")!=std::string::npos) {
     fillPFCandidatePlots=false;
     fillZPlots=true;
@@ -287,15 +302,17 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
     hMEx        = ibooker.book1D("MEx",        "MEx",        200, -500,  500);
     hMEy        = ibooker.book1D("MEy",        "MEy",        200, -500,  500);
     hMET        = ibooker.book1D("MET",        "MET",        200,    0, 1000);
+    hMET_2      = ibooker.book1D("MET_2",      "MET Range 2",200,    0, 2000);
     hSumET      = ibooker.book1D("SumET",      "SumET",      400,    0, 4000);
     hMETSig     = ibooker.book1D("METSig",     "METSig",      51,    0,   51);
     hMETPhi     = ibooker.book1D("METPhi",     "METPhi",      60, -M_PI,  M_PI);
-    hMET_logx   = ibooker.book1D("MET_logx",   "MET_logx",    40,   -1,    7);
-    hSumET_logx = ibooker.book1D("SumET_logx", "SumET_logx",  40,   -1,    7);
+    hMET_logx   = ibooker.book1D("MET_logx",   "MET_logx",    40,   -1,    9);
+    hSumET_logx = ibooker.book1D("SumET_logx", "SumET_logx",  40,   -1,    9);
     
     hMEx       ->setAxisTitle("MEx [GeV]",        1);
     hMEy       ->setAxisTitle("MEy [GeV]",        1);
     hMET       ->setAxisTitle("MET [GeV]",        1);
+    hMET_2     ->setAxisTitle("MET [GeV]",        1);
     hSumET     ->setAxisTitle("SumET [GeV]",      1);
     hMETSig    ->setAxisTitle("METSig",       1);
     hMETPhi    ->setAxisTitle("METPhi [rad]",     1);
@@ -306,11 +323,30 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MEx",hMEx));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MEy",hMEy));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET",hMET));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2",hMET_2));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SumET",hSumET));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METSig",hMETSig));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhi",hMETPhi));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_logx",hMET_logx));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"SumET_logx",hSumET_logx));
+
+    hMET_HBHENoiseFilter        = ibooker.book1D("MET_HBHENoiseFilter",        "MET_HBHENoiseFiltered",        200,    0, 1000);
+    hMET_2_HBHENoiseFilter      = ibooker.book1D("MET_2_HBHENoiseFilter",      "MET_HBHENoiseFiltered Range 2",200,    0, 2000);
+    hMET_CSCTightHaloFilter    = ibooker.book1D("MET_CSCTightHaloFilter",        "MET_CSCTightHaloFiltered",        200,    0, 1000);
+    hMET_2_CSCTightHaloFilter     = ibooker.book1D("MET_2_CSCTightHaloFilter",      "MET_CSCTightHaloFiltered Range 2",200,    0, 2000);
+    hMET_eeBadScFilter    = ibooker.book1D("MET_eeBadScFilter",        "MET_eeBadScFiltered",        200,    0, 1000);
+    hMET_2_eeBadScFilter     = ibooker.book1D("MET_2_eeBadScFilter",      "MET_eeBadScFiltered Range 2",200,    0, 2000);
+    hMET_EcalDeadCellTriggerFilter    = ibooker.book1D("MET_EcalDeadCellTriggerFilter",        "MET_EcalDeadCellTriggerFiltered",        200,    0, 1000);
+    hMET_2_EcalDeadCellTriggerFilter     = ibooker.book1D("MET_2_EcalDeadCellTriggerFilter",      "MET_EcalDeadCellTriggerFiltered Range 2",200,    0, 2000);
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_HBHENoiseFilter",hMET_HBHENoiseFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_HBHENoiseFilter",hMET_2_HBHENoiseFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_CSCTightHaloFilter",hMET_CSCTightHaloFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_CSCTightHaloFilter",hMET_2_CSCTightHaloFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_eeBadScFilter",hMET_eeBadScFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_eeBadScFilter",hMET_2_eeBadScFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_EcalDeadCellTriggerFilter",hMET_EcalDeadCellTriggerFilter));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"MET_2_EcalDeadCellTriggerFilter",hMET_2_EcalDeadCellTriggerFilter));
     
     // Book NPV profiles --> would some of these profiles be interesting for other MET types too
     //----------------------------------------------------------------------------
@@ -701,41 +737,8 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
 	map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhiHFHadronsMinus"               ,meMETPhiHFHadronsMinus));
 	map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhiHFEGammasPlus"                ,meMETPhiHFEGammasPlus));
 	map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"METPhiHFEGammasMinus"               ,meMETPhiHFEGammasMinus));
-      }
-      mePhotonEt                = ibooker.book1D("PfPhotonEt",                "photonEt()",                50, 0, 1000);
-      meNeutralHadronEt         = ibooker.book1D("PfNeutralHadronEt",         "neutralHadronEt()",         50, 0, 1000);
-      meElectronEt              = ibooker.book1D("PfElectronEt",              "electronEt()",              50, 0, 100);
-      meChargedHadronEt         = ibooker.book1D("PfChargedHadronEt",         "chargedHadronEt()",         50, 0, 1000);
-      meMuonEt                  = ibooker.book1D("PfMuonEt",                  "muonEt()",                  50, 0, 100);
-      meHFHadronEt              = ibooker.book1D("PfHFHadronEt",              "HFHadronEt()",              50, 0, 1000);
-      meHFEMEt                  = ibooker.book1D("PfHFEMEt",                  "HFEMEt()",                  50, 0, 1000);
-
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt"               ,mePhotonEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt"        ,meNeutralHadronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfElectronEt"             ,meElectronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt"        ,meChargedHadronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfMuonEt"                 ,meMuonEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt"             ,meHFHadronEt));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt"                 ,meHFEMEt));
-      
-      mePhotonEt_profile                = ibooker.bookProfile("PfPhotonEt_profile",                "photonEt()",                nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meNeutralHadronEt_profile         = ibooker.bookProfile("PfNeutralHadronEt_profile",         "neutralHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meChargedHadronEt_profile         = ibooker.bookProfile("PfChargedHadronEt_profile",         "chargedHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meHFHadronEt_profile              = ibooker.bookProfile("PfHFHadronEt_profile",              "HFHadronEt()",              nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      meHFEMEt_profile                  = ibooker.bookProfile("PfHFEMEt_profile",                  "HFEMEt()",                  nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
-      
-      mePhotonEt_profile               ->setAxisTitle("nvtx", 1);
-      meNeutralHadronEt_profile        ->setAxisTitle("nvtx", 1);
-      meChargedHadronEt_profile        ->setAxisTitle("nvtx", 1);
-      meHFHadronEt_profile             ->setAxisTitle("nvtx", 1);
-      meHFEMEt_profile                 ->setAxisTitle("nvtx", 1);
-      
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt_profile"                ,mePhotonEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt_profile"         ,meNeutralHadronEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt_profile"         ,meChargedHadronEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt_profile"              ,meHFHadronEt_profile));
-      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt_profile"                  ,meHFEMEt_profile));
-      
+      } 
+     
       if(fillPFCandPlots && fillCandidateMap_histos){
 	if(!etaMinPFCand_.empty()){
 	  etaMinPFCand_.clear();
@@ -880,6 +883,40 @@ void METAnalyzer::bookMonitorElement(std::string DirName,DQMStore::IBooker & ibo
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEtFraction_profile" ,meChargedHadronEtFraction_profile));
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEtFraction_profile"      ,meHFHadronEtFraction_profile));
       map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEtFraction_profile"          ,meHFEMEtFraction_profile));
+
+      mePhotonEt                = ibooker.book1D("PfPhotonEt",                "photonEt()",                50, 0, 1000);
+      meNeutralHadronEt         = ibooker.book1D("PfNeutralHadronEt",         "neutralHadronEt()",         50, 0, 1000);
+      meElectronEt              = ibooker.book1D("PfElectronEt",              "electronEt()",              50, 0, 100);
+      meChargedHadronEt         = ibooker.book1D("PfChargedHadronEt",         "chargedHadronEt()",         50, 0, 2000);
+      meMuonEt                  = ibooker.book1D("PfMuonEt",                  "muonEt()",                  50, 0, 100);
+      meHFHadronEt              = ibooker.book1D("PfHFHadronEt",              "HFHadronEt()",              50, 0, 2000);
+      meHFEMEt                  = ibooker.book1D("PfHFEMEt",                  "HFEMEt()",                  50, 0, 1000);
+
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt"               ,mePhotonEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt"        ,meNeutralHadronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfElectronEt"             ,meElectronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt"        ,meChargedHadronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfMuonEt"                 ,meMuonEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt"             ,meHFHadronEt));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt"                 ,meHFEMEt));
+      
+      mePhotonEt_profile                = ibooker.bookProfile("PfPhotonEt_profile",                "photonEt()",                nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meNeutralHadronEt_profile         = ibooker.bookProfile("PfNeutralHadronEt_profile",         "neutralHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meChargedHadronEt_profile         = ibooker.bookProfile("PfChargedHadronEt_profile",         "chargedHadronEt()",         nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meHFHadronEt_profile              = ibooker.bookProfile("PfHFHadronEt_profile",              "HFHadronEt()",              nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      meHFEMEt_profile                  = ibooker.bookProfile("PfHFEMEt_profile",                  "HFEMEt()",                  nbinsPV_, nPVMin_, nPVMax_, 50, 0, 1000);
+      
+      mePhotonEt_profile               ->setAxisTitle("nvtx", 1);
+      meNeutralHadronEt_profile        ->setAxisTitle("nvtx", 1);
+      meChargedHadronEt_profile        ->setAxisTitle("nvtx", 1);
+      meHFHadronEt_profile             ->setAxisTitle("nvtx", 1);
+      meHFEMEt_profile                 ->setAxisTitle("nvtx", 1);
+      
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfPhotonEt_profile"                ,mePhotonEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfNeutralHadronEt_profile"         ,meNeutralHadronEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfChargedHadronEt_profile"         ,meChargedHadronEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFHadronEt_profile"              ,meHFHadronEt_profile));
+      map_of_MEs.insert(std::pair<std::string,MonitorElement*>(DirName+"/"+"PfHFEMEt_profile"                  ,meHFEMEt_profile));
     }
     
     if (isCaloMet_){
@@ -956,6 +993,59 @@ void METAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
       }
     }
   }
+  if(isMiniAODMet_){
+    bool changed_filter=true;
+    if (FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel_.process(),changed_filter)){
+      miniaodfilterdec=0;
+      std::vector<int>initializeFilter(4,-1);
+      miniaodFilterIndex_=initializeFilter; 
+      for(unsigned int i=0;i<FilterhltConfig_.size();i++){
+	std::string search=FilterhltConfig_.triggerName(i).substr(5);//actual label of filter, the first 5 items are Flag_
+	std::size_t found=hbheNoiseFilterResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[0]=i;
+	}
+	found=CSCHaloResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[1]=i;
+	}
+	found=eeBadScFilterTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[2]=i;
+	}
+	found=EcalDeadCellTriggerTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[3]=i;
+	}
+      }
+    }else if(FilterhltConfig_.init(iRun,iSetup,METFilterMiniAODLabel2_.process(),changed_filter)){
+      miniaodfilterdec=1;
+      std::vector<int>initializeFilter(4,-1);
+      miniaodFilterIndex_=initializeFilter; 
+      for(unsigned int i=0;i<FilterhltConfig_.size();i++){
+	std::string search=FilterhltConfig_.triggerName(i).substr(5);//actual label of filter, the first 5 items are Flag_
+	std::size_t found=hbheNoiseFilterResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[0]=i;
+	}
+	found=CSCHaloResultTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[1]=i;
+	}
+	found=eeBadScFilterTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[2]=i;
+	}
+	found=EcalDeadCellTriggerTag_.label().find(search);
+	if(found!=std::string::npos){
+	  miniaodFilterIndex_[3]=i;
+	}
+      }
+    }else{
+      std::cout<<"nothing found with both RECO and reRECO label"<<std::endl;
+    }
+  }
+
 }
 
 // ***********************************************************
@@ -1168,19 +1258,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     //}
 
   // ==========================================================
-  //
-
-  edm::Handle<bool> HBHENoiseFilterResultHandle;
-  bool HBHENoiseFilterResult=true;
-  if(!isMiniAODMet_){//not checked for MiniAOD
-    iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
-    if (!HBHENoiseFilterResultHandle.isValid()) {
-      LogDebug("") << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
-      if (verbose_) std::cout << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
-    }
-    HBHENoiseFilterResult = *HBHENoiseFilterResultHandle;
-  }
-  // ==========================================================
   bool bJetID = false;
   bool bDiJetID = false;
   // Jet ID -------------------------------------------------------
@@ -1345,9 +1422,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }
   }
   // ==========================================================
-  // HCAL Noise filter
-
-  bool bHBHENoiseFilter = HBHENoiseFilterResult;
   // ==========================================================
   //Vertex information
   Handle<VertexCollection> vertexHandle;
@@ -1462,6 +1536,92 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     trigger_flag[3]=true;
   }
 
+  std::vector<bool>filter_decisions(4,false);
+  if(!isMiniAODMet_){//not checked for MiniAOD -> for miniaod decision filled as "triggerResults" bool
+    edm::Handle<bool> HBHENoiseFilterResultHandle;
+    iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
+    if (!HBHENoiseFilterResultHandle.isValid()) {
+     std::cout<<"wrong1"<<std::endl;
+      LogDebug("") << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: Could not find HBHENoiseFilterResult" << std::endl;
+    }
+    filter_decisions[0]= *HBHENoiseFilterResultHandle;
+    edm::Handle<bool> CSCTightHaloFilterResultHandle;
+    iEvent.getByToken(CSCHaloResultToken_, CSCTightHaloFilterResultHandle);
+    if (!CSCTightHaloFilterResultHandle.isValid()) {
+     std::cout<<"wrong2"<<std::endl;
+      LogDebug("") << "METAnalyzer: Could not find CSCTightHaloFilterResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: CSCTightHaloFilterResultHandle" << std::endl;
+    }
+    if(*CSCTightHaloFilterResultHandle==false){
+      std::cout<<"filter is false CSC"<<std::endl;
+    }else{
+      //std::cout<<"filter is passed CSC"<<(*CSCTightHaloFilterResultHandle)<<std::endl;
+    }
+    filter_decisions[1]= *CSCTightHaloFilterResultHandle;
+    edm::Handle<bool> eeBadScFilterResultHandle;
+    iEvent.getByToken(eeBadScFilterToken_, eeBadScFilterResultHandle);
+    if (!eeBadScFilterResultHandle.isValid()) {
+     std::cout<<"wrong3"<<std::endl;
+      LogDebug("") << "METAnalyzer: Could not find eeBadScFilterResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: eeBadScFilterResultHandle" << std::endl;
+    }
+    filter_decisions[2]= *eeBadScFilterResultHandle;
+    if(*eeBadScFilterResultHandle==false){
+      std::cout<<"filter is false eebadsc"<<std::endl;
+    }
+    edm::Handle<bool> EcalDeadCellTriggerFilterResultHandle;
+    iEvent.getByToken(EcalDeadCellTriggerToken_, EcalDeadCellTriggerFilterResultHandle);
+    if (!EcalDeadCellTriggerFilterResultHandle.isValid()) {
+      std::cout<<"wrong4"<<std::endl;
+      LogDebug("") << "METAnalyzer: Could not find EcalDeadCellTriggerFilterResultHandle" << std::endl;
+      if (verbose_) std::cout << "METAnalyzer: EcalDeadCellTriggerFilterResultHandle" << std::endl;
+    }
+    filter_decisions[3]= *EcalDeadCellTriggerFilterResultHandle;
+    if(*EcalDeadCellTriggerFilterResultHandle==false){
+      std::cout<<"filter is false ecalD"<<std::endl;
+    }
+  }else{
+    edm::Handle<edm::TriggerResults> metFilterResults;
+    iEvent.getByToken(METFilterMiniAODToken_, metFilterResults);
+
+    if(metFilterResults.isValid()){
+      if(miniaodFilterIndex_[0]!=-1){
+	filter_decisions[0] = metFilterResults->accept(miniaodFilterIndex_[0]);
+      }
+      if(miniaodFilterIndex_[1]!=-1){
+	filter_decisions[1] = metFilterResults->accept(miniaodFilterIndex_[1]);
+      }
+      if(miniaodFilterIndex_[2]!=-1){
+	filter_decisions[2] = metFilterResults->accept(miniaodFilterIndex_[2]);
+      }
+      if(miniaodFilterIndex_[3]!=-1){
+	filter_decisions[3] = metFilterResults->accept(miniaodFilterIndex_[3]);
+      }
+    }else{
+      iEvent.getByToken(METFilterMiniAODToken2_, metFilterResults);
+      if(metFilterResults.isValid()){
+	if(miniaodFilterIndex_[0]!=-1){
+	  filter_decisions[0] = metFilterResults->accept(miniaodFilterIndex_[0]);
+	}
+	if(miniaodFilterIndex_[1]!=-1){
+	  filter_decisions[1] = metFilterResults->accept(miniaodFilterIndex_[1]);
+	}
+	if(miniaodFilterIndex_[2]!=-1){
+	  filter_decisions[2] = metFilterResults->accept(miniaodFilterIndex_[2]);
+	}
+	if(miniaodFilterIndex_[3]!=-1){
+	  filter_decisions[3] = metFilterResults->accept(miniaodFilterIndex_[3]);
+	}
+      }
+    }
+  }
+
+  bool HBHENoiseFilterResultFlag=filter_decisions[0];//setup for RECO and MINIAOD
+  // ==========================================================
+  // HCAL Noise filter
+  bool bHBHENoiseFilter = HBHENoiseFilterResultFlag;
+
   // DCS Filter
   bool bDCSFilter = (bypassAllDCSChecks_ || DCSFilter_->filter(iEvent, iSetup));
   // ==========================================================
@@ -1471,20 +1631,20 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
        ic != folderNames_.end(); ic++){
     bool pass_selection = false;
     if ((*ic=="Uncleaned")  &&(isCaloMet_ || bPrimaryVertex)){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet, *pfmet,*calomet,zCand, map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet, *pfmet,*calomet,zCand, map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection =true;
     }
     //take two lines out for first check
-    if ((*ic=="Cleaned")    &&bDCSFilter&&bHBHENoiseFilter&&bPrimaryVertex&&bJetID){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag);
+    if ((*ic=="Cleaned")    && bDCSFilter && bHBHENoiseFilter && bPrimaryVertex && bJetID){
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection=true;
     }
     if ((*ic=="DiJet" )     &&bDCSFilter&&bHBHENoiseFilter&& bPrimaryVertex&& bDiJetID){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection=true;
     }
     if ((*ic=="ZJets" )     &&bDCSFilter&&bHBHENoiseFilter&& bPrimaryVertex&& bZJets){
-      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag);
+      fillMESet(iEvent, DirName_old+"/"+*ic, *met,*patmet,*pfmet,*calomet,zCand,map_dijet_MEs,trigger_flag,filter_decisions);
       pass_selection=true;
     }
     if(pass_selection && isPFMet_){
@@ -1497,28 +1657,28 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
 // ***********************************************************
 void METAnalyzer::fillMESet(const edm::Event& iEvent, std::string DirName,
-			    const reco::MET& met, const pat::MET& patmet, const reco::PFMET& pfmet, const reco::CaloMET& calomet,const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs, std::vector<bool>techTriggerCase)
+			    const reco::MET& met, const pat::MET& patmet, const reco::PFMET& pfmet, const reco::CaloMET& calomet,const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs, std::vector<bool>techTriggerCase, std::vector<bool>METFilterDecision)
 {
   bool bLumiSecPlot=fill_met_high_level_histo;
   bool fillPFCandidatePlots=false;
   if (DirName.find("Cleaned")!=std::string::npos) {
     fillPFCandidatePlots=true;
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
     for (unsigned int i = 0; i<triggerFolderLabels_.size(); i++) {
       fillPFCandidatePlots=false;
       if (triggerFolderDecisions_[i]){  
-	fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+	fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
       }
     }
   }else if (DirName.find("DiJet")!=std::string::npos) {
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
     for (unsigned int i = 0; i<triggerFolderLabels_.size(); i++) {
-      if (triggerFolderDecisions_[i])  fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+      if (triggerFolderDecisions_[i])  fillMonitorElement(iEvent, DirName, triggerFolderLabels_[i], met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
     }
   }else if (DirName.find("ZJets")!=std::string::npos) {
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
   }else{
-    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase);
+    fillMonitorElement(iEvent, DirName, std::string(""), met, patmet, pfmet, calomet, zCand, map_of_MEs,bLumiSecPlot,fillPFCandidatePlots,techTriggerCase,METFilterDecision);
   }
   
 
@@ -1527,7 +1687,7 @@ void METAnalyzer::fillMESet(const edm::Event& iEvent, std::string DirName,
 // ***********************************************************
 void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirName,
 					 std::string subFolderName,
-				     const reco::MET& met,const pat::MET & patmet, const reco::PFMET & pfmet, const reco::CaloMET &calomet, const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs,bool bLumiSecPlot, bool fillPFCandidatePlots,std::vector<bool> techTriggerCase)
+				     const reco::MET& met,const pat::MET & patmet, const reco::PFMET & pfmet, const reco::CaloMET &calomet, const reco::Candidate::PolarLorentzVector& zCand,std::map<std::string,MonitorElement*>&  map_of_MEs,bool bLumiSecPlot, bool fillPFCandidatePlots,std::vector<bool> techTriggerCase,std::vector<bool> METFilterDecision)
 {
   bool do_only_Z_histograms=false;
   if(DirName.find("ZJets")!=std::string::npos) {//do Z plots only
@@ -1616,6 +1776,34 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
     hMEx    = map_of_MEs[DirName+"/"+"MEx"];     if (hMEx           && hMEx->getRootObject())    hMEx          ->Fill(MEx);
     hMEy    = map_of_MEs[DirName+"/"+"MEy"];     if (hMEy           && hMEy->getRootObject())     hMEy          ->Fill(MEy);
     hMET    = map_of_MEs[DirName+"/"+"MET"];     if (hMET           && hMET->getRootObject())     hMET          ->Fill(MET);
+    hMET_2  = map_of_MEs[DirName+"/"+"MET_2"];   if (hMET_2         && hMET_2->getRootObject())   hMET_2        ->Fill(MET);
+
+    bool HBHENoiseFilterResult=true;
+    bool CSCTightHaloFilterResult=true;
+    bool eeBadScFilterResult=true;
+    bool EcalDeadCellTriggerFilterResult=true;
+    HBHENoiseFilterResult = METFilterDecision[0];
+    if(HBHENoiseFilterResult){
+      hMET_HBHENoiseFilter    = map_of_MEs[DirName+"/"+"MET_HBHENoiseFilter"];     if (hMET_HBHENoiseFilter           && hMET_HBHENoiseFilter->getRootObject())     hMET_HBHENoiseFilter          ->Fill(MET);
+      hMET_2_HBHENoiseFilter  = map_of_MEs[DirName+"/"+"MET_2_HBHENoiseFilter"];   if (hMET_2_HBHENoiseFilter         && hMET_2_HBHENoiseFilter->getRootObject())   hMET_2_HBHENoiseFilter        ->Fill(MET);
+    }
+    CSCTightHaloFilterResult =  METFilterDecision[1];
+    if(CSCTightHaloFilterResult){
+      hMET_CSCTightHaloFilter    = map_of_MEs[DirName+"/"+"MET_CSCTightHaloFilter"];     if (hMET_CSCTightHaloFilter           && hMET_CSCTightHaloFilter->getRootObject())     hMET_CSCTightHaloFilter          ->Fill(MET);
+      hMET_2_CSCTightHaloFilter  = map_of_MEs[DirName+"/"+"MET_2_CSCTightHaloFilter"];   if (hMET_2_CSCTightHaloFilter         && hMET_2_CSCTightHaloFilter->getRootObject())   hMET_2_CSCTightHaloFilter        ->Fill(MET);
+    }
+    eeBadScFilterResult =  METFilterDecision[2];
+    if(eeBadScFilterResult){
+      hMET_eeBadScFilter    = map_of_MEs[DirName+"/"+"MET_eeBadScFilter"];     if (hMET_eeBadScFilter           && hMET_eeBadScFilter->getRootObject())     hMET_eeBadScFilter          ->Fill(MET);
+      hMET_2_eeBadScFilter  = map_of_MEs[DirName+"/"+"MET_2_eeBadScFilter"];   if (hMET_2_eeBadScFilter         && hMET_2_eeBadScFilter->getRootObject())   hMET_2_eeBadScFilter        ->Fill(MET);
+    }
+    EcalDeadCellTriggerFilterResult =  METFilterDecision[3];
+    if(EcalDeadCellTriggerFilterResult){
+      hMET_EcalDeadCellTriggerFilter    = map_of_MEs[DirName+"/"+"MET_EcalDeadCellTriggerFilter"];     if (hMET_EcalDeadCellTriggerFilter           && hMET_EcalDeadCellTriggerFilter->getRootObject())     hMET_EcalDeadCellTriggerFilter          ->Fill(MET);
+      hMET_2_EcalDeadCellTriggerFilter  = map_of_MEs[DirName+"/"+"MET_2_EcalDeadCellTriggerFilter"];   if (hMET_2_EcalDeadCellTriggerFilter         && hMET_2_EcalDeadCellTriggerFilter->getRootObject())   hMET_2_EcalDeadCellTriggerFilter        ->Fill(MET);
+    }
+
+
     hMETPhi = map_of_MEs[DirName+"/"+"METPhi"];  if (hMETPhi        && hMETPhi->getRootObject())  hMETPhi       ->Fill(METPhi);
     hSumET  = map_of_MEs[DirName+"/"+"SumET"];   if (hSumET         && hSumET->getRootObject())   hSumET        ->Fill(SumET);
     hMETSig = map_of_MEs[DirName+"/"+"METSig"];  if (hMETSig        && hMETSig->getRootObject())  hMETSig       ->Fill(METSig);
@@ -2300,6 +2488,35 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent, std::string DirNa
       if (meChargedHadronEtFraction_profile && meChargedHadronEtFraction_profile->getRootObject()) meChargedHadronEtFraction_profile->Fill(numPV_, patmet.ChargedHadEtFraction());
       if (meHFHadronEtFraction_profile      && meHFHadronEtFraction_profile     ->getRootObject()) meHFHadronEtFraction_profile     ->Fill(numPV_, patmet.Type6EtFraction());
       if (meHFEMEtFraction_profile          && meHFEMEtFraction_profile         ->getRootObject()) meHFEMEtFraction_profile         ->Fill(numPV_, patmet.Type7EtFraction());
+
+      mePhotonEt        = map_of_MEs[DirName + "/PfPhotonEt"];
+      meNeutralHadronEt = map_of_MEs[DirName + "/PfNeutralHadronEt"];
+      meChargedHadronEt = map_of_MEs[DirName + "/PfChargedHadronEt"];
+      meHFHadronEt      = map_of_MEs[DirName + "/PfHFHadronEt"];
+      meHFEMEt          = map_of_MEs[DirName + "/PfHFEMEt"];
+      meMuonEt          = map_of_MEs[DirName + "/PfMuonEt"];
+      meElectronEt      = map_of_MEs[DirName + "/PfElectronEt"];
+
+      if (mePhotonEt        && mePhotonEt       ->getRootObject()) mePhotonEt       ->Fill(patmet.NeutralEMFraction()*patmet.sumEt());
+      if (meNeutralHadronEt && meNeutralHadronEt->getRootObject()) meNeutralHadronEt->Fill(patmet.NeutralHadEtFraction()*patmet.sumEt());
+      if (meChargedHadronEt && meChargedHadronEt->getRootObject()) meChargedHadronEt->Fill(patmet.ChargedHadEtFraction()*patmet.sumEt());
+      if (meHFHadronEt      && meHFHadronEt     ->getRootObject()) meHFHadronEt     ->Fill(patmet.Type6EtFraction()*patmet.sumEt());//HFHadrons
+      if (meHFEMEt          && meHFEMEt         ->getRootObject()) meHFEMEt         ->Fill(patmet.Type7EtFraction()*patmet.sumEt());
+      if (meMuonEt          && meMuonEt         ->getRootObject()) meMuonEt         ->Fill(patmet.MuonEtFraction()*patmet.sumEt());
+      if (meElectronEt      && meElectronEt     ->getRootObject()) meElectronEt     ->Fill(patmet.ChargedEMEtFraction()*patmet.sumEt());
+
+      //NPV profiles     
+      mePhotonEt_profile        = map_of_MEs[DirName + "/PfPhotonEt_profile"];
+      meNeutralHadronEt_profile = map_of_MEs[DirName + "/PfNeutralHadronEt_profile"];
+      meChargedHadronEt_profile = map_of_MEs[DirName + "/PfChargedHadronEt_profile"];
+      meHFHadronEt_profile      = map_of_MEs[DirName + "/PfHFHadronEt_profile"];
+      meHFEMEt_profile          = map_of_MEs[DirName + "/PfHFEMEt_profile"];
+      
+      if (mePhotonEt_profile        && mePhotonEt_profile       ->getRootObject()) mePhotonEt_profile       ->Fill(numPV_, patmet.NeutralEMFraction()*patmet.sumEt());
+      if (meNeutralHadronEt_profile && meNeutralHadronEt_profile->getRootObject()) meNeutralHadronEt_profile->Fill(numPV_, patmet.NeutralHadEtFraction()*patmet.sumEt());
+      if (meChargedHadronEt_profile && meChargedHadronEt_profile->getRootObject()) meChargedHadronEt_profile->Fill(numPV_, patmet.ChargedHadEtFraction()*patmet.sumEt());
+      if (meHFHadronEt_profile      && meHFHadronEt_profile     ->getRootObject()) meHFHadronEt_profile     ->Fill(numPV_, patmet.Type6EtFraction()*patmet.sumEt());
+      if (meHFEMEt_profile          && meHFEMEt_profile         ->getRootObject()) meHFEMEt_profile         ->Fill(numPV_, patmet.Type7EtFraction()*patmet.sumEt());
     }
 
     if (isCaloMet_){

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -1678,7 +1678,7 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     trigger_flag[3]=true;
   }
   std::vector<bool>filter_decisions(8,false);//include all recommended filters, old filters in MiniAOD, and 2 new filters in testing phase
-  if(!isMiniAODMet_){//not checked for MiniAOD -> for miniaod decision filled as "triggerResults" bool
+  if(!isMiniAODMet_ && !runcosmics_){//not checked for MiniAOD -> for miniaod decision filled as "triggerResults" bool
     edm::Handle<bool> HBHENoiseFilterResultHandle;
     iEvent.getByToken(hbheNoiseFilterResultToken_, HBHENoiseFilterResultHandle);
     if (!HBHENoiseFilterResultHandle.isValid()) {

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -13,7 +13,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.Services_cff')
 
 #for data in 720pre7
-process.GlobalTag.globaltag ='76X_mcRun2_startup_v2'
+process.GlobalTag.globaltag ='76X_mcRun2_asymptotic_v5'
 
 # check # of bins
 process.load("DQMServices.Components.DQMStoreStats_cfi")
@@ -22,10 +22,8 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
-       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/3413F100-655C-E511-B0AC-002618943906.root',
-       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/369AE1B5-775C-E511-BC97-0026189437F9.root',
-       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/40D3F851-685C-E511-BD1B-00248C55CC7F.root',
-       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/4248D270-675C-E511-BFF8-0025905A60AA.root'
+       '/store/relval/CMSSW_7_6_0_pre7/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/76X_mcRun2_asymptotic_v5-v1/00000/7E692CF1-2971-E511-9609-0025905A497A.root',
+       '/store/relval/CMSSW_7_6_0_pre7/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/76X_mcRun2_asymptotic_v5-v1/00000/B4DD46D7-2971-E511-B4DD-0025905A4964.root' 
        #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/7CEB618B-8151-E511-8D05-002618943857.root',
        #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/8A6ED13D-8351-E511-A6E1-0025905964C2.root',
        #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/9A6F45A5-8251-E511-8BB5-0025905964A6.root',
@@ -67,11 +65,11 @@ process.dqmSaver.workflow = Workflow
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 
 process.p = cms.Path(                    #process.dump*
-                     #process.jetMETDQMOfflineSourceMiniAOD*
+                     process.jetMETDQMOfflineSourceMiniAOD*
                      #for cosmic data and MC
                      #process.jetMETDQMOfflineSourceCosmic*
                      #for Data and MC pp and HI
-                     process.jetMETDQMOfflineSource*
+                     #process.jetMETDQMOfflineSource*
                      process.dataCertificationJetMETSequence*
                      process.dqmSaver
                      )

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -7,12 +7,13 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 from Configuration.StandardSequences.GeometryRecoDB_cff import *
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.Services_cff')
 
 #for data in 720pre7
-process.GlobalTag.globaltag ='75X_mcRun2_asymptotic_v5'
+process.GlobalTag.globaltag ='76X_mcRun2_startup_v2'
 
 # check # of bins
 process.load("DQMServices.Components.DQMStoreStats_cfi")
@@ -21,9 +22,10 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
-       '/store/relval/CMSSW_7_5_2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v5-v1/00000/BEB01DEE-9D50-E511-B44A-0025905A610C.root',
-       '/store/relval/CMSSW_7_5_2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v5-v1/00000/E0487EF1-9D50-E511-9CD4-0025905A60CE.root',
-       '/store/relval/CMSSW_7_5_2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v5-v1/00000/EAB96718-A950-E511-81CB-0025905B858C.root' 
+       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/3413F100-655C-E511-B0AC-002618943906.root',
+       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/369AE1B5-775C-E511-BC97-0026189437F9.root',
+       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/40D3F851-685C-E511-BD1B-00248C55CC7F.root',
+       '/store/relval/CMSSW_7_6_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v1-v1/00000/4248D270-675C-E511-BFF8-0025905A60AA.root'
        #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/7CEB618B-8151-E511-8D05-002618943857.root',
        #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/8A6ED13D-8351-E511-A6E1-0025905964C2.root',
        #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/9A6F45A5-8251-E511-8BB5-0025905964A6.root',

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -12,7 +12,7 @@ process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
 #for data in 720pre7
-process.GlobalTag.globaltag ='75X_dataRun1_v2'
+process.GlobalTag.globaltag ='75X_mcRun2_asymptotic_v5'
 
 # check # of bins
 process.load("DQMServices.Components.DQMStoreStats_cfi")
@@ -21,12 +21,14 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
-        '/store/relval/CMSSW_7_5_0_pre6/JetHT/RECO/75X_dataRun1_v2_RelVal_jet2012D-v1/00000/003E50FE-F71B-E511-B849-002590593902.root',
-        '/store/relval/CMSSW_7_5_0_pre6/JetHT/RECO/75X_dataRun1_v2_RelVal_jet2012D-v1/00000/0212B89F-401C-E511-90B7-0025905964A2.root',
-        '/store/relval/CMSSW_7_5_0_pre6/JetHT/RECO/75X_dataRun1_v2_RelVal_jet2012D-v1/00000/02925C10-FC1B-E511-A4B4-0025905B85A2.root',
-        '/store/relval/CMSSW_7_5_0_pre6/JetHT/RECO/75X_dataRun1_v2_RelVal_jet2012D-v1/00000/040DBAE5-FB1B-E511-9854-0025905B85D0.root',
-        '/store/relval/CMSSW_7_5_0_pre6/JetHT/RECO/75X_dataRun1_v2_RelVal_jet2012D-v1/00000/0658D146-2C1C-E511-BCA1-0025905A48F2.root',
-        '/store/relval/CMSSW_7_5_0_pre6/JetHT/RECO/75X_dataRun1_v2_RelVal_jet2012D-v1/00000/0A06BB23-401C-E511-ACE9-0025905A610C.root'
+       '/store/relval/CMSSW_7_5_2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v5-v1/00000/BEB01DEE-9D50-E511-B44A-0025905A610C.root',
+       '/store/relval/CMSSW_7_5_2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v5-v1/00000/E0487EF1-9D50-E511-9CD4-0025905A60CE.root',
+       '/store/relval/CMSSW_7_5_2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v5-v1/00000/EAB96718-A950-E511-81CB-0025905B858C.root' 
+       #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/7CEB618B-8151-E511-8D05-002618943857.root',
+       #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/8A6ED13D-8351-E511-A6E1-0025905964C2.root',
+       #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/9A6F45A5-8251-E511-8BB5-0025905964A6.root',
+       #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/D6536366-7E51-E511-BC81-0025905A48F2.root',
+       #'/store/relval/CMSSW_7_5_2/JetHT/MINIAOD/75X_dataRun1_HLT_frozen_v2_RelVal_jet2012D-v1/00000/DE6F609B-8251-E511-940D-002618943916.root' 
        ] );
 
 

--- a/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 
 pfJetIDSelector = cms.PSet(
-        version = cms.string('FIRSTDATA'),
+        version = cms.string('RUNIISTARTUP'),
         quality = cms.string('LOOSE')
     )

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -253,6 +253,11 @@ JetTester::JetTester(const edm::ParameterSet& iConfig) :
   HOEnergy = 0;
   /// HOEnergyFraction (relative to corrected jet energy)
   HOEnergyFraction = 0;
+
+  hadronFlavor=0;
+  partonFlavor=0;
+  genPartonPDGID=0;
+
 }
 
 void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
@@ -289,7 +294,12 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
     mMass         = ibooker.book1D("Mass",         "Mass",         100,    0,  200); 
     mConstituents = ibooker.book1D("Constituents", "Constituents", 100,    0,  100); 
     mJetArea      = ibooker.book1D("JetArea",      "JetArea",       100,   0, 4);
-
+    //jet flavors contained in MiniAOD
+    if (isMiniAODJet){
+      hadronFlavor=ibooker.book1D("HadronFlavor",  "HadronFlavor",  44,  -22, 22);
+      partonFlavor=ibooker.book1D("PartonFlavor",  "PartonFlavor",  44,  -22, 22);
+      genPartonPDGID=ibooker.book1D("genPartonPDGID",  "genPartonPDGID",  44,  -22, 22);
+    }
     // Corrected jets
     if (isMiniAODJet || !mJetCorrector.label().empty())	{//if correction label is filled, but fill also for MiniAOD though
       mCorrJetPt  = ibooker.book1D("CorrJetPt",  "CorrJetPt",  150,    0, 1500);
@@ -358,6 +368,32 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
     mPtRecoOverGen_B_3500      = ibooker.book1D("PtRecoOverGen_B_3500",      "genpt>3500",      90, 0, 2);
     mPtRecoOverGen_E_3500      = ibooker.book1D("PtRecoOverGen_E_3500",      "genpt>3500",      90, 0, 2);
     mPtRecoOverGen_F_3500      = ibooker.book1D("PtRecoOverGen_F_3500",      "genpt>3500",      90, 0, 2);
+
+    mMassRecoOverGen_B_20_40    = ibooker.book1D("MassRecoOverGen_B_20_40",    "20<genpt<40",    90, 0, 3);
+    mMassRecoOverGen_E_20_40    = ibooker.book1D("MassRecoOverGen_E_20_40",    "20<genpt<40",    90, 0, 3);
+    mMassRecoOverGen_F_20_40    = ibooker.book1D("MassRecoOverGen_F_20_40",    "20<genpt<40",    90, 0, 3);
+    mMassRecoOverGen_B_40_200    = ibooker.book1D("MassRecoOverGen_B_40_200",    "40<genpt<200",    90, 0, 3);
+    mMassRecoOverGen_E_40_200    = ibooker.book1D("MassRecoOverGen_E_40_200",    "40<genpt<200",    90, 0, 3);
+    mMassRecoOverGen_F_40_200    = ibooker.book1D("MassRecoOverGen_F_40_200",    "40<genpt<200",    90, 0, 3);
+    mMassRecoOverGen_B_200_500    = ibooker.book1D("MassRecoOverGen_B_200_500",    "200<genpt<500",    90, 0, 3);
+    mMassRecoOverGen_E_200_500    = ibooker.book1D("MassRecoOverGen_E_200_500",    "200<genpt<500",    90, 0, 3);
+    mMassRecoOverGen_F_200_500    = ibooker.book1D("MassRecoOverGen_F_200_500",    "200<genpt<500",    90, 0, 3);
+    mMassRecoOverGen_B_500_750    = ibooker.book1D("MassRecoOverGen_B_500_750",    "500<genpt<750",    90, 0, 3);
+    mMassRecoOverGen_E_500_750    = ibooker.book1D("MassRecoOverGen_E_500_750",    "500<genpt<750",    90, 0, 3);
+    mMassRecoOverGen_F_500_750    = ibooker.book1D("MassRecoOverGen_F_500_750",    "500<genpt<750",    90, 0, 3);
+    mMassRecoOverGen_B_750_1000    = ibooker.book1D("MassRecoOverGen_B_750_1000",    "750<genpt<1000",    90, 0, 3);
+    mMassRecoOverGen_E_750_1000    = ibooker.book1D("MassRecoOverGen_E_750_1000",    "750<genpt<1000",    90, 0, 3);
+    mMassRecoOverGen_F_750_1000    = ibooker.book1D("MassRecoOverGen_F_750_1000",    "750<genpt<1000",    90, 0, 3);
+    mMassRecoOverGen_B_1000_1500    = ibooker.book1D("MassRecoOverGen_B_1000_1500",    "1000<genpt<1500",    90, 0, 3);
+    mMassRecoOverGen_E_1000_1500    = ibooker.book1D("MassRecoOverGen_E_1000_1500",    "1000<genpt<1500",    90, 0, 3);
+    mMassRecoOverGen_F_1000_1500    = ibooker.book1D("MassRecoOverGen_F_1000_1500",    "1000<genpt<1500",    90, 0, 3);
+    mMassRecoOverGen_B_1500_3500    = ibooker.book1D("MassRecoOverGen_B_1500_3500",    "1500<genpt<3500",    90, 0, 3);
+    mMassRecoOverGen_E_1500_3500    = ibooker.book1D("MassRecoOverGen_E_1500_3500",    "1500<genpt<3500",    90, 0, 3);
+    mMassRecoOverGen_F_1500         = ibooker.book1D("MassRecoOverGen_F_1500",         "genpt>1500",    90, 0, 3);
+    mMassRecoOverGen_B_3500_5000    = ibooker.book1D("MassRecoOverGen_B_3500_5000",    "3500<genpt<5000",    90, 0, 3);
+    mMassRecoOverGen_E_3500_5000    = ibooker.book1D("MassRecoOverGen_E_3500_5000",    "3500<genpt<5000",    90, 0, 3);
+    mMassRecoOverGen_B_5000         = ibooker.book1D("MassRecoOverGen_B_5000",    "genpt>5000",    90, 0, 3);
+    mMassRecoOverGen_E_5000         = ibooker.book1D("MassRecoOverGen_E_5000",    "genpt>5000",    90, 0, 3);
 
     // Generation profiles
     mPtRecoOverGen_GenPt_B          = ibooker.bookProfile("PtRecoOverGen_GenPt_B",          "0<|eta|<1.5",     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
@@ -791,6 +827,13 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
       }
       
       if (correctedJet.pt() < 20) continue;
+
+      if (isMiniAODJet){
+	if(hadronFlavor)hadronFlavor->Fill((*patJets)[ijet].hadronFlavour());
+	if(partonFlavor)partonFlavor->Fill((*patJets)[ijet].partonFlavour());
+	if(genPartonPDGID && (*patJets)[ijet].genParton()!=NULL)genPartonPDGID->Fill((*patJets)[ijet].genParton()->pdgId());
+      }
+
       
       mCorrJetEta->Fill(correctedJet.eta());
       mCorrJetPhi->Fill(correctedJet.phi());
@@ -873,6 +916,7 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
 	int iMatch    =   -1;
 	double CorrdeltaRBest = 999;
 	double CorrJetPtBest  =   0;
+	double CorrJetMassBest  =   0;
 	for (unsigned ijet=0; ijet<recoJets.size(); ++ijet) {
 	  Jet correctedJet = recoJets[ijet];
 	  if(pass_correction_flag && !isMiniAODJet){
@@ -884,6 +928,7 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
 	  if (CorrJetPt > 10) {
 	    double CorrdR = deltaR(gjet->eta(), gjet->phi(), correctedJet.eta(), correctedJet.phi());
 	    if (CorrdR < CorrdeltaRBest) {
+	      CorrJetMassBest = correctedJet.mass();
 	      CorrdeltaRBest = CorrdR;
 	      CorrJetPtBest  = CorrJetPt;
 	      iMatch = ijet;
@@ -891,10 +936,11 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
 	  }
 	}
 	if (iMatch<0) continue;
+	//use mass after jet energy correction -> for MiniAOD that is the case per default
 	if(!isMiniAODJet){
-	    fillMatchHists(gjet->eta(),  gjet->phi(),  gjet->pt(), recoJets[iMatch].eta(), recoJets[iMatch].phi(),  recoJets[iMatch].pt());
-	  }else{
-	  fillMatchHists(gjet->eta(),  gjet->phi(),  gjet->pt(), (*patJets)[iMatch].eta(), (*patJets)[iMatch].phi(),(*patJets)[iMatch].pt()*(*patJets)[iMatch].jecFactor("Uncorrected"));
+	  fillMatchHists(gjet->eta(),  gjet->phi(),  gjet->pt(), gjet->mass(), recoJets[iMatch].eta(), recoJets[iMatch].phi(),  recoJets[iMatch].pt(),CorrJetMassBest);
+	}else{
+	  fillMatchHists(gjet->eta(),  gjet->phi(),  gjet->pt(),  gjet->mass(), (*patJets)[iMatch].eta(), (*patJets)[iMatch].phi(),(*patJets)[iMatch].pt()*(*patJets)[iMatch].jecFactor("Uncorrected"),recoJets[iMatch].mass());
 	}
         if (pass_correction_flag) {//fill only for corrected jets
 	  if (CorrdeltaRBest < mRThreshold) {
@@ -928,9 +974,11 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
 void JetTester::fillMatchHists(const double GenEta,
 			       const double GenPhi,
 			       const double GenPt,
+			       const double GenMass,
 			       const double RecoEta,
 			       const double RecoPhi,
-			       const double RecoPt) 
+			       const double RecoPt,
+			       const double RecoMass) 
 {
   if (GenPt > mMatchGenPtThreshold) {
     mDeltaEta->Fill(GenEta - RecoEta);
@@ -943,6 +991,16 @@ void JetTester::fillMatchHists(const double GenEta,
       mPtRecoOverGen_GenPt_B ->Fill(log10(GenPt),  RecoPt / GenPt);
       mPtRecoOverGen_GenPhi_B->Fill(GenPhi, RecoPt / GenPt);
     
+      if (GenPt > 20 && GenPt < 40) mMassRecoOverGen_B_20_40     ->Fill(RecoMass / GenMass);
+      else if (GenPt < 200)         mMassRecoOverGen_B_40_200    ->Fill(RecoMass / GenMass);
+      else if (GenPt < 500)         mMassRecoOverGen_B_200_500   ->Fill(RecoMass / GenMass);
+      else if (GenPt < 750)         mMassRecoOverGen_B_500_750   ->Fill(RecoMass / GenMass);
+      else if (GenPt < 1000)        mMassRecoOverGen_B_750_1000  ->Fill(RecoMass / GenMass);
+      else if (GenPt < 1500)        mMassRecoOverGen_B_1000_1500 ->Fill(RecoMass / GenMass);
+      else if (GenPt < 3500)        mMassRecoOverGen_B_1500_3500 ->Fill(RecoMass / GenMass);
+      else if (GenPt < 5000)        mMassRecoOverGen_B_3500_5000 ->Fill(RecoMass / GenMass);
+      else if (GenPt >= 5000)       mMassRecoOverGen_B_5000      ->Fill(RecoMass / GenMass);
+
       if (GenPt > 20 && GenPt < 40) mPtRecoOverGen_B_20_40   ->Fill(RecoPt / GenPt);
       else if (GenPt <  200)         mPtRecoOverGen_B_40_200  ->Fill(RecoPt / GenPt);
       else if (GenPt <  600)         mPtRecoOverGen_B_200_600  ->Fill(RecoPt / GenPt);
@@ -965,6 +1023,17 @@ void JetTester::fillMatchHists(const double GenEta,
       else if (GenPt < 5000)         mPtRecoOverGen_E_3500_5000->Fill(RecoPt / GenPt);
       else if (GenPt < 6500)         mPtRecoOverGen_E_5000_6500->Fill(RecoPt / GenPt);
       if (GenPt>3500)         mPtRecoOverGen_E_3500->Fill(RecoPt / GenPt);
+
+      if (GenPt > 20 && GenPt < 40) mMassRecoOverGen_E_20_40     ->Fill(RecoMass / GenMass);
+      else if (GenPt < 200)         mMassRecoOverGen_E_40_200    ->Fill(RecoMass / GenMass);
+      else if (GenPt < 500)         mMassRecoOverGen_E_200_500   ->Fill(RecoMass / GenMass);
+      else if (GenPt < 750)         mMassRecoOverGen_E_500_750   ->Fill(RecoMass / GenMass);
+      else if (GenPt < 1000)        mMassRecoOverGen_E_750_1000  ->Fill(RecoMass / GenMass);
+      else if (GenPt < 1500)        mMassRecoOverGen_E_1000_1500 ->Fill(RecoMass / GenMass);
+      else if (GenPt < 3500)        mMassRecoOverGen_E_1500_3500 ->Fill(RecoMass / GenMass);
+      else if (GenPt < 5000)        mMassRecoOverGen_E_3500_5000 ->Fill(RecoMass / GenMass);
+      else if (GenPt >= 5000)       mMassRecoOverGen_E_5000      ->Fill(RecoMass / GenMass);
+
     }
   else if (fabs(GenEta) < 6.0)
     {
@@ -977,6 +1046,14 @@ void JetTester::fillMatchHists(const double GenEta,
       else if (GenPt < 1500)         mPtRecoOverGen_F_600_1500 ->Fill(RecoPt / GenPt);
       else if (GenPt < 3500)         mPtRecoOverGen_F_1500_3500->Fill(RecoPt / GenPt);
       if (GenPt>3500)                mPtRecoOverGen_F_3500->Fill(RecoPt / GenPt);
+
+      if (GenPt > 20 && GenPt < 40) mMassRecoOverGen_F_20_40     ->Fill(RecoMass / GenMass);
+      else if (GenPt < 200)         mMassRecoOverGen_F_40_200    ->Fill(RecoMass / GenMass);
+      else if (GenPt < 500)         mMassRecoOverGen_F_200_500   ->Fill(RecoMass / GenMass);
+      else if (GenPt < 750)         mMassRecoOverGen_F_500_750   ->Fill(RecoMass / GenMass);
+      else if (GenPt < 1000)        mMassRecoOverGen_F_750_1000  ->Fill(RecoMass / GenMass);
+      else if (GenPt < 1500)        mMassRecoOverGen_F_1000_1500 ->Fill(RecoMass / GenMass);
+      else if (GenPt >=1500)        mMassRecoOverGen_F_1500      ->Fill(RecoMass / GenMass);
     }
 
   if (GenPt > 20 && GenPt < 40) mPtRecoOverGen_GenEta_20_40   ->Fill(GenEta, RecoPt / GenPt);

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -51,8 +51,8 @@ class JetTester : public DQMEDAnalyzer {
 
  private:
   
-  void fillMatchHists(const double GenEta,  const double GenPhi,  const double GenPt,
-		      const double RecoEta, const double RecoPhi, const double RecoPt);
+  void fillMatchHists(const double GenEta,  const double GenPhi,  const double GenPt, const double GenMass,
+		      const double RecoEta, const double RecoPhi, const double RecoPt, const double RecoMass);
   
   edm::InputTag   mInputCollection;
   edm::InputTag   mInputGenCollection;
@@ -138,11 +138,39 @@ class JetTester : public DQMEDAnalyzer {
   MonitorElement* mPtRecoOverGen_B_1500_3500;
   MonitorElement* mPtRecoOverGen_E_1500_3500;
   MonitorElement* mPtRecoOverGen_F_1500_3500;
-
   MonitorElement* mPtRecoOverGen_B_3500_5000;
   MonitorElement* mPtRecoOverGen_E_3500_5000;
   MonitorElement* mPtRecoOverGen_B_5000_6500;
   MonitorElement* mPtRecoOverGen_E_5000_6500;
+
+  //jet mass resolution as function of gen-pt
+  MonitorElement* mMassRecoOverGen_B_20_40;
+  MonitorElement* mMassRecoOverGen_E_20_40;
+  MonitorElement* mMassRecoOverGen_F_20_40;
+  MonitorElement* mMassRecoOverGen_B_40_200;
+  MonitorElement* mMassRecoOverGen_E_40_200;
+  MonitorElement* mMassRecoOverGen_F_40_200;
+  MonitorElement* mMassRecoOverGen_B_200_500;
+  MonitorElement* mMassRecoOverGen_E_200_500;
+  MonitorElement* mMassRecoOverGen_F_200_500;
+  MonitorElement* mMassRecoOverGen_B_500_750;
+  MonitorElement* mMassRecoOverGen_E_500_750;
+  MonitorElement* mMassRecoOverGen_F_500_750;
+  MonitorElement* mMassRecoOverGen_B_750_1000;
+  MonitorElement* mMassRecoOverGen_E_750_1000;
+  MonitorElement* mMassRecoOverGen_F_750_1000;
+  MonitorElement* mMassRecoOverGen_B_1000_1500;
+  MonitorElement* mMassRecoOverGen_E_1000_1500;
+  MonitorElement* mMassRecoOverGen_F_1000_1500;
+  MonitorElement* mMassRecoOverGen_B_1500_3500;
+  MonitorElement* mMassRecoOverGen_E_1500_3500;
+  MonitorElement* mMassRecoOverGen_F_1500;
+  MonitorElement* mMassRecoOverGen_B_3500_5000;
+  MonitorElement* mMassRecoOverGen_E_3500_5000;
+  MonitorElement* mMassRecoOverGen_B_5000;
+  MonitorElement* mMassRecoOverGen_E_5000;
+
+
   MonitorElement* mPtRecoOverGen_B_3500;
   MonitorElement* mPtRecoOverGen_E_3500;
   MonitorElement* mPtRecoOverGen_F_3500;
@@ -227,6 +255,11 @@ class JetTester : public DQMEDAnalyzer {
   MonitorElement* neutralMultiplicity;
   MonitorElement* HOEnergy;
   MonitorElement* HOEnergyFraction;
+
+  //contained in MiniAOD
+  MonitorElement* hadronFlavor;
+  MonitorElement* partonFlavor;
+  MonitorElement* genPartonPDGID;
 
   // Parameters
   double          mRecoJetPtThreshold;

--- a/Validation/RecoJets/python/JetValidation_cff.py
+++ b/Validation/RecoJets/python/JetValidation_cff.py
@@ -60,4 +60,5 @@ JetValidation = cms.Sequence(
 #    *JetAnalyzerCA8PFCHS
     )
 
-JetValidationMiniAOD=cms.Sequence(JetAnalyzerAk4PFCHSMiniAOD)
+
+JetValidationMiniAOD=cms.Sequence(JetAnalyzerAk4PFCHSMiniAOD*JetAnalyzerAk4PFPUPPIMiniAOD*JetAnalyzerAk8PFCHSMiniAOD)

--- a/Validation/RecoJets/python/JetValidation_cfi.py
+++ b/Validation/RecoJets/python/JetValidation_cfi.py
@@ -157,3 +157,26 @@ JetAnalyzerAk4PFCHSMiniAOD = cms.EDAnalyzer("JetTester",
                                   RThreshold                     = cms.double(0.3)
                                   )
 
+JetAnalyzerAk4PFPUPPIMiniAOD = cms.EDAnalyzer("JetTester",
+                                  JetType = cms.untracked.string('miniaod'),
+                                  src            = cms.InputTag("slimmedJetsPuppi"),
+                                  srcGen         = cms.InputTag("slimmedGenJets"),
+                                  JetCorrections = cms.InputTag(""),#not called for MiniAOD
+                                  primVertex     = cms.InputTag("offlineSlimmedPrimaryVertices"),
+                                  recoJetPtThreshold = cms.double(40),
+                                  matchGenPtThreshold                 = cms.double(20.0),
+                                  RThreshold                     = cms.double(0.3)
+                                  )
+
+JetAnalyzerAk8PFCHSMiniAOD = cms.EDAnalyzer("JetTester",
+                                  JetType = cms.untracked.string('miniaod'),
+                                  src            = cms.InputTag("slimmedJetsAK8"),
+                                  srcGen         = cms.InputTag("slimmedGenJetsAK8"),
+                                  JetCorrections = cms.InputTag(""),#not called for MiniAOD
+                                  primVertex     = cms.InputTag("offlineSlimmedPrimaryVertices"),
+                                  recoJetPtThreshold = cms.double(40),
+                                  matchGenPtThreshold                 = cms.double(20.0),
+                                  RThreshold                     = cms.double(0.3)
+                                  )
+
+

--- a/Validation/RecoJets/test/sequence_validation_cfg.py
+++ b/Validation/RecoJets/test/sequence_validation_cfg.py
@@ -1,0 +1,63 @@
+import os
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("METVALIDATION")
+
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+#process.GlobalTag.globaltag = 'START42_V17::All'
+##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
+## for 6_2_0 QCD
+process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_v4'
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+#
+#
+# DQM
+#
+
+process.load("Validation.RecoJets.JetValidation_cff")
+process.load("Validation.RecoJets.JetPostProcessor_cff")
+
+
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/relval/CMSSW_7_6_0_pre7/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/76X_mcRun2_asymptotic_v5-v1/00000/7E692CF1-2971-E511-9609-0025905A497A.root',
+       '/store/relval/CMSSW_7_6_0_pre7/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/76X_mcRun2_asymptotic_v5-v1/00000/B4DD46D7-2971-E511-B4DD-0025905A4964.root' 
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/5C506D9D-AA6B-E511-8AB0-003048FFD732.root',
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/5E68FFC6-B66B-E511-9085-0025905A6084.root',
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/724E805D-816C-E511-A163-0025905B8562.root',
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/88117A83-A76B-E511-9A30-002590596490.root'
+        #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/0847033F-706C-E511-8170-0025905A60CE.root',
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/98244E0E-C56C-E511-A5AF-0025905B85EE.root',
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/B6EB8FF6-C46C-E511-911A-0025905B8592.root',
+       #'/store/relval/CMSSW_7_6_0_pre6/RelValTTbar_13/MINIAODSIM/PU25ns_76X_mcRun2_asymptotic_v4-v1/00000/FABE0A3D-6F6C-E511-A404-0025905A6076.root' 
+] );
+
+process.load('Configuration/StandardSequences/EDMtoMEAtJobEnd_cff')
+process.dqmSaver.referenceHandling = cms.untracked.string('all')
+#
+cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
+Workflow = '/JetMET/'+str(cmssw_version)+'/JetValidation'
+process.dqmSaver.workflow = Workflow
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.dump = cms.EDAnalyzer("EventContentAnalyzer")
+
+process.p = cms.Path(#process.dump*
+                     #for RECO
+                     #process.jetPreValidSeq*
+                     #process.JetValidation*
+                     #for MiniAOD
+                     process.JetValidationMiniAOD*
+                     process.JetPostProcessor
+                     *process.dqmSaver
+)
+
+

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -78,4 +78,4 @@ METValidation = cms.Sequence(
     pfType01CorrectedMetAnalyzer
     )
 
-METValidationMiniAOD = cms.Sequence(pfType1CorrectedMetAnalyzerMiniAOD)
+METValidationMiniAOD = cms.Sequence(pfType1CorrectedMetAnalyzerMiniAOD*pfPuppiMetAnalyzerMiniAOD)

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -14,48 +14,45 @@ from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT0pc,pfMetT0pcT1,pf
 from JetMETCorrections.Type1MET.correctionTermsPfMetType0PFCandidate_cff import *
 from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPfMetType1
 
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3CorrectorChain,ak4PFL1FastL2L3Corrector,ak4PFL3AbsoluteCorrector,ak4PFL2RelativeCorrector,ak4PFL1FastjetCorrector
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3ResidualCorrectorChain,ak4PFCHSL1FastL2L3CorrectorChain,ak4PFCHSL1FastL2L3ResidualCorrector,ak4PFCHSResidualCorrector,ak4PFCHSL1FastL2L3Corrector,ak4PFCHSL3AbsoluteCorrector,ak4PFCHSL2RelativeCorrector,ak4PFCHSL1FastjetCorrector
 
-newAK4PFL1FastL2L3Corrector = ak4PFL1FastL2L3Corrector.clone()
-newAK4PFL1FastL2L3CorrectorChain = cms.Sequence(
-    #ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * 
-    newAK4PFL1FastL2L3Corrector
+newAK4PFCHSL1FastL2L3Corrector = ak4PFCHSL1FastL2L3Corrector.clone()
+newAK4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
+    #ak4PFCHSL1FastjetCorrector * ak4PFCHSL2RelativeCorrector * ak4PFCHSL3AbsoluteCorrector * 
+    newAK4PFCHSL1FastL2L3Corrector
     )
 
-metPreValidSeq=cms.Sequence(ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector)
+newAK4PFCHSL1FastL2L3ResidualCorrector = ak4PFCHSL1FastL2L3ResidualCorrector.clone()
+newAK4PFCHSL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+    #ak4PFCHSL1FastjetCorrector * ak4PFCHSL2RelativeCorrector * ak4PFCHSL3AbsoluteCorrector * 
+    newAK4PFCHSL1FastL2L3ResidualCorrector
+    )
 
-valCorrPfMetType1=corrPfMetType1.clone(jetCorrLabel = cms.InputTag('newAK4PFL1FastL2L3Corrector'))
+metPreValidSeq=cms.Sequence(ak4PFCHSL1FastjetCorrector * ak4PFCHSL2RelativeCorrector * ak4PFCHSL3AbsoluteCorrector * ak4PFCHSResidualCorrector)
+
+valCorrPfMetType1=corrPfMetType1.clone(jetCorrLabel = cms.InputTag('newAK4PFCHSL1FastL2L3Corrector'),
+                                       jetCorrLabelRes = cms.InputTag('newAK4PFCHSL1FastL2L3ResidualCorrector')
+                                      )
 
 PfMetT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
-         cms.InputTag('valCorrPfMetType1', 'type1')
-     ))
+        cms.InputTag('valCorrPfMetType1', 'type1')
+        ))
 
 PfMetT0pcT1=pfMetT0pcT1.clone(
-     srcCorrections = cms.VInputTag(
-         cms.InputTag('corrPfMetType0PfCand'),
-         cms.InputTag('valCorrPfMetType1', 'type1')
-         )
-     )
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0PfCand'),
+        cms.InputTag('valCorrPfMetType1', 'type1')
+        )
+    )
 
 METRelValSequence = cms.Sequence(
     metAnalyzer*
-    #metHOAnalyzer*
-    #metNoHFAnalyzer*
-    #metNoHFHOAnalyzer*
-    #metOptAnalyzer*
-    #metOptHOAnalyzer*
-    #metOptNoHFAnalyzer*
-    #metOptNoHFHOAnalyzer
     pfMetAnalyzer*
-    #tcMetAnalyzer*
-    #corMetGlobalMuonsAnalyzer*
     genMetTrueAnalyzer*
-    #genMetCaloAnalyzer*
-    #genMetCaloAndNonPromptAnalyzer
     correctionTermsPfMetType0PFCandidateForValidation*
-    newAK4PFL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3ResidualCorrectorChain*
     valCorrPfMetType1*
-    #pfchsMETcorr*
     pfMetT0pc*
     PfMetT1*
     PfMetT0pcT1*
@@ -67,23 +64,12 @@ METRelValSequence = cms.Sequence(
 
 METValidation = cms.Sequence(
     metAnalyzer*
-    #metHOAnalyzer*
-    #metNoHFAnalyzer*
-    #metNoHFHOAnalyzer*
-    #metOptAnalyzer*
-    #metOptHOAnalyzer*
-    #metOptNoHFAnalyzer*
-    #metOptNoHFHOAnalyzer*
     pfMetAnalyzer*
-    #tcMetAnalyzer*
-    #corMetGlobalMuonsAnalyzer*
-    genMetTrueAnalyzer*#*
-    #genMetCaloAnalyzer*
-    #genMetCaloAndNonPromptAnalyzer
+    genMetTrueAnalyzer*
     correctionTermsPfMetType0PFCandidateForValidation*
-    newAK4PFL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3CorrectorChain*
+    newAK4PFCHSL1FastL2L3ResidualCorrectorChain*
     valCorrPfMetType1*
-    #pfchsMETcorr*
     pfMetT0pc*
     PfMetT1*
     PfMetT0pcT1*

--- a/Validation/RecoMET/python/METValidation_cfi.py
+++ b/Validation/RecoMET/python/METValidation_cfi.py
@@ -146,3 +146,9 @@ pfType1CorrectedMetAnalyzerMiniAOD = cms.EDAnalyzer(
    PrimaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices")
    )
 
+pfPuppiMetAnalyzerMiniAOD = cms.EDAnalyzer(
+   "METTester",
+   InputMETLabel = cms.InputTag("slimmedMETsPuppi"),
+   METType = cms.untracked.string("miniaod"),
+   PrimaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices")
+   )

--- a/Validation/RecoMET/python/METValidation_cfi.py
+++ b/Validation/RecoMET/python/METValidation_cfi.py
@@ -146,4 +146,3 @@ pfType1CorrectedMetAnalyzerMiniAOD = cms.EDAnalyzer(
    PrimaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices")
    )
 
-

--- a/Validation/RecoMET/test/sequence_validation_cfg.py
+++ b/Validation/RecoMET/test/sequence_validation_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("METVALIDATION")
 
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
@@ -11,7 +11,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = 'MCRUN2_74_V9'
+process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_v1'
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
@@ -29,16 +29,10 @@ secFiles = cms.untracked.vstring()
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
        #for RECO
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/403FA79E-251A-E511-B21A-0025905B855C.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/623B1740-551A-E511-8A61-0025905A60CA.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/6AEC1D6D-361A-E511-8AFF-0025905938A8.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/801ABCFB-5B1A-E511-BB68-0025905A4964.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/9429572C-221A-E511-8613-0025905A6064.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/B6B7C7EA-1E1B-E511-8472-0025905B8576.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/D6833B78-3C1A-E511-9D9B-0026189438B5.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/DA508AF0-4E1A-E511-A655-0025905A60E0.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/F479010F-491A-E511-98F9-0025905938B4.root',
-        '/store/relval/CMSSW_7_4_6/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V9-v2/00000/F837DA4C-561B-E511-BB00-0025905A6138.root'
+       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/06121D17-661B-E511-AE2A-0025905A60B2.root',
+       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/103A92CC-681B-E511-A923-002618943935.root',
+       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/16752615-911B-E511-991B-0025905A613C.root',
+       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/1C073F39-671B-E511-94BE-0025905A60D0.root'
         #for MINIAODtests 
         #'/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/MINIAODSIM/PU50ns_PRE_LS172_V16-v1/00000/9886ACB4-F45E-E411-9E5D-02163E00F01E.root' 
 ] );

--- a/Validation/RecoMET/test/sequence_validation_cfg.py
+++ b/Validation/RecoMET/test/sequence_validation_cfg.py
@@ -11,7 +11,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_v1'
+process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_v5'
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
@@ -29,10 +29,8 @@ secFiles = cms.untracked.vstring()
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
        #for RECO
-       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/06121D17-661B-E511-AE2A-0025905A60B2.root',
-       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/103A92CC-681B-E511-A923-002618943935.root',
-       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/16752615-911B-E511-991B-0025905A613C.root',
-       '/store/relval/CMSSW_7_5_0_pre6/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/1C073F39-671B-E511-94BE-0025905A60D0.root'
+       '/store/relval/CMSSW_7_6_0_pre7/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/76X_mcRun2_asymptotic_v5-v1/00000/7E692CF1-2971-E511-9609-0025905A497A.root',
+       '/store/relval/CMSSW_7_6_0_pre7/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/76X_mcRun2_asymptotic_v5-v1/00000/B4DD46D7-2971-E511-B4DD-0025905A4964.root' 
         #for MINIAODtests 
         #'/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/MINIAODSIM/PU50ns_PRE_LS172_V16-v1/00000/9886ACB4-F45E-E411-9E5D-02163E00F01E.root' 
 ] );
@@ -45,13 +43,15 @@ Workflow = '/JetMET/'+str(cmssw_version)+'/METValidation'
 process.dqmSaver.workflow = Workflow
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
+process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 
 process.p = cms.Path(#for RECO
-                     process.metPreValidSeq*
-                     process.METValidation
+                     #process.dump*
+                     #process.metPreValidSeq*
+                     #process.METValidation
                      #for MiniAOD
-                     #process.METValidationMiniAOD
-                     process.METPostProcessor
+                     process.METValidationMiniAOD
+                     *process.METPostProcessor
                      *process.METPostProcessorHarvesting
                      *process.dqmSaver
 )


### PR DESCRIPTION
monitor substructure variables in JetMET DQM for ak8 jets. update PFJetID Selector to new recommended RunII JetID, move type1 corrections to ak4CHS JetEnergyCorrector. 
