### PR TITLE
Removed use of '#define private public' for testing

### DIFF
--- a/DataFormats/Common/interface/DataFrame.h
+++ b/DataFormats/Common/interface/DataFrame.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_Common_DataFrame_h
 #define DataFormats_Common_DataFrame_h
 
+class TestDataFrame;
 namespace edm {
 
   class DataFrameContainer;
@@ -63,6 +64,9 @@ namespace edm {
     size_type size() const { return m_size; }
     
   private:
+    //for testing
+    friend class ::TestDataFrame;
+
     data_type * data() {
       return const_cast<data_type *>(m_data);
     }

--- a/DataFormats/Common/interface/DataFrameContainer.h
+++ b/DataFormats/Common/interface/DataFrameContainer.h
@@ -9,6 +9,8 @@
 #include<vector>
 #include<algorithm>
 
+class TestDataFrame;
+
 namespace edm {
 
   /** an optitimized container that linearized a "vector of vector".
@@ -183,6 +185,9 @@ namespace edm {
     // DataContainer const & data() const { return  m_data;}
     
   private:
+    //for testing
+    friend class ::TestDataFrame;
+    
     // subdetector id (as returned by  DetId::subdetId())
     int m_subdetId;
 

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -18,6 +18,8 @@
 #include<vector>
 #include <cassert>
 
+class TestDetSet;
+
 namespace edm { namespace refhelper { template<typename T> struct FindForNewDetSetVector; } }
 
 //FIXME remove New when ready
@@ -203,6 +205,9 @@ namespace edmNew {
       data_type & back() { return v.m_data.back();}
       
     private:
+      //for testing
+      friend class ::TestDetSet;
+      
       DetSetVector<T> & v;
       typename DetSetVector<T>::Item & item;
       bool saveEmpty;
@@ -420,6 +425,9 @@ namespace edmNew {
     void updateImpl(Item & item);
     
   private:
+    //for testing
+    friend class ::TestDetSet;
+
     // subdetector id (as returned by  DetId::subdetId())
     int m_subdetId;
     

--- a/DataFormats/Common/interface/MapOfVectors.h
+++ b/DataFormats/Common/interface/MapOfVectors.h
@@ -7,6 +7,8 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
+class TestMapOfVectors;
+
 namespace edm {
 
   /* a linearized read-only map-of vectors
@@ -147,6 +149,9 @@ namespace edm {
     }
 
   private:
+    //for testing
+    friend class ::TestMapOfVectors;
+    
     std::vector<K> m_keys;
     std::vector<size_type> m_offsets;
     std::vector<T> m_data;

--- a/DataFormats/Common/test/DataFrame_t.cpp
+++ b/DataFormats/Common/test/DataFrame_t.cpp
@@ -1,10 +1,8 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#define private public
 #include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/Common/interface/DataFrameContainer.h"
-#undef private
 #include <vector>
 #include <algorithm>
 #include <cstdlib>

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -1,12 +1,10 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#define private public
 #include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/DetSetAlgorithm.h"
 #include "DataFormats/Common/interface/DetSet2RangeMap.h"
-#undef private
 
 #include "FWCore/Utilities/interface/EDMException.h"
 

--- a/DataFormats/Common/test/MapOfVectors_t.cpp
+++ b/DataFormats/Common/test/MapOfVectors_t.cpp
@@ -1,9 +1,7 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#define private public
 #include "DataFormats/Common/interface/MapOfVectors.h"
-#undef private
 
 #include<vector>
 #include<algorithm>

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -176,6 +176,13 @@ The interface is too complex for general use.
 #include <set>
 #include <vector>
 
+class TestIndexIntoFile;
+class TestIndexIntoFile1;
+class TestIndexIntoFile2;
+class TestIndexIntoFile3;
+class TestIndexIntoFile4;
+class TestIndexIntoFile5;
+
 namespace edm {
 
   class ProcessHistoryRegistry;
@@ -336,6 +343,7 @@ namespace edm {
         }
 
       private:
+
         // All Runs, Lumis, and Events associated with the same
         // ProcessHistory and Run in the same input file are processed
         // contiguously.  This parameter establishes the default order
@@ -757,7 +765,12 @@ namespace edm {
         void copyPosition(IndexIntoFileItr const& position);
 
       private:
-
+        //for testing
+        friend class ::TestIndexIntoFile;
+        friend class ::TestIndexIntoFile3;
+        friend class ::TestIndexIntoFile4;
+        friend class ::TestIndexIntoFile5;
+        
         // The rest of these are intended to be used only by code which tests
         // this class.
         IndexIntoFile const* indexIntoFile() const { return impl_->indexIntoFile(); }
@@ -1015,6 +1028,14 @@ namespace edm {
       };
 
     private:
+
+      //for testing
+      friend class ::TestIndexIntoFile;
+      friend class ::TestIndexIntoFile1;
+      friend class ::TestIndexIntoFile2;
+      friend class ::TestIndexIntoFile3;
+      friend class ::TestIndexIntoFile4;
+      friend class ::TestIndexIntoFile5;
 
       /// This function will automatically get called when needed.
       /// It depends only on the fact that the persistent data has been filled already.

--- a/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
@@ -9,10 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -9,10 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -9,10 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
@@ -9,10 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
@@ -9,10 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -9,10 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-// This is very ugly, but I am told OK for white box  unit tests 
-#define private public
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#undef private
 
 #include <string>
 #include <iostream>

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -44,6 +44,8 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include <typeinfo>
 #include <vector>
 
+class testEventGetRefBeforePut;
+
 namespace edm {
 
   class BranchDescription;
@@ -229,6 +231,8 @@ namespace edm {
     productGetter() const;
 
   private:
+    //for testing
+    friend class ::testEventGetRefBeforePut;
 
     EventPrincipal const&
     eventPrincipal() const;

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -36,10 +36,7 @@ Test of the EventPrincipal class.
 #include <string>
 #include <typeinfo>
 
-//have to do this evil in order to access commit_ member function
-#define private public
 #include "FWCore/Framework/interface/Event.h"
-#undef private
 
 class testEventGetRefBeforePut: public CppUnit::TestFixture {
 CPPUNIT_TEST_SUITE(testEventGetRefBeforePut);

--- a/FWCore/PluginManager/interface/CacheParser.h
+++ b/FWCore/PluginManager/interface/CacheParser.h
@@ -34,6 +34,8 @@ If a space exists in either of these three fields, it will be replaced with a %,
 #include "FWCore/PluginManager/interface/PluginInfo.h"
 
 // forward declarations
+class TestCacheParser;
+
 namespace edmplugin {
 class CacheParser
 {
@@ -59,6 +61,8 @@ class CacheParser
       static void read(std::istream&, LoadableToPlugins& oOut);
       static void write(LoadableToPlugins& iIn, std::ostream&);
    private:
+      //for testing
+      friend class ::TestCacheParser;
       CacheParser(const CacheParser&); // stop default
 
       const CacheParser& operator=(const CacheParser&); // stop default

--- a/FWCore/PluginManager/test/cacheparser_t.cc
+++ b/FWCore/PluginManager/test/cacheparser_t.cc
@@ -17,7 +17,6 @@
 #include <sstream>
 
 // user include files
-#define private public
 #include "FWCore/PluginManager/interface/CacheParser.h"
 
 class TestCacheParser : public CppUnit::TestFixture

--- a/FWCore/ServiceRegistry/interface/ServiceToken.h
+++ b/FWCore/ServiceRegistry/interface/ServiceToken.h
@@ -26,6 +26,9 @@
 // user include files
 
 // forward declarations
+class testServicesManager;
+class TestServicesManagerOrder;
+
 namespace edm {
    class ServiceRegistry;
    class ActivityRegistry;
@@ -38,6 +41,10 @@ namespace edm {
    {
       friend class edm::ServiceRegistry;
       friend class edm::serviceregistry::ServicesManager;
+      //for testing
+      friend class ::testServicesManager;
+      friend class ::TestServicesManagerOrder;
+     
     public:
       ServiceToken() {}
       //virtual ~ServiceToken();

--- a/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
+++ b/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
@@ -7,15 +7,19 @@
 #include "FWCore/ServiceRegistry/interface/ServiceWrapper.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-//NOTE: I need to open a 'back door' so I can test ServiceManager 'inheritance'
-#define private public
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
-#undef private
 
 #include <cstdlib>
 #include <vector>
 #include <memory>
 #include <iostream>
+
+class TestServicesManagerOrder {
+public:
+  static edm::ServiceToken makeToken(std::shared_ptr<edm::serviceregistry::ServicesManager> iManager) {
+    return edm::ServiceToken(iManager);
+  }
+};
 
 int main() try {
   using namespace edm::serviceregistry;
@@ -47,7 +51,7 @@ int main() try {
   auto wrapper = std::make_shared<ServiceWrapper<Service0> >(s0);
   legacy->put(wrapper);
   legacy->copySlotsFrom(ar);
-  edm::ServiceToken legacyToken(legacy);
+  edm::ServiceToken legacyToken = TestServicesManagerOrder::makeToken(legacy);
 
   std::vector<edm::ParameterSet> vps1;
 
@@ -72,7 +76,7 @@ int main() try {
   vps1.push_back(ps2);
 
   auto legacy2 = std::make_shared<ServicesManager>(legacyToken, kTokenOverrides, vps1);
-  edm::ServiceToken legacyToken2(legacy2);
+  edm::ServiceToken legacyToken2 = TestServicesManagerOrder::makeToken(legacy2);
 
 
   ServicesManager sm(legacyToken2, kOverlapIsError, vps);

--- a/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
@@ -5,10 +5,7 @@
  *  Created by Chris Jones on 9/5/05.
  *
  */
-//NOTE: I need to open a 'back door' so I can test ServiceManager 'inheritance'
-#define private public
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
-#undef private
 
 #include "FWCore/ServiceRegistry/interface/ServicesManager.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"

--- a/FWCore/Utilities/interface/EDGetToken.h
+++ b/FWCore/Utilities/interface/EDGetToken.h
@@ -47,7 +47,9 @@ namespace edm {
     bool isUninitialized() const { return m_value == s_uninitializedValue; }
 
   private:
-
+    //for testing
+    friend class TestEDGetToken;
+    
     static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
 
     explicit EDGetToken(unsigned int iValue) : m_value(iValue) { }
@@ -71,6 +73,8 @@ namespace edm {
     bool isUninitialized() const { return m_value == s_uninitializedValue; }
 
   private:
+    //for testing
+    friend class TestEDGetToken;
 
     static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
 

--- a/FWCore/Utilities/test/EDGetToken_t.cpp
+++ b/FWCore/Utilities/test/EDGetToken_t.cpp
@@ -1,35 +1,47 @@
-// have to do this evil in order to access constructors.
-// This is acceptable only for white box tests like this.
-#define private public
+#include <functional>
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#undef private
+
+namespace edm {
+  class TestEDGetToken {
+  public:
+    template <typename... Args>
+    static edm::EDGetToken makeToken( Args&&... iArgs) {
+      return edm::EDGetToken(std::forward<Args>(iArgs)...);
+    }
+  
+    template <typename T, typename... Args>
+    static edm::EDGetTokenT<T> makeTokenT( Args&&... iArgs) {
+      return edm::EDGetTokenT<T>(std::forward<Args>(iArgs)...);
+    }
+  };
+}
 
 #include <iostream>
 
 int main() {
 
-  edm::EDGetTokenT<int> token1;
+  edm::EDGetTokenT<int> token1 = edm::TestEDGetToken::makeTokenT<int>();
   if(!token1.isUninitialized() ||
      !(token1.index() == 0xFFFFFFFF)) {
     std::cout << "EDGetTokenT no argument constructor failed 1" << std::endl;
     abort();
   }
 
-  edm::EDGetTokenT<int> token2(11);
+  edm::EDGetTokenT<int> token2 = edm::TestEDGetToken::makeTokenT<int>(11);
   if(token2.isUninitialized() ||
      !(token2.index() == 11)) {
     std::cout << "EDGetTokenT 1 argument constructor failed 2" << std::endl;
     abort();
   }
 
-  edm::EDGetToken token10;
+  edm::EDGetToken token10 = edm::TestEDGetToken::makeToken();
   if(!token10.isUninitialized() ||
      !(token10.index() == 0xFFFFFFFF)) {
     std::cout << "EDGetToken no argument constructor failed 10" << std::endl;
     abort();
   }
 
-  edm::EDGetToken token11(100);
+  edm::EDGetToken token11 = edm::TestEDGetToken::makeToken(100);
   if(token11.isUninitialized() ||
      !(token11.index() == 100)) {
     std::cout << "EDGetToken 1 argument constructor failed 11" << std::endl;


### PR DESCRIPTION
Tests had converted all private to public in order to test internals. This no longer works with newer versions of gcc since it messes up linking. Switched to using friend instead.
