### PR TITLE
CalibTracker/SiStripDCS: remove intrusive macros breaking libstdc++

### DIFF
--- a/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
@@ -33,8 +33,13 @@
    \author J.Cole modified by Marco De Mattia
 */
 
+// Unit test class for SiStripDetVOffBuilder
+class TestSiStripDetVOffBuilder;
+
 class SiStripDetVOffBuilder
 {
+  friend class TestSiStripDetVOffBuilder;
+
  public:
   /** Destructor. */
   ~SiStripDetVOffBuilder();

--- a/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
@@ -9,12 +9,7 @@
 
 #include <vector>
 
-// Make everything public to access all methods
-#define protected public
-#define private public
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
-#undef protected
-#undef private
 
 std::vector<int> vectorDate(const int year, const int month,
 			    const int day, const int hour,


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
