### PR TITLE
const thread-safe packed classes

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -91,7 +91,7 @@ namespace pat {
       packBoth();
     }
 
-    explicit PackedCandidate( const PackedCandidate& iOther) :
+    PackedCandidate( const PackedCandidate& iOther) :
       packedPt_(iOther.packedPt_), packedEta_(iOther.packedEta_),
       packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
       packedDxy_(iOther.packedDxy_), packedDz_(iOther.packedDz_), packedDPhi_(iOther.packedDPhi_),
@@ -116,7 +116,7 @@ namespace pat {
       dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), normalizedChi2_(iOther.normalizedChi2_) {
       }
 
-    explicit PackedCandidate( PackedCandidate&& iOther) :
+    PackedCandidate( PackedCandidate&& iOther) :
       packedPt_(iOther.packedPt_), packedEta_(iOther.packedEta_),
       packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
       packedDxy_(iOther.packedDxy_), packedDz_(iOther.packedDz_), packedDPhi_(iOther.packedDPhi_),

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -1,6 +1,7 @@
 #ifndef __DataFormats_PatCandidates_PackedCandidate_h__
 #define __DataFormats_PatCandidates_PackedCandidate_h__
 
+#include <atomic>
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Common/interface/RefVector.h"
@@ -9,6 +10,9 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Math/interface/deltaPhi.h" 
 /* #include "DataFormats/Math/interface/PtEtaPhiMass.h" */
+
+//forward declare testing structure
+class testPackedCandidate;
 
 namespace pat {
   class PackedCandidate : public reco::Candidate {
@@ -28,19 +32,32 @@ namespace pat {
 
     /// default constructor
     PackedCandidate() :
-      p4_(0,0,0,0), p4c_(0,0,0,0), vertex_(0,0,0), dphi_(0), pdgId_(0),
+      packedPt_(0), packedEta_(0),
+      packedPhi_(0), packedM_(0),
+      packedDxy_(0), packedDz_(0), packedDPhi_(0),
+      packedCovarianceDxyDxy_(0),packedCovarianceDxyDz_(0),
+      packedCovarianceDzDz_(0),
+      packedCovarianceDlambdaDz_(0),
+      packedCovarianceDphiDxy_(0),
+      packedCovarianceDptDpt_(0),
+      packedCovarianceDetaDeta_(0),
+      packedCovarianceDphiDphi_(0),
+      packedPuppiweight_(0),
+      packedPuppiweightNoLepDiff_(0),
+      p4_(new PolarLorentzVector(0,0,0,0)), p4c_( new LorentzVector(0,0,0,0)), 
+      vertex_(new Point(0,0,0)), dphi_(0), track_(nullptr), pdgId_(0),
       qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()),
-      unpacked_(false), unpackedVtx_(true), unpackedTrk_(false), dxydxy_(0),
+      dxydxy_(0),
       dzdz_(0),dxydz_(0),dlambdadz_(0), dphidxy_(0),dptdpt_(0),detadeta_(0),
       dphidphi_(0), packedHits_(0), normalizedChi2_(0) { }
 
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      p4_(c.pt(), c.eta(), c.phi(), c.mass()), p4c_(p4_), vertex_(c.vertex()),
-      dphi_(0), pdgId_(c.pdgId()), qualityFlags_(0), pvRefProd_(pvRefProd),
-      pvRefKey_(pvRefKey), unpacked_(true), unpackedVtx_(true),
-      unpackedTrk_(false), dxydxy_(0),dzdz_(0),dxydz_(0), dlambdadz_(0),
+      p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
+      p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), dphi_(0), 
+      track_(nullptr), pdgId_(c.pdgId()), qualityFlags_(0), pvRefProd_(pvRefProd),
+      pvRefKey_(pvRefKey),dxydxy_(0),dzdz_(0),dxydz_(0), dlambdadz_(0),
       dphidxy_(0),dptdpt_(0), detadeta_(0),dphidphi_(0), packedHits_(0),
       normalizedChi2_(0) {
       packBoth();
@@ -50,11 +67,11 @@ namespace pat {
                               float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      p4_(p4), p4c_(p4_), vertex_(vtx),
-      dphi_(reco::deltaPhi(phiAtVtx,p4_.phi())), pdgId_(pdgId),
+      p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
+      vertex_( new Point(vtx) ), dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
+      track_(nullptr), pdgId_(pdgId),
       qualityFlags_(0), pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
-      unpacked_(true), unpackedVtx_(true), unpackedTrk_(false),
-      dxydxy_(0),dzdz_(0),dxydz_(0),dlambdadz_(0),dphidxy_(0),dptdpt_(0),
+            dxydxy_(0),dzdz_(0),dxydz_(0),dlambdadz_(0),dphidxy_(0),dptdpt_(0),
       detadeta_(0),dphidphi_(0),packedHits_(0),normalizedChi2_(0) {
       packBoth();
     }
@@ -63,13 +80,178 @@ namespace pat {
                               float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      p4_(p4.Pt(), p4.Eta(), p4.Phi(), p4.M()), p4c_(p4), vertex_(vtx),
-      dphi_(reco::deltaPhi(phiAtVtx,p4_.phi())), pdgId_(pdgId), qualityFlags_(0),
-      pvRefProd_(pvRefProd), pvRefKey_(pvRefKey), unpacked_(true),
-      unpackedVtx_(true), unpackedTrk_(false), dxydxy_(0),dzdz_(0),dxydz_(0),
+      p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
+      p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
+      dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
+      track_(nullptr), pdgId_(pdgId), qualityFlags_(0),
+      pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
+      dxydxy_(0),dzdz_(0),dxydz_(0),
       dlambdadz_(0),dphidxy_(0),dptdpt_(0), detadeta_(0),dphidphi_(0),
       packedHits_(0),normalizedChi2_(0) {
       packBoth();
+    }
+
+    explicit PackedCandidate( const PackedCandidate& iOther) :
+      packedPt_(iOther.packedPt_), packedEta_(iOther.packedEta_),
+      packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
+      packedDxy_(iOther.packedDxy_), packedDz_(iOther.packedDz_), packedDPhi_(iOther.packedDPhi_),
+      packedCovarianceDxyDxy_(iOther.packedCovarianceDxyDxy_),packedCovarianceDxyDz_(iOther.packedCovarianceDxyDz_),
+      packedCovarianceDzDz_(iOther.packedCovarianceDzDz_),
+      packedCovarianceDlambdaDz_(iOther.packedCovarianceDlambdaDz_),
+      packedCovarianceDphiDxy_(iOther.packedCovarianceDphiDxy_),
+      packedCovarianceDptDpt_(iOther.packedCovarianceDptDpt_),
+      packedCovarianceDetaDeta_(iOther.packedCovarianceDetaDeta_),
+      packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
+      packedPuppiweight_(iOther.packedPuppiweight_), 
+      packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      //Need to trigger unpacking in iOther
+      p4_( new PolarLorentzVector(iOther.polarP4() ) ),
+      p4c_( new LorentzVector(iOther.p4())), vertex_( new Point(iOther.vertex())),
+      dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_), 
+      track_( iOther.track_ ? new reco::Track(*iOther.track_) : nullptr),
+      pdgId_(iOther.pdgId_), qualityFlags_(iOther.qualityFlags_), 
+      pvRefProd_(iOther.pvRefProd_),pvRefKey_(iOther.pvRefKey_),
+      dxydxy_(iOther.dxydxy_),dzdz_(iOther.dzdz_),dxydz_(iOther.dxydz_), dlambdadz_(iOther.dlambdadz_),
+      dphidxy_(iOther.dphidxy_),dptdpt_(iOther.dptdpt_), detadeta_(iOther.detadeta_),
+      dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), normalizedChi2_(iOther.normalizedChi2_) {
+      }
+
+    explicit PackedCandidate( PackedCandidate&& iOther) :
+      packedPt_(iOther.packedPt_), packedEta_(iOther.packedEta_),
+      packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
+      packedDxy_(iOther.packedDxy_), packedDz_(iOther.packedDz_), packedDPhi_(iOther.packedDPhi_),
+      packedCovarianceDxyDxy_(iOther.packedCovarianceDxyDxy_),packedCovarianceDxyDz_(iOther.packedCovarianceDxyDz_),
+      packedCovarianceDzDz_(iOther.packedCovarianceDzDz_),
+      packedCovarianceDlambdaDz_(iOther.packedCovarianceDlambdaDz_),
+      packedCovarianceDphiDxy_(iOther.packedCovarianceDphiDxy_),
+      packedCovarianceDptDpt_(iOther.packedCovarianceDptDpt_),
+      packedCovarianceDetaDeta_(iOther.packedCovarianceDetaDeta_),
+      packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
+      packedPuppiweight_(iOther.packedPuppiweight_), 
+      packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      p4_( iOther.p4_.exchange(nullptr) ) ,
+      p4c_( iOther.p4c_.exchange(nullptr)), vertex_(iOther.vertex_.exchange(nullptr)),
+      dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_), 
+      track_( iOther.track_.exchange(nullptr) ),
+      pdgId_(iOther.pdgId_), qualityFlags_(iOther.qualityFlags_), 
+      pvRefProd_(std::move(iOther.pvRefProd_)),pvRefKey_(iOther.pvRefKey_),
+      dxydxy_(iOther.dxydxy_),dzdz_(iOther.dzdz_),dxydz_(iOther.dxydz_), dlambdadz_(iOther.dlambdadz_),
+      dphidxy_(iOther.dphidxy_),dptdpt_(iOther.dptdpt_), detadeta_(iOther.detadeta_),
+      dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), normalizedChi2_(iOther.normalizedChi2_) {
+      }
+
+
+    PackedCandidate& operator=(const PackedCandidate& iOther) {
+      if(this == &iOther) {
+        return *this;
+      }
+      packedPt_ =iOther.packedPt_;
+      packedEta_=iOther.packedEta_;
+      packedPhi_=iOther.packedPhi_; 
+      packedM_=iOther.packedM_;
+      packedDxy_=iOther.packedDxy_; 
+      packedDz_=iOther.packedDz_; 
+      packedDPhi_=iOther.packedDPhi_;
+      packedCovarianceDxyDxy_=iOther.packedCovarianceDxyDxy_;
+      packedCovarianceDxyDz_=iOther.packedCovarianceDxyDz_;
+      packedCovarianceDzDz_=iOther.packedCovarianceDzDz_;
+      packedCovarianceDlambdaDz_=iOther.packedCovarianceDlambdaDz_;
+      packedCovarianceDphiDxy_=iOther.packedCovarianceDphiDxy_;
+      packedCovarianceDptDpt_=iOther.packedCovarianceDptDpt_;
+      packedCovarianceDetaDeta_=iOther.packedCovarianceDetaDeta_;
+      packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
+      packedPuppiweight_=iOther.packedPuppiweight_; 
+      packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      //Need to trigger unpacking in iOther
+      if(p4_) {
+        *p4_ = iOther.polarP4();
+      } else {
+        p4_.store( new PolarLorentzVector(iOther.polarP4() ) ) ;
+      }
+      if(p4c_) {
+        *p4c_ = iOther.p4();
+      } else {
+        p4c_.store( new LorentzVector(iOther.p4()));
+      }
+      if(vertex_) {
+        *vertex_ = iOther.vertex();
+      } else {
+        vertex_.store( new Point(iOther.vertex()));
+      }
+      dxy_=iOther.dxy_;
+      dz_ = iOther.dz_;
+      dphi_=iOther.dphi_; 
+      
+      if(!iOther.track_) {
+        delete track_.exchange(nullptr);
+      } else {
+        if(!track_) {
+          track_.store( new reco::Track(*iOther.track_));
+        } else {
+          *track_ = *(iOther.track_);
+        }
+      }
+
+      pdgId_=iOther.pdgId_; 
+      qualityFlags_=iOther.qualityFlags_; 
+      pvRefProd_=iOther.pvRefProd_;
+      pvRefKey_=iOther.pvRefKey_;
+      dxydxy_=iOther.dxydxy_;
+      dzdz_=iOther.dzdz_;
+      dxydz_=iOther.dxydz_; 
+      dlambdadz_=iOther.dlambdadz_;
+      dphidxy_=iOther.dphidxy_;
+      dptdpt_=iOther.dptdpt_; 
+      detadeta_=iOther.detadeta_;
+      dphidphi_=iOther.dphidphi_; 
+      packedHits_=iOther.packedHits_; 
+      normalizedChi2_=iOther.normalizedChi2_;
+      return *this;
+    }
+
+    PackedCandidate& operator=(PackedCandidate&& iOther) {
+      if(this == &iOther) {
+        return *this;
+      }
+      packedPt_ =iOther.packedPt_;
+      packedEta_=iOther.packedEta_;
+      packedPhi_=iOther.packedPhi_; 
+      packedM_=iOther.packedM_;
+      packedDxy_=iOther.packedDxy_; 
+      packedDz_=iOther.packedDz_; 
+      packedDPhi_=iOther.packedDPhi_;
+      packedCovarianceDxyDxy_=iOther.packedCovarianceDxyDxy_;
+      packedCovarianceDxyDz_=iOther.packedCovarianceDxyDz_;
+      packedCovarianceDzDz_=iOther.packedCovarianceDzDz_;
+      packedCovarianceDlambdaDz_=iOther.packedCovarianceDlambdaDz_;
+      packedCovarianceDphiDxy_=iOther.packedCovarianceDphiDxy_;
+      packedCovarianceDptDpt_=iOther.packedCovarianceDptDpt_;
+      packedCovarianceDetaDeta_=iOther.packedCovarianceDetaDeta_;
+      packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
+      packedPuppiweight_=iOther.packedPuppiweight_; 
+      packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      delete p4_.exchange(iOther.p4_.exchange(nullptr));
+      delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
+      delete vertex_.exchange(iOther.vertex_.exchange(nullptr));
+      dxy_=iOther.dxy_;
+      dz_ = iOther.dz_;
+      dphi_=iOther.dphi_; 
+      delete track_.exchange(iOther.track_.exchange( nullptr));
+      pdgId_=iOther.pdgId_; 
+      qualityFlags_=iOther.qualityFlags_; 
+      pvRefProd_=iOther.pvRefProd_;
+      pvRefKey_=iOther.pvRefKey_;
+      dxydxy_=iOther.dxydxy_;
+      dzdz_=iOther.dzdz_;
+      dxydz_=iOther.dxydz_; 
+      dlambdadz_=iOther.dlambdadz_;
+      dphidxy_=iOther.dphidxy_;
+      dptdpt_=iOther.dptdpt_; 
+      detadeta_=iOther.detadeta_;
+      dphidphi_=iOther.dphidphi_; 
+      packedHits_=iOther.packedHits_; 
+      normalizedChi2_=iOther.normalizedChi2_;
+      return *this;
     }
 
     /// destructor
@@ -115,79 +297,79 @@ namespace pat {
     /// set electric charge                                                               
     virtual void setThreeCharge( int threecharge) {}
     /// four-momentum Lorentz vecto r                                                      
-    virtual const LorentzVector & p4() const { if (!unpacked_) unpack(); return p4c_; }  
+    virtual const LorentzVector & p4() const { if (!p4c_) unpack(); return *p4c_; }  
     /// four-momentum Lorentz vector                                                      
-    virtual const PolarLorentzVector & polarP4() const { if (!unpacked_) unpack(); return p4_; }
+    virtual const PolarLorentzVector & polarP4() const { if (!p4c_) unpack(); return *p4_; }
     /// spatial momentum vector                                                           
-    virtual Vector momentum() const  { if (!unpacked_) unpack(); return p4c_.Vect(); }
+    virtual Vector momentum() const  { if (!p4c_) unpack(); return p4c_.load()->Vect(); }
     /// boost vector to boost a Lorentz vector                                            
     /// to the particle center of mass system                                             
-    virtual Vector boostToCM() const { if (!unpacked_) unpack(); return p4c_.BoostToCM(); }
+    virtual Vector boostToCM() const { if (!p4c_) unpack(); return p4c_.load()->BoostToCM(); }
     /// magnitude of momentum vector                                                      
-    virtual double p() const { if (!unpacked_) unpack(); return p4c_.P(); }
+    virtual double p() const { if (!p4c_) unpack(); return p4c_.load()->P(); }
     /// energy                                                                            
-    virtual double energy() const { if (!unpacked_) unpack(); return p4c_.E(); }
+    virtual double energy() const { if (!p4c_) unpack(); return p4c_.load()->E(); }
    /// transverse energy 
-    double et() const { return (pt()<=0) ? 0 : p4c_.Et(); }  
+    double et() const { return (pt()<=0) ? 0 : p4c_.load()->Et(); }  
     /// transverse energy squared (use this for cuts)!
-    double et2() const { return (pt()<=0) ? 0 : p4c_.Et2(); }   
+    double et2() const { return (pt()<=0) ? 0 : p4c_.load()->Et2(); }   
     /// mass                                                                              
-    virtual double mass() const { if (!unpacked_) unpack(); return p4_.M(); }
+    virtual double mass() const { if (!p4c_) unpack(); return p4_.load()->M(); }
     /// mass squared                                                                      
-    virtual double massSqr() const { if (!unpacked_) unpack(); return p4_.M()*p4_.M(); }
+    virtual double massSqr() const { if (!p4c_) unpack(); auto m = p4_.load()->M(); return m*m;}
 
     /// transverse mass                                                                   
-    virtual double mt() const { if (!unpacked_) unpack(); return p4_.Mt(); }
+    virtual double mt() const { if (!p4c_) unpack(); return p4_.load()->Mt(); }
     /// transverse mass squared                                                           
-    virtual double mtSqr() const { if (!unpacked_) unpack(); return p4_.Mt2(); }
+    virtual double mtSqr() const { if (!p4c_) unpack(); return p4_.load()->Mt2(); }
     /// x coordinate of momentum vector                                                   
-    virtual double px() const { if (!unpacked_) unpack(); return p4c_.Px(); }
+    virtual double px() const { if (!p4c_) unpack(); return p4c_.load()->Px(); }
     /// y coordinate of momentum vector                                                   
-    virtual double py() const { if (!unpacked_) unpack(); return p4c_.Py(); }
+    virtual double py() const { if (!p4c_) unpack(); return p4c_.load()->Py(); }
     /// z coordinate of momentum vector                                                   
-    virtual double pz() const { if (!unpacked_) unpack(); return p4c_.Pz(); }
+    virtual double pz() const { if (!p4c_) unpack(); return p4c_.load()->Pz(); }
     /// transverse momentum                                                               
-    virtual double pt() const { if (!unpacked_) unpack(); return p4_.Pt();}
+    virtual double pt() const { if (!p4c_) unpack(); return p4_.load()->Pt();}
     /// momentum azimuthal angle                                                          
-    virtual double phi() const { if (!unpacked_) unpack(); return p4_.Phi(); }
+    virtual double phi() const { if (!p4c_) unpack(); return p4_.load()->Phi(); }
     /// momentum azimuthal angle from the track (normally identical to phi())
     virtual float phiAtVtx() const { 
         maybeUnpackBoth(); 
-        float ret = p4_.Phi() + dphi_; 
+        float ret = p4_.load()->Phi() + dphi_; 
         while (ret >  float(M_PI)) ret -= 2*float(M_PI); 
         while (ret < -float(M_PI)) ret += 2*float(M_PI); 
         return ret; 
     }
     /// momentum polar angle                                                              
-    virtual double theta() const { if (!unpacked_) unpack(); return p4_.Theta(); }
+    virtual double theta() const { if (!p4c_) unpack(); return p4_.load()->Theta(); }
     /// momentum pseudorapidity                                                           
-    virtual double eta() const { if (!unpacked_) unpack(); return p4_.Eta(); }
+    virtual double eta() const { if (!p4c_) unpack(); return p4_.load()->Eta(); }
     /// rapidity                                                                          
-    virtual double rapidity() const { if (!unpacked_) unpack(); return p4_.Rapidity(); }
+    virtual double rapidity() const { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
     /// rapidity                                                                          
-    virtual double y() const { if (!unpacked_) unpack(); return p4_.Rapidity(); }
+    virtual double y() const { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
     /// set 4-momentum                                                                    
     virtual void setP4( const LorentzVector & p4 ) { 
         maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
-        p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
+        *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
         packBoth();
     }
     /// set 4-momentum                                                                    
     virtual void setP4( const PolarLorentzVector & p4 ) { 
         maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
-        p4_ = p4; 
+        *p4_ = p4; 
         packBoth();
     }
     /// set particle mass                                                                 
     virtual void setMass( double m ) {
-      if (!unpacked_) unpack(); 
-      p4_ = PolarLorentzVector(p4_.Pt(), p4_.Eta(), p4_.Phi(), m); 
+      if (!p4c_) unpack(); 
+      *p4_ = PolarLorentzVector(p4_.load()->Pt(), p4_.load()->Eta(), p4_.load()->Phi(), m); 
       pack();
     }
     virtual void setPz( double pz ) {
       maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
-      p4c_ = LorentzVector(p4c_.Px(), p4c_.Py(), pz, p4c_.E());
-      p4_  = PolarLorentzVector(p4c_.Pt(), p4c_.Eta(), p4c_.Phi(), p4c_.M());
+      *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz, p4c_.load()->E());
+      *p4_  = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
       packBoth();
     }
     /// set impact parameters covariance
@@ -219,15 +401,15 @@ namespace pat {
     int numberOfHits() const { return (packedHits_ >> 3) + numberOfPixelHits(); }
 	
     /// vertex position
-    virtual const Point & vertex() const { maybeUnpackBoth(); return vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
+    virtual const Point & vertex() const { maybeUnpackBoth(); return *vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
     /// x coordinate of vertex position                                                   
-    virtual double vx() const  { maybeUnpackBoth(); return vertex_.X(); }//{ return 0; }
+    virtual double vx() const  { maybeUnpackBoth(); return vertex_.load()->X(); }//{ return 0; }
     /// y coordinate of vertex position                                                   
-    virtual double vy() const  { maybeUnpackBoth(); return vertex_.Y(); }//{ return 0; }
+    virtual double vy() const  { maybeUnpackBoth(); return vertex_.load()->Y(); }//{ return 0; }
     /// z coordinate of vertex position                                                   
-    virtual double vz() const  { maybeUnpackBoth(); return vertex_.Z(); }//{ if (fromPV_) return 0; else return 100; }
+    virtual double vz() const  { maybeUnpackBoth(); return vertex_.load()->Z(); }//{ if (fromPV_) return 0; else return 100; }
     /// set vertex                                                                        
-    virtual void setVertex( const Point & vertex ) { maybeUnpackBoth(); vertex_ = vertex; packVtx(); }
+    virtual void setVertex( const Point & vertex ) { maybeUnpackBoth(); *vertex_ = vertex; packVtx(); }
 
     ///This refers to the association to PV=ipv. >=PVLoose corresponds to JME definition, >=PVTight to isolation definition
     enum PVAssoc { NoPV=0, PVLoose=1, PVTight=2, PVUsedInFit=3 } ;
@@ -266,13 +448,13 @@ namespace pat {
 
 
     /// Return reference to a pseudo track made with candidate kinematics, parameterized error for eta,phi,pt and full IP covariance	
-    virtual const reco::Track & pseudoTrack() const { if (!unpackedTrk_) unpackTrk(); return track_; }
+    virtual const reco::Track & pseudoTrack() const { if (!track_) unpackTrk(); return *track_; }
 
     /// return a pointer to the track if present. otherwise, return a null pointer
     virtual const reco::Track * bestTrack() const {
       if (packedHits_!=0) {
-        if (!unpackedTrk_) unpackTrk();
-        return &track_;
+        if (!track_) unpackTrk();
+        return track_.load();
       }
       else
         return nullptr;
@@ -381,6 +563,8 @@ namespace pat {
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
   protected:
+    friend class ::testPackedCandidate;
+
     uint16_t packedPt_, packedEta_, packedPhi_, packedM_;
     uint16_t packedDxy_, packedDz_, packedDPhi_;
     uint16_t packedCovarianceDxyDxy_,packedCovarianceDxyDz_,packedCovarianceDzDz_;
@@ -390,34 +574,29 @@ namespace pat {
     void unpack() const ;
     void packVtx(bool unpackAfterwards=true) ;
     void unpackVtx() const ;
-    void maybeUnpackBoth() const { if (!unpacked_) unpack(); if (!unpackedVtx_) unpackVtx(); }
+    void maybeUnpackBoth() const { if (!p4c_) unpack(); if (!vertex_) unpackVtx(); }
     void packBoth() { pack(false); packVtx(false); unpack(); unpackVtx(); } // do it this way, so that we don't loose precision on the angles before computing dxy,dz
     void unpackTrk() const ;
 
     int8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
     /// the four vector                                                 
-    mutable PolarLorentzVector p4_;
-    mutable LorentzVector p4c_;
+    mutable std::atomic<PolarLorentzVector*> p4_;
+    mutable std::atomic<LorentzVector*> p4c_;
     /// vertex position                                                                   
-    mutable Point vertex_;
-    mutable float dxy_, dz_, dphi_;
+    mutable std::atomic<Point*> vertex_;
+    [[cms::thread_guard("vertex_")]] mutable float dxy_, dz_, dphi_;
     /// reco::Track                                                                   
-    mutable reco::Track track_;
+    mutable std::atomic<reco::Track*> track_;
     /// PDG identifier                                                                    
     int pdgId_;
     uint16_t qualityFlags_;
     /// Use these to build a Ref to primary vertex
     reco::VertexRefProd pvRefProd_;
     reco::VertexRef::key_type pvRefKey_;
-    // is the momentum p4 unpacked
-    mutable bool unpacked_;
-    // are the dxy, dz and vertex unpacked
-    mutable bool unpackedVtx_;
-    // is the track unpacked
-    mutable bool unpackedTrk_;
+
     /// IP covariance	
-    mutable float dxydxy_, dzdz_, dxydz_,dlambdadz_,dphidxy_,dptdpt_,detadeta_,dphidphi_;
+    [[cms::thread_guard("vertex_")]] mutable float dxydxy_, dzdz_, dxydz_,dlambdadz_,dphidxy_,dptdpt_,detadeta_,dphidphi_;
     uint8_t packedHits_;
     /// track quality information
     uint8_t normalizedChi2_; 

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -5,11 +5,15 @@
 
 
 void pat::PackedGenParticle::pack(bool unpackAfterwards) {
-    packedPt_  =  MiniFloatConverter::float32to16(p4_.Pt());
-    packedY_ =  int16_t(p4_.Rapidity()/6.0f*std::numeric_limits<int16_t>::max());
-    packedPhi_ =  int16_t(p4_.Phi()/3.2f*std::numeric_limits<int16_t>::max());
-    packedM_   =  MiniFloatConverter::float32to16(p4_.M());
-    if (unpackAfterwards) unpack(); // force the values to match with the packed ones
+    packedPt_  =  MiniFloatConverter::float32to16(p4_.load()->Pt());
+    packedY_ =  int16_t(p4_.load()->Rapidity()/6.0f*std::numeric_limits<int16_t>::max());
+    packedPhi_ =  int16_t(p4_.load()->Phi()/3.2f*std::numeric_limits<int16_t>::max());
+    packedM_   =  MiniFloatConverter::float32to16(p4_.load()->M());
+    if (unpackAfterwards) {
+      delete p4_.exchange(nullptr);
+      delete p4c_.exchange(nullptr);
+      unpack(); // force the values to match with the packed ones
+    }
 }
 
 
@@ -18,25 +22,38 @@ void pat::PackedGenParticle::unpack() const {
     float pt=MiniFloatConverter::float16to32(packedPt_);
     float m=MiniFloatConverter::float16to32(packedM_);
     float pz = std::tanh(y)*std::sqrt((m*m+pt*pt)/(1.-std::tanh(y)*std::tanh(y)));
-    float eta = std::asinh(pz/pt);
+    float eta = 0;
+    if(pt != 0.) {
+      eta = std::asinh(pz/pt);
+    }
     double shift = (pt<1. ? 0.1*pt : 0.1/pt); // shift particle phi to break degeneracies in angular separations
     double sign = ( ( int(pt*10) % 2 == 0 ) ? 1 : -1 ); // introduce a pseudo-random sign of the shift
     double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + sign*shift*3.2/std::numeric_limits<int16_t>::max();
-    p4_ = PolarLorentzVector(pt,eta,phi,m);
-    p4c_ = p4_;
-    unpacked_ = true;
+    auto p4 = std::make_unique<PolarLorentzVector>(pt,eta,phi,m);
+    PolarLorentzVector* expectp4 = nullptr;
+    if(p4_.compare_exchange_strong(expectp4,p4.get())) {
+      p4.release();
+    }
+    auto p4c = std::make_unique<LorentzVector>(*p4_);
+    LorentzVector* expectp4c = nullptr;
+    if(p4c_.compare_exchange_strong(expectp4c,p4c.get())) {
+      p4c.release();
+    }
 }
 
-pat::PackedGenParticle::~PackedGenParticle() { }
+pat::PackedGenParticle::~PackedGenParticle() {
+  delete p4_.load();
+  delete p4c_.load();
+ }
 
 
 float pat::PackedGenParticle::dxy(const Point &p) const {
 	unpack();
-	return -(vertex_.X()-p.X()) * std::sin(float(p4_.Phi())) + (vertex_.Y()-p.Y()) * std::cos(float(p4_.Phi()));
+	return -(vertex_.X()-p.X()) * std::sin(float(p4_.load()->Phi())) + (vertex_.Y()-p.Y()) * std::cos(float(p4_.load()->Phi()));
 }
 float pat::PackedGenParticle::dz(const Point &p) const {
     unpack();
-    return (vertex_.Z()-p.X())  - ((vertex_.X()-p.X()) * std::cos(float(p4_.Phi())) + (vertex_.Y()-p.Y()) * std::sin(float(p4_.Phi()))) * p4_.Pz()/p4_.Pt();
+    return (vertex_.Z()-p.X())  - ((vertex_.X()-p.X()) * std::cos(float(p4_.load()->Phi())) + (vertex_.Y()-p.Y()) * std::sin(float(p4_.load()->Phi()))) * p4_.load()->Pz()/p4_.load()->Pt();
 }
 
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -333,7 +333,6 @@
     <version ClassVersion="10" checksum="389883266"/>
     <field name="p4_" transient="true" />
     <field name="p4c_" transient="true" />
-    <field name="unpacked_" transient="true" />
   </class>
   <ioread sourceClass="pat::PackedGenParticle" source="int16_t packedEta_;int16_t packedPt_;int16_t packedM_;" version="[-10]" checksum="[389883266]" targetClass="pat::PackedGenParticle"
   	 target="packedY_" embed="false" include="DataFormats/PatCandidates/interface/ioread_packedgen.h" >
@@ -342,8 +341,12 @@
 	]]>
    </ioread>
 
-  <ioread sourceClass="pat::PackedGenParticle"  version="[1-]" targetClass="pat::PackedGenParticle" source="" target="unpacked_">
-    <![CDATA[unpacked_ = false;
+  <ioread sourceClass="pat::PackedGenParticle"  version="[1-]" targetClass="pat::PackedGenParticle" source="" target="p4_">
+    <![CDATA[delete p4_.exchange(nullptr);
+    ]]>
+  </ioread>
+  <ioread sourceClass="pat::PackedGenParticle"  version="[1-]" targetClass="pat::PackedGenParticle" source="" target="p4c_">
+    <![CDATA[delete p4c_.exchange(nullptr);
     ]]>
   </ioread>
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -277,7 +277,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="21">
+  <class name="pat::PackedCandidate" ClassVersion="25">
+    <version ClassVersion="25" checksum="3654469025"/>
     <version ClassVersion="24" checksum="663492232"/>
     <version ClassVersion="23" checksum="559934341"/>
     <version ClassVersion="22" checksum="691064527"/>
@@ -296,8 +297,6 @@
     <field name="p4_" transient="true" />
     <field name="p4c_" transient="true" />
     <field name="vertex_" transient="true" />
-    <field name="unpacked_" transient="true" />
-    <field name="unpackedVtx_" transient="true" />
     <field name="dxy_" transient="true" />
     <field name="dz_" transient="true" />
     <field name="dphi_" transient="true" />
@@ -309,18 +308,22 @@
     <field name="dphidphi_" transient="true" />
     <field name="detadeta_" transient="true" />
     <field name="dptdpt_" transient="true" />
-  <field name="track_" transient="true" />
+    <field name="track_" transient="true" />
   </class>
-  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="unpacked_">
-    <![CDATA[unpacked_ = false;
+  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="p4_">
+    <![CDATA[delete p4_.exchange(nullptr);
     ]]>
   </ioread>
-  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="unpackedVtx_">
-    <![CDATA[unpackedVtx_ = false;
+  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="p4c_">
+    <![CDATA[delete p4c_.exchange(nullptr);
     ]]>
   </ioread>
-  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="unpackedTrk_">
-    <![CDATA[unpackedTrk_ = false;
+  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="vertex_">
+    <![CDATA[delete vertex_.exchange(nullptr);
+    ]]>
+  </ioread>
+  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="track_">
+    <![CDATA[delete track_.exchange(nullptr);
     ]]>
   </ioread>
 

--- a/DataFormats/PatCandidates/test/BuildFile.xml
+++ b/DataFormats/PatCandidates/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/PatCandidates"/>
+<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testRunner.cpp"/>
 <bin   name="testKinResolutions" file="testKinParametrizations.cc,testKinResolutions.cc,testRunner.cpp">
   <flags   NO_TESTRUN="1"/>
 </bin>

--- a/DataFormats/PatCandidates/test/BuildFile.xml
+++ b/DataFormats/PatCandidates/test/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/PatCandidates"/>
-<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testRunner.cpp"/>
+<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testPackedGenParticle.cc,testRunner.cpp"/>
 <bin   name="testKinResolutions" file="testKinParametrizations.cc,testKinResolutions.cc,testRunner.cpp">
   <flags   NO_TESTRUN="1"/>
 </bin>

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -1,0 +1,140 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <algorithm>
+#include <iterator>
+#include <iostream>
+#include <iomanip>
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+class testPackedCandidate : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testPackedCandidate);
+
+  CPPUNIT_TEST(testDefaultConstructor);
+  CPPUNIT_TEST(testCopyConstructor);
+  CPPUNIT_TEST(testPackUnpack);
+  CPPUNIT_TEST(testSimulateReadFromRoot);
+
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void testDefaultConstructor() ;
+  void testCopyConstructor();
+  void testPackUnpack();
+  void testSimulateReadFromRoot();
+
+
+private:
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testPackedCandidate);
+
+
+
+void testPackedCandidate::testDefaultConstructor() {
+
+  pat::PackedCandidate pc;
+
+  CPPUNIT_ASSERT(pc.polarP4() == pat::PackedCandidate::PolarLorentzVector(0,0,0,0));
+  CPPUNIT_ASSERT(pc.p4() == pat::PackedCandidate::LorentzVector(0,0,0,0) );
+  CPPUNIT_ASSERT(pc.vertex() == pat::PackedCandidate::Point(0,0,0));
+}
+
+void testPackedCandidate::testCopyConstructor() {
+  pat::PackedCandidate::LorentzVector lv(1.,0.5,0., std::sqrt(1.+0.25 +0.120*0.120));
+  pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
+
+  pat::PackedCandidate::Point v(0.01,0.02,0.);
+
+  //invalid Refs use a special key
+  pat::PackedCandidate pc(lv, v, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
+
+  CPPUNIT_ASSERT(pc.polarP4() == plv);
+  CPPUNIT_ASSERT(pc.p4() == lv);
+  CPPUNIT_ASSERT(pc.vertex() == v);
+
+  pat::PackedCandidate copy_pc(pc);
+
+  CPPUNIT_ASSERT(copy_pc.polarP4() == plv);
+  CPPUNIT_ASSERT(copy_pc.p4() == lv);
+  CPPUNIT_ASSERT(copy_pc.vertex() == v);
+
+  CPPUNIT_ASSERT(&copy_pc.polarP4() != &pc.polarP4());
+  CPPUNIT_ASSERT(&copy_pc.p4() != &pc.p4());
+  CPPUNIT_ASSERT(&copy_pc.vertex() != &pc.vertex());
+
+}
+
+static bool tolerance(double iLHS, double iRHS, double fraction) {
+  return std::abs(iLHS-iRHS) <= fraction*std::abs(iLHS+iRHS)/2.;
+}
+
+void 
+testPackedCandidate::testPackUnpack() {
+
+  pat::PackedCandidate::LorentzVector lv(1.,1.,0., std::sqrt(2.+0.120*0.120));
+  pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
+
+  pat::PackedCandidate::Point v(-0.005,0.005,0.1);
+
+  //invalid Refs use a special key
+  pat::PackedCandidate pc(lv, v, -3./4.*3.1416, 11, reco::VertexRefProd(), reco::VertexRef().key());
+
+  CPPUNIT_ASSERT(pc.polarP4() == plv);
+  CPPUNIT_ASSERT(pc.p4() == lv);
+  CPPUNIT_ASSERT(pc.vertex() == v);
+  CPPUNIT_ASSERT(pc.pseudoTrack().p() == lv.P());
+
+  pc.pack(true);
+  pc.packVtx(true);
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));
+}
+
+void testPackedCandidate::testSimulateReadFromRoot() {
+
+  pat::PackedCandidate::LorentzVector lv(1.,1.,0., std::sqrt(2. +0.120*0.120));
+  pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
+
+  pat::PackedCandidate::Point v(-0.005,0.005,0.1);
+
+  //invalid Refs use a special key
+  pat::PackedCandidate pc(lv, v, -3./4.*3.1416, 11, reco::VertexRefProd(), reco::VertexRef().key());
+
+  CPPUNIT_ASSERT(pc.polarP4() == plv);
+  CPPUNIT_ASSERT(pc.p4() == lv);
+  CPPUNIT_ASSERT(pc.vertex() == v);
+  CPPUNIT_ASSERT(pc.pseudoTrack().p() == lv.P());
+
+  //When reading back from ROOT, these were not stored and are nulled out
+  delete pc.p4_.exchange(nullptr);
+  delete pc.p4c_.exchange(nullptr);
+  delete pc.vertex_.exchange(nullptr);
+  delete pc.track_.exchange(nullptr);
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().p(),lv.P(),0.001));
+  
+}
+

--- a/DataFormats/PatCandidates/test/testPackedGenParticle.cc
+++ b/DataFormats/PatCandidates/test/testPackedGenParticle.cc
@@ -1,0 +1,141 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <algorithm>
+#include <iterator>
+#include <iostream>
+#include <iomanip>
+
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+
+class testPackedGenParticle : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testPackedGenParticle);
+
+  CPPUNIT_TEST(testDefaultConstructor);
+  CPPUNIT_TEST(testCopyConstructor);
+  CPPUNIT_TEST(testPackUnpack);
+  CPPUNIT_TEST(testSimulateReadFromRoot);
+
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void testDefaultConstructor() ;
+  void testCopyConstructor();
+  void testPackUnpack();
+  void testSimulateReadFromRoot();
+
+
+private:
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testPackedGenParticle);
+
+
+
+void testPackedGenParticle::testDefaultConstructor() {
+
+  pat::PackedGenParticle pc;
+
+  CPPUNIT_ASSERT(pc.polarP4() == pat::PackedGenParticle::PolarLorentzVector(0,0,0,0));
+  CPPUNIT_ASSERT(pc.p4() == pat::PackedGenParticle::LorentzVector(0,0,0,0) );
+  CPPUNIT_ASSERT(pc.vertex() == pat::PackedGenParticle::Point(0,0,0));
+}
+
+static bool tolerance(double iLHS, double iRHS, double fraction) {
+  return std::abs(iLHS-iRHS) <= fraction*std::abs(iLHS+iRHS)/2.;
+}
+
+void testPackedGenParticle::testCopyConstructor() {
+  pat::PackedGenParticle::LorentzVector lv(1.,0.5,0., std::sqrt(1.+0.25 +0.120*0.120));
+  pat::PackedGenParticle::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
+
+  pat::PackedGenParticle::Point v(0.01,0.02,0.);
+
+  pat::PackedGenParticle pc(reco::GenParticle(-1.,lv,v,11,0,false), edm::Ref<reco::GenParticleCollection>() );
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  //CPPUNIT_ASSERT(pc.vertex() == v);
+
+  pat::PackedGenParticle copy_pc(pc);
+
+  CPPUNIT_ASSERT(copy_pc.polarP4() == pc.polarP4());
+  CPPUNIT_ASSERT(copy_pc.p4() == pc.p4());
+  CPPUNIT_ASSERT(copy_pc.vertex() == pc.vertex());
+
+  CPPUNIT_ASSERT(&copy_pc.polarP4() != &pc.polarP4());
+  CPPUNIT_ASSERT(&copy_pc.p4() != &pc.p4());
+  CPPUNIT_ASSERT(&copy_pc.vertex() != &pc.vertex());
+
+}
+
+void 
+testPackedGenParticle::testPackUnpack() {
+
+  pat::PackedGenParticle::LorentzVector lv(1.,1.,0., std::sqrt(2.+0.120*0.120));
+  pat::PackedGenParticle::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
+
+  pat::PackedGenParticle::Point v(-0.005,0.005,0.1);
+
+  pat::PackedGenParticle pc(reco::GenParticle(-1.,lv,v,11,0,false), edm::Ref<reco::GenParticleCollection>() );
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+
+  pc.pack();
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+}
+
+void testPackedGenParticle::testSimulateReadFromRoot() {
+
+  pat::PackedGenParticle::LorentzVector lv(1.,1.,0., std::sqrt(2. +0.120*0.120));
+  pat::PackedGenParticle::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
+
+  pat::PackedGenParticle::Point v(-0.005,0.005,0.1);
+
+  pat::PackedGenParticle pc(reco::GenParticle(-1.,lv,v,11,0,false),edm::Ref<reco::GenParticleCollection>() );
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+
+  //When reading back from ROOT, these were not stored and are nulled out
+  delete pc.p4_.exchange(nullptr);
+  delete pc.p4c_.exchange(nullptr);
+
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  
+}
+


### PR DESCRIPTION
Made the mutable members of pat::PackedCandidate and pat::PackedGenParticle being changed in const functions be thread-safe. Added unit tests.
