### PR TITLE
DataFormats/Common: change from std::swap to edm::swap

### DIFF
--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -188,7 +188,7 @@ namespace edm {
   template<typename C>
   inline
   void RefProd<C>::swap(RefProd<C> & other) {
-    std::swap(product_, other.product_);
+    edm::swap(product_, other.product_);
   }
 
   template<typename C>

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -165,7 +165,7 @@ namespace edm {
   template<typename T>
   inline
   void RefToBaseProd<T>::swap(RefToBaseProd<T>& other) {
-    std::swap(product_, other.product_);
+    edm::swap(product_, other.product_);
   }
 
   template<typename T>


### PR DESCRIPTION
Due to a bug in ICC `std::swap` attempts to call `atomic( const atomic&
) = delete;` and fails. Using `edm::swap` does not trigger ICC to
call this ctor.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
