### PR TITLE
Migrate away from explicit comparisons of GeomDetEnumerators::PixelBarrel/PixelEndcap

### DIFF
--- a/CalibTracker/SiPixelESProducers/src/SiPixelCPEGenericDBErrorParametrization.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelCPEGenericDBErrorParametrization.cc
@@ -62,19 +62,16 @@ std::pair<float,float> SiPixelCPEGenericDBErrorParametrization::getError(const S
 	std::pair<float,float> element;
   std::pair<float,float> errors;
 	
-  switch (GeomDetEnumerators::subDetGeom[pixelPart])  // the _real_ subdetector enumerator is projected into the geometry subdetector enumerator
-        {
-		case GeomDetEnumerators::PixelBarrel:
-			element = std::pair<float,float>(index(1, sizex, alpha, beta, bigInX),  //1 -- Bx
-                          			       index(0, sizey, alpha, beta, bigInY)); //0 -- By
-			break;
-		case GeomDetEnumerators::PixelEndcap:
-			element = std::pair<float,float>(index(3, sizex, alpha, beta, bigInX),  //3 -- Fx
-                          				     index(2, sizey, alpha, beta, bigInY)); //2 -- Fy
-			break;
-		default:
-			throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError")
-				<< "Non-pixel detector type !!!" ;
+	if(!GeomDetEnumerators::isTrackerPixel(pixelPart))
+		throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError")
+			<< "Non-pixel detector type !!!" ;
+	if(GeomDetEnumerators::isBarrel(pixelPart)) {
+		element = std::pair<float,float>(index(1, sizex, alpha, beta, bigInX),  //1 -- Bx
+                          		       index(0, sizey, alpha, beta, bigInY)); //0 -- By
+	}
+	else {
+		element = std::pair<float,float>(index(3, sizex, alpha, beta, bigInX),  //3 -- Fx
+                          			     index(2, sizey, alpha, beta, bigInY)); //2 -- Fy
 	}
 	
 	if (bigInX && sizex == 1) errors.first  = element.first;
@@ -94,19 +91,16 @@ std::pair<float,float> SiPixelCPEGenericDBErrorParametrization::getError(GeomDet
 	std::pair<float,float> element;
   std::pair<float,float> errors;
 	
-  switch (GeomDetEnumerators::subDetGeom[pixelPart])  // the _real_ subdetector enumerator is projected into the geometry subdetector enumerator
-	{
-		case GeomDetEnumerators::PixelBarrel:
-			element = std::pair<float,float>(index(1, sizex, alpha, beta, bigInX),  //1 -- Bx
-                          			       index(0, sizey, alpha, beta, bigInY)); //0 -- By
-			break;
-		case GeomDetEnumerators::PixelEndcap:
-			element = std::pair<float,float>(index(3, sizex, alpha, beta, bigInX),  //3 -- Fx
-                          				     index(2, sizey, alpha, beta, bigInY)); //2 -- Fy
-			break;
-		default:
-			throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError")
-				<< "Non-pixel detector type !!!" ;
+	if(!GeomDetEnumerators::isTrackerPixel(pixelPart))
+		throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError")
+			<< "Non-pixel detector type !!!" ;
+	if(GeomDetEnumerators::isBarrel(pixelPart)) {
+		element = std::pair<float,float>(index(1, sizex, alpha, beta, bigInX),  //1 -- Bx
+                          		       index(0, sizey, alpha, beta, bigInY)); //0 -- By
+	}
+	else {
+		element = std::pair<float,float>(index(3, sizex, alpha, beta, bigInX),  //3 -- Fx
+                          			     index(2, sizey, alpha, beta, bigInY)); //2 -- Fy
 	}
 	
 	if (bigInX && sizex == 1) errors.first  = element.first;

--- a/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
@@ -50,7 +50,11 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
   thePixelResolutionFile1=0;
   thePixelResolutionFile2=0;
 
-  if( thePixelPart == GeomDetEnumerators::PixelBarrel ) {
+  if(!GeomDetEnumerators::isTrackerPixel(thePixelPart))
+     throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm :")
+       <<"Not a pixel detector"<<endl;
+
+  if( GeomDetEnumerators::isBarrel(thePixelPart) ) {
      isForward = false;
      thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelBarrelResolutionFile1" );
      thePixelResolutionFile1 = new 
@@ -71,8 +75,7 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
      cout<<"The Barrel map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
 #endif
   }
-  else
-  if ( thePixelPart == GeomDetEnumerators::PixelEndcap ) {
+  else {
      isForward = true;
      thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelForwardResolutionFile" );
      thePixelResolutionFile1 = new
@@ -90,9 +93,6 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
      cout<<"The Forward map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
 #endif
   }
-  else
-     throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm :")
-       <<"Not a pixel detector"<<endl;
 
   if ( thePixelResolutionFile2) {
     thePixelResolutionFile2->Close();

--- a/Geometry/CommonDetUnit/test/BuildFile.xml
+++ b/Geometry/CommonDetUnit/test/BuildFile.xml
@@ -3,3 +3,6 @@
   <use   name="DataFormats/DetId"/>
   <use   name="boost"/>
 </bin>
+<bin   file="testGeomDetEnumerators.cpp" name="testGeomDetEnumerators">
+  <use   name="Geometry/CommonDetUnit"/>
+</bin>

--- a/Geometry/CommonDetUnit/test/testGeomDetEnumerators.cpp
+++ b/Geometry/CommonDetUnit/test/testGeomDetEnumerators.cpp
@@ -1,0 +1,23 @@
+#include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
+
+#include <iostream>
+
+int main(void) {
+  // Test that each SubDetector is either barrel or endcap
+
+  bool success = true;
+  for(int subdetRaw = GeomDetEnumerators::PixelBarrel; subdetRaw != GeomDetEnumerators::invalidDet; ++subdetRaw) {
+    auto subdet = static_cast<GeomDetEnumerators::SubDetector>(subdetRaw);
+    if(!(GeomDetEnumerators::isBarrel(subdet) || GeomDetEnumerators::isEndcap(subdet))) {
+      success = false;
+      std::cout << "GeomDetEnumerator::SubDetector " << subdet << " (" << subdetRaw << ") is not barrel or endcap!";
+    }
+    if(GeomDetEnumerators::isBarrel(subdet) && GeomDetEnumerators::isEndcap(subdet)) {
+      success = false;
+      std::cout << "GeomDetEnumerator::SubDetector " << subdet << " (" << subdetRaw << ") is both barrel and endcap!";
+    }
+  }
+
+
+  return success ? 0 : 1;
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelMatchNextLayers.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelMatchNextLayers.cc
@@ -56,10 +56,10 @@ PixelMatchNextLayers::PixelMatchNextLayers(const LayerMeasurements * theLayerMea
     {    
       for (std::vector<const DetLayer*>::const_iterator il = allayers.begin(); il != allayers.end(); il++) 
 	{
-	  if ( (*il)->subDetector()==GeomDetEnumerators::PixelBarrel || (*il)->subDetector()==GeomDetEnumerators::PixelEndcap ) {
+	  if ( GeomDetEnumerators::isTrackerPixel((*il)->subDetector()) ) {
 	    
 	    std::vector<TrajectoryMeasurement> pixelMeasurements;
-	    if ((*il)->subDetector()==GeomDetEnumerators::PixelBarrel) {
+	    if (GeomDetEnumerators::isBarrel((*il)->subDetector())) {
 	      pixelMeasurements = theLayerMeasurements->measurements( **il, tsos , *aProp, *aBarrelMeas); 
 	    } else {
 	      pixelMeasurements = theLayerMeasurements->measurements( **il, tsos, *aProp, *aForwardMeas);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -694,8 +694,9 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
     // This are the simple errors, hardcoded in the code 
     //cout << "Track angles are not known " << endl; 
     //cout << "Default angle estimation which assumes track from PV (0,0,0) does not work." << endl;
-      
-    if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel || theDetParam.thePart == GeomDetEnumerators::P1PXB )  {
+
+    if ( GeomDetEnumerators::isTrackerPixel(theDetParam.thePart) ) {
+     if(GeomDetEnumerators::isBarrel(theDetParam.thePart)) {
 
       DetId id = (theDetParam.theDet->geographicalId());
       int layer=ttopo_.layer(id);
@@ -721,9 +722,7 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
 	}
       }
 
-    } else if ( theDetParam.thePart == GeomDetEnumerators::PixelEndcap || 
-		theDetParam.thePart == GeomDetEnumerators::P1PXEC  ||
-		theDetParam.thePart == GeomDetEnumerators::P2PXEC )  { // EndCap
+     } else { // EndCap
 
       if ( !edgex ) {
 	if ( sizex<=xerr_endcap_.size() ) xerr=xerr_endcap_[sizex-1];
@@ -734,7 +733,8 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
 	if ( sizey<=yerr_endcap_.size() ) yerr=yerr_endcap_[sizey-1];
 	else yerr=yerr_endcap_def_;
       }
-    } // end endcap
+     } // end endcap
+    }
 
     if(inflate_errors) {
       int n_bigx = 0;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -118,11 +118,11 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
 
   ClusterParamTemplate & theClusterParam = static_cast<ClusterParamTemplate &>(theClusterParamBase);
 
-  bool fpix;  //  barrel(false) or forward(true)
-  if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel )   
-    fpix = false;    // no, it's not forward -- it's barrel
-  else                                              
-    fpix = true;     // yes, it's forward
+  if(!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
+    throw cms::Exception("PixelCPETemplateReco::localPosition :")
+      << "A non-pixel detector type in here?";
+  //  barrel(false) or forward(true)
+  const bool fpix = GeomDetEnumerators::isEndcap(theDetParam.thePart);
   
   int ID = -9999;
   if ( LoadTemplatesFromDB_ ) {
@@ -252,13 +252,10 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       // In the x case, apply a rough Lorentz drift average correction
       // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
       float lorentz_drift = -999.9;
-      if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel )
+      if ( !fpix )
 	lorentz_drift = 60.0f; // in microns
-      else if ( theDetParam.thePart == GeomDetEnumerators::PixelEndcap )
+      else
 	lorentz_drift = 10.0f; // in microns
-      else 
-	throw cms::Exception("PixelCPETemplateReco::localPosition :") 
-	  << "A non-pixel detector type in here?" << "\n";
       // ggiurgiu@jhu.edu, 21/09/2010 : trk angles needed to correct for bows/kinks
       if ( theClusterParam.with_track_angle )
 	{
@@ -318,13 +315,10 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
 	  // In the x case, apply a rough Lorentz drift average correction
 	  // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
 	  float lorentz_drift = -999.9f;
-	  if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel )
+	  if ( !fpix )
 	    lorentz_drift = 60.0f; // in microns
-	  else if ( theDetParam.thePart == GeomDetEnumerators::PixelEndcap )
+	  else
 	    lorentz_drift = 10.0f; // in microns
-	  else 
-	    throw cms::Exception("PixelCPETemplateReco::localPosition :") 
-	      << "A non-pixel detector type in here?" << "\n";
 
 	  // ggiurgiu@jhu.edu, 12/09/2010 : trk angles needed to correct for bows/kinks
 	  if ( theClusterParam.with_track_angle )
@@ -507,20 +501,22 @@ PixelCPETemplateReco::localError(DetParam const & theDetParam,  ClusterParam & t
 	  // corrected in x by average Lorentz drift. Assign huge errors.
 	  //xerr = 10.0 * (float)theClusterParam.theCluster->sizeX() * xerr;
 	  //yerr = 10.0 * (float)theClusterParam.theCluster->sizeX() * yerr;
+
+          if(!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
+            throw cms::Exception("PixelCPETemplateReco::localPosition :")
+              << "A non-pixel detector type in here?";
 	  
 	  // Assign better errors based on the residuals for failed template cases
-	  if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel )
+	  if ( GeomDetEnumerators::isBarrel(theDetParam.thePart) )
 	    {
 	      xerr = 55.0f * micronsToCm;
 	      yerr = 36.0f * micronsToCm;
 	    }
-	  else if ( theDetParam.thePart == GeomDetEnumerators::PixelEndcap )
+	  else
 	    {
 	      xerr = 42.0f * micronsToCm;
 	      yerr = 39.0f * micronsToCm;
 	    }
-	  else 
-	    throw cms::Exception("PixelCPETemplateReco::localError :") << "A non-pixel detector type in here?" ;
 
 	  //cout << "xerr = " << xerr << endl;
 	  //cout << "yerr = " << yerr << endl;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
@@ -160,7 +160,7 @@ void TSGForRoadSearch::makeSeeds_0(const reco::Track & muon, std::vector<Traject
 
   //loop the parts until at least a compatible is found
   while (compatible.size()==0) {
-    switch ( inLayer->subDetector() ) {
+    switch ( GeomDetEnumerators::subDetGeom[inLayer->subDetector()] ) {
     case GeomDetEnumerators::PixelBarrel:
     case GeomDetEnumerators::PixelEndcap:
     case GeomDetEnumerators::TOB:
@@ -251,7 +251,7 @@ void TSGForRoadSearch::makeSeeds_3(const reco::Track & muon, std::vector<Traject
 
   //loop the parts until at least a compatible is found
   while (compatible.size()==0) {
-    switch ( inLayer->subDetector() ) {
+    switch ( GeomDetEnumerators::subDetGeom[inLayer->subDetector()] ) {
     case GeomDetEnumerators::PixelBarrel:
     case GeomDetEnumerators::PixelEndcap:
     case GeomDetEnumerators::TIB:
@@ -364,7 +364,7 @@ void TSGForRoadSearch::makeSeeds_4(const reco::Track & muon, std::vector<Traject
     if (!dynamic_cast<const ForwardDetLayer*>(inLayer)) layerIt =pxlBegin--;
     
     while (compatible.size()==0) {
-      switch ( (*layerIt)->subDetector() ) {
+      switch ( GeomDetEnumerators::subDetGeom[(*layerIt)->subDetector()] ) {
       case GeomDetEnumerators::PixelEndcap:
 	{
 	  layerIt++;

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -199,8 +199,7 @@ ConvBremSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	      
 	 long int detid=i->first->geographicalId().rawId();
 	 
-	 if ((tkLayer->subDetector()!=GeomDetEnumerators::PixelBarrel)&&
-	     (tkLayer->subDetector()!=GeomDetEnumerators::PixelEndcap)){
+	 if (!GeomDetEnumerators::isTrackerPixel(tkLayer->subDetector())){
 	   
 	    
 	   StDetMatch DetMatch = (rphirecHits.product())->find((detid));

--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -103,7 +103,7 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
   // Get barrel layers
   vector<BarrelDetLayer const*> const& blc = theTracker->barrelLayers();
   for ( auto i = blc.begin(); i != blc.end(); i++) {
-    if (conf.noPXB && (*i)->subDetector() == GeomDetEnumerators::PixelBarrel) continue;
+    if (conf.noPXB && GeomDetEnumerators::isTrackerPixel((*i)->subDetector())) continue;
     if (conf.noTOB && (*i)->subDetector() == GeomDetEnumerators::TOB) continue;
     if (conf.noTIB && (*i)->subDetector() == GeomDetEnumerators::TIB) continue;
     theBarrelLayers.push_back( (*i) );
@@ -112,7 +112,7 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
   // get forward layers
   vector<ForwardDetLayer const*> const& flc = theTracker->forwardLayers();
   for ( auto i = flc.begin(); i != flc.end(); i++) {
-    if (conf.noPXF && (*i)->subDetector() == GeomDetEnumerators::PixelEndcap) continue;
+    if (conf.noPXF && GeomDetEnumerators::isTrackerPixel((*i)->subDetector())) continue;
     if (conf.noTEC && (*i)->subDetector() == GeomDetEnumerators::TEC) continue;
     if (conf.noTID && (*i)->subDetector() == GeomDetEnumerators::TID) continue;
     theForwardLayers.push_back( (*i) );

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -75,36 +75,26 @@ void NavigationSchoolAnalyzer::print(std::ostream& os,const DetLayer* dl){
   unsigned int LorW=0;
   unsigned int side=0;
 
+  if(GeomDetEnumerators::isTracker(dl->subDetector())) {
+    LorW = tTopo->layer(tag->geographicalId());
+    side = tTopo->side(tag->geographicalId());
+  }
+  else {
   switch (dl->subDetector()){
-  case GeomDetEnumerators::PixelBarrel :
-    LorW = tTopo->pxbLayer(tag->geographicalId()); break;
-  case GeomDetEnumerators::TIB :
-    LorW = tTopo->tibLayer(tag->geographicalId()); break;
-  case GeomDetEnumerators::TOB :
-    LorW = tTopo->tobLayer(tag->geographicalId()); break;
-  case GeomDetEnumerators::DT :
-    LorW = DTChamberId(tag->geographicalId().rawId()).station(); break;
   case GeomDetEnumerators::RPCEndcap :
     side = (unsigned int)((RPCDetId(tag->geographicalId().rawId()).region()/2.+1)*2.);
   case GeomDetEnumerators::RPCBarrel :
     LorW = RPCDetId(tag->geographicalId().rawId()).station(); break;
 
-  case GeomDetEnumerators::PixelEndcap :    
-    LorW = tTopo->pxfDisk(tag->geographicalId());
-    side = tTopo->pxfSide(tag->geographicalId());break;
-  case GeomDetEnumerators::TID :
-    LorW = tTopo->tidWheel(tag->geographicalId());
-    side = tTopo->tidSide(tag->geographicalId());break;
-  case GeomDetEnumerators::TEC :
-    LorW = tTopo->tecWheel(tag->geographicalId());
-    side = tTopo->tecSide(tag->geographicalId()); break;
   case GeomDetEnumerators::CSC :
     LorW = CSCDetId(tag->geographicalId().rawId()).layer();
     side = CSCDetId(tag->geographicalId().rawId()).endcap(); break;
   case GeomDetEnumerators::invalidDet: // make gcc happy
-  default:
     // edm::LogError("InvalidDet") << "At " << __FILE__ << ", line " << __LINE__ << "\n";
     break;
+  default:
+    break;
+  }
   }
   
   switch (dl->location()){

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -81,6 +81,8 @@ void NavigationSchoolAnalyzer::print(std::ostream& os,const DetLayer* dl){
   }
   else {
   switch (dl->subDetector()){
+  case GeomDetEnumerators::DT :
+    LorW = DTChamberId(tag->geographicalId().rawId()).station(); break;
   case GeomDetEnumerators::RPCEndcap :
     side = (unsigned int)((RPCDetId(tag->geographicalId().rawId()).region()/2.+1)*2.);
   case GeomDetEnumerators::RPCBarrel :

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -323,11 +323,11 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(
     const GlobalPoint vtx = origin();
     GlobalVector dir = direction();
     
-    if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector()) == GeomDetEnumerators::PixelBarrel) ||
+    if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector())) ||
         (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::barrel)) {
       const BarrelDetLayer& bl = dynamic_cast<const BarrelDetLayer&>(*detLayer);
       est = estimator(&bl,es);
-    } else if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector()) == GeomDetEnumerators::PixelEndcap) ||
+    } else if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector())) ||
                (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::endcap)) {
       const ForwardDetLayer& fl = dynamic_cast<const ForwardDetLayer&>(*detLayer);
       est = estimator(&fl,es);

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -313,8 +313,7 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(
   bool measurementMethod = false;
   if(theMeasurementTrackerUsage == UseMeasurementTracker::kAlways) measurementMethod = true;
   else if(theMeasurementTrackerUsage == UseMeasurementTracker::kForSiStrips &&
-       !(detLayer->subDetector() == GeomDetEnumerators::PixelBarrel ||
-         detLayer->subDetector() == GeomDetEnumerators::PixelEndcap) ) measurementMethod = true;
+          GeomDetEnumerators::isTrackerStrip(detLayer->subDetector())) measurementMethod = true;
 
   if(measurementMethod) {
     edm::ESHandle<MagneticField> field;
@@ -324,10 +323,12 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(
     const GlobalPoint vtx = origin();
     GlobalVector dir = direction();
     
-    if (detLayer->subDetector() == GeomDetEnumerators::PixelBarrel || (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::barrel)){
+    if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector()) == GeomDetEnumerators::PixelBarrel) ||
+        (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::barrel)) {
       const BarrelDetLayer& bl = dynamic_cast<const BarrelDetLayer&>(*detLayer);
       est = estimator(&bl,es);
-    } else if (detLayer->subDetector() == GeomDetEnumerators::PixelEndcap || (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::endcap)) {
+    } else if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector()) == GeomDetEnumerators::PixelEndcap) ||
+               (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::endcap)) {
       const ForwardDetLayer& fl = dynamic_cast<const ForwardDetLayer&>(*detLayer);
       est = estimator(&fl,es);
     }


### PR DESCRIPTION
This PR migrates all code (found with `git grep GeomDetEnumerators::Pixel`) from using `GeomDetEnumerators::PixelBarrel/PixelEndcap` to either use the helper functions in GeomDetEnumerators, or `GeomDetEnumerators::subDetGeom` (one case) (one case was also from `subDetGeom` to the helper functions). These changes are needed for the Phase1/2 upgrades, where pixel barrel has `P1PXB` and pixel endcap `P1PXEC` or `P2PXEC` values. (Something similar is probably needed for Phase2 strips, but that is left for future work).

I also added a simple unit test for GeomDetEnumerators to ensure that all subdets are either `isBarrel()` or `isEndcap()`, so that I can safely assume in production code that, according to these functions, if something is not barrel, it is endcap (and vice versa). (Mostly because the condition that spurred this PR was `if(pixel barrel) ... else if(pixel endcap) ... else throw`).

Together with #11621 and #11609, the reco step of phase1 workflow `runTheMatrix.py --what upgrade -l 10000` technically works. (The final HARVESTING step fails on missing input file, because DQM/VALIDATION are not part of the reco step)

Tested in 760pre6, no changes expected in Run1/2 workflows.

@rovere @VinInn @boudoul @venturia @mark-grimes 
