### PR TITLE
remove outlier rejection from mergedDuplicateTracks

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -9,9 +9,9 @@ duplicateTrackCandidates = RecoTracker.FinalTrackSelectors.DuplicateTrackMerger_
     ) 
                                      
 import RecoTracker.TrackProducer.TrackProducer_cfi
-mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = cms.InputTag("duplicateTrackCandidates","candidates"),
-    )
+mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()
+mergedDuplicateTracks.src = cms.InputTag("duplicateTrackCandidates","candidates")
+mergedDuplicateTracks.Fitter='RKFittingSmoother' # no outlier rejection!
 
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
 duplicateTrackClassifier = TrackCutClassifier.clone()


### PR DESCRIPTION
Outlier rejection was essentially defeating the intentions of the mergedDuplicate algorithm.
The effect of this PR can be seen (for TTBAR 13TeV 25s 35PU aka 25202.0) in
http://innocent.home.cern.ch/innocent/RelVal/dup/plots_summary_highPurity/summary.pdf
more details
http://innocent.home.cern.ch/innocent/RelVal/dup/plots_highPurity/effandfake1.pdf
http://innocent.home.cern.ch/innocent/RelVal/dup/plots_highPurity/dupandfake1.pdf
etc
my interpretation is that MergeDuplicate merges PixelLess and TobTec with PixelSeeded (that’s the intention).
So we have less good tracks in particular in PixelLess and TobTec while fakes are not merged and stays the same.
At the end efficiency decreases (good duplicates are not accounted twice anymore), fake-rate increases (denominator is smaller)

The new tracks are of a "lower quality" (longer but with a higher chi2), but again this is in the intention of the algorithm
