### PR TITLE
Central bunch spacing producer

### DIFF
--- a/Configuration/StandardSequences/python/PATMC_cff.py
+++ b/Configuration/StandardSequences/python/PATMC_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff import *
 from PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff import *
 from PhysicsTools.PatAlgos.slimming.slimming_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 
 miniAOD=cms.Sequence()

--- a/Configuration/StandardSequences/python/PAT_cff.py
+++ b/Configuration/StandardSequences/python/PAT_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff import *
 from PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff import *
 from PhysicsTools.PatAlgos.slimming.slimming_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 
 miniAOD=cms.Sequence()

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 # no bunchspacing in cosmics
-bunchSpacingProducer.overrideBunchSpacing=true
+bunchSpacingProducer.overrideBunchSpacing=True
 bunchSpacingProducer.bunchSpacingOverride=50
 
 #

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -3,6 +3,11 @@ import FWCore.ParameterSet.Config as cms
 # luminosity
 #
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
+# no bunchspacing in cosmics
+bunchSpacingProducer.overrideBunchSpacing=true
+bunchSpacingProducer.bunchSpacingOverride=50
+
 #
 # tracker
 #
@@ -46,8 +51,8 @@ caloCosmics = cms.Sequence(calolocalreco*ecalClusters)
 caloCosmics_HcalNZS = cms.Sequence(calolocalrecoNZS*ecalClusters)
 muonsLocalRecoCosmics = cms.Sequence(muonlocalreco+muonlocalrecoT0Seg)
 
-localReconstructionCosmics         = cms.Sequence(trackerCosmics*caloCosmics*muonsLocalRecoCosmics*vertexrecoCosmics+lumiProducer)
-localReconstructionCosmics_HcalNZS = cms.Sequence(trackerCosmics*caloCosmics_HcalNZS*muonsLocalRecoCosmics*vertexrecoCosmics +lumiProducer)
+localReconstructionCosmics         = cms.Sequence(bunchSpacingProducer*trackerCosmics*caloCosmics*muonsLocalRecoCosmics*vertexrecoCosmics+lumiProducer)
+localReconstructionCosmics_HcalNZS = cms.Sequence(bunchSpacingProducer*trackerCosmics*caloCosmics_HcalNZS*muonsLocalRecoCosmics*vertexrecoCosmics +lumiProducer)
 
 
 # global reco

--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Tracker
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 from RecoLocalTracker.Configuration.RecoLocalTrackerHeavyIons_cff import *
 from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
 from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
@@ -37,12 +38,12 @@ caloReco = cms.Sequence(ecalLocalRecoSequence*hcalLocalRecoSequence)
 hbhereco = hbheprereco.clone()
 hcalLocalRecoSequence.replace(hbheprereco,hbhereco)
 muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEvent+siPixelClusterShapeCache+muonlocalreco)
-localReco = cms.Sequence(offlineBeamSpot*muonReco*caloReco*castorreco)
+localReco = cms.Sequence(bunchSpacingProducer*offlineBeamSpot*muonReco*caloReco*castorreco)
 
 #hbherecoMB = hbheprerecoMB.clone()
 #hcalLocalRecoSequenceNZS.replace(hbheprerecoMB,hbherecoMB)
 caloRecoNZS = cms.Sequence(caloReco+hcalLocalRecoSequenceNZS)
-localReco_HcalNZS = cms.Sequence(offlineBeamSpot*muonReco*caloRecoNZS)
+localReco_HcalNZS = cms.Sequence(bunchSpacingProducer*offlineBeamSpot*muonReco*caloRecoNZS)
 
 #--------------------------------------------------------------------------
 # Main Sequence

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 from RecoLocalCalo.Configuration.RecoLocalCalo_cff import *
 from RecoTracker.Configuration.RecoTracker_cff import *
@@ -91,7 +92,7 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
 from FWCore.Modules.logErrorHarvester_cfi import *
 
 # "Export" Section
-reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
+reconstruction         = cms.Sequence(bunchSpacingProducer*localreco*globalreco*highlevelreco*logErrorHarvester)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -79,7 +79,7 @@ private:
   bool autoDetectBunchSpacing_;
   int bunchspacing_;
   edm::InputTag bunchspacingTag_;
-  edm::EDGetTokenT<int> bunchSpacingToken_;
+  edm::EDGetTokenT<unsigned int> bunchSpacingToken_;
   float rhoValue_;
   edm::InputTag rhoTag_;
   edm::EDGetTokenT<double> rhoToken_;
@@ -244,29 +244,9 @@ void EGExtraInfoModifierFromDB::setEvent(const edm::Event& evt) {
   }
   
   if (autoDetectBunchSpacing_) {
-    if (evt.isRealData()) {
-      edm::RunNumber_t run = evt.run();
-      if (run == 178003 ||
-          run == 178004 ||
-          run == 209089 ||
-          run == 209106 ||
-          run == 209109 ||
-          run == 209146 ||
-          run == 209148 ||
-          run == 209151) {
-        bunchspacing_ = 25;
-      }
-      else if (run < 253000) {
-        bunchspacing_ = 50;
-      } 
-      else {
-	bunchspacing_ = 25;
-      }
-    } else {
-      edm::Handle<int> bunchSpacingH;
+      edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacingToken_,bunchSpacingH);
       bunchspacing_ = *bunchSpacingH;
-    }
   }
 
   edm::Handle<double> rhoH;
@@ -329,7 +309,7 @@ void EGExtraInfoModifierFromDB::setConsumes(edm::ConsumesCollector& sumes) {
   vtxToken_ = sumes.consumes<reco::VertexCollection>(vtxTag_);
 
   if (autoDetectBunchSpacing_)
-    bunchSpacingToken_ = sumes.consumes<int>(bunchspacingTag_);
+    bunchSpacingToken_ = sumes.consumes<unsigned int>(bunchspacingTag_);
 
   //setup electrons
   if(!(empty_tag == e_conf.electron_src))

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 regressionModifier = \
     cms.PSet( modifierName    = cms.string('EGExtraInfoModifierFromDB'),  
               autoDetectBunchSpacing = cms.bool(True),
-              bunchSpacingTag = cms.InputTag("addPileupInfo:bunchSpacing"),
+              bunchSpacingTag = cms.InputTag("bunchSpacingProducer"),
               manualBunchSpacing = cms.int32(50),              
               rhoCollection = cms.InputTag("fixedGridRhoFastjetAll"),
               vertexCollection = cms.InputTag("offlinePrimaryVertices"),

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -42,7 +42,7 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   useLumiInfoRunHeader_ = ps.getParameter<bool>("useLumiInfoRunHeader");
   
   if (useLumiInfoRunHeader_) {
-    bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+    bunchSpacing_ = c.consumes<unsigned int>(edm::InputTag("bunchSpacingProducer"));
     bunchSpacingManual_ = 0;
   } else {
     bunchSpacingManual_ = ps.getParameter<int>("bunchSpacing");
@@ -130,35 +130,13 @@ void
 EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
 {
 
-  int bunchspacing = 450;
+  unsigned int bunchspacing = 450;
 
   if (useLumiInfoRunHeader_) {
 
-    if (evt.isRealData()) {
-      edm::RunNumber_t run = evt.run();
-      if (run == 178003 ||
-          run == 178004 ||
-          run == 209089 ||
-          run == 209106 ||
-          run == 209109 ||
-          run == 209146 ||
-          run == 209148 ||
-          run == 209151) {
-        bunchspacing = 25;
-      }
-      else if (run < 253000) {
-        bunchspacing = 50;
-      }
-      else {
-	bunchspacing = 25;
-      }
-    }
-    else {
-      edm::Handle<int> bunchSpacingH;
+      edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacing_,bunchSpacingH);
       bunchspacing = *bunchSpacingH;
-    }
-    
   }
   else {
     bunchspacing = bunchSpacingManual_;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -83,7 +83,7 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
 		int bunchSpacingManual_;
-                edm::EDGetTokenT<int> bunchSpacing_; 
+                edm::EDGetTokenT<unsigned int> bunchSpacing_; 
 
                 // determine which of the samples must actually be used by ECAL local reco
                 edm::ESHandle<EcalSampleMask> sampleMaskHand_;                

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -74,6 +74,11 @@
   <use name="xerces-c"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="BunchSpacingProducer.cc" name="BunchSpacingProducer">
+  <use name="FWCore/PluginManager"/>
+  <use name="DataFormats/Provenance"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
 <library file="ExpressLumiProducer.cc" name="ExpressLumiProducer">
   <use name="RecoLuminosity/LumiProducer"/>
   <use name="FWCore/PluginManager"/>

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -105,7 +105,7 @@ void BunchSpacingProducer::fillDescriptions( edm::ConfigurationDescriptions & de
 {
   edm::ParameterSetDescription desc ;
   desc.add<bool>("overrideBunchSpacing",false); // true for prompt reco
-  desc.add<unsigned int>("bunchSpacingOverride_",25); // override value
+  desc.add<unsigned int>("bunchSpacingOverride",25); // override value
   
   descriptions.add("bunchSpacingProducer",desc) ;
 }

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -1,0 +1,93 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+namespace edm {
+  class EventSetup;
+}
+
+//
+// class declaration
+//
+class BunchSpacingProducer : public edm::stream::EDProducer<> {
+
+public:
+
+  explicit BunchSpacingProducer(const edm::ParameterSet&);
+
+  ~BunchSpacingProducer();
+
+  virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+
+  static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
+  
+private:
+  
+  edm::EDGetTokenT<int> bunchSpacing_;
+};
+
+//
+// constructors and destructor
+//
+
+
+BunchSpacingProducer::
+BunchSpacingProducer::BunchSpacingProducer(const edm::ParameterSet& iConfig)
+{
+  // register your products
+  produces<unsigned int>();
+  bunchSpacing_ = consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+}
+
+BunchSpacingProducer::~BunchSpacingProducer(){ 
+}
+
+//
+// member functions
+//
+void BunchSpacingProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
+{ 
+  unsigned int bunchSpacing=50;
+  unsigned int run=e.run();
+
+  if ( e.isRealData()) {
+    if ( ( run > 252126 && run != 254833 )|| 
+	run == 178003 ||
+	run == 178004 ||
+	run == 209089 ||
+	run == 209106 ||
+	run == 209109 ||
+	run == 209146 ||
+	run == 209148 ||
+	run == 209151) {
+      bunchSpacing = 25;
+    }
+  }
+  else{
+    edm::Handle<int> bunchSpacingH;
+    e.getByToken(bunchSpacing_,bunchSpacingH);
+    bunchSpacing = *bunchSpacingH;
+  }
+
+  std::auto_ptr<unsigned int> pOut1(new unsigned int);
+  *pOut1=bunchSpacing;
+  e.put(pOut1);
+
+}
+
+void BunchSpacingProducer::fillDescriptions( edm::ConfigurationDescriptions & descriptions )
+{
+  edm::ParameterSetDescription desc ;
+
+  descriptions.add("bunchSpacingProducer",desc) ;
+}
+
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(BunchSpacingProducer);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -29,7 +29,7 @@ class PFClusterEMEnergyCorrector {
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;
   
-  edm::EDGetTokenT<int> bunchSpacing_; 
+  edm::EDGetTokenT<unsigned int> bunchSpacing_; 
   
   edm::EDGetTokenT<EcalRecHitCollection> _recHitsEB;
   edm::EDGetTokenT<EcalRecHitCollection> _recHitsEE;  

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -27,7 +27,7 @@ PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet& 
     autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
 
     if (autoDetectBunchSpacing_) {
-      bunchSpacing_ = cc.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+      bunchSpacing_ = cc.consumes<unsigned int>(edm::InputTag("bunchSpacingProducer"));
       bunchSpacingManual_ = 0;
     }
     else {
@@ -125,30 +125,9 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
   int bunchspacing = 450;  
   
   if (autoDetectBunchSpacing_) {
-    if (evt.isRealData()) {
-      edm::RunNumber_t run = evt.run();
-      if (run == 178003 ||
-          run == 178004 ||
-          run == 209089 ||
-          run == 209106 ||
-          run == 209109 ||
-          run == 209146 ||
-          run == 209148 ||
-          run == 209151) {
-        bunchspacing = 25;
-      }
-      else if (run < 253000) {
-        bunchspacing = 50;
-      } 
-      else {
-	bunchspacing = 25;
-      }
-    }
-    else {
-      edm::Handle<int> bunchSpacingH;
+      edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacing_,bunchSpacingH);
       bunchspacing = *bunchSpacingH;
-    }
   }
   else {
     bunchspacing = bunchSpacingManual_;

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -66,7 +66,7 @@ def customise(process):
             cms.InputTag("interestingEcalDetIdEE"),
             )            
 
-    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
+    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.bunchSpacingProducer * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
 
     process.schedule.append(process.local_digireco)
 


### PR DESCRIPTION
attempt two at making a PR for a new module to centralize the bunch spacing in reco/analysis. This time I've included a parameter to allow prompt to override the bunch spacing in configuration based on the processing scenario being used.

Instead of storing this output, I suggest that this module just be run as needed. I've added it to the reco sequence, which should be sufficient for all current consumers. Eventually we'll need it in PAT as well.
