### PR TITLE
Do not use ROOT6 specific code in ROOT5 releases

### DIFF
--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -303,7 +303,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
 
        histname = "NumberOfTracksVsPUPVtx";
        NumberOfTracksVsPUPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0., 100.,"");
-       NumberOfTracksVsPUPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfTracksVsPUPVtx->getTH1()->SetBit(TH1::kCanRebin);
        NumberOfTracksVsPUPVtx->setAxisTitle("Number of PU",1);
        NumberOfTracksVsPUPVtx->setAxisTitle("Mean number of Tracks per PUvtx",2);
 


### PR DESCRIPTION
Fix build error caused by ROOT6 specific code being carried into ROOT5 based release.
Purely technical. Please expedite.
