### PR TITLE
Removed old LazyGetter calls from HLTDummyCollections

### DIFF
--- a/HLTrigger/special/python/HLTDummyCollections_cff.py
+++ b/HLTrigger/special/python/HLTDummyCollections_cff.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-hltDummyEcalRawToRecHitFacility = cms.EDProducer("HLTDummyCollections",
-  action = cms.string("doEcal"),
-  UnpackZDC = cms.bool(False),          # not actually needed here
-  ESdigiCollection = cms.string( "" )   # not actually needed here
-)
+#out of data interface
+#hltDummyEcalRawToRecHitFacility = cms.EDProducer("HLTDummyCollections",
+#  action = cms.string("doEcal"),
+#  UnpackZDC = cms.bool(False),          # not actually needed here
+#  ESdigiCollection = cms.string( "" )   # not actually needed here
+#)
 
 hltDummyHcalDigis = cms.EDProducer("HLTDummyCollections",
   action = cms.string("doHcal"),

--- a/HLTrigger/special/src/HLTDummyCollections.cc
+++ b/HLTrigger/special/src/HLTDummyCollections.cc
@@ -32,7 +32,6 @@ Implementation:
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 // -- Ecal
-#include "DataFormats/Common/interface/LazyGetter.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitComparison.h"
 // -- Hcal
@@ -55,7 +54,7 @@ Implementation:
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 // -- SiStrips
-#include "DataFormats/Common/interface/LazyGetter.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 // --- GCT
 #include "EventFilter/GctRawToDigi/plugins/GctRawToDigi.h"
@@ -80,7 +79,7 @@ class HLTDummyCollections : public edm::EDProducer {
     // ----------member data ---------------------------
 
     std::string action_;
-    bool doEcal_ ;
+  //bool doEcal_ ;
     bool doHcal_; 
     bool unpackZDC_ ;
     bool doEcalPreshower_ ;
@@ -112,7 +111,7 @@ HLTDummyCollections::HLTDummyCollections(const edm::ParameterSet& iConfig)
   unpackZDC_        = iConfig.getParameter<bool>("UnpackZDC");
   ESdigiCollection_ = iConfig.getParameter<std::string>("ESdigiCollection");
 
-  doEcal_           = ( action_ == "doEcal");
+  //  doEcal_           = ( action_ == "doEcal");
   doHcal_           = ( action_ == "doHcal");
   doEcalPreshower_  = ( action_ == "doEcalPreshower");
   doMuonDTDigis_    = ( action_ == "doMuonDT");
@@ -122,10 +121,11 @@ HLTDummyCollections::HLTDummyCollections(const edm::ParameterSet& iConfig)
   doObjectMap_      = ( action_ == "doObjectMap");
   doGCT_	    = ( action_ == "doGCT");
 
+/* This interface is out of data and I do not know what is the proper replacement
   if (doEcal_) {
     // ECAL unpacking :
     produces< edm::LazyGetter<EcalRecHit> >();
-  }
+  } */
 
   if (doHcal_) {
     // HCAL unpacking
@@ -164,7 +164,7 @@ HLTDummyCollections::HLTDummyCollections(const edm::ParameterSet& iConfig)
   }
 
   if (doSiStrip_) {
-    produces< edm::LazyGetter<SiStripCluster> >();
+    produces< edmNew::DetSetVector<SiStripCluster> >();
   }
 
   if (doGCT_) {
@@ -214,10 +214,11 @@ HLTDummyCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   using namespace edm;
 
+  /*
   if (doEcal_) {
     std::auto_ptr< edm::LazyGetter<EcalRecHit> > Ecalcollection( new edm::LazyGetter<EcalRecHit> );
     iEvent.put(Ecalcollection);
-  }
+    } */
 
   if (doHcal_) {
     std::auto_ptr<HBHEDigiCollection> hbhe_prod(new HBHEDigiCollection()); 
@@ -272,7 +273,7 @@ HLTDummyCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
 
   if (doSiStrip_) {
-    std::auto_ptr< edm::LazyGetter<SiStripCluster> > SiStripcollection( new edm::LazyGetter<SiStripCluster> );
+    std::auto_ptr< edmNew::DetSetVector<SiStripCluster> > SiStripcollection( new edmNew::DetSetVector<SiStripCluster> );
     iEvent.put(SiStripcollection);
   }
 


### PR DESCRIPTION
The module HLTDummyCollections is the last module to produce LazyGetter
objects. The SiStrip case was changed to match the modern class type
used. the ECal was commented out since it is unclear what is the proper
replacement since the module label that was used by the HLTDummyCollections
when delivering ECal hits is no longer associated to an existing module
type.
