### PR TITLE
Add caloConfig and caloConfigSource to L1 step

### DIFF
--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -167,6 +167,7 @@ def _extendForStage1Trigger( theProcess ) :
     """
     theProcess.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
     theProcess.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+    theProcess.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
     # Note that this function is applied before the objects in this file are added
     # to the process. So things declared in this file should be used "bare", i.e.
     # not with "theProcess." in front of them. L1TCaloStage1 is an exception because


### PR DESCRIPTION
AddOn tests for #11690 (switch AddOn tests to eras) showed that the L1 step was missing `process.caloConfig` and `process.caloConfigSource` when configured with eras.  This adds them in.  I'm still checking why this wasn't noticed in the checks for #11466 (switch matrix tests to eras).  I'm pretty sure it's because whenever L1 was run, L1Reco is also run which also adds them.  It's only when L1 is run without L1Reco.

Once this is submitted I'll run config diffs of with and without this change.

Eras in this config file are a bit messy.  After talking with some L1 experts I think it would be much better to flatten out the structure by getting rid of the cfi files in the `load` commands and applying the changes directly in SimL1Emulator_cff.  I'll leave this for another time though.
