### PR TITLE
Fix the definition of pileup tracks in MultiTrackValidator

### DIFF
--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -731,7 +731,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
             if(numAssocRecoTracks>1) {
               h_looper_coll[ww]->Fill(www);
             }
-            else if(!isSigSimMatched) {
+            if(!isSigSimMatched) {
               h_pileup_coll[ww]->Fill(www);
             }
           }

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -811,7 +811,7 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
         fillPlotNoFlow(h_looperdzpv[count], dzpv);
       }
     }
-    else if(!isSigMatched) {
+    if(!isSigMatched) {
       fillPlotNoFlow(h_pileupeta[count], eta);
       fillPlotNoFlow(h_pileupphi[count], phi);
       fillPlotNoFlow(h_pileuppT[count], pt);


### PR DESCRIPTION
Previously a track was classified as a pileup track if it was not matched to a signal TrackingParticle, and it was not a duplicate. The latter requirement makes actually little sense, so this PR removes it and makes the track classes "duplicate" and "pileup" independent of each other.

Tested in 760pre6, expecting increase in all pileup plots in `HLT/Tracking/ValidationWRTtp`, `Tracking/Track`, and `Tracking/TrackFromPVAllTP` (although for the last the PR test statistics may be too small).

@rovere @VinInn 
