### PR TITLE
Update Run 2 eras to configure FastSim properly

### DIFF
--- a/FastSimulation/Configuration/python/L1Reco_cff.py
+++ b/FastSimulation/Configuration/python/L1Reco_cff.py
@@ -9,23 +9,33 @@ from Configuration.StandardSequences.Eras import eras
 modifyFastSimulationConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
 
 # some collections have different labels
-l1extraParticles.isolatedEmSource    = cms.InputTag("simGctDigis","isoEm")
-l1extraParticles.nonIsolatedEmSource = cms.InputTag("simGctDigis","nonIsoEm")
+def _changeLabelForFastSim( object ) :
+    """
+    Takes an InputTag, changes the first letter of the module label to a capital
+    and adds "sim" in front, e.g. "gctDigid" -> "simGctDigis".
+    This works for both Run 1 and Run 2 collections.
+    """
+    object.moduleLabel="sim"+object.moduleLabel[0].upper()+object.moduleLabel[1:]
 
-l1extraParticles.centralJetSource = cms.InputTag("simGctDigis","cenJets")
-l1extraParticles.tauJetSource     = cms.InputTag("simGctDigis","tauJets")
-l1extraParticles.isoTauJetSource  = cms.InputTag("simGctDigis","isoTauJets")
-l1extraParticles.forwardJetSource = cms.InputTag("simGctDigis","forJets")
+_changeLabelForFastSim( l1extraParticles.isolatedEmSource )
+_changeLabelForFastSim( l1extraParticles.nonIsolatedEmSource )
 
+_changeLabelForFastSim( l1extraParticles.centralJetSource )
+_changeLabelForFastSim( l1extraParticles.tauJetSource )
+_changeLabelForFastSim( l1extraParticles.isoTauJetSource )
+_changeLabelForFastSim( l1extraParticles.forwardJetSource )
+
+_changeLabelForFastSim( l1extraParticles.etTotalSource )
+_changeLabelForFastSim( l1extraParticles.etHadSource )
+_changeLabelForFastSim( l1extraParticles.htMissSource )
+_changeLabelForFastSim( l1extraParticles.etMissSource )
+
+_changeLabelForFastSim( l1extraParticles.hfRingEtSumsSource )
+_changeLabelForFastSim( l1extraParticles.hfRingBitCountsSource )
+
+# This one is subtly different, but is the same for Run 1 and Run 2 FastSim
 l1extraParticles.muonSource = cms.InputTag('simGmtDigis')
 
-l1extraParticles.etTotalSource = cms.InputTag("simGctDigis")
-l1extraParticles.etHadSource   = cms.InputTag("simGctDigis")
-l1extraParticles.htMissSource  = cms.InputTag("simGctDigis")
-l1extraParticles.etMissSource  = cms.InputTag("simGctDigis")
-
-l1extraParticles.hfRingEtSumsSource    = cms.InputTag("simGctDigis")
-l1extraParticles.hfRingBitCountsSource = cms.InputTag("simGctDigis")
 
 # must be set to true when used in HLT, as is the case for FastSim
 l1extraParticles.centralBxOnly = True


### PR DESCRIPTION
Currently the Run 2 eras do not configure FastSim the same as the postLS1Customs.  This brings them both into line.  I've done this in a functional way so that it works for both "gctDigis" -> "simGctDigis" (Run 1); and "caloStage1LegacyFormatDigis" -> "simCaloStage1LegacyFormatDigis" (Run 2).  If preferred I could keep the Run 1 lines the same and add

```
eras.stage1L1Trigger.toModify( l1extraParticles, etTotalSource = cms.InputTag("simCaloStage1LegacyFormatDigis") )
```

etcetera.

**Note there is still a difference between the era and the customisation**
In the customisation, `process.misalignedCSCGeometry.useGangedStripsInME1a` is True whereas in the era it's False.  I'm pretty sure the value for the era is correct, and the customisation wrong.  Could someone from FastSim confirm?

I've done a comparison of how the config for era differs to customisations in workflows 5.1, 5.2, 135.1 and 135.4 here:

http://grimes.web.cern.ch/grimes/eraProcessDiffs/processDiffs_FastSim-7_6_X_2015-09-30-1100-PR11466-mark-grimes_fixRun2EraInFastSim.html

The 5.x tests show nothing there because they're exactly the same.  Don't worry `outputCommands` "unexpected" difference, the commands are just in a different order but functionally the same.
