### PR TITLE
A fix for the DQMStreamerReader (74x)

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -324,13 +324,15 @@ bool DQMStreamerReader::matchTriggerSel(Strings const& tnames) {
     std::string hltPath(*i);
     boost::erase_all(hltPath, " \t");
     std::vector<Strings::const_iterator> matches = edm::regexMatch(tnames, hltPath);
-    if (matches.empty()){
-      edm::LogWarning("Trigger selection does not match any trigger path!!!") << std::endl; 
-      matchTriggerSel_ = false;
-    }else{
+    if (!matches.empty()) {
       matchTriggerSel_ = true;
     }
   }
+
+  if (!matchTriggerSel_) {
+    edm::LogWarning("Trigger selection does not match any trigger path!!!") << std::endl;
+  }
+
   return matchTriggerSel_;
 }
 


### PR DESCRIPTION
(discussion: https://github.com/cms-sw/cmssw/pull/11551)

DQMStreamerReader would incorrectly set matchTriggerSel_ to false
if the last component didn't match. (it should be _or_).

Minor fixes for esMonitoring script:
- added a few more fields to the report document
- fixed 'stdlog*' fields
- added command line parameter 'path' (previously it was hardcoded into
  /tmp/dqm_monitoring)

(cherry picked from commit 6b2ffbe5251ec9184fb71d9c63f102b5c62b2e19)
