### PR TITLE
Copy muonDetIdAssociator customisation changes to eras

### DIFF
--- a/TrackingTools/TrackAssociator/python/DetIdAssociatorESProducer_cff.py
+++ b/TrackingTools/TrackAssociator/python/DetIdAssociatorESProducer_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# Use this object to make changes when different configurations are active
+from Configuration.StandardSequences.Eras import eras
+
 ecalDetIdAssociator = cms.ESProducer("DetIdAssociatorESProducer",
     ComponentName = cms.string('EcalDetIdAssociator'),
     etaBinSize = cms.double(0.02),
@@ -35,6 +38,9 @@ muonDetIdAssociator = cms.ESProducer("DetIdAssociatorESProducer",
     nPhi = cms.int32(48),
     includeBadChambers = cms.bool(False)
 )
+
+# If running in Run 2, include bad chambers
+eras.run2_common.toModify( muonDetIdAssociator, includeBadChambers = True )
 
 preshowerDetIdAssociator = cms.ESProducer("DetIdAssociatorESProducer",
     ComponentName = cms.string('PreshowerDetIdAssociator'),


### PR DESCRIPTION
Pull request #11248 made a change that takes the Run 2 eras out of synch.  This PR adds the change to the Run 2 eras as well.

The divergence was seen in
http://grimes.web.cern.ch/grimes/eraProcessDiffs/processDiffs-7_6_X_2015-10-05-1838-PR11466.html

With this PR, post LS1 customs should be functionally equivalent to Run 2 eras, a check on a smaller subset of workflows is at
http://grimes.web.cern.ch/grimes/eraProcessDiffs/processDiffs-7_6_X_2015-10-05-2300-mark-grimes_copyChangesIn11248ToEras-PR11466.html
