### PR TITLE
Fix a typo in MaterialNames, new material in HGCEE

### DIFF
--- a/Geometry/HGCalCommonData/data/v7/hgcalEE.xml
+++ b/Geometry/HGCalCommonData/data/v7/hgcalEE.xml
@@ -32,7 +32,7 @@
   <rParent name="hgcalEE:HGCalEEM"/>
   <Vector name="MaterialNames" type="string" nEntries="15">
    materials:Carbon_fibre_str_Upgrade2, materials:Tungsten, materials:Tungsten, 
-   materials:Tungsten, materials:WCu, materials:WCu, materials:Wcu, 
+   materials:Tungsten, materials:WCu, materials:WCu, materials:WCu, 
    materials:Copper, materials:Copper, materials:Silicon, materials:M_NEMA FR4 plate, 
    materials:Air, materials:Foam, materials:Aluminium, materials:Air</Vector>
   <Vector name="VolumeNames" type="string" nEntries="15">


### PR DESCRIPTION
@ianna @bsunanda @lgray @pfs @kpedro88 Fixing a typo in V7 HGCEE newMaterial
Automatically ported from CMSSW_7_6_X #11798 (original by @vandreev11).
