### PR TITLE
Convert NjettinessAdder to edm::stream

### DIFF
--- a/RecoJets/JetProducers/interface/NjettinessAdder.h
+++ b/RecoJets/JetProducers/interface/NjettinessAdder.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -12,7 +12,7 @@
 #include "fastjet/contrib/Njettiness.hh"
 
 
-class NjettinessAdder : public edm::one::EDProducer<> { 
+class NjettinessAdder : public edm::stream::EDProducer<> { 
  public:
 
     enum MeasureDefinition_t {


### PR DESCRIPTION
Move NjettinessAdder to edm::stream since the underlying external is fixed by https://github.com/cms-sw/cmsdist/pull/1745.

Purely technical.
