### PR TITLE
Do not use private 'XrdCl::FileSystem::FileSystem(const XrdCl::FileSystem&)

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -6,6 +6,7 @@
 
 #include "XrdCl/XrdClFile.hh"
 #include "XrdCl/XrdClDefaultEnv.hh"
+#include "XrdCl/XrdClFileSystem.hh"
 
 #include "FWCore/Utilities/interface/CPUTimer.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -96,7 +97,8 @@ SendMonitoringInfo(XrdCl::File &file)
     file.GetProperty("LastURL", lastUrl);
     if (jobId && lastUrl.size())
     {
-        XrdCl::FileSystem fs = XrdCl::FileSystem(XrdCl::URL(lastUrl));
+        XrdCl::URL url(lastUrl);
+        XrdCl::FileSystem fs(url);
         fs.SendInfo(jobId, &nullHandler, 30);
         edm::LogInfo("XrdAdaptorInternal") << "Set monitoring ID to " << jobId << ".";
     }


### PR DESCRIPTION
The following showed up after a switch to xrootd 4.2.3 happened in
CMSSW_7_6_DEVEL_X IBs. The ctor 'XrdCl::FileSystem::FileSystem(const
XrdCl::FileSystem&)' is private and should not be used.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
