### PR TITLE
Fix thread safety problem in ParametrizationHelper::fromString

### DIFF
--- a/DataFormats/PatCandidates/src/ParametrizationHelper.cc
+++ b/DataFormats/PatCandidates/src/ParametrizationHelper.cc
@@ -17,22 +17,21 @@ pat::helper::ParametrizationHelper::fromString(const std::string &name) {
 
     typedef pat::CandKinResolution::Parametrization Parametrization;
 
-    static map<string,Parametrization> parMaps;
-    if (parMaps.empty()) {
-        parMaps["Cart"]          = pat::CandKinResolution::Cart;  
-        parMaps["ECart"]         = pat::CandKinResolution::ECart;  
-        parMaps["MCCart"]        = pat::CandKinResolution::MCCart;  
-        parMaps["Spher"]         = pat::CandKinResolution::Spher;  
-        parMaps["ESpher"]        = pat::CandKinResolution::ESpher;  
-        parMaps["MCSpher"]       = pat::CandKinResolution::MCSpher;  
-        parMaps["MCPInvSpher"]   = pat::CandKinResolution::MCPInvSpher;  
-        parMaps["EtEtaPhi"]      = pat::CandKinResolution::EtEtaPhi;  
-        parMaps["EtThetaPhi"]    = pat::CandKinResolution::EtThetaPhi;
-        parMaps["MomDev"]        = pat::CandKinResolution::MomDev;
-        parMaps["EMomDev"]       = pat::CandKinResolution::EMomDev;
-        parMaps["MCMomDev"]      = pat::CandKinResolution::MCMomDev;
-        parMaps["EScaledMomDev"] = pat::CandKinResolution::EScaledMomDev;
-    }
+    static map<string,Parametrization> const parMaps = {
+      {"Cart"          , pat::CandKinResolution::Cart},
+      {"ECart"         , pat::CandKinResolution::ECart},  
+      {"MCCart"        , pat::CandKinResolution::MCCart},  
+      {"Spher"         , pat::CandKinResolution::Spher},  
+      {"ESpher"        , pat::CandKinResolution::ESpher},  
+      {"MCSpher"       , pat::CandKinResolution::MCSpher},  
+      {"MCPInvSpher"   , pat::CandKinResolution::MCPInvSpher},  
+      {"EtEtaPhi"      , pat::CandKinResolution::EtEtaPhi},  
+      {"EtThetaPhi"    , pat::CandKinResolution::EtThetaPhi},
+      {"MomDev"        , pat::CandKinResolution::MomDev},
+      {"EMomDev"       , pat::CandKinResolution::EMomDev},
+      {"MCMomDev"      , pat::CandKinResolution::MCMomDev},
+      {"EScaledMomDev" , pat::CandKinResolution::EScaledMomDev}
+    };
     map<string,Parametrization>::const_iterator itP = parMaps.find(name);
     if (itP == parMaps.end()) {
         throw cms::Exception("StringResolutionProvider") << "Bad parametrization '" << name.c_str() << "'";


### PR DESCRIPTION
The function ParametrizationHelper::fromString has a static function
local map that is filled the first time called. However the way it
was done if the function were called the first time from two different
threads you would get a datarace. Initializing the map in its constructor
avoids the problem and allows the static to be declared const.
Problem found by the static analyzer.
