### PR TITLE
Fix --dump_python option in cmsDriver

### DIFF
--- a/Configuration/Applications/scripts/cmsDriver.py
+++ b/Configuration/Applications/scripts/cmsDriver.py
@@ -12,6 +12,18 @@ def run():
         
         # after cleanup of all config parameters pass it to the ConfigBuilder
         configBuilder = ConfigBuilder(options, with_output = True, with_input = True)
+
+        # Switch on any eras that have been specified. This is not required to create
+        # the file, it is only relevant if dump_python is set. It does have to be done
+        # before the prepare() call though. If not, then the config files will be loaded
+        # without applying the era changes. This doesn't affect the config file written,
+        # but when the dump_python branch uses execfile to read it back in it doesn't
+        # reload the modules - it picks up a reference to the already loaded ones. 
+        if hasattr( options, "era" ) :
+            from Configuration.StandardSequences.Eras import eras
+            for eraName in options.era.split(',') :
+                getattr( eras, eraName )._setChosen()
+        
         configBuilder.prepare()
         # fetch the results and write it to file
         config = file(options.python_filename,"w")


### PR DESCRIPTION
Currently, if you specify the --dump_python option to cmsDriver the resulting file will have none of the era changes applied.  When `execfile` is used on the confg file during the `if options.dump_python:` branch, it picks up references to the modules already loaded (which don't have eras applied) rather than reloading any modules.
This fixes that by switching on any eras before the first reading of the modules.

@lveldere, @Dr15Jones 
