### PR TITLE
Switch default HBHENoiseFilter settings to Run2-25ns configuration - 76X

### DIFF
--- a/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
@@ -5,9 +5,9 @@ HBHENoiseFilterResultProducer = cms.EDProducer(
     noiselabel = cms.InputTag('hcalnoise'),
     minHPDHits = cms.int32(17),
     minHPDNoOtherHits = cms.int32(10),
-    minZeros = cms.int32(10),
-    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(True),
-    defaultDecision = cms.string("HBHENoiseFilterResultRun1"),
+    minZeros = cms.int32(9999),
+    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(False),
+    defaultDecision = cms.string("HBHENoiseFilterResultRun2Loose"),
     minNumIsolatedNoiseChannels = cms.int32(10),
     minIsolatedNoiseSumE = cms.double(50.0),
     minIsolatedNoiseSumEt = cms.double(25.0)
@@ -16,3 +16,4 @@ HBHENoiseFilterResultProducer = cms.EDProducer(
 from Configuration.StandardSequences.Eras import eras
 eras.run2_common.toModify(HBHENoiseFilterResultProducer, IgnoreTS4TS5ifJetInLowBVRegion=False)
 eras.run2_25ns_specific.toModify(HBHENoiseFilterResultProducer, defaultDecision="HBHENoiseFilterResultRun2Loose")
+eras.run2_50ns_specific.toModify(HBHENoiseFilterResultProducer, defaultDecision="HBHENoiseFilterResultRun1")


### PR DESCRIPTION
This is to switch the default HBHENoiseFilterResultProducer settings to Run2-25ns configuration such that users get correct noise flags out of the box for the bulk of 2015 data (and beyond) which is with 25ns bunch spacing.
@abdoulline @igv4321 @mariadalfonso
