### PR TITLE
set reco::CandViewCandViewAssociation as transient

### DIFF
--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -215,7 +215,9 @@
   <class name="edm::reftobase::RefVectorHolder<reco::NamedCompositeCandidateRefVector>" />
 
    <class name="edm::Wrapper<reco::CandViewCandViewAssociation>"/>
-   <class name="reco::CandViewCandViewAssociation"/>
+   <class name="reco::CandViewCandViewAssociation">
+     <field name="transientMap_" transient="true" />
+   </class>
 
    <class name="std::vector<std::pair<edm::RefToBase<reco::Candidate>,bool> >" />
    <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::Candidate>,std::vector<std::pair<edm::RefToBase<reco::Candidate>,bool> > > >" />


### PR DESCRIPTION
In order to enable new configuration/build rules with checks for Class Transients, this change need to go in.
