### PR TITLE
Replace cryptic assert with informative exception for missing Wrapper dictionary

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -354,7 +354,24 @@ namespace edm {
   TypeWithDict::typeInfo() const {
     if(*ti_ == typeid(dummyType) || isPointer() || isArray()) {
       // No accurate type_info
-      assert(qualifiedName().c_str() == nullptr);
+      if(qualifiedName().c_str() != nullptr) {
+        std::string category("unknown");
+        if(isPointer()) {
+          category = "a pointer";
+        } else if(isArray()) {
+          category = "an array";
+        } else if(isEnum()) {
+          category = "an enum";
+        } else if(isClass()) {
+          throw Exception(errors::DictionaryNotFound)
+          << "No Dictionary for class: '" << name() << "'" << std::endl;
+        }
+        throw Exception(errors::LogicError)
+          << "Function TypeWithDict::typeInfo: Type\n"
+          << qualifiedName()
+          << "\ndoes not have valid type_info information in ROOT\n"
+          << "because it is " << category << ".\n";
+      }
     }
     return *ti_;
   }
@@ -490,6 +507,8 @@ namespace edm {
          out <<  "::";
       }
       out << enum_->GetName();
+    } else if (*ti_ == typeid(dummyType) && isClass())  {
+      out << class_->GetName();
     } else {
       out << TypeID(*ti_).className();
     }


### PR DESCRIPTION
If an attempt is made to produce a product whose wrapped class (edm::Wrapper<ProductType>) does not have a dictionary, a cryptic assert resulted. This cryptic assert could also occur for other reasons.
This simple PR replaces the cryptic assert with an informative exception, which in the above case is a missing dictionary exception. This PR also fixes another minor problem. If TypeWithDict::name() or any related function was used to get the name of a class that has no dictionary, "dummyType" was returned, rather than the correct name of the class.
This problem is ROOT6 specific, but it also occurs in CMSSW_7_5_X. This fix can be back ported to 7_5_X if needed. This problem does not directly affect 7_4_X.
