### PR TITLE
Removed edm::LazyGetter<> related dictionaries

### DIFF
--- a/DataFormats/EcalRecHit/src/classes.h
+++ b/DataFormats/EcalRecHit/src/classes.h
@@ -42,7 +42,6 @@ namespace DataFormats_EcalRecHit {
 }
 
 //raw to rechit specific formats
-#include "DataFormats/Common/interface/RefGetter.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -57,12 +56,5 @@ namespace DataFormats_EcalRecHit {
     edm::Wrapper< std::vector<edm::DetSet<EcalRecHit> > > dummy31;
     edm::Wrapper< edm::DetSetVector<EcalRecHit> > dummy41;
     edm::Wrapper< std::vector< std::vector < edm::DetSet<EcalRecHit> > > > dummy51;
-    edm::Wrapper< edm::RegionIndex<EcalRecHit> > dummy71;
-    edm::Wrapper< std::vector< edm::RegionIndex<EcalRecHit> > > dummy72;
-    edm::Wrapper< edm::LazyGetter<EcalRecHit> > dummy73;
-    edm::Wrapper< edm::Ref<edm::LazyGetter<EcalRecHit>,edm::RegionIndex<EcalRecHit>,edm::FindRegion<EcalRecHit> > > dummy74;
-    edm::Wrapper< std::vector<edm::Ref<edm::LazyGetter<EcalRecHit>,edm::RegionIndex<EcalRecHit>,edm::FindRegion<EcalRecHit> > > > dummy75;
-    edm::Wrapper< edm::RefGetter<EcalRecHit> > dummy76;
-    edm::Wrapper< edm::Ref< edm::LazyGetter<EcalRecHit>, EcalRecHit, edm::FindValue<EcalRecHit> > > dummy77;
   };
 }

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -39,15 +39,4 @@
   <class name="edm::Wrapper<edm::DetSetVector<EcalRecHit> >"/>
   <class name="edm::Wrapper<std::vector<std::vector<edm::DetSet<EcalRecHit> > > >"/>
 
-  <class name="edm::RegionIndex<EcalRecHit>"><field name="getter_" transient="true"/> </class>
-  <class name="std::vector< edm::RegionIndex<EcalRecHit> >"/>
-  <class name="edm::LazyGetter<EcalRecHit>"><field name="unpacker_" transient="true"/> </class>
-  <class name="edm::Ref<edm::LazyGetter<EcalRecHit>,edm::RegionIndex<EcalRecHit>,edm::FindRegion<EcalRecHit> >"/>
-  <class name="std::vector<edm::Ref<edm::LazyGetter<EcalRecHit>,edm::RegionIndex<EcalRecHit>,edm::FindRegion<EcalRecHit> > >"/>
-  <class name="edm::RefGetter<EcalRecHit>"/>
-
-  <class name="edm::Wrapper<edm::LazyGetter<EcalRecHit> >"/>
-  <class name="edm::Wrapper<edm::RefGetter<EcalRecHit> >"/>
- 
-  <class name="edm::Ref< edm::LazyGetter<EcalRecHit>, EcalRecHit, edm::FindValue<EcalRecHit> >"/>
 </lcgdict>

--- a/DataFormats/HGCRecHit/src/classes.h
+++ b/DataFormats/HGCRecHit/src/classes.h
@@ -43,7 +43,6 @@ namespace DataFormats_HGCalRecHit {
 }
 
 //raw to rechit specific formats
-#include "DataFormats/Common/interface/RefGetter.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -58,12 +57,5 @@ namespace DataFormats_HGCalRecHit {
     edm::Wrapper< std::vector<edm::DetSet<HGCRecHit> > > dummy31;
     edm::Wrapper< edm::DetSetVector<HGCRecHit> > dummy41;
     edm::Wrapper< std::vector< std::vector < edm::DetSet<HGCRecHit> > > > dummy51;
-    edm::Wrapper< edm::RegionIndex<HGCRecHit> > dummy71;
-    edm::Wrapper< std::vector< edm::RegionIndex<HGCRecHit> > > dummy72;
-    edm::Wrapper< edm::LazyGetter<HGCRecHit> > dummy73;
-    edm::Wrapper< edm::Ref<edm::LazyGetter<HGCRecHit>,edm::RegionIndex<HGCRecHit>,edm::FindRegion<HGCRecHit> > > dummy74;
-    edm::Wrapper< std::vector<edm::Ref<edm::LazyGetter<HGCRecHit>,edm::RegionIndex<HGCRecHit>,edm::FindRegion<HGCRecHit> > > > dummy75;
-    edm::Wrapper< edm::RefGetter<HGCRecHit> > dummy76;
-    edm::Wrapper< edm::Ref< edm::LazyGetter<HGCRecHit>, HGCRecHit, edm::FindValue<HGCRecHit> > > dummy77;
   };
 }

--- a/DataFormats/HGCRecHit/src/classes_def.xml
+++ b/DataFormats/HGCRecHit/src/classes_def.xml
@@ -31,18 +31,6 @@
   <class name="edm::Wrapper<edm::DetSetVector<HGCRecHit> >"/>
   <class name="edm::Wrapper<std::vector<std::vector<edm::DetSet<HGCRecHit> > > >"/>
 
-  <class name="edm::RegionIndex<HGCRecHit>"><field name="getter_" transient="true"/> </class>
-  <class name="std::vector< edm::RegionIndex<HGCRecHit> >"/>
-  <class name="edm::LazyGetter<HGCRecHit>"><field name="unpacker_" transient="true"/> </class>
-  <class name="edm::Ref<edm::LazyGetter<HGCRecHit>,edm::RegionIndex<HGCRecHit>,edm::FindRegion<HGCRecHit> >"/>
-  <class name="std::vector<edm::Ref<edm::LazyGetter<HGCRecHit>,edm::RegionIndex<HGCRecHit>,edm::FindRegion<HGCRecHit> > >"/>
-  <class name="edm::RefGetter<HGCRecHit>"/>
-
-  <class name="edm::Wrapper<edm::LazyGetter<HGCRecHit> >"/>
-  <class name="edm::Wrapper<edm::RefGetter<HGCRecHit> >"/>
- 
-  <class name="edm::Ref< edm::LazyGetter<HGCRecHit>, HGCRecHit, edm::FindValue<HGCRecHit> >"/>
-
   <class name="edm::reftobase::Holder<CaloRecHit, edm::Ref<edm::SortedCollection<HGCRecHit, edm::StrictWeakOrdering<HGCRecHit> >, HGCRecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HGCRecHit, edm::StrictWeakOrdering<HGCRecHit> >, HGCRecHit> > >" />
   <enum name="HGCSeverityLevel::SeverityLevel"/> 
 </lcgdict>


### PR DESCRIPTION
The class edm::LazyGetter<> and its helper classes (edm::RefGetter<>
and edm::RegionIndex<>) are no longer in use. This pull request removes
the last dictionaries which are begin generated using those classes.
