### PR TITLE
Added a formula evaluator to replace TFormula calls

### DIFF
--- a/CommonTools/Utils/interface/FormulaEvaluator.h
+++ b/CommonTools/Utils/interface/FormulaEvaluator.h
@@ -1,0 +1,81 @@
+#ifndef CommonTools_Utils_FormulaEvaluator_h
+#define CommonTools_Utils_FormulaEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     FormulaEvaluator
+// 
+/**\class FormulaEvaluator FormulaEvaluator.h "CommonTools/Utils/interface/FormulaEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 21:12:11 GMT
+//
+
+// system include files
+#include <array>
+#include <vector>
+#include <memory>
+
+// user include files
+
+// forward declarations
+namespace reco {
+  namespace formula {
+    class EvaluatorBase;
+    inline double const* startingAddress(std::vector<double> const& iV) {
+      if(iV.empty()) {
+        return nullptr;
+      }
+      return &iV[0];
+    }
+
+    template<size_t t>
+      inline double const* startingAddress(std::array<double,t> const& iV) {
+      if(iV.empty()) {
+        return nullptr;
+      }
+      return &iV[0];
+    }
+
+  }
+
+  class FormulaEvaluator
+  {
+    
+  public:
+    explicit FormulaEvaluator(std::string const& iFormula);
+
+    template<typename V, typename P>
+      double evaluate( V const& iVariables, P const& iParameters) const {
+      if (m_nVariables > iVariables.size()) {
+        throwWrongNumberOfVariables(iVariables.size());
+      }
+      if (m_nParameters > iParameters.size()) {
+        throwWrongNumberOfParameters(iParameters.size());
+      }
+      return evaluate( formula::startingAddress(iVariables),
+                       formula::startingAddress(iParameters));
+    }
+    // ---------- const member functions ---------------------
+    
+  private:
+    double evaluate(double const* iVariables, double const* iParameters) const;
+
+    void throwWrongNumberOfVariables(size_t) const ;
+    void throwWrongNumberOfParameters(size_t) const;
+
+    std::shared_ptr<formula::EvaluatorBase const> m_evaluator; 
+    unsigned int m_nVariables = 0;
+    unsigned int m_nParameters = 0;
+
+};
+}
+
+#endif

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -1,0 +1,590 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     FormulaEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 24 Sep 2015 19:07:58 GMT
+//
+
+// system include files
+#include <cassert>
+#include <functional>
+#include <cstdlib>
+#include <cmath>
+
+// user include files
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "formulaEvaluatorBase.h"
+#include "formulaUnaryMinusEvaluator.h"
+#include "formulaBinaryOperatorEvaluator.h"
+#include "formulaConstantEvaluator.h"
+#include "formulaVariableEvaluator.h"
+#include "formulaParameterEvaluator.h"
+#include "formulaFunctionOneArgEvaluator.h"
+#include "formulaFunctionTwoArgsEvaluator.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+using namespace reco;
+
+namespace {
+  //Formula Parser Code
+  struct EvaluatorInfo {
+    std::unique_ptr<reco::formula::EvaluatorBase> evaluator;
+    int nextParseIndex=0;
+    unsigned int maxNumVariables=0;
+    unsigned int maxNumParameters=0;
+  };
+
+  class ExpressionElementFinderBase {
+  public:
+    virtual bool checkStart(char) const = 0;
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator, std::string::const_iterator) const = 0;
+  };
+
+  std::string::const_iterator findMatchingParenthesis(std::string::const_iterator iBegin, std::string::const_iterator iEnd) {
+    if (iBegin == iEnd) {
+      return iBegin;
+    }
+    if( *iBegin != '(') {
+      return iBegin;
+    }
+    int level = 1;
+    size_t index = 0;
+    for( auto it = iBegin+1; it != iEnd; ++it) {
+      ++index;
+      if (*it == '(') {
+        ++level;
+      } else if (*it == ')') {
+        --level;
+        if (level == 0) {
+          break;
+        }
+      }
+    }
+    return iBegin + index;
+  }
+
+  class ConstantFinder : public ExpressionElementFinderBase {
+    virtual bool checkStart(char iSymbol) const override final {
+      if( iSymbol == '-' or iSymbol == '.' or std::isdigit(iSymbol) ) {
+        return true;
+      }
+      return false;
+    }
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final {
+      EvaluatorInfo info;
+      try {
+        size_t endIndex=0;
+        std::string s(iBegin,iEnd);
+        double value = stod(s, &endIndex);
+
+        info.nextParseIndex = endIndex;
+        info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ConstantEvaluator(value));
+      } catch ( std::invalid_argument ) {}
+
+      return info;
+
+    }
+  };
+
+
+  class ParameterFinder : public ExpressionElementFinderBase {
+    virtual bool checkStart(char iSymbol) const override final {
+      if( iSymbol == '[') {
+        return true;
+      }
+      return false;
+    }
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final {
+      EvaluatorInfo info;
+      if(iEnd == iBegin) {
+        return info;
+      }
+      if(*iBegin != '[') {
+        return info;
+      }
+      info.nextParseIndex = 1;
+      try {
+        size_t endIndex=0;
+        std::string s(iBegin+1,iEnd);
+        unsigned long value = stoul(s, &endIndex);
+        
+        if( iBegin+endIndex+1 == iEnd or *(iBegin+1+endIndex) != ']' ) {
+          return info;
+        }
+        
+        
+        info.nextParseIndex = endIndex+2;
+        info.maxNumParameters = value;
+        info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ParameterEvaluator(value));
+      } catch ( std::invalid_argument ) {}
+      
+      return info;
+
+    }
+  };
+  
+  class VariableFinder : public ExpressionElementFinderBase {
+    virtual bool checkStart(char iSymbol) const override final {
+      if( iSymbol == 'x' or iSymbol == 'y' or iSymbol == 'z' or iSymbol == 't' ) {
+        return true;
+      }
+      return false;
+    }
+    
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final {
+      EvaluatorInfo info;
+      if(iBegin == iEnd) {
+        return info;
+      }
+      unsigned int index = 4;
+      switch (*iBegin) {
+      case 'x':
+        { index = 0; break;}
+      case 'y':
+        { index = 1; break;}
+      case 'z':
+        { index = 2; break;}
+      case 't':
+        {index = 3; break;}
+      }
+      if(index == 4) {
+        return info;
+      }
+      info.nextParseIndex = 1;
+      info.maxNumVariables = index+1;
+      info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>(new reco::formula::VariableEvaluator(index) );
+      return info;
+    }
+  };
+
+  class ExpressionFinder;
+
+  class FunctionFinder : public ExpressionElementFinderBase {
+  public:
+    FunctionFinder(ExpressionFinder const* iEF):
+      m_expressionFinder(iEF) {};
+
+    virtual bool checkStart(char iSymbol) const override final {
+      return std::isalpha(iSymbol);
+    }
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final;
+
+  private:
+    ExpressionFinder const* m_expressionFinder;
+  };
+
+
+  EvaluatorInfo createBinaryOperatorEvaluator( ExpressionFinder const&,
+                                               std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
+                                               std::string::const_iterator iBegin,
+                                               std::string::const_iterator iEnd) ;
+
+  class ExpressionFinder {
+
+  public:
+    ExpressionFinder() {
+      m_elements.reserve(4);
+      m_elements.emplace_back(new FunctionFinder{this});
+      m_elements.emplace_back(new ConstantFinder{});
+      m_elements.emplace_back(new ParameterFinder{});
+      m_elements.emplace_back(new VariableFinder{});
+    }
+  
+    bool checkStart(char iChar) const {
+      if ( '(' == iChar or '-' == iChar or '+' ==iChar) {
+        return true;
+      }
+      for( auto const& e : m_elements) {
+        if (e->checkStart(iChar) ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const {
+      EvaluatorInfo leftEvaluatorInfo ;
+      if( iBegin == iEnd) {
+        return leftEvaluatorInfo;
+      }
+      //Start with '+'
+      if (*iBegin == '+' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
+        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd);
+
+        //have to account for the '+' we skipped over
+        leftEvaluatorInfo.nextParseIndex +=1;
+        if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
+          return leftEvaluatorInfo;
+        }
+        if( leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+          return leftEvaluatorInfo;
+        }
+      }
+      //Start with '-'
+      else if (*iBegin == '-' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
+        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd);
+
+        //have to account for the '+' we skipped over
+        leftEvaluatorInfo.nextParseIndex +=1;
+        if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
+          return leftEvaluatorInfo;
+        }
+        leftEvaluatorInfo.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::UnaryMinusEvaluator( std::move(leftEvaluatorInfo.evaluator)) );
+        if( leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+          return leftEvaluatorInfo;
+        }
+      }
+      //Start with '('
+      else if( *iBegin == '(') {
+        auto endParenthesis = findMatchingParenthesis(iBegin,iEnd);
+        if(iBegin== endParenthesis) {
+          return leftEvaluatorInfo;
+        }
+        leftEvaluatorInfo = createEvaluator(iBegin+1,endParenthesis);
+        ++leftEvaluatorInfo.nextParseIndex;
+        if(leftEvaluatorInfo.evaluator.get() == nullptr) {
+          return leftEvaluatorInfo;
+        }
+        //need to account for closing parenthesis
+        ++leftEvaluatorInfo.nextParseIndex;
+        leftEvaluatorInfo.evaluator->setPrecidenceToParenthesis();
+        if( iBegin+leftEvaluatorInfo.nextParseIndex == iEnd) {
+          return leftEvaluatorInfo;
+        }
+      } else {
+        //Does not start with a '('
+        int maxParseDistance = 0;
+        for( auto const& e: m_elements) {
+          if(e->checkStart(*iBegin) ) {
+            leftEvaluatorInfo = e->createEvaluator(iBegin,iEnd);
+            if(leftEvaluatorInfo.evaluator != nullptr) {
+              break;
+            }
+            if (leftEvaluatorInfo.nextParseIndex > maxParseDistance) {
+              maxParseDistance = leftEvaluatorInfo.nextParseIndex;
+            }
+          }
+        }
+        if(leftEvaluatorInfo.evaluator.get() == nullptr) {
+          //failed to parse
+          leftEvaluatorInfo.nextParseIndex = maxParseDistance;
+          return leftEvaluatorInfo;
+        }
+      }
+      //did we evaluate the full expression?
+      if(leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+        return leftEvaluatorInfo;
+      }
+
+      //see if this is a binary expression
+      auto fullExpression = createBinaryOperatorEvaluator(*this, std::move(leftEvaluatorInfo.evaluator), iBegin+leftEvaluatorInfo.nextParseIndex, iEnd);
+      fullExpression.nextParseIndex +=leftEvaluatorInfo.nextParseIndex;
+      fullExpression.maxNumVariables = std::max(leftEvaluatorInfo.maxNumVariables, fullExpression.maxNumVariables);
+      fullExpression.maxNumParameters = std::max(leftEvaluatorInfo.maxNumParameters, fullExpression.maxNumParameters);
+      if (iBegin + fullExpression.nextParseIndex != iEnd) {
+        //did not parse the full expression
+        fullExpression.evaluator.release();
+      }
+      return fullExpression;
+    }
+
+  private:
+    std::vector<std::unique_ptr<ExpressionElementFinderBase>> m_elements;
+
+  };
+
+  template<typename Op>
+  EvaluatorInfo createBinaryOperatorEvaluatorT(int iSymbolLength,
+                                               reco::formula::EvaluatorBase::Precidence iPrec,
+                                               ExpressionFinder const& iEF,
+                                               std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
+                                               std::string::const_iterator iBegin,
+                                               std::string::const_iterator iEnd) {
+    EvaluatorInfo evalInfo = iEF.createEvaluator(iBegin+iSymbolLength,iEnd);
+    evalInfo.nextParseIndex += iSymbolLength;
+
+    if(evalInfo.evaluator.get() == nullptr) {
+      return evalInfo;
+    }
+
+    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precidence() ) {
+      auto b = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>( evalInfo.evaluator.get() );
+      assert(b != nullptr);
+      std::unique_ptr<reco::formula::EvaluatorBase> temp;
+      b->swapLeftEvaluator(temp);
+      std::unique_ptr<reco::formula::EvaluatorBase> op{ new reco::formula::BinaryOperatorEvaluator<Op>(std::move(iLHS), std::move(temp), iPrec) };
+      b->swapLeftEvaluator(op);
+
+    } else {
+      std::unique_ptr<reco::formula::EvaluatorBase> op{ new reco::formula::BinaryOperatorEvaluator<Op>(std::move(iLHS), std::move(evalInfo.evaluator), iPrec) };
+        evalInfo.evaluator.swap(op);
+    }
+    return evalInfo;
+  }
+
+  struct power {
+    double operator()(double iLHS, double iRHS) const {
+      return std::pow(iLHS,iRHS);
+    }
+  };
+
+
+  EvaluatorInfo 
+  createBinaryOperatorEvaluator( ExpressionFinder const& iEF,
+                                 std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
+                                 std::string::const_iterator iBegin,
+                                 std::string::const_iterator iEnd) {
+    EvaluatorInfo evalInfo;
+    if(iBegin == iEnd) {
+      return evalInfo;
+    }
+
+    if(*iBegin == '+') {
+      return createBinaryOperatorEvaluatorT<std::plus<double>>(1,
+                                                               reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                               iEF,
+                                                               std::move(iLHS),
+                                                               iBegin,
+                                                               iEnd);
+    }
+
+    else if(*iBegin == '-') {
+      return createBinaryOperatorEvaluatorT<std::minus<double>>(1,
+                                                                reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                                iEF,
+                                                                std::move(iLHS),
+                                                                iBegin,
+                                                                iEnd);
+    }
+    else if(*iBegin == '*') {
+      return createBinaryOperatorEvaluatorT<std::multiplies<double>>(1,
+                                                                     reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                     iEF,
+                                                                     std::move(iLHS),
+                                                                     iBegin,
+                                                                     iEnd);
+    }
+    else if(*iBegin == '/') {
+      return createBinaryOperatorEvaluatorT<std::divides<double>>(1,
+                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+    }
+
+    else if(*iBegin == '^') {
+      return createBinaryOperatorEvaluatorT<power>(1,
+                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+    }
+
+    return evalInfo;
+  }
+
+
+  template<typename Op>
+  EvaluatorInfo
+  checkForSingleArgFunction(std::string::const_iterator iBegin,
+                            std::string::const_iterator iEnd,
+                            ExpressionFinder const* iExpressionFinder,
+                            const std::string& iName,
+                            Op op) {
+    EvaluatorInfo info;
+    if(iName.size()+2 > static_cast<unsigned int>(iEnd-iBegin) ) {
+      return info;
+    }
+    auto pos = iName.find(&(*iBegin), 0,iName.size());
+
+    if(std::string::npos == pos or *(iBegin+iName.size()) != '(') {
+      return info;
+    }
+    
+    info.nextParseIndex = iName.size()+1;
+
+    auto itEndParen = findMatchingParenthesis(iBegin+iName.size(),iEnd);
+    if(iBegin+iName.size() == itEndParen) {
+      return info;
+    }
+
+    auto argEvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itEndParen);
+    info.nextParseIndex += argEvaluatorInfo.nextParseIndex;
+    if(argEvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
+      return info;
+    }
+    //account for closing parenthesis
+    ++info.nextParseIndex;
+
+    info.evaluator.reset( new reco::formula::FunctionOneArgEvaluator(std::move(argEvaluatorInfo.evaluator),
+                                                                     op) );
+    return info;
+  }
+
+  std::string::const_iterator findCommaNotInParenthesis(std::string::const_iterator iBegin,
+                                                        std::string::const_iterator iEnd ) {
+    int level = 0;
+    std::string::const_iterator it = iBegin;
+    for(; it != iEnd; ++it) {
+      if (*it == '(') {
+        ++level;
+      } else if(*it == ')') {
+        --level;
+      }
+      else if( *it ==',' and level == 0 ) {
+        return it;
+      }
+    }
+
+    return it;
+  }
+
+
+  template<typename Op>
+  EvaluatorInfo
+  checkForTwoArgsFunction(std::string::const_iterator iBegin,
+                          std::string::const_iterator iEnd,
+                          ExpressionFinder const* iExpressionFinder,
+                          const std::string& iName,
+                          Op op) {
+    EvaluatorInfo info;
+    if(iName.size()+2 > static_cast<unsigned int>(iEnd-iBegin) ) {
+      return info;
+    }
+    auto pos = iName.find(&(*iBegin), 0,iName.size());
+
+    if(std::string::npos == pos or *(iBegin+iName.size()) != '(') {
+      return info;
+    }
+    
+    info.nextParseIndex = iName.size()+1;
+
+    auto itEndParen = findMatchingParenthesis(iBegin+iName.size(),iEnd);
+    if(iBegin+iName.size() == itEndParen) {
+      return info;
+    }
+
+    auto itComma = findCommaNotInParenthesis(iBegin+iName.size()+1, itEndParen);
+
+    auto arg1EvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itComma);
+    info.nextParseIndex += arg1EvaluatorInfo.nextParseIndex;
+    if(arg1EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex != itComma-iBegin ) {
+      return info;
+    }
+    //account for commas
+    ++info.nextParseIndex;
+
+    auto arg2EvaluatorInfo = iExpressionFinder->createEvaluator(itComma+1, itEndParen);
+    info.nextParseIndex += arg2EvaluatorInfo.nextParseIndex;
+
+    if(arg2EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
+      return info;
+    }
+    //account for closing parenthesis
+    ++info.nextParseIndex;
+
+    info.evaluator.reset( new reco::formula::FunctionTwoArgsEvaluator(std::move(arg1EvaluatorInfo.evaluator),
+                                                                      std::move(arg2EvaluatorInfo.evaluator),
+                                                                      op) );
+    return info;
+  }
+
+  static const std::string k_log("log");
+  static const std::string k_log10("log10");
+  static const std::string k_TMath__Log("TMath::Log");
+  double const kLog10Inv = 1./std::log(10.);
+  static const std::string k_exp("exp");
+  static const std::string k_max("max");
+
+
+  EvaluatorInfo 
+  FunctionFinder::createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const {
+    EvaluatorInfo info;
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_log, [](double iArg)->double { return std::log(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_TMath__Log, [](double iArg)->double { return std::log(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_log10, [](double iArg)->double { return std::log(iArg)*kLog10Inv; } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_exp, [](double iArg)->double { return std::exp(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_max, [](double iArg1, double iArg2)->double { return std::max(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    return info;
+  };
+
+  static ExpressionFinder const s_expressionFinder;
+  
+}
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+FormulaEvaluator::FormulaEvaluator( std::string const& iFormula )
+{
+  auto info  = s_expressionFinder.createEvaluator(iFormula.begin(), iFormula.end());
+
+  if(info.nextParseIndex != static_cast<int>(iFormula.size()) or info.evaluator.get() == nullptr) {
+    throw cms::Exception("FormulaEvaluatorParseError")<<"While parsing '"<<iFormula<<"' could not parse beyond '"<<std::string(iFormula.begin(),iFormula.begin()+info.nextParseIndex) <<"'";
+  }
+  m_evaluator = std::move(info.evaluator);
+  m_nVariables = info.maxNumVariables;
+  m_nParameters = info.maxNumParameters;
+}
+
+//
+// const member functions
+//
+double
+FormulaEvaluator::evaluate(double const* iVariables, double const* iParameters) const
+{
+  return m_evaluator->evaluate(iVariables, iParameters);
+}
+
+void 
+FormulaEvaluator::throwWrongNumberOfVariables(size_t iSize) const {
+  throw cms::Exception("WrongNumVariables")<<"FormulaEvaluator expected at least "<<m_nVariables<<" but was passed only "<<iSize;
+}
+void 
+FormulaEvaluator::throwWrongNumberOfParameters(size_t iSize) const {
+  throw cms::Exception("WrongNumParameters")<<"FormulaEvaluator expected at least "<<m_nParameters<<" but was passed only "<<iSize;
+}

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -1,0 +1,74 @@
+#ifndef CommonTools_Utils_formulaBinaryOperatorEvaluator_h
+#define CommonTools_Utils_formulaBinaryOperatorEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaBinaryOperatorEvaluator
+// 
+/**\class reco::formula::BinaryOperatorEvaluator formulaBinaryOperatorEvaluator.h "formulaBinaryOperatorEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class BinaryOperatorEvaluatorBase : public EvaluatorBase {
+    public:
+    BinaryOperatorEvaluatorBase( Precidence iPrec) :
+      EvaluatorBase(iPrec) {}
+      virtual void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew) = 0;
+    };
+    template<typename Op>
+      class BinaryOperatorEvaluator : public BinaryOperatorEvaluatorBase
+    {
+      
+    public:
+      BinaryOperatorEvaluator(std::unique_ptr<EvaluatorBase> iLHS, 
+                              std::unique_ptr<EvaluatorBase> iRHS,
+                              Precidence iPrec):
+      BinaryOperatorEvaluatorBase(iPrec),
+        m_lhs(std::move(iLHS)),
+        m_rhs(std::move(iRHS)) {
+        }
+       
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return m_operator(m_lhs->evaluate(iVariables,iParameters),m_rhs->evaluate(iVariables,iParameters));
+      }
+
+      void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew ) override final {
+        m_lhs.swap(iNew);
+      }
+
+    private:
+      BinaryOperatorEvaluator(const BinaryOperatorEvaluator&) = delete;
+      
+      const BinaryOperatorEvaluator& operator=(const BinaryOperatorEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_lhs;
+      std::unique_ptr<EvaluatorBase> m_rhs;
+      Op m_operator;
+
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaConstantEvaluator.cc
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ConstantEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaConstantEvaluator.h"
+
+
+namespace reco {
+  namespace formula {
+    double ConstantEvaluator::evaluate(double const* /*iVariables*/, double const* /*iParameters*/) const {
+      return m_value;
+    }
+  }
+}

--- a/CommonTools/Utils/src/formulaConstantEvaluator.h
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.h
@@ -1,0 +1,52 @@
+#ifndef CommonTools_Utils_formulaConstantEvaluator_h
+#define CommonTools_Utils_formulaConstantEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ConstantEvaluator
+// 
+/**\class reco::formula::ConstantEvaluator formulaConstantEvaluator.h "formulaConstantEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:27 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class ConstantEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit ConstantEvaluator(double iValue) : m_value(iValue) {}
+      
+
+      // ---------- const member functions ---------------------
+      double evaluate(double const* iVariables, double const* iParameters) const override final;
+      
+    private:
+      ConstantEvaluator(const ConstantEvaluator&) = delete;
+      
+      const ConstantEvaluator& operator=(const ConstantEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      double m_value;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaEvaluatorBase.cc
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.cc
@@ -1,0 +1,43 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::EvaluatorBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 16:26:03 GMT
+//
+
+// system include files
+
+// user include files
+#include "CommonTools/Utils/src/formulaEvaluatorBase.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+reco::formula::EvaluatorBase::EvaluatorBase():
+  m_precidence(static_cast<unsigned int>(Precidence::kFunction))
+{
+}
+
+reco::formula::EvaluatorBase::EvaluatorBase(Precidence iPrec):
+  m_precidence(static_cast<unsigned int>(iPrec))
+{
+}
+
+reco::formula::EvaluatorBase::~EvaluatorBase()
+{
+}
+

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -1,0 +1,68 @@
+#ifndef CommonTools_Utils_formulaEvaluatorBase_h
+#define CommonTools_Utils_formulaEvaluatorBase_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::EvaluatorBase
+// 
+/**\class reco::formula::EvaluatorBase formulaEvaluatorBase.h "formulaEvaluatorBase.h"
+
+ Description: Base class for formula evaluators
+
+ Usage:
+    Used as an internal detail on the reco::FormulaEvalutor class. 
+    Base class for all objects used in the abstract evaluation tree where one node
+    corresponds to one syntax element of the formula.
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 16:26:00 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class EvaluatorBase
+    {
+      
+    public:
+      enum class Precidence { 
+        kPlusMinus = 1,
+          kMultDiv = 2,
+          kPower = 3,
+          kFunction = 4, //default
+          kParenthesis = 5,
+          kUnaryMinusOperator = 6
+          };
+
+      EvaluatorBase();
+      EvaluatorBase(Precidence);
+      virtual ~EvaluatorBase();
+      
+      // ---------- const member functions ---------------------
+      //inputs are considered to be 'arrays' which have already been validated to 
+      // be of the appropriate length
+      virtual double evaluate(double const* iVariables, double const* iParameters) const = 0;
+
+      unsigned int precidence() const { return m_precidence; }
+      void setPrecidenceToParenthesis() { m_precidence = static_cast<unsigned int>(Precidence::kParenthesis); }
+
+    private:
+      EvaluatorBase(const EvaluatorBase&) = delete; 
+      
+      const EvaluatorBase& operator=(const EvaluatorBase&) = delete;
+      
+      // ---------- member data --------------------------------
+      unsigned int m_precidence;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
@@ -1,0 +1,59 @@
+#ifndef CommonTools_Utils_formulaFunctionOneArgEvaluator_h
+#define CommonTools_Utils_formulaFunctionOneArgEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaFunctionOneArgEvaluator
+// 
+/**\class reco::formula::FunctionOneArgEvaluator formulaFunctionOneArgEvaluator.h "formulaFunctionOneArgEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+#include <functional>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class FunctionOneArgEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      template<typename T>
+      explicit FunctionOneArgEvaluator(std::unique_ptr<EvaluatorBase> iArg, T iFunc):
+        m_arg(std::move(iArg)),
+        m_function(iFunc) {}
+       
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return m_function( m_arg->evaluate(iVariables,iParameters) );
+      }
+
+    private:
+      FunctionOneArgEvaluator(const FunctionOneArgEvaluator&) = delete;
+      
+      const FunctionOneArgEvaluator& operator=(const FunctionOneArgEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_arg;
+      std::function<double(double)> m_function;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
@@ -1,0 +1,65 @@
+#ifndef CommonTools_Utils_formulaFunctionTwoArgsEvaluator_h
+#define CommonTools_Utils_formulaFunctionTwoArgsEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaFunctionTwoArgsEvaluator
+// 
+/**\class reco::formula::FunctionTwoArgsEvaluator formulaFunctionTwoArgsEvaluator.h "formulaFunctionTwoArgsEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+#include <functional>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class FunctionTwoArgsEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      template<typename T>
+    FunctionTwoArgsEvaluator(std::unique_ptr<EvaluatorBase> iArg1,
+                             std::unique_ptr<EvaluatorBase> iArg2,
+                             T iFunc):
+      m_arg1(std::move(iArg1)),
+        m_arg2(std::move(iArg2)),
+        m_function(iFunc)
+        {}
+
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return m_function( m_arg1->evaluate(iVariables,iParameters),
+                           m_arg2->evaluate(iVariables,iParameters) );
+      }
+
+    private:
+      FunctionTwoArgsEvaluator(const FunctionTwoArgsEvaluator&) = delete;
+      
+      const FunctionTwoArgsEvaluator& operator=(const FunctionTwoArgsEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_arg1;
+      std::unique_ptr<EvaluatorBase> m_arg2;
+      std::function<double(double,double)> m_function;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaParameterEvaluator.cc
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ParameterEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaParameterEvaluator.h"
+
+
+namespace reco {
+  namespace formula {
+    double ParameterEvaluator::evaluate(double const* /*iVariables*/, double const* iParameters) const {
+      return iParameters[m_index];
+    }
+  }
+}

--- a/CommonTools/Utils/src/formulaParameterEvaluator.h
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.h
@@ -1,0 +1,52 @@
+#ifndef CommonTools_Utils_formulaParameterEvaluator_h
+#define CommonTools_Utils_formulaParameterEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ParameterEvaluator
+// 
+/**\class reco::formula::ParameterEvaluator formulaParameterEvaluator.h "formulaParameterEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:27 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class ParameterEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit ParameterEvaluator(unsigned int iIndex) : m_index(iIndex) {}
+      
+
+      // ---------- const member functions ---------------------
+      double evaluate(double const* iVariables, double const* iParameters) const override final;
+      
+    private:
+      ParameterEvaluator(const ParameterEvaluator&) = delete;
+      
+      const ParameterEvaluator& operator=(const ParameterEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      unsigned int m_index;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -1,0 +1,57 @@
+#ifndef CommonTools_Utils_formulaUnaryMinusEvaluator_h
+#define CommonTools_Utils_formulaUnaryMinusEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaUnaryMinusEvaluator
+// 
+/**\class reco::formula::UnaryMinusEvaluator formulaUnaryMinusEvaluator.h "formulaUnaryMinusEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+#include <functional>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class UnaryMinusEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit UnaryMinusEvaluator(std::unique_ptr<EvaluatorBase> iArg):
+      EvaluatorBase(Precidence::kUnaryMinusOperator ),
+      m_arg(std::move(iArg)) {}
+       
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return -1. * m_arg->evaluate(iVariables,iParameters) ;
+      }
+
+    private:
+      UnaryMinusEvaluator(const UnaryMinusEvaluator&) = delete;
+      
+      const UnaryMinusEvaluator& operator=(const UnaryMinusEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_arg;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaVariableEvaluator.cc
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::VariableEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaVariableEvaluator.h"
+
+
+namespace reco {
+  namespace formula {
+    double VariableEvaluator::evaluate(double const* iVariables, double const* /*iParameters*/) const {
+      return iVariables[m_index];
+    }
+  }
+}

--- a/CommonTools/Utils/src/formulaVariableEvaluator.h
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.h
@@ -1,0 +1,52 @@
+#ifndef CommonTools_Utils_formulaVariableEvaluator_h
+#define CommonTools_Utils_formulaVariableEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::VariableEvaluator
+// 
+/**\class reco::formula::VariableEvaluator formulaVariableEvaluator.h "formulaVariableEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:27 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class VariableEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit VariableEvaluator(unsigned int iIndex) : m_index(iIndex) {}
+      
+
+      // ---------- const member functions ---------------------
+      double evaluate(double const* iVariables, double const* iParameters) const override final;
+      
+    private:
+      VariableEvaluator(const VariableEvaluator&) = delete;
+      
+      const VariableEvaluator& operator=(const VariableEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      unsigned int m_index;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<bin   name="testCommonToolsUtil" file="testSelectors.cc,testSelectIterator.cc,testComparators.cc,testCutParser.cc,testExpressionParser.cc,testRunner.cpp">
+<bin   name="testCommonToolsUtil" file="testSelectors.cc,testSelectIterator.cc,testComparators.cc,testCutParser.cc,testExpressionParser.cc,testFormulaEvaluator.cc,testRunner.cpp">
   <use   name="Geometry/CommonDetUnit"/>
   <use   name="DataFormats/TrackReco"/>
   <use   name="DataFormats/TrackerRecHit2D"/>

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -1,0 +1,291 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include "CommonTools/Utils/src/formulaConstantEvaluator.h"
+#include "CommonTools/Utils/src/formulaParameterEvaluator.h"
+#include "CommonTools/Utils/src/formulaVariableEvaluator.h"
+#include "CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h"
+#include "CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h"
+#include "CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h"
+#include "CommonTools/Utils/src/formulaUnaryMinusEvaluator.h"
+
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+
+#include <algorithm>
+
+class testFormulaEvaluator : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testFormulaEvaluator);
+  CPPUNIT_TEST(checkEvaluators);
+  CPPUNIT_TEST(checkFormulaEvaluator);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+  void checkEvaluators(); 
+  void checkFormulaEvaluator();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testFormulaEvaluator);
+
+void testFormulaEvaluator::checkEvaluators() {
+  using namespace reco::formula;
+  {
+    ConstantEvaluator c{4};
+
+    CPPUNIT_ASSERT( c.evaluate(nullptr,nullptr) == 4. );
+  }
+
+  {
+    ParameterEvaluator pe{0};
+
+    double p = 5.;
+
+    CPPUNIT_ASSERT( pe.evaluate(nullptr, &p) == p);
+  }
+
+  {
+    VariableEvaluator ve{0};
+
+    double v = 3.;
+
+    CPPUNIT_ASSERT( ve.evaluate(&v, nullptr) == v);
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+    auto cr = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(3) );
+
+    BinaryOperatorEvaluator<std::minus<double>> be( std::move(cl), std::move(cr), EvaluatorBase::Precidence::kPlusMinus);
+
+    CPPUNIT_ASSERT( be.evaluate(nullptr,nullptr) == 1. );
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+
+    FunctionOneArgEvaluator f( std::move(cl), [](double v) { return std::exp(v); } );
+
+    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == std::exp(4.) );
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+    auto cr = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(3) );
+
+    FunctionTwoArgsEvaluator f( std::move(cl), std::move(cr),
+                                [](double v1, double v2) { return std::max(v1,v2); });
+
+    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == 4. );
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+
+    UnaryMinusEvaluator f( std::move(cl) );
+
+    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == -4. );
+  }
+
+}
+
+void 
+testFormulaEvaluator::checkFormulaEvaluator() {
+  {
+    reco::FormulaEvaluator f("5");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3+2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3-2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3*2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 6. );
+  }
+
+  {
+    reco::FormulaEvaluator f("6/2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3^2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 9. );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("1+2*3");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 7. );
+  }
+
+  {
+    reco::FormulaEvaluator f("(1+2)*3");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 9. );
+  }
+
+  {
+    reco::FormulaEvaluator f("2*3+1");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 7. );
+  }
+
+  {
+    reco::FormulaEvaluator f("2*(3+1)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 8. );
+  }
+
+  {
+    reco::FormulaEvaluator f("x");
+    
+    std::vector<double> emptyV;
+    std::array<double,1> v ={{3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("y");
+    
+    std::vector<double> emptyV;
+    std::array<double,2> v = {{0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("z");
+    
+    std::vector<double> emptyV;
+    std::array<double,3> v = {{0.,0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("t");
+    
+    std::vector<double> emptyV;
+    std::array<double,4> v = {{0.,0.,0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("[0]");
+    
+    std::vector<double> emptyV;
+    std::array<double,1> v = {{3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("[1]");
+    
+    std::vector<double> emptyV;
+    std::array<double,2> v = {{0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("log(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.) );
+  }
+  {
+    reco::FormulaEvaluator f("TMath::Log(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("log10(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.)/std::log(10.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("exp(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::exp(2.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(2,1)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(1,2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(max(5,3),2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(2,max(5,3))");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+  }
+
+}


### PR DESCRIPTION
Created a reco::FormulaEvaluator class which can parse a subset of
the TFormula expressions. The parsing and function evaluation are
done using stateless classes so are thread safe and extremely thread
efficient. The formula parser is shared by all reco::FormulaEvaluators
to save memory and since the parser is stateless it can efficiently
be called by multiple threads simultaneously.

This is a back port from CMSSW_7_6 of #11516
