### PR TITLE
Make the L1REPACK step work with the Run 2 eras

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_GCTGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_GCTGT_cff.py
@@ -1,6 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 ## L1REPACK: redo GCT,GT, using Run-1 or Run-2 input, making Run-2 output
+
+# If the Stage 1 trigger is running, there is also some different configuration.
+# Note that this next file does nothing if the stage1L1Trigger era is not active, so
+# it is safe to import even if the Stage 1 trigger is not required. It *MUST* be
+# imported into this namespace, i.e. "from <module> import *".
+from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
+
 ##
 ## run the L1 unpackers
 ##

--- a/FastSimulation/Configuration/python/L1Reco_cff.py
+++ b/FastSimulation/Configuration/python/L1Reco_cff.py
@@ -1,12 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 # the only thing FastSim runs from L1Reco is l1extraParticles
-from L1Trigger.Configuration.L1Reco_cff import l1extraParticles, _customiseForStage1
+from L1Trigger.Configuration.L1Reco_cff import l1extraParticles
 
-# These next few lines copy the L1 era changes to FastSim
-from Configuration.StandardSequences.Eras import eras
-# A unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
-modifyFastSimulationConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
+# If the Stage 1 trigger is running, there is also some different configuration.
+# Note that this next file does nothing if the stage1L1Trigger era is not active, so
+# it is safe to import even if the Stage 1 trigger is not required. It *MUST* be
+# imported into this namespace, i.e. "from <module> import *".
+from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
 
 # some collections have different labels
 def _changeLabelForFastSim( object ) :

--- a/L1Trigger/Configuration/python/ConditionalStage1Configuration_cff.py
+++ b/L1Trigger/Configuration/python/ConditionalStage1Configuration_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+#
+# The purpose of this file is to make configuration changes for the Stage1
+# L1 trigger, but *ONLY* if the era is active. If it is not, this file should
+# do nothing.
+# Hence it is safe to import this file all the time, and the changes will only
+# be triggered when required.
+#
+# DO NOT add anything to this file that is not conditional on eras.stage1L1Trigger
+# being active. Files importing this one assume that is safe to do so all the
+# time.
+#
+# This file MUST be imported with the "*" format, i.e.
+#    from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
+# If you import with just a plain "import", i.e.
+#    import L1Trigger.Configuration.ConditionalStage1Configuration_cff
+# then the ProcessModifier will be in the wrong namespace and it will not be
+# run, so the era customisations will not be applied.
+#
+
+from Configuration.StandardSequences.Eras import eras
+
+def _loadStage1Fragments( processObject ) :
+    processObject.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
+    processObject.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+    processObject.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
+
+# A unique name is required so I'll use make sure the name includes the filename
+modifyL1TriggerConfigurationConditionalStage1Configuration_cff_ = eras.stage1L1Trigger.makeProcessModifier( _loadStage1Fragments )

--- a/L1Trigger/Configuration/python/L1Reco_cff.py
+++ b/L1Trigger/Configuration/python/L1Reco_cff.py
@@ -19,16 +19,10 @@ from EventFilter.L1GlobalTriggerRawToDigi.l1GtRecord_cfi import *
 # L1GtTriggerMenuLite
 from EventFilter.L1GlobalTriggerRawToDigi.l1GtTriggerMenuLite_cfi import *
 
-#
-# If the Stage 1 trigger is running, there is also some different configuration than
-# the general Run 2 stuff.
-#
-def _customiseForStage1( processObject ) :
-    processObject.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
-    processObject.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
-# A unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
-from Configuration.StandardSequences.Eras import eras
-modifyL1TriggerConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
+# If the Stage 1 trigger is running, there is also some different configuration.
+# Note that this file does nothing if the stage1L1Trigger era is not active, so
+# it is safe to import even if the Stage 1 trigger is not required.
+from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
 
 # conditions in edm
 import EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -8,8 +8,12 @@ import FWCore.ParameterSet.Config as cms
 
 
 # This object is used to make changes for different running scenarios. In
-# this case for Run 2
+# this case for the Stage 1 trigger in run 2
 from Configuration.StandardSequences.Eras import eras
+# Note that this next file does nothing if the stage1L1Trigger era is not active, so
+# it is safe to import even if the Stage 1 trigger is not required. It *MUST* be
+# imported into this namespace, i.e. "from <file> import *".
+from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
 
 # ECAL TPG emulator and HCAL TPG run in the simulation sequence in order to be able 
 # to use unsuppressed digis produced by ECAL and HCAL simulation, respectively
@@ -160,20 +164,6 @@ SimL1Emulator = cms.Sequence(
 ##
 ## Make changes for Run 2
 ##
-def _extendForStage1Trigger( theProcess ) :
-    """
-    ProcessModifier that loads config fragments required for Run 2 into the process object.
-    Also switches the GCT digis for the Stage1 digis in the SimL1Emulator sequence
-    """
-    theProcess.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
-    theProcess.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
-    theProcess.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
-    # Note that this function is applied before the objects in this file are added
-    # to the process. So things declared in this file should be used "bare", i.e.
-    # not with "theProcess." in front of them. L1TCaloStage1 is an exception because
-    # it is not declared in this file but loaded into the process in one of the "load"
-    # statements above.
-    SimL1Emulator.replace( simGctDigis, theProcess.L1TCaloStage1 )
-
-# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
-modifyL1TriggerConfigurationSimL1EmulatorForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _extendForStage1Trigger )
+if eras.stage1L1Trigger.isChosen() :
+    from L1Trigger.L1TCalorimeter.L1TCaloStage1_cff import L1TCaloStage1
+    SimL1Emulator.replace( simGctDigis, L1TCaloStage1 )


### PR DESCRIPTION
This PR is mainly to make the L1REPACK step work with the Run 2 eras.  In doing so I've rearranged the era configuration slightly to make it a little more modular.  Files import one new cff file, all of the commands in which are conditional on the stage1L1Trigger era being active.  Hence it is always safe to import whether the Stage 1 trigger is being used or not.  This simplifies the higher level config files, and should hopefully make them more intuitive.

If trigger experts have suggestions of a better arrangement please feel free to comment.

I've run diffs of the config files for the following workflows, and there are no differences:

```
1000.0,1001.0,1003.0,101.0,1306.0,1306.0,1330.0,135.1,135.4,140.53,25.0,25.0,250203.0,25202.0,25203.0,4.22,4.52,4.53,5.1,500203.0,50202.0,50203.0,8.0,9.0
```

@Martin-Grunewald - Once this is merged the AddOn tests will work with eras (I've checked) and I'll reopen #11690.
