### PR TITLE
Removed unnecessary include and forward declaration of RefGetter

### DIFF
--- a/DataFormats/TrackerRecHit2D/src/classes.h
+++ b/DataFormats/TrackerRecHit2D/src/classes.h
@@ -18,7 +18,6 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/OwnVector.h"
-#include "DataFormats/Common/interface/RefGetter.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/ClusterRemovalInfo.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"

--- a/HLTrigger/special/interface/HLTTrackerHaloFilter.h
+++ b/HLTrigger/special/interface/HLTTrackerHaloFilter.h
@@ -34,7 +34,6 @@
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
-#include "DataFormats/Common/interface/RefGetter.h"
 
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -14,7 +14,6 @@
 
 namespace edm {
    class ParameterSet;
-   template<typename T> class RefGetter;
    class EventSetup;
 }
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -15,7 +15,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
-#include "DataFormats/Common/interface/RefGetter.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h"
 


### PR DESCRIPTION
The edm::RefGetter class is no longer used by any code but its
include file was still being referenced in a few files.
