### PR TITLE
[UB] Initialize 'WasDecodingOk_' in 'EcalDCCHeaderRuntypeDecoder'

### DIFF
--- a/EventFilter/EcalRawToDigi/interface/EcalDCCHeaderRuntypeDecoder.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalDCCHeaderRuntypeDecoder.h
@@ -12,7 +12,7 @@ class EcalDCCHeaderRuntypeDecoder
   ~EcalDCCHeaderRuntypeDecoder();
   bool Decode( unsigned long TrTy, unsigned long detTrTy, unsigned long runType,   EcalDCCHeaderBlock * theHeader);
   protected:
-  bool WasDecodingOk_;
+  bool WasDecodingOk_ = true;
   void DecodeSetting ( int settings,  EcalDCCHeaderBlock * theHeader );
   void DecodeSettingGlobal ( unsigned long TrigType, unsigned long detTrigType,  EcalDCCHeaderBlock * theHeader );
   void CleanEcalDCCSettingsInfo(  EcalDCCHeaderBlock::EcalDCCEventSettings * theEventSettings);// Re-initialize theEventSettings  before filling with the deocoded event


### PR DESCRIPTION
Resolves undefined behavior in `EcalDCCHeaderRuntypeDecoder`. It's
triggered 410 times in RelVals. Example workflows: 4000.0, 4.76, 10.0,
50200.0, 50202.0.

```
EventFilter/EcalRawToDigi/src/EcalDCCHeaderRuntypeDecoder.cc:78:10:
runtime error: load of value 19, which is not a valid value for type
'bool'
```

The class contains user provided constructor, but `WasDecodingOk_` is
not initialized in constructor or/and at member declaration place thus
  it's default-initialized to indeterminate value.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
