### PR TITLE
New Global Tags for 74X: data Run2 reprocessing + taxonomy changes 

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '74X_mcRun1_design_v1',
+    'run1_design'       :   '74X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '74X_mcRun1_realistic_v1',
+    'run1_mc'           :   '74X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '74X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '74X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '74X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '74X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '74X_mcRun2_design_v2',
+    'run2_design'       :   '74X_mcRun2_design_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '74X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '74X_mcRun2_startup_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '74X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '74X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '74X_dataRun1_v3',
+    'run1_data'         :   '74X_dataRun1_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '74X_dataRun2_v3',
+    'run2_data'         :   '74X_dataRun2_v4',
     # GlobalTag for Run1 HLT
-    'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v2',
+    'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v3',
     # GlobalTag for Run2 HLT
-    'run2_hlt'          :   '74X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '74X_dataRun2_HLT_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -10,17 +10,17 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '74X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '74X_mcRun2_design_v3',
+    'run2_design'       :   '74X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '74X_mcRun2_startup_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '74X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '74X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v3',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '74X_dataRun1_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '74X_dataRun2_v4',
+    'run2_data'         :   '74X_dataRun2_v5',
     # GlobalTag for Run1 HLT
     'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v3',
     # GlobalTag for Run2 HLT


### PR DESCRIPTION
# Summary of changes
## Run I simulation
- **Ideal scenario** : [74X_mcRun1_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_design_v2) as [74X_mcRun1_design_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_design_v1/74X_mcRun1_design_v2):
  - adding new b-tag GBRForest payloads  
  - taxonomy changes to avoid fully qualified account names in the tag name for several records
- **Realistic scenario** : [74X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_realistic_v2) as [74X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_realistic_v1/74X_mcRun1_realistic_v2):
  - adding new b-tag GBRForest payloads  
  - taxonomy changes to avoid fully qualified account names in the tag name for several records
- **Heavy Ions** : [74X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_HeavyIon_v2) as [74X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_HeavyIon_v1/74X_mcRun1_HeavyIon_v2):
  - adding new b-tag GBRForest payloads  
  - taxonomy changes to avoid fully qualified account names in the tag name for several records
- **Proton-Lead** : [74X_mcRun1_pA_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_pA_v2) as [74X_mcRun1_pA_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_pA_v1/74X_mcRun1_pA_v2): 
  - adding new b-tag GBRForest payloads  
  - taxonomy changes to avoid fully qualified account names in the tag name for several records
## Run II simulation
- **Asymptotic scenario** : [74X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_asymptotic_v4) as [74X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_asymptotic_v2/74X_mcRun2_asymptotic_v4):
  - taxonomy changes (removing account names from tags) for DT reconstruction uncertainties, ECAL intercalibration errors, ECAL electronic mapping
  - added new label for BDT MVA discriminators for Btagging
  - updated Pixel bad channel map as at the beginning of Run2015D
  - updated HCAL ZS threshold in order to read-out HF as fully NZS
  - updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario
  - updated Jet energy corrections for 25 ns.
- **Ideal scenario** : [74X_mcRun2_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_design_v4) as [74X_mcRun2_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_design_v2/74X_mcRun2_design_v4):
  - taxonomy changes (removing account names from tags) for DT reconstruction uncertainties, ECAL intercalibration errors, ECAL electronic mapping
  - added new label for BDT MVA discriminators for Btagging
  - updated Pixel bad channel map as at the beginning of Run2015D
  - updated HCAL ZS threshold in order to read-out HF as fully NZS
  - updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario
  - updated Jet energy corrections for 25 ns.
- **Startup scenario** : [74X_mcRun2_startup_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_startup_v3) as [74X_mcRun2_startup_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_startup_v2/74X_mcRun2_startup_v3):
  - taxonomy changes (removing account names from tags) for DT reconstruction uncertainties, ECAL intercalibration errors, ECAL electronic mapping
  - added new label for BDT MVA discriminators for Btagging
  - updated Pixel bad channel map as at the beginning of Run2015D
  - updated HCAL ZS threshold in order to read-out HF as fully NZS.
- **Heavy Ion** : [74X_mcRun2_HeavyIon_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_HeavyIon_v3) as [74X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_HeavyIon_v2/74X_mcRun2_HeavyIon_v3):
  - taxonomy changes (removing account names from tags) for DT reconstruction uncertainties, ECAL intercalibration errors, ECAL electronic mapping
  - added new label for BDT MVA discriminators for Btagging
  - updated Pixel bad channel map as at the beginning of Run2015D
  - updated HCAL ZS threshold in order to read-out HF as fully NZS
  - updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario.
## Run II data
- **HLT processing** : [74X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_HLT_frozen_v3) as [74X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_HLT_frozen_v2) (snapshot time set to 2015-10-14 10:09:00 UTC) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_HLT_frozen_v2/74X_dataRun2_HLT_frozen_v3):
  - taxonomy changes (removing account names from tags or separating MC and data tags) for DT reconstruction uncertainties, ECAL intercalibration errors, ECAL electronic mapping, Tracker and Castor reconstruction geometry, L1 RPC Hardware configuration, DT and CSC APE.
- **Offline processing** : [74X_dataRun2_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v5) as [74X_dataRun2_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_v3/74X_dataRun2_v5):
  - all changes intended for Run2015A+B+C re-reco
  - taxonomy changes to avoid fully qualified account names in the tag name for several records
  - removing unused b-tagging working point records 
  - new set of tags covering the update of JEC for the 25ns data taking period. L2L3Residuals and uncertainties for 25ns have been updated.
## Run I data
- **HLT processing** : [74X_dataRun1_HLT_frozen_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_HLT_frozen_v3) as [74X_dataRun1_HLT_frozen_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_HLT_frozen_v2) (snapshot time set to 2015-10-14 10:09:00 UTC) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_HLT_frozen_v2/74X_dataRun1_HLT_frozen_v3):
  - taxonomy changes (removing account names from tags or separating MC and data tags) for DT reconstruction uncertainties, ECAL intercalibration errors, ECAL electronic mapping, Tracker and Castor reconstruction geometry, L1 RPC Hardware configuration, DT and CSC APE.
- **Offline processing** :  [74X_dataRun1_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v4) as [74X_dataRun1_v3](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v3) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_v3/74X_dataRun1_v4):
  - all changes intended for Run2015A+B+C re-reco
  - taxonomy changes to avoid fully qualified account names in the tag name for several records
