### PR TITLE
Change CandidateBoostedDoubleSecondaryVertexComputer to use GBRForest (76X)

### DIFF
--- a/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
@@ -13,9 +13,6 @@
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/contrib/Njettiness.hh"
 
-#include <mutex>
-
-
 class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
 
   public:
@@ -37,8 +34,7 @@ class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
     const double maxSVDeltaRToJet_;
 
     const edm::FileInPath weightFile_;
-    mutable std::mutex m_mutex;
-    [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVAEvaluator> mvaID;
+    std::unique_ptr<TMVAEvaluator> mvaID;
 };
 
 #endif // RecoBTag_SecondaryVertex_CandidateBoostedDoubleSecondaryVertexComputer_h

--- a/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
@@ -36,7 +36,7 @@ class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
 
     const double maxSVDeltaRToJet_;
 
-    edm::FileInPath weightFile_;
+    const edm::FileInPath weightFile_;
     mutable std::mutex m_mutex;
     [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -27,7 +27,7 @@ CandidateBoostedDoubleSecondaryVertexComputer::CandidateBoostedDoubleSecondaryVe
                                       "SV_vtx_EnergyRatio_1","PFLepton_IP2D", "tau2/tau1", "nSL", "jetNTracksEtaRel"});
   std::vector<std::string> spectators({"massGroomed", "flavour", "nbHadrons", "ptGroomed", "etaGroomed"});
 
-  mvaID->initialize("Color:Silent:Error", "BDTG", weightFile_.fullPath(), variables, spectators);
+  mvaID->initialize("Color:Silent:Error", "BDTG", weightFile_.fullPath(), variables, spectators,true,false);
 }
 
 
@@ -41,9 +41,6 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
 
   // default discriminator value
   float value = -10.;
-
-  // TMVAEvaluator is not thread safe
-  std::lock_guard<std::mutex> lock(m_mutex);
 
   // default variable values
   float z_ratio = -1. , tau_dot = -1., SV_pt_0 = -1., SV_mass_0 = -1., SV_EnergyRatio_0 = -1., SV_EnergyRatio_1 = -1., tau21 = -1.;
@@ -161,6 +158,9 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
   inputs["PFLepton_IP2D"] = PFLepton_IP2D;
   inputs["nSL"] = nSL;
   inputs["tau2/tau1"] = tau21;
+
+  // TMVAEvaluator is not thread safe
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   // evaluate the MVA
   value = mvaID->evaluate(inputs);

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -158,10 +158,7 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
   inputs["PFLepton_IP2D"] = PFLepton_IP2D;
   inputs["nSL"] = nSL;
   inputs["tau2/tau1"] = tau21;
-
-  // TMVAEvaluator is not thread safe
-  std::lock_guard<std::mutex> lock(m_mutex);
-
+  
   // evaluate the MVA
   value = mvaID->evaluate(inputs);
 


### PR DESCRIPTION
Change the TMVA evaluator in CandidateBoostedDoubleSecondaryVertexComputer to use GBRForest for internal storage rather than TMVA::Reader.

Purely technical, no changes expected/observed.
