### PR TITLE
bugfix: assign muon PDG id using PFMuon charge

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -364,10 +364,12 @@ void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
      // search for the corresponding pf candidate
        MuToPFMap::iterator iter =  muToPFMap.find(muRef);
        if(iter != muToPFMap.end()){
-	 outMuon.setPFP4(pfCandidates->at(iter->second).p4());
-	 outMuon.setP4(pfCandidates->at(iter->second).p4());//PF is the default
-	 outMuon.setCharge(pfCandidates->at(iter->second).charge());//PF is the default
-	 outMuon.setBestTrack(pfCandidates->at(iter->second).bestMuonTrackType());
+	 const auto& pfMu = pfCandidates->at(iter->second);
+	 outMuon.setPFP4(pfMu.p4());
+	 outMuon.setP4(pfMu.p4());//PF is the default
+	 outMuon.setCharge(pfMu.charge());//PF is the default
+	 outMuon.setPdgId(-13*pfMu.charge());
+	 outMuon.setBestTrack(pfMu.bestMuonTrackType());
 	 muToPFMap.erase(iter);
 	 dout << "MuonRef: " << muRef.id() << " " << muRef.key() 
 	      << " Is it PF? " << outMuon.isPFMuon() 


### PR DESCRIPTION
This PR is a bugfix for inconsistent PDG id assignment in the MuonProducer.

The MuonProducer sets variables from the PF muon but the PDG ID was omitted. Inconsistency between sign of pdg id and charge is spotted by Nicola;

> event 1:19778:3823145
> 
> /store/mc/RunIISpring15DR74/ZZTo4L_13TeV_powheg_pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/10000/A43364CC-1C17-E511-AEF2-00266CFAE8C4.root
> 
> has a muon with pT=38.6605,  charge -1, pdgId=-13 (mu+), muonBestTrackType=4.

Automatically ported from CMSSW_7_6_X #11838 (original by @jhgoh).
