### PR TITLE
Fix ICC issue with 'decltype(..) a, decltype(a) b' in lambda

### DIFF
--- a/CondFormats/Serialization/interface/Equal.h
+++ b/CondFormats/Serialization/interface/Equal.h
@@ -191,7 +191,7 @@ struct access<TYPE<T>> \
     static bool equal_(const TYPE<T> & first, const TYPE<T> & second) \
     { \
         return first.size() == second.size() && std::equal(first.cbegin(), first.cend(), second.cbegin(), \
-            [](decltype(*first.cbegin()) a, decltype(a) b) -> bool { \
+            [](decltype(*first.cbegin()) a, decltype(*first.cbegin()) b) -> bool { \
                 return equal(a, b); \
             } \
         ); \
@@ -234,7 +234,7 @@ struct access<TYPE<T, U>> \
     static bool equal_(const TYPE<T, U> & first, const TYPE<T, U> & second) \
     { \
         return first.size() == second.size() && std::equal(first.cbegin(), first.cend(), second.cbegin(), \
-            [](decltype(*first.cbegin()) a, decltype(a) b) -> bool { \
+            [](decltype(*first.cbegin()) a, decltype(*first.cbegin()) b) -> bool { \
                 return equal(a, b); \
             } \
         ); \


### PR DESCRIPTION
ICC cannot hadle 'decltype(..) a, decltype(a) b' in lambda arguments:

```
CondFormats/Serialization/interface/Equal.h(201): error: identifier "a"
is undefined
```

This is to be fixed in forthcoming ICC releases (2016).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
Automatically ported from CMSSW_7_6_X #11844 (original by @davidlt).
