### PR TITLE
74X "cumulative" Noise flags re-arrangement  (backporting of two merged + one yet unmerged 76X PRs)

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -60,6 +60,10 @@ def customiseDataRun2Common(process):
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common(process)
 
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
+
     from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
     process=customiseL1RecoForStage1(process)
 

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -16,25 +16,6 @@ for qTest in particleFlowRecHitHF.producers[0].qualityTests:
         qTest.cleaningThresholds.append(30.)
         qTest.flags.append('HFDigi')
              
-particleFlowRecHitHF.producers[0].qualityTests.append(
-    cms.PSet(
-        name = cms.string("PFRecHitQTestHCALTimeVsDepth"),
-        cuts = cms.VPSet(
-            cms.PSet(
-                depth = cms.int32(1),
-                threshold = cms.double(30.),
-                minTime   = cms.double(-5.),
-                maxTime   = cms.double(+5.),
-            ),
-            cms.PSet(
-                depth = cms.int32(2),
-                threshold = cms.double(30.),
-                minTime   = cms.double(-5.),
-                maxTime   = cms.double(+5.),
-            ) 
-        )
-    )
-)
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -19,6 +19,6 @@ for qTest in particleFlowRecHitHF.producers[0].qualityTests:
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)
-HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHESpikeNoise",12)
+HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHENegativeNoise",12)
 
 CSCHaloData.ExpectedBX = cms.int32(3)

--- a/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py
+++ b/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py
@@ -120,6 +120,6 @@ hcalnoise = cms.EDProducer(
     # severity level
     HcalAcceptSeverityLevel = cms.uint32(9),
 
-    # which hcal calo flags to mask (HBHEIsolatedNoise=11, HBHEFlatNoise=12, HBHESpikeNoise=13, HBHETriangleNoise=14, HBHETS4TS5Noise=15)
-    HcalRecHitFlagsToBeExcluded = cms.vint32(11, 12, 13, 14, 15),
+    # which hcal calo flags to mask (HBHEIsolatedNoise=11, HBHEFlatNoise=12, HBHESpikeNoise=13, HBHETriangleNoise=14, HBHETS4TS5Noise=15, HBHENegativeNoise=27)
+    HcalRecHitFlagsToBeExcluded = cms.vint32(11, 12, 13, 14, 15, 27)
 )


### PR DESCRIPTION
Backporting of merged 76X PR #11481 
- lowering SeverityLevel of HFDigiTime and HBHEFlatNoise flags for 25ns
- removal of PFlow HF time-based selection

_and_ adding also merged in 76X  https://github.com/cms-sw/cmssw/pull/11667
- replacing SpikeNoise flag by NegativeNoise one  

Finally:  adding HBHENegativeNoise bit to HcalRecHitFlagsToBeExcluded as in 76X 
https://github.com/cms-sw/cmssw/pull/11751
