### PR TITLE
added FEVTDEBUGHLT as output of step2 data relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -889,7 +889,9 @@ steps['HLTD']=merge([{'--process':'reHLT',
                       '-s':'L1REPACK,HLT:@%s'%hltKey,
                       '--conditions':'auto:run1_hlt_%s'%menu,
                       '--data':'',
-                      '--output':'\'[{"e":"RAW","t":"RAW","o":["drop FEDRawDataCollection_rawDataCollector__LHC"]}]\'',
+                      '--eventcontent': 'FEVTDEBUGHLT',
+                      '--datatier': 'FEVTDEBUGHLT',
+#                      '--output':'\'[{"e":"RAW","t":"RAW","o":["drop FEDRawDataCollection_rawDataCollector__LHC"]}]\'',
                       },])
 steps['HLTDSKIM']=merge([{'--inputCommands':'"keep *","drop *_*_*_RECO"'},steps['HLTD']])
 


### PR DESCRIPTION
FEVTDEBUGHLT as output of step2 data relvals.
This PR, togheter with changes in PR #11629 (re-enabling HLTMon sequence), 
is needed to fix tracking HLT missing folders in DQM.
Automatically ported from CMSSW_7_6_X #11811 (original by @fabozzi).
