### PR TITLE
Added a formula evaluator to replace TFormula calls

### DIFF
--- a/CommonTools/Utils/interface/FormulaEvaluator.h
+++ b/CommonTools/Utils/interface/FormulaEvaluator.h
@@ -1,0 +1,81 @@
+#ifndef CommonTools_Utils_FormulaEvaluator_h
+#define CommonTools_Utils_FormulaEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     FormulaEvaluator
+// 
+/**\class FormulaEvaluator FormulaEvaluator.h "CommonTools/Utils/interface/FormulaEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 21:12:11 GMT
+//
+
+// system include files
+#include <array>
+#include <vector>
+#include <memory>
+
+// user include files
+
+// forward declarations
+namespace reco {
+  namespace formula {
+    class EvaluatorBase;
+    inline double const* startingAddress(std::vector<double> const& iV) {
+      if(iV.empty()) {
+        return nullptr;
+      }
+      return &iV[0];
+    }
+
+    template<size_t t>
+      inline double const* startingAddress(std::array<double,t> const& iV) {
+      if(iV.empty()) {
+        return nullptr;
+      }
+      return &iV[0];
+    }
+
+  }
+
+  class FormulaEvaluator
+  {
+    
+  public:
+    explicit FormulaEvaluator(std::string const& iFormula);
+
+    template<typename V, typename P>
+      double evaluate( V const& iVariables, P const& iParameters) const {
+      if (m_nVariables > iVariables.size()) {
+        throwWrongNumberOfVariables(iVariables.size());
+      }
+      if (m_nParameters > iParameters.size()) {
+        throwWrongNumberOfParameters(iParameters.size());
+      }
+      return evaluate( formula::startingAddress(iVariables),
+                       formula::startingAddress(iParameters));
+    }
+    // ---------- const member functions ---------------------
+    
+  private:
+    double evaluate(double const* iVariables, double const* iParameters) const;
+
+    void throwWrongNumberOfVariables(size_t) const ;
+    void throwWrongNumberOfParameters(size_t) const;
+
+    std::shared_ptr<formula::EvaluatorBase const> m_evaluator; 
+    unsigned int m_nVariables = 0;
+    unsigned int m_nParameters = 0;
+
+};
+}
+
+#endif

--- a/CommonTools/Utils/interface/FormulaEvaluator.h
+++ b/CommonTools/Utils/interface/FormulaEvaluator.h
@@ -28,6 +28,23 @@
 // forward declarations
 namespace reco {
   namespace formula {
+    struct ArrayAdaptor {
+    ArrayAdaptor(double const* iStart, size_t iSize):
+      m_start(iStart), m_size(iSize) {}
+      size_t size() const { return m_size; }
+      bool empty() const {return m_size == 0; }
+      double const* start() const { return m_start; }
+    private:
+      double const* m_start;
+      size_t m_size;
+    };
+    inline double const* startingAddress(ArrayAdaptor const& iV) {
+      if(iV.empty()) {
+        return nullptr;
+      }
+      return iV.start();
+    }
+
     class EvaluatorBase;
     inline double const* startingAddress(std::vector<double> const& iV) {
       if(iV.empty()) {
@@ -52,6 +69,7 @@ namespace reco {
   public:
     explicit FormulaEvaluator(std::string const& iFormula);
 
+    // ---------- const member functions ---------------------
     template<typename V, typename P>
       double evaluate( V const& iVariables, P const& iParameters) const {
       if (m_nVariables > iVariables.size()) {
@@ -63,7 +81,9 @@ namespace reco {
       return evaluate( formula::startingAddress(iVariables),
                        formula::startingAddress(iParameters));
     }
-    // ---------- const member functions ---------------------
+    
+    unsigned int numberOfParameters() const { return m_nParameters; }
+    unsigned int numberOfVariables() const { return m_nVariables; }
     
   private:
     double evaluate(double const* iVariables, double const* iParameters) const;

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -1,0 +1,590 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     FormulaEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 24 Sep 2015 19:07:58 GMT
+//
+
+// system include files
+#include <cassert>
+#include <functional>
+#include <cstdlib>
+#include <cmath>
+
+// user include files
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "formulaEvaluatorBase.h"
+#include "formulaUnaryMinusEvaluator.h"
+#include "formulaBinaryOperatorEvaluator.h"
+#include "formulaConstantEvaluator.h"
+#include "formulaVariableEvaluator.h"
+#include "formulaParameterEvaluator.h"
+#include "formulaFunctionOneArgEvaluator.h"
+#include "formulaFunctionTwoArgsEvaluator.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+using namespace reco;
+
+namespace {
+  //Formula Parser Code
+  struct EvaluatorInfo {
+    std::unique_ptr<reco::formula::EvaluatorBase> evaluator;
+    int nextParseIndex=0;
+    unsigned int maxNumVariables=0;
+    unsigned int maxNumParameters=0;
+  };
+
+  class ExpressionElementFinderBase {
+  public:
+    virtual bool checkStart(char) const = 0;
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator, std::string::const_iterator) const = 0;
+  };
+
+  std::string::const_iterator findMatchingParenthesis(std::string::const_iterator iBegin, std::string::const_iterator iEnd) {
+    if (iBegin == iEnd) {
+      return iBegin;
+    }
+    if( *iBegin != '(') {
+      return iBegin;
+    }
+    int level = 1;
+    size_t index = 0;
+    for( auto it = iBegin+1; it != iEnd; ++it) {
+      ++index;
+      if (*it == '(') {
+        ++level;
+      } else if (*it == ')') {
+        --level;
+        if (level == 0) {
+          break;
+        }
+      }
+    }
+    return iBegin + index;
+  }
+
+  class ConstantFinder : public ExpressionElementFinderBase {
+    virtual bool checkStart(char iSymbol) const override final {
+      if( iSymbol == '-' or iSymbol == '.' or std::isdigit(iSymbol) ) {
+        return true;
+      }
+      return false;
+    }
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final {
+      EvaluatorInfo info;
+      try {
+        size_t endIndex=0;
+        std::string s(iBegin,iEnd);
+        double value = stod(s, &endIndex);
+
+        info.nextParseIndex = endIndex;
+        info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ConstantEvaluator(value));
+      } catch ( std::invalid_argument ) {}
+
+      return info;
+
+    }
+  };
+
+
+  class ParameterFinder : public ExpressionElementFinderBase {
+    virtual bool checkStart(char iSymbol) const override final {
+      if( iSymbol == '[') {
+        return true;
+      }
+      return false;
+    }
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final {
+      EvaluatorInfo info;
+      if(iEnd == iBegin) {
+        return info;
+      }
+      if(*iBegin != '[') {
+        return info;
+      }
+      info.nextParseIndex = 1;
+      try {
+        size_t endIndex=0;
+        std::string s(iBegin+1,iEnd);
+        unsigned long value = stoul(s, &endIndex);
+        
+        if( iBegin+endIndex+1 == iEnd or *(iBegin+1+endIndex) != ']' ) {
+          return info;
+        }
+        
+        
+        info.nextParseIndex = endIndex+2;
+        info.maxNumParameters = value;
+        info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ParameterEvaluator(value));
+      } catch ( std::invalid_argument ) {}
+      
+      return info;
+
+    }
+  };
+  
+  class VariableFinder : public ExpressionElementFinderBase {
+    virtual bool checkStart(char iSymbol) const override final {
+      if( iSymbol == 'x' or iSymbol == 'y' or iSymbol == 'z' or iSymbol == 't' ) {
+        return true;
+      }
+      return false;
+    }
+    
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final {
+      EvaluatorInfo info;
+      if(iBegin == iEnd) {
+        return info;
+      }
+      unsigned int index = 4;
+      switch (*iBegin) {
+      case 'x':
+        { index = 0; break;}
+      case 'y':
+        { index = 1; break;}
+      case 'z':
+        { index = 2; break;}
+      case 't':
+        {index = 3; break;}
+      }
+      if(index == 4) {
+        return info;
+      }
+      info.nextParseIndex = 1;
+      info.maxNumVariables = index+1;
+      info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>(new reco::formula::VariableEvaluator(index) );
+      return info;
+    }
+  };
+
+  class ExpressionFinder;
+
+  class FunctionFinder : public ExpressionElementFinderBase {
+  public:
+    FunctionFinder(ExpressionFinder const* iEF):
+      m_expressionFinder(iEF) {};
+
+    virtual bool checkStart(char iSymbol) const override final {
+      return std::isalpha(iSymbol);
+    }
+
+    virtual EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const override final;
+
+  private:
+    ExpressionFinder const* m_expressionFinder;
+  };
+
+
+  EvaluatorInfo createBinaryOperatorEvaluator( ExpressionFinder const&,
+                                               std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
+                                               std::string::const_iterator iBegin,
+                                               std::string::const_iterator iEnd) ;
+
+  class ExpressionFinder {
+
+  public:
+    ExpressionFinder() {
+      m_elements.reserve(4);
+      m_elements.emplace_back(new FunctionFinder{this});
+      m_elements.emplace_back(new ConstantFinder{});
+      m_elements.emplace_back(new ParameterFinder{});
+      m_elements.emplace_back(new VariableFinder{});
+    }
+  
+    bool checkStart(char iChar) const {
+      if ( '(' == iChar or '-' == iChar or '+' ==iChar) {
+        return true;
+      }
+      for( auto const& e : m_elements) {
+        if (e->checkStart(iChar) ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const {
+      EvaluatorInfo leftEvaluatorInfo ;
+      if( iBegin == iEnd) {
+        return leftEvaluatorInfo;
+      }
+      //Start with '+'
+      if (*iBegin == '+' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
+        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd);
+
+        //have to account for the '+' we skipped over
+        leftEvaluatorInfo.nextParseIndex +=1;
+        if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
+          return leftEvaluatorInfo;
+        }
+        if( leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+          return leftEvaluatorInfo;
+        }
+      }
+      //Start with '-'
+      else if (*iBegin == '-' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
+        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd);
+
+        //have to account for the '+' we skipped over
+        leftEvaluatorInfo.nextParseIndex +=1;
+        if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
+          return leftEvaluatorInfo;
+        }
+        leftEvaluatorInfo.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::UnaryMinusEvaluator( std::move(leftEvaluatorInfo.evaluator)) );
+        if( leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+          return leftEvaluatorInfo;
+        }
+      }
+      //Start with '('
+      else if( *iBegin == '(') {
+        auto endParenthesis = findMatchingParenthesis(iBegin,iEnd);
+        if(iBegin== endParenthesis) {
+          return leftEvaluatorInfo;
+        }
+        leftEvaluatorInfo = createEvaluator(iBegin+1,endParenthesis);
+        ++leftEvaluatorInfo.nextParseIndex;
+        if(leftEvaluatorInfo.evaluator.get() == nullptr) {
+          return leftEvaluatorInfo;
+        }
+        //need to account for closing parenthesis
+        ++leftEvaluatorInfo.nextParseIndex;
+        leftEvaluatorInfo.evaluator->setPrecidenceToParenthesis();
+        if( iBegin+leftEvaluatorInfo.nextParseIndex == iEnd) {
+          return leftEvaluatorInfo;
+        }
+      } else {
+        //Does not start with a '('
+        int maxParseDistance = 0;
+        for( auto const& e: m_elements) {
+          if(e->checkStart(*iBegin) ) {
+            leftEvaluatorInfo = e->createEvaluator(iBegin,iEnd);
+            if(leftEvaluatorInfo.evaluator != nullptr) {
+              break;
+            }
+            if (leftEvaluatorInfo.nextParseIndex > maxParseDistance) {
+              maxParseDistance = leftEvaluatorInfo.nextParseIndex;
+            }
+          }
+        }
+        if(leftEvaluatorInfo.evaluator.get() == nullptr) {
+          //failed to parse
+          leftEvaluatorInfo.nextParseIndex = maxParseDistance;
+          return leftEvaluatorInfo;
+        }
+      }
+      //did we evaluate the full expression?
+      if(leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+        return leftEvaluatorInfo;
+      }
+
+      //see if this is a binary expression
+      auto fullExpression = createBinaryOperatorEvaluator(*this, std::move(leftEvaluatorInfo.evaluator), iBegin+leftEvaluatorInfo.nextParseIndex, iEnd);
+      fullExpression.nextParseIndex +=leftEvaluatorInfo.nextParseIndex;
+      fullExpression.maxNumVariables = std::max(leftEvaluatorInfo.maxNumVariables, fullExpression.maxNumVariables);
+      fullExpression.maxNumParameters = std::max(leftEvaluatorInfo.maxNumParameters, fullExpression.maxNumParameters);
+      if (iBegin + fullExpression.nextParseIndex != iEnd) {
+        //did not parse the full expression
+        fullExpression.evaluator.release();
+      }
+      return fullExpression;
+    }
+
+  private:
+    std::vector<std::unique_ptr<ExpressionElementFinderBase>> m_elements;
+
+  };
+
+  template<typename Op>
+  EvaluatorInfo createBinaryOperatorEvaluatorT(int iSymbolLength,
+                                               reco::formula::EvaluatorBase::Precidence iPrec,
+                                               ExpressionFinder const& iEF,
+                                               std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
+                                               std::string::const_iterator iBegin,
+                                               std::string::const_iterator iEnd) {
+    EvaluatorInfo evalInfo = iEF.createEvaluator(iBegin+iSymbolLength,iEnd);
+    evalInfo.nextParseIndex += iSymbolLength;
+
+    if(evalInfo.evaluator.get() == nullptr) {
+      return evalInfo;
+    }
+
+    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precidence() ) {
+      auto b = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>( evalInfo.evaluator.get() );
+      assert(b != nullptr);
+      std::unique_ptr<reco::formula::EvaluatorBase> temp;
+      b->swapLeftEvaluator(temp);
+      std::unique_ptr<reco::formula::EvaluatorBase> op{ new reco::formula::BinaryOperatorEvaluator<Op>(std::move(iLHS), std::move(temp), iPrec) };
+      b->swapLeftEvaluator(op);
+
+    } else {
+      std::unique_ptr<reco::formula::EvaluatorBase> op{ new reco::formula::BinaryOperatorEvaluator<Op>(std::move(iLHS), std::move(evalInfo.evaluator), iPrec) };
+        evalInfo.evaluator.swap(op);
+    }
+    return evalInfo;
+  }
+
+  struct power {
+    double operator()(double iLHS, double iRHS) const {
+      return std::pow(iLHS,iRHS);
+    }
+  };
+
+
+  EvaluatorInfo 
+  createBinaryOperatorEvaluator( ExpressionFinder const& iEF,
+                                 std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
+                                 std::string::const_iterator iBegin,
+                                 std::string::const_iterator iEnd) {
+    EvaluatorInfo evalInfo;
+    if(iBegin == iEnd) {
+      return evalInfo;
+    }
+
+    if(*iBegin == '+') {
+      return createBinaryOperatorEvaluatorT<std::plus<double>>(1,
+                                                               reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                               iEF,
+                                                               std::move(iLHS),
+                                                               iBegin,
+                                                               iEnd);
+    }
+
+    else if(*iBegin == '-') {
+      return createBinaryOperatorEvaluatorT<std::minus<double>>(1,
+                                                                reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                                iEF,
+                                                                std::move(iLHS),
+                                                                iBegin,
+                                                                iEnd);
+    }
+    else if(*iBegin == '*') {
+      return createBinaryOperatorEvaluatorT<std::multiplies<double>>(1,
+                                                                     reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                     iEF,
+                                                                     std::move(iLHS),
+                                                                     iBegin,
+                                                                     iEnd);
+    }
+    else if(*iBegin == '/') {
+      return createBinaryOperatorEvaluatorT<std::divides<double>>(1,
+                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+    }
+
+    else if(*iBegin == '^') {
+      return createBinaryOperatorEvaluatorT<power>(1,
+                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+    }
+
+    return evalInfo;
+  }
+
+
+  template<typename Op>
+  EvaluatorInfo
+  checkForSingleArgFunction(std::string::const_iterator iBegin,
+                            std::string::const_iterator iEnd,
+                            ExpressionFinder const* iExpressionFinder,
+                            const std::string& iName,
+                            Op op) {
+    EvaluatorInfo info;
+    if(iName.size()+2 > static_cast<unsigned int>(iEnd-iBegin) ) {
+      return info;
+    }
+    auto pos = iName.find(&(*iBegin), 0,iName.size());
+
+    if(std::string::npos == pos or *(iBegin+iName.size()) != '(') {
+      return info;
+    }
+    
+    info.nextParseIndex = iName.size()+1;
+
+    auto itEndParen = findMatchingParenthesis(iBegin+iName.size(),iEnd);
+    if(iBegin+iName.size() == itEndParen) {
+      return info;
+    }
+
+    auto argEvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itEndParen);
+    info.nextParseIndex += argEvaluatorInfo.nextParseIndex;
+    if(argEvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
+      return info;
+    }
+    //account for closing parenthesis
+    ++info.nextParseIndex;
+
+    info.evaluator.reset( new reco::formula::FunctionOneArgEvaluator(std::move(argEvaluatorInfo.evaluator),
+                                                                     op) );
+    return info;
+  }
+
+  std::string::const_iterator findCommaNotInParenthesis(std::string::const_iterator iBegin,
+                                                        std::string::const_iterator iEnd ) {
+    int level = 0;
+    std::string::const_iterator it = iBegin;
+    for(; it != iEnd; ++it) {
+      if (*it == '(') {
+        ++level;
+      } else if(*it == ')') {
+        --level;
+      }
+      else if( *it ==',' and level == 0 ) {
+        return it;
+      }
+    }
+
+    return it;
+  }
+
+
+  template<typename Op>
+  EvaluatorInfo
+  checkForTwoArgsFunction(std::string::const_iterator iBegin,
+                          std::string::const_iterator iEnd,
+                          ExpressionFinder const* iExpressionFinder,
+                          const std::string& iName,
+                          Op op) {
+    EvaluatorInfo info;
+    if(iName.size()+2 > static_cast<unsigned int>(iEnd-iBegin) ) {
+      return info;
+    }
+    auto pos = iName.find(&(*iBegin), 0,iName.size());
+
+    if(std::string::npos == pos or *(iBegin+iName.size()) != '(') {
+      return info;
+    }
+    
+    info.nextParseIndex = iName.size()+1;
+
+    auto itEndParen = findMatchingParenthesis(iBegin+iName.size(),iEnd);
+    if(iBegin+iName.size() == itEndParen) {
+      return info;
+    }
+
+    auto itComma = findCommaNotInParenthesis(iBegin+iName.size()+1, itEndParen);
+
+    auto arg1EvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itComma);
+    info.nextParseIndex += arg1EvaluatorInfo.nextParseIndex;
+    if(arg1EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex != itComma-iBegin ) {
+      return info;
+    }
+    //account for commas
+    ++info.nextParseIndex;
+
+    auto arg2EvaluatorInfo = iExpressionFinder->createEvaluator(itComma+1, itEndParen);
+    info.nextParseIndex += arg2EvaluatorInfo.nextParseIndex;
+
+    if(arg2EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
+      return info;
+    }
+    //account for closing parenthesis
+    ++info.nextParseIndex;
+
+    info.evaluator.reset( new reco::formula::FunctionTwoArgsEvaluator(std::move(arg1EvaluatorInfo.evaluator),
+                                                                      std::move(arg2EvaluatorInfo.evaluator),
+                                                                      op) );
+    return info;
+  }
+
+  static const std::string k_log("log");
+  static const std::string k_log10("log10");
+  static const std::string k_TMath__Log("TMath::Log");
+  double const kLog10Inv = 1./std::log(10.);
+  static const std::string k_exp("exp");
+  static const std::string k_max("max");
+
+
+  EvaluatorInfo 
+  FunctionFinder::createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const {
+    EvaluatorInfo info;
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_log, [](double iArg)->double { return std::log(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_TMath__Log, [](double iArg)->double { return std::log(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_log10, [](double iArg)->double { return std::log(iArg)*kLog10Inv; } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_exp, [](double iArg)->double { return std::exp(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_max, [](double iArg1, double iArg2)->double { return std::max(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    return info;
+  };
+
+  static ExpressionFinder const s_expressionFinder;
+  
+}
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+FormulaEvaluator::FormulaEvaluator( std::string const& iFormula )
+{
+  auto info  = s_expressionFinder.createEvaluator(iFormula.begin(), iFormula.end());
+
+  if(info.nextParseIndex != static_cast<int>(iFormula.size()) or info.evaluator.get() == nullptr) {
+    throw cms::Exception("FormulaEvaluatorParseError")<<"While parsing '"<<iFormula<<"' could not parse beyond '"<<std::string(iFormula.begin(),iFormula.begin()+info.nextParseIndex) <<"'";
+  }
+  m_evaluator = std::move(info.evaluator);
+  m_nVariables = info.maxNumVariables;
+  m_nParameters = info.maxNumParameters;
+}
+
+//
+// const member functions
+//
+double
+FormulaEvaluator::evaluate(double const* iVariables, double const* iParameters) const
+{
+  return m_evaluator->evaluate(iVariables, iParameters);
+}
+
+void 
+FormulaEvaluator::throwWrongNumberOfVariables(size_t iSize) const {
+  throw cms::Exception("WrongNumVariables")<<"FormulaEvaluator expected at least "<<m_nVariables<<" but was passed only "<<iSize;
+}
+void 
+FormulaEvaluator::throwWrongNumberOfParameters(size_t iSize) const {
+  throw cms::Exception("WrongNumParameters")<<"FormulaEvaluator expected at least "<<m_nParameters<<" but was passed only "<<iSize;
+}

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -33,7 +33,8 @@ using namespace reco;
 namespace {
   //Formula Parser Code
   struct EvaluatorInfo {
-    std::unique_ptr<reco::formula::EvaluatorBase> evaluator;
+    std::shared_ptr<reco::formula::EvaluatorBase> evaluator;
+    std::shared_ptr<reco::formula::EvaluatorBase> top;
     int nextParseIndex=0;
     unsigned int maxNumVariables=0;
     unsigned int maxNumParameters=0;
@@ -85,7 +86,8 @@ namespace {
         double value = stod(s, &endIndex);
 
         info.nextParseIndex = endIndex;
-        info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ConstantEvaluator(value));
+        info.evaluator = std::make_shared<reco::formula::ConstantEvaluator>(value);
+        info.top = info.evaluator;
       } catch ( std::invalid_argument ) {}
 
       return info;
@@ -123,7 +125,8 @@ namespace {
         
         info.nextParseIndex = endIndex+2;
         info.maxNumParameters = value+1;
-        info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ParameterEvaluator(value));
+        info.evaluator = std::make_shared<reco::formula::ParameterEvaluator>(value);
+        info.top = info.evaluator;
       } catch ( std::invalid_argument ) {}
       
       return info;
@@ -160,7 +163,8 @@ namespace {
       }
       info.nextParseIndex = 1;
       info.maxNumVariables = index+1;
-      info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>(new reco::formula::VariableEvaluator(index) );
+      info.evaluator = std::make_shared<reco::formula::VariableEvaluator>(index);
+      info.top = info.evaluator;
       return info;
     }
   };
@@ -184,7 +188,6 @@ namespace {
 
 
   EvaluatorInfo createBinaryOperatorEvaluator( ExpressionFinder const&,
-                                               std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
                                                std::string::const_iterator iBegin,
                                                std::string::const_iterator iEnd) ;
 
@@ -211,37 +214,32 @@ namespace {
       return false;
     }
 
-    EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const {
+    EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase> iPreviousBinary) const {
       EvaluatorInfo leftEvaluatorInfo ;
       if( iBegin == iEnd) {
         return leftEvaluatorInfo;
       }
       //Start with '+'
       if (*iBegin == '+' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
-        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd);
+        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd, iPreviousBinary);
 
         //have to account for the '+' we skipped over
         leftEvaluatorInfo.nextParseIndex +=1;
         if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
-          return leftEvaluatorInfo;
-        }
-        if( leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
           return leftEvaluatorInfo;
         }
       }
       //Start with '-'
       else if (*iBegin == '-' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
-        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd);
+        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd,iPreviousBinary);
 
         //have to account for the '+' we skipped over
         leftEvaluatorInfo.nextParseIndex +=1;
         if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
           return leftEvaluatorInfo;
         }
-        leftEvaluatorInfo.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::UnaryMinusEvaluator( std::move(leftEvaluatorInfo.evaluator)) );
-        if( leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
-          return leftEvaluatorInfo;
-        }
+        leftEvaluatorInfo.evaluator = std::make_shared<reco::formula::UnaryMinusEvaluator>( std::move(leftEvaluatorInfo.evaluator));
+        leftEvaluatorInfo.top = leftEvaluatorInfo.evaluator;
       }
       //Start with '('
       else if( *iBegin == '(') {
@@ -249,7 +247,7 @@ namespace {
         if(iBegin== endParenthesis) {
           return leftEvaluatorInfo;
         }
-        leftEvaluatorInfo = createEvaluator(iBegin+1,endParenthesis);
+        leftEvaluatorInfo = createEvaluator(iBegin+1,endParenthesis,std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
         ++leftEvaluatorInfo.nextParseIndex;
         if(leftEvaluatorInfo.evaluator.get() == nullptr) {
           return leftEvaluatorInfo;
@@ -257,9 +255,6 @@ namespace {
         //need to account for closing parenthesis
         ++leftEvaluatorInfo.nextParseIndex;
         leftEvaluatorInfo.evaluator->setPrecedenceToParenthesis();
-        if( iBegin+leftEvaluatorInfo.nextParseIndex == iEnd) {
-          return leftEvaluatorInfo;
-        }
       } else {
         //Does not start with a '('
         int maxParseDistance = 0;
@@ -282,18 +277,49 @@ namespace {
       }
       //did we evaluate the full expression?
       if(leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+        if (iPreviousBinary) {
+          iPreviousBinary->setRightEvaluator(leftEvaluatorInfo.top);
+          leftEvaluatorInfo.top = iPreviousBinary;
+        }
         return leftEvaluatorInfo;
       }
 
       //see if this is a binary expression
-      auto fullExpression = createBinaryOperatorEvaluator(*this, std::move(leftEvaluatorInfo.evaluator), iBegin+leftEvaluatorInfo.nextParseIndex, iEnd);
+      auto fullExpression = createBinaryOperatorEvaluator(*this, iBegin+leftEvaluatorInfo.nextParseIndex, iEnd);
       fullExpression.nextParseIndex +=leftEvaluatorInfo.nextParseIndex;
       fullExpression.maxNumVariables = std::max(leftEvaluatorInfo.maxNumVariables, fullExpression.maxNumVariables);
       fullExpression.maxNumParameters = std::max(leftEvaluatorInfo.maxNumParameters, fullExpression.maxNumParameters);
       if (iBegin + fullExpression.nextParseIndex != iEnd) {
         //did not parse the full expression
-        fullExpression.evaluator.release();
+        fullExpression.evaluator.reset();
       }
+
+      //Now to handle precedence
+      auto topNode = fullExpression.top;
+      auto binaryEval = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>(fullExpression.evaluator.get());
+      if (iPreviousBinary) {
+        if (iPreviousBinary->precedence() >= fullExpression.evaluator->precedence() ) {
+          iPreviousBinary->setRightEvaluator(leftEvaluatorInfo.evaluator);
+          binaryEval->setLeftEvaluator(iPreviousBinary);
+        } else {
+          binaryEval->setLeftEvaluator(leftEvaluatorInfo.evaluator);
+          if(iPreviousBinary->precedence()<topNode->precedence() ) {
+            topNode = iPreviousBinary;
+            iPreviousBinary->setRightEvaluator(fullExpression.top);
+          }else {
+            std::shared_ptr<reco::formula::EvaluatorBase> toSwap = iPreviousBinary;
+            auto topBinary = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>(topNode.get()); 
+            topBinary->swapLeftEvaluator(toSwap);
+            iPreviousBinary->setRightEvaluator(toSwap);
+          }
+        }
+      } else {
+        binaryEval->setLeftEvaluator(leftEvaluatorInfo.evaluator);
+        if (topNode->precedence() > binaryEval->precedence()) {
+          topNode = fullExpression.evaluator;
+        }
+      }
+      fullExpression.top = topNode;
       return fullExpression;
     }
 
@@ -306,28 +332,17 @@ namespace {
   EvaluatorInfo createBinaryOperatorEvaluatorT(int iSymbolLength,
                                                reco::formula::EvaluatorBase::Precedence iPrec,
                                                ExpressionFinder const& iEF,
-                                               std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
                                                std::string::const_iterator iBegin,
                                                std::string::const_iterator iEnd) {
-    EvaluatorInfo evalInfo = iEF.createEvaluator(iBegin+iSymbolLength,iEnd);
+    auto op = std::make_shared<reco::formula::BinaryOperatorEvaluator<Op> >(iPrec);
+    EvaluatorInfo evalInfo = iEF.createEvaluator(iBegin+iSymbolLength,iEnd,op);
     evalInfo.nextParseIndex += iSymbolLength;
 
     if(evalInfo.evaluator.get() == nullptr) {
       return evalInfo;
     }
 
-    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precedence() ) {
-      auto b = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>( evalInfo.evaluator.get() );
-      assert(b != nullptr);
-      std::unique_ptr<reco::formula::EvaluatorBase> temp;
-      b->swapLeftEvaluator(temp);
-      std::unique_ptr<reco::formula::EvaluatorBase> op{ new reco::formula::BinaryOperatorEvaluator<Op>(std::move(iLHS), std::move(temp), iPrec) };
-      b->swapLeftEvaluator(op);
-
-    } else {
-      std::unique_ptr<reco::formula::EvaluatorBase> op{ new reco::formula::BinaryOperatorEvaluator<Op>(std::move(iLHS), std::move(evalInfo.evaluator), iPrec) };
-        evalInfo.evaluator.swap(op);
-    }
+    evalInfo.evaluator = op;
     return evalInfo;
   }
 
@@ -340,7 +355,6 @@ namespace {
 
   EvaluatorInfo 
   createBinaryOperatorEvaluator( ExpressionFinder const& iEF,
-                                 std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
                                  std::string::const_iterator iBegin,
                                  std::string::const_iterator iEnd) {
     EvaluatorInfo evalInfo;
@@ -352,7 +366,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::plus<double>>(1,
                                                                reco::formula::EvaluatorBase::Precedence::kPlusMinus,
                                                                iEF,
-                                                               std::move(iLHS),
                                                                iBegin,
                                                                iEnd);
     }
@@ -361,7 +374,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::minus<double>>(1,
                                                                 reco::formula::EvaluatorBase::Precedence::kPlusMinus,
                                                                 iEF,
-                                                                std::move(iLHS),
                                                                 iBegin,
                                                                 iEnd);
     }
@@ -369,7 +381,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::multiplies<double>>(1,
                                                                      reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                      iEF,
-                                                                     std::move(iLHS),
                                                                      iBegin,
                                                                      iEnd);
     }
@@ -377,7 +388,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::divides<double>>(1,
                                                                   reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
     }
@@ -386,7 +396,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<power>(1,
                                                                   reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
     }
@@ -394,7 +403,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::less_equal<double>>(2,
                                                                   reco::formula::EvaluatorBase::Precedence::kComparison,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
 
@@ -403,7 +411,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::greater_equal<double>>(2,
                                                                   reco::formula::EvaluatorBase::Precedence::kComparison,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
 
@@ -412,7 +419,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::less<double>>(1,
                                                                   reco::formula::EvaluatorBase::Precedence::kComparison,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
 
@@ -421,7 +427,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::greater<double>>(1,
                                                                   reco::formula::EvaluatorBase::Precedence::kComparison,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
 
@@ -430,7 +435,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::equal_to<double>>(2,
                                                                   reco::formula::EvaluatorBase::Precedence::kIdentity,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
 
@@ -439,7 +443,6 @@ namespace {
       return createBinaryOperatorEvaluatorT<std::not_equal_to<double>>(2,
                                                                   reco::formula::EvaluatorBase::Precedence::kIdentity,
                                                                   iEF,
-                                                                  std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
 
@@ -472,7 +475,8 @@ namespace {
       return info;
     }
 
-    auto argEvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itEndParen);
+    auto argEvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itEndParen,
+                                                               std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
     info.nextParseIndex += argEvaluatorInfo.nextParseIndex;
     if(argEvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
       return info;
@@ -480,8 +484,9 @@ namespace {
     //account for closing parenthesis
     ++info.nextParseIndex;
 
-    info.evaluator.reset( new reco::formula::FunctionOneArgEvaluator(std::move(argEvaluatorInfo.evaluator),
-                                                                     op) );
+    info.evaluator = std::make_shared<reco::formula::FunctionOneArgEvaluator>(std::move(argEvaluatorInfo.evaluator),
+                                                                              op);
+    info.top = info.evaluator;
     return info;
   }
 
@@ -530,7 +535,7 @@ namespace {
 
     auto itComma = findCommaNotInParenthesis(iBegin+iName.size()+1, itEndParen);
 
-    auto arg1EvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itComma);
+    auto arg1EvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itComma, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
     info.nextParseIndex += arg1EvaluatorInfo.nextParseIndex;
     if(arg1EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex != itComma-iBegin ) {
       return info;
@@ -538,7 +543,7 @@ namespace {
     //account for commas
     ++info.nextParseIndex;
 
-    auto arg2EvaluatorInfo = iExpressionFinder->createEvaluator(itComma+1, itEndParen);
+    auto arg2EvaluatorInfo = iExpressionFinder->createEvaluator(itComma+1, itEndParen, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
     info.nextParseIndex += arg2EvaluatorInfo.nextParseIndex;
 
     if(arg2EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
@@ -547,9 +552,10 @@ namespace {
     //account for closing parenthesis
     ++info.nextParseIndex;
 
-    info.evaluator.reset( new reco::formula::FunctionTwoArgsEvaluator(std::move(arg1EvaluatorInfo.evaluator),
-                                                                      std::move(arg2EvaluatorInfo.evaluator),
-                                                                      op) );
+    info.evaluator = std::make_shared<reco::formula::FunctionTwoArgsEvaluator>(std::move(arg1EvaluatorInfo.evaluator),
+                                                                               std::move(arg2EvaluatorInfo.evaluator),
+                                                                               op);
+    info.top = info.evaluator;
     return info;
   }
 
@@ -558,7 +564,12 @@ namespace {
   static const std::string k_TMath__Log("TMath::Log");
   double const kLog10Inv = 1./std::log(10.);
   static const std::string k_exp("exp");
+  static const std::string k_pow("pow");
+  static const std::string k_TMath__Power("TMath::Power");
   static const std::string k_max("max");
+  static const std::string k_min("min");
+  static const std::string k_TMath__Max("TMath::Max");
+  static const std::string k_TMath__Min("TMath::Min");
 
 
   EvaluatorInfo 
@@ -590,7 +601,37 @@ namespace {
     }
 
     info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_pow, [](double iArg1, double iArg2)->double { return std::pow(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_TMath__Power, [](double iArg1, double iArg2)->double { return std::pow(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
                                    k_max, [](double iArg1, double iArg2)->double { return std::max(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_min, [](double iArg1, double iArg2)->double { return std::min(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_TMath__Max, [](double iArg1, double iArg2)->double { return std::max(iArg1,iArg2); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
+                                   k_TMath__Min, [](double iArg1, double iArg2)->double { return std::min(iArg1,iArg2); } );
     if(info.evaluator.get() != nullptr) {
       return info;
     }
@@ -614,12 +655,12 @@ namespace {
 //
 FormulaEvaluator::FormulaEvaluator( std::string const& iFormula )
 {
-  auto info  = s_expressionFinder.createEvaluator(iFormula.begin(), iFormula.end());
+  auto info  = s_expressionFinder.createEvaluator(iFormula.begin(), iFormula.end(),std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
 
-  if(info.nextParseIndex != static_cast<int>(iFormula.size()) or info.evaluator.get() == nullptr) {
+  if(info.nextParseIndex != static_cast<int>(iFormula.size()) or info.top.get() == nullptr) {
     throw cms::Exception("FormulaEvaluatorParseError")<<"While parsing '"<<iFormula<<"' could not parse beyond '"<<std::string(iFormula.begin(),iFormula.begin()+info.nextParseIndex) <<"'";
   }
-  m_evaluator = std::move(info.evaluator);
+  m_evaluator = std::move(info.top);
   m_nVariables = info.maxNumVariables;
   m_nParameters = info.maxNumParameters;
 }

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -122,7 +122,7 @@ namespace {
         
         
         info.nextParseIndex = endIndex+2;
-        info.maxNumParameters = value;
+        info.maxNumParameters = value+1;
         info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ParameterEvaluator(value));
       } catch ( std::invalid_argument ) {}
       
@@ -256,7 +256,7 @@ namespace {
         }
         //need to account for closing parenthesis
         ++leftEvaluatorInfo.nextParseIndex;
-        leftEvaluatorInfo.evaluator->setPrecidenceToParenthesis();
+        leftEvaluatorInfo.evaluator->setPrecedenceToParenthesis();
         if( iBegin+leftEvaluatorInfo.nextParseIndex == iEnd) {
           return leftEvaluatorInfo;
         }
@@ -304,7 +304,7 @@ namespace {
 
   template<typename Op>
   EvaluatorInfo createBinaryOperatorEvaluatorT(int iSymbolLength,
-                                               reco::formula::EvaluatorBase::Precidence iPrec,
+                                               reco::formula::EvaluatorBase::Precedence iPrec,
                                                ExpressionFinder const& iEF,
                                                std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
                                                std::string::const_iterator iBegin,
@@ -316,7 +316,7 @@ namespace {
       return evalInfo;
     }
 
-    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precidence() ) {
+    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precedence() ) {
       auto b = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>( evalInfo.evaluator.get() );
       assert(b != nullptr);
       std::unique_ptr<reco::formula::EvaluatorBase> temp;
@@ -350,7 +350,7 @@ namespace {
 
     if(*iBegin == '+') {
       return createBinaryOperatorEvaluatorT<std::plus<double>>(1,
-                                                               reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                               reco::formula::EvaluatorBase::Precedence::kPlusMinus,
                                                                iEF,
                                                                std::move(iLHS),
                                                                iBegin,
@@ -359,7 +359,7 @@ namespace {
 
     else if(*iBegin == '-') {
       return createBinaryOperatorEvaluatorT<std::minus<double>>(1,
-                                                                reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                                reco::formula::EvaluatorBase::Precedence::kPlusMinus,
                                                                 iEF,
                                                                 std::move(iLHS),
                                                                 iBegin,
@@ -367,7 +367,7 @@ namespace {
     }
     else if(*iBegin == '*') {
       return createBinaryOperatorEvaluatorT<std::multiplies<double>>(1,
-                                                                     reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                     reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                      iEF,
                                                                      std::move(iLHS),
                                                                      iBegin,
@@ -375,7 +375,7 @@ namespace {
     }
     else if(*iBegin == '/') {
       return createBinaryOperatorEvaluatorT<std::divides<double>>(1,
-                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                   iEF,
                                                                   std::move(iLHS),
                                                                   iBegin,
@@ -384,13 +384,66 @@ namespace {
 
     else if(*iBegin == '^') {
       return createBinaryOperatorEvaluatorT<power>(1,
-                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                   iEF,
                                                                   std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
     }
+    else if (*iBegin =='<' and iBegin+1 != iEnd and *(iBegin+1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::less_equal<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
 
+    }
+    else if (*iBegin =='>' and iBegin+1 != iEnd and *(iBegin+1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::greater_equal<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='<' ) {
+      return createBinaryOperatorEvaluatorT<std::less<double>>(1,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='>' ) {
+      return createBinaryOperatorEvaluatorT<std::greater<double>>(1,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='=' and iBegin+1 != iEnd and *(iBegin+1) == '=' ) {
+      return createBinaryOperatorEvaluatorT<std::equal_to<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kIdentity,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='!' and iBegin+1 != iEnd and *(iBegin+1) == '=' ) {
+      return createBinaryOperatorEvaluatorT<std::not_equal_to<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kIdentity,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
     return evalInfo;
   }
 

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -1,0 +1,74 @@
+#ifndef CommonTools_Utils_formulaBinaryOperatorEvaluator_h
+#define CommonTools_Utils_formulaBinaryOperatorEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaBinaryOperatorEvaluator
+// 
+/**\class reco::formula::BinaryOperatorEvaluator formulaBinaryOperatorEvaluator.h "formulaBinaryOperatorEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class BinaryOperatorEvaluatorBase : public EvaluatorBase {
+    public:
+    BinaryOperatorEvaluatorBase( Precidence iPrec) :
+      EvaluatorBase(iPrec) {}
+      virtual void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew) = 0;
+    };
+    template<typename Op>
+      class BinaryOperatorEvaluator : public BinaryOperatorEvaluatorBase
+    {
+      
+    public:
+      BinaryOperatorEvaluator(std::unique_ptr<EvaluatorBase> iLHS, 
+                              std::unique_ptr<EvaluatorBase> iRHS,
+                              Precidence iPrec):
+      BinaryOperatorEvaluatorBase(iPrec),
+        m_lhs(std::move(iLHS)),
+        m_rhs(std::move(iRHS)) {
+        }
+       
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return m_operator(m_lhs->evaluate(iVariables,iParameters),m_rhs->evaluate(iVariables,iParameters));
+      }
+
+      void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew ) override final {
+        m_lhs.swap(iNew);
+      }
+
+    private:
+      BinaryOperatorEvaluator(const BinaryOperatorEvaluator&) = delete;
+      
+      const BinaryOperatorEvaluator& operator=(const BinaryOperatorEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_lhs;
+      std::unique_ptr<EvaluatorBase> m_rhs;
+      Op m_operator;
+
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -30,9 +30,33 @@ namespace reco {
   namespace formula {
     class BinaryOperatorEvaluatorBase : public EvaluatorBase {
     public:
-    BinaryOperatorEvaluatorBase( Precedence iPrec) :
+    BinaryOperatorEvaluatorBase( std::shared_ptr<EvaluatorBase> iLHS, 
+                                 std::shared_ptr<EvaluatorBase> iRHS,
+                                 Precedence iPrec) :
+      EvaluatorBase(iPrec),
+        m_lhs(iLHS),
+        m_rhs(iRHS) {}
+
+    BinaryOperatorEvaluatorBase(Precedence iPrec) :
       EvaluatorBase(iPrec) {}
-      virtual void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew) = 0;
+
+      void swapLeftEvaluator(std::shared_ptr<EvaluatorBase>& iNew ) {
+        m_lhs.swap(iNew);
+      }
+
+      void setLeftEvaluator(std::shared_ptr<EvaluatorBase> iOther) {
+        m_lhs = std::move(iOther);
+      }
+      void setRightEvaluator(std::shared_ptr<EvaluatorBase> iOther) {
+        m_rhs = std::move(iOther);
+      }
+      
+      EvaluatorBase const* lhs() const { return m_lhs.get(); }
+      EvaluatorBase const* rhs() const { return m_rhs.get(); }
+
+    private:
+      std::shared_ptr<EvaluatorBase> m_lhs;
+      std::shared_ptr<EvaluatorBase> m_rhs;
     };
 
     template<typename Op>
@@ -40,21 +64,17 @@ namespace reco {
     {
       
     public:
-      BinaryOperatorEvaluator(std::unique_ptr<EvaluatorBase> iLHS, 
-                              std::unique_ptr<EvaluatorBase> iRHS,
+      BinaryOperatorEvaluator(std::shared_ptr<EvaluatorBase> iLHS, 
+                              std::shared_ptr<EvaluatorBase> iRHS,
                               Precedence iPrec):
-      BinaryOperatorEvaluatorBase(iPrec),
-        m_lhs(std::move(iLHS)),
-        m_rhs(std::move(iRHS)) {
-        }
-       
+      BinaryOperatorEvaluatorBase(std::move(iLHS), std::move(iRHS), iPrec) {}
+
+    BinaryOperatorEvaluator(Precedence iPrec):
+      BinaryOperatorEvaluatorBase(iPrec) {}
+
       // ---------- const member functions ---------------------
       virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
-        return m_operator(m_lhs->evaluate(iVariables,iParameters),m_rhs->evaluate(iVariables,iParameters));
-      }
-
-      void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew ) override final {
-        m_lhs.swap(iNew);
+        return m_operator(lhs()->evaluate(iVariables,iParameters),rhs()->evaluate(iVariables,iParameters));
       }
 
     private:
@@ -63,8 +83,6 @@ namespace reco {
       const BinaryOperatorEvaluator& operator=(const BinaryOperatorEvaluator&) = delete;
       
       // ---------- member data --------------------------------
-      std::unique_ptr<EvaluatorBase> m_lhs;
-      std::unique_ptr<EvaluatorBase> m_rhs;
       Op m_operator;
 
     };

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -30,10 +30,11 @@ namespace reco {
   namespace formula {
     class BinaryOperatorEvaluatorBase : public EvaluatorBase {
     public:
-    BinaryOperatorEvaluatorBase( Precidence iPrec) :
+    BinaryOperatorEvaluatorBase( Precedence iPrec) :
       EvaluatorBase(iPrec) {}
       virtual void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew) = 0;
     };
+
     template<typename Op>
       class BinaryOperatorEvaluator : public BinaryOperatorEvaluatorBase
     {
@@ -41,7 +42,7 @@ namespace reco {
     public:
       BinaryOperatorEvaluator(std::unique_ptr<EvaluatorBase> iLHS, 
                               std::unique_ptr<EvaluatorBase> iRHS,
-                              Precidence iPrec):
+                              Precedence iPrec):
       BinaryOperatorEvaluatorBase(iPrec),
         m_lhs(std::move(iLHS)),
         m_rhs(std::move(iRHS)) {

--- a/CommonTools/Utils/src/formulaConstantEvaluator.cc
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ConstantEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaConstantEvaluator.h"
+
+
+namespace reco {
+  namespace formula {
+    double ConstantEvaluator::evaluate(double const* /*iVariables*/, double const* /*iParameters*/) const {
+      return m_value;
+    }
+  }
+}

--- a/CommonTools/Utils/src/formulaConstantEvaluator.h
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.h
@@ -1,0 +1,52 @@
+#ifndef CommonTools_Utils_formulaConstantEvaluator_h
+#define CommonTools_Utils_formulaConstantEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ConstantEvaluator
+// 
+/**\class reco::formula::ConstantEvaluator formulaConstantEvaluator.h "formulaConstantEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:27 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class ConstantEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit ConstantEvaluator(double iValue) : m_value(iValue) {}
+      
+
+      // ---------- const member functions ---------------------
+      double evaluate(double const* iVariables, double const* iParameters) const override final;
+      
+    private:
+      ConstantEvaluator(const ConstantEvaluator&) = delete;
+      
+      const ConstantEvaluator& operator=(const ConstantEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      double m_value;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaEvaluatorBase.cc
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.cc
@@ -1,0 +1,43 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::EvaluatorBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 16:26:03 GMT
+//
+
+// system include files
+
+// user include files
+#include "CommonTools/Utils/src/formulaEvaluatorBase.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+reco::formula::EvaluatorBase::EvaluatorBase():
+  m_precidence(static_cast<unsigned int>(Precidence::kFunction))
+{
+}
+
+reco::formula::EvaluatorBase::EvaluatorBase(Precidence iPrec):
+  m_precidence(static_cast<unsigned int>(iPrec))
+{
+}
+
+reco::formula::EvaluatorBase::~EvaluatorBase()
+{
+}
+

--- a/CommonTools/Utils/src/formulaEvaluatorBase.cc
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.cc
@@ -28,12 +28,12 @@
 // constructors and destructor
 //
 reco::formula::EvaluatorBase::EvaluatorBase():
-  m_precidence(static_cast<unsigned int>(Precidence::kFunction))
+  m_precedence(static_cast<unsigned int>(Precedence::kFunction))
 {
 }
 
-reco::formula::EvaluatorBase::EvaluatorBase(Precidence iPrec):
-  m_precidence(static_cast<unsigned int>(iPrec))
+reco::formula::EvaluatorBase::EvaluatorBase(Precedence iPrec):
+  m_precedence(static_cast<unsigned int>(iPrec))
 {
 }
 

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -1,0 +1,68 @@
+#ifndef CommonTools_Utils_formulaEvaluatorBase_h
+#define CommonTools_Utils_formulaEvaluatorBase_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::EvaluatorBase
+// 
+/**\class reco::formula::EvaluatorBase formulaEvaluatorBase.h "formulaEvaluatorBase.h"
+
+ Description: Base class for formula evaluators
+
+ Usage:
+    Used as an internal detail on the reco::FormulaEvalutor class. 
+    Base class for all objects used in the abstract evaluation tree where one node
+    corresponds to one syntax element of the formula.
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 16:26:00 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class EvaluatorBase
+    {
+      
+    public:
+      enum class Precidence { 
+        kPlusMinus = 1,
+          kMultDiv = 2,
+          kPower = 3,
+          kFunction = 4, //default
+          kParenthesis = 5,
+          kUnaryMinusOperator = 6
+          };
+
+      EvaluatorBase();
+      EvaluatorBase(Precidence);
+      virtual ~EvaluatorBase();
+      
+      // ---------- const member functions ---------------------
+      //inputs are considered to be 'arrays' which have already been validated to 
+      // be of the appropriate length
+      virtual double evaluate(double const* iVariables, double const* iParameters) const = 0;
+
+      unsigned int precidence() const { return m_precidence; }
+      void setPrecidenceToParenthesis() { m_precidence = static_cast<unsigned int>(Precidence::kParenthesis); }
+
+    private:
+      EvaluatorBase(const EvaluatorBase&) = delete; 
+      
+      const EvaluatorBase& operator=(const EvaluatorBase&) = delete;
+      
+      // ---------- member data --------------------------------
+      unsigned int m_precidence;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -32,17 +32,19 @@ namespace reco {
     {
       
     public:
-      enum class Precidence { 
-        kPlusMinus = 1,
-          kMultDiv = 2,
-          kPower = 3,
-          kFunction = 4, //default
-          kParenthesis = 5,
-          kUnaryMinusOperator = 6
+      enum class Precedence {
+          kIdentity = 1,
+          kComparison=2,
+          kPlusMinus = 3,
+          kMultDiv = 4,
+          kPower = 5,
+          kFunction = 6, //default
+          kParenthesis = 7,
+          kUnaryMinusOperator = 8
           };
 
       EvaluatorBase();
-      EvaluatorBase(Precidence);
+      EvaluatorBase(Precedence);
       virtual ~EvaluatorBase();
       
       // ---------- const member functions ---------------------
@@ -50,8 +52,8 @@ namespace reco {
       // be of the appropriate length
       virtual double evaluate(double const* iVariables, double const* iParameters) const = 0;
 
-      unsigned int precidence() const { return m_precidence; }
-      void setPrecidenceToParenthesis() { m_precidence = static_cast<unsigned int>(Precidence::kParenthesis); }
+      unsigned int precedence() const { return m_precedence; }
+      void setPrecedenceToParenthesis() { m_precedence = static_cast<unsigned int>(Precedence::kParenthesis); }
 
     private:
       EvaluatorBase(const EvaluatorBase&) = delete; 
@@ -59,7 +61,7 @@ namespace reco {
       const EvaluatorBase& operator=(const EvaluatorBase&) = delete;
       
       // ---------- member data --------------------------------
-      unsigned int m_precidence;
+      unsigned int m_precedence;
     };
   }
 }

--- a/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
@@ -1,0 +1,59 @@
+#ifndef CommonTools_Utils_formulaFunctionOneArgEvaluator_h
+#define CommonTools_Utils_formulaFunctionOneArgEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaFunctionOneArgEvaluator
+// 
+/**\class reco::formula::FunctionOneArgEvaluator formulaFunctionOneArgEvaluator.h "formulaFunctionOneArgEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+#include <functional>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class FunctionOneArgEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      template<typename T>
+      explicit FunctionOneArgEvaluator(std::unique_ptr<EvaluatorBase> iArg, T iFunc):
+        m_arg(std::move(iArg)),
+        m_function(iFunc) {}
+       
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return m_function( m_arg->evaluate(iVariables,iParameters) );
+      }
+
+    private:
+      FunctionOneArgEvaluator(const FunctionOneArgEvaluator&) = delete;
+      
+      const FunctionOneArgEvaluator& operator=(const FunctionOneArgEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_arg;
+      std::function<double(double)> m_function;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
@@ -34,7 +34,7 @@ namespace reco {
       
     public:
       template<typename T>
-      explicit FunctionOneArgEvaluator(std::unique_ptr<EvaluatorBase> iArg, T iFunc):
+      explicit FunctionOneArgEvaluator(std::shared_ptr<EvaluatorBase> iArg, T iFunc):
         m_arg(std::move(iArg)),
         m_function(iFunc) {}
        
@@ -49,7 +49,7 @@ namespace reco {
       const FunctionOneArgEvaluator& operator=(const FunctionOneArgEvaluator&) = delete;
       
       // ---------- member data --------------------------------
-      std::unique_ptr<EvaluatorBase> m_arg;
+      std::shared_ptr<EvaluatorBase> m_arg;
       std::function<double(double)> m_function;
     };
   }

--- a/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
@@ -1,0 +1,65 @@
+#ifndef CommonTools_Utils_formulaFunctionTwoArgsEvaluator_h
+#define CommonTools_Utils_formulaFunctionTwoArgsEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaFunctionTwoArgsEvaluator
+// 
+/**\class reco::formula::FunctionTwoArgsEvaluator formulaFunctionTwoArgsEvaluator.h "formulaFunctionTwoArgsEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+#include <functional>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class FunctionTwoArgsEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      template<typename T>
+    FunctionTwoArgsEvaluator(std::unique_ptr<EvaluatorBase> iArg1,
+                             std::unique_ptr<EvaluatorBase> iArg2,
+                             T iFunc):
+      m_arg1(std::move(iArg1)),
+        m_arg2(std::move(iArg2)),
+        m_function(iFunc)
+        {}
+
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return m_function( m_arg1->evaluate(iVariables,iParameters),
+                           m_arg2->evaluate(iVariables,iParameters) );
+      }
+
+    private:
+      FunctionTwoArgsEvaluator(const FunctionTwoArgsEvaluator&) = delete;
+      
+      const FunctionTwoArgsEvaluator& operator=(const FunctionTwoArgsEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_arg1;
+      std::unique_ptr<EvaluatorBase> m_arg2;
+      std::function<double(double,double)> m_function;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
@@ -34,8 +34,8 @@ namespace reco {
       
     public:
       template<typename T>
-    FunctionTwoArgsEvaluator(std::unique_ptr<EvaluatorBase> iArg1,
-                             std::unique_ptr<EvaluatorBase> iArg2,
+    FunctionTwoArgsEvaluator(std::shared_ptr<EvaluatorBase> iArg1,
+                             std::shared_ptr<EvaluatorBase> iArg2,
                              T iFunc):
       m_arg1(std::move(iArg1)),
         m_arg2(std::move(iArg2)),
@@ -54,8 +54,8 @@ namespace reco {
       const FunctionTwoArgsEvaluator& operator=(const FunctionTwoArgsEvaluator&) = delete;
       
       // ---------- member data --------------------------------
-      std::unique_ptr<EvaluatorBase> m_arg1;
-      std::unique_ptr<EvaluatorBase> m_arg2;
+      std::shared_ptr<EvaluatorBase> m_arg1;
+      std::shared_ptr<EvaluatorBase> m_arg2;
       std::function<double(double,double)> m_function;
     };
   }

--- a/CommonTools/Utils/src/formulaParameterEvaluator.cc
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ParameterEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaParameterEvaluator.h"
+
+
+namespace reco {
+  namespace formula {
+    double ParameterEvaluator::evaluate(double const* /*iVariables*/, double const* iParameters) const {
+      return iParameters[m_index];
+    }
+  }
+}

--- a/CommonTools/Utils/src/formulaParameterEvaluator.h
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.h
@@ -1,0 +1,52 @@
+#ifndef CommonTools_Utils_formulaParameterEvaluator_h
+#define CommonTools_Utils_formulaParameterEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::ParameterEvaluator
+// 
+/**\class reco::formula::ParameterEvaluator formulaParameterEvaluator.h "formulaParameterEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:27 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class ParameterEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit ParameterEvaluator(unsigned int iIndex) : m_index(iIndex) {}
+      
+
+      // ---------- const member functions ---------------------
+      double evaluate(double const* iVariables, double const* iParameters) const override final;
+      
+    private:
+      ParameterEvaluator(const ParameterEvaluator&) = delete;
+      
+      const ParameterEvaluator& operator=(const ParameterEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      unsigned int m_index;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -1,0 +1,57 @@
+#ifndef CommonTools_Utils_formulaUnaryMinusEvaluator_h
+#define CommonTools_Utils_formulaUnaryMinusEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     formulaUnaryMinusEvaluator
+// 
+/**\class reco::formula::UnaryMinusEvaluator formulaUnaryMinusEvaluator.h "formulaUnaryMinusEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 17:41:33 GMT
+//
+
+// system include files
+#include <memory>
+#include <functional>
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class UnaryMinusEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit UnaryMinusEvaluator(std::unique_ptr<EvaluatorBase> iArg):
+      EvaluatorBase(Precidence::kUnaryMinusOperator ),
+      m_arg(std::move(iArg)) {}
+       
+      // ---------- const member functions ---------------------
+      virtual double evaluate(double const* iVariables, double const* iParameters) const override final {
+        return -1. * m_arg->evaluate(iVariables,iParameters) ;
+      }
+
+    private:
+      UnaryMinusEvaluator(const UnaryMinusEvaluator&) = delete;
+      
+      const UnaryMinusEvaluator& operator=(const UnaryMinusEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      std::unique_ptr<EvaluatorBase> m_arg;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -34,7 +34,7 @@ namespace reco {
       
     public:
       explicit UnaryMinusEvaluator(std::unique_ptr<EvaluatorBase> iArg):
-      EvaluatorBase(Precidence::kUnaryMinusOperator ),
+      EvaluatorBase(Precedence::kUnaryMinusOperator ),
       m_arg(std::move(iArg)) {}
        
       // ---------- const member functions ---------------------

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -33,7 +33,7 @@ namespace reco {
     {
       
     public:
-      explicit UnaryMinusEvaluator(std::unique_ptr<EvaluatorBase> iArg):
+      explicit UnaryMinusEvaluator(std::shared_ptr<EvaluatorBase> iArg):
       EvaluatorBase(Precedence::kUnaryMinusOperator ),
       m_arg(std::move(iArg)) {}
        
@@ -48,7 +48,7 @@ namespace reco {
       const UnaryMinusEvaluator& operator=(const UnaryMinusEvaluator&) = delete;
       
       // ---------- member data --------------------------------
-      std::unique_ptr<EvaluatorBase> m_arg;
+      std::shared_ptr<EvaluatorBase> m_arg;
     };
   }
 }

--- a/CommonTools/Utils/src/formulaVariableEvaluator.cc
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::VariableEvaluator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaVariableEvaluator.h"
+
+
+namespace reco {
+  namespace formula {
+    double VariableEvaluator::evaluate(double const* iVariables, double const* /*iParameters*/) const {
+      return iVariables[m_index];
+    }
+  }
+}

--- a/CommonTools/Utils/src/formulaVariableEvaluator.h
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.h
@@ -1,0 +1,52 @@
+#ifndef CommonTools_Utils_formulaVariableEvaluator_h
+#define CommonTools_Utils_formulaVariableEvaluator_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/Utils
+// Class  :     reco::formula::VariableEvaluator
+// 
+/**\class reco::formula::VariableEvaluator formulaVariableEvaluator.h "formulaVariableEvaluator.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Sep 2015 18:06:27 GMT
+//
+
+// system include files
+
+// user include files
+#include "formulaEvaluatorBase.h"
+
+// forward declarations
+
+namespace reco {
+  namespace formula {
+    class VariableEvaluator : public EvaluatorBase
+    {
+      
+    public:
+      explicit VariableEvaluator(unsigned int iIndex) : m_index(iIndex) {}
+      
+
+      // ---------- const member functions ---------------------
+      double evaluate(double const* iVariables, double const* iParameters) const override final;
+      
+    private:
+      VariableEvaluator(const VariableEvaluator&) = delete;
+      
+      const VariableEvaluator& operator=(const VariableEvaluator&) = delete;
+      
+      // ---------- member data --------------------------------
+      unsigned int m_index;
+    };
+  }
+}
+
+
+#endif

--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<bin   name="testCommonToolsUtil" file="testSelectors.cc,testSelectIterator.cc,testComparators.cc,testCutParser.cc,testExpressionParser.cc,testAssociationMapFilterValues.cc,testRunner.cpp">
+<bin   name="testCommonToolsUtil" file="testSelectors.cc,testSelectIterator.cc,testComparators.cc,testCutParser.cc,testExpressionParser.cc,testAssociationMapFilterValues.cc,testFormulaEvaluator.cc,testRunner.cpp">
   <use   name="Geometry/CommonDetUnit"/>
   <use   name="DataFormats/TrackReco"/>
   <use   name="DataFormats/TrackerRecHit2D"/>

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -1,0 +1,291 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include "CommonTools/Utils/src/formulaConstantEvaluator.h"
+#include "CommonTools/Utils/src/formulaParameterEvaluator.h"
+#include "CommonTools/Utils/src/formulaVariableEvaluator.h"
+#include "CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h"
+#include "CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h"
+#include "CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h"
+#include "CommonTools/Utils/src/formulaUnaryMinusEvaluator.h"
+
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+
+#include <algorithm>
+
+class testFormulaEvaluator : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testFormulaEvaluator);
+  CPPUNIT_TEST(checkEvaluators);
+  CPPUNIT_TEST(checkFormulaEvaluator);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+  void checkEvaluators(); 
+  void checkFormulaEvaluator();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testFormulaEvaluator);
+
+void testFormulaEvaluator::checkEvaluators() {
+  using namespace reco::formula;
+  {
+    ConstantEvaluator c{4};
+
+    CPPUNIT_ASSERT( c.evaluate(nullptr,nullptr) == 4. );
+  }
+
+  {
+    ParameterEvaluator pe{0};
+
+    double p = 5.;
+
+    CPPUNIT_ASSERT( pe.evaluate(nullptr, &p) == p);
+  }
+
+  {
+    VariableEvaluator ve{0};
+
+    double v = 3.;
+
+    CPPUNIT_ASSERT( ve.evaluate(&v, nullptr) == v);
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+    auto cr = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(3) );
+
+    BinaryOperatorEvaluator<std::minus<double>> be( std::move(cl), std::move(cr), EvaluatorBase::Precidence::kPlusMinus);
+
+    CPPUNIT_ASSERT( be.evaluate(nullptr,nullptr) == 1. );
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+
+    FunctionOneArgEvaluator f( std::move(cl), [](double v) { return std::exp(v); } );
+
+    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == std::exp(4.) );
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+    auto cr = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(3) );
+
+    FunctionTwoArgsEvaluator f( std::move(cl), std::move(cr),
+                                [](double v1, double v2) { return std::max(v1,v2); });
+
+    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == 4. );
+  }
+
+  {
+    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+
+    UnaryMinusEvaluator f( std::move(cl) );
+
+    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == -4. );
+  }
+
+}
+
+void 
+testFormulaEvaluator::checkFormulaEvaluator() {
+  {
+    reco::FormulaEvaluator f("5");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3+2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3-2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3*2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 6. );
+  }
+
+  {
+    reco::FormulaEvaluator f("6/2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("3^2");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 9. );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("1+2*3");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 7. );
+  }
+
+  {
+    reco::FormulaEvaluator f("(1+2)*3");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 9. );
+  }
+
+  {
+    reco::FormulaEvaluator f("2*3+1");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 7. );
+  }
+
+  {
+    reco::FormulaEvaluator f("2*(3+1)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 8. );
+  }
+
+  {
+    reco::FormulaEvaluator f("x");
+    
+    std::vector<double> emptyV;
+    std::array<double,1> v ={{3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("y");
+    
+    std::vector<double> emptyV;
+    std::array<double,2> v = {{0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("z");
+    
+    std::vector<double> emptyV;
+    std::array<double,3> v = {{0.,0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("t");
+    
+    std::vector<double> emptyV;
+    std::array<double,4> v = {{0.,0.,0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("[0]");
+    
+    std::vector<double> emptyV;
+    std::array<double,1> v = {{3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("[1]");
+    
+    std::vector<double> emptyV;
+    std::array<double,2> v = {{0.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 3. );
+  }
+
+  {
+    reco::FormulaEvaluator f("log(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.) );
+  }
+  {
+    reco::FormulaEvaluator f("TMath::Log(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("log10(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.)/std::log(10.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("exp(2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::exp(2.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(2,1)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(1,2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(max(5,3),2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(2,max(5,3))");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+  }
+
+}

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -296,6 +296,78 @@ testFormulaEvaluator::checkFormulaEvaluator() {
   }
 
   {
+    reco::FormulaEvaluator f("4/2*3");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 6. );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("1-2+3");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2. );
+  }
+
+  {
+    reco::FormulaEvaluator f("(1+2)-(3+4)");
+    std::vector<double> emptyV;
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == -4. );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("3/2*4+1");
+
+    std::vector<double> emptyV;
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 3./2.*4.+1 );
+  }
+
+  {
+    reco::FormulaEvaluator f("1+3/2*4");
+    std::vector<double> emptyV;
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+3./2.*4. );
+  }
+
+  {
+    reco::FormulaEvaluator f("1+4*(3/2+5)");
+    std::vector<double> emptyV;
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+4*(3./2.+5.) );
+  }
+
+  {
+    reco::FormulaEvaluator f("1+2*3/4*5");
+    std::vector<double> emptyV;
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+2.*3./4.*5 );
+  }
+      
+  {
+    reco::FormulaEvaluator f("1+2*3/(4+5)+6");
+    std::vector<double> emptyV;
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+2.*3./(4+5)+6 );
+  }
+
+
+  {
+    reco::FormulaEvaluator f("100./3.*2+1");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 100./3.*2.+1 );
+  }
+
+  {
+    reco::FormulaEvaluator f("100./3.*(4-2)+2*(3+1)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 100./3.*(4-2)+2*(3+1) );
+  }
+
+  {
     reco::FormulaEvaluator f("x");
     
     std::vector<double> emptyV;
@@ -351,6 +423,15 @@ testFormulaEvaluator::checkFormulaEvaluator() {
   }
 
   {
+    reco::FormulaEvaluator f("[0]+[1]*3");
+    
+    std::vector<double> emptyV;
+    std::array<double,2> v = {{1.,3.}};
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 10. );
+  }
+
+  {
     reco::FormulaEvaluator f("log(2)");
     
     std::vector<double> emptyV;
@@ -382,6 +463,22 @@ testFormulaEvaluator::checkFormulaEvaluator() {
   }
 
   {
+    reco::FormulaEvaluator f("pow(2,0.3)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::pow(2.,0.3) );
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Power(2,0.3)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::pow(2.,0.3) );
+  }
+
+  {
     reco::FormulaEvaluator f("max(2,1)");
     
     std::vector<double> emptyV;
@@ -391,6 +488,22 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
   {
     reco::FormulaEvaluator f("max(1,2)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Max(2,1)");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Max(1,2)");
     
     std::vector<double> emptyV;
 
@@ -411,6 +524,13 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     std::vector<double> emptyV;
 
     CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+  }
+
+  {
+    reco::FormulaEvaluator f("-(-2.36997+0.413917*TMath::Log(208))/208");
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == -(-2.36997+0.413917*std::log(208.))/208.);
   }
 
   {
@@ -484,7 +604,54 @@ testFormulaEvaluator::checkFormulaEvaluator() {
       CPPUNIT_ASSERT(compare(f.evaluate(v, p),func(v[0],v[1],v[2])) );
     }
   }
+  {
+    reco::FormulaEvaluator f("(-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208");
 
+    std::vector<double> x ={1.};
+
+    std::vector<double> v;
+
+    auto func = [](double x) {return (-2.36997+0.413917*std::log(x))/x-(-2.36997+0.413917*std::log(208))/208;};
+
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+    }
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227))");
+    std::vector<double> x ={1.};
+
+    std::vector<double> v;
+
+
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+
+
+    auto func = [](double x) { return std::max(0.,1.03091-0.051154*std::pow(x,-0.154227))-std::max(0.,1.03091-0.051154*std::pow(208.,-0.154227)); };
+
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+    }
+  }
+
+  {
+    reco::FormulaEvaluator f("[2]*([3]+[4]*TMath::Log(max([0],min([1],x))))");
+
+    std::vector<double> x = {1.};
+
+    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+
+    auto func =[&v](double x) { return v[2]*(v[3]+v[4]*std::log(std::max(v[0],std::min(v[1],x)))); };
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+    }
+  }
   {
     //From SimpleJetCorrector
     reco::FormulaEvaluator f("((x>=[6])*(([0]+([1]/((log10(x)^2)+[2])))+([3]*exp(-([4]*((log10(x)-[5])*(log10(x)-[5])))))))+((x<[6])*[7])");
@@ -498,6 +665,62 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
     auto func = [&v](double x) { return ((x>=v[6])*((v[0]+(v[1]/(( (std::log(x)/std::log(10))*(std::log(x)/std::log(10)) ) +v[2])))+(v[3]*std::exp(-1.*(v[4]*((std::log(x)/std::log(10.)-v[5])*(std::log(x)/std::log(10.)-v[5])))))))+((x<v[6])*v[7]); };
 
+
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+    }
+  }
+
+
+  {
+    reco::FormulaEvaluator f("(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+[7]*((-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208)");
+
+    std::vector<double> x = {1.};
+
+    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+
+
+    auto func =[&v](double x) { return (std::max(0.,1.03091-0.051154*std::pow(x,-0.154227))-std::max(0.,1.03091-0.051154*std::pow(208.,-0.154227)))+v[7]*((-2.36997+0.413917*std::log(x))/x-(-2.36997+0.413917*std::log(208))/208); };
+
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+    }
+  }
+
+  {
+    //From SimpleJetCorrector
+    reco::FormulaEvaluator f("100./3.*0.154227+2.36997");
+
+    std::vector<double> x = {1.};
+
+    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+
+
+    auto func =[&v](double x) {return 100./3.*0.154227+2.36997;
+    };
+
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+    }
+  }
+
+  {
+    //From SimpleJetCorrector
+    reco::FormulaEvaluator f("[2]*([3]+[4]*TMath::Log(max([0],min([1],x))))*1./([5]+[6]*100./3.*(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+[7]*((-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208))");
+
+    std::vector<double> x = {1.};
+
+    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+
+
+    auto func =[&v](double x) {return v[2]*(v[3]+v[4]*std::log(std::max(v[0],std::min(v[1],x))))*1./(v[5]+v[6]*100./3.*(std::max(0.,1.03091-0.051154*std::pow(x,-0.154227))-std::max(0.,1.03091-0.051154*std::pow(208.,-0.154227)))+v[7]*((-2.36997+0.413917*std::log(x))/x-(-2.36997+0.413917*std::log(208))/208));
+    };
 
     for(auto const xv: xValues) {
       x[0] = xv;


### PR DESCRIPTION
Created a reco::FormulaEvaluator class which can parse a subset of
the TFormula expressions. The parsing and function evaluation are
done using stateless classes so are thread safe and extremely thread
efficient. The formula parser is shared by all reco::FormulaEvaluators
to save memory and since the parser is stateless it can efficiently
be called by multiple threads simultaneously.

This is a back port from CMSSW_7_6 of #11516
