### PR TITLE
Add member function in FillInfo to check the injection scheme for 25 ns.

### DIFF
--- a/CondFormats/RunInfo/interface/FillInfo.h
+++ b/CondFormats/RunInfo/interface/FillInfo.h
@@ -62,7 +62,11 @@ class FillInfo {
   cond::Time_t const endTime() const;
   
   std::string const & injectionScheme() const;
-    
+
+  //returns a boolean, true if the injection scheme has a leading 25ns
+  //TODO: parse the circulating bunch configuration, instead of the string.
+  bool is25nsBunchSpacing() const;
+
   //returns a boolean, true if the bunch slot number is in the circulating bunch configuration
   bool isBunchInBeam1( size_t const & bunch ) const;
   

--- a/CondFormats/RunInfo/src/FillInfo.cc
+++ b/CondFormats/RunInfo/src/FillInfo.cc
@@ -208,6 +208,13 @@ std::string const & FillInfo::injectionScheme() const {
   return m_injectionScheme;
 }
 
+//returns a boolean, true if the injection scheme has a leading 25ns
+//TODO: parse the circulating bunch configuration, instead of the string.
+bool FillInfo::is25nsBunchSpacing() const {
+  const std::string prefix( "25ns" );
+  return std::equal( prefix.begin(), prefix.end(), m_injectionScheme.begin() );
+}
+
 //returns a boolean, true if the bunch slot number is in the circulating bunch configuration
 bool FillInfo::isBunchInBeam1( size_t const & bunch ) const {
   if( bunch == 0 )


### PR DESCRIPTION
This adds a dummy test for the bunch spacing information: it returns true if the injection scheme string starts with `25ns`.
The correct check to be done is to test the `bitset` and look for "holes".
