### PR TITLE
Adding no-HF grid-based rho

### DIFF
--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -61,6 +61,9 @@ kt6PFJetsCentralNeutralTight = kt6PFJetsCentralNeutral.clone(
     )
 
 
+fixedGridRhoFastjetCentral = fixedGridRhoFastjetAll.clone(
+    maxRapidity = cms.double(2.5)
+    )
 
 fixedGridRhoFastjetCentralChargedPileUp = fixedGridRhoFastjetAll.clone(
     src = cms.InputTag("pfPileUpAllChargedParticles"),
@@ -183,10 +186,11 @@ hepTopTagPFJetsCHS.src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents"
 
 recoPFJets   =cms.Sequence(fixedGridRhoAll+
                            fixedGridRhoFastjetAll+
+                           fixedGridRhoFastjetCentral+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
                            ak4PFJets+
-			   pfNoPileUpJMESequence+
+                           pfNoPileUpJMESequence+
                            ak4PFJetsCHS+                           
                            ak8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
@@ -203,6 +207,7 @@ recoAllPFJets=cms.Sequence(sisCone5PFJets+sisCone7PFJets+
                            kt6PFJetsCentralNeutralTight+
                            fixedGridRhoAll+
                            fixedGridRhoFastjetAll+
+                           fixedGridRhoFastjetCentral+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
                            iterativeCone5PFJets+
@@ -246,6 +251,7 @@ recoAllPFJets=cms.Sequence(sisCone5PFJets+sisCone7PFJets+
 recoPFJetsWithSubstructure=cms.Sequence(
                            fixedGridRhoAll+
                            fixedGridRhoFastjetAll+
+                           fixedGridRhoFastjetCentral+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
                            ak4PFJets+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -66,13 +66,13 @@ fixedGridRhoFastjetCentral = fixedGridRhoFastjetAll.clone(
     )
 
 fixedGridRhoFastjetCentralChargedPileUp = fixedGridRhoFastjetAll.clone(
-    src = cms.InputTag("pfPileUpAllChargedParticles"),
-    maxRapidity = cms.double(2.5)
+    pfCandidatesTag = "pfPileUpAllChargedParticles",
+    maxRapidity = 2.5
     )
 
 fixedGridRhoFastjetCentralNeutral = fixedGridRhoFastjetAll.clone(
-    src = cms.InputTag("pfAllNeutralHadronsAndPhotons"),
-    maxRapidity = cms.double(2.5)
+    pfCandidatesTag = "pfAllNeutralHadronsAndPhotons",
+    maxRapidity = 2.5
     )
 
 


### PR DESCRIPTION
As per request of PPD and the collaboration, this is the addition of an eta-restricted (no HF) grid-based rho. This can be used for miniAOD and/or future reco. 
