### PR TITLE
Adding no-HF grid-based rho (76x forward-port #11773), and fixing existing bugged central rho values

### DIFF
--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -78,6 +78,7 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_fixedGridRhoFastjetAll_*_*',
                                            'keep *_fixedGridRhoFastjetAllTmp_*_*',
                                            'keep *_fixedGridRhoFastjetAllCalo_*_*',
+                                           'keep *_fixedGridRhoFastjetCentral_*_*',
                                            'keep *_fixedGridRhoFastjetCentralCalo_*_*',
                                            'keep *_fixedGridRhoFastjetCentralChargedPileUp_*_*',
                                            'keep *_fixedGridRhoFastjetCentralNeutral_*_*',

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -118,6 +118,7 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_fixedGridRhoAll_*_*',
                                            'keep *_fixedGridRhoFastjetAll_*_*',
                                            'keep *_fixedGridRhoFastjetAllTmp_*_*',
+                                           'keep *_fixedGridRhoFastjetCentral_*_*',
                                            'keep *_fixedGridRhoFastjetAllCalo_*_*',
                                            'keep *_fixedGridRhoFastjetCentralCalo_*_*',
                                            'keep *_fixedGridRhoFastjetCentralChargedPileUp_*_*',

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -116,6 +116,7 @@ RecoJetsAOD = cms.PSet(
                                            #'keep *_fixedGridRho*_*_*',
                                            'keep *_fixedGridRhoAll_*_*',
                                            'keep *_fixedGridRhoFastjetAll_*_*',
+                                           'keep *_fixedGridRhoFastjetCentral_*_*',
                                            'keep *_fixedGridRhoFastjetAllCalo_*_*',
                                            'keep *_fixedGridRhoFastjetCentralCalo_*_*',
                                            'keep *_fixedGridRhoFastjetCentralChargedPileUp_*_*',

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -77,6 +77,7 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_fixedGridRhoAll_*_*',
                                            'keep *_fixedGridRhoFastjetAll_*_*',
                                            'keep *_fixedGridRhoFastjetAllCalo_*_*',
+                                           'keep *_fixedGridRhoFastjetCentral_*_*',
                                            'keep *_fixedGridRhoFastjetCentralCalo_*_*',
                                            'keep *_fixedGridRhoFastjetCentralChargedPileUp_*_*',
                                            'keep *_fixedGridRhoFastjetCentralNeutral_*_*',

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -61,6 +61,9 @@ kt6PFJetsCentralNeutralTight = kt6PFJetsCentralNeutral.clone(
     )
 
 
+fixedGridRhoFastjetCentral = fixedGridRhoFastjetAll.clone(
+    maxRapidity = cms.double(2.5)
+    )
 
 fixedGridRhoFastjetCentralChargedPileUp = fixedGridRhoFastjetAll.clone(
     src = cms.InputTag("pfPileUpAllChargedParticles"),
@@ -183,10 +186,11 @@ hepTopTagPFJetsCHS.src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents"
 
 recoPFJets   =cms.Sequence(fixedGridRhoAll+
                            fixedGridRhoFastjetAll+
+                           fixedGridRhoFastjetCentral+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
                            ak4PFJets+
-			   pfNoPileUpJMESequence+
+                           pfNoPileUpJMESequence+
                            ak4PFJetsCHS+                           
                            ak8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
@@ -203,6 +207,7 @@ recoAllPFJets=cms.Sequence(sisCone5PFJets+sisCone7PFJets+
                            kt6PFJetsCentralNeutralTight+
                            fixedGridRhoAll+
                            fixedGridRhoFastjetAll+
+                           fixedGridRhoFastjetCentral+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
                            iterativeCone5PFJets+
@@ -246,6 +251,7 @@ recoAllPFJets=cms.Sequence(sisCone5PFJets+sisCone7PFJets+
 recoPFJetsWithSubstructure=cms.Sequence(
                            fixedGridRhoAll+
                            fixedGridRhoFastjetAll+
+                           fixedGridRhoFastjetCentral+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
                            ak4PFJets+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -66,13 +66,13 @@ fixedGridRhoFastjetCentral = fixedGridRhoFastjetAll.clone(
     )
 
 fixedGridRhoFastjetCentralChargedPileUp = fixedGridRhoFastjetAll.clone(
-    src = cms.InputTag("pfPileUpAllChargedParticles"),
-    maxRapidity = cms.double(2.5)
+    pfCandidatesTag = "pfPileUpAllChargedParticles",
+    maxRapidity = 2.5
     )
 
 fixedGridRhoFastjetCentralNeutral = fixedGridRhoFastjetAll.clone(
-    src = cms.InputTag("pfAllNeutralHadronsAndPhotons"),
-    maxRapidity = cms.double(2.5)
+    pfCandidatesTag = "pfAllNeutralHadronsAndPhotons",
+    maxRapidity = 2.5
     )
 
 


### PR DESCRIPTION
In the forward-port of #11773 now adding the fixed grid central version explicitly. 

Also, found a bug in the central "charged pileup" and "neutral hadron" rho values. They incorrectly overrode the "particleFlow" input source, so ALL of these were exactly the same. Now fixed. 
