### PR TITLE
Splitted HT category into CaloHT and PFHT categories. Added paths that are removde JetIdCleaned suffix (MonoJet, PhotonMET,and PureMET). Optimized binning of sumEt plot in MonoJet category. Added new paths in PFHT category.

### DIFF
--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -174,6 +174,7 @@ private:
     StringCutObjectSelector<reco::PFMET>       * _recPFMHTSelector;
     StringCutObjectSelector<reco::GenMET>      * _genMETSelector;
     StringCutObjectSelector<reco::CaloMET>     * _recCaloMETSelector;
+    StringCutObjectSelector<reco::CaloMET>     * _recCaloMHTSelector;
     StringCutObjectSelector<l1extra::L1EtMissParticle> * _l1METSelector;
     StringCutObjectSelector<reco::PFTau>       * _recPFTauSelector;
     StringCutObjectSelector<reco::Photon>      * _recPhotonSelector;

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -76,6 +76,7 @@ public:
     ~HLTExoticaSubAnalysis();
     void beginJob();
     void beginRun(const edm::Run & iRun, const edm::EventSetup & iEventSetup);
+    void endRun();
 
     /// Method to book all relevant histograms in the DQMStore.
     /// Uses the IBooker interface for thread safety.
@@ -150,6 +151,10 @@ private:
     std::vector<double> _parametersTurnOnSumEt;
     std::vector<double> _parametersDxy;
 
+    // flag to switch off
+    bool _drop_pt2;
+    bool _drop_pt3;
+
     /// gen/rec objects cuts
     std::map<unsigned int, std::string> _genCut;
     std::map<unsigned int, std::string> _recCut;
@@ -169,6 +174,7 @@ private:
     StringCutObjectSelector<reco::PFMET>       * _recPFMHTSelector;
     StringCutObjectSelector<reco::GenMET>      * _genMETSelector;
     StringCutObjectSelector<reco::CaloMET>     * _recCaloMETSelector;
+    StringCutObjectSelector<reco::CaloMET>     * _recCaloMHTSelector;
     StringCutObjectSelector<l1extra::L1EtMissParticle> * _l1METSelector;
     StringCutObjectSelector<reco::PFTau>       * _recPFTauSelector;
     StringCutObjectSelector<reco::Photon>      * _recPhotonSelector;
@@ -177,6 +183,9 @@ private:
 
     /// The plotters: managers of each hlt path where the plots are done
     std::vector<HLTExoticaPlotter> _plotters;
+
+    /// counting HLT passed events  
+    std::map<std::string,int> _triggerCounter;
 
     /// Interface to the HLT information
     HLTConfigProvider _hltConfig;

--- a/HLTriggerOffline/Exotica/python/ExoticaValidation_cff.py
+++ b/HLTriggerOffline/Exotica/python/ExoticaValidation_cff.py
@@ -42,8 +42,18 @@ recoExoticaValidationMHTNoMu = cms.EDProducer(
     excludePFMuons = cms.bool( True )
     )   
 
+recoExoticaValidationCaloHT = cms.EDProducer(
+    "CaloMETProducer",
+    src = cms.InputTag("ak4CaloJets"),
+    noHF = cms.bool(True),
+    alias = cms.string('CaloMHT'),
+    globalThreshold = cms.double(30.0),
+    calculateSignificance = cms.bool(False),
+    jets = cms.InputTag("ak4CaloJets") # for significance calculation
+    )
+
 ExoticaValidationProdSeq = cms.Sequence(
-    recoExoticaValidationHT + recoExoticaValidationMETNoMu + recoExoticaValidationMHTNoMu
+    recoExoticaValidationHT + recoExoticaValidationMETNoMu + recoExoticaValidationMHTNoMu + recoExoticaValidationCaloHT
     )
 
 ExoticaValidationSequence = cms.Sequence(

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+CaloHTPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_HT900_v",         # Run2
+        "HLT_HT300_v",         # Run2
+        "HLT_ECALHT800_v",     # Run2 7e33
+        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
+        "HLT_HT650_v",           
+        "HLT_HT450to470_v",        # HT Parking
+        "HLT_HT470to500_v",        # HT Parking
+        "HLT_HT500to550_v",        # HT Parking
+        "HLT_HT550to650_v",        # HT Parking
+        "DST_HT250_CaloScouting_v", # scouting
+        "DST_CaloJet40_CaloScouting_v",
+        "DST_L1HTT125ORHTT150ORHTT175_CaloScouting_v"
+        ),
+    recCaloMHTLabel  = cms.InputTag("recoExoticaValidationCaloHT"),
+    recCaloJetLabel  = cms.InputTag("ak4CaloJets"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(1),
+    # -- Analysis specific binnings
+    parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 470, 
+                                   500, 550, 600, 650, 700, 800, 900, 1000
+                                   )
+)

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+CaloHTPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_HT900_v",         # Run2
+        "HLT_HT300_v",         # Run2
+        "HLT_ECALHT800_v",     # Run2 7e33
+        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
+        "HLT_HT650_v",           
+        "HLT_HT450to470_v",        # HT Parking
+        "HLT_HT470to500_v",        # HT Parking
+        "HLT_HT500to550_v",        # HT Parking
+        "HLT_HT550to650_v",        # HT Parking
+        "DST_HT250_CaloScouting_v", # scouting
+        "DST_CaloJet40_CaloScouting_v",
+        "DST_L1HT_CaloScouting_v"
+        ),
+    recCaloMHTLabel  = cms.InputTag("recoExoticaValidationCaloHT"),
+    recCaloJetLabel  = cms.InputTag("ak4CaloJets"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(1),
+    # -- Analysis specific binnings
+    parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 470, 
+                                   500, 550, 600, 650, 700, 800, 900, 1000
+                                   )
+)

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
@@ -13,7 +13,7 @@ CaloHTPSet = cms.PSet(
         "HLT_HT550to650_v",        # HT Parking
         "DST_HT250_CaloScouting_v", # scouting
         "DST_CaloJet40_CaloScouting_v",
-        "DST_L1HT_CaloScouting_v"
+        "DST_L1HTT125ORHTT150ORHTT175_CaloScouting_v"
         ),
     recCaloMHTLabel  = cms.InputTag("recoExoticaValidationCaloHT"),
     recCaloJetLabel  = cms.InputTag("ak4CaloJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
@@ -2,14 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 MonojetPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        #"HLT_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v", 
+        "HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v",
+        "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v",
+        "HLT_MET200_v",
+        "HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v",
+        "HLT_MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_IDTight_v",
+
+        # For backward compatibility
         "HLT_PFMETNoMu90_JetIdCleaned_PFMHTNoMu90_IDTight_v",
-        #"HLT_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v", 
         "HLT_PFMETNoMu120_JetIdCleaned_PFMHTNoMu120_IDTight_v",
         "HLT_MET200_JetIdCleaned_v",
-        #"HLT_MonoCentralPFJet80_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v",
         "HLT_MonoCentralPFJet80_PFMETNoMu120_JetIdCleaned_PFMHTNoMu120_IDTight_v",
-        #"HLT_MonoCentralPFJet80_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v"
         "HLT_MonoCentralPFJet80_PFMETNoMu90_JetIdCleaned_PFMHTNoMu90_IDTight_v"
     ),
 
@@ -33,6 +36,11 @@ MonojetPSet = cms.PSet(
                                     320, 340, 360, 380, 400,
                                     420, 440, 460, 480, 500,600,700,800,900,1100,1200,
                                     1400,1600,1800,2000,2200,2400,2600,2800,3000),
+
+    parametersTurnOnSumEt = cms.vdouble(    0,  100,  200,  300,  400,  500,  600,  700,  800,  900,
+                                         1000, 1100, 1200, 1300, 1400, 1500
+                                       ),
+
     dropPt2 = cms.bool(True),
     dropPt3 = cms.bool(True),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
@@ -10,9 +10,9 @@ PFHTPSet = cms.PSet(
         "HLT_PFHT550_4Jet_v", # Run2
         "HLT_PFHT800_v",
         "HLT_PFHT650_v",
-        "DST_HT450_PFScouting_v",
-        "DST_L1HT_PFScouting_v",
-        "DST_CaloJet40_PFScouting_v"
+        "DST_HT450_PFReco_PFBTagCSVReco_PFScouting_v",
+        "DST_L1HTT125ORHTT150ORHTT175_PFReco_PFBTagCSVReco_PFScouting_v",
+        "DST_CaloJet40_PFReco_PFBTagCSVReco_PFScouting_v"
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
@@ -1,32 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-HTPSet = cms.PSet(
+PFHTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v",
         "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v",
-        #"HLT_PFHT750_4Jet_v", # Run2
         "HLT_PFHT750_4Jet_v",
+        "HLT_PFHT550_4JetPt50_v",
+        "HLT_PFHT650_4JetPt50_v",
+        "HLT_PFHT750_4JetPt50_v",
         "HLT_PFHT650_4Jet_v", # Run2
         "HLT_PFHT550_4Jet_v", # Run2
-        #"HLT_PFHT900_v",      # Run2
         "HLT_PFHT800_v",
         "HLT_PFHT650_v",
-        "HLT_HT900_v",        # Run2
-        "HLT_HT300_v",        # Run2
-        "HLT_HT450to470_v",        # HT Parking
-        "HLT_HT470to500_v",        # HT Parking
-        "HLT_HT500to550_v",        # HT Parking
-        "HLT_HT550to650_v",        # HT Parking
-        "HLT_HT650_v",        # HT Parking
-        "HLT_ECALHT800_v",     # Run2 7e33
-        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
-        #"HLT_HT750_v"        # Run1 (frozenHLT)
+        "DST_HT450_PFReco_PFBTagCSVReco_PFScouting_v",
+        "DST_L1HTT125ORHTT150ORHTT175_PFReco_PFBTagCSVReco_PFScouting_v",
+        "DST_CaloJet40_PFReco_PFBTagCSVReco_PFScouting_v"
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),
     # -- Analysis specific cuts
-    MET_genCut      = cms.string("sumEt > 75"),
-    MET_recCut      = cms.string("sumEt > 75"),
+    #MET_genCut      = cms.string("sumEt > 75"),
+    #MET_recCut      = cms.string("sumEt > 75"),
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 470, 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
@@ -1,32 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-HTPSet = cms.PSet(
+PFHTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v",
         "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v",
-        #"HLT_PFHT750_4Jet_v", # Run2
-        "HLT_PFHT750_4Jet_Pt50_v",
+        "HLT_PFHT750_4Jet_v",
+        "HLT_PFHT750_4JetPt50_v",
         "HLT_PFHT650_4Jet_v", # Run2
         "HLT_PFHT550_4Jet_v", # Run2
-        #"HLT_PFHT900_v",      # Run2
         "HLT_PFHT800_v",
         "HLT_PFHT650_v",
-        "HLT_HT900_v",        # Run2
-        "HLT_HT300_v",        # Run2
-        "HLT_HT450to470_v",        # HT Parking
-        "HLT_HT470to500_v",        # HT Parking
-        "HLT_HT500to550_v",        # HT Parking
-        "HLT_HT550to650_v",        # HT Parking
-        "HLT_HT650_v",        # HT Parking
-        "HLT_ECALHT800_v",     # Run2 7e33
-        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
-        #"HLT_HT750_v"        # Run1 (frozenHLT)
+        "DST_HT450_PFScouting_v",
+        "DST_L1HT_PFScouting_v",
+        "DST_CaloJet40_PFScouting_v"
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),
     # -- Analysis specific cuts
-    MET_genCut      = cms.string("sumEt > 75"),
-    MET_recCut      = cms.string("sumEt > 75"),
+    #MET_genCut      = cms.string("sumEt > 75"),
+    #MET_recCut      = cms.string("sumEt > 75"),
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 470, 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPhotonMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPhotonMET_cff.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 PhotonMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        #"HLT_Photon135_PFMET100_NoiseCleaned_v"
-        "HLT_Photon135_PFMET100_JetIdCleaned_v",
+        "HLT_Photon135_PFMET100_v",
+        "HLT_Photon135_PFMET100_JetIdCleaned_v", # For backward compatibility
         "HLT_Photon125_v" # 0T
         ),
     recPFMETLabel  = cms.InputTag("pfMet"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
@@ -4,8 +4,14 @@ PureMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_PFMET170_v",
         "HLT_PFMET170_HBHECleaned_v",
-        "HLT_PFMET170_JetIdCleaned_v",
+        "HLT_PFMET170_v",
         "HLT_PFMET170_NoiseCleaned_v",  # Run2
+        "HLT_MET200_v",
+        "HLT_MET100_v",    # 0T
+        "HLT_MET150_v",    # 0T
+
+        # For backward compatibility
+        "HLT_PFMET170_JetIdCleaned_v",  
         "HLT_MET200_JetIdCleaned_v",
         "HLT_MET100_JetIdCleaned_v",    # 0T
         "HLT_MET150_JetIdCleaned_v"     # 0T

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -71,7 +71,7 @@ plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "E
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
 obj_types  = ["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet"
-             ,"CaloMET","l1MET"]
+             ,"CaloMET","CaloMHT","l1MET"]
 #--- IMPORTANT: Trigger are extracted from the hltExoticaValidator_cfi.py module
 triggers = [ ] 
 efficiency_strings = []
@@ -138,9 +138,13 @@ hltExoticaPostSingleMuon = hltExoticaPostProcessor.clone()
 hltExoticaPostSingleMuon.subDirs = ['HLT/Exotica/SingleMuon']
 hltExoticaPostSingleMuon.efficiencyProfile = efficiency_strings
 
-hltExoticaPostHT = hltExoticaPostProcessor.clone()
-hltExoticaPostHT.subDirs = ['HLT/Exotica/HT']
-hltExoticaPostHT.efficiencyProfile = efficiency_strings
+hltExoticaPostPFHT = hltExoticaPostProcessor.clone()
+hltExoticaPostPFHT.subDirs = ['HLT/Exotica/PFHT']
+hltExoticaPostPFHT.efficiencyProfile = efficiency_strings
+
+hltExoticaPostCaloHT = hltExoticaPostProcessor.clone()
+hltExoticaPostCaloHT.subDirs = ['HLT/Exotica/CaloHT']
+hltExoticaPostCaloHT.efficiencyProfile = efficiency_strings
 
 hltExoticaPostJetNoBptx = hltExoticaPostProcessor.clone()
 hltExoticaPostJetNoBptx.subDirs = ['HLT/Exotica/JetNoBptx']
@@ -209,7 +213,8 @@ hltExoticaPostProcessors = cms.Sequence(
     hltExoticaPostHighPtPhoton +
     hltExoticaPostDiPhoton +
     # HT path
-    hltExoticaPostHT +
+    hltExoticaPostPFHT +
+    hltExoticaPostCaloHT +
     # NoBptx paths
     hltExoticaPostJetNoBptx +
     hltExoticaPostMuonNoBptx +

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -23,7 +23,8 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtElectron_cff    import Hi
 #from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtElectron_cff     import LowPtElectronPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtPhoton_cff      import HighPtPhotonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDiPhoton_cff          import DiPhotonPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaHT_cff                import HTPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaPFHT_cff              import PFHTPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaCaloHT_cff            import CaloHTPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaJetNoBptx_cff         import JetNoBptxPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMuonNoBptx_cff        import MuonNoBptxPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedMuEG_cff     import DisplacedMuEGPSet
@@ -62,7 +63,8 @@ hltExoticaValidator = cms.EDAnalyzer(
         "SingleMuon",
         "JetNoBptx",
         "MuonNoBptx",
-        "HT",
+        "PFHT",
+        "CaloHT",
         "DisplacedMuEG",
         "DisplacedMuJet",
         "DisplacedDimuon",
@@ -178,6 +180,9 @@ hltExoticaValidator = cms.EDAnalyzer(
     CaloMET_genCut  = cms.string("pt > 75"),
     CaloMET_recCut  = cms.string("pt > 75"),
 
+    CaloMHT_genCut  = cms.string("pt > 75"),
+    CaloMHT_recCut  = cms.string("pt > 75"),  
+   
     hltMET_genCut   = cms.string("pt > 75"),
     hltMET_recCut   = cms.string("pt > 75"),  
    
@@ -219,7 +224,8 @@ hltExoticaValidator = cms.EDAnalyzer(
     METplusTrack     = METplusTrackPSet,                                 
     Monojet          = MonojetPSet,
     MonojetBackup    = MonojetBackupPSet,
-    HT               = HTPSet,
+    PFHT             = PFHTPSet,
+    CaloHT           = CaloHTPSet,
     #DisplacedDimuonDijet = DisplacedDimuonDijetPSet,
     EleMu            = EleMuPSet,
     PhotonMET        = PhotonMETPSet,

--- a/HLTriggerOffline/Exotica/src/EVTColContainer.cc
+++ b/HLTriggerOffline/Exotica/src/EVTColContainer.cc
@@ -59,6 +59,7 @@ struct EVTColContainer {
         L1MET   = 390004,
         PFJET   = 211,
         CALOJET = 111, 
+	CALOMHT = 400002,
         _nMAX
     };
 
@@ -75,6 +76,7 @@ struct EVTColContainer {
     const std::vector<reco::PFMET>               * pfMHTs;
     const std::vector<reco::GenMET>              * genMETs;
     const std::vector<reco::CaloMET>             * caloMETs;
+    const std::vector<reco::CaloMET>             * caloMHTs;
     const std::vector<l1extra::L1EtMissParticle> * l1METs;
     const std::vector<reco::PFTau>               * pfTaus;
     const std::vector<reco::PFJet>               * pfJets;
@@ -95,6 +97,7 @@ struct EVTColContainer {
         pfMHTs(0),
         genMETs(0),
         caloMETs(0),
+        caloMHTs(0),
         l1METs(0),
         pfTaus(0),
         pfJets(0),
@@ -128,6 +131,7 @@ struct EVTColContainer {
         pfMHTs = 0;
         genMETs = 0;
         caloMETs = 0;
+        caloMHTs = 0;
         l1METs = 0;
         pfTaus = 0;
         pfJets = 0;
@@ -182,6 +186,11 @@ struct EVTColContainer {
         caloMETs = v;
         ++nInitialized;
     }
+    void setCaloMHT(const reco::CaloMETCollection * v)
+    {
+        caloMHTs = v;
+        ++nInitialized;
+    }
     void set(const l1extra::L1EtMissParticleCollection * v)
     {
         l1METs = v;
@@ -227,6 +236,8 @@ struct EVTColContainer {
             size = genMETs->size();
         } else if (objtype == EVTColContainer::CALOMET && caloMETs != 0) {
             size = caloMETs->size();
+        } else if (objtype == EVTColContainer::CALOMHT && caloMHTs != 0) {
+            size = caloMHTs->size();
         } else if (objtype == EVTColContainer::L1MET && l1METs != 0) {
             size = l1METs->size();
         } else if (objtype == EVTColContainer::PFTAU && pfTaus != 0) {
@@ -265,6 +276,8 @@ struct EVTColContainer {
             objTypestr = "GenMET";
         } else if (objtype == EVTColContainer::CALOMET) {
             objTypestr = "CaloMET";
+        } else if (objtype == EVTColContainer::CALOMHT) {
+            objTypestr = "CaloMHT";
         } else if (objtype == EVTColContainer::L1MET) {
             objTypestr = "l1MET";
         } else if (objtype == EVTColContainer::PFTAU) {


### PR DESCRIPTION
Solved a conflict at #11152 (Splitted HT category into CaloHT and PFHT categories.)
Included the changes of #11596 and #11619.
