### PR TITLE
Made RefCore and RefCoreWithIndex icc compatible

### DIFF
--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -34,7 +34,8 @@ namespace edm {
     RefCore& operator=(RefCore const&);
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    RefCore( RefCore&& ) = default;
+    RefCore( RefCore&& iOther) : cachePtr_(iOther.cachePtr_.load()), processIndex_(iOther.processIndex_),
+    productIndex_(iOther.productIndex_) {}
     RefCore& operator=(RefCore&&) = default;
 #endif
     

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -36,7 +36,8 @@ namespace edm {
     RefCoreWithIndex& operator=(RefCoreWithIndex const&);
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    RefCoreWithIndex( RefCoreWithIndex&& ) = default;
+    RefCoreWithIndex( RefCoreWithIndex&& iOther): cachePtr_(iOther.cachePtr_.load()),processIndex_(iOther.processIndex_),
+    productIndex_(iOther.productIndex_),elementIndex_(iOther.elementIndex_) {}
     RefCoreWithIndex& operator=(RefCoreWithIndex&&) = default;
 #endif
 


### PR DESCRIPTION
The icc compiler does not have a move constructor for its version of an std::atomic while gcc does. Therefore the ICC compiler can not create default version of move constructors for RefCore and RefCoreWithIndex. Instead we have made them by hand.
