### PR TITLE
Switch on hadronFlavourHasPriority for b-tag Validation module.

### DIFF
--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -12,7 +12,10 @@ bTagPlotsDATA = cms.Sequence(bTagAnalysis)
 #Matching
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
 from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
-myak4JetFlavourInfos = ak4JetFlavourInfos.clone(jets = cms.InputTag("ak4PFJetsCHS"))
+myak4JetFlavourInfos = ak4JetFlavourInfos.clone(
+    jets = cms.InputTag("ak4PFJetsCHS"),
+    hadronFlavourHasPriority = cms.bool(True)
+    )
 
 #Get gen jet collection for real jets
 ak4GenJetsForPUid = cms.EDFilter("GenJetSelector",


### PR DESCRIPTION
Following the changes observed by the validation of 760pre5 and their understanding:
https://hypernews.cern.ch/HyperNews/CMS/get/relval/4093/44/1.html
the issue comes from the fact that hadronFlavourHasPriority was set to by default to False but the b-ta DQM stay unchanged implying an undesired changed from hadron based flavour to parton based flavour for b and c-jets.

In summary, this PR allow to get back to the definition of 760pre4.
In a close future we have to make sure to synchronize better the light flavour definition with the one which will be used to extract the b-tag SFs, by the analyses and according to the miniAOD definition (based on prunedGenParticles): it means probably merging udsg+non-identified jets in one single category.

If this PR is ok for everyone, we have to backport it to 75x and 74x.

Adding @swertz @pablodecm as they may want to follow the discussion if any.
