### PR TITLE
removed private_public in unit test

### DIFF
--- a/SimG4Core/Geometry/interface/DDG4SolidConverter.h
+++ b/SimG4Core/Geometry/interface/DDG4SolidConverter.h
@@ -16,6 +16,7 @@ public:
     ~DDG4SolidConverter();
     typedef G4VSolid * (*FNPTR) (const DDSolid &); // pointer to function
     G4VSolid * convert(const DDSolid &);  
+
 private:  
     /* foreach supported solid add a static conversion routine ,
        register this method in the convDispatch_-map */    
@@ -32,8 +33,8 @@ private:
     static G4VSolid * polycone_rrz(const DDSolid &);
     static G4VSolid * polyhedra_rz(const DDSolid &);
     static G4VSolid * polyhedra_rrz(const DDSolid &);
+    static G4VSolid * pseudotrap(const DDSolid & s);
     static G4VSolid * torus(const DDSolid &);
-    static G4VSolid * pseudotrap(const DDSolid &);
     static G4VSolid * trunctubs(const DDSolid &);
     static G4VSolid * sphere(const DDSolid &);
     static G4VSolid * orb(const DDSolid &);
@@ -42,6 +43,9 @@ private:
     static G4VSolid * para(const DDSolid &);
     static const std::vector<double>* par_;
     std::map<DDSolidShape,FNPTR> convDispatch_;
+
+    friend class testTruncTubs;
+    friend class testPseudoTrap;
 };
 
 #endif

--- a/SimG4Core/Geometry/test/PseudoTrap_.cpp
+++ b/SimG4Core/Geometry/test/PseudoTrap_.cpp
@@ -9,7 +9,6 @@
 #include <G4VSolid.hh>
 
 #include <string>
-#define private public
 #include <SimG4Core/Geometry/interface/DDG4SolidConverter.h>
 
 class testPseudoTrap : public CppUnit::TestFixture

--- a/SimG4Core/Geometry/test/TruncTubs_.cpp
+++ b/SimG4Core/Geometry/test/TruncTubs_.cpp
@@ -9,8 +9,6 @@
 #include <G4VSolid.hh>
 
 #include <string>
-
-#define private public
 #include <SimG4Core/Geometry/interface/DDG4SolidConverter.h>
 
 class testTruncTubs : public CppUnit::TestFixture


### PR DESCRIPTION
Removed '#define private public' from geometry unit test. 
