### PR TITLE
DQM/PixelLumi: definite static const int members

### DIFF
--- a/DQM/PixelLumi/plugins/PixelLumiDQM.cc
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.cc
@@ -42,6 +42,8 @@
 #include <time.h>
 #include <vector>
 
+const unsigned int PixelLumiDQM::lastBunchCrossing;
+
 // Constructors and destructor.
 PixelLumiDQM::PixelLumiDQM(const edm::ParameterSet& iConfig):
   fPixelClusterLabel(consumes<edmNew::DetSetVector<SiPixelCluster> >(iConfig.getUntrackedParameter<edm::InputTag>("pixelClusterLabel",


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard), 9.4.2/3

```
...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
```

9.4.2/4 talks about how `const static` data members are being handled.

Also standard says that no diagnostic is required by compiler.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
