### PR TITLE
Flag the globalEfficiencies plot in the DQMGenericClient

### DIFF
--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -582,6 +582,7 @@ void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::
                               << "Cannot book globalEffic-ME from the DQM\n";
     return;
   }
+  globalEfficME->setEfficiencyFlag();
   TH1F* hGlobalEffic = globalEfficME->getTH1F();
   if ( !hGlobalEffic ) {
     LogInfo("DQMGenericClient") << "computeEfficiency() : "


### PR DESCRIPTION
The DQMGenericClient internally creates a MonitorElement called
globalEfficiencies, that shows the efficiencies and fake rates of
all the plots that have been configured in the harvesting step. Unfortunately
this MonitorElement has not been marked as an efficiency plot so that, when
overlaid in the DQMGUI, strange normalization effects can appear. This PR fix
this problem.
Automatically ported from CMSSW_7_6_X #11831 (original by @rovere).
