### PR TITLE
Add pcc info to WBM text file and update PCC x-section for 75X

### DIFF
--- a/DQM/PixelLumi/plugins/PixelLumiDQM.cc
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.cc
@@ -666,6 +666,12 @@ PixelLumiDQM::endLuminosityBlock(edm::LuminosityBlock const& lumiBlock,
   strftime(datestring, sizeof(datestring),"%Y.%m.%d %T GMT %s",ts);
   logFile_ << "RunNumber "<< fRunNo << std::endl;
   logFile_ << "EndTimeOfFit " << datestring << std::endl;
+  logFile_ << "LumiRange "<< ls << "-" << ls << std::endl;
+  logFile_ << "Fill "<< -99 << std::endl;
+  logFile_ << "ActiveBunchCrossings "<< filledAndUnmaskedBunches << std::endl;
+  logFile_ << "PixelLumi "<< fHistTotalRecordedLumiByLS->getBinContent(ls) * 0.98 << std::endl;
+  logFile_ << "HFLumi "<< -99 << std::endl;
+  logFile_ << "Ratio " << -99 << std::endl;
   logFile_.close();
 }
 

--- a/DQM/PixelLumi/plugins/PixelLumiDQM.h
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.h
@@ -47,8 +47,8 @@ public:
   static constexpr double XSEC_PIXEL_CLUSTER_UNC = 0.17e-24;
 
   // Excluding the inner barrel layer.
-  static constexpr double rXSEC_PIXEL_CLUSTER = 6.08e-24; //in cm^2
-  static constexpr double rXSEC_PIXEL_CLUSTER_UNC = 0.084e-24;
+  static constexpr double rXSEC_PIXEL_CLUSTER = 9.4e-24; //in cm^2
+  static constexpr double rXSEC_PIXEL_CLUSTER_UNC = 0.119e-24;
   static constexpr double CM2_TO_NANOBARN = 1.0/1.e-33;
   static const unsigned int lastBunchCrossing = 3564;
 


### PR DESCRIPTION
The pcc lumi info propagates to the wbm from the text file pixel_lumi.txt. I add the pcc lumi to the text file. The pcc cross section has also been updated to match the value measured in the Aug. 15' vdM scan. 

https://github.com/cms-sw/cmssw/pull/11580
