### PR TITLE
Restore v0 validation  

### DIFF
--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -15,6 +15,7 @@ from Validation.RPCRecHits.postValidation_cfi import *
 from Validation.RecoTau.DQMMCValidation_cfi import *
 from Validation.RecoEgamma.photonFastSimPostProcessor_cff import *
 from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_Client_cfi import *
+from Validation.RecoVertex.PostProcessorV0_cfi import *
 from Validation.RecoMET.METPostProcessor_cff import *
 from DQMOffline.RecoB.dqmCollector_cff import *
 
@@ -23,6 +24,7 @@ postValidation = cms.Sequence(
       recoMuonPostProcessors
     + postProcessorTrackSequence
     + postProcessorVertex
+    + postProcessorV0
     + MuIsoValPostProcessor
     + calotowersPostProcessor
     + hcalSimHitsPostProcessor

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -94,7 +94,6 @@ private:
   float LamGenX, LamGenY, LamGenZ, KsGenX, KsGenY, KsGenZ;
   float K0sCandEta, LamCandEta, K0sCandpT, LamCandpT, K0sCandR, LamCandR;
   unsigned int K0sGenStatus, LamGenStatus, K0sCandStatus, LamCandStatus;
-  unsigned int K0sPiCandStatus[2], LamPiCandStatus[2], K0sPiEff[2], LamPiEff[2];
 
   //Bookkeeping quantities
   int genLam, genK0s, realLamFound, realK0sFound, realLamFoundEff, realK0sFoundEff;

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -144,21 +144,8 @@ private:
   std::array<MonitorElement *, 2> candidateStatus_;
   std::array<MonitorElement *, 2> fakeCandidateMass_;
   std::array<MonitorElement *, 2> candidateFakeDauRadDist_;
-
-  MonitorElement* ksXResolution;
-  MonitorElement* ksYResolution;
-  MonitorElement* ksZResolution;
-  MonitorElement* ksAbsoluteDistResolution;
-  MonitorElement* lamXResolution;
-  MonitorElement* lamYResolution;
-  MonitorElement* lamZResolution;
-  MonitorElement* lamAbsoluteDistResolution;
-
-  MonitorElement* goodKsMass;
-  MonitorElement* goodLamMass;
-
-  MonitorElement* ksMassAll;
-  MonitorElement* lamMassAll;
+  std::array<MonitorElement *, 2> candidateMassAll;
+  std::array<MonitorElement *, 2> goodCandidateMass;
 
   std::string theDQMRootFileName;
   std::string dirName;

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -2,8 +2,9 @@
 //
 // Package:    V0Validator
 // Class:      V0Validator
-// 
-/**\class V0Validator V0Validator.cc Validation/RecoVertex/interface/V0Validator.h
+//
+/**\class V0Validator V0Validator.cc
+ Validation/RecoVertex/interface/V0Validator.h
 
  Description: Creates validation histograms for RecoVertex/V0Producer
 
@@ -15,7 +16,6 @@
 //         Created:  Wed Feb 18 17:21:04 MST 2009
 //
 //
-
 
 // system include files
 #include <memory>
@@ -69,7 +69,6 @@
 #include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-
 #include "HepMC/GenVertex.h"
 #include "HepMC/GenParticle.h"
 
@@ -80,43 +79,45 @@
 #include "TH2F.h"
 
 class V0Validator : public DQMEDAnalyzer {
-
-public:
-  explicit V0Validator(const edm::ParameterSet&);
+ public:
+  explicit V0Validator(const edm::ParameterSet &);
   ~V0Validator();
-  enum V0Type {KSHORT, LAMBDA};
+  enum V0Type { KSHORT, LAMBDA };
   struct V0Couple {
     reco::TrackRef one;
     reco::TrackRef two;
-    explicit V0Couple(reco::TrackRef first_daughter, reco::TrackRef second_daughter) {
-      one = first_daughter.key() < second_daughter.key() ? first_daughter : second_daughter;
-      two = first_daughter.key() > second_daughter.key() ? first_daughter : second_daughter;
+    explicit V0Couple(reco::TrackRef first_daughter,
+                      reco::TrackRef second_daughter) {
+      one = first_daughter.key() < second_daughter.key() ? first_daughter
+                                                         : second_daughter;
+      two = first_daughter.key() > second_daughter.key() ? first_daughter
+                                                         : second_daughter;
       assert(one != two);
     }
     bool operator<(const V0Couple &rh) const {
       return one.key() < rh.one.key();
     }
     bool operator==(const V0Couple &rh) const {
-      return ( (one.key() == rh.one.key()) &&
-               (two.key() == rh.two.key()));
+      return ((one.key() == rh.one.key()) && (two.key() == rh.two.key()));
     }
   };
-private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void doFakeRates(const reco::VertexCompositeCandidateCollection & collection,
-                   const reco::RecoToSimCollection & recotosimCollection,
-                   V0Type t,
-                   int particle_pdgid,
+
+ private:
+  virtual void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
+                      edm::EventSetup const &) override;
+  void doFakeRates(const reco::VertexCompositeCandidateCollection &collection,
+                   const reco::RecoToSimCollection &recotosimCollection,
+                   V0Type t, int particle_pdgid,
                    int misreconstructed_particle_pdgid);
 
-  void doEfficiencies(const TrackingVertexCollection & gen_vertices,
-                      V0Type t,
-                      int parent_particle_id,
-                      int first_daughter_id, /* give only positive charge */
-                      int second_daughter_id, /* give only positive charge */
-                      const reco::VertexCompositeCandidateCollection & collection,
-                      const reco::SimToRecoCollection & simtorecoCollection);
+  void doEfficiencies(
+      const TrackingVertexCollection &gen_vertices, V0Type t,
+      int parent_particle_id,
+      int first_daughter_id,  /* give only positive charge */
+      int second_daughter_id, /* give only positive charge */
+      const reco::VertexCompositeCandidateCollection &collection,
+      const reco::SimToRecoCollection &simtorecoCollection);
 
   // MonitorElements for final histograms
 
@@ -152,7 +153,8 @@ private:
   edm::EDGetTokenT<reco::RecoToSimCollection> recoRecoToSimCollectionToken_;
   edm::EDGetTokenT<reco::SimToRecoCollection> recoSimToRecoCollectionToken_;
   edm::EDGetTokenT<TrackingVertexCollection> trackingVertexCollection_Token_;
-  edm::EDGetTokenT< std::vector<reco::Vertex> > vec_recoVertex_Token_;
-  edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> recoVertexCompositeCandidateCollection_k0s_Token_, recoVertexCompositeCandidateCollection_lambda_Token_;
+  edm::EDGetTokenT<std::vector<reco::Vertex> > vec_recoVertex_Token_;
+  edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>
+      recoVertexCompositeCandidateCollection_k0s_Token_,
+      recoVertexCompositeCandidateCollection_lambda_Token_;
 };
-

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -101,18 +101,6 @@ private:
   int lamTracksFound, k0sTracksFound, lamCandFound, k0sCandFound, noTPforK0sCand, noTPforLamCand;
 
   // MonitorElements for final histograms
-  MonitorElement* ksEffVsR;
-  MonitorElement* ksEffVsEta;
-  MonitorElement* ksEffVsPt;
-  MonitorElement* ksTkEffVsR;
-  MonitorElement* ksTkEffVsEta;
-  MonitorElement* ksTkEffVsPt;
-  MonitorElement* ksFakeVsR;
-  MonitorElement* ksFakeVsEta;
-  MonitorElement* ksFakeVsPt;
-  MonitorElement* ksTkFakeVsR;
-  MonitorElement* ksTkFakeVsEta;
-  MonitorElement* ksTkFakeVsPt;
 
   MonitorElement* ksEffVsR_num;
   MonitorElement* ksEffVsEta_num;
@@ -140,19 +128,6 @@ private:
   MonitorElement* lamEffVsR_denom;
   MonitorElement* lamEffVsEta_denom;
   MonitorElement* lamEffVsPt_denom;
-
-  MonitorElement* lamEffVsR;
-  MonitorElement* lamEffVsEta;
-  MonitorElement* lamEffVsPt;
-  MonitorElement* lamTkEffVsR;
-  MonitorElement* lamTkEffVsEta;
-  MonitorElement* lamTkEffVsPt;
-  MonitorElement* lamFakeVsR;
-  MonitorElement* lamFakeVsEta;
-  MonitorElement* lamFakeVsPt;
-  MonitorElement* lamTkFakeVsR;
-  MonitorElement* lamTkFakeVsEta;
-  MonitorElement* lamTkFakeVsPt;
 
   MonitorElement* lamEffVsR_num;
   MonitorElement* lamEffVsEta_num;

--- a/Validation/RecoVertex/python/PostProcessorV0_cfi.py
+++ b/Validation/RecoVertex/python/PostProcessorV0_cfi.py
@@ -1,35 +1,34 @@
-#   "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
-
 import FWCore.ParameterSet.Config as cms
 
 postProcessorV0 = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Vertexing/V0V/EffFakes/*"),
+    subDirs = cms.untracked.vstring("Vertexing/V0V/*"),
     efficiency = cms.vstring(
        "K0sEffVsR 'K^{0}_{S} efficiency vs R (radial)' K0sEffVsR_num K0sEffVsR_denom", 
        "K0sEffVsEta 'K^{0}_{S} efficiency vs #eta' K0sEffVsEta_num K0sEffVsEta_denom",
        "K0sEffVsPt 'K^{0}_{S} efficiency vs p_{T}' K0sEffVsPt_num K0sEffVsPt_denom",
-       "LamEffVsR '#Lambda efficiency vs R (radial)' LamEffVsR_num LamEffVsR_denom",
-       "LamEffVsEta '#Lambda efficiency vs #eta' LamEffVsEta_num LamEffVsEta_denom",
-       "LamEffVsPt '#Lambda efficiency vs p_{T}' LamEffVsPt_num LamEffVsPt_denom",
        "K0sFakeVsR 'K^{0}_{S} fake rate vs R (radial)' K0sFakeVsR_num K0sFakeVsR_denom",
        "K0sFakeVsEta 'K^{0}_{S} fake rate vs #eta' K0sFakeVsEta_num K0sFakeVsEta_denom",
        "K0sFakeVsPt 'K^{0}_{S} fake rate vs p_{T}' K0sFakeVsPt_num K0sFakeVsPt_denom",
-       "LamFakeVsR '#Lambda fake rate vs R (radial)' LamFakeVsR_num LamFakeVsR_denom",
-       "LamFakeVsEta '#Lambda fake rate vs #eta' LamFakeVsEta_num LamFakeVsEta_denom",
-       "LamFakeVsPt '#Lambda fake rate vs p{T}' LamFakeVsPt_num LamFakeVsPt_denom",
        "K0sTkEffVsR 'K^{0}_{S} tracking efficiency vs R (radial)' K0sTkEffVsR_num K0sEffVsR_denom", 
        "K0sTkEffVsEta 'K^{0}_{S} tracking efficiency vs #eta' K0sTkEffVsEta_num K0sEffVsEta_denom",
        "K0sTkEffVsPt 'K^{0}_{S} tracking efficiency vs p_{T}' K0sTkEffVsPt_num K0sEffVsPt_denom",
-       "LamTkEffVsR '#Lambda tracking efficiency vs R (radial)' LamTkEffVsR_num LamEffVsR_denom",
-       "LamTkEffVsEta '#Lambda tracking efficiency vs #eta' LamTkEffVsEta_num LamEffVsEta_denom",
-       "LamTkEffVsPt '#Lambda tracking efficiency vs p_{T}' LamTkEffVsPt_num LamEffVsPt_denom",
        "K0sTkFakeVsR 'K^{0}_{S} tracking fake rate vs R (radial)' K0sTkFakeVsR_num K0sFakeVsR_denom",
        "K0sTkFakeVsEta 'K^{0}_{S} tracking fake rate vs #eta' K0sTkFakeVsEta_num K0sFakeVsEta_denom",
        "K0sTkFakeVsPt 'K^{0}_{S} tracking fake rate vs p_{T}' K0sTkFakeVsPt_num K0sFakeVsPt_denom",
+       "LamEffVsR '#Lambda efficiency vs R (radial)' LamEffVsR_num LamEffVsR_denom",
+       "LamEffVsEta '#Lambda efficiency vs #eta' LamEffVsEta_num LamEffVsEta_denom",
+       "LamEffVsPt '#Lambda efficiency vs p_{T}' LamEffVsPt_num LamEffVsPt_denom",
+       "LamFakeVsR '#Lambda fake rate vs R (radial)' LamFakeVsR_num LamFakeVsR_denom",
+       "LamFakeVsEta '#Lambda fake rate vs #eta' LamFakeVsEta_num LamFakeVsEta_denom",
+       "LamFakeVsPt '#Lambda fake rate vs p{T}' LamFakeVsPt_num LamFakeVsPt_denom",
+       "LamTkEffVsR '#Lambda tracking efficiency vs R (radial)' LamTkEffVsR_num LamEffVsR_denom",
+       "LamTkEffVsEta '#Lambda tracking efficiency vs #eta' LamTkEffVsEta_num LamEffVsEta_denom",
+       "LamTkEffVsPt '#Lambda tracking efficiency vs p_{T}' LamTkEffVsPt_num LamEffVsPt_denom",
        "LamTkFakeVsR '#Lambda tracking fake rate vs R (radial)' LamTkFakeVsR_num LamFakeVsR_denom",
        "LamTkFakeVsEta '#Lambda tracking fake rate vs #eta' LamTkFakeVsEta_num LamFakeVsEta_denom",
-       "LamTkFakeVsPt '#Lambda tracking fake rate vs p{T}' LamTkFakeVsPt_num LamFakeVsPt_denom"
+       "LamTkFakeVsPt '#Lambda tracking fake rate vs p{T}' LamTkFakeVsPt_num LamFakeVsPt_denom",
    ),
    resolution = cms.vstring(),
-   outputFileName = cms.untracked.string("")
+   outputFileName = cms.untracked.string(""),
+   verbose = cms.untracked.uint32(0)
 )

--- a/Validation/RecoVertex/python/v0validator_cfi.py
+++ b/Validation/RecoVertex/python/v0validator_cfi.py
@@ -5,7 +5,7 @@ v0Validator = cms.EDAnalyzer('V0Validator',
     kShortCollection = cms.untracked.InputTag('generalV0Candidates:Kshort'),
     lambdaCollection = cms.untracked.InputTag('generalV0Candidates:Lambda'),
     trackAssociatorMap = cms.untracked.InputTag("trackingParticleRecoTrackAsssociation"),
-    trackingParticleCollectionEff = cms.untracked.InputTag("mix", "MergedTrackTruth"),
+    trackingVertexCollection = cms.untracked.InputTag("mix", "MergedTrackTruth"),
     vertexCollection = cms.untracked.InputTag("offlinePrimaryVertices"),
     dirName = cms.untracked.string('Vertexing/V0V')
 )

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -49,54 +49,26 @@ void V0Validator::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &, 
   std::string subDirName = V0Validator::dirName + "/EffFakes";
   ibooker.setCurrentFolder(subDirName.c_str());
 
-  ksEffVsR = ibooker.book1D("K0sEffVsR", 
-			  "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
-  ksEffVsEta = ibooker.book1D("K0sEffVsEta",
-			    "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
-  ksEffVsPt = ibooker.book1D("K0sEffVsPt",
-			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);;
-
-  ksTkEffVsR = ibooker.book1D("K0sTkEffVsR", 
-			  "K^{0}_{S} Tracking Efficiency vs #rho", 40, 0., 40.);
-  ksTkEffVsEta = ibooker.book1D("K0sTkEffVsEta",
-			    "K^{0}_{S} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
-  ksTkEffVsPt = ibooker.book1D("K0sTkEffVsPt",
-			   "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);
-
   ksEffVsR_num = ibooker.book1D("K0sEffVsR_num", 
-			  "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
+                                "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
   ksEffVsEta_num = ibooker.book1D("K0sEffVsEta_num",
 			    "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   ksEffVsPt_num = ibooker.book1D("K0sEffVsPt_num",
-			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);;
+			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
   ksTkEffVsR_num = ibooker.book1D("K0sTkEffVsR_num", 
 			  "K^{0}_{S} Tracking Efficiency vs #rho", 40, 0., 40.);
   ksTkEffVsEta_num = ibooker.book1D("K0sTkEffVsEta_num",
 			    "K^{0}_{S} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
   ksTkEffVsPt_num = ibooker.book1D("K0sTkEffVsPt_num",
-			   "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);;
+			   "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);
 
   ksEffVsR_denom = ibooker.book1D("K0sEffVsR_denom", 
 			  "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
   ksEffVsEta_denom = ibooker.book1D("K0sEffVsEta_denom",
 			    "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   ksEffVsPt_denom = ibooker.book1D("K0sEffVsPt_denom",
-			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);;
-
-  lamEffVsR = ibooker.book1D("LamEffVsR",
-			   "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
-  lamEffVsEta = ibooker.book1D("LamEffVsEta",
-			     "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
-  lamEffVsPt = ibooker.book1D("LamEffVsPt",
-			    "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
-
-  lamTkEffVsR = ibooker.book1D("LamTkEffVsR",
-			   "#Lambda^{0} TrackingEfficiency vs #rho", 40, 0., 40.);
-  lamTkEffVsEta = ibooker.book1D("LamTkEffVsEta",
-			     "#Lambda^{0} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
-  lamTkEffVsPt = ibooker.book1D("LamTkEffVsPt",
-			    "#Lambda^{0} Tracking Efficiency vs p_{T}", 70, 0., 20.);
+			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
   lamEffVsR_num = ibooker.book1D("LamEffVsR_num",
 			   "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
@@ -119,19 +91,6 @@ void V0Validator::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &, 
   lamEffVsPt_denom = ibooker.book1D("LamEffVsPt_denom",
 			    "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
-  ksFakeVsR = ibooker.book1D("K0sFakeVsR",
-			   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
-  ksFakeVsEta = ibooker.book1D("K0sFakeVsEta",
-			     "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksFakeVsPt = ibooker.book1D("K0sFakeVsPt",
-			    "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
-  ksTkFakeVsR = ibooker.book1D("K0sTkFakeVsR",
-			   "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
-  ksTkFakeVsEta = ibooker.book1D("K0sTkFakeVsEta",
-			     "K^{0}_{S} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksTkFakeVsPt = ibooker.book1D("K0sTkFakeVsPt",
-			    "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
-
   ksFakeVsR_num = ibooker.book1D("K0sFakeVsR_num",
 			   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
   ksFakeVsEta_num = ibooker.book1D("K0sFakeVsEta_num",
@@ -151,19 +110,6 @@ void V0Validator::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &, 
 			     "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
   ksFakeVsPt_denom = ibooker.book1D("K0sFakeVsPt_denom",
 			    "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
-
-  lamFakeVsR = ibooker.book1D("LamFakeVsR",
-			    "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
-  lamFakeVsEta = ibooker.book1D("LamFakeVsEta",
-			      "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
-  lamFakeVsPt = ibooker.book1D("LamFakeVsPt",
-			     "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
-  lamTkFakeVsR = ibooker.book1D("LamTkFakeVsR",
-			    "#Lambda^{0} Tracking Fake Rate vs #rho", 40, 0., 40.);
-  lamTkFakeVsEta = ibooker.book1D("LamTkFakeVsEta",
-			      "#Lambda^{0} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
-  lamTkFakeVsPt = ibooker.book1D("LamTkFakeVsPt",
-			     "#Lambda^{0} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
 
   lamFakeVsR_num = ibooker.book1D("LamFakeVsR_num",
 			    "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -122,6 +122,8 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   candidateFakeDauRadDist_[V0Validator::KSHORT] = ibooker.book1D(
       "radDistFakeKs", "Production radius of daughter particle of Ks fake", 100,
       0., 15.);
+  candidateStatus_[V0Validator::KSHORT] =
+      ibooker.book1D("ksCandStatus", "Fake type by cand status", 10, 0., 10.);
 
   // Lambda Plots follow
 
@@ -189,6 +191,9 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   candidateFakeDauRadDist_[V0Validator::LAMBDA] = ibooker.book1D(
       "radDistFakeLam", "Production radius of daughter particle of Lam fake",
       100, 0., 15.);
+
+  candidateStatus_[V0Validator::LAMBDA] =
+      ibooker.book1D("ksCandStatus", "Fake type by cand status", 10, 0., 10.);
 }
 
 void V0Validator::doFakeRates(

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -67,14 +67,14 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   ibooker.setCurrentFolder(subDirName.c_str());
 
   candidateEffVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
-      "K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
+      "K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho", 80, 0., 40.);
   candidateEffVsEta_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsEta_num", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   candidateEffVsPt_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsPt_num", "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateTkEffVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
-      "K0sTkEffVsR_num", "K^{0}_{S} Tracking Efficiency vs #rho", 40, 0., 40.);
+      "K0sTkEffVsR_num", "K^{0}_{S} Tracking Efficiency vs #rho", 80, 0., 40.);
   candidateTkEffVsEta_num_[V0Validator::KSHORT] =
       ibooker.book1D("K0sTkEffVsEta_num",
                      "K^{0}_{S} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
@@ -83,20 +83,20 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
                      "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateEffVsR_denom_[V0Validator::KSHORT] = ibooker.book1D(
-      "K0sEffVsR_denom", "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
+      "K0sEffVsR_denom", "K^{0}_{S} Efficiency vs #rho", 80, 0., 40.);
   candidateEffVsEta_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsEta_denom", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   candidateEffVsPt_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsPt_denom", "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateFakeVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
-      "K0sFakeVsR_num", "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+      "K0sFakeVsR_num", "K^{0}_{S} Fake Rate vs #rho", 80, 0., 40.);
   candidateFakeVsEta_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsEta_num", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsPt_num", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
   candidateTkFakeVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
-      "K0sTkFakeVsR_num", "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
+      "K0sTkFakeVsR_num", "K^{0}_{S} Tracking Fake Rate vs #rho", 80, 0., 80.);
   candidateTkFakeVsEta_num_[V0Validator::KSHORT] =
       ibooker.book1D("K0sTkFakeVsEta_num",
                      "K^{0}_{S} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
@@ -105,7 +105,7 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
                      "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
 
   candidateFakeVsR_denom_[V0Validator::KSHORT] = ibooker.book1D(
-      "K0sFakeVsR_denom", "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+      "K0sFakeVsR_denom", "K^{0}_{S} Fake Rate vs #rho", 80, 0., 40.);
   candidateFakeVsEta_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsEta_denom", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_denom_[V0Validator::KSHORT] = ibooker.book1D(
@@ -131,14 +131,14 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   ibooker.setCurrentFolder(subDirName.c_str());
 
   candidateEffVsR_num_[V0Validator::LAMBDA] = ibooker.book1D(
-      "LamEffVsR_num", "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
+      "LamEffVsR_num", "#Lambda^{0} Efficiency vs #rho", 80, 0., 40.);
   candidateEffVsEta_num_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamEffVsEta_num", "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
   candidateEffVsPt_num_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamEffVsPt_num", "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateTkEffVsR_num_[V0Validator::LAMBDA] = ibooker.book1D(
-      "LamTkEffVsR_num", "#Lambda^{0} TrackingEfficiency vs #rho", 40, 0., 40.);
+      "LamTkEffVsR_num", "#Lambda^{0} TrackingEfficiency vs #rho", 80, 0., 40.);
   candidateTkEffVsEta_num_[V0Validator::LAMBDA] =
       ibooker.book1D("LamTkEffVsEta_num",
                      "#Lambda^{0} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
@@ -147,21 +147,21 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
                      "#Lambda^{0} Tracking Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateEffVsR_denom_[V0Validator::LAMBDA] = ibooker.book1D(
-      "LamEffVsR_denom", "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
+      "LamEffVsR_denom", "#Lambda^{0} Efficiency vs #rho", 80, 0., 40.);
   candidateEffVsEta_denom_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamEffVsEta_denom", "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
   candidateEffVsPt_denom_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamEffVsPt_denom", "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateFakeVsR_num_[V0Validator::LAMBDA] = ibooker.book1D(
-      "LamFakeVsR_num", "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
+      "LamFakeVsR_num", "#Lambda^{0} Fake Rate vs #rho", 80, 0., 40.);
   candidateFakeVsEta_num_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamFakeVsEta_num", "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_num_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamFakeVsPt_num", "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
   candidateTkFakeVsR_num_[V0Validator::LAMBDA] =
       ibooker.book1D("LamTkFakeVsR_num",
-                     "#Lambda^{0} Tracking Fake Rate vs #rho", 40, 0., 40.);
+                     "#Lambda^{0} Tracking Fake Rate vs #rho", 80, 0., 40.);
   candidateTkFakeVsEta_num_[V0Validator::LAMBDA] =
       ibooker.book1D("LamTkFakeVsEta_num",
                      "#Lambda^{0} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
@@ -170,7 +170,7 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
                      "#Lambda^{0} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
 
   candidateFakeVsR_denom_[V0Validator::LAMBDA] = ibooker.book1D(
-      "LamFakeVsR_denom", "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
+      "LamFakeVsR_denom", "#Lambda^{0} Fake Rate vs #rho", 80, 0., 40.);
   candidateFakeVsEta_denom_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamFakeVsEta_denom", "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_denom_[V0Validator::LAMBDA] = ibooker.book1D(

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -224,7 +224,6 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
         (*(dynamic_cast<const reco::RecoChargedCandidate*>(
             iCandidate->daughter(1)))).track()} };
 
-      std::vector<std::pair<TrackingParticleRef, double> > tp;
       TrackingParticleRef tpref;
       TrackingParticleRef firstDauTP;
       TrackingVertexRef candidateVtx;
@@ -238,7 +237,8 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
         RefToBase<reco::Track> track(theDaughterTracks.at(i));
 
         if (recotosimCollection.find(track) != recotosimCollection.end()) {
-          tp = recotosimCollection[track];
+          const std::vector<std::pair<TrackingParticleRef, double> > & tp =
+              recotosimCollection[track];
           if (tp.size() != 0) {
             tpref = tp.begin()->first;
 
@@ -249,8 +249,9 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
                 if (candidateVtx->position() == parentVertex->position()) {
                   if (parentVertex->nDaughterTracks() == 2) {
                     if (parentVertex->nSourceTracks() == 0) {
-                      // No source tracks found for candidate's vertex; shouldn't
-                      // happen, but does for evtGen events
+                      // No source tracks found for candidate's
+                      // vertex: it shouldn't happen, but does for
+                      // evtGen events
                       CandidateStatus = 6;
                     }
 
@@ -261,11 +262,6 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
                         CandidateStatus = 1;
                         realCandidateFound++;
                         numCandidateFound += 1.;
-                        // std::pair<TrackingParticleRef, TrackingParticleRef>
-                        //     pair(firstDauTP, tpref);
-                        // // Pushing back a good V0
-                        // trueCandidates.push_back(pair);
-                        // trueCandidateMasses.push_back(mass);
                       } else {
                         CandidateStatus = 2;
                         if ((*iTP)->pdgId() == misreconstructed_particle_pdgid) {
@@ -274,18 +270,19 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
                       }
                     }
                   } else {
-                    // Found a bad match because the mother has too many
-                    // daughters
+                    // Found a bad match because the mother has too
+                    // many daughters
                     CandidateStatus = 3;
                   }
                 } else {
-                  // Found a bad match because the parent vertices from the two
-                  // tracks are different
+                  // Found a bad match because the parent vertices
+                  // from the two tracks are different
                   CandidateStatus = 4;
                 }
               } else {
-                // if candidateVtx is null, fill it with parentVertex to compare to
-                // the parentVertex from the second track
+                // if candidateVtx is null, fill it with parentVertex
+                // to compare to the parentVertex from the second
+                // track
                 candidateVtx = parentVertex;
                 firstDauTP = tpref;
               }
@@ -294,7 +291,7 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
         } else {
           CandidateStatus = 5;
         }
-      } // Loop on K0s daughter tracks
+      } // Loop on candidate's daughter tracks
 
       // fill the fake rate histograms
       if (CandidateStatus > 1) {
@@ -316,8 +313,8 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
       candidateFakeVsR_denom_[v0_type]->Fill(CandidateR);
       candidateFakeVsEta_denom_[v0_type]->Fill(CandidateEta);
       candidateFakeVsPt_denom_[v0_type]->Fill(CandidatepT);
-    } // Loop on K0s candidates
-  } // check on presence of K0s collection in the event
+    } // Loop on candidates
+  } // check on presence of candidate's collection in the event
   nCandidates_[v0_type]->Fill((float)numCandidateFound);
 }
 

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -2,7 +2,7 @@
 //
 // Package:    V0Validator
 // Class:      V0Validator
-// 
+//
 /**\class V0Validator V0Validator.cc Validation/RecoVertex/src/V0Validator.cc
 
  Description: Creates validation histograms for RecoVertex/V0Producer
@@ -16,155 +16,181 @@
 //
 //
 
-
 #include "Validation/RecoVertex/interface/V0Validator.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 typedef std::vector<TrackingVertex> TrackingVertexCollection;
 typedef edm::Ref<TrackingVertexCollection> TrackingVertexRef;
-typedef edm::RefVector<edm::HepMCProduct, HepMC::GenVertex > GenVertexRefVector;
-typedef edm::RefVector<edm::HepMCProduct, HepMC::GenParticle > GenParticleRefVector;
+typedef edm::RefVector<edm::HepMCProduct, HepMC::GenVertex> GenVertexRefVector;
+typedef edm::RefVector<edm::HepMCProduct, HepMC::GenParticle>
+    GenParticleRefVector;
 
 V0Validator::V0Validator(const edm::ParameterSet& iConfig)
-  : theDQMRootFileName(iConfig.getUntrackedParameter<std::string>("DQMRootFileName"))
-  , dirName(iConfig.getUntrackedParameter<std::string>("dirName"))
-  , recoRecoToSimCollectionToken_( consumes<reco::RecoToSimCollection>( iConfig.getUntrackedParameter<edm::InputTag>("trackAssociatorMap") ) )
-  , recoSimToRecoCollectionToken_( consumes<reco::SimToRecoCollection>( iConfig.getUntrackedParameter<edm::InputTag>("trackAssociatorMap") ) )
-  , trackingParticleCollection_Eff_Token_( consumes<TrackingParticleCollection>( iConfig.getUntrackedParameter<edm::InputTag>("trackingParticleCollectionEff") ) )
-  , vec_recoVertex_Token_( consumes< std::vector<reco::Vertex> >( iConfig.getUntrackedParameter<edm::InputTag>("vertexCollection") ) )
-  , recoVertexCompositeCandidateCollection_k0s_Token_( consumes<reco::VertexCompositeCandidateCollection>( iConfig.getUntrackedParameter<edm::InputTag>( "kShortCollection" ) ) )
-  , recoVertexCompositeCandidateCollection_lambda_Token_( consumes<reco::VertexCompositeCandidateCollection>( iConfig.getUntrackedParameter<edm::InputTag>( "lambdaCollection" ) ) )
-{
-
-  genLam = genK0s = realLamFoundEff = realK0sFoundEff = lamCandFound = k0sCandFound = noTPforK0sCand = noTPforLamCand = realK0sFound = realLamFound = 0;
-  
+    : theDQMRootFileName(
+          iConfig.getUntrackedParameter<std::string>("DQMRootFileName")),
+      dirName(iConfig.getUntrackedParameter<std::string>("dirName")),
+      recoRecoToSimCollectionToken_(consumes<reco::RecoToSimCollection>(
+          iConfig.getUntrackedParameter<edm::InputTag>("trackAssociatorMap"))),
+      recoSimToRecoCollectionToken_(consumes<reco::SimToRecoCollection>(
+          iConfig.getUntrackedParameter<edm::InputTag>("trackAssociatorMap"))),
+      trackingParticleCollection_Eff_Token_(
+          consumes<TrackingParticleCollection>(
+              iConfig.getUntrackedParameter<edm::InputTag>(
+                  "trackingParticleCollectionEff"))),
+      vec_recoVertex_Token_(consumes<std::vector<reco::Vertex> >(
+          iConfig.getUntrackedParameter<edm::InputTag>("vertexCollection"))),
+      recoVertexCompositeCandidateCollection_k0s_Token_(
+          consumes<reco::VertexCompositeCandidateCollection>(
+              iConfig.getUntrackedParameter<edm::InputTag>(
+                  "kShortCollection"))),
+      recoVertexCompositeCandidateCollection_lambda_Token_(
+          consumes<reco::VertexCompositeCandidateCollection>(
+              iConfig.getUntrackedParameter<edm::InputTag>(
+                  "lambdaCollection"))) {
+  genLam = genK0s = realLamFoundEff = realK0sFoundEff = lamCandFound =
+      k0sCandFound = noTPforK0sCand = noTPforLamCand = realK0sFound =
+          realLamFound = 0;
 }
 
-V0Validator::~V0Validator() {
+V0Validator::~V0Validator() {}
 
-}
-
-void V0Validator::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &, edm::EventSetup const &) {
+void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
+                                 edm::EventSetup const&) {
   ibooker.cd();
   std::string subDirName = V0Validator::dirName + "/EffFakes";
   ibooker.setCurrentFolder(subDirName.c_str());
 
-  ksEffVsR_num = ibooker.book1D("K0sEffVsR_num", 
-                                "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
-  ksEffVsEta_num = ibooker.book1D("K0sEffVsEta_num",
-			    "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
+  ksEffVsR_num = ibooker.book1D("K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho",
+                                40, 0., 40.);
+  ksEffVsEta_num = ibooker.book1D(
+      "K0sEffVsEta_num", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   ksEffVsPt_num = ibooker.book1D("K0sEffVsPt_num",
-			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
+                                 "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
-  ksTkEffVsR_num = ibooker.book1D("K0sTkEffVsR_num", 
-			  "K^{0}_{S} Tracking Efficiency vs #rho", 40, 0., 40.);
-  ksTkEffVsEta_num = ibooker.book1D("K0sTkEffVsEta_num",
-			    "K^{0}_{S} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
-  ksTkEffVsPt_num = ibooker.book1D("K0sTkEffVsPt_num",
-			   "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);
+  ksTkEffVsR_num = ibooker.book1D(
+      "K0sTkEffVsR_num", "K^{0}_{S} Tracking Efficiency vs #rho", 40, 0., 40.);
+  ksTkEffVsEta_num =
+      ibooker.book1D("K0sTkEffVsEta_num",
+                     "K^{0}_{S} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
+  ksTkEffVsPt_num =
+      ibooker.book1D("K0sTkEffVsPt_num",
+                     "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);
 
-  ksEffVsR_denom = ibooker.book1D("K0sEffVsR_denom", 
-			  "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
-  ksEffVsEta_denom = ibooker.book1D("K0sEffVsEta_denom",
-			    "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
-  ksEffVsPt_denom = ibooker.book1D("K0sEffVsPt_denom",
-			   "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
+  ksEffVsR_denom = ibooker.book1D("K0sEffVsR_denom",
+                                  "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
+  ksEffVsEta_denom = ibooker.book1D(
+      "K0sEffVsEta_denom", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
+  ksEffVsPt_denom = ibooker.book1D(
+      "K0sEffVsPt_denom", "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
   lamEffVsR_num = ibooker.book1D("LamEffVsR_num",
-			   "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
-  lamEffVsEta_num = ibooker.book1D("LamEffVsEta_num",
-			     "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
-  lamEffVsPt_num = ibooker.book1D("LamEffVsPt_num",
-			    "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
+                                 "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
+  lamEffVsEta_num = ibooker.book1D(
+      "LamEffVsEta_num", "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
+  lamEffVsPt_num = ibooker.book1D(
+      "LamEffVsPt_num", "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
-  lamTkEffVsR_num = ibooker.book1D("LamTkEffVsR_num",
-			   "#Lambda^{0} TrackingEfficiency vs #rho", 40, 0., 40.);
-  lamTkEffVsEta_num = ibooker.book1D("LamTkEffVsEta_num",
-			     "#Lambda^{0} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
-  lamTkEffVsPt_num = ibooker.book1D("LamTkEffVsPt_num",
-			    "#Lambda^{0} Tracking Efficiency vs p_{T}", 70, 0., 20.);
+  lamTkEffVsR_num = ibooker.book1D(
+      "LamTkEffVsR_num", "#Lambda^{0} TrackingEfficiency vs #rho", 40, 0., 40.);
+  lamTkEffVsEta_num =
+      ibooker.book1D("LamTkEffVsEta_num",
+                     "#Lambda^{0} Tracking Efficiency vs #eta", 40, -2.5, 2.5);
+  lamTkEffVsPt_num =
+      ibooker.book1D("LamTkEffVsPt_num",
+                     "#Lambda^{0} Tracking Efficiency vs p_{T}", 70, 0., 20.);
 
-  lamEffVsR_denom = ibooker.book1D("LamEffVsR_denom",
-			   "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
-  lamEffVsEta_denom = ibooker.book1D("LamEffVsEta_denom",
-			     "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
-  lamEffVsPt_denom = ibooker.book1D("LamEffVsPt_denom",
-			    "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
+  lamEffVsR_denom = ibooker.book1D(
+      "LamEffVsR_denom", "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
+  lamEffVsEta_denom = ibooker.book1D(
+      "LamEffVsEta_denom", "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
+  lamEffVsPt_denom = ibooker.book1D(
+      "LamEffVsPt_denom", "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
   ksFakeVsR_num = ibooker.book1D("K0sFakeVsR_num",
-			   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
-  ksFakeVsEta_num = ibooker.book1D("K0sFakeVsEta_num",
-			     "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
+                                 "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+  ksFakeVsEta_num = ibooker.book1D(
+      "K0sFakeVsEta_num", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
   ksFakeVsPt_num = ibooker.book1D("K0sFakeVsPt_num",
-			    "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
-  ksTkFakeVsR_num = ibooker.book1D("K0sTkFakeVsR_num",
-			   "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
-  ksTkFakeVsEta_num = ibooker.book1D("K0sTkFakeVsEta_num",
-			     "K^{0}_{S} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksTkFakeVsPt_num = ibooker.book1D("K0sTkFakeVsPt_num",
-			    "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
+                                  "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
+  ksTkFakeVsR_num = ibooker.book1D(
+      "K0sTkFakeVsR_num", "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
+  ksTkFakeVsEta_num =
+      ibooker.book1D("K0sTkFakeVsEta_num",
+                     "K^{0}_{S} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
+  ksTkFakeVsPt_num =
+      ibooker.book1D("K0sTkFakeVsPt_num",
+                     "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
 
   ksFakeVsR_denom = ibooker.book1D("K0sFakeVsR_denom",
-			   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
-  ksFakeVsEta_denom = ibooker.book1D("K0sFakeVsEta_denom",
-			     "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksFakeVsPt_denom = ibooker.book1D("K0sFakeVsPt_denom",
-			    "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
+                                   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+  ksFakeVsEta_denom = ibooker.book1D(
+      "K0sFakeVsEta_denom", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
+  ksFakeVsPt_denom = ibooker.book1D(
+      "K0sFakeVsPt_denom", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
 
   lamFakeVsR_num = ibooker.book1D("LamFakeVsR_num",
-			    "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
-  lamFakeVsEta_num = ibooker.book1D("LamFakeVsEta_num",
-			      "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
-  lamFakeVsPt_num = ibooker.book1D("LamFakeVsPt_num",
-			     "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
-  lamTkFakeVsR_num = ibooker.book1D("LamTkFakeVsR_num",
-			    "#Lambda^{0} Tracking Fake Rate vs #rho", 40, 0., 40.);
-  lamTkFakeVsEta_num = ibooker.book1D("LamTkFakeVsEta_num",
-			      "#Lambda^{0} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
-  lamTkFakeVsPt_num = ibooker.book1D("LamTkFakeVsPt_num",
-			     "#Lambda^{0} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
+                                  "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
+  lamFakeVsEta_num = ibooker.book1D(
+      "LamFakeVsEta_num", "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
+  lamFakeVsPt_num = ibooker.book1D(
+      "LamFakeVsPt_num", "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
+  lamTkFakeVsR_num =
+      ibooker.book1D("LamTkFakeVsR_num",
+                     "#Lambda^{0} Tracking Fake Rate vs #rho", 40, 0., 40.);
+  lamTkFakeVsEta_num =
+      ibooker.book1D("LamTkFakeVsEta_num",
+                     "#Lambda^{0} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
+  lamTkFakeVsPt_num =
+      ibooker.book1D("LamTkFakeVsPt_num",
+                     "#Lambda^{0} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
 
-  lamFakeVsR_denom = ibooker.book1D("LamFakeVsR_denom",
-			    "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
-  lamFakeVsEta_denom = ibooker.book1D("LamFakeVsEta_denom",
-			      "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
-  lamFakeVsPt_denom = ibooker.book1D("LamFakeVsPt_denom",
-			     "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
+  lamFakeVsR_denom = ibooker.book1D(
+      "LamFakeVsR_denom", "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
+  lamFakeVsEta_denom = ibooker.book1D(
+      "LamFakeVsEta_denom", "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
+  lamFakeVsPt_denom = ibooker.book1D(
+      "LamFakeVsPt_denom", "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
 
   ibooker.cd();
   subDirName = dirName + "/Other";
   ibooker.setCurrentFolder(subDirName.c_str());
 
-  nKs = ibooker.book1D("nK0s",
-		     "Number of K^{0}_{S} found per event", 60, 0., 60.);
-  nLam = ibooker.book1D("nLam",
-		      "Number of #Lambda^{0} found per event", 60, 0., 60.);
+  nKs = ibooker.book1D("nK0s", "Number of K^{0}_{S} found per event", 60, 0.,
+                       60.);
+  nLam = ibooker.book1D("nLam", "Number of #Lambda^{0} found per event", 60, 0.,
+                        60.);
 
-  ksXResolution = ibooker.book1D("ksXResolution",
-			       "Resolution of V0 decay vertex X coordinate", 50, 0., 50.);
-  ksYResolution = ibooker.book1D("ksYResolution",
-			       "Resolution of V0 decay vertex Y coordinate", 50, 0., 50.);
-  ksZResolution = ibooker.book1D("ksZResolution",
-			       "Resolution of V0 decay vertex Z coordinate", 50, 0., 50.);
-  lamXResolution = ibooker.book1D("lamXResolution",
-				"Resolution of V0 decay vertex X coordinate", 50, 0., 50.);
-  lamYResolution = ibooker.book1D("lamYResolution",
-				"Resolution of V0 decay vertex Y coordinate", 50, 0., 50.);
-  lamZResolution = ibooker.book1D("lamZResolution",
-				"Resolution of V0 decay vertex Z coordinate", 50, 0., 50.);
-  ksAbsoluteDistResolution = ibooker.book1D("ksRResolution",
-					  "Resolution of absolute distance from primary vertex to V0 vertex",
-					  100, 0., 50.);
-  lamAbsoluteDistResolution = ibooker.book1D("lamRResolution",
-					   "Resolution of absolute distance from primary vertex to V0 vertex",
-					   100, 0., 50.);
+  ksXResolution =
+      ibooker.book1D("ksXResolution",
+                     "Resolution of V0 decay vertex X coordinate", 50, 0., 50.);
+  ksYResolution =
+      ibooker.book1D("ksYResolution",
+                     "Resolution of V0 decay vertex Y coordinate", 50, 0., 50.);
+  ksZResolution =
+      ibooker.book1D("ksZResolution",
+                     "Resolution of V0 decay vertex Z coordinate", 50, 0., 50.);
+  lamXResolution =
+      ibooker.book1D("lamXResolution",
+                     "Resolution of V0 decay vertex X coordinate", 50, 0., 50.);
+  lamYResolution =
+      ibooker.book1D("lamYResolution",
+                     "Resolution of V0 decay vertex Y coordinate", 50, 0., 50.);
+  lamZResolution =
+      ibooker.book1D("lamZResolution",
+                     "Resolution of V0 decay vertex Z coordinate", 50, 0., 50.);
+  ksAbsoluteDistResolution = ibooker.book1D(
+      "ksRResolution",
+      "Resolution of absolute distance from primary vertex to V0 vertex", 100,
+      0., 50.);
+  lamAbsoluteDistResolution = ibooker.book1D(
+      "lamRResolution",
+      "Resolution of absolute distance from primary vertex to V0 vertex", 100,
+      0., 50.);
 
-  ksCandStatus = ibooker.book1D("ksCandStatus",
-			  "Fake type by cand status",
-			  10, 0., 10.);
-  lamCandStatus = ibooker.book1D("ksCandStatus",
-			  "Fake type by cand status",
-			  10, 0., 10.);
+  ksCandStatus =
+      ibooker.book1D("ksCandStatus", "Fake type by cand status", 10, 0., 10.);
+  lamCandStatus =
+      ibooker.book1D("ksCandStatus", "Fake type by cand status", 10, 0., 10.);
 
   double minKsMass = 0.49767 - 0.07;
   double maxKsMass = 0.49767 + 0.07;
@@ -177,36 +203,30 @@ void V0Validator::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &, 
   double lamMassXmin = minLamMass;
   double lamMassXmax = maxLamMass;
 
-  fakeKsMass = ibooker.book1D("ksMassFake",
-			     "Mass of fake K0S",
-			     ksMassNbins, minKsMass, maxKsMass);
-  goodKsMass = ibooker.book1D("ksMassGood",
-			     "Mass of good reco K0S",
-			     ksMassNbins, minKsMass, maxKsMass);
-  fakeLamMass = ibooker.book1D("lamMassFake",
-			      "Mass of fake Lambda",
-			      lamMassNbins, minLamMass, maxLamMass);
-  goodLamMass = ibooker.book1D("lamMassGood",
-			      "Mass of good Lambda",
-			      lamMassNbins, minLamMass, maxLamMass);
+  fakeKsMass = ibooker.book1D("ksMassFake", "Mass of fake K0S", ksMassNbins,
+                              minKsMass, maxKsMass);
+  goodKsMass = ibooker.book1D("ksMassGood", "Mass of good reco K0S",
+                              ksMassNbins, minKsMass, maxKsMass);
+  fakeLamMass = ibooker.book1D("lamMassFake", "Mass of fake Lambda",
+                               lamMassNbins, minLamMass, maxLamMass);
+  goodLamMass = ibooker.book1D("lamMassGood", "Mass of good Lambda",
+                               lamMassNbins, minLamMass, maxLamMass);
 
-  ksMassAll = ibooker.book1D("ksMassAll",
-				  "Invariant mass of all K0S",
-				  ksMassNbins, ksMassXmin, ksMassXmax);
-  lamMassAll = ibooker.book1D("lamMassAll",
-				   "Invariant mass of all #Lambda^{0}",
-				   lamMassNbins, lamMassXmin, lamMassXmax);
+  ksMassAll = ibooker.book1D("ksMassAll", "Invariant mass of all K0S",
+                             ksMassNbins, ksMassXmin, ksMassXmax);
+  lamMassAll = ibooker.book1D("lamMassAll", "Invariant mass of all #Lambda^{0}",
+                              lamMassNbins, lamMassXmin, lamMassXmax);
 
-  ksFakeDauRadDist = ibooker.book1D("radDistFakeKs",
-				   "Production radius of daughter particle of Ks fake",
-				   100, 0., 15.);
-  lamFakeDauRadDist = ibooker.book1D("radDistFakeLam",
-				    "Production radius of daughter particle of Lam fake",
-				    100, 0., 15.);
+  ksFakeDauRadDist = ibooker.book1D(
+      "radDistFakeKs", "Production radius of daughter particle of Ks fake", 100,
+      0., 15.);
+  lamFakeDauRadDist = ibooker.book1D(
+      "radDistFakeLam", "Production radius of daughter particle of Lam fake",
+      100, 0., 15.);
 }
 
-void V0Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
+void V0Validator::analyze(const edm::Event& iEvent,
+                          const edm::EventSetup& iSetup) {
   using std::cout;
   using std::endl;
   using namespace edm;
@@ -219,41 +239,44 @@ void V0Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   iSetup.get<GlobalTrackingGeometryRecord>().get(globTkGeomHandle);
 
   // Make matching collections
-  Handle<reco::RecoToSimCollection > recotosimCollectionH;
-  iEvent.getByToken( recoRecoToSimCollectionToken_, recotosimCollectionH );
-  
-  Handle<reco::SimToRecoCollection> simtorecoCollectionH;
-  iEvent.getByToken( recoSimToRecoCollectionToken_, simtorecoCollectionH );
+  Handle<reco::RecoToSimCollection> recotosimCollectionH;
+  iEvent.getByToken(recoRecoToSimCollectionToken_, recotosimCollectionH);
 
-  edm::Handle<TrackingParticleCollection>  TPCollectionEff ;
-  iEvent.getByToken( trackingParticleCollection_Eff_Token_, TPCollectionEff );
-  const TrackingParticleCollection& tPCeff = *( TPCollectionEff.product() );
+  Handle<reco::SimToRecoCollection> simtorecoCollectionH;
+  iEvent.getByToken(recoSimToRecoCollectionToken_, simtorecoCollectionH);
+
+  edm::Handle<TrackingParticleCollection> TPCollectionEff;
+  iEvent.getByToken(trackingParticleCollection_Eff_Token_, TPCollectionEff);
+  const TrackingParticleCollection& tPCeff = *(TPCollectionEff.product());
 
   // Select the primary vertex, create a new reco::Vertex to hold it
-  edm::Handle< std::vector<reco::Vertex> > primaryVtxCollectionH;
-  iEvent.getByToken( vec_recoVertex_Token_, primaryVtxCollectionH );
+  edm::Handle<std::vector<reco::Vertex> > primaryVtxCollectionH;
+  iEvent.getByToken(vec_recoVertex_Token_, primaryVtxCollectionH);
 
-  std::vector<reco::Vertex>::const_iterator iVtxPH = primaryVtxCollectionH->begin();
-  for(std::vector<reco::Vertex>::const_iterator iVtx = primaryVtxCollectionH->begin();
-      iVtx < primaryVtxCollectionH->end();
-      iVtx++) {
-    if(primaryVtxCollectionH->size() > 1) {
-      if(iVtx->tracksSize() > iVtxPH->tracksSize()) {
-	iVtxPH = iVtx;
+  std::vector<reco::Vertex>::const_iterator iVtxPH =
+      primaryVtxCollectionH->begin();
+  for (std::vector<reco::Vertex>::const_iterator iVtx =
+           primaryVtxCollectionH->begin();
+       iVtx < primaryVtxCollectionH->end(); iVtx++) {
+    if (primaryVtxCollectionH->size() > 1) {
+      if (iVtx->tracksSize() > iVtxPH->tracksSize()) {
+        iVtxPH = iVtx;
       }
-    }
-    else iVtxPH = iVtx;
+    } else
+      iVtxPH = iVtx;
   }
 
-  //get the V0s;   
+  // get the V0s;
   edm::Handle<reco::VertexCompositeCandidateCollection> k0sCollection;
   edm::Handle<reco::VertexCompositeCandidateCollection> lambdaCollection;
-  iEvent.getByToken( recoVertexCompositeCandidateCollection_k0s_Token_, k0sCollection );
-  iEvent.getByToken( recoVertexCompositeCandidateCollection_lambda_Token_, lambdaCollection );
+  iEvent.getByToken(recoVertexCompositeCandidateCollection_k0s_Token_,
+                    k0sCollection);
+  iEvent.getByToken(recoVertexCompositeCandidateCollection_lambda_Token_,
+                    lambdaCollection);
 
-  //make vector of pair of trackingParticles to hold good V0 candidates
-  std::vector< pair<TrackingParticleRef, TrackingParticleRef> > trueK0s;
-  std::vector< pair<TrackingParticleRef, TrackingParticleRef> > trueLams;
+  // make vector of pair of trackingParticles to hold good V0 candidates
+  std::vector<pair<TrackingParticleRef, TrackingParticleRef> > trueK0s;
+  std::vector<pair<TrackingParticleRef, TrackingParticleRef> > trueLams;
   std::vector<double> trueKsMasses;
   std::vector<double> trueLamMasses;
 
@@ -265,539 +288,575 @@ void V0Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   double numK0sFound = 0.;
   double mass = 0.;
   std::vector<double> radDist;
-  if ( k0sCollection->size() > 0 ) {
+  if (k0sCollection->size() > 0) {
     vector<reco::TrackRef> theDaughterTracks;
-    for( reco::VertexCompositeCandidateCollection::const_iterator iK0s = k0sCollection->begin();
-	 iK0s != k0sCollection->end();
-	 iK0s++) {
+    for (reco::VertexCompositeCandidateCollection::const_iterator iK0s =
+             k0sCollection->begin();
+         iK0s != k0sCollection->end(); iK0s++) {
       // Fill mass of all K0S
-      ksMassAll->Fill( iK0s->mass() );
+      ksMassAll->Fill(iK0s->mass());
       // Fill values to be histogrammed
-      K0sCandpT = (sqrt( iK0s->momentum().perp2() ));
+      K0sCandpT = (sqrt(iK0s->momentum().perp2()));
       K0sCandEta = iK0s->momentum().eta();
-      K0sCandR = (sqrt( iK0s->vertex().perp2() ));
+      K0sCandR = (sqrt(iK0s->vertex().perp2()));
       K0sCandStatus = 0;
       mass = iK0s->mass();
 
-      theDaughterTracks.push_back( (*(dynamic_cast<const reco::RecoChargedCandidate *> (iK0s->daughter(0)) )).track() );
-      theDaughterTracks.push_back( (*(dynamic_cast<const reco::RecoChargedCandidate *> (iK0s->daughter(1)) )).track() );
-       
+      theDaughterTracks.push_back(
+          (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+               iK0s->daughter(0)))).track());
+      theDaughterTracks.push_back(
+          (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+               iK0s->daughter(1)))).track());
+
       for (int itrack = 0; itrack < 2; itrack++) {
-	K0sPiCandStatus[itrack] = 0;
+        K0sPiCandStatus[itrack] = 0;
       }
 
-      std::vector< std::pair<TrackingParticleRef, double> > tp;
+      std::vector<std::pair<TrackingParticleRef, double> > tp;
       TrackingParticleRef tpref;
       TrackingParticleRef firstDauTP;
       TrackingVertexRef k0sVtx;
 
       // Loop through K0s candidate daugher tracks
-      for(View<reco::Track>::size_type i=0; i<theDaughterTracks.size(); ++i){
-	// Found track from theDaughterTracks
-	RefToBase<reco::Track> track( theDaughterTracks.at(i) );
-        
-	if(recotosimCollectionH->find(track) != recotosimCollectionH->end()) {
-	  tp = (*recotosimCollectionH)[track];
-	  if (tp.size() != 0) {
-	    K0sPiCandStatus[i] = 1;
-	    tpref = tp.begin()->first;
+      for (View<reco::Track>::size_type i = 0; i < theDaughterTracks.size();
+           ++i) {
+        // Found track from theDaughterTracks
+        RefToBase<reco::Track> track(theDaughterTracks.at(i));
 
-	    if( simtorecoCollectionH->find(tpref) == simtorecoCollectionH->end() ) {
-	      K0sPiCandStatus[i] = 3;
-	    }
-	    TrackingVertexRef parentVertex = tpref->parentVertex();
-	    if(parentVertex.isNonnull()) radDist.push_back(parentVertex->position().R());
-	     
-	    if( parentVertex.isNonnull() ) {
-	      if( k0sVtx.isNonnull() ) {
-		if( k0sVtx->position() == parentVertex->position() ) {
-		  if( parentVertex->nDaughterTracks() == 2 ) {
-		    if( parentVertex->nSourceTracks() == 0 ) {
-		      // No source tracks found for K0s vertex; shouldn't happen, but does for evtGen events
-		      K0sCandStatus = 6;
-		    }
-		    
-		    for( TrackingVertex::tp_iterator iTP = parentVertex->sourceTracks_begin();
-			 iTP != parentVertex->sourceTracks_end(); iTP++) {
-		      if( (*iTP)->pdgId() == 310 ) {
-			K0sCandStatus = 1;
-			realK0sFound++;
-			numK0sFound += 1.;
-			std::pair<TrackingParticleRef, TrackingParticleRef> pair(firstDauTP, tpref);
-			// Pushing back a good V0
-			trueK0s.push_back(pair);
-			trueKsMasses.push_back(mass);
-		      }
-		      else {
-			K0sCandStatus = 2;
-			if( (*iTP)->pdgId() == 3122 ) {
-			  K0sCandStatus = 7;
-			}
-		      }
-		    }
-		  }
-		  else {
-		    // Found a bad match because the mother has too many daughters
-		    K0sCandStatus = 3;
-		  }
-		}
-		else {
-		  // Found a bad match because the parent vertices from the two tracks are different
-		  K0sCandStatus = 4;
-		}
-	      }
-	      else {
-		// if k0sVtx is null, fill it with parentVertex to compare to the parentVertex from the second track
-		k0sVtx = parentVertex;
-		firstDauTP = tpref;
-	      }
-	    }//parent vertex is null
-	  }//tp size zero
-	}
-	else {
-	  K0sPiCandStatus[i] = 2;
-	  noTPforK0sCand++;
-	  K0sCandStatus = 5;
-	  theDaughterTracks.clear();
-	}
+        if (recotosimCollectionH->find(track) != recotosimCollectionH->end()) {
+          tp = (*recotosimCollectionH)[track];
+          if (tp.size() != 0) {
+            K0sPiCandStatus[i] = 1;
+            tpref = tp.begin()->first;
+
+            if (simtorecoCollectionH->find(tpref) ==
+                simtorecoCollectionH->end()) {
+              K0sPiCandStatus[i] = 3;
+            }
+            TrackingVertexRef parentVertex = tpref->parentVertex();
+            if (parentVertex.isNonnull())
+              radDist.push_back(parentVertex->position().R());
+
+            if (parentVertex.isNonnull()) {
+              if (k0sVtx.isNonnull()) {
+                if (k0sVtx->position() == parentVertex->position()) {
+                  if (parentVertex->nDaughterTracks() == 2) {
+                    if (parentVertex->nSourceTracks() == 0) {
+                      // No source tracks found for K0s vertex; shouldn't
+                      // happen, but does for evtGen events
+                      K0sCandStatus = 6;
+                    }
+
+                    for (TrackingVertex::tp_iterator iTP =
+                             parentVertex->sourceTracks_begin();
+                         iTP != parentVertex->sourceTracks_end(); iTP++) {
+                      if ((*iTP)->pdgId() == 310) {
+                        K0sCandStatus = 1;
+                        realK0sFound++;
+                        numK0sFound += 1.;
+                        std::pair<TrackingParticleRef, TrackingParticleRef>
+                            pair(firstDauTP, tpref);
+                        // Pushing back a good V0
+                        trueK0s.push_back(pair);
+                        trueKsMasses.push_back(mass);
+                      } else {
+                        K0sCandStatus = 2;
+                        if ((*iTP)->pdgId() == 3122) {
+                          K0sCandStatus = 7;
+                        }
+                      }
+                    }
+                  } else {
+                    // Found a bad match because the mother has too many
+                    // daughters
+                    K0sCandStatus = 3;
+                  }
+                } else {
+                  // Found a bad match because the parent vertices from the two
+                  // tracks are different
+                  K0sCandStatus = 4;
+                }
+              } else {
+                // if k0sVtx is null, fill it with parentVertex to compare to
+                // the parentVertex from the second track
+                k0sVtx = parentVertex;
+                firstDauTP = tpref;
+              }
+            }  // parent vertex is null
+          }  // tp size zero
+        } else {
+          K0sPiCandStatus[i] = 2;
+          noTPforK0sCand++;
+          K0sCandStatus = 5;
+          theDaughterTracks.clear();
+        }
       }
       theDaughterTracks.clear();
       // fill the fake rate histograms
-      if( K0sCandStatus > 1 ) {
-	ksFakeVsR_num->Fill(K0sCandR);
-	ksFakeVsEta_num->Fill(K0sCandEta);
-	ksFakeVsPt_num->Fill(K0sCandpT);
-	ksCandStatus->Fill((float) K0sCandStatus);
-	fakeKsMass->Fill(mass);
-	for( unsigned int ndx = 0; ndx < radDist.size(); ndx++ ) {
-	  ksFakeDauRadDist->Fill(radDist[ndx]);
-	}
+      if (K0sCandStatus > 1) {
+        ksFakeVsR_num->Fill(K0sCandR);
+        ksFakeVsEta_num->Fill(K0sCandEta);
+        ksFakeVsPt_num->Fill(K0sCandpT);
+        ksCandStatus->Fill((float)K0sCandStatus);
+        fakeKsMass->Fill(mass);
+        for (unsigned int ndx = 0; ndx < radDist.size(); ndx++) {
+          ksFakeDauRadDist->Fill(radDist[ndx]);
+        }
       }
-      if( K0sCandStatus == 5 ) {
-	ksTkFakeVsR_num->Fill(K0sCandR);
-	ksTkFakeVsEta_num->Fill(K0sCandEta);
-	ksTkFakeVsPt_num->Fill(K0sCandpT);
+      if (K0sCandStatus == 5) {
+        ksTkFakeVsR_num->Fill(K0sCandR);
+        ksTkFakeVsEta_num->Fill(K0sCandEta);
+        ksTkFakeVsPt_num->Fill(K0sCandpT);
       }
       ksFakeVsR_denom->Fill(K0sCandR);
       ksFakeVsEta_denom->Fill(K0sCandEta);
       ksFakeVsPt_denom->Fill(K0sCandpT);
     }
   }
-  nKs->Fill( (float) numK0sFound );
+  nKs->Fill((float)numK0sFound);
 
   double numLamFound = 0.;
   radDist.clear();
   // Lambdas
-  if ( lambdaCollection->size() > 0 ) {
+  if (lambdaCollection->size() > 0) {
     vector<reco::TrackRef> theDaughterTracks;
-    for( reco::VertexCompositeCandidateCollection::const_iterator iLam = lambdaCollection->begin();
-	 iLam != lambdaCollection->end();
-	 iLam++) {
+    for (reco::VertexCompositeCandidateCollection::const_iterator iLam =
+             lambdaCollection->begin();
+         iLam != lambdaCollection->end(); iLam++) {
       // Fill mass plot with ALL lambdas
-      lamMassAll->Fill( iLam->mass() );
+      lamMassAll->Fill(iLam->mass());
       // Fill values to be histogrammed
-      LamCandpT = (sqrt( iLam->momentum().perp2() ));
+      LamCandpT = (sqrt(iLam->momentum().perp2()));
       LamCandEta = iLam->momentum().eta();
-      LamCandR = (sqrt( iLam->vertex().perp2() ));
+      LamCandR = (sqrt(iLam->vertex().perp2()));
       LamCandStatus = 0;
       mass = iLam->mass();
-      
-      //cout << "Lam daughter tracks" << endl;
-      theDaughterTracks.push_back( (*(dynamic_cast<const reco::RecoChargedCandidate *> (iLam->daughter(0)) )).track() );
-      theDaughterTracks.push_back( (*(dynamic_cast<const reco::RecoChargedCandidate *> (iLam->daughter(1)) )).track() );
-      
+
+      // cout << "Lam daughter tracks" << endl;
+      theDaughterTracks.push_back(
+          (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+               iLam->daughter(0)))).track());
+      theDaughterTracks.push_back(
+          (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+               iLam->daughter(1)))).track());
+
       for (int itrack = 0; itrack < 2; itrack++) {
-	LamPiCandStatus[itrack] = 0;
+        LamPiCandStatus[itrack] = 0;
       }
-      
-      std::vector< std::pair<TrackingParticleRef, double> > tp;
+
+      std::vector<std::pair<TrackingParticleRef, double> > tp;
       TrackingParticleRef tpref;
       TrackingParticleRef firstDauTP;
       TrackingVertexRef LamVtx;
       // Loop through Lambda candidate daughter tracks
-      for(View<reco::Track>::size_type i=0; i<theDaughterTracks.size(); ++i){
-	// Found track from theDaughterTracks
-	RefToBase<reco::Track> track( theDaughterTracks.at(i) );
-	
-	if(recotosimCollectionH->find(track) != recotosimCollectionH->end()) {
-	  tp = (*recotosimCollectionH)[track];
-	  if (tp.size() != 0) {
-	    LamPiCandStatus[i] = 1;
-	    tpref = tp.begin()->first;
-	    if( simtorecoCollectionH->find(tpref) == simtorecoCollectionH->end() ) {
-	      LamPiCandStatus[i] = 3;
-	    }
-	    TrackingVertexRef parentVertex = tpref->parentVertex();
-	    if( parentVertex.isNonnull() ) radDist.push_back(parentVertex->position().R());
-	     
-	    if( parentVertex.isNonnull() ) {
-	      if( LamVtx.isNonnull() ) {
-		if( LamVtx->position() == parentVertex->position() ) {
-		  if( parentVertex->nDaughterTracks() == 2 ) {
-		    if( parentVertex->nSourceTracks() == 0 ) {
-		      // No source tracks found for K0s vertex; shouldn't happen, but does for evtGen events
-		      LamCandStatus = 6;
-		    }
+      for (View<reco::Track>::size_type i = 0; i < theDaughterTracks.size();
+           ++i) {
+        // Found track from theDaughterTracks
+        RefToBase<reco::Track> track(theDaughterTracks.at(i));
 
-		    for( TrackingVertex::tp_iterator iTP = parentVertex->sourceTracks_begin();
-			 iTP != parentVertex->sourceTracks_end(); ++iTP) {
-		      if( abs((*iTP)->pdgId()) == 3122 ) {
-			LamCandStatus = 1;
-			realLamFound++;
-			numLamFound += 1.;
-			std::pair<TrackingParticleRef, TrackingParticleRef> pair(firstDauTP, tpref);
-			// Pushing back a good V0
-			trueLams.push_back(pair);
-			trueLamMasses.push_back(mass);
-		      }
-		      else {
-			LamCandStatus = 2;
-			if( abs((*iTP)->pdgId() ) == 310 ) {
-			  LamCandStatus = 7;
-			}
-		      }
-		    }
-		  }
-		  else {
-		    // Found a bad match because the mother has too many daughters
-		    LamCandStatus = 3;
-		  }
-		}
-		else {
-		  // Found a bad match because the parent vertices from the two tracks are different
-		  LamCandStatus = 4;
-		}
-	      }
-	      else {
-		// if lamVtx is null, fill it with parentVertex to compare to the parentVertex from the second track
-		LamVtx = parentVertex;
-		firstDauTP = tpref;
-	      }
-	    }//parent vertex is null
-	  }//tp size zero
-	}
-	else {
-	  LamPiCandStatus[i] = 2;
-	  noTPforLamCand++;
-	  LamCandStatus = 5;
-	  theDaughterTracks.clear();
-	}
+        if (recotosimCollectionH->find(track) != recotosimCollectionH->end()) {
+          tp = (*recotosimCollectionH)[track];
+          if (tp.size() != 0) {
+            LamPiCandStatus[i] = 1;
+            tpref = tp.begin()->first;
+            if (simtorecoCollectionH->find(tpref) ==
+                simtorecoCollectionH->end()) {
+              LamPiCandStatus[i] = 3;
+            }
+            TrackingVertexRef parentVertex = tpref->parentVertex();
+            if (parentVertex.isNonnull())
+              radDist.push_back(parentVertex->position().R());
+
+            if (parentVertex.isNonnull()) {
+              if (LamVtx.isNonnull()) {
+                if (LamVtx->position() == parentVertex->position()) {
+                  if (parentVertex->nDaughterTracks() == 2) {
+                    if (parentVertex->nSourceTracks() == 0) {
+                      // No source tracks found for K0s vertex; shouldn't
+                      // happen, but does for evtGen events
+                      LamCandStatus = 6;
+                    }
+
+                    for (TrackingVertex::tp_iterator iTP =
+                             parentVertex->sourceTracks_begin();
+                         iTP != parentVertex->sourceTracks_end(); ++iTP) {
+                      if (abs((*iTP)->pdgId()) == 3122) {
+                        LamCandStatus = 1;
+                        realLamFound++;
+                        numLamFound += 1.;
+                        std::pair<TrackingParticleRef, TrackingParticleRef>
+                            pair(firstDauTP, tpref);
+                        // Pushing back a good V0
+                        trueLams.push_back(pair);
+                        trueLamMasses.push_back(mass);
+                      } else {
+                        LamCandStatus = 2;
+                        if (abs((*iTP)->pdgId()) == 310) {
+                          LamCandStatus = 7;
+                        }
+                      }
+                    }
+                  } else {
+                    // Found a bad match because the mother has too many
+                    // daughters
+                    LamCandStatus = 3;
+                  }
+                } else {
+                  // Found a bad match because the parent vertices from the two
+                  // tracks are different
+                  LamCandStatus = 4;
+                }
+              } else {
+                // if lamVtx is null, fill it with parentVertex to compare to
+                // the parentVertex from the second track
+                LamVtx = parentVertex;
+                firstDauTP = tpref;
+              }
+            }  // parent vertex is null
+          }  // tp size zero
+        } else {
+          LamPiCandStatus[i] = 2;
+          noTPforLamCand++;
+          LamCandStatus = 5;
+          theDaughterTracks.clear();
+        }
       }
       theDaughterTracks.clear();
       // fill the fake rate histograms
-      if( LamCandStatus > 1 ) {
-	lamFakeVsR_num->Fill(LamCandR);
-	lamFakeVsEta_num->Fill(LamCandEta);
-	lamFakeVsPt_num->Fill(LamCandpT);
-	lamCandStatus->Fill((float) LamCandStatus);
-	fakeLamMass->Fill(mass);
-	for( unsigned int ndx = 0; ndx < radDist.size(); ndx++ ) {
-	  lamFakeDauRadDist->Fill(radDist[ndx]);
-	}
+      if (LamCandStatus > 1) {
+        lamFakeVsR_num->Fill(LamCandR);
+        lamFakeVsEta_num->Fill(LamCandEta);
+        lamFakeVsPt_num->Fill(LamCandpT);
+        lamCandStatus->Fill((float)LamCandStatus);
+        fakeLamMass->Fill(mass);
+        for (unsigned int ndx = 0; ndx < radDist.size(); ndx++) {
+          lamFakeDauRadDist->Fill(radDist[ndx]);
+        }
       }
-      if( K0sCandStatus == 5 ) {
-	lamTkFakeVsR_num->Fill(LamCandR);
-	lamTkFakeVsEta_num->Fill(LamCandEta);
-	lamTkFakeVsPt_num->Fill(LamCandpT);
+      if (K0sCandStatus == 5) {
+        lamTkFakeVsR_num->Fill(LamCandR);
+        lamTkFakeVsEta_num->Fill(LamCandEta);
+        lamTkFakeVsPt_num->Fill(LamCandpT);
       }
       lamFakeVsR_denom->Fill(LamCandR);
       lamFakeVsEta_denom->Fill(LamCandEta);
       lamFakeVsPt_denom->Fill(LamCandpT);
     }
   }
-  nLam->Fill( (double) numLamFound );
-
+  nLam->Fill((double)numLamFound);
 
   ///////////////////////////////
   // Do efficiency calculation //
   ///////////////////////////////
   // Lambdas
-  for(TrackingParticleCollection::size_type i = 0; i < tPCeff.size(); i++) {
+  for (TrackingParticleCollection::size_type i = 0; i < tPCeff.size(); i++) {
     TrackingParticleRef tpr1(TPCollectionEff, i);
     const TrackingParticle* itp1 = tpr1.get();
-    if( (itp1->pdgId() == 211 || itp1->pdgId() == 2212)
-	&& itp1->parentVertex().isNonnull()
-	&& abs(itp1->momentum().eta()) < 2.4
-	&& sqrt( itp1->momentum().perp2() ) > 0.9) {
+    if ((itp1->pdgId() == 211 || itp1->pdgId() == 2212) &&
+        itp1->parentVertex().isNonnull() && abs(itp1->momentum().eta()) < 2.4 &&
+        sqrt(itp1->momentum().perp2()) > 0.9) {
       bool isLambda = false;
-      if( itp1->pdgId() == 2212 ) isLambda = true;
-      if( itp1->parentVertex()->nDaughterTracks() == 2 ) {
+      if (itp1->pdgId() == 2212) isLambda = true;
+      if (itp1->parentVertex()->nDaughterTracks() == 2) {
+        TrackingVertexRef piCand1Vertex = itp1->parentVertex();
+        for (TrackingVertex::tp_iterator iTP1 =
+                 piCand1Vertex->sourceTracks_begin();
+             iTP1 != piCand1Vertex->sourceTracks_end(); iTP1++) {
+          if (abs((*iTP1)->pdgId()) == 3122) {
+            //	     ----->>>>>>Keep going here
+            for (TrackingParticleCollection::size_type j = 0; j < tPCeff.size();
+                 j++) {
+              TrackingParticleRef tpr2(TPCollectionEff, j);
+              const TrackingParticle* itp2 = tpr2.get();
+              int particle2pdgId;
+              if (isLambda)
+                particle2pdgId = -211;
+              else
+                particle2pdgId = -2212;
+              if (itp2->pdgId() == particle2pdgId &&
+                  itp2->parentVertex().isNonnull() &&
+                  abs(itp2->momentum().eta()) < 2.4 &&
+                  sqrt(itp2->momentum().perp2()) > 0.9) {
+                if (itp2->parentVertex() == itp1->parentVertex()) {
+                  // Found a good pair of Lambda daughters
+                  TrackingVertexRef piCand2Vertex = itp2->parentVertex();
+                  for (TrackingVertex::tp_iterator iTP2 =
+                           piCand2Vertex->sourceTracks_begin();
+                       iTP2 != piCand2Vertex->sourceTracks_end(); ++iTP2) {
+                    LamGenEta = LamGenpT = LamGenR = 0.;
+                    LamGenStatus = 0;
+                    for (int ifill = 0; ifill < 2; ifill++) {
+                      // do nothing?
+                    }
+                    if (abs((*iTP2)->pdgId()) == 3122) {
+                      // found generated Lambda
+                      LamGenpT = sqrt((*iTP2)->momentum().perp2());
+                      LamGenEta = (*iTP2)->momentum().eta();
+                      LamGenR = sqrt(itp2->vertex().perp2());
+                      genLam++;
+                      if (trueLams.size() > 0) {
+                        int loop_1 = 0;
+                        for (std::vector<pair<TrackingParticleRef,
+                                              TrackingParticleRef> >::
+                                 const_iterator iEffCheck = trueLams.begin();
+                             iEffCheck != trueLams.end(); iEffCheck++) {
+                          if (itp1->parentVertex() ==
+                                  iEffCheck->first->parentVertex() &&
+                              itp2->parentVertex() ==
+                                  iEffCheck->second->parentVertex()) {
+                            realLamFoundEff++;
+                            // V0Producer found the generated Lambda
+                            LamGenStatus = 1;
+                            goodLamMass->Fill(trueLamMasses[loop_1]);
+                            break;
+                          } else {
+                            // V0Producer didn't find the generated Lambda
+                            LamGenStatus = 2;
+                          }
+                          loop_1++;
+                        }
+                      } else {
+                        // No V0 cand found, so V0Producer didn't find the
+                        // generated Lambda
+                        LamGenStatus = 2;
+                      }
+                      std::vector<std::pair<RefToBase<reco::Track>, double> >
+                          rt1;
+                      std::vector<std::pair<RefToBase<reco::Track>, double> >
+                          rt2;
 
-	TrackingVertexRef piCand1Vertex = itp1->parentVertex();
-	for(TrackingVertex::tp_iterator iTP1 = piCand1Vertex->sourceTracks_begin();
-	    iTP1 != piCand1Vertex->sourceTracks_end(); iTP1++) {
-	  if( abs((*iTP1)->pdgId()) == 3122 ) {
-	    //	     ----->>>>>>Keep going here
-	    for(TrackingParticleCollection::size_type j=0;
-		j < tPCeff.size();
-		j++) {
-	      TrackingParticleRef tpr2(TPCollectionEff, j);
-	      const TrackingParticle* itp2 = tpr2.get();
-	      int particle2pdgId;
-	      if (isLambda) particle2pdgId = -211;
-	      else particle2pdgId = -2212;
-	      if( itp2->pdgId() == particle2pdgId
-		  && itp2->parentVertex().isNonnull()
-		  && abs(itp2->momentum().eta()) < 2.4
-		  && sqrt(itp2->momentum().perp2()) > 0.9) {
-		if(itp2->parentVertex() == itp1->parentVertex()) {
-		  // Found a good pair of Lambda daughters
-		  TrackingVertexRef piCand2Vertex = itp2->parentVertex();
-		  for (TrackingVertex::tp_iterator iTP2 = piCand2Vertex->sourceTracks_begin();
-		       iTP2 != piCand2Vertex->sourceTracks_end(); 
-		       ++iTP2) {
-		    LamGenEta = LamGenpT = LamGenR = 0.;
-		    LamGenStatus = 0;
-		    for(int ifill = 0;
-			ifill < 2;
-			ifill++) {
-		      // do nothing?
-		    }
-		    if( abs((*iTP2)->pdgId()) == 3122 ) {
-		      // found generated Lambda
-		      LamGenpT = sqrt((*iTP2)->momentum().perp2());
-		      LamGenEta = (*iTP2)->momentum().eta();
-		      LamGenR = sqrt(itp2->vertex().perp2());
-		      genLam++;
-		      if(trueLams.size() > 0) {
-			int loop_1 = 0;
-			for(std::vector< pair<TrackingParticleRef, TrackingParticleRef> >::const_iterator iEffCheck = trueLams.begin();
-			    iEffCheck != trueLams.end();
-			    iEffCheck++) {
-			  if( itp1->parentVertex() == iEffCheck->first->parentVertex()
-			      && itp2->parentVertex() == iEffCheck->second->parentVertex() ) {
-			    realLamFoundEff++;
-			    //V0Producer found the generated Lambda
-			    LamGenStatus = 1;
-			    goodLamMass->Fill(trueLamMasses[loop_1]);
-			    break;
-			  }
-			  else {
-			    //V0Producer didn't find the generated Lambda
-			    LamGenStatus = 2;
-			  }
-			  loop_1++;
-			}
-		      }
-		      else {
-			//No V0 cand found, so V0Producer didn't find the generated Lambda
-			LamGenStatus = 2;
-		      }
-		      std::vector< std::pair<RefToBase<reco::Track>, double> > rt1;
-		      std::vector< std::pair<RefToBase<reco::Track>, double> > rt2;
-		      
-		      if( simtorecoCollectionH->find(tpr1) != simtorecoCollectionH->end() ) {
-			rt1 = (std::vector<std::pair<RefToBase<reco::Track>, double> >) (*simtorecoCollectionH)[tpr1];
-			if(rt1.size() != 0) {
-			  LamPiEff[0] = 1; //Found the first daughter track
-			  edm::RefToBase<reco::Track> t1 = rt1.begin()->first;
-			}
-		      }
-		      else {
-			LamPiEff[0] = 2;//First daughter not found
-		      }
-		      if( (simtorecoCollectionH->find(tpr2) != simtorecoCollectionH->end()) ) {
-			rt2 = (std::vector<std::pair<RefToBase<reco::Track>, double> >) (*simtorecoCollectionH)[tpr2];
-			if(rt2.size() != 0) {
-			  LamPiEff[1] = 1;//Found the second daughter track
-			  edm::RefToBase<reco::Track> t2 = rt2.begin()->first;
-			}
-		      }
-		      else {
-			LamPiEff[1] = 2;//Second daughter not found
-		      }
-		      
-		      if( LamGenStatus == 1
-			  && (LamPiEff[0] == 2 || LamPiEff[1] == 2) ) {
-			// Good Lambda found, but recoTrack->trackingParticle->recoTrack didn't work
-			LamGenStatus = 4;
-			realLamFoundEff--;
-		      }
-		      if( LamGenStatus == 2
-			  && (LamPiEff[0] == 2 || LamPiEff[1] == 2) ) {
-			// Lambda not found because we didn't find a daughter track
-			LamGenStatus = 3;
-		      }
-		      // Fill histograms
-		      if(LamGenR > 0.) {
-			if(LamGenStatus == 1) {
-			  lamEffVsR_num->Fill(LamGenR);
-			}
-			if((double) LamGenStatus < 2.5) {
-			  lamTkEffVsR_num->Fill(LamGenR);
-			}
-			lamEffVsR_denom->Fill(LamGenR);
-		      }
-		      if(abs(LamGenEta) > 0.) {
-			if(LamGenStatus == 1) {
-			  lamEffVsEta_num->Fill(LamGenEta);
-			}
-			if((double) LamGenStatus < 2.5) {
-			  lamTkEffVsEta_num->Fill(LamGenEta);
-			}
-			lamEffVsEta_denom->Fill(LamGenEta);
-		      }
-		      if(LamGenpT > 0.) {
-			if(LamGenStatus == 1) {
-			  lamEffVsPt_num->Fill(LamGenpT);
-			}
-			if((double) LamGenStatus < 2.5) {
-			  lamTkEffVsPt_num->Fill(LamGenpT);
-			}
-			lamEffVsPt_denom->Fill(LamGenpT);
-		      }
-		    }
-		  }
-		}
-	      }
-	    }
-	  }
-	}
+                      if (simtorecoCollectionH->find(tpr1) !=
+                          simtorecoCollectionH->end()) {
+                        rt1 = (std::vector<
+                            std::pair<RefToBase<reco::Track>,
+                                      double> >)(*simtorecoCollectionH)[tpr1];
+                        if (rt1.size() != 0) {
+                          LamPiEff[0] = 1;  // Found the first daughter track
+                          edm::RefToBase<reco::Track> t1 = rt1.begin()->first;
+                        }
+                      } else {
+                        LamPiEff[0] = 2;  // First daughter not found
+                      }
+                      if ((simtorecoCollectionH->find(tpr2) !=
+                           simtorecoCollectionH->end())) {
+                        rt2 = (std::vector<
+                            std::pair<RefToBase<reco::Track>,
+                                      double> >)(*simtorecoCollectionH)[tpr2];
+                        if (rt2.size() != 0) {
+                          LamPiEff[1] = 1;  // Found the second daughter track
+                          edm::RefToBase<reco::Track> t2 = rt2.begin()->first;
+                        }
+                      } else {
+                        LamPiEff[1] = 2;  // Second daughter not found
+                      }
+
+                      if (LamGenStatus == 1 &&
+                          (LamPiEff[0] == 2 || LamPiEff[1] == 2)) {
+                        // Good Lambda found, but
+                        // recoTrack->trackingParticle->recoTrack didn't work
+                        LamGenStatus = 4;
+                        realLamFoundEff--;
+                      }
+                      if (LamGenStatus == 2 &&
+                          (LamPiEff[0] == 2 || LamPiEff[1] == 2)) {
+                        // Lambda not found because we didn't find a daughter
+                        // track
+                        LamGenStatus = 3;
+                      }
+                      // Fill histograms
+                      if (LamGenR > 0.) {
+                        if (LamGenStatus == 1) {
+                          lamEffVsR_num->Fill(LamGenR);
+                        }
+                        if ((double)LamGenStatus < 2.5) {
+                          lamTkEffVsR_num->Fill(LamGenR);
+                        }
+                        lamEffVsR_denom->Fill(LamGenR);
+                      }
+                      if (abs(LamGenEta) > 0.) {
+                        if (LamGenStatus == 1) {
+                          lamEffVsEta_num->Fill(LamGenEta);
+                        }
+                        if ((double)LamGenStatus < 2.5) {
+                          lamTkEffVsEta_num->Fill(LamGenEta);
+                        }
+                        lamEffVsEta_denom->Fill(LamGenEta);
+                      }
+                      if (LamGenpT > 0.) {
+                        if (LamGenStatus == 1) {
+                          lamEffVsPt_num->Fill(LamGenpT);
+                        }
+                        if ((double)LamGenStatus < 2.5) {
+                          lamTkEffVsPt_num->Fill(LamGenpT);
+                        }
+                        lamEffVsPt_denom->Fill(LamGenpT);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
 
-  //Kshorts
+  // Kshorts
 
-  for (TrackingParticleCollection::size_type i=0; i<tPCeff.size(); i++){
+  for (TrackingParticleCollection::size_type i = 0; i < tPCeff.size(); i++) {
     TrackingParticleRef tpr1(TPCollectionEff, i);
     const TrackingParticle* itp1 = tpr1.get();
-    // only count the efficiency for pions with |eta|<2.4 and pT>0.9 GeV. First search for a suitable pi+
-    if ( itp1->pdgId() == 211 
-	 && itp1->parentVertex().isNonnull() 
-	 && abs(itp1->momentum().eta()) < 2.4 
-	 && sqrt(itp1->momentum().perp2()) > 0.9) {
-      if ( itp1->parentVertex()->nDaughterTracks() == 2 ) {
-	TrackingVertexRef piCand1Vertex = itp1->parentVertex();	       
-	//check trackingParticle pion for a Ks mother
-	for (TrackingVertex::tp_iterator iTP1 = piCand1Vertex->sourceTracks_begin();
-	     iTP1 != piCand1Vertex->sourceTracks_end(); ++iTP1) {
-	  //iTP1 is a TrackingParticle
-	  if ( (*iTP1)->pdgId()==310 ) {
-	    //with a Ks mother found for the pi+, loop through trackingParticles again to find a pi-
-	    for (TrackingParticleCollection::size_type j=0; j<tPCeff.size(); j++){
-	      TrackingParticleRef tpr2(TPCollectionEff, j);
-	      const TrackingParticle* itp2 = tpr2.get();
-	      
-	      if ( itp2->pdgId() == -211 && itp2->parentVertex().isNonnull()  
-		   && abs(itp2->momentum().eta()) < 2.4 
-		   && sqrt(itp2->momentum().perp2()) > 0.9) {
-		//check the pi+ and pi- have the same vertex
-		if ( itp2->parentVertex() == itp1->parentVertex() ) {
-		  TrackingVertexRef piCand2Vertex = itp2->parentVertex();	       
-		  for (TrackingVertex::tp_iterator iTP2 = piCand2Vertex->sourceTracks_begin();
-		       iTP2 != piCand2Vertex->sourceTracks_end(); ++iTP2) {
-		    //iTP2 is a TrackingParticle
-		    K0sGenEta = K0sGenpT = K0sGenR = 0.;
-		    K0sGenStatus = 0;
-		    if( (*iTP2)->pdgId() == 310 ) {
-		      K0sGenpT = sqrt( (*iTP2)->momentum().perp2() );
-		      K0sGenEta = (*iTP2)->momentum().eta();
-		      K0sGenR = sqrt(itp2->vertex().perp2());
-		      genK0s++;
-		      int loop_2 = 0;
-		      if( trueK0s.size() > 0 ) {
-			for( std::vector< pair<TrackingParticleRef, TrackingParticleRef> >::const_iterator iEffCheck = trueK0s.begin();
-			     iEffCheck != trueK0s.end();
-			     iEffCheck++) {
-			  //if the parent vertices for the tracks are the same, then the generated Ks was found
-			  if (itp1->parentVertex()==iEffCheck->first->parentVertex() &&
-			      itp2->parentVertex()==iEffCheck->second->parentVertex())  {
-			    realK0sFoundEff++;
-			    K0sGenStatus = 1;
-			    goodKsMass->Fill(trueKsMasses[loop_2]);
-			    break;
-			  }
-			  else {
-			    K0sGenStatus = 2;
-			  }
-			}
-		      }
-		      else {
-			K0sGenStatus = 2;
-		      }
+    // only count the efficiency for pions with |eta|<2.4 and pT>0.9 GeV. First
+    // search for a suitable pi+
+    if (itp1->pdgId() == 211 && itp1->parentVertex().isNonnull() &&
+        abs(itp1->momentum().eta()) < 2.4 &&
+        sqrt(itp1->momentum().perp2()) > 0.9) {
+      if (itp1->parentVertex()->nDaughterTracks() == 2) {
+        TrackingVertexRef piCand1Vertex = itp1->parentVertex();
+        // check trackingParticle pion for a Ks mother
+        for (TrackingVertex::tp_iterator iTP1 =
+                 piCand1Vertex->sourceTracks_begin();
+             iTP1 != piCand1Vertex->sourceTracks_end(); ++iTP1) {
+          // iTP1 is a TrackingParticle
+          if ((*iTP1)->pdgId() == 310) {
+            // with a Ks mother found for the pi+, loop through
+            // trackingParticles again to find a pi-
+            for (TrackingParticleCollection::size_type j = 0; j < tPCeff.size();
+                 j++) {
+              TrackingParticleRef tpr2(TPCollectionEff, j);
+              const TrackingParticle* itp2 = tpr2.get();
 
-		      // Check if the generated Ks tracks were found or not
-		      // by searching the recoTracks list for a match to the trackingParticles
+              if (itp2->pdgId() == -211 && itp2->parentVertex().isNonnull() &&
+                  abs(itp2->momentum().eta()) < 2.4 &&
+                  sqrt(itp2->momentum().perp2()) > 0.9) {
+                // check the pi+ and pi- have the same vertex
+                if (itp2->parentVertex() == itp1->parentVertex()) {
+                  TrackingVertexRef piCand2Vertex = itp2->parentVertex();
+                  for (TrackingVertex::tp_iterator iTP2 =
+                           piCand2Vertex->sourceTracks_begin();
+                       iTP2 != piCand2Vertex->sourceTracks_end(); ++iTP2) {
+                    // iTP2 is a TrackingParticle
+                    K0sGenEta = K0sGenpT = K0sGenR = 0.;
+                    K0sGenStatus = 0;
+                    if ((*iTP2)->pdgId() == 310) {
+                      K0sGenpT = sqrt((*iTP2)->momentum().perp2());
+                      K0sGenEta = (*iTP2)->momentum().eta();
+                      K0sGenR = sqrt(itp2->vertex().perp2());
+                      genK0s++;
+                      int loop_2 = 0;
+                      if (trueK0s.size() > 0) {
+                        for (std::vector<pair<TrackingParticleRef,
+                                              TrackingParticleRef> >::
+                                 const_iterator iEffCheck = trueK0s.begin();
+                             iEffCheck != trueK0s.end(); iEffCheck++) {
+                          // if the parent vertices for the tracks are the same,
+                          // then the generated Ks was found
+                          if (itp1->parentVertex() ==
+                                  iEffCheck->first->parentVertex() &&
+                              itp2->parentVertex() ==
+                                  iEffCheck->second->parentVertex()) {
+                            realK0sFoundEff++;
+                            K0sGenStatus = 1;
+                            goodKsMass->Fill(trueKsMasses[loop_2]);
+                            break;
+                          } else {
+                            K0sGenStatus = 2;
+                          }
+                        }
+                      } else {
+                        K0sGenStatus = 2;
+                      }
 
-		      std::vector<std::pair<RefToBase<reco::Track>, double> > rt1;
-		      std::vector<std::pair<RefToBase<reco::Track>, double> > rt2;
-		      
-		      if( simtorecoCollectionH->find(tpr1) != simtorecoCollectionH->end() ) {
-			rt1 = (std::vector< std::pair<RefToBase<reco::Track>, double> >) (*simtorecoCollectionH)[tpr1];
-			if(rt1.size() != 0) {
-			  //First pion found
-			  K0sPiEff[0] = 1;
-			  edm::RefToBase<reco::Track> t1 = rt1.begin()->first;
-			}
-		      }
-		      else {
-			//First pion not found
-			K0sPiEff[0] = 2;
-		      }
-		      
-		      if( simtorecoCollectionH->find(tpr2) != simtorecoCollectionH->end() ) {
-			rt2 = (std::vector< std::pair<RefToBase<reco::Track>, double> >) (*simtorecoCollectionH)[tpr2];
-			if(rt2.size() != 0) {
-			  //Second pion found
-			  K0sPiEff[1] = 1;
-			  edm::RefToBase<reco::Track> t2 = rt2.begin()->first;
-			}
-		      }
-		      else {
-			K0sPiEff[1] = 2;
-		      }
-		      if(K0sGenStatus == 1
-			 && (K0sPiEff[0] == 2 || K0sPiEff[1] == 2)) {
-			K0sGenStatus = 4;
-			realK0sFoundEff--;
-		      }
-		      if(K0sGenStatus == 2
-			 && (K0sPiEff[0] == 2 || K0sPiEff[1] == 2)) {
-			K0sGenStatus = 3;
-		      }
-		      if(K0sPiEff[0] == 1 && K0sPiEff[1] == 1) {
-			k0sTracksFound++;
-		      }
-		      //Fill Histograms
-		      if(K0sGenR > 0.) {
-			if(K0sGenStatus == 1) {
-			  ksEffVsR_num->Fill(K0sGenR);
-			}
-			if((double) K0sGenStatus < 2.5) {			  
-			  ksTkEffVsR_num->Fill(K0sGenR);
-			}
-			ksEffVsR_denom->Fill(K0sGenR);
-		      }
-		      if(abs(K0sGenEta) > 0.) {
-			if(K0sGenStatus == 1) {
-			  ksEffVsEta_num->Fill(K0sGenEta);
-			}
-			if((double) K0sGenStatus < 2.5) {
-			  ksTkEffVsEta_num->Fill(K0sGenEta);
-			}
-			ksEffVsEta_denom->Fill(K0sGenEta);
-		      }
-		      if(K0sGenpT > 0.) {
-			if(K0sGenStatus == 1) {
-			  ksEffVsPt_num->Fill(K0sGenpT);
-			}
-			if((double) K0sGenStatus < 2.5) {
-			  ksTkEffVsPt_num->Fill(K0sGenpT);
-			}
-			ksEffVsPt_denom->Fill(K0sGenpT);
-		      }
-		    }
-		  }
-		}
-	      }
-	    }
-	  }
-	}
+                      // Check if the generated Ks tracks were found or not
+                      // by searching the recoTracks list for a match to the
+                      // trackingParticles
+
+                      std::vector<std::pair<RefToBase<reco::Track>, double> >
+                          rt1;
+                      std::vector<std::pair<RefToBase<reco::Track>, double> >
+                          rt2;
+
+                      if (simtorecoCollectionH->find(tpr1) !=
+                          simtorecoCollectionH->end()) {
+                        rt1 = (std::vector<
+                            std::pair<RefToBase<reco::Track>,
+                                      double> >)(*simtorecoCollectionH)[tpr1];
+                        if (rt1.size() != 0) {
+                          // First pion found
+                          K0sPiEff[0] = 1;
+                          edm::RefToBase<reco::Track> t1 = rt1.begin()->first;
+                        }
+                      } else {
+                        // First pion not found
+                        K0sPiEff[0] = 2;
+                      }
+
+                      if (simtorecoCollectionH->find(tpr2) !=
+                          simtorecoCollectionH->end()) {
+                        rt2 = (std::vector<
+                            std::pair<RefToBase<reco::Track>,
+                                      double> >)(*simtorecoCollectionH)[tpr2];
+                        if (rt2.size() != 0) {
+                          // Second pion found
+                          K0sPiEff[1] = 1;
+                          edm::RefToBase<reco::Track> t2 = rt2.begin()->first;
+                        }
+                      } else {
+                        K0sPiEff[1] = 2;
+                      }
+                      if (K0sGenStatus == 1 &&
+                          (K0sPiEff[0] == 2 || K0sPiEff[1] == 2)) {
+                        K0sGenStatus = 4;
+                        realK0sFoundEff--;
+                      }
+                      if (K0sGenStatus == 2 &&
+                          (K0sPiEff[0] == 2 || K0sPiEff[1] == 2)) {
+                        K0sGenStatus = 3;
+                      }
+                      if (K0sPiEff[0] == 1 && K0sPiEff[1] == 1) {
+                        k0sTracksFound++;
+                      }
+                      // Fill Histograms
+                      if (K0sGenR > 0.) {
+                        if (K0sGenStatus == 1) {
+                          ksEffVsR_num->Fill(K0sGenR);
+                        }
+                        if ((double)K0sGenStatus < 2.5) {
+                          ksTkEffVsR_num->Fill(K0sGenR);
+                        }
+                        ksEffVsR_denom->Fill(K0sGenR);
+                      }
+                      if (abs(K0sGenEta) > 0.) {
+                        if (K0sGenStatus == 1) {
+                          ksEffVsEta_num->Fill(K0sGenEta);
+                        }
+                        if ((double)K0sGenStatus < 2.5) {
+                          ksTkEffVsEta_num->Fill(K0sGenEta);
+                        }
+                        ksEffVsEta_denom->Fill(K0sGenEta);
+                      }
+                      if (K0sGenpT > 0.) {
+                        if (K0sGenStatus == 1) {
+                          ksEffVsPt_num->Fill(K0sGenpT);
+                        }
+                        if ((double)K0sGenStatus < 2.5) {
+                          ksTkEffVsPt_num->Fill(K0sGenpT);
+                        }
+                        ksEffVsPt_denom->Fill(K0sGenpT);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
 }
 
-//define this as a plug-in
-//DEFINE_FWK_MODULE(V0Validator);
+// define this as a plug-in
+// DEFINE_FWK_MODULE(V0Validator);

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -60,6 +60,8 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   std::string subDirName = V0Validator::dirName + "/EffFakes";
   ibooker.setCurrentFolder(subDirName.c_str());
 
+  // Ks Plots follow
+
   ksEffVsR_num = ibooker.book1D("K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho",
                                 40, 0., 40.);
   ksEffVsEta_num = ibooker.book1D(
@@ -82,6 +84,30 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
       "K0sEffVsEta_denom", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   ksEffVsPt_denom = ibooker.book1D(
       "K0sEffVsPt_denom", "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
+
+  ksFakeVsR_num = ibooker.book1D("K0sFakeVsR_num",
+                                 "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+  ksFakeVsEta_num = ibooker.book1D(
+      "K0sFakeVsEta_num", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
+  ksFakeVsPt_num = ibooker.book1D("K0sFakeVsPt_num",
+                                  "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
+  ksTkFakeVsR_num = ibooker.book1D(
+      "K0sTkFakeVsR_num", "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
+  ksTkFakeVsEta_num =
+      ibooker.book1D("K0sTkFakeVsEta_num",
+                     "K^{0}_{S} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
+  ksTkFakeVsPt_num =
+      ibooker.book1D("K0sTkFakeVsPt_num",
+                     "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
+
+  ksFakeVsR_denom = ibooker.book1D("K0sFakeVsR_denom",
+                                   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+  ksFakeVsEta_denom = ibooker.book1D(
+      "K0sFakeVsEta_denom", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
+  ksFakeVsPt_denom = ibooker.book1D(
+      "K0sFakeVsPt_denom", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
+
+  // Lambda Plots follow
 
   lamEffVsR_num = ibooker.book1D("LamEffVsR_num",
                                  "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
@@ -106,27 +132,6 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   lamEffVsPt_denom = ibooker.book1D(
       "LamEffVsPt_denom", "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
-  ksFakeVsR_num = ibooker.book1D("K0sFakeVsR_num",
-                                 "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
-  ksFakeVsEta_num = ibooker.book1D(
-      "K0sFakeVsEta_num", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksFakeVsPt_num = ibooker.book1D("K0sFakeVsPt_num",
-                                  "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
-  ksTkFakeVsR_num = ibooker.book1D(
-      "K0sTkFakeVsR_num", "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
-  ksTkFakeVsEta_num =
-      ibooker.book1D("K0sTkFakeVsEta_num",
-                     "K^{0}_{S} Tracking Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksTkFakeVsPt_num =
-      ibooker.book1D("K0sTkFakeVsPt_num",
-                     "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
-
-  ksFakeVsR_denom = ibooker.book1D("K0sFakeVsR_denom",
-                                   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
-  ksFakeVsEta_denom = ibooker.book1D(
-      "K0sFakeVsEta_denom", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
-  ksFakeVsPt_denom = ibooker.book1D(
-      "K0sFakeVsPt_denom", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
 
   lamFakeVsR_num = ibooker.book1D("LamFakeVsR_num",
                                   "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -53,8 +53,20 @@ V0Validator::~V0Validator() {}
 
 void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
                                  edm::EventSetup const&) {
+
+  double minKsMass = 0.49767 - 0.07;
+  double maxKsMass = 0.49767 + 0.07;
+  double minLamMass = 1.1156 - 0.05;
+  double maxLamMass = 1.1156 + 0.05;
+  int ksMassNbins = 100;
+  double ksMassXmin = minKsMass;
+  double ksMassXmax = maxKsMass;
+  int lamMassNbins = 100;
+  double lamMassXmin = minLamMass;
+  double lamMassXmax = maxLamMass;
+
   ibooker.cd();
-  std::string subDirName = V0Validator::dirName + "/EffFakes";
+  std::string subDirName = V0Validator::dirName + "/K0";
   ibooker.setCurrentFolder(subDirName.c_str());
 
   candidateEffVsR_num_[V0Validator::KSHORT] = ibooker.book1D("K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho",
@@ -101,8 +113,22 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
       "K0sFakeVsEta_denom", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsPt_denom", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
+  nCandidates_[V0Validator::KSHORT] = ibooker.book1D("nK0s", "Number of K^{0}_{S} found per event", 60, 0.,
+                                                     60.);
+  fakeCandidateMass_[V0Validator::KSHORT] = ibooker.book1D("ksMassFake", "Mass of fake K0S", ksMassNbins,
+                                                           minKsMass, maxKsMass);
+  goodCandidateMass[V0Validator::KSHORT] = ibooker.book1D("ksMassGood", "Mass of good reco K0S",
+                                                          ksMassNbins, minKsMass, maxKsMass);
+  candidateMassAll[V0Validator::KSHORT] = ibooker.book1D("ksMassAll", "Invariant mass of all K0S",
+                                                         ksMassNbins, ksMassXmin, ksMassXmax);
+  candidateFakeDauRadDist_[V0Validator::KSHORT] = ibooker.book1D(
+      "radDistFakeKs", "Production radius of daughter particle of Ks fake", 100,
+      0., 15.);
 
   // Lambda Plots follow
+
+  subDirName = V0Validator::dirName + "/Lambda";
+  ibooker.setCurrentFolder(subDirName.c_str());
 
   candidateEffVsR_num_[V0Validator::LAMBDA] = ibooker.book1D("LamEffVsR_num",
                                  "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
@@ -151,75 +177,15 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   candidateFakeVsPt_denom_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamFakeVsPt_denom", "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
 
-  ibooker.cd();
-  subDirName = dirName + "/Other";
-  ibooker.setCurrentFolder(subDirName.c_str());
-
-  nCandidates_[V0Validator::KSHORT] = ibooker.book1D("nK0s", "Number of K^{0}_{S} found per event", 60, 0.,
-                                   60.);
   nCandidates_[V0Validator::LAMBDA] = ibooker.book1D("nLam", "Number of #Lambda^{0} found per event", 60, 0.,
-                                   60.);
-
-  ksXResolution =
-      ibooker.book1D("ksXResolution",
-                     "Resolution of V0 decay vertex X coordinate", 50, 0., 50.);
-  ksYResolution =
-      ibooker.book1D("ksYResolution",
-                     "Resolution of V0 decay vertex Y coordinate", 50, 0., 50.);
-  ksZResolution =
-      ibooker.book1D("ksZResolution",
-                     "Resolution of V0 decay vertex Z coordinate", 50, 0., 50.);
-  lamXResolution =
-      ibooker.book1D("lamXResolution",
-                     "Resolution of V0 decay vertex X coordinate", 50, 0., 50.);
-  lamYResolution =
-      ibooker.book1D("lamYResolution",
-                     "Resolution of V0 decay vertex Y coordinate", 50, 0., 50.);
-  lamZResolution =
-      ibooker.book1D("lamZResolution",
-                     "Resolution of V0 decay vertex Z coordinate", 50, 0., 50.);
-  ksAbsoluteDistResolution = ibooker.book1D(
-      "ksRResolution",
-      "Resolution of absolute distance from primary vertex to V0 vertex", 100,
-      0., 50.);
-  lamAbsoluteDistResolution = ibooker.book1D(
-      "lamRResolution",
-      "Resolution of absolute distance from primary vertex to V0 vertex", 100,
-      0., 50.);
-
-  candidateStatus_[V0Validator::KSHORT] =
-      ibooker.book1D("ksCandStatus", "Fake type by cand status", 10, 0., 10.);
-  candidateStatus_[V0Validator::LAMBDA] =
-      ibooker.book1D("ksCandStatus", "Fake type by cand status", 10, 0., 10.);
-
-  double minKsMass = 0.49767 - 0.07;
-  double maxKsMass = 0.49767 + 0.07;
-  double minLamMass = 1.1156 - 0.05;
-  double maxLamMass = 1.1156 + 0.05;
-  int ksMassNbins = 100;
-  double ksMassXmin = minKsMass;
-  double ksMassXmax = maxKsMass;
-  int lamMassNbins = 100;
-  double lamMassXmin = minLamMass;
-  double lamMassXmax = maxLamMass;
-
-  fakeCandidateMass_[V0Validator::KSHORT] = ibooker.book1D("ksMassFake", "Mass of fake K0S", ksMassNbins,
-                                                      minKsMass, maxKsMass);
+                                                     60.);
   fakeCandidateMass_[V0Validator::LAMBDA] = ibooker.book1D("lamMassFake", "Mass of fake Lambda",
-                                                      lamMassNbins, minLamMass, maxLamMass);
-  goodKsMass = ibooker.book1D("ksMassGood", "Mass of good reco K0S",
-                              ksMassNbins, minKsMass, maxKsMass);
-  goodLamMass = ibooker.book1D("lamMassGood", "Mass of good Lambda",
-                               lamMassNbins, minLamMass, maxLamMass);
+                                                           lamMassNbins, minLamMass, maxLamMass);
+  goodCandidateMass[V0Validator::LAMBDA] = ibooker.book1D("lamMassGood", "Mass of good Lambda",
+                                                        lamMassNbins, minLamMass, maxLamMass);
 
-  ksMassAll = ibooker.book1D("ksMassAll", "Invariant mass of all K0S",
-                             ksMassNbins, ksMassXmin, ksMassXmax);
-  lamMassAll = ibooker.book1D("lamMassAll", "Invariant mass of all #Lambda^{0}",
-                              lamMassNbins, lamMassXmin, lamMassXmax);
-
-  candidateFakeDauRadDist_[V0Validator::KSHORT] = ibooker.book1D(
-      "radDistFakeKs", "Production radius of daughter particle of Ks fake", 100,
-      0., 15.);
+  candidateMassAll[V0Validator::LAMBDA] = ibooker.book1D("lamMassAll", "Invariant mass of all #Lambda^{0}",
+                                                         lamMassNbins, lamMassXmin, lamMassXmax);
   candidateFakeDauRadDist_[V0Validator::LAMBDA] = ibooker.book1D(
       "radDistFakeLam", "Production radius of daughter particle of Lam fake",
       100, 0., 15.);
@@ -244,14 +210,13 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
     for (reco::VertexCompositeCandidateCollection::const_iterator iCandidate =
              collection.begin();
          iCandidate != collection.end(); iCandidate++) {
-      // Fill mass of all Candidates
-      ksMassAll->Fill(iCandidate->mass());
       // Fill values to be histogrammed
+      mass = iCandidate->mass();
       CandidatepT = (sqrt(iCandidate->momentum().perp2()));
       CandidateEta = iCandidate->momentum().eta();
       CandidateR = (sqrt(iCandidate->vertex().perp2()));
+      candidateMassAll[v0_type]->Fill(mass);
       CandidateStatus = 0;
-      mass = iCandidate->mass();
 
       std::array<reco::TrackRef, NUM_DAUGHTERS> theDaughterTracks = { {
         (*(dynamic_cast<const reco::RecoChargedCandidate*>(

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -33,10 +33,9 @@ V0Validator::V0Validator(const edm::ParameterSet& iConfig)
           iConfig.getUntrackedParameter<edm::InputTag>("trackAssociatorMap"))),
       recoSimToRecoCollectionToken_(consumes<reco::SimToRecoCollection>(
           iConfig.getUntrackedParameter<edm::InputTag>("trackAssociatorMap"))),
-      trackingVertexCollection_Token_(
-          consumes<TrackingVertexCollection>(
-              iConfig.getUntrackedParameter<edm::InputTag>(
-                  "trackingVertexCollection"))),
+      trackingVertexCollection_Token_(consumes<TrackingVertexCollection>(
+          iConfig.getUntrackedParameter<edm::InputTag>(
+              "trackingVertexCollection"))),
       vec_recoVertex_Token_(consumes<std::vector<reco::Vertex> >(
           iConfig.getUntrackedParameter<edm::InputTag>("vertexCollection"))),
       recoVertexCompositeCandidateCollection_k0s_Token_(
@@ -46,14 +45,12 @@ V0Validator::V0Validator(const edm::ParameterSet& iConfig)
       recoVertexCompositeCandidateCollection_lambda_Token_(
           consumes<reco::VertexCompositeCandidateCollection>(
               iConfig.getUntrackedParameter<edm::InputTag>(
-                  "lambdaCollection"))) {
-}
+                  "lambdaCollection"))) {}
 
 V0Validator::~V0Validator() {}
 
 void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
                                  edm::EventSetup const&) {
-
   double minKsMass = 0.49767 - 0.07;
   double maxKsMass = 0.49767 + 0.07;
   double minLamMass = 1.1156 - 0.05;
@@ -69,12 +66,12 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   std::string subDirName = V0Validator::dirName + "/K0";
   ibooker.setCurrentFolder(subDirName.c_str());
 
-  candidateEffVsR_num_[V0Validator::KSHORT] = ibooker.book1D("K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho",
-                                40, 0., 40.);
+  candidateEffVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
+      "K0sEffVsR_num", "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
   candidateEffVsEta_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsEta_num", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
-  candidateEffVsPt_num_[V0Validator::KSHORT] = ibooker.book1D("K0sEffVsPt_num",
-                                 "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
+  candidateEffVsPt_num_[V0Validator::KSHORT] = ibooker.book1D(
+      "K0sEffVsPt_num", "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
   candidateTkEffVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sTkEffVsR_num", "K^{0}_{S} Tracking Efficiency vs #rho", 40, 0., 40.);
@@ -85,19 +82,19 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
       ibooker.book1D("K0sTkEffVsPt_num",
                      "K^{0}_{S} Tracking Efficiency vs p_{T}", 70, 0., 20.);
 
-  candidateEffVsR_denom_[V0Validator::KSHORT] = ibooker.book1D("K0sEffVsR_denom",
-                                  "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
+  candidateEffVsR_denom_[V0Validator::KSHORT] = ibooker.book1D(
+      "K0sEffVsR_denom", "K^{0}_{S} Efficiency vs #rho", 40, 0., 40.);
   candidateEffVsEta_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsEta_denom", "K^{0}_{S} Efficiency vs #eta", 40, -2.5, 2.5);
   candidateEffVsPt_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sEffVsPt_denom", "K^{0}_{S} Efficiency vs p_{T}", 70, 0., 20.);
 
-  candidateFakeVsR_num_[V0Validator::KSHORT] = ibooker.book1D("K0sFakeVsR_num",
-                                 "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+  candidateFakeVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
+      "K0sFakeVsR_num", "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
   candidateFakeVsEta_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsEta_num", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
-  candidateFakeVsPt_num_[V0Validator::KSHORT] = ibooker.book1D("K0sFakeVsPt_num",
-                                  "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
+  candidateFakeVsPt_num_[V0Validator::KSHORT] = ibooker.book1D(
+      "K0sFakeVsPt_num", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
   candidateTkFakeVsR_num_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sTkFakeVsR_num", "K^{0}_{S} Tracking Fake Rate vs #rho", 40, 0., 40.);
   candidateTkFakeVsEta_num_[V0Validator::KSHORT] =
@@ -107,20 +104,21 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
       ibooker.book1D("K0sTkFakeVsPt_num",
                      "K^{0}_{S} Tracking Fake Rate vs p_{T}", 70, 0., 20.);
 
-  candidateFakeVsR_denom_[V0Validator::KSHORT] = ibooker.book1D("K0sFakeVsR_denom",
-                                   "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
+  candidateFakeVsR_denom_[V0Validator::KSHORT] = ibooker.book1D(
+      "K0sFakeVsR_denom", "K^{0}_{S} Fake Rate vs #rho", 40, 0., 40.);
   candidateFakeVsEta_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsEta_denom", "K^{0}_{S} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_denom_[V0Validator::KSHORT] = ibooker.book1D(
       "K0sFakeVsPt_denom", "K^{0}_{S} Fake Rate vs p_{T}", 70, 0., 20.);
-  nCandidates_[V0Validator::KSHORT] = ibooker.book1D("nK0s", "Number of K^{0}_{S} found per event", 60, 0.,
-                                                     60.);
-  fakeCandidateMass_[V0Validator::KSHORT] = ibooker.book1D("ksMassFake", "Mass of fake K0S", ksMassNbins,
-                                                           minKsMass, maxKsMass);
-  goodCandidateMass[V0Validator::KSHORT] = ibooker.book1D("ksMassGood", "Mass of good reco K0S",
-                                                          ksMassNbins, minKsMass, maxKsMass);
-  candidateMassAll[V0Validator::KSHORT] = ibooker.book1D("ksMassAll", "Invariant mass of all K0S",
-                                                         ksMassNbins, ksMassXmin, ksMassXmax);
+  nCandidates_[V0Validator::KSHORT] = ibooker.book1D(
+      "nK0s", "Number of K^{0}_{S} found per event", 60, 0., 60.);
+  fakeCandidateMass_[V0Validator::KSHORT] = ibooker.book1D(
+      "ksMassFake", "Mass of fake K0S", ksMassNbins, minKsMass, maxKsMass);
+  goodCandidateMass[V0Validator::KSHORT] = ibooker.book1D(
+      "ksMassGood", "Mass of good reco K0S", ksMassNbins, minKsMass, maxKsMass);
+  candidateMassAll[V0Validator::KSHORT] =
+      ibooker.book1D("ksMassAll", "Invariant mass of all K0S", ksMassNbins,
+                     ksMassXmin, ksMassXmax);
   candidateFakeDauRadDist_[V0Validator::KSHORT] = ibooker.book1D(
       "radDistFakeKs", "Production radius of daughter particle of Ks fake", 100,
       0., 15.);
@@ -130,8 +128,8 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   subDirName = V0Validator::dirName + "/Lambda";
   ibooker.setCurrentFolder(subDirName.c_str());
 
-  candidateEffVsR_num_[V0Validator::LAMBDA] = ibooker.book1D("LamEffVsR_num",
-                                 "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
+  candidateEffVsR_num_[V0Validator::LAMBDA] = ibooker.book1D(
+      "LamEffVsR_num", "#Lambda^{0} Efficiency vs #rho", 40, 0., 40.);
   candidateEffVsEta_num_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamEffVsEta_num", "#Lambda^{0} Efficiency vs #eta", 40, -2.5, 2.5);
   candidateEffVsPt_num_[V0Validator::LAMBDA] = ibooker.book1D(
@@ -153,9 +151,8 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   candidateEffVsPt_denom_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamEffVsPt_denom", "#Lambda^{0} Efficiency vs p_{T}", 70, 0., 20.);
 
-
-  candidateFakeVsR_num_[V0Validator::LAMBDA] = ibooker.book1D("LamFakeVsR_num",
-                                  "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
+  candidateFakeVsR_num_[V0Validator::LAMBDA] = ibooker.book1D(
+      "LamFakeVsR_num", "#Lambda^{0} Fake Rate vs #rho", 40, 0., 40.);
   candidateFakeVsEta_num_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamFakeVsEta_num", "#Lambda^{0} Fake Rate vs #eta", 40, -2.5, 2.5);
   candidateFakeVsPt_num_[V0Validator::LAMBDA] = ibooker.book1D(
@@ -177,25 +174,27 @@ void V0Validator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
   candidateFakeVsPt_denom_[V0Validator::LAMBDA] = ibooker.book1D(
       "LamFakeVsPt_denom", "#Lambda^{0} Fake Rate vs p_{T}", 70, 0., 20.);
 
-  nCandidates_[V0Validator::LAMBDA] = ibooker.book1D("nLam", "Number of #Lambda^{0} found per event", 60, 0.,
-                                                     60.);
-  fakeCandidateMass_[V0Validator::LAMBDA] = ibooker.book1D("lamMassFake", "Mass of fake Lambda",
-                                                           lamMassNbins, minLamMass, maxLamMass);
-  goodCandidateMass[V0Validator::LAMBDA] = ibooker.book1D("lamMassGood", "Mass of good Lambda",
-                                                        lamMassNbins, minLamMass, maxLamMass);
+  nCandidates_[V0Validator::LAMBDA] = ibooker.book1D(
+      "nLam", "Number of #Lambda^{0} found per event", 60, 0., 60.);
+  fakeCandidateMass_[V0Validator::LAMBDA] =
+      ibooker.book1D("lamMassFake", "Mass of fake Lambda", lamMassNbins,
+                     minLamMass, maxLamMass);
+  goodCandidateMass[V0Validator::LAMBDA] =
+      ibooker.book1D("lamMassGood", "Mass of good Lambda", lamMassNbins,
+                     minLamMass, maxLamMass);
 
-  candidateMassAll[V0Validator::LAMBDA] = ibooker.book1D("lamMassAll", "Invariant mass of all #Lambda^{0}",
-                                                         lamMassNbins, lamMassXmin, lamMassXmax);
+  candidateMassAll[V0Validator::LAMBDA] =
+      ibooker.book1D("lamMassAll", "Invariant mass of all #Lambda^{0}",
+                     lamMassNbins, lamMassXmin, lamMassXmax);
   candidateFakeDauRadDist_[V0Validator::LAMBDA] = ibooker.book1D(
       "radDistFakeLam", "Production radius of daughter particle of Lam fake",
       100, 0., 15.);
 }
 
-void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & collection,
-                              const reco::RecoToSimCollection & recotosimCollection,
-                              V0Type v0_type,
-                              int particle_pdgid,
-                              int misreconstructed_particle_pdgid) {
+void V0Validator::doFakeRates(
+    const reco::VertexCompositeCandidateCollection& collection,
+    const reco::RecoToSimCollection& recotosimCollection, V0Type v0_type,
+    int particle_pdgid, int misreconstructed_particle_pdgid) {
   using namespace edm;
 
   int numCandidateFound = 0;
@@ -218,11 +217,11 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
       candidateMassAll[v0_type]->Fill(mass);
       CandidateStatus = 0;
 
-      std::array<reco::TrackRef, NUM_DAUGHTERS> theDaughterTracks = { {
-        (*(dynamic_cast<const reco::RecoChargedCandidate*>(
-            iCandidate->daughter(0)))).track(),
-        (*(dynamic_cast<const reco::RecoChargedCandidate*>(
-            iCandidate->daughter(1)))).track()} };
+      std::array<reco::TrackRef, NUM_DAUGHTERS> theDaughterTracks = {
+          {(*(dynamic_cast<const reco::RecoChargedCandidate*>(
+                iCandidate->daughter(0)))).track(),
+           (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+                iCandidate->daughter(1)))).track()}};
 
       TrackingParticleRef tpref;
       TrackingParticleRef firstDauTP;
@@ -237,7 +236,7 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
         RefToBase<reco::Track> track(theDaughterTracks.at(i));
 
         if (recotosimCollection.find(track) != recotosimCollection.end()) {
-          const std::vector<std::pair<TrackingParticleRef, double> > & tp =
+          const std::vector<std::pair<TrackingParticleRef, double> >& tp =
               recotosimCollection[track];
           if (tp.size() != 0) {
             tpref = tp.begin()->first;
@@ -264,7 +263,8 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
                         numCandidateFound += 1.;
                       } else {
                         CandidateStatus = 2;
-                        if ((*iTP)->pdgId() == misreconstructed_particle_pdgid) {
+                        if ((*iTP)->pdgId() ==
+                            misreconstructed_particle_pdgid) {
                           CandidateStatus = 7;
                         }
                       }
@@ -287,11 +287,11 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
                 firstDauTP = tpref;
               }
             }  // parent vertex is null
-          }  // check on associated tp size zero
+          }    // check on associated tp size zero
         } else {
           CandidateStatus = 5;
         }
-      } // Loop on candidate's daughter tracks
+      }  // Loop on candidate's daughter tracks
 
       // fill the fake rate histograms
       if (CandidateStatus > 1) {
@@ -301,8 +301,7 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
         candidateStatus_[v0_type]->Fill((float)CandidateStatus);
         fakeCandidateMass_[v0_type]->Fill(mass);
         for (auto distance : radDist) {
-          if (distance > 0)
-            candidateFakeDauRadDist_[v0_type]->Fill(distance);
+          if (distance > 0) candidateFakeDauRadDist_[v0_type]->Fill(distance);
         }
       }
       if (CandidateStatus == 5) {
@@ -313,18 +312,18 @@ void V0Validator::doFakeRates(const reco::VertexCompositeCandidateCollection & c
       candidateFakeVsR_denom_[v0_type]->Fill(CandidateR);
       candidateFakeVsEta_denom_[v0_type]->Fill(CandidateEta);
       candidateFakeVsPt_denom_[v0_type]->Fill(CandidatepT);
-    } // Loop on candidates
-  } // check on presence of candidate's collection in the event
+    }  // Loop on candidates
+  }    // check on presence of candidate's collection in the event
   nCandidates_[v0_type]->Fill((float)numCandidateFound);
 }
 
-void V0Validator::doEfficiencies(const TrackingVertexCollection & gen_vertices,
-                                 V0Type v0_type,
-                                 int parent_particle_id,
-                                 int first_daughter_id, /* give only positive charge */
-                                 int second_daughter_id, /* give only positive charge */
-                                 const reco::VertexCompositeCandidateCollection & collection,
-                                 const reco::SimToRecoCollection & simtorecoCollection) {
+void V0Validator::doEfficiencies(
+    const TrackingVertexCollection& gen_vertices, V0Type v0_type,
+    int parent_particle_id,
+    int first_daughter_id,  /* give only positive charge */
+    int second_daughter_id, /* give only positive charge */
+    const reco::VertexCompositeCandidateCollection& collection,
+    const reco::SimToRecoCollection& simtorecoCollection) {
   /* We store the TrackRef of the tracks that have been used to
    * produce the V0 under consideration here. This is used later to
    * check if a specific V0 has been really reconstructed or not. The
@@ -336,11 +335,11 @@ void V0Validator::doEfficiencies(const TrackingVertexCollection & gen_vertices,
     for (reco::VertexCompositeCandidateCollection::const_iterator iCandidate =
              collection.begin();
          iCandidate != collection.end(); iCandidate++) {
-      reconstructed_V0_couples.insert(V0Couple(
-          (dynamic_cast<const reco::RecoChargedCandidate*>(
-              iCandidate->daughter(0)))->track(),
-              (dynamic_cast<const reco::RecoChargedCandidate*>(
-                  iCandidate->daughter(1)))->track()));
+      reconstructed_V0_couples.insert(
+          V0Couple((dynamic_cast<const reco::RecoChargedCandidate*>(
+                        iCandidate->daughter(0)))->track(),
+                   (dynamic_cast<const reco::RecoChargedCandidate*>(
+                        iCandidate->daughter(1)))->track()));
     }
   }
 
@@ -355,20 +354,27 @@ void V0Validator::doEfficiencies(const TrackingVertexCollection & gen_vertices,
              decay_found
    */
   unsigned int candidateEff[2] = {0, 0};
-  for (auto const & gen_vertex : gen_vertices) {
-    if (gen_vertex.eventId().bunchCrossing() != 0) continue;  // Consider only in-time events
+  for (auto const& gen_vertex : gen_vertices) {
+    if (gen_vertex.eventId().bunchCrossing() != 0)
+      continue;  // Consider only in-time events
     if (gen_vertex.nDaughterTracks() != 2) continue;  // Keep only V0 vertices
     for (TrackingVertex::tp_iterator source = gen_vertex.sourceTracks_begin();
          source != gen_vertex.sourceTracks_end(); ++source) {
       if (std::abs((*source)->pdgId()) == parent_particle_id) {
-        if ( (std::abs((gen_vertex.daughterTracks().at(0))->pdgId()) == first_daughter_id &&
-              std::abs((gen_vertex.daughterTracks().at(1))->pdgId()) == second_daughter_id) ||
-             (std::abs((gen_vertex.daughterTracks().at(0))->pdgId()) == second_daughter_id &&
-              std::abs((gen_vertex.daughterTracks().at(1))->pdgId()) == first_daughter_id) ) {
-          if ( (std::abs((gen_vertex.daughterTracks().at(0))->momentum().eta()) < 2.4 &&
-                gen_vertex.daughterTracks().at(0)->pt() > 0.9) &&
-               (std::abs((gen_vertex.daughterTracks().at(1))->momentum().eta()) < 2.4 &&
-                gen_vertex.daughterTracks().at(1)->pt() > 0.9) ) {
+        if ((std::abs((gen_vertex.daughterTracks().at(0))->pdgId()) ==
+                 first_daughter_id &&
+             std::abs((gen_vertex.daughterTracks().at(1))->pdgId()) ==
+                 second_daughter_id) ||
+            (std::abs((gen_vertex.daughterTracks().at(0))->pdgId()) ==
+                 second_daughter_id &&
+             std::abs((gen_vertex.daughterTracks().at(1))->pdgId()) ==
+                 first_daughter_id)) {
+          if ((std::abs((gen_vertex.daughterTracks().at(0))->momentum().eta()) <
+                   2.4 &&
+               gen_vertex.daughterTracks().at(0)->pt() > 0.9) &&
+              (std::abs((gen_vertex.daughterTracks().at(1))->momentum().eta()) <
+                   2.4 &&
+               gen_vertex.daughterTracks().at(1)->pt() > 0.9)) {
             // found desired generated Candidate
             float candidateGenpT = sqrt((*source)->momentum().perp2());
             float candidateGenEta = (*source)->momentum().eta();
@@ -380,34 +386,34 @@ void V0Validator::doEfficiencies(const TrackingVertexCollection & gen_vertices,
             std::array<reco::TrackRef, 2> reco_daughter;
 
             for (unsigned int daughter = 0; daughter < 2; ++daughter) {
-              if (simtorecoCollection.find(gen_vertex.daughterTracks()[daughter]) !=
+              if (simtorecoCollection.find(
+                      gen_vertex.daughterTracks()[daughter]) !=
                   simtorecoCollection.end()) {
-                // rt = (std::vector<
-                //       std::pair<edm::RefToBase<reco::Track>,
-                //       double> >)simtorecoCollection[gen_vertex.daughterTracks()[daughter]];
-                if (simtorecoCollection[gen_vertex.daughterTracks()[daughter]].size() != 0) {
+                if (simtorecoCollection[gen_vertex.daughterTracks()[daughter]]
+                        .size() != 0) {
                   candidateEff[daughter] = 1;  // Found a daughter track
                   reco_daughter[daughter] =
-                      simtorecoCollection[gen_vertex.daughterTracks()[daughter]].begin()
-                      ->first.castTo<reco::TrackRef>();
+                      simtorecoCollection[gen_vertex.daughterTracks()[daughter]]
+                          .begin()
+                          ->first.castTo<reco::TrackRef>();
                 }
               } else {
                 candidateEff[daughter] = 2;  // First daughter not found
               }
             }
-            if ( (candidateEff[0] == 1 && candidateEff[1] == 1)
-                 && (
-                     reconstructed_V0_couples.find(V0Couple(reco_daughter[0], reco_daughter[1]))
-                     != reconstructed_V0_couples.end())) {
+            if ((candidateEff[0] == 1 && candidateEff[1] == 1) &&
+                (reconstructed_V0_couples.find(
+                     V0Couple(reco_daughter[0], reco_daughter[1])) !=
+                 reconstructed_V0_couples.end())) {
               candidateEffVsPt_num_[v0_type]->Fill(candidateGenpT);
               candidateEffVsEta_num_[v0_type]->Fill(candidateGenEta);
               candidateEffVsR_num_[v0_type]->Fill(candidateGenR);
             }
           }  // Check that daughters are inside the desired kinematic region
-        }  // Check decay products of the current generatex vertex
-      }  // Check pdgId of the source of the current generated vertex
-    }  // Loop over all sources of the current generated vertex
-  }  // Loop over all generated vertices
+        }    // Check decay products of the current generatex vertex
+      }      // Check pdgId of the source of the current generated vertex
+    }        // Loop over all sources of the current generated vertex
+  }          // Loop over all generated vertices
 }
 
 void V0Validator::analyze(const edm::Event& iEvent,
@@ -461,19 +467,20 @@ void V0Validator::analyze(const edm::Event& iEvent,
 
   // Do fake rate and efficiency calculation
 
-
-  // Get gen vertex collection out of the event, as done in the Vertex validation package!!!
+  // Get gen vertex collection out of the event, as done in the Vertex
+  // validation package!!!
   if (k0sCollection.isValid()) {
-    doFakeRates(*k0sCollection.product(),
-                *recotosimCollectionH.product(), V0Type::KSHORT, 310, 3122);
-    doEfficiencies(*TVCollectionH.product(), V0Type::KSHORT,
-                   310, 211, 211, *k0sCollection.product(), *simtorecoCollectionH.product());
+    doFakeRates(*k0sCollection.product(), *recotosimCollectionH.product(),
+                V0Type::KSHORT, 310, 3122);
+    doEfficiencies(*TVCollectionH.product(), V0Type::KSHORT, 310, 211, 211,
+                   *k0sCollection.product(), *simtorecoCollectionH.product());
   }
   if (lambdaCollection.isValid()) {
-    doFakeRates(*lambdaCollection.product(),
-                *recotosimCollectionH.product(), V0Type::LAMBDA, 3122, 310);
-    doEfficiencies(*TVCollectionH.product(), V0Type::LAMBDA,
-                   3122, 211, 2212, *lambdaCollection.product(), *simtorecoCollectionH.product());
+    doFakeRates(*lambdaCollection.product(), *recotosimCollectionH.product(),
+                V0Type::LAMBDA, 3122, 310);
+    doEfficiencies(*TVCollectionH.product(), V0Type::LAMBDA, 3122, 211, 2212,
+                   *lambdaCollection.product(),
+                   *simtorecoCollectionH.product());
   }
 }
 

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -294,7 +294,6 @@ void V0Validator::analyze(const edm::Event& iEvent,
   double mass = 0.;
   std::vector<double> radDist;
   if (k0sCollection->size() > 0) {
-    vector<reco::TrackRef> theDaughterTracks;
     for (reco::VertexCompositeCandidateCollection::const_iterator iK0s =
              k0sCollection->begin();
          iK0s != k0sCollection->end(); iK0s++) {
@@ -307,12 +306,11 @@ void V0Validator::analyze(const edm::Event& iEvent,
       K0sCandStatus = 0;
       mass = iK0s->mass();
 
-      theDaughterTracks.push_back(
-          (*(dynamic_cast<const reco::RecoChargedCandidate*>(
-               iK0s->daughter(0)))).track());
-      theDaughterTracks.push_back(
-          (*(dynamic_cast<const reco::RecoChargedCandidate*>(
-               iK0s->daughter(1)))).track());
+      std::array<reco::TrackRef, 2> theDaughterTracks = { {
+        (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+            iK0s->daughter(0)))).track(),
+        (*(dynamic_cast<const reco::RecoChargedCandidate*>(
+            iK0s->daughter(1)))).track()} };
 
       for (int itrack = 0; itrack < 2; itrack++) {
         K0sPiCandStatus[itrack] = 0;
@@ -394,10 +392,8 @@ void V0Validator::analyze(const edm::Event& iEvent,
           K0sPiCandStatus[i] = 2;
           noTPforK0sCand++;
           K0sCandStatus = 5;
-          theDaughterTracks.clear();
         }
       }
-      theDaughterTracks.clear();
       // fill the fake rate histograms
       if (K0sCandStatus > 1) {
         ksFakeVsR_num->Fill(K0sCandR);
@@ -425,7 +421,6 @@ void V0Validator::analyze(const edm::Event& iEvent,
   radDist.clear();
   // Lambdas
   if (lambdaCollection->size() > 0) {
-    vector<reco::TrackRef> theDaughterTracks;
     for (reco::VertexCompositeCandidateCollection::const_iterator iLam =
              lambdaCollection->begin();
          iLam != lambdaCollection->end(); iLam++) {
@@ -439,12 +434,11 @@ void V0Validator::analyze(const edm::Event& iEvent,
       mass = iLam->mass();
 
       // cout << "Lam daughter tracks" << endl;
-      theDaughterTracks.push_back(
+      std::array<reco::TrackRef, 2> theDaughterTracks = { {
           (*(dynamic_cast<const reco::RecoChargedCandidate*>(
-               iLam->daughter(0)))).track());
-      theDaughterTracks.push_back(
+              iLam->daughter(0)))).track(),
           (*(dynamic_cast<const reco::RecoChargedCandidate*>(
-               iLam->daughter(1)))).track());
+              iLam->daughter(1)))).track() } };
 
       for (int itrack = 0; itrack < 2; itrack++) {
         LamPiCandStatus[itrack] = 0;
@@ -524,10 +518,8 @@ void V0Validator::analyze(const edm::Event& iEvent,
           LamPiCandStatus[i] = 2;
           noTPforLamCand++;
           LamCandStatus = 5;
-          theDaughterTracks.clear();
         }
       }
-      theDaughterTracks.clear();
       // fill the fake rate histograms
       if (LamCandStatus > 1) {
         lamFakeVsR_num->Fill(LamCandR);

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -266,6 +266,7 @@ void V0Validator::doFakeRates(
                         CandidateStatus = 1;
                         realCandidateFound++;
                         numCandidateFound += 1.;
+                        goodCandidateMass[v0_type]->Fill(mass);
                       } else {
                         CandidateStatus = 2;
                         if ((*iTP)->pdgId() ==

--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -293,6 +293,8 @@ void V0Validator::analyze(const edm::Event& iEvent,
   double numK0sFound = 0.;
   double mass = 0.;
   std::vector<double> radDist;
+  unsigned int K0sPiEff[2] = {0, 0};
+  unsigned int LamPiEff[2] = {0, 0};
   if (k0sCollection->size() > 0) {
     for (reco::VertexCompositeCandidateCollection::const_iterator iK0s =
              k0sCollection->begin();
@@ -312,10 +314,6 @@ void V0Validator::analyze(const edm::Event& iEvent,
         (*(dynamic_cast<const reco::RecoChargedCandidate*>(
             iK0s->daughter(1)))).track()} };
 
-      for (int itrack = 0; itrack < 2; itrack++) {
-        K0sPiCandStatus[itrack] = 0;
-      }
-
       std::vector<std::pair<TrackingParticleRef, double> > tp;
       TrackingParticleRef tpref;
       TrackingParticleRef firstDauTP;
@@ -330,13 +328,8 @@ void V0Validator::analyze(const edm::Event& iEvent,
         if (recotosimCollectionH->find(track) != recotosimCollectionH->end()) {
           tp = (*recotosimCollectionH)[track];
           if (tp.size() != 0) {
-            K0sPiCandStatus[i] = 1;
             tpref = tp.begin()->first;
 
-            if (simtorecoCollectionH->find(tpref) ==
-                simtorecoCollectionH->end()) {
-              K0sPiCandStatus[i] = 3;
-            }
             TrackingVertexRef parentVertex = tpref->parentVertex();
             if (parentVertex.isNonnull())
               radDist.push_back(parentVertex->position().R());
@@ -389,7 +382,6 @@ void V0Validator::analyze(const edm::Event& iEvent,
             }  // parent vertex is null
           }  // tp size zero
         } else {
-          K0sPiCandStatus[i] = 2;
           noTPforK0sCand++;
           K0sCandStatus = 5;
         }
@@ -440,10 +432,6 @@ void V0Validator::analyze(const edm::Event& iEvent,
           (*(dynamic_cast<const reco::RecoChargedCandidate*>(
               iLam->daughter(1)))).track() } };
 
-      for (int itrack = 0; itrack < 2; itrack++) {
-        LamPiCandStatus[itrack] = 0;
-      }
-
       std::vector<std::pair<TrackingParticleRef, double> > tp;
       TrackingParticleRef tpref;
       TrackingParticleRef firstDauTP;
@@ -457,12 +445,7 @@ void V0Validator::analyze(const edm::Event& iEvent,
         if (recotosimCollectionH->find(track) != recotosimCollectionH->end()) {
           tp = (*recotosimCollectionH)[track];
           if (tp.size() != 0) {
-            LamPiCandStatus[i] = 1;
             tpref = tp.begin()->first;
-            if (simtorecoCollectionH->find(tpref) ==
-                simtorecoCollectionH->end()) {
-              LamPiCandStatus[i] = 3;
-            }
             TrackingVertexRef parentVertex = tpref->parentVertex();
             if (parentVertex.isNonnull())
               radDist.push_back(parentVertex->position().R());
@@ -515,7 +498,6 @@ void V0Validator::analyze(const edm::Event& iEvent,
             }  // parent vertex is null
           }  // tp size zero
         } else {
-          LamPiCandStatus[i] = 2;
           noTPforLamCand++;
           LamCandStatus = 5;
         }


### PR DESCRIPTION
This PR will put back in place a bare minimal, working, V0 Validation package. The package can be expanded at will, depending on man-power availability. This very same package will have to be tuned so that we can run it also on real data. To be discussed with current DQM L2.
