### PR TITLE
Adding HBHENegativeNoise bit to HcalRecHitFlagsToBeExcluded - 76X

### DIFF
--- a/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py
+++ b/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py
@@ -120,6 +120,6 @@ hcalnoise = cms.EDProducer(
     # severity level
     HcalAcceptSeverityLevel = cms.uint32(9),
 
-    # which hcal calo flags to mask (HBHEIsolatedNoise=11, HBHEFlatNoise=12, HBHESpikeNoise=13, HBHETriangleNoise=14, HBHETS4TS5Noise=15)
-    HcalRecHitFlagsToBeExcluded = cms.vint32(11, 12, 13, 14, 15),
+    # which hcal calo flags to mask (HBHEIsolatedNoise=11, HBHEFlatNoise=12, HBHESpikeNoise=13, HBHETriangleNoise=14, HBHETS4TS5Noise=15, HBHENegativeNoise=27)
+    HcalRecHitFlagsToBeExcluded = cms.vint32(11, 12, 13, 14, 15, 27)
 )


### PR DESCRIPTION
Adding HBHENegativeNoise bit to the HcalRecHitFlagsToBeExcluded list, so that NEF related quantities (nnegativenoise_, negativenoisee_, negativenoiseet_) are correctly computed in HcalNoiseInfoProducer once the NEF severity level is raised as in PR #11667 .
Otherwise they will always compute to be zero.
(please see: http://cmslxr.fnal.gov/lxr/source/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc?v=CMSSW_7_6_0_pre2#0574)
