### PR TITLE
New GTs for 76X: L1,HLT,Geometry and HCAL changes

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '76X_mcRun1_design_v2',
+    'run1_design'       :   '76X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '76X_mcRun1_realistic_v2',
+    'run1_mc'           :   '76X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '76X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v2',
+    'run2_design'       :   '76X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v2',
+    'run1_data'         :   '76X_dataRun1_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v2',
+    'run2_data'         :   '76X_dataRun2_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v0',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v0',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v1',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -2,8 +2,8 @@
 #   cmsDiver.py hlt -s HLT:@relval
 
 autoHLT = {
-  'frozen25ns' : '25ns14e33_v3',
-  'relval25ns' : '25ns14e33_v3',
+  'frozen25ns' : '25ns14e33_v4',
+  'relval25ns' : '25ns14e33_v4',
   'frozen50ns' : '50ns_5e33_v3',
   'relval50ns' : '50ns_5e33_v3',
   'fake'       : 'Fake',


### PR DESCRIPTION
# Summary of changes
## Run I Simulation:
- _Ideal_: [76X_mcRun1_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_design_v4) as [76X_mcRun1_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_design_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_design_v4/76X_mcRun1_design_v2):
  - updated HCAL response corrections from Data/MC studies
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
- _Realistic_: [76X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_realistic_v4) as [76X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_realistic_v4/76X_mcRun1_realistic_v2):
  - updated HCAL response corrections from Data/MC studies  
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
- _Heavy Ion_: [76X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_HeavyIon_v4) as [76X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_HeavyIon_v4/76X_mcRun1_HeavyIon_v2):
  - Adding BDT taggers as GBRForest payloads with new labels for GBRWrapperRcd
  - Adding new label for HeavyIonRcd handling HF Towers HydjetDrum method;
  - Updating HCAL response corrections to take into account the change of scale in Method3
- _proton-Lead_:  [76X_mcRun1_pA_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_pA_v4) as [76X_mcRun1_pA_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_pA_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_pA_v4/76X_mcRun1_pA_v2):
  - updated HCAL response corrections from Data/MC studies
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
## Run II Simulation:
- _Ideal_: [76X_mcRun2_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v4) as [76X_mcRun2_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_design_v4/76X_mcRun2_design_v2):
  - updated HCAL response corrections from Data/MC studies
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
  - adding new offline JEC from 2015 data analysis 
  - adding new HLT JEC from 2015 data anaylsis
  - moving to V5 version of L1Trigger Menu for Stage1
  - fixing L1 RCT parameters
  - updating Zero Suppression threshold for HCAL: HF is non-ZS 
  - adding L1TCaloParams payload
- _Asymptotic_: [76X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v4) as [76X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_asymptotic_v4/76X_mcRun2_asymptotic_v2):
  - Adding Calorimeter Parameters for L1T
  - Adding BDT taggers as GBRForest payloads with new labels for GBRWrapperRcd
  - Updating L1T menu to be in synch with online data taking
  - Updating L1T RCT parameters to be in synch with online data taking
  - Updating Pixel bad channel map as at the beginning of Run2015D era
  - Updating Zero Suppression threshold for HCAL: HF is non-ZS
  - Updating HCAL response corrections to take into account the change of scale in Method3
  - Updating JEC for HLT and RECO (also supporting Puppi).
- _Startup_ [76X_mcRun2_startup_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v4) as [76X_mcRun2_startup_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_startup_v4/76X_mcRun2_startup_v2):
  - updated HCAL response corrections from Data/MC studies
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
  - adding new offline JEC from 2015 data analysis 
  - moving to V5 version of L1Trigger Menu for Stage1
  - fixing L1 RCT parameters
  - updating Zero Suppression threshold for HCAL: HF is non-ZS
  - adding L1TCaloParams payload
  - updating SiPixelQuality dead channel map to v28
- _Heavy Ion_ [76X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v4) as [76X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_HeavyIon_v4/76X_mcRun2_HeavyIon_v2):
  - updated HCAL response corrections from Data/MC studies
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
  - adding new offline JEC from 2015 data analysis 
  - adding new HLT JEC from 2015 data anaylsis
  - moving to V5 version of L1Trigger Menu for Stage1
  - fixing L1 RCT parameters
  - updating Zero Suppression threshold for HCAL: HF is non-ZS
  - adding L1TCaloParams payload
  - updating SiPixelQuality dead channel map to v28
  - adding new label for HeavyIonRcd handling HF Towers HydjetDrum5 method;
## Run2 data
- _Offline Processing_ [76X_dataRun2_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v3)  as [76X_dataRun2_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v3/76X_dataRun2_v2):
  - taxonomy changes for DT and CSC Alignment parameter errors
  - updated HCAL response corrections from Data/MC studies
  - fixing ECAL pulse shapes for ECAL multifit 
  - updated HCAL channel quality
  - adding BTV tagger as GBRForest payloads for GBRWrapperRcd
  - adding new offline JEC from 2015 data analysis 
  - adding new HLT JEC from 2015 data analysis
  - taxonomy change for the SiStrip O2O tags 
  - updating HF Towers label for HeavyIonRcd
- _HLT Processing_ [76X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_frozen_v3) as [76X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_frozen_v2) (snapshot time 2015-10-01 16:41:00 UTC) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_HLT_frozen_v3/76X_dataRun2_HLT_frozen_v2):
  - Taxonomy change for CSC and DT APE
  - Taxonomy change for SiStrip Backplane corrections in deconvolution mode
## Run1 Data
- _Offline Processing_ [76X_dataRun1_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v3) as [76X_dataRun1_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v3/76X_dataRun1_v2):
  - Taxonomy change for CSC and DT APE
  - Adding BDT taggers as GBRForest payloads with new labels for GBRWrapperRcd
  - Updating SiStrip O2O tags (bad channels, FED cabling, latency, pedestals, threshold) with the prompt version. BEWARE: the noise tag is not updated yet, so it does not cover Run2.
  - Updating ECAL pulse shapes for Multi fit method in local reco: first IOV covering Run1 as in MC, second IOV covering Run2 as per Run2015B analysis
  - Updating HCAL bad channel map as per Run2015B-C analysis
  - Updating HCAL response corrections to take into account the change of scale in Method3 starting from Run2015B
  - Updating HF Towers centrality for Heavy Ion
- _HLT Processing_ [76X_dataRun1_HLT_frozen_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_HLT_frozen_v3) as [76X_dataRun1_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_HLT_frozen_v2) (snapshot time 2015-10-01 16:41:00 UTC) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_HLT_frozen_v3/76X_dataRun1_HLT_frozen_v2):
  - Taxonomy change for CSC and DT APE
  - Taxonomy change for SiStrip Backplane corrections in deconvolution mode
## Upgrades
- _Upgrade (phase-I)_ [76X_upgrade2017_design_v0](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v0) as [75X_upgrade2017_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_upgrade2017_design_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_upgrade2017_design_v0/75X_upgrade2017_design_v4):
  - Added L1T Calorimeter Parameters
  - Added HCAL parameters in new version of the condition object
  - Updated HCAL RECO geometry as for Run2
  - Updated SIM geometry in the `Ideal` scenario (as a placeholder for Run2)
  - Removed unused SIM geometries.
