### PR TITLE
Fix UB by settting firstStep in AnnealingGhostTrackFitter

### DIFF
--- a/RecoVertex/GhostTrackFitter/src/AnnealingGhostTrackFitter.cc
+++ b/RecoVertex/GhostTrackFitter/src/AnnealingGhostTrackFitter.cc
@@ -9,7 +9,7 @@
 
 using namespace reco;
 
-AnnealingGhostTrackFitter::AnnealingGhostTrackFitter()
+AnnealingGhostTrackFitter::AnnealingGhostTrackFitter() : firstStep(true)
 {
 	annealing.reset(new GeometricAnnealing(3.0, 64.0, 0.25));
 }


### PR DESCRIPTION
Resolved undefined behavior triggered in `AnnealingGhostTrackFitter`:

```
RecoVertex/GhostTrackFitter/interface/AnnealingGhostTrackFitter.h:22:27:
runtime error: load of value 105, which is not a valid value for type
'bool'
```

The class has user provided ctor, but `firstStep` is not explicitly
initialized thus it's default-initialized to indeterminate value.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
