### PR TITLE
Remove constexpr from ringOrder

### DIFF
--- a/RecoTracker/TkDetLayers/src/Phase2OTECRingedLayer.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTECRingedLayer.cc
@@ -128,7 +128,11 @@ Phase2OTECRingedLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& s
   }
 
   //order is odd rings in front of even rings
+#ifdef __INTEL_COMPILER
+  const int ringOrder[NOTECRINGS]{0,1,0,1,0,1,0,1,0,1,0,1,0,1,0};
+#else
   constexpr int ringOrder[NOTECRINGS]{0,1,0,1,0,1,0,1,0,1,0,1,0,1,0};
+#endif
   auto index = [&ringIndices,& ringOrder](int i) { return ringOrder[ringIndices[i]];};
 
   std::vector<DetGroup> closestResult;

--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -203,7 +203,11 @@ TIDLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& startingState,
   std::array<vector<DetGroup>,3> groupsAtRingLevel;
   //order is ring3,ring1,ring2 i.e. 2 0 1
   //                                0 1 2  
+#ifdef __INTEL_COMPILER
+  const int ringOrder[3]{1,2,0};
+#else
   constexpr int ringOrder[3]{1,2,0};
+#endif
   auto index = [&ringIndices,& ringOrder](int i) { return ringOrder[ringIndices[i]];};
 
   auto & closestResult =  groupsAtRingLevel[index(0)];


### PR DESCRIPTION
ICC segfaults due to to `constexpr` on `ringOrder`. This is reported and
due to be fixed in forthcoming ICC releases (2016).

Removal of `constexpr` did not change assembly in any significant,
actually compiler generated 5 instructions less for this function.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
Automatically ported from CMSSW_7_6_X #11848 (original by @davidlt).
