### PR TITLE
Remove use of non-const static in pat::UserData<>

### DIFF
--- a/DataFormats/PatCandidates/interface/UserData.h
+++ b/DataFormats/PatCandidates/interface/UserData.h
@@ -16,8 +16,7 @@
 #include <string>
 #include <vector>
 #include <typeinfo>
-#include <cxxabi.h>
-#include <DataFormats/Common/interface/OwnVector.h>
+#include "DataFormats/Common/interface/OwnVector.h"
 
 
 namespace pat {
@@ -57,6 +56,7 @@ namespace pat {
   protected:
     /// Get out the data (can't template non virtual functions)
     virtual const void * data_  () const = 0;
+    static std::string typeNameFor(std::type_info const& iInfo);
 
   private:
     static void checkDictionaries(const std::type_info &type) ;
@@ -69,13 +69,13 @@ namespace pat {
         UserHolder() : obj_() {}
         UserHolder(const T &data) : obj_(data) {}
         /// Clone
-        virtual UserHolder<T> * clone() const { return new UserHolder<T>(*this); }
+        virtual UserHolder<T> * clone() const override { return new UserHolder<T>(*this); }
         /// Concrete type of stored data
-        virtual const std::type_info & typeId()   const { return typeid(T); }
+        virtual const std::type_info & typeId()   const override { return typeid(T); }
         /// Human readable name of the concrete type of stored data
-        virtual const std::string    & typeName() const { return typeName_(); }
+        virtual const std::string    & typeName() const override { return typeName_(); }
     protected:
-        virtual const void *           data_()  const { return &obj_; }
+        virtual const void *           data_()  const override { return &obj_; }
     private: 
         T obj_;
         static const std::string & typeName_() ;
@@ -96,9 +96,7 @@ std::auto_ptr<pat::UserData> pat::UserData::make(const T &value, bool transientO
 
 template<typename T> 
 const std::string & pat::UserHolder<T>::typeName_() {
-    static int status = 0;
-    static const char * demangled = abi::__cxa_demangle(typeid(T).name(),  0, 0, &status);
-    static const std::string name(status == 0 ? demangled : "[UNKNOWN]");
+    static const std::string name(typeNameFor(typeid(T)));
     return name;
 }
 

--- a/DataFormats/PatCandidates/src/UserData.cc
+++ b/DataFormats/PatCandidates/src/UserData.cc
@@ -1,3 +1,4 @@
+#include <cxxabi.h>
 #include "DataFormats/PatCandidates/interface/UserData.h"
 // Note: these two below are allowed in FWLite even if they come from FWCore
 #include "FWCore/Utilities/interface/TypeWithDict.h"
@@ -22,4 +23,10 @@ void pat::UserData::checkDictionaries(const std::type_info &type) {
             << "   Also, if this class has any transient members,\n"
             << "   you need to specify them in classes_def.xml.\n";
     } // check for dictionary
+}
+
+std::string pat::UserData::typeNameFor(std::type_info const& iType) {
+    int status = 0;
+    const char * demangled = abi::__cxa_demangle(iType.name(),  0, 0, &status);
+    return std::string(status == 0 ? demangled : "[UNKNOWN]");
 }


### PR DESCRIPTION
Instead of using three statics to determine the typename of
the type in the UserData we now call a function to get the type
and cache the results of the function. This also avoids instantiating
a large function for each template type of UserData<>.
Found by the static analyzer.
