### PR TITLE
Use rand(0) instead of ran(0) for compatibility with Intel Fortran (i…

### DIFF
--- a/GeneratorInterface/GenExtensions/bin/BCVEGPY/bcvegpy.f
+++ b/GeneratorInterface/GenExtensions/bin/BCVEGPY/bcvegpy.f
@@ -158,7 +158,7 @@ c**************The unweighting scheme****************
 c******the ratio of xwgtup and the xwgtup_max setted at the beginning******
       xwt_r=xwgtup/MAXWGT
 
-      x_r = ran(0)
+      x_r = rand(0)
 
       if (x_r.le.xwt_r.and.xwt_r.le.1) then
 c         write(*,*) "random number ",x_r," ratio ",xwt_r 
@@ -171,7 +171,7 @@ c         write(*,*) "fill times",ic
          call bcvegpy_write_lhe
          end do
          sxwt=xwt_r-int(xwt_r)
-         x_r = ran(0)
+         x_r = rand(0)
          if (x_r.le.sxwt) then
          call bcvegpy_write_lhe
          end if


### PR DESCRIPTION
…fort)

Intel Fortran (ifort) compile rejects use on `ran(0)`, but it works
without any additional arguments -- `ran()`.

```
GeneratorInterface/GenExtensions/bin/BCVEGPY/bcvegpy.f(174): error
6672: This intrinsic procedure or system subprogram must not have an
expression or constant as an argument.   [RAN]
        x_r = ran(0)
-------------------^
```

According to GCC documentation `RAN` intrinsic is alias to `RAND` for
compatibility with HP FORTRAN 77/iX. Both, `RAN` and `RAND`, are GNU
extensions. To be compliant with standard one should use `RANDOM_NUMBER`
intrinsic (Fortran 95 and above).

It looks like _gfortran_ and _ifort_ are both happy if `rand(0)` is
used.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
Automatically ported from CMSSW_7_6_X #11849 (original by @davidlt).
