### PR TITLE
b-tag GBRForest payloads from GT

### DIFF
--- a/CommonTools/Utils/plugins/BuildFile.xml
+++ b/CommonTools/Utils/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="CondCore/DBOutputService"/>
 <use name="CondFormats/EgammaObjects"/>
+<use name="CommonTools/Utils"/>
 <use name="root"/>
 <use name="roottmva"/>
 <flags EDM_PLUGIN="1"/>

--- a/CommonTools/Utils/plugins/GBRForestWriter.cc
+++ b/CommonTools/Utils/plugins/GBRForestWriter.cc
@@ -1,5 +1,6 @@
 #include "CommonTools/Utils/plugins/GBRForestWriter.h"
 
+#include "CommonTools/Utils/interface/TMVAZipReader.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -59,7 +60,7 @@ void GBRForestWriter::analyze(const edm::Event&, const edm::EventSetup&)
 	  dummyVariables.push_back(0.);
 	  mvaReader->AddSpectator(spectatorVariable->data(), &dummyVariables.back());
 	}
-	mvaReader->BookMVA((*category)->methodName_.data(), (*category)->inputFileName_.data());
+	reco::details::loadTMVAWeights(mvaReader, (*category)->methodName_.data(), (*category)->inputFileName_.data());
 	TMVA::MethodBDT* bdt = dynamic_cast<TMVA::MethodBDT*>(mvaReader->FindMVA((*category)->methodName_.data()));
 	if ( !bdt )
 	  throw cms::Exception("GBRForestWriter") 

--- a/CommonTools/Utils/plugins/GBRForestWriter.h
+++ b/CommonTools/Utils/plugins/GBRForestWriter.h
@@ -39,9 +39,6 @@ class GBRForestWriter : public edm::EDAnalyzer
     {
       if ( cfg.existsAs<edm::FileInPath>("inputFileName") ) {
 	edm::FileInPath inputFileName_fip = cfg.getParameter<edm::FileInPath>("inputFileName");
-	if ( inputFileName_fip.location()!=edm::FileInPath::Local)
-	  throw cms::Exception("GBRForestWriter") 
-	    << " Failed to find File = " << inputFileName_fip << " !!\n";
 	inputFileName_ = inputFileName_fip.fullPath();
       } else if ( cfg.existsAs<std::string>("inputFileName") ) {
 	inputFileName_ = cfg.getParameter<std::string>("inputFileName");

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -47,6 +47,7 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("softPFMuonBJetTags"),
         cms.InputTag("softPFElectronBJetTags"),
         cms.InputTag("pfCombinedMVABJetTags"),
+        cms.InputTag("pfCombinedMVAV2BJetTags")
         #CTagging -- temporary commented out waiting for RelVals
         ## cms.InputTag('pfCombinedCvsLJetTags'),
         ## cms.InputTag('pfCombinedCvsBJetTags')

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -72,6 +72,7 @@ supportedBtagDiscr = {
   , 'combinedMVABJetTags'                                   : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'combinedMVAV2BJetTags'                                 : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
@@ -126,6 +127,7 @@ supportedBtagDiscr = {
   , 'pfCombinedMVABJetTags'                                 : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfPositiveCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfCombinedMVAV2BJetTags'                               : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedSecondaryVertexSoftLeptonBJetTags'           : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags'   : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfBoostedDoubleSecondaryVertexAK8BJetTags'             : ['pfImpactParameterTagInfosAK8', 'pfInclusiveSecondaryVertexFinderTagInfosAK8', 'softPFMuonsTagInfosAK8', 'softPFElectronsTagInfosAK8']

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -48,6 +48,7 @@ btagDiscriminators = [
     ,'combinedMVABJetTags'
     ,'positiveCombinedMVABJetTags'
     ,'negativeCombinedMVABJetTags'
+    ,'combinedMVAV2BJetTags'
      # new candidate-based framework (supported with RECO/AOD/MiniAOD)
     ,'pfJetBProbabilityBJetTags'
     ,'pfJetProbabilityBJetTags'
@@ -104,6 +105,7 @@ btagDiscriminators = [
     ,'pfCombinedMVABJetTags'
     ,'pfPositiveCombinedMVABJetTags'
     ,'pfNegativeCombinedMVABJetTags'
+    ,'pfCombinedMVAV2BJetTags'
     #CTagging
     ,'pfCombinedCvsLJetTags'
     ,'pfCombinedCvsBJetTags'

--- a/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
@@ -8,13 +8,14 @@ candidateCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
 		'softPFMuonComputer',
 		'softPFElectronComputer'
 	),
-    mvaName = cms.string("bdt"),
+	mvaName = cms.string("bdt"),
 	variables = cms.vstring(
-        ["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+		["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
 	),
 	spectators = cms.vstring([]),
-    useCondDB = cms.bool(False),
-    useGBRForest = cms.bool(True),
-    useAdaBoost = cms.bool(True),
+	useCondDB = cms.bool(False),
+	gbrForestLabel = cms.string("btag_CombinedMVAv2_BDT"),
+	useGBRForest = cms.bool(True),
+	useAdaBoost = cms.bool(True),
 	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
 )

--- a/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
@@ -16,6 +16,6 @@ candidateCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
 	useCondDB = cms.bool(False),
 	gbrForestLabel = cms.string("btag_CombinedMVAv2_BDT"),
 	useGBRForest = cms.bool(True),
-	useAdaBoost = cms.bool(True),
+	useAdaBoost = cms.bool(False),
 	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
 )

--- a/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
@@ -13,7 +13,7 @@ candidateCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
 		["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
 	),
 	spectators = cms.vstring([]),
-	useCondDB = cms.bool(False),
+	useCondDB = cms.bool(True),
 	gbrForestLabel = cms.string("btag_CombinedMVAv2_BDT"),
 	useGBRForest = cms.bool(True),
 	useAdaBoost = cms.bool(False),

--- a/RecoBTag/Combined/test/writeGBRForests_cfg.py
+++ b/RecoBTag/Combined/test/writeGBRForests_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("writeGBRForests")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1) # NB: needs to be set to 1 so that GBRForestWriter::analyze method gets called exactly once
+)
+
+process.source = cms.Source("EmptySource")
+
+process.load('Configuration/StandardSequences/Services_cff')
+
+process.gbrForestWriter = cms.EDAnalyzer("GBRForestWriter",
+    jobs = cms.VPSet(
+        cms.PSet(
+            inputFileName = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz'),
+            inputFileType = cms.string("XML"),
+            inputVariables = cms.vstring("Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"),
+            spectatorVariables = cms.vstring(),
+            methodName = cms.string("BDT"),
+            outputFileType = cms.string("SQLLite"),
+            outputRecord = cms.string("btag_CombinedMVAv2_BDT_TMVAv420_74X_v1")
+        )
+    )
+)
+
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.CondDBCommon.connect = 'sqlite_file:btag_CombinedMVAv2_BDT_TMVAv420_GBRForest_74X_v1.db'
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDBCommon,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string('btag_CombinedMVAv2_BDT_TMVAv420_74X_v1'),
+            tag = cms.string('btag_CombinedMVAv2_BDT_TMVAv420_74X_v1'),
+            label = cms.untracked.string('btag_CombinedMVAv2_BDT')
+        )
+    )
+)
+
+process.p = cms.Path(process.gbrForestWriter)

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 softPFElectronCommon = cms.PSet(
-    useCondDB = cms.bool(False),
+    useCondDB = cms.bool(True),
     gbrForestLabel = cms.string("btag_SoftPFElectron_BDT"),
     weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
     useGBRForest = cms.bool(True),
@@ -9,7 +9,7 @@ softPFElectronCommon = cms.PSet(
 )
 
 softPFMuonCommon = cms.PSet(
-    useCondDB = cms.bool(False),
+    useCondDB = cms.bool(True),
     gbrForestLabel = cms.string("btag_SoftPFMuon_BDT"),
     weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
     useGBRForest = cms.bool(True),

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 softPFElectronCommon = cms.PSet(
     useCondDB = cms.bool(False),
-    gbrForestLabel = cms.string("btag_SoftPFElectron_TMVA420_BDT_74X_v1"),
+    gbrForestLabel = cms.string("btag_SoftPFElectron_BDT"),
     weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False)
@@ -10,7 +10,7 @@ softPFElectronCommon = cms.PSet(
 
 softPFMuonCommon = cms.PSet(
     useCondDB = cms.bool(False),
-    gbrForestLabel = cms.string("btag_SoftPFMuon_TMVA420_BDT_74X_v1"),
+    gbrForestLabel = cms.string("btag_SoftPFMuon_BDT"),
     weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(True)

--- a/RecoBTag/SoftLepton/test/writeGBRForests_cfg.py
+++ b/RecoBTag/SoftLepton/test/writeGBRForests_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("writeGBRForests")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1) # NB: needs to be set to 1 so that GBRForestWriter::analyze method gets called exactly once
+)
+
+process.source = cms.Source("EmptySource")
+
+process.load('Configuration/StandardSequences/Services_cff')
+
+process.gbrForestWriter = cms.EDAnalyzer("GBRForestWriter",
+    jobs = cms.VPSet(
+        cms.PSet(
+            inputFileName = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
+            inputFileType = cms.string("XML"),
+            inputVariables = cms.vstring("sip3d", "sip2d", "ptRel", "deltaR", "ratio", "mva_e_pi"),
+            spectatorVariables = cms.vstring(),
+            methodName = cms.string("BDT"),
+            outputFileType = cms.string("SQLLite"),
+            outputRecord = cms.string("btag_SoftPFElectron_BDT_TMVAv420_74X_v1")
+        ),
+        cms.PSet(
+            inputFileName = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
+            inputFileType = cms.string("XML"),
+            inputVariables = cms.vstring("TagInfo1.sip3d", "TagInfo1.sip2d", "TagInfo1.ptRel", "TagInfo1.deltaR", "TagInfo1.ratio"),
+            spectatorVariables = cms.vstring(),
+            methodName = cms.string("BDT"),
+            outputFileType = cms.string("SQLLite"),
+            outputRecord = cms.string("btag_SoftPFMuon_BDT_TMVAv420_74X_v1")
+        )
+    )
+)
+
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.CondDBCommon.connect = 'sqlite_file:btag_SoftPFLepton_BDT_TMVAv420_GBRForest_74X_v1.db'
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDBCommon,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string('btag_SoftPFElectron_BDT_TMVAv420_74X_v1'),
+            tag = cms.string('btag_SoftPFElectron_BDT_TMVAv420_74X_v1'),
+            label = cms.untracked.string('btag_SoftPFElectron_BDT')
+        ),
+        cms.PSet(
+            record = cms.string('btag_SoftPFMuon_BDT_TMVAv420_74X_v1'),
+            tag = cms.string('btag_SoftPFMuon_BDT_TMVAv420_74X_v1'),
+            label = cms.untracked.string('btag_SoftPFMuon_BDT')
+        )
+    )
+)
+
+process.p = cms.Path(process.gbrForestWriter)


### PR DESCRIPTION
This PR enables fetching the b-tag GBRForest payloads from the global tag. In addition, the pfCombinedMVAv2 tagger is now added to PAT jets by default.

@jpata, it appears that the AdaBoost flag for the CombinedMVAv2 taggers was not set correctly. Please check that everything is configured correctly in the PR.
