### PR TITLE
Replacing SpikeNoise flag by NegativeNoise one  

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -20,7 +20,7 @@ for qTest in particleFlowRecHitHF.producers[0].qualityTests:
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)
-HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHESpikeNoise",12)
+HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHENegativeNoise",12)
 
 CSCHaloData.ExpectedBX = cms.int32(3)
 


### PR DESCRIPTION
Followup on the presentation (by THONG Nguyen) and a subsequent discussion at PPD General   https://indico.cern.ch/event/452395/
:
Replacement of HBHSpikeNoise (not quite efficient in 25ns data) with "universal" (good both for 25ns and 50ns) HBHNegativeNoise rechit filter.
