### PR TITLE
For HI HLT: migration of 5 HI tracking modules to stream modules

### DIFF
--- a/RecoHI/HiTracking/interface/HIBestVertexProducer.h
+++ b/RecoHI/HiTracking/interface/HIBestVertexProducer.h
@@ -1,7 +1,7 @@
 #ifndef HIBestVertexProducer_H
 #define HIBestVertexProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -9,12 +9,12 @@
 
 namespace edm { class Event; class EventSetup; }
 
-class HIBestVertexProducer : public edm::EDProducer
+class HIBestVertexProducer : public edm::stream::EDProducer<>
 {
 public:
 	explicit HIBestVertexProducer(const edm::ParameterSet& ps);
 	~HIBestVertexProducer();
-	virtual void produce(edm::Event& ev, const edm::EventSetup& es);
+	virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
 	
 private:
 	void beginJob();

--- a/RecoHI/HiTracking/plugins/HIBestVertexSelector.cc
+++ b/RecoHI/HiTracking/plugins/HIBestVertexSelector.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "CommonTools/UtilAlgos/interface/SortCollectionSelector.h"
 #include "RecoHI/HiTracking/interface/BestVertexComparator.h"
 
@@ -13,7 +13,7 @@ namespace reco
 	{
 		
 		// define your producer name
-		typedef ObjectSelector<
+		typedef ObjectSelectorStream<
 			SortCollectionSelector<
 			reco::VertexCollection,
 			GreaterByTracksSize<reco::Vertex>

--- a/RecoHI/HiTracking/plugins/HIPixelClusterVtxProducer.h
+++ b/RecoHI/HiTracking/plugins/HIPixelClusterVtxProducer.h
@@ -1,7 +1,7 @@
 #ifndef HIPixelClusterVtxProducer_H
 #define HIPixelClusterVtxProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
@@ -10,7 +10,7 @@ namespace edm { class Run; class Event; class EventSetup; }
 
 class TrackerGeometry;
 
-class HIPixelClusterVtxProducer : public edm::EDProducer
+class HIPixelClusterVtxProducer : public edm::stream::EDProducer<>
 {
 public:
   explicit HIPixelClusterVtxProducer(const edm::ParameterSet& ps);
@@ -24,7 +24,7 @@ private:
     float w;
   };
 
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es);
+  virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
   int getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi);
 
   std::string srcPixelsString_; //pixel rec hits

--- a/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.h
+++ b/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.h
@@ -1,7 +1,7 @@
 #ifndef HIPixelMedianVtxProducer_H
 #define HIPixelMedianVtxProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -9,12 +9,12 @@
 
 namespace edm { class Event; class EventSetup; }
 
-class HIPixelMedianVtxProducer : public edm::EDProducer
+class HIPixelMedianVtxProducer : public edm::stream::EDProducer<>
 {
 public:
 	explicit HIPixelMedianVtxProducer(const edm::ParameterSet& ps);
 	~HIPixelMedianVtxProducer(){};
-	virtual void produce(edm::Event& ev, const edm::EventSetup& es);
+	virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
 	
 private:
 	void beginJob(){};

--- a/RecoHI/HiTracking/plugins/HIProtoTrackSelector.cc
+++ b/RecoHI/HiTracking/plugins/HIProtoTrackSelector.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "RecoHI/HiTracking/plugins/HIProtoTrackSelector.h"
 
 namespace reco
@@ -9,7 +9,7 @@ namespace reco
 	{
 		
 		// define your producer name
-		typedef ObjectSelector<HIProtoTrackSelector> HIProtoTrackSelection;
+		typedef ObjectSelectorStream<HIProtoTrackSelector> HIProtoTrackSelection;
 		
 		// declare the module as plugin
 		DEFINE_FWK_MODULE( HIProtoTrackSelection );


### PR DESCRIPTION
Dear all,

5 HI Tracking modules used by HI HLT have been migrated to stream modules in this PR. The purpose was to make the modules multithread-compliant. A 75X backport will follow in minutes. I have tested the HI HLT results with and without this PR and achieved the same rates in the two cases.

Cheers,
Krisztian

@fwyzard, @mandrenguyen, @istaslis, @dgulhan, @perrotta, @Martin-Grunewald 
