### PR TITLE
heavyIonsRun2 scenario for data processing

### DIFF
--- a/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""
+_HeavyIonsRun2_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+
+class HeavyIonsRun2(Reco):
+    def __init__(self):
+        self.recoSeq=''
+        self.cbSc='HeavyIons'
+        self.promptCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2PromptHI'
+        self.expressCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2ExpressHI'
+        self.visCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2ExpressHI'
+    """
+    _HeavyIonsRun2_
+
+    Implement configuration building for data processing for Heavy Ions
+    collision data taking for Run2
+
+    """
+
+
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Heavy ions collision data taking prompt reco
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForPrompt']
+
+        customsFunction = self.promptCustoms
+        if not 'customs' in args:
+            args['customs']=[ customsFunction ]
+        else:
+            args['customs'].append(customsFunction)
+
+        process = Reco.promptReco(self,globalTag, **args)
+
+        return process
+
+
+    def expressProcessing(self, globalTag, **args):
+        """
+        _expressProcessing_
+
+        Heavy ions collision data taking express processing
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForExpress']
+
+        customsFunction = self.expressCustoms
+        if not 'customs' in args:
+            args['customs']=[ customsFunction ]
+        else:
+            args['customs'].append( customsFunction )
+
+        process = Reco.expressProcessing(self,globalTag, **args)
+        
+        return process
+
+    def visualizationProcessing(self, globalTag, **args):
+        """
+        _visualizationProcessing_
+
+        Heavy ions collision data taking visualization processing
+
+        """
+        customsFunction = self.visCustoms
+        if not 'customs' in args:
+            args['customs']=[ customsFunction ]
+        else:
+            args['customs'].append( customsFunction )
+
+        process = Reco.visualizationProcessing(self,globalTag, **args)
+        
+        return process
+
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+        """
+        _alcaHarvesting_
+
+        Heavy ions collisions data taking AlCa Harvesting
+
+        """
+
+
+        if not 'skims' in args and not 'alcapromptdataset' in args:
+            args['skims']=['BeamSpotByRun',
+                           'BeamSpotByLumi',
+                           'SiStripQuality']
+            
+        return Reco.alcaHarvesting(self, globalTag, datasetName, **args)
+

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -49,7 +49,11 @@ class Reco(Scenario):
             for a in args['outputs']:
                 if a['dataTier'] == 'MINIAOD':
                     miniAODStep=',PAT' 
-                    options.runUnscheduled=True
+
+        """
+        Unscheduled for all
+        """
+        options.runUnscheduled=True
                     
 
         if 'customs' in args:

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -1,6 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.Configuration.customiseForRunI import customiseForRunI
+
+##############################################################################
+# common utilities
+##############################################################################
+def _swapOfflineBSwithOnline(process):
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
+    return process
+
+def _addLumiProducer(process):
+    if not hasattr(process,'lumiProducer'):
+        #unscheduled.. 
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
+        process.lumiProducer=lumiProducer
+    #if it's scheduled
+    if hasattr(process, 'reconstruction_step'):
+        process.reconstruction_step+=process.lumiProducer
+
+    return process
+
 #gone with the fact that there is no difference between production and development sequence
 #def customiseCommon(process):
 #    return (process)
@@ -30,15 +50,10 @@ def customiseCosmicData(process):
 ##############################################################################
 # this is supposed to be added on top of other (Run1) data customs
 def customiseDataRun2Common(process):
-    if hasattr(process,'CSCGeometryESModule'):
-        process.CSCGeometryESModule.useGangedStripsInME1a = cms.bool(False)
-    if hasattr(process,'CSCIndexerESProducer'):
-        process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
-    if hasattr(process,'CSCChannelMapperESProducer'):
-        process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
-    if hasattr(process,'csc2DRecHits'):
-        process.csc2DRecHits.readBadChannels = cms.bool(False)
-        process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
+    from SLHCUpgradeSimulations.Configuration.muonCustoms import unganged_me1a_geometry,customise_csc_LocalReco
+    process = unganged_me1a_geometry(process)
+    process = customise_csc_LocalReco(process)
+
     if hasattr(process,'valCscTriggerPrimitiveDigis'):
         #this is not doing anything at the moment
         process.valCscTriggerPrimitiveDigis.commonParam.gangedME1a = cms.bool(False)
@@ -55,13 +70,19 @@ def customiseDataRun2Common(process):
 
     return process
 
-##############################################################################
-# common+ "25ns" Use this for data daking starting from runs in 2015C (>= 253256 )
-def customiseDataRun2Common_25ns(process):
+# add stage1
+def customiseDataRun2Common_withStage1(process):
     process = customiseDataRun2Common(process)
 
     from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
     process=customiseL1RecoForStage1(process)
+
+    return process 
+
+##############################################################################
+# common+ "25ns" Use this for data daking starting from runs in 2015C (>= 253256 )
+def customiseDataRun2Common_25ns(process):
+    process = customiseDataRun2Common_withStage1(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):
@@ -70,10 +91,7 @@ def customiseDataRun2Common_25ns(process):
 
 # common+50ns. Needed only for runs >= 253000 if taken with 50ns
 def customiseDataRun2Common_50nsRunsAfter253000(process):
-    process = customiseDataRun2Common(process)
-
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
-    process=customiseL1RecoForStage1(process)
+    process = customiseDataRun2Common_withStage1(process)
 
     if hasattr(process,'particleFlowClusterECAL'):
         process.particleFlowClusterECAL.energyCorrector.autoDetectBunchSpacing = False
@@ -102,13 +120,12 @@ def customiseVALSKIM(process):
     print "this method is outdated, please use RecoTLR.customisePPData"
     process= customisePPData(process)
     return process
+
                 
 ##############################################################################
 def customiseExpress(process):
     process= customisePPData(process)
-
-    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
-    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
+    process = _swapOfflineBSwithOnline(process)
     
     return process
 
@@ -131,13 +148,7 @@ def customiseExpressRun2B0T(process):
 ##############################################################################
 def customisePrompt(process):
     process= customisePPData(process)
-
-    #add the lumi producer in the prompt reco only configuration
-    if not hasattr(process,'lumiProducer'):
-        #unscheduled..
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
-        process.lumiProducer=lumiProducer
-    process.reconstruction_step+=process.lumiProducer
+    process = _addLumiProducer(process)
 
     return process
 
@@ -159,34 +170,52 @@ def customisePromptRun2B0T(process):
 
 
 ##############################################################################
-
-#gone with the fact that there is no difference between production and development sequence
-#def customiseCommonHI(process):
-#    return process
+# Heavy Ions
+##############################################################################
+# keep it in case modification is needed
+def customiseCommonHI(process):
+    return process
 
 ##############################################################################
 def customiseExpressHI(process):
-    #deprecated process= customiseCommonHI(process)
-
-    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
-    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
+    process = customiseCommonHI(process)
+    process = _swapOfflineBSwithOnline(process)
     
     return process
 
 ##############################################################################
 def customisePromptHI(process):
-    #deprecated process= customiseCommonHI(process)
+    process = customiseCommonHI(process)
+    process = _swapOfflineBSwithOnline(process)
 
-    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
-    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
+    process = _addLumiProducer(process)
 
-     #add the lumi producer in the prompt reco only configuration
-    if not hasattr(process,'lumiProducer'):
-        #unscheduled..
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
-        process.lumiProducer=lumiProducer
-    process.reconstruction_step+=process.lumiProducer
-        
+    return process
+
+##############################################################################
+# keep it in case modification is needed
+def customiseRun2CommonHI(process):
+    process = customiseDataRun2Common_withStage1(process)
+    
+    # HI Specific additional customizations:
+    # from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_Additional_HI
+    # process = customiseSimL1EmulatorForPostLS1_Additional_HI(process)
+
+    return process
+
+##############################################################################
+def customiseRun2ExpressHI(process):
+    process = customiseRun2CommonHI(process)
+    process = _swapOfflineBSwithOnline(process)
+    
+    return process
+
+##############################################################################
+def customiseRun2PromptHI(process):
+    process = customiseRun2CommonHI(process)
+    process = _swapOfflineBSwithOnline(process)
+
+    process = _addLumiProducer(process)
 
     return process
 

--- a/Configuration/DataProcessing/test/HeavyIonsRun2_t.py
+++ b/Configuration/DataProcessing/test/HeavyIonsRun2_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_HeavyIonsRun2_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class HeavyIonsRun2ScenarioTest(unittest.TestCase):
+    """
+    unittest for HeavyIonsRun2 collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("HeavyIonsRun2")
+        except Exception, ex:
+            msg = "Failed to get HeavyIonsRun2 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("HeavyIonsRun2")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception, ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for HeavyIonsRun2 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("HeavyIonsRun2")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception, ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for HeavyIonsRun2 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("HeavyIonsRun2")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception, ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for HeavyIonsRun2 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("HeavyIonsRun2")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception, ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for HeavyIonsRun2 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -28,8 +28,15 @@ do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
+declare -a arr=("HeavyIonsRun2")
+for scenario in "${arr[@]}"
+do
+     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBiasHI+SiStripCalMinBias "
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBiasHI+SiStripCalMinBias"
+done
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns")
+
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "HeavyIonsRun2" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -86,6 +86,9 @@ DQMOfflineHeavyIonsPrePOG = cms.Sequence( muonMonitors
                                           * dqmPhysicsHI
                                           )
 
+#disabled, until an appropriate configuration is set
+hltTauOfflineMonitor_PFTaus.Matching.doMatching = False
+
 DQMOfflineHeavyIonsPOG = cms.Sequence( DQMOfflineHeavyIonsPrePOG *
                                        DQMMessageLogger )
 


### PR DESCRIPTION
- HeavyIonsRun2 scenario for T0 processing: created based on ppRun2 
  - (the old Run1 HI scenario seems somewhat outdated compared to pp and ppRun2; I found it easier to spawn from ppRun2. The run1 HI scenario still runs. Chances are, the Run1 part may need an update to be able to run replays to get realistic resource load scale tests.)
  - to go with this, the suggested customization for interactive Run2 data running is Configuration/DataProcessing/RecoTLR.customiseRun2CommonHI
- The HI sequence didn't work out of the box due to a somewhat bogus setup of the HLT Tau DQM: this was fixed by turning off matching to reco objects (most actually don't exist in HI sequence: caloMet, hpsPFTauProducer, gedGsfElectrons). 
  - The L1 part of the tau sequence in this case at least has some non-trivial output (no reco object matching is applied -> plots get filled).
  - Instead of removing the module completely I found it easier to modify the configuration in  DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
  - Someone in HI should review the contents of DQMOfflineHeavyIons.
- additionally I cleaned up slightly the pp RecoTLR (some refactoring to reduce copy-paste)

Tested on pp run 256729 with 

```
python Configuration/DataProcessing/test/RunPromptReco.py --scenario HeavyIonsRun2\
 --reco --aod --dqmio --global-tag 75X_dataRun2_v5 --alcareco TkAlMinBiasHI+SiStripCalMinBias\
 --lfn=/store/data/Run2015D/DoubleEG/RAW/v1/000/256/729/00000/9271C53F-805D-E511-B380-02163E01449B.root
```

@mandrenguyen 

Also tested on short matrix (pp and HI workflows) in CMSSW_7_5_3_patch1
- there are no differences in pp workflows (including PromptReco workflow check)
- there are expected differences in the HLT/TauOffline/PFTaus/L1  plots: L1 taus are now plotted without the matching requirement with the offline reco objects (nonexistent in HI)
