### PR TITLE
New Global Tags with cleanup and fixes for all scenarios.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '76X_mcRun1_design_v5',
+    'run1_design'       :   '76X_mcRun1_design_v7',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '76X_mcRun1_realistic_v5',
+    'run1_mc'           :   '76X_mcRun1_realistic_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v5',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v7',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '76X_mcRun1_pA_v5',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v5',
+    'run2_design'       :   '76X_mcRun2_design_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v5',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v5',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v7',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v4',
+    'run1_data'         :   '76X_dataRun1_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v4',
+    'run2_data'         :   '76X_dataRun2_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v4',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v4',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v1',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes
## Run1 simulations

_Ideal scenario_: 76X_mcRun1_design_v7: As 76X_mcRun1_design_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X

_Realistic scenario_: 76X_mcRun1_realistic_v7: As 76X_mcRun1_realistic_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X

_Heavy ions_: 76X_mcRun1_HeavyIon_v7: As 76X_mcRun1_HeavyIon_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X

_Proton lead_: 76X_mcRun1_pA_v7: As 76X_mcRun1_pA_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X
## Run2 design

_Ideal scenario_: 76X_mcRun2_design_v7: As 76X_mcRun2_design_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X
- updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario.

_Startup scenario_: 76X_mcRun2_startup_v7: As 76X_mcRun2_startup_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X.

_Asymptotic scenario_: 76X_mcRun2_asymptotic_v7: As 76X_mcRun2_asymptotic_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X
- updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario.

_Heavy ions_: 76X_mcRun2_HeavyIon_v7: As 76X_mcRun2_HeavyIon_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X
- updated RCT parameters for Heavy Ion setup
- updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario.
## Upgrade 2017 simulation

_Ideal scenario_: 76X_upgrade2017_design_v3: As 76X_upgrade2017_design_v1 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, and HCAL reconstruction geometry
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X
- updated Jet probability calibration as a result of Spring15 campaign in asymptotic scenario.
## Run1 data

_HLT data processing_: 76X_dataRun1_HLT_frozen_v6: As 76X_dataRun1_HLT_frozen_v4 (snapshot time set to 2015-10-14 17:45:00 UTC) with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, Tracker, HCAL and Castor reconstruction geometry, and L1 RPC Hardware configuration
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X.

_Offline processing_: 76X_dataRun1_v6: As 76X_dataRun1_v4 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, Tracker, HCAL and Castor reconstruction geometry, and L1 RPC Hardware configuration, DQM ref histos, Track probability and Jet probability calibration.
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X.
## Run2 data

_HLT processing_: 76X_dataRun2_HLT_frozen_v6: As 76X_dataRun2_HLT_frozen_v4 (snapshot time set to 2015-10-14 17:45:00 UTC) with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, Tracker, HCAL and Castor reconstruction geometry, and L1 RPC Hardware configuration
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X.

_Offline processing_: 76X_dataRun2_v6: As 76X_dataRun1_v4 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronic mapping, Tracker, HCAL and Castor reconstruction geometry, and L1 RPC Hardware configuration, DQM ref histos, Track probability and Jet probability calibration.
- removed BTag scale factors (already deprecated, to be inserted with different condition object)
- updated Calo tower geometry based on more precise Hcal reco geometry, needed for integrating SLHC digitisation in 76X.
