### PR TITLE
Updated flavor parton selection for Pythia8

### DIFF
--- a/PhysicsTools/JetMCAlgos/src/Pythia8PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Pythia8PartonSelector.cc
@@ -1,8 +1,8 @@
 
 /**
- * This is a Pythia8-specific parton selector that selects all status==71 or 72 partons. An explanation of
- * the particle status codes returned by Pythia8 can be found in Pythia8 online manual
- * (http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html).
+ * This is a Pythia8-specific parton selector that selects all partons that don't have other partons as daughters, i.e., partons
+ * from the end of the parton showering sequence. An explanation of the particle status codes returned by Pythia8 can be found in
+ * Pythia8 online manual (http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html).
  */
 
 #include "PhysicsTools/JetMCAlgos/interface/Pythia8PartonSelector.h"
@@ -25,10 +25,20 @@ Pythia8PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & part
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
    {
      int status = it->status();
-     if( !(status==71 || status==72) ) continue;       // only accept status==71 or 72 particles
+     if( status==1 ) continue;                         // skip stable particles
+     if( status==2 ) continue;                         // skip decayed Standard Model hadrons and leptons
      if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
 
-     partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
+     // check if the parton has other partons as daughters
+     int nparton_daughters = 0;
+     for(unsigned i=0; i<it->numberOfDaughters(); ++i)
+     {
+       if( CandMCTagUtils::isParton( *(it->daughter(i)) ) )
+         ++nparton_daughters;
+     }
+
+     if( nparton_daughters==0 )
+       partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
    }
 
    return;

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -16,7 +16,7 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
         "keep abs(pdgId) == 23 || abs(pdgId) == 24 || abs(pdgId) == 25 || abs(pdgId) == 6 || abs(pdgId) == 37 ",   # keep VIP(articles)s
         "keep abs(pdgId) == 310 && abs(eta) < 2.5 && pt > 1 ",                                                     # keep K0
 # keep heavy flavour quarks for parton-based jet flavour
-	"keep (4 <= abs(pdgId) <= 5) & (status = 2 || status = 11 || status = 71 || status = 72)",
+	"keep (4 <= abs(pdgId) <= 5)",
 # keep light-flavour quarks and gluons for parton-based jet flavour
 	"keep (1 <= abs(pdgId) <= 3 || pdgId = 21) & (status = 2 || status = 11 || status = 71 || status = 72) && pt>5", 
 # keep b and c hadrons for hadron-based jet flavour


### PR DESCRIPTION
This is a follow up to #10751, #11076, and #11501 where the hadron- and parton-based jet flavors were decoupled. This led to the realization that the parton selection for Pythia8 was not inclusive enough and in particular was failing to pick up some of the b and c quarks, resulting in spoiled b-tag performance curves in the b-tag DQM.

In addition, the selection of b and c quarks for MiniAOD was updated by dropping any selection based on the particle status code. The increase in the MiniAOD size resulting from this PR was tested by making MiniAOD from /RelValTTbar_13/CMSSW_7_6_0_pre5-76X_mcRun2_asymptotic_v1-v1/GEN-SIM-RECO and was found to be small (~0.9%).

**Update (Oct. 5, 2015):** More details in the following presentation https://indico.cern.ch/event/449888/contribution/5/attachments/1164881/1679186/FlavourValidation.pdf shown in the b-tag meeting on Oct. 5
