### PR TITLE
Add L1 copad collection and ME0 validation on valid.

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/gemCustom.py
+++ b/SLHCUpgradeSimulations/Configuration/python/gemCustom.py
@@ -27,7 +27,7 @@ def customise_L1simulation(process):
   process.simCscTriggerPrimitiveDigis.commonParam.isSLHC = True
   process.simCscTriggerPrimitiveDigis.commonParam.smartME1aME1b = True
 
-  from Validation.MuonGEMDigis.MuonGEMDigis_cfi import me11tmbSLHCGEM
+  from Validation.MuonGEMDigis.MuonGEMDigis_cff import me11tmbSLHCGEM
   process.simCscTriggerPrimitiveDigis.commonParam.runME11ILT = cms.bool(True)
   process.simCscTriggerPrimitiveDigis.me11tmbSLHCGEM = me11tmbSLHCGEM
   process.simCscTriggerPrimitiveDigis.clctSLHC.clctNplanesHitPattern = 3
@@ -35,7 +35,7 @@ def customise_L1simulation(process):
   process.simCscTriggerPrimitiveDigis.clctParam07.clctPidThreshPretrig = 2
   process.simCscTriggerPrimitiveDigis.GEMPadDigiProducer = "simMuonGEMPadDigis"
 
-  from Validation.MuonGEMDigis.MuonGEMDigis_cfi import me21tmbSLHCGEM
+  from Validation.MuonGEMDigis.MuonGEMDigis_cff import me21tmbSLHCGEM
   process.simCscTriggerPrimitiveDigis.commonParam.runME21ILT = cms.bool(True)
   process.simCscTriggerPrimitiveDigis.me21tmbSLHCGEM = me21tmbSLHCGEM
   ## ME21 has its own SLHC processors

--- a/SLHCUpgradeSimulations/Configuration/python/gemCustom.py
+++ b/SLHCUpgradeSimulations/Configuration/python/gemCustom.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 def customise2023(process):
   if hasattr(process,'digitisation_step') :
     process=customise_digitization(process)
+  if hasattr(process, 'L1simulation_step') :
+    process=customise_L1simulation(process)
   if hasattr(process,'dqmHarvesting'):
     process=customise_harvesting(process)
   if hasattr(process,'validation_step'):
@@ -17,9 +19,39 @@ def customise_digitization(process):
       process.simMuonME0Digis.mixLabel = cms.string("mix")
   return process
 
+def customise_L1simulation(process):
+  if (not hasattr(process, 'caloConfigSource')) :
+    process.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
+  from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi import cscTriggerPrimitiveDigis
+  process.simCscTriggerPrimitiveDigis = cscTriggerPrimitiveDigis
+  process.simCscTriggerPrimitiveDigis.commonParam.isSLHC = True
+  process.simCscTriggerPrimitiveDigis.commonParam.smartME1aME1b = True
+
+  from Validation.MuonGEMDigis.MuonGEMDigis_cfi import me11tmbSLHCGEM
+  process.simCscTriggerPrimitiveDigis.commonParam.runME11ILT = cms.bool(True)
+  process.simCscTriggerPrimitiveDigis.me11tmbSLHCGEM = me11tmbSLHCGEM
+  process.simCscTriggerPrimitiveDigis.clctSLHC.clctNplanesHitPattern = 3
+  process.simCscTriggerPrimitiveDigis.clctSLHC.clctPidThreshPretrig = 2
+  process.simCscTriggerPrimitiveDigis.clctParam07.clctPidThreshPretrig = 2
+  process.simCscTriggerPrimitiveDigis.GEMPadDigiProducer = "simMuonGEMPadDigis"
+
+  from Validation.MuonGEMDigis.MuonGEMDigis_cfi import me21tmbSLHCGEM
+  process.simCscTriggerPrimitiveDigis.commonParam.runME21ILT = cms.bool(True)
+  process.simCscTriggerPrimitiveDigis.me21tmbSLHCGEM = me21tmbSLHCGEM
+  ## ME21 has its own SLHC processors
+  process.simCscTriggerPrimitiveDigis.alctSLHCME21 = process.simCscTriggerPrimitiveDigis.alctSLHC.clone()
+  process.simCscTriggerPrimitiveDigis.clctSLHCME21 = process.simCscTriggerPrimitiveDigis.clctSLHC.clone()
+  process.simCscTriggerPrimitiveDigis.alctSLHCME21.alctNplanesHitPattern = 3
+  #process.simCscTriggerPrimitiveDigis.alctSLHCME21.runME21ILT = cms.bool(True)
+  process.simCscTriggerPrimitiveDigis.clctSLHCME21.clctNplanesHitPattern = 3
+  process.simCscTriggerPrimitiveDigis.clctSLHCME21.clctPidThreshPretrig = 2
+  return process
+
 def customise_Validation(process):
   process.load('Validation.MuonGEMHits.gemSimValid_cff')
   process.genvalid_all += process.gemSimValid
+  if ( hasattr(process,"me0SimValid") ) :
+    process.genvalid_all += process.me0SimValid
   return process
 
 def customise_harvesting(process):


### PR DESCRIPTION
1. Enable to L1 copad collection's validation
   - As default option, L1 copad validatior can not work due to lack configurations.
     This PR can support SLHC option to enable GEM GE11, GE21 MainBoard class. 
   - This option should be replaced by cmsDriver's "--era" option.However, "--era" is not updated for long time.
2. Add ME0 Validation step on gemCustom.
   - To run ME0 validatiors with GEM's ones are required for developer.
