### PR TITLE
New GT for re-reco fixing issues with HCAL and ECAL tags.

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -18,9 +18,9 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '74X_dataRun1_v2',
+    'run1_data'         :   '74X_dataRun1_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '74X_dataRun2_v2',
+    'run2_data'         :   '74X_dataRun2_v3',
     # GlobalTag for Run1 HLT
     'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v2',
     # GlobalTag for Run2 HLT


### PR DESCRIPTION
# Summary of changes
## Run1 data

[74X_dataRun1_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v3): as [74X_dataRun1_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_v3/74X_dataRun1_v2):
- taxonomy change for Muon APE
- added BTV discriminators as GBRForest payloads with new labels
- updated SiStrip O2O conditions: now using prompt version. BEWARE: Noise tag must be reviewed: keeping the old offline version
- updated ECAL pulse shapes with Run2 values (Run1 value kepts as MC in the first IOV)
- updated HCAL electronic maps in order to unpack all HF FED
- updated HCAL response corrections with the latest scale computed in the Early Commissioning studies.
## Run2 data

[74X_dataRun2_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v3): as [74X_dataRun2_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_v3/74X_dataRun2_v2):
- taxonomy change for Muon APE
- added BTV discriminators as GBRForest payloads with new labels
- updated SiStrip O2O conditions: now using prompt version. BEWARE: Noise tag must be reviewed: keeping the old offline version
- updated ECAL pulse shapes with Run2 values (Run1 value kepts as MC in the first IOV)
- updated HCAL electronic maps in order to unpack all HF FED
- updated HCAL response corrections with the latest scale computed in the Early Commissioning studies.
