### PR TITLE
remove bad ES rechits from PF clustering

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -438,6 +438,7 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
  PFRecHitQTestES(const edm::ParameterSet& iConfig):
   PFRecHitQTestBase(iConfig)
   {
+    thresholdCleaning_   = iConfig.getParameter<double>("cleaningThreshold");
     topologicalCleaning_ = iConfig.getParameter<bool>("topologicalCleaning");
   }
 
@@ -446,6 +447,11 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
 
   bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
 
+    if ( rh.energy() < thresholdCleaning_ ) {
+      clean=true;
+      return false;
+    }
+    
     if ( topologicalCleaning_ && 
 	 ( rh.checkFlag(EcalRecHit::kESDead) || 
 	   rh.checkFlag(EcalRecHit::kESTS13Sigmas) || 
@@ -484,9 +490,7 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
 
  protected:
   double thresholdCleaning_;
-  bool timingCleaning_;
   bool topologicalCleaning_;
-  bool skipTTRecoveredHits_;
 
 };
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -448,7 +448,7 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
   bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
 
     if ( rh.energy() < thresholdCleaning_ ) {
-      clean=true;
+      clean=false;
       return false;
     }
     

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -425,9 +425,70 @@ class PFRecHitQTestECAL : public PFRecHitQTestBase {
 
 };
 
+//
+//  Quality test that checks ES quality cuts
+//
+class PFRecHitQTestES : public PFRecHitQTestBase {
+
+ public:
+  PFRecHitQTestES() {
+
+  }
+
+ PFRecHitQTestES(const edm::ParameterSet& iConfig):
+  PFRecHitQTestBase(iConfig)
+  {
+    topologicalCleaning_ = iConfig.getParameter<bool>("topologicalCleaning");
+  }
+
+  void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
+  }
+
+  bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+
+    if ( topologicalCleaning_ && 
+	 ( rh.checkFlag(EcalRecHit::kESDead) || 
+	   rh.checkFlag(EcalRecHit::kESTS13Sigmas) || 
+	   rh.checkFlag(EcalRecHit::kESBadRatioFor12) || 
+	   rh.checkFlag(EcalRecHit::kESBadRatioFor23Upper) || 
+	   rh.checkFlag(EcalRecHit::kESBadRatioFor23Lower) || 
+	   rh.checkFlag(EcalRecHit::kESTS1Largest) || 
+	   rh.checkFlag(EcalRecHit::kESTS3Largest) || 
+	   rh.checkFlag(EcalRecHit::kESTS3Negative)
+	   )) {
+      clean=true;
+      return false;
+    }
+
+    return true;
+  }
+
+  bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
+    return true;
+  }
+
+  bool test(reco::PFRecHit& hit,const HFRecHit& rh,bool& clean){
+    return true;
+
+  }
+
+  bool test(reco::PFRecHit& hit,const HORecHit& rh,bool& clean){
+    return true;
+  }
+
+  bool test(reco::PFRecHit& hit,const CaloTower& rh,bool& clean){
+    return true;
+
+  }
 
 
+ protected:
+  double thresholdCleaning_;
+  bool timingCleaning_;
+  bool topologicalCleaning_;
+  bool skipTTRecoveredHits_;
 
+};
 
 //
 //  Quality test that calibrates tower 29 of HCAL

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -5,7 +5,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
-
+#include <iostream>
+using namespace std;
 
 //
 //  Quality test that checks threshold
@@ -462,7 +463,7 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
 	   rh.checkFlag(EcalRecHit::kESTS3Largest) || 
 	   rh.checkFlag(EcalRecHit::kESTS3Negative)
 	   )) {
-      clean=true;
+      clean=false;
       return false;
     }
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
@@ -15,6 +15,7 @@ particleFlowRecHitPS = cms.EDProducer("PFRecHitProducer",
                     ),
                 cms.PSet(
                     name = cms.string("PFRecHitQTestES"),
+                    cleaningThreshold = cms.double(7e-6),
                     topologicalCleaning = cms.bool(True)
                     )
                 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
@@ -15,7 +15,7 @@ particleFlowRecHitPS = cms.EDProducer("PFRecHitProducer",
                     ),
                 cms.PSet(
                     name = cms.string("PFRecHitQTestES"),
-                    cleaningThreshold = cms.double(7e-6),
+                    cleaningThreshold = cms.double(1.2e-4),
                     topologicalCleaning = cms.bool(True)
                     )
                 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
@@ -15,7 +15,7 @@ particleFlowRecHitPS = cms.EDProducer("PFRecHitProducer",
                     ),
                 cms.PSet(
                     name = cms.string("PFRecHitQTestES"),
-                    cleaningThreshold = cms.double(1.2e-4),
+                    cleaningThreshold = cms.double(1400.),
                     topologicalCleaning = cms.bool(True)
                     )
                 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
@@ -5,17 +5,21 @@ particleFlowRecHitPS = cms.EDProducer("PFRecHitProducer",
         name = cms.string("PFRecHitPreshowerNavigator")
     ),
     producers = cms.VPSet(
-           cms.PSet(
-             name = cms.string("PFPSRecHitCreator"),
-             src  = cms.InputTag("ecalPreshowerRecHit","EcalRecHitsES"),
-             qualityTests = cms.VPSet(
-                  cms.PSet(
-                  name = cms.string("PFRecHitQTestThreshold"),
-                  threshold = cms.double(7e-6)
-                  )
-             )
-           )
-    )
+        cms.PSet(
+            name = cms.string("PFPSRecHitCreator"),
+            src  = cms.InputTag("ecalPreshowerRecHit","EcalRecHitsES"),
+            qualityTests = cms.VPSet(
+                cms.PSet(
+                    name = cms.string("PFRecHitQTestThreshold"),
+                    threshold = cms.double(7e-6)
+                    ),
+                cms.PSet(
+                    name = cms.string("PFRecHitQTestES"),
+                    topologicalCleaning = cms.bool(True)
+                    )
+                )
+            )
+        )
+                                      )
 
-)
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitPS_cfi.py
@@ -11,11 +11,11 @@ particleFlowRecHitPS = cms.EDProducer("PFRecHitProducer",
             qualityTests = cms.VPSet(
                 cms.PSet(
                     name = cms.string("PFRecHitQTestThreshold"),
-                    threshold = cms.double(7e-6)
+                    threshold = cms.double(0.)
                     ),
                 cms.PSet(
                     name = cms.string("PFRecHitQTestES"),
-                    cleaningThreshold = cms.double(1400.),
+                    cleaningThreshold = cms.double(0.),
                     topologicalCleaning = cms.bool(True)
                     )
                 )

--- a/RecoParticleFlow/PFClusterProducer/src/RecHitQualityTests.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/RecHitQualityTests.cc
@@ -8,6 +8,7 @@ DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestThreshold, "PFRecHitQTestTh
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHOThreshold, "PFRecHitQTestHOThreshold");
 
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestECAL, "PFRecHitQTestECAL");
+DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestES, "PFRecHitQTestES");
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHCALCalib29, "PFRecHitQTestHCALCalib29");
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHCALChannel, "PFRecHitQTestHCALChannel");
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHCALTimeVsDepth, "PFRecHitQTestHCALTimeVsDepth");


### PR DESCRIPTION
remove ES rechits with bad status flag from PF ES clustering 
Automatically ported from CMSSW_7_6_X #11858 (original by @cmkuo).
