### PR TITLE
Updating the upgrade queue

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v1',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes
## 2017 Upgrade

 [75X_upgrade2017_design_v4](https://cms-conddb.cern.ch/browser/#search/Prod/75X_upgrade2017_design_v4) as  with these changes [75X_upgrade2017_design_v1](https://cms-conddb.cern.ch/browser/#search/Prod/75X_upgrade2017_design_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_upgrade2017_design_v1/75X_upgrade2017_design_v4) : 
- new e/gamma regression for run2 
- correct Sim geometry for upgrade 
- Tracker Reco params and reco geometry for 2017 upgrade 
- New JECs from Run2 25ns 
-  Updated Hcal zero suppresion threshold 
- Updated L1 menu for Stage1
