### PR TITLE
Fix python2.6 SyntaxError.

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -711,7 +711,7 @@ if __name__ == "__main__":
                 def __init__(self):
                     self.tLPTest = tLPTest
                     self.tLPTestType = tLPTestType
-            p = tLPTest("MyType",** { "a"+str(x): tLPTestType(x) for x in xrange(0,300) } )
+            p = tLPTest("MyType",** dict( [ ("a"+str(x), tLPTestType(x)) for x in xrange(0,300) ] ) )
             #check they are the same
             self.assertEqual(p.dumpPython(), eval(p.dumpPython(),{"cms": __DummyModule()}).dumpPython())
     unittest.main()


### PR DESCRIPTION
FWCore/ParameterSet/python/Mixins.py uses syntax that is not valid
in python2.6; breaks ability to import this file in current CMSSW_7_6_X
(and hence submit to CRAB).

Backported from CMSSW_7_6.
