### PR TITLE
74x Fireworks: fix MuonDigi accessor type

### DIFF
--- a/Fireworks/Core/src/FWItemAccessorFactory.cc
+++ b/Fireworks/Core/src/FWItemAccessorFactory.cc
@@ -76,14 +76,14 @@ FWItemAccessorFactory::~FWItemAccessorFactory()
     we return the a FWItemTVirtualCollectionProxyAccessor 
     constructed using the associated TVirtualCollectionProxy.
   
+    If above is not true, we lookup the plugin based
+    FWItemAccessorRegistry for a plugin that can handle the
+    given type.
+
     If the type is not a collection but it contains only
     one element which is a collection, we return a 
     FWItemTVirtualCollectionProxyAccessor using the 
     TVirtualCollectionProxy of that element.
-
-    If none of the above is true, we lookup the plugin based
-    FWItemAccessorRegistry for a plugin that can handle the
-    given type.
 
     Failing that, we return a FWItemSingleAccessor which threats
     the object as if it was not a collection. Notice that this also will
@@ -107,19 +107,6 @@ FWItemAccessorFactory::accessorFor(const TClass* iClass) const
          new FWItemTVirtualCollectionProxyAccessor(iClass,
             boost::shared_ptr<TVirtualCollectionProxy>(iClass->GetCollectionProxy()->Generate())));
    } 
-   else if (hasMemberTVirtualCollectionProxy(iClass, member,offset)) 
-   {
-      if (debug)
-         fwLog(fwlog::kDebug) << "class "<< iClass->GetName()
-                              << " only contains data member " << member->GetName()
-                              << " which uses FWItemTVirtualCollectionProxyAccessor."
-                              << std::endl;
-   	   
-      return boost::shared_ptr<FWItemAccessorBase>(
-         new FWItemTVirtualCollectionProxyAccessor(iClass,
-            boost::shared_ptr<TVirtualCollectionProxy>(member->GetCollectionProxy()->Generate()),
-                                                   offset));
-   }
    
    // Iterate on the available plugins and use the one which handles 
    // the iClass type. 
@@ -137,6 +124,20 @@ FWItemAccessorFactory::accessorFor(const TClass* iClass) const
       return boost::shared_ptr<FWItemAccessorBase>(FWItemAccessorRegistry::get()->create(accessorName, iClass));
    }
    
+   if (hasMemberTVirtualCollectionProxy(iClass, member,offset)) 
+   {
+      if (debug)
+         fwLog(fwlog::kDebug) << "class "<< iClass->GetName()
+                              << " only contains data member " << member->GetName()
+                              << " which uses FWItemTVirtualCollectionProxyAccessor."
+                              << std::endl;
+   	   
+      return boost::shared_ptr<FWItemAccessorBase>(
+         new FWItemTVirtualCollectionProxyAccessor(iClass,
+            boost::shared_ptr<TVirtualCollectionProxy>(member->GetCollectionProxy()->Generate()),
+                                                   offset));
+   }
+
    return boost::shared_ptr<FWItemAccessorBase>(new FWItemSingleAccessor(iClass));
 }
 


### PR DESCRIPTION
With ROOT6 muon digi accessor type was set to TVirtualCollectionProxyAccessor instead of fireworks specific FWItemMuonDigiAccessor.

Changing test order in FWItemAccessorFactory::accessorFor fixes the problem.
