### PR TITLE
Fix problems found by static analyzer in DataFormats/Scalers

### DIFF
--- a/DataFormats/Scalers/interface/DcsStatus.h
+++ b/DataFormats/Scalers/interface/DcsStatus.h
@@ -30,7 +30,7 @@ class DcsStatus
  public:
 
   static const int partitionList[];
-  static const char * partitionName[];
+  static const char * const partitionName[];
 
   enum
   {

--- a/DataFormats/Scalers/src/BeamSpotOnline.cc
+++ b/DataFormats/Scalers/src/BeamSpotOnline.cc
@@ -37,8 +37,8 @@ BeamSpotOnline::BeamSpotOnline(const unsigned char * rawData)
 { 
   BeamSpotOnline();
 
-  struct ScalersEventRecordRaw_v4 * raw 
-    = (struct ScalersEventRecordRaw_v4 *)rawData;
+  struct ScalersEventRecordRaw_v4 const* raw 
+    = reinterpret_cast<struct ScalersEventRecordRaw_v4 const*>(rawData);
   trigType_     = ( raw->header >> 56 ) &        0xFULL;
   eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
   sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;

--- a/DataFormats/Scalers/src/DcsStatus.cc
+++ b/DataFormats/Scalers/src/DcsStatus.cc
@@ -34,7 +34,7 @@ const int DcsStatus::partitionList[DcsStatus::nPartitions] = {
   ESp         ,
   ESm };
 
-const char * DcsStatus::partitionName[DcsStatus::nPartitions] = {
+const char * const DcsStatus::partitionName[DcsStatus::nPartitions] = {
   "EBp"         ,
   "EBm"         ,
   "EEp"         ,
@@ -78,8 +78,8 @@ DcsStatus::DcsStatus(const unsigned char * rawData)
 { 
   DcsStatus();
 
-  struct ScalersEventRecordRaw_v4 * raw 
-    = (struct ScalersEventRecordRaw_v4 *)rawData;
+  struct ScalersEventRecordRaw_v4 const * raw 
+    = reinterpret_cast<struct ScalersEventRecordRaw_v4 const *>(rawData);
   trigType_     = ( raw->header >> 56 ) &        0xFULL;
   eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
   sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;

--- a/DataFormats/Scalers/src/L1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/L1TriggerScalers.cc
@@ -44,8 +44,8 @@ L1TriggerScalers::L1TriggerScalers(const unsigned char * rawData)
 { 
   L1TriggerScalers();
 
-  struct ScalersEventRecordRaw_v1 * raw 
-    = (struct ScalersEventRecordRaw_v1 *)rawData;
+  struct ScalersEventRecordRaw_v1 const * raw 
+    = reinterpret_cast<struct ScalersEventRecordRaw_v1 const *>(rawData);
 
   trigType_     = ( raw->header >> 56 ) &        0xFULL;
   eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;

--- a/DataFormats/Scalers/src/Level1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/Level1TriggerScalers.cc
@@ -62,8 +62,8 @@ Level1TriggerScalers::Level1TriggerScalers(const unsigned char * rawData)
 { 
   Level1TriggerScalers();
 
-  struct ScalersEventRecordRaw_v5 * raw 
-    = (struct ScalersEventRecordRaw_v5 *)rawData;
+  struct ScalersEventRecordRaw_v5 const * raw 
+    = reinterpret_cast<struct ScalersEventRecordRaw_v5 const *>(rawData);
 
   trigType_     = ( raw->header >> 56 ) &        0xFULL;
   eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;

--- a/DataFormats/Scalers/src/LumiScalers.cc
+++ b/DataFormats/Scalers/src/LumiScalers.cc
@@ -52,15 +52,15 @@ LumiScalers::LumiScalers(const unsigned char * rawData)
 { 
   LumiScalers();
 
-  struct ScalersEventRecordRaw_v1 * raw 
-    = (struct ScalersEventRecordRaw_v1 *)rawData;
+  struct ScalersEventRecordRaw_v1 const* raw 
+    = reinterpret_cast<struct ScalersEventRecordRaw_v1 const*>(rawData);
   trigType_     = ( raw->header >> 56 ) &        0xFULL;
   eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
   sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;
   bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
   version_      = raw->version;
 
-  struct LumiScalersRaw_v1 * lumi = NULL;
+  struct LumiScalersRaw_v1 const * lumi = NULL;
 
   if ( version_ >= 1 )
   {
@@ -70,8 +70,8 @@ LumiScalers::LumiScalers(const unsigned char * rawData)
     }
     else 
     {
-      struct ScalersEventRecordRaw_v3 * raw3 
-	= (struct ScalersEventRecordRaw_v3 *)rawData;
+      struct ScalersEventRecordRaw_v3 const* raw3 
+	= reinterpret_cast<struct ScalersEventRecordRaw_v3 const*>(rawData);
       lumi = & (raw3->lumi);
     }
     collectionTime_.set_tv_sec(static_cast<long>(lumi->collectionTime_sec));
@@ -109,9 +109,9 @@ LumiScalers::LumiScalers(const unsigned char * rawData)
 
     if ( version_ >= 7 )
     {
-      struct ScalersEventRecordRaw_v6 * raw6 
-	= (struct ScalersEventRecordRaw_v6 *)rawData;
-      float * fspare = (float *) raw6->spare;
+      struct ScalersEventRecordRaw_v6 const * raw6 
+	= (struct ScalersEventRecordRaw_v6 const *)rawData;
+      float const* fspare = reinterpret_cast<float const*>( raw6->spare);
       pileup_    = fspare[ScalersRaw::I_SPARE_PILEUP_v7];
       pileupRMS_ = fspare[ScalersRaw::I_SPARE_PILEUPRMS_v7];
       if ( version_ >= 8 )


### PR DESCRIPTION
The static analyzer found accidental casting away of const as well
as a global array which was not const. Switching to const correct
usage had not affect on any other code.
