### PR TITLE
Adding to all GTs the updated CaloTowers tag

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '76X_mcRun1_design_v4',
+    'run1_design'       :   '76X_mcRun1_design_v6',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '76X_mcRun1_realistic_v4',
+    'run1_mc'           :   '76X_mcRun1_realistic_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v4',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v6',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '76X_mcRun1_pA_v4',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v4',
+    'run2_design'       :   '76X_mcRun2_design_v6',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v4',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v6',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v4',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v4',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v6',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v3',
+    'run1_data'         :   '76X_dataRun1_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v3',
+    'run2_data'         :   '76X_dataRun2_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v3',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v5',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v0',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
Technical PR to let HCAL people to test the new SLHC updates for CaloTowers (#11497).
# Summary of changes
## Run I Simulation:
- Ideal: [76X_mcRun1_design_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_design_v6) as [76X_mcRun1_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_design_v4)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_design_v6/76X_mcRun1_design_v4):
  - updated PF Calibration for new Hcal method 3 time slew parametrization
  - new dense index for Calo Towers geometry
- Realistic: [76X_mcRun1_realistic_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_realistic_v6) as [76X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_realistic_v4)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_realistic_v6/76X_mcRun1_realistic_v4):
  - updated PF Calibration for new Hcal method 3 time slew parametrization 
  - new dense index for Calo Towers geometry
- Heavy Ion: [76X_mcRun1_HeavyIon_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_HeavyIon_v6) as [76X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_HeavyIon_v4)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_HeavyIon_v6/76X_mcRun1_HeavyIon_v4):
  - updated PF Calibration for new Hcal method 3 time slew parametrization
  - new dense index for Calo Towers geometry
- Proton lead: [76X_mcRun1_pA_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_pA_v6) as [76X_mcRun1_pA_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_pA_v4)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_pA_v6/76X_mcRun1_pA_v4):
  - updated PF Calibration for new Hcal method 3 time slew parametrization
  - new dense index for Calo Towers geometry
## Run I Data:
- Offline processing: [76X_dataRun1_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v5) as [76X_dataRun1_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v3)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v5/76X_dataRun1_v3):
  - updated PF Calibration for new Hcal method 3 time slew parametrization
  - new dense index for Calo Towers geometry
## Run II Data:
- Offline processing: [76X_dataRun2_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v5) as [76X_dataRun2_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v3)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v5/76X_dataRun2_v3):
  - updated PF Calibration for new Hcal method 3 time slew parametrization
  - updated JEC from 2015 data analysis (Summer15 V2) 
  - taxonomy change for BTagTrackProbability3DRcd tag (appending also 2015B IOV)
  - new dense index for Calo Towers geometry
## Upgrade:
- 2017: [76X_upgrade2017_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v2) as [76X_upgrade2017_design_v0](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v0)  with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_upgrade2017_design_v2/76X_upgrade2017_design_v0):
  - updated PF Calibration for new Hcal method 3 time slew parametrization
  - updated JEC from 2015 data analysis (Summer15 V2)
  - new dense index for Calo Towers geometry
