### PR TITLE
Removed unnecessary const_cast in DataFormats/L1GlobalTrigger

### DIFF
--- a/DataFormats/L1GlobalTrigger/src/L1GtFdlWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtFdlWord.cc
@@ -895,7 +895,7 @@ void L1GtFdlWord::unpack(const unsigned char* fdlPtr)
     << std::endl;
 
     const cms_uint64_t* payload =
-        reinterpret_cast<cms_uint64_t*>(const_cast<unsigned char*>(fdlPtr));
+        reinterpret_cast<cms_uint64_t const*>(fdlPtr);
 
     setBoardId(payload[BoardIdWord]);
     setBxInEvent(payload[BxInEventWord]);

--- a/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
@@ -601,7 +601,7 @@ void L1GtfeExtWord::unpack(const unsigned char* gtfePtr)
     const unsigned char* gtfeExtPtr = gtfePtr + gtfeWord.getSize();
 
     const cms_uint64_t* payload =
-        reinterpret_cast<cms_uint64_t*>(const_cast<unsigned char*>(gtfeExtPtr));
+        reinterpret_cast<cms_uint64_t const*>(gtfeExtPtr);
 
     int BlockSizeExt = this->getSize()/8;
     int NumberBstBlocks = m_bst.size();

--- a/DataFormats/L1GlobalTrigger/src/L1GtfeWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtfeWord.cc
@@ -384,7 +384,7 @@ void L1GtfeWord::unpack(const unsigned char* gtfePtr)
     << std::endl;
 
     const cms_uint64_t* payload =
-        reinterpret_cast<cms_uint64_t*>(const_cast<unsigned char*>(gtfePtr));
+        reinterpret_cast<cms_uint64_t const*>(gtfePtr);
 
     setBoardId(payload[BoardIdWord]);
     setRecordLength1(payload[RecordLength1Word]);

--- a/DataFormats/L1GlobalTrigger/src/L1TcsWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1TcsWord.cc
@@ -504,7 +504,7 @@ void L1TcsWord::unpack(const unsigned char* tcsPtr)
     << std::endl;
 
     const cms_uint64_t* payload =
-        reinterpret_cast<cms_uint64_t*>(const_cast<unsigned char*>(tcsPtr));
+        reinterpret_cast<cms_uint64_t const*>(tcsPtr);
 
     setBoardId(payload[BoardIdWord]);
     setBxNr(payload[BxNrWord]);


### PR DESCRIPTION
Removed const_cast which were then followed by reinterpret_cast
but whose value was bound to a const variable. Adding const to
the reinterpret_cast removed the need for const_cast.
This was found by the static analyzer.
