### PR TITLE
Fixes for phase1 workflow

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/Phase1PU70_preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/Phase1PU70_preDuplicateMergingGeneralTracks_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+import RecoTracker.FinalTrackSelectors.Phase1PU70_earlyGeneralTracks_cfi
+preDuplicateMergingGeneralTracks =  RecoTracker.FinalTrackSelectors.Phase1PU70_earlyGeneralTracks_cfi.earlyGeneralTracks.clone(
+    TrackProducers = cms.VInputTag(
+        cms.InputTag("earlyGeneralTracks"),
+        cms.InputTag("muonSeededTracksInOut"),
+        cms.InputTag("muonSeededTracksOutIn"),
+    ),
+    hasSelector = cms.vint32(0,1,1),
+    selectedTrackQuals = cms.VInputTag(
+        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"), # not used but needed
+        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"),
+        cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
+    ),
+    mvaValueTags = cms.VInputTag(
+        cms.InputTag("earlyGeneralTracks","MVAVals"),
+        cms.InputTag("muonSeededTracksInOutSelector","MVAVals"),
+        cms.InputTag("muonSeededTracksOutInSelector","MVAVals"),
+    ),
+    setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(True), tLists = cms.vint32(0, 1,2))),
+    FoundHitBonus  = 100.0,
+    LostHitPenalty =   1.0,
+)

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_iterativeTk_cff.py
@@ -7,8 +7,8 @@ from RecoTracker.IterativeTracking.Phase1PU140_LowPtTripletStep_cff import *
 from RecoTracker.IterativeTracking.Phase1PU140_DetachedQuadStep_cff import *
 from RecoTracker.IterativeTracking.Phase1PU140_PixelPairStep_cff import *
 from RecoTracker.FinalTrackSelectors.Phase1PU140_earlyGeneralTracks_cfi import *
-from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
-from RecoTracker.FinalTrackSelectors.preDuplicateMergingGeneralTracks_cfi import *
+from RecoTracker.IterativeTracking.Phase1PU70_MuonSeededStep_cff import *
+from RecoTracker.FinalTrackSelectors.Phase1PU70_preDuplicateMergingGeneralTracks_cfi import *
 from RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
 from RecoTracker.ConversionSeedGenerators.Phase1PU140_ConversionStep_cff import *
 

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_MuonSeededStep_cff.py
@@ -1,0 +1,219 @@
+import FWCore.ParameterSet.Config as cms
+
+###### Muon reconstruction module #####
+from RecoMuon.MuonIdentification.earlyMuons_cfi import earlyMuons
+
+###### SEEDER MODELS ######
+import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
+import RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi
+muonSeededSeedsOutIn = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
+    src = "earlyMuons",
+)
+muonSeededSeedsInOut = RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi.inOutSeedsFromTrackerMuons.clone(
+    src = "earlyMuons",
+)
+### This is also needed for seeding
+from RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi import hitCollectorForOutInMuonSeeds
+
+###### EVENT-SETUP STUFF #######
+###---------- Trajectory Cleaner, deciding how overlapping track candidates are arbitrated  ----------------
+import TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi
+muonSeededTrajectoryCleanerBySharedHits = TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi.trajectoryCleanerBySharedHits.clone(
+    ComponentName = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
+    fractionShared = cms.double(0.1),
+    ValidHitBonus = cms.double(1000.0),
+    MissingHitPenalty = cms.double(1.0),
+    ComponentType = cms.string('TrajectoryCleanerBySharedHits'),
+    allowSharedFirstHit = cms.bool(True)
+)
+
+###------------- MeasurementEstimator, defining the searcgh window for pattern recongnition ----------------
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+muonSeededMeasurementEstimatorForInOut = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('muonSeededMeasurementEstimatorForInOut'),
+    MaxChi2 = cms.double(400.0), ## was 30 ## TO BE TUNED
+    nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED
+)
+muonSeededMeasurementEstimatorForOutIn = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('muonSeededMeasurementEstimatorForOutIn'),
+    MaxChi2 = cms.double(30.0), ## was 30 ## TO BE TUNED
+    nSigma  = cms.double(3.),    ## was 3  ## TO BE TUNED
+)
+
+###------------- TrajectoryFilter, defining selections on the trajectories while building them ----------------
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+muonSeededTrajectoryFilterForInOut = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone()
+muonSeededTrajectoryFilterForInOut.constantValueForLostHitsFractionFilter = 10 ## allow more lost hits
+muonSeededTrajectoryFilterForInOut.minimumNumberOfHits = 3 ## allow more lost hits
+
+muonSeededTrajectoryFilterForOutIn = muonSeededTrajectoryFilterForInOut.clone()
+muonSeededTrajectoryFilterForOutIn.constantValueForLostHitsFractionFilter = 10 ## allow more lost hits
+muonSeededTrajectoryFilterForOutIn.minimumNumberOfHits = 5 ## allow more lost hits
+
+###------------- TrajectoryBuilders ----------------
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+muonSeededTrajectoryBuilderForInOut = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    foundHitBonus = cms.double(1000.0),
+    lostHitPenalty = cms.double(1.0),
+    maxCand   = cms.int32(5),
+    estimator = cms.string('muonSeededMeasurementEstimatorForInOut'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')),
+    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')), # not sure if it is used
+    minNrOfHitsForRebuild    = cms.int32(2),
+    requireSeedHitsInRebuild = cms.bool(True),
+    keepOriginalIfRebuildFails = cms.bool(True),
+)
+muonSeededTrajectoryBuilderForOutIn = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    foundHitBonus = cms.double(1000.0),
+    lostHitPenalty = cms.double(1.0),
+    maxCand   = cms.int32(3),
+    estimator = cms.string('muonSeededMeasurementEstimatorForOutIn'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')),
+    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')), # not sure if it is used
+    minNrOfHitsForRebuild    = cms.int32(5),
+    requireSeedHitsInRebuild = cms.bool(True),
+    keepOriginalIfRebuildFails = cms.bool(False),
+)
+
+###-------------  Fitter-Smoother -------------------
+import TrackingTools.TrackFitters.RungeKuttaFitters_cff
+muonSeededFittingSmootherWithOutliersRejectionAndRK = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
+    ComponentName = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
+    BreakTrajWith2ConsecutiveMissing = cms.bool(False),
+    EstimateCut = cms.double(50.), ## was 20.
+)
+
+######## TRACK CANDIDATE MAKERS
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+muonSeededTrackCandidatesInOut = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag("muonSeededSeedsInOut"),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string("muonSeededTrajectoryBuilderForInOut")),
+    TrajectoryCleaner = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
+    RedundantSeedCleaner = cms.string("none"),
+)
+muonSeededTrackCandidatesOutIn = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag("muonSeededSeedsOutIn"),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string("muonSeededTrajectoryBuilderForOutIn")),
+    TrajectoryCleaner = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(False),
+)
+
+######## TRACK PRODUCERS
+import RecoTracker.TrackProducer.TrackProducer_cfi
+muonSeededTracksOutIn = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = cms.InputTag("muonSeededTrackCandidatesOutIn"),
+    AlgorithmName = cms.string('muonSeededStepOutIn'),
+    Fitter = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
+)
+muonSeededTracksInOut = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = cms.InputTag("muonSeededTrackCandidatesInOut"),
+    AlgorithmName = cms.string('muonSeededStepInOut'),
+    Fitter = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
+)
+
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+muonSeededTracksInOutSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='muonSeededTracksInOut',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'muonSeededTracksInOutLoose',
+            applyAdaptedPVCuts = cms.bool(False),
+            chi2n_par = 10.0,
+            minNumberLayers = 3,
+            min_nhits = 5,
+            maxNumberLostLayers = 4,
+            minNumber3DLayers = 0,
+            minHitsToBypassChecks = 7
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'muonSeededTracksInOutTight',
+            preFilterName = 'muonSeededTracksInOutLoose',
+            applyAdaptedPVCuts = cms.bool(False),
+            chi2n_par = 1.0,
+            minNumberLayers = 5,
+            min_nhits = 6,
+            maxNumberLostLayers = 3,
+            minNumber3DLayers = 2,
+            minHitsToBypassChecks = 10
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'muonSeededTracksInOutHighPurity',
+            preFilterName = 'muonSeededTracksInOutTight',
+            applyAdaptedPVCuts = cms.bool(False),
+            chi2n_par = 0.4,
+            minNumberLayers = 5,
+            min_nhits = 7,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 2,
+            minHitsToBypassChecks = 20
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+muonSeededTracksOutInSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='muonSeededTracksOutIn',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'muonSeededTracksOutInLoose',
+            applyAdaptedPVCuts = cms.bool(False),
+            chi2n_par = 10.0,
+            minNumberLayers = 3,
+            min_nhits = 5,
+            maxNumberLostLayers = 4,
+            minNumber3DLayers = 0,
+            minHitsToBypassChecks = 7
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'muonSeededTracksOutInTight',
+            preFilterName = 'muonSeededTracksOutInLoose',
+            applyAdaptedPVCuts = cms.bool(False),
+            chi2n_par = 1.0,
+            minNumberLayers = 5,
+            min_nhits = 6,
+            maxNumberLostLayers = 3,
+            minNumber3DLayers = 2,
+            minHitsToBypassChecks = 10
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'muonSeededTracksOutInHighPurity',
+            preFilterName = 'muonSeededTracksOutInTight',
+            applyAdaptedPVCuts = cms.bool(False),
+            chi2n_par = 0.4,
+            minNumberLayers = 5,
+            min_nhits = 7,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 2,
+            minHitsToBypassChecks = 20
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+
+
+muonSeededStepCore = cms.Sequence(
+    muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut +
+    muonSeededSeedsOutIn + muonSeededTrackCandidatesOutIn + muonSeededTracksOutIn
+)
+muonSeededStepExtra = cms.Sequence(
+    muonSeededTracksInOutSelector +
+    muonSeededTracksOutInSelector
+)
+
+muonSeededStep = cms.Sequence(
+    earlyMuons +
+    muonSeededStepCore +
+    muonSeededStepExtra
+)
+
+
+##### MODULES FOR DEBUGGING ###############3
+muonSeededSeedsInOutAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src = cms.InputTag("muonSeededSeedsInOut"))
+muonSeededSeedsOutInAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src = cms.InputTag("muonSeededSeedsOutIn"))
+muonSeededTrackCandidatesInOutAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesInOut"))
+muonSeededTrackCandidatesOutInAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesOutIn"))
+muonSeededStepDebug = cms.Sequence(
+    muonSeededSeedsOutInAsTracks + muonSeededTrackCandidatesOutInAsTracks +
+    muonSeededSeedsInOutAsTracks + muonSeededTrackCandidatesInOutAsTracks
+)

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_iterativeTk_cff.py
@@ -9,8 +9,8 @@ from RecoTracker.IterativeTracking.Phase1PU70_MixedTripletStep_cff import *
 from RecoTracker.IterativeTracking.Phase1PU70_PixelPairStep_cff import *
 from RecoTracker.IterativeTracking.Phase1PU70_TobTecStep_cff import *
 from RecoTracker.FinalTrackSelectors.Phase1PU70_earlyGeneralTracks_cfi import *
-from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
-from RecoTracker.FinalTrackSelectors.preDuplicateMergingGeneralTracks_cfi import *
+from RecoTracker.IterativeTracking.Phase1PU70_MuonSeededStep_cff import *
+from RecoTracker.FinalTrackSelectors.Phase1PU70_preDuplicateMergingGeneralTracks_cfi import *
 from RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
 from RecoTracker.ConversionSeedGenerators.Phase1PU70_ConversionStep_cff import *
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -319,8 +319,11 @@ def customise_Reco(process,pileup):
 
     process.reconstruction.remove(process.castorreco)
     process.reconstruction.remove(process.CastorTowerReco)
+    process.reconstruction.remove(process.ak5CastorJets)
+    process.reconstruction.remove(process.ak5CastorJetID)
+    process.reconstruction.remove(process.ak7CastorJets)
     #process.reconstruction.remove(process.ak7BasicJets)
-    #process.reconstruction.remove(process.ak7CastorJetID)
+    process.reconstruction.remove(process.ak7CastorJetID)
 
     #the quadruplet merger configuration     
     process.load("RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff")

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -258,12 +258,31 @@ def customise_Reco(process,pileup):
     process.reconstruction_fromRECO.remove(tobTecStepTrackCandidates)
     process.reconstruction_fromRECO.remove(tobTecStepTracks)
 
+    # Yes, needs to be done twice for InOut...
+    process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededSeedsOutIn)
+    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesOutIn)
+    process.reconstruction_fromRECO.remove(process.muonSeededTracksOutIn)
+    # Why are these modules in this sequence (isn't iterTracking enough)?
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsInOut)
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededTrackCandidatesInOut)
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededTracksInOut)
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsOutIn)
+    process.muonSeededStepExtraDisplaced.remove(process.muonSeededTracksInOutClassifier)
+
     process.reconstruction_fromRECO.remove(process.convClusters)
     process.reconstruction_fromRECO.remove(process.convLayerPairs)
     process.reconstruction_fromRECO.remove(process.convStepSelector)
     process.reconstruction_fromRECO.remove(process.convTrackCandidates)
     process.reconstruction_fromRECO.remove(process.convStepTracks)
     process.reconstruction_fromRECO.remove(process.photonConvTrajSeedFromSingleLeg)
+
+    process.reconstruction_fromRECO.remove(process.preDuplicateMergingGeneralTracks)
 
     # Needed to make the loading of recoFromSimDigis_cff below to work
     process.InitialStepPreSplitting.remove(siPixelClusters)
@@ -283,6 +302,10 @@ def customise_Reco(process,pileup):
     del process.PixelLessStep
     del process.TobTecStep
     del process.earlyGeneralTracks
+    del process.muonSeededStep
+    del process.muonSeededStepCore
+    del process.muonSeededStepDebug
+    del process.muonSeededStepDebugDisplaced
     del process.ConvStep
     # add the correct tracking back in
     process.load("RecoTracker.Configuration.RecoTrackerPhase1PU"+str(nPU)+"_cff")
@@ -352,12 +375,14 @@ def customise_Reco(process,pileup):
     process.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = "pixelVertices"
     process.pixelPairStepSelector.vertices = "pixelVertices"
     process.tobTecStepSelector.vertices = "pixelVertices"
-    process.muonSeededTracksInOutClassifier.vertices = "pixelVertices"
-    process.muonSeededTracksOutInClassifier.vertices = "pixelVertices"
+    process.muonSeededTracksInOutSelector.vertices = "pixelVertices"
+    process.muonSeededTracksOutInSelector.vertices = "pixelVertices"
     process.duplicateTrackClassifier.vertices = "pixelVertices"
     process.convStepSelector.vertices = "pixelVertices"
     process.ak4CaloJetsForTrk.srcPVs = "pixelVertices"
-    
+    process.muonSeededTracksOutInDisplacedClassifier.vertices = "pixelVertices"
+    process.duplicateDisplacedTrackClassifier.vertices = "pixelVertices"
+
     # Make pixelTracks use quadruplets
     process.pixelTracks.SeedMergerPSet = cms.PSet(
         layerList = cms.PSet(refToPSet_ = cms.string('PixelSeedMergerQuadruplets')),
@@ -371,5 +396,11 @@ def customise_Reco(process,pileup):
     process.templates.DoLorentz=False
     process.templates.LoadTemplatesFromDB = cms.bool(False)
     process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
+
+    # This probably breaks badly the "displaced muon" reconstruction,
+    # but let's do it for now, until the upgrade tracking sequences
+    # are modernized
+    process.preDuplicateMergingDisplacedTracks.inputClassifiers.remove("muonSeededTracksInOutClassifier")
+    process.preDuplicateMergingDisplacedTracks.trackProducers.remove("muonSeededTracksInOut")
 
     return process


### PR DESCRIPTION
This PR fixes issues in the phase1 workflow `runTheMatrix.py --what upgrade -l 10000`. The changes are mainly to recover from #10373, and to remove the remaining CASTOR modules in reconstruction sequence (I guessed from the existing removals that this is the intention for now).

I also intentionally "broke" the "displaced muon reconstruction" (#7531) for Phase1 by taking InOut iteration out of its merger (technically it still should work but the results bad). It should be enabled again after the Phase1 tracking sequences are migrated to the new classifiers+mergers of #10373 (but I want to see the 76X-Phase1 tracking validated against 62X_SLHC Phase1 tracking before that).

Together with #11609 (GT update) this PR gets the reco step of upgrade wf 10000.0 to technically work on a DIGI step2.root produced with the earlier default GT (75X_upgrade2017_design_v1), but when using the same GT consistently, the reco step still fails. This failure is addressed separately in #11624.

Tested in 760pre6, no changes expected in Run1/2 workflows.

@rovere @VinInn @boudoul @venturia
