### PR TITLE
76X - Fix for handling of rare case of CFEB data corruption

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
@@ -576,7 +576,7 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
                           for ( icfeb = 0; icfeb < 7; ++icfeb )
                             {
                               layer = pcrate->detId( vmecrate, dmb, icfeb,ilayer );
-                              if (cscData[iCSC].cfebData(icfeb))
+                              if (cscData[iCSC].cfebData(icfeb) && cscData[iCSC].cfebData(icfeb)->check())
                                 {
                                   std::vector<CSCStripDigi> stripDigis;
                                   cscData[iCSC].cfebData(icfeb)->digis(layer.rawId(),stripDigis);


### PR DESCRIPTION
76X - The CSC Unpacker side fix for handling of rare case CFEB data corruption, which could cause assertion failure in CSC Segment RECO module.

Original issue is described at https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1391.html
Assertion failure is triggered, when number of expected time bins in CFEB data is not equal to 8.
