### PR TITLE
Removed unused typedef from HLTTrackHaloFilter

### DIFF
--- a/HLTrigger/special/src/HLTTrackerHaloFilter.cc
+++ b/HLTrigger/special/src/HLTTrackerHaloFilter.cc
@@ -12,7 +12,6 @@
 #include "HLTrigger/special/interface/HLTTrackerHaloFilter.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
-typedef edmNew::DetSetVector<SiStripCluster>::Getter Getter;
 //
 // constructors and destructor
 //


### PR DESCRIPTION
The typedef was to a thread unsafe class. The typedef was not being
used so removing it is harmless and it avoids false positives when
searching for thread-safety issues.
