### PR TITLE
fix for LS range in case LS is there but no event processed

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -494,11 +494,12 @@ if(nthlumi > nextlumi_){
      map<int, std::time_t>::iterator itbstime=mapBeginBSTime.begin();
      map<int, std::time_t>::iterator itpvtime=mapBeginPVTime.begin();
 
+    if(processed_){// if LS is there but no event then processed = false and Fit&Fill will not be called, countLumi_ will not be increamented and it will overwrite the map last value. Hence we do not delete first one here to keep the range same as last in las LUMI. This is equivalanet as LS is missing
      mapBeginBSLS.erase(itbs);
      mapBeginPVLS.erase(itpv);
      mapBeginBSTime.erase(itbstime);
      mapBeginPVTime.erase(itpvtime);
-
+   }
             /*//not sure if want this or not ??
             map<int, int>::iterator itgapb=mapBeginBSLS.begin();
             map<int, int>::iterator itgape=mapBeginBSLS.end(); itgape--;


### PR DESCRIPTION
This fixes the LS stamp in beam spot application for online DQM. The fix is for LS  stamp of fit range if LS is seen but no event is processed in the application.
