### PR TITLE
fix wrong auto-forward-port of RecoTLR of  #11741 

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -74,13 +74,19 @@ def customiseDataRun2Common(process):
 def customiseDataRun2Common_withStage1(process):
     process = customiseDataRun2Common(process)
 
-    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
-
     from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
     process=customiseL1RecoForStage1(process)
 
+    return process 
+
+##############################################################################
+# common+ "25ns" Use this for data daking starting from runs in 2015C (>= 253256 )
+def customiseDataRun2Common_25ns(process):
+    process = customiseDataRun2Common_withStage1(process)
+
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):


### PR DESCRIPTION
auto-forward-port of  #11741  made multiple wrong choices.
It's good that in this case the wrong choices would break compilation and will be noticeable.

Note for the future: better backport than forward port (not sure it would have helped though in this case)
