### PR TITLE
Change RPCDigisValidation default input collection

### DIFF
--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -106,6 +106,8 @@ private:
   //Tokens for accessing run data. Used for passing to edm::Event. - stanislav
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken;
   edm::EDGetTokenT<RPCDigiCollection> rpcDigiToken;
+  edm::EDGetTokenT<RPCDigiCollection> rpcDigiForPUToken;
+  bool isPileup_;
 };
 
 #endif

--- a/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
+++ b/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 validationMuonRPCDigis = cms.EDAnalyzer("RPCDigiValid",
 
     # Tag for Digis event data retrieval
-    rpcDigiTag = cms.untracked.InputTag("hltMuonRPCDigis"),
+    rpcDigiTag = cms.untracked.InputTag("simMuonRPCDigis"),
+    rpcDigiForPileup = cms.untracked.InputTag("hltMuonRPCDigis"),
     # Tag for simulated hits event data retrieval
     simHitTag = cms.untracked.InputTag("g4SimHits", "MuonRPCHits"),
 

--- a/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
+++ b/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 validationMuonRPCDigis = cms.EDAnalyzer("RPCDigiValid",
 
     # Tag for Digis event data retrieval
-    rpcDigiTag = cms.untracked.InputTag("simMuonRPCDigis"),
+    rpcDigiTag = cms.untracked.InputTag("hltMuonRPCDigis"),
     # Tag for simulated hits event data retrieval
     simHitTag = cms.untracked.InputTag("g4SimHits", "MuonRPCHits"),
 

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -23,9 +23,12 @@ RPCDigiValid::RPCDigiValid(const ParameterSet& ps)
 //  module, instance and process labels may be passed in a single string if separated by colon ':'
 //  (@see the edm::InputTag constructor documentation)
   simHitToken = consumes<PSimHitContainer>(ps.getUntrackedParameter<edm::InputTag >("simHitTag", edm::InputTag("g4SimHits:MuonRPCHits")));
-  rpcDigiToken    = consumes<RPCDigiCollection>(ps.getUntrackedParameter<edm::InputTag>("rpcDigiTag", edm::InputTag("simMuonRPCDigis")));
+  rpcDigiToken = consumes<RPCDigiCollection>(ps.getUntrackedParameter<edm::InputTag>("rpcDigiTag", edm::InputTag("simMuonRPCDigis")));
+  rpcDigiForPUToken = consumes<RPCDigiCollection>(ps.getUntrackedParameter<edm::InputTag>("rpcDigiForPileup", edm::InputTag("hltMuonRPCDigis")));
 
   outputFile_ = ps.getUntrackedParameter<string> ("outputFile", "rpcDigiValidPlots.root");
+
+  isPileup_ = true;
 }
 
 RPCDigiValid::~RPCDigiValid()
@@ -43,7 +46,11 @@ void RPCDigiValid::analyze(const Event& event, const EventSetup& eventSetup)
   edm::Handle<PSimHitContainer> simHit;
   edm::Handle<RPCDigiCollection> rpcDigis;
   event.getByToken(simHitToken, simHit);
-  event.getByToken(rpcDigiToken, rpcDigis);
+  if ( isPileup_ ) {
+    event.getByToken(rpcDigiForPUToken, rpcDigis);
+    if ( !rpcDigis.isValid() ) isPileup_ = false;
+  }
+  if ( !isPileup_ ) event.getByToken(rpcDigiToken, rpcDigis);
 
   // Loop on simhits
   PSimHitContainer::const_iterator simIt;


### PR DESCRIPTION
This PR is to change default input collection to the RPCDigis validaiton.
RPC validation team have been running validation module privately with this change to do the premixing vs classic mixing validation.
