### PR TITLE
New GT for 2017 scenario.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v1',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
[`75X_upgrade2017_design_v4`](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_upgrade2017_design_v4): as [`75X_upgrade2017_design_v1`](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_upgrade2017_design_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_upgrade2017_design_v1/75X_upgrade2017_design_v4):
- Adding new set of E/gamma regressions;
- Adding BDT taggers as `GBRForest` payloads with new labels for `GBRWrapperRcd`;
- Updating `Extended` geometry for 2017 upgrade (and removing un-needed labels);
- Updating Tracker RECO geometry with 2017 scenario;
- Updating Tracker parameters with 2017 scenario;
- Updating L1T RCT parameters to be in synch with data taking;
- Updating L1T menu to be in synch with data taking;
- Updating Zero Suppression threshold for HCAL: HF is non-ZS;
- Updating HCAL response corrections to take into account the change of scale in Method3;
- Updating JEC for HLT and RECO (also supporting Puppi).
