### PR TITLE
Fireworks cleanup for {private,protected} macro removal

### DIFF
--- a/Fireworks/Core/interface/FWEventItem.h
+++ b/Fireworks/Core/interface/FWEventItem.h
@@ -161,6 +161,7 @@ public:
    // ---------- member functions ---------------------------
    void setEvent(const edm::EventBase* iEvent);
 
+   void getPrimaryData() const;
    const FWGeometry* getGeom() const;
    FWProxyBuilderConfiguration* getConfig() const { return m_proxyBuilderConfig; }
 
@@ -218,7 +219,6 @@ private:
    //const FWEventItem& operator=(const FWEventItem&); // stop default
    void setData(const edm::ObjectWithDict& ) const;
 
-   void getPrimaryData() const;
    void runFilter();
    void handleChange();
    // ---------- member data --------------------------------

--- a/Fireworks/Core/src/FWEveView.cc
+++ b/Fireworks/Core/src/FWEveView.cc
@@ -15,7 +15,7 @@
 #include <RVersion.h>
 #include <boost/bind.hpp>
 #include <stdexcept>
-
+#include <string>
 
 // user include files
 
@@ -418,11 +418,9 @@ void
 FWEveView::addToOrthoCamera(TGLOrthoCamera* camera, FWConfiguration& iTo) const
 {
    // zoom
-   std::ostringstream s;
-   s<<(camera->fZoom);
    std::string name("cameraZoom");
-   iTo.addKeyValue(name+typeName(),FWConfiguration(s.str()));
-   
+   iTo.addKeyValue(name+typeName(),FWConfiguration(std::to_string(camera->GetZoom())));
+
    // transformation matrix
    std::string matrixName("cameraMatrix");
    for ( unsigned int i = 0; i < 16; ++i ) {
@@ -444,8 +442,7 @@ FWEveView::setFromOrthoCamera(TGLOrthoCamera* camera,  const FWConfiguration& iF
       {
          throw std::runtime_error("can't restore parameter cameraZoom");
       }
-      std::istringstream s(iFrom.valueForKey(zoomName)->value());
-      s>>(camera->fZoom);
+      camera->SetZoom(std::stod(iFrom.valueForKey(zoomName)->value()));
       
       // transformation matrix
       std::string matrixName("cameraMatrix");
@@ -493,9 +490,7 @@ FWEveView::addToPerspectiveCamera(TGLPerspectiveCamera* cam, const std::string& 
       iTo.addKeyValue(matrixName+osIndex.str()+name,FWConfiguration(osValue.str()));
    }
    {
-      std::ostringstream osValue;
-      osValue << cam->fFOV;
-      iTo.addKeyValue(name+" FOV",FWConfiguration(osValue.str()));
+      iTo.addKeyValue(name+" FOV",FWConfiguration(std::to_string(cam->GetFOV())));
    }
 }
 

--- a/Fireworks/Core/src/FWEveViewManager.cc
+++ b/Fireworks/Core/src/FWEveViewManager.cc
@@ -685,7 +685,7 @@ FWEveViewManager::eventEnd()
    }
 
    // Process changes in scenes.
-   gEve->fScenes->ProcessSceneChanges(gEve->fDropLogicals, gEve->fStampedElements);
+   gEve->GetScenes()->ProcessSceneChanges(gEve->fDropLogicals, gEve->fStampedElements);
 
    // To synchronize buffer swapping set swap_on_render to false.
    // Note that this costs 25-40% extra time with 4 views, depending on V-sync settings.
@@ -709,7 +709,7 @@ FWEveViewManager::eventEnd()
       }
    }
 
-   gEve->fViewers->RepaintChangedViewers(gEve->fResetCameras, gEve->fDropLogicals);
+   gEve->GetViewers()->RepaintChangedViewers(gEve->fResetCameras, gEve->fDropLogicals);
 
    {
       Long64_t   key, value;

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -274,14 +274,14 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng)
            end = eiMng->end(); i != end; ++i)
    {
       FWEventItem *item = *i;
-      if (item == 0) 
+      if (item == nullptr)
          continue;
       // FIXME: hack to get full branch name filled
-      if (item->m_event == 0) 
+      if (!item->hasEvent())
       {
-         item->m_event = m_event;
+         item->setEvent(m_event);
          item->getPrimaryData();
-         item->m_event = 0;
+         item->setEvent(nullptr);
       }
 
       boost::regex re(std::string("\\$") + (*i)->name());

--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -152,15 +152,15 @@ FWTEveViewer::CaptureAndSaveImage(const TString& file, int height)
    }
 
    int ww, hh;
-   if (fbo->fIsRescaled)
+   if (fbo->GetIsRescaled())
    {
-      ww = TMath::Nint(fbo->fW * fbo->fWScale);
-      hh = TMath::Nint(fbo->fH * fbo->fHScale);
+      ww = TMath::Nint(fbo->GetW() * fbo->GetWScale());
+      hh = TMath::Nint(fbo->GetH() * fbo->GetHScale());
    }
    else
    {
-      ww = fbo->fW;
-      hh = fbo->fH;
+      ww = fbo->GetW();
+      hh = fbo->GetH();
    }
 
    fbo->SetAsReadBuffer();


### PR DESCRIPTION
The two commits in this PR makes sure that Fireworks code uses already available public APIs either from ROOT or from Fireworks code itself. This builds fine, but requires testing various affected places to make sure that behaviour is not changed.

Proportional work for cleanup of {private,protect} macros.
