### PR TITLE
Made static const in LimiDetails

### DIFF
--- a/DataFormats/Luminosity/interface/LumiDetails.h
+++ b/DataFormats/Luminosity/interface/LumiDetails.h
@@ -78,7 +78,7 @@ private:
   void checkAlgo(AlgoType algo) const;
   void checkAlgoAndBX(AlgoType algo, unsigned int bx) const;
 
-  static std::vector<std::string> m_algoNames;
+  static std::vector<std::string> const m_algoNames;
 
   std::string m_lumiVersion;
 

--- a/DataFormats/Luminosity/src/LumiDetails.cc
+++ b/DataFormats/Luminosity/src/LumiDetails.cc
@@ -5,7 +5,18 @@
 #include <iomanip>
 #include <ostream>
 
-std::vector<std::string> LumiDetails::m_algoNames;
+std::vector<std::string> const LumiDetails::m_algoNames = {
+    // If in the future additional algorithm names are added,
+    // it is important that they be added at the end of the list.
+    // The Algos enum in LumiDetails.h also would need to be
+    // updated to keep the list of names in sync.
+  {"OCC1"},
+  {"OCC2"},
+  {"ET"},
+  {"PLT"}
+};
+
+static std::vector<std::string> const s_dipalgoNames = {  {"DIP"} };
 
 LumiDetails::LumiDetails() :
   m_lumiVersion("-1"),
@@ -138,25 +149,13 @@ LumiDetails::lumiBeam2Intensities() const {
 
 std::vector<std::string> const&
 LumiDetails::algoNames() {
-  if (m_algoNames.size() != kMaxNumAlgos) {
-    assert(m_algoNames.size() == 0U);
-    // If in the future additional algorithm names are added,
-    // it is important that they be added at the end of the list.
-    // The Algos enum in LumiDetails.h also would need to be
-    // updated to keep the list of names in sync.
-    m_algoNames.push_back(std::string("OCC1"));
-    m_algoNames.push_back(std::string("OCC2"));
-    m_algoNames.push_back(std::string("ET"));
-    m_algoNames.push_back(std::string("PLT"));
-    assert(m_algoNames.size() == kMaxNumAlgos);
-  }
+  assert(m_algoNames.size() == kMaxNumAlgos);
   return m_algoNames;
 }
 
 std::vector<std::string> const&
 LumiDetails::dipalgoNames() {
-  m_algoNames.push_back(std::string("DIP"));
-  return m_algoNames;
+  return s_dipalgoNames;
 }
 bool
 LumiDetails::isProductEqual(LumiDetails const& lumiDetails) const {


### PR DESCRIPTION
The class static member m_algoNames was changed to const and initialized
at constructor time. Also seperated storage of dipalgoNames from
algoNames since if dipalgoNames() was called before algoNames() the
code would assert while the other direction was OK. Based on the
implementation of operator<< it appears that those two functions
were meant to have different contains with dipalgoNames() not containing
the results from algoNames().
