### PR TITLE
Replace TFormula in SimpleJetCorrector

### DIFF
--- a/CommonTools/Utils/interface/FormulaEvaluator.h
+++ b/CommonTools/Utils/interface/FormulaEvaluator.h
@@ -28,6 +28,23 @@
 // forward declarations
 namespace reco {
   namespace formula {
+    struct ArrayAdaptor {
+    ArrayAdaptor(double const* iStart, size_t iSize):
+      m_start(iStart), m_size(iSize) {}
+      size_t size() const { return m_size; }
+      bool empty() const {return m_size == 0; }
+      double const* start() const { return m_start; }
+    private:
+      double const* m_start;
+      size_t m_size;
+    };
+    inline double const* startingAddress(ArrayAdaptor const& iV) {
+      if(iV.empty()) {
+        return nullptr;
+      }
+      return iV.start();
+    }
+
     class EvaluatorBase;
     inline double const* startingAddress(std::vector<double> const& iV) {
       if(iV.empty()) {
@@ -52,6 +69,7 @@ namespace reco {
   public:
     explicit FormulaEvaluator(std::string const& iFormula);
 
+    // ---------- const member functions ---------------------
     template<typename V, typename P>
       double evaluate( V const& iVariables, P const& iParameters) const {
       if (m_nVariables > iVariables.size()) {
@@ -63,7 +81,9 @@ namespace reco {
       return evaluate( formula::startingAddress(iVariables),
                        formula::startingAddress(iParameters));
     }
-    // ---------- const member functions ---------------------
+    
+    unsigned int numberOfParameters() const { return m_nParameters; }
+    unsigned int numberOfVariables() const { return m_nVariables; }
     
   private:
     double evaluate(double const* iVariables, double const* iParameters) const;

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -122,7 +122,7 @@ namespace {
         
         
         info.nextParseIndex = endIndex+2;
-        info.maxNumParameters = value;
+        info.maxNumParameters = value+1;
         info.evaluator = std::unique_ptr<reco::formula::EvaluatorBase>( new reco::formula::ParameterEvaluator(value));
       } catch ( std::invalid_argument ) {}
       
@@ -256,7 +256,7 @@ namespace {
         }
         //need to account for closing parenthesis
         ++leftEvaluatorInfo.nextParseIndex;
-        leftEvaluatorInfo.evaluator->setPrecidenceToParenthesis();
+        leftEvaluatorInfo.evaluator->setPrecedenceToParenthesis();
         if( iBegin+leftEvaluatorInfo.nextParseIndex == iEnd) {
           return leftEvaluatorInfo;
         }
@@ -304,7 +304,7 @@ namespace {
 
   template<typename Op>
   EvaluatorInfo createBinaryOperatorEvaluatorT(int iSymbolLength,
-                                               reco::formula::EvaluatorBase::Precidence iPrec,
+                                               reco::formula::EvaluatorBase::Precedence iPrec,
                                                ExpressionFinder const& iEF,
                                                std::unique_ptr<reco::formula::EvaluatorBase> iLHS,
                                                std::string::const_iterator iBegin,
@@ -316,7 +316,7 @@ namespace {
       return evalInfo;
     }
 
-    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precidence() ) {
+    if( static_cast<unsigned int>(iPrec) >= evalInfo.evaluator->precedence() ) {
       auto b = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>( evalInfo.evaluator.get() );
       assert(b != nullptr);
       std::unique_ptr<reco::formula::EvaluatorBase> temp;
@@ -350,7 +350,7 @@ namespace {
 
     if(*iBegin == '+') {
       return createBinaryOperatorEvaluatorT<std::plus<double>>(1,
-                                                               reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                               reco::formula::EvaluatorBase::Precedence::kPlusMinus,
                                                                iEF,
                                                                std::move(iLHS),
                                                                iBegin,
@@ -359,7 +359,7 @@ namespace {
 
     else if(*iBegin == '-') {
       return createBinaryOperatorEvaluatorT<std::minus<double>>(1,
-                                                                reco::formula::EvaluatorBase::Precidence::kPlusMinus,
+                                                                reco::formula::EvaluatorBase::Precedence::kPlusMinus,
                                                                 iEF,
                                                                 std::move(iLHS),
                                                                 iBegin,
@@ -367,7 +367,7 @@ namespace {
     }
     else if(*iBegin == '*') {
       return createBinaryOperatorEvaluatorT<std::multiplies<double>>(1,
-                                                                     reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                     reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                      iEF,
                                                                      std::move(iLHS),
                                                                      iBegin,
@@ -375,7 +375,7 @@ namespace {
     }
     else if(*iBegin == '/') {
       return createBinaryOperatorEvaluatorT<std::divides<double>>(1,
-                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                   iEF,
                                                                   std::move(iLHS),
                                                                   iBegin,
@@ -384,13 +384,66 @@ namespace {
 
     else if(*iBegin == '^') {
       return createBinaryOperatorEvaluatorT<power>(1,
-                                                                  reco::formula::EvaluatorBase::Precidence::kMultDiv,
+                                                                  reco::formula::EvaluatorBase::Precedence::kMultDiv,
                                                                   iEF,
                                                                   std::move(iLHS),
                                                                   iBegin,
                                                                   iEnd);
     }
+    else if (*iBegin =='<' and iBegin+1 != iEnd and *(iBegin+1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::less_equal<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
 
+    }
+    else if (*iBegin =='>' and iBegin+1 != iEnd and *(iBegin+1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::greater_equal<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='<' ) {
+      return createBinaryOperatorEvaluatorT<std::less<double>>(1,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='>' ) {
+      return createBinaryOperatorEvaluatorT<std::greater<double>>(1,
+                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='=' and iBegin+1 != iEnd and *(iBegin+1) == '=' ) {
+      return createBinaryOperatorEvaluatorT<std::equal_to<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kIdentity,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
+    else if (*iBegin =='!' and iBegin+1 != iEnd and *(iBegin+1) == '=' ) {
+      return createBinaryOperatorEvaluatorT<std::not_equal_to<double>>(2,
+                                                                  reco::formula::EvaluatorBase::Precedence::kIdentity,
+                                                                  iEF,
+                                                                  std::move(iLHS),
+                                                                  iBegin,
+                                                                  iEnd);
+
+    }
     return evalInfo;
   }
 

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -30,10 +30,11 @@ namespace reco {
   namespace formula {
     class BinaryOperatorEvaluatorBase : public EvaluatorBase {
     public:
-    BinaryOperatorEvaluatorBase( Precidence iPrec) :
+    BinaryOperatorEvaluatorBase( Precedence iPrec) :
       EvaluatorBase(iPrec) {}
       virtual void swapLeftEvaluator(std::unique_ptr<EvaluatorBase>& iNew) = 0;
     };
+
     template<typename Op>
       class BinaryOperatorEvaluator : public BinaryOperatorEvaluatorBase
     {
@@ -41,7 +42,7 @@ namespace reco {
     public:
       BinaryOperatorEvaluator(std::unique_ptr<EvaluatorBase> iLHS, 
                               std::unique_ptr<EvaluatorBase> iRHS,
-                              Precidence iPrec):
+                              Precedence iPrec):
       BinaryOperatorEvaluatorBase(iPrec),
         m_lhs(std::move(iLHS)),
         m_rhs(std::move(iRHS)) {

--- a/CommonTools/Utils/src/formulaEvaluatorBase.cc
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.cc
@@ -28,12 +28,12 @@
 // constructors and destructor
 //
 reco::formula::EvaluatorBase::EvaluatorBase():
-  m_precidence(static_cast<unsigned int>(Precidence::kFunction))
+  m_precedence(static_cast<unsigned int>(Precedence::kFunction))
 {
 }
 
-reco::formula::EvaluatorBase::EvaluatorBase(Precidence iPrec):
-  m_precidence(static_cast<unsigned int>(iPrec))
+reco::formula::EvaluatorBase::EvaluatorBase(Precedence iPrec):
+  m_precedence(static_cast<unsigned int>(iPrec))
 {
 }
 

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -32,17 +32,19 @@ namespace reco {
     {
       
     public:
-      enum class Precidence { 
-        kPlusMinus = 1,
-          kMultDiv = 2,
-          kPower = 3,
-          kFunction = 4, //default
-          kParenthesis = 5,
-          kUnaryMinusOperator = 6
+      enum class Precedence {
+          kIdentity = 1,
+          kComparison=2,
+          kPlusMinus = 3,
+          kMultDiv = 4,
+          kPower = 5,
+          kFunction = 6, //default
+          kParenthesis = 7,
+          kUnaryMinusOperator = 8
           };
 
       EvaluatorBase();
-      EvaluatorBase(Precidence);
+      EvaluatorBase(Precedence);
       virtual ~EvaluatorBase();
       
       // ---------- const member functions ---------------------
@@ -50,8 +52,8 @@ namespace reco {
       // be of the appropriate length
       virtual double evaluate(double const* iVariables, double const* iParameters) const = 0;
 
-      unsigned int precidence() const { return m_precidence; }
-      void setPrecidenceToParenthesis() { m_precidence = static_cast<unsigned int>(Precidence::kParenthesis); }
+      unsigned int precedence() const { return m_precedence; }
+      void setPrecedenceToParenthesis() { m_precedence = static_cast<unsigned int>(Precedence::kParenthesis); }
 
     private:
       EvaluatorBase(const EvaluatorBase&) = delete; 
@@ -59,7 +61,7 @@ namespace reco {
       const EvaluatorBase& operator=(const EvaluatorBase&) = delete;
       
       // ---------- member data --------------------------------
-      unsigned int m_precidence;
+      unsigned int m_precedence;
     };
   }
 }

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -34,7 +34,7 @@ namespace reco {
       
     public:
       explicit UnaryMinusEvaluator(std::unique_ptr<EvaluatorBase> iArg):
-      EvaluatorBase(Precidence::kUnaryMinusOperator ),
+      EvaluatorBase(Precedence::kUnaryMinusOperator ),
       m_arg(std::move(iArg)) {}
        
       // ---------- const member functions ---------------------

--- a/CondFormats/JetMETObjects/BuildFile.xml
+++ b/CondFormats/JetMETObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/CaloTowers"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
+<use   name="CommonTools/Utils"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="boost_serialization"/>

--- a/CondFormats/JetMETObjects/interface/SimpleJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/SimpleJetCorrector.h
@@ -6,9 +6,9 @@
 #include <string>
 #include <vector>
 
-#include <TFormula.h>
-#include <RVersion.h>
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
 
 class JetCorrectorParameters;
 
@@ -16,11 +16,8 @@ class SimpleJetCorrector
 {
  public:
   //-------- Constructors --------------
-  SimpleJetCorrector();
   SimpleJetCorrector(const std::string& fDataFile, const std::string& fOption = "");
   SimpleJetCorrector(const JetCorrectorParameters& fParameters);
-  //-------- Destructor -----------------
-  ~SimpleJetCorrector();
   //-------- Member functions -----------
   void   setInterpolation(bool fInterpolation) {mDoInterpolation = fInterpolation;}
   float  correction(const std::vector<float>& fX,const std::vector<float>& fY) const;  
@@ -30,17 +27,13 @@ class SimpleJetCorrector
   //-------- Member functions -----------
   SimpleJetCorrector(const SimpleJetCorrector&);
   SimpleJetCorrector& operator= (const SimpleJetCorrector&);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
-  float    invert(const Double_t *args, const Double_t *params) const;
-#else
-  float    invert(const std::vector<float>& fX, TFormula&) const;
-#endif
+  float    invert(const double *args, const double *params) const;
   float    correctionBin(unsigned fBin,const std::vector<float>& fY) const;
   unsigned findInvertVar();
   void     setFuncParameters();
   //-------- Member variables -----------
   JetCorrectorParameters  mParameters;
-  TFormula                mFunc;
+  reco::FormulaEvaluator  mFunc;
   unsigned                mInvertVar; 
   bool                    mDoInterpolation;
 };

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -6,20 +6,12 @@
 #include <cmath>
 
 //------------------------------------------------------------------------
-//--- Default SimpleJetCorrector constructor -----------------------------
-//------------------------------------------------------------------------
-SimpleJetCorrector::SimpleJetCorrector()
-{
-  mDoInterpolation = false;
-  mInvertVar       = 9999;
-}
-//------------------------------------------------------------------------
 //--- SimpleJetCorrector constructor -------------------------------------
 //--- reads arguments from a file ----------------------------------------
 //------------------------------------------------------------------------
 SimpleJetCorrector::SimpleJetCorrector(const std::string& fDataFile, const std::string& fOption):
   mParameters(fDataFile,fOption),
-  mFunc("function",((mParameters.definitions()).formula()).c_str())
+  mFunc((mParameters.definitions()).formula())
 {
   mDoInterpolation = false;
   if (mParameters.definitions().isResponse())
@@ -31,17 +23,11 @@ SimpleJetCorrector::SimpleJetCorrector(const std::string& fDataFile, const std::
 //------------------------------------------------------------------------
 SimpleJetCorrector::SimpleJetCorrector(const JetCorrectorParameters& fParameters):
   mParameters(fParameters),
-  mFunc("function",((mParameters.definitions()).formula()).c_str())
+  mFunc((mParameters.definitions()).formula())
 {
   mDoInterpolation = false;
   if (mParameters.definitions().isResponse())
     mInvertVar = findInvertVar();
-}
-//------------------------------------------------------------------------
-//--- SimpleJetCorrector destructor --------------------------------------
-//------------------------------------------------------------------------
-SimpleJetCorrector::~SimpleJetCorrector()
-{
 }
 
 //------------------------------------------------------------------------
@@ -106,13 +92,12 @@ float SimpleJetCorrector::correctionBin(unsigned fBin,const std::vector<float>& 
     }
   const std::vector<float>& par = mParameters.record(fBin).parameters();
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
-  Double_t params[par.size() - 2 * N];
+  double params[par.size() - 2 * N];
   for(unsigned int i=2*N;i<par.size();i++)
     {
       params[i-2*N] = par[i];
     }
-  Double_t x[4] = {};
+  double x[4] = {};
   for(unsigned i=0;i<N;i++)
     {
       x[i] = (fY[i] < par[2*i]) ? par[2*i] : (fY[i] > par[2*i+1]) ? par[2*i+1] : fY[i];
@@ -120,28 +105,7 @@ float SimpleJetCorrector::correctionBin(unsigned fBin,const std::vector<float>& 
   if (mParameters.definitions().isResponse()) {
     return invert(x, params);
   }
-  return mFunc.EvalPar(x, params);
-#else
-  float result = -1;
-  //Have to do calculation using a temporary TFormula to avoid
-  // thread safety issues
-  TFormula tFunc(mFunc);
-
-  for(unsigned int i=2*N;i<par.size();i++)
-    tFunc.SetParameter(i-2*N,par[i]);
-  float x[4] = {};
-  std::vector<float> tmp;
-  for(unsigned i=0;i<N;i++)
-    {
-      x[i] = (fY[i] < par[2*i]) ? par[2*i] : (fY[i] > par[2*i+1]) ? par[2*i+1] : fY[i];
-      tmp.push_back(x[i]);
-    }
-  if (mParameters.definitions().isResponse())
-    result = invert(tmp,tFunc);
-  else
-    result = tFunc.Eval(x[0],x[1],x[2],x[3]);
-  return result;
-#endif
+  return mFunc.evaluate(reco::formula::ArrayAdaptor(x,N), reco::formula::ArrayAdaptor(params,par.size()-2*N) );
 }
 //------------------------------------------------------------------------
 //--- find invertion variable (JetPt) ------------------------------------
@@ -163,22 +127,21 @@ unsigned SimpleJetCorrector::findInvertVar()
 //------------------------------------------------------------------------
 //--- inversion ----------------------------------------------------------
 //------------------------------------------------------------------------
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
-float SimpleJetCorrector::invert(const Double_t *args, const Double_t *params) const
+float SimpleJetCorrector::invert(const double *args, const double *params) const
 {
   unsigned nMax = 50;
   float precision = 0.0001;
   float rsp = 1.0;
   float e = 1.0;
-  Double_t x[4];
+  double x[4];
   unsigned nLoop=0;
 
   // 4 dimensions (x, y, z, t) supported in TFormula
-  memcpy(&x, args, sizeof(Double_t) * 4);
+  memcpy(&x, args, sizeof(double) * 4);
 
   while(e > precision && nLoop < nMax)
     {
-      rsp = mFunc.EvalPar(x, params);
+      rsp = mFunc.evaluate(reco::formula::ArrayAdaptor(x,4), reco::formula::ArrayAdaptor(params,mFunc.numberOfParameters()));
       float tmp = x[mInvertVar] * rsp;
       e = fabs(tmp - args[mInvertVar])/args[mInvertVar];
       x[mInvertVar] = args[mInvertVar]/rsp;
@@ -186,26 +149,3 @@ float SimpleJetCorrector::invert(const Double_t *args, const Double_t *params) c
     }
   return 1./rsp;
 }
-#else
-float SimpleJetCorrector::invert(const std::vector<float>& fX, TFormula& tFunc) const
-{
-  unsigned nMax = 50;
-  unsigned N = fX.size();
-  float precision = 0.0001;
-  float rsp = 1.0;
-  float e = 1.0;
-  float x[4] = {0.0,0.0,0.0,0.0};
-  for(unsigned i=0;i<N;i++)
-    x[i] = fX[i];
-  unsigned nLoop=0;
-  while(e > precision && nLoop < nMax)
-    {
-      rsp = tFunc.Eval(x[0],x[1],x[2],x[3]);
-      float tmp = x[mInvertVar] * rsp;
-      e = fabs(tmp - fX[mInvertVar])/fX[mInvertVar];
-      x[mInvertVar] = fX[mInvertVar]/rsp;
-      nLoop++;
-    }
-  return 1./rsp;
-}
-#endif


### PR DESCRIPTION
Threaded performance measurements using Intel's VTune showed that
TFormula use was requiring many locks and was causing significant
inefficiencies in CMSSW_7_4 with ROOT 6.02. Although much of the
problem goes away in ROOT 6.04 with the new TFormula implementation,
moving away from TFormula and to the completely thread efficient
reco::FormulaEvaluator also makes construction of the formula
thread efficient.
