### PR TITLE
Switch default HBHENoiseFilter settings to Run2-25ns configuration V2 - 76X

### DIFF
--- a/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
@@ -6,13 +6,10 @@ HBHENoiseFilterResultProducer = cms.EDProducer(
     minHPDHits = cms.int32(17),
     minHPDNoOtherHits = cms.int32(10),
     minZeros = cms.int32(9999),
-    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(True),
-    defaultDecision = cms.string("HBHENoiseFilterResultRun1"),
+    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(False),
+    defaultDecision = cms.string("HBHENoiseFilterResultRun2Loose"),
     minNumIsolatedNoiseChannels = cms.int32(10),
     minIsolatedNoiseSumE = cms.double(50.0),
-    minIsolatedNoiseSumEt = cms.double(25.0)
+    minIsolatedNoiseSumEt = cms.double(25.0),
+    useBunchSpacingProducer = cms.bool(True)
 )
-
-from Configuration.StandardSequences.Eras import eras
-eras.run2_common.toModify(HBHENoiseFilterResultProducer, IgnoreTS4TS5ifJetInLowBVRegion=False)
-eras.run2_25ns_specific.toModify(HBHENoiseFilterResultProducer, defaultDecision="HBHENoiseFilterResultRun2Loose")

--- a/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
@@ -6,10 +6,13 @@ HBHENoiseFilterResultProducer = cms.EDProducer(
     minHPDHits = cms.int32(17),
     minHPDNoOtherHits = cms.int32(10),
     minZeros = cms.int32(9999),
-    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(False),
+    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(True),
     defaultDecision = cms.string("HBHENoiseFilterResultRun2Loose"),
     minNumIsolatedNoiseChannels = cms.int32(10),
     minIsolatedNoiseSumE = cms.double(50.0),
     minIsolatedNoiseSumEt = cms.double(25.0),
     useBunchSpacingProducer = cms.bool(True)
 )
+
+from Configuration.StandardSequences.Eras import eras
+eras.run2_common.toModify(HBHENoiseFilterResultProducer, IgnoreTS4TS5ifJetInLowBVRegion=False)

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -191,9 +191,7 @@ def customise_DQM(process):
 
 
 def customise_DQM_25ns(process):
-    # Switch the default decision of the HCAL noise filter
-    if hasattr(process,'HBHENoiseFilterResultProducer'):
-        process.HBHENoiseFilterResultProducer.defaultDecision = cms.string("HBHENoiseFilterResultRun2Loose")
+    #Empty place-holder
     return process
 
 


### PR DESCRIPTION
This is take-2 to switch the default HBHENoiseFilterResultProducer settings to Run2-25ns configuration such that users get correct noise flags out of the box for the bulk of 2015 data (and beyond) which is with 25ns bunch spacing.
As per @slava77's request (see PR #11778 ), Eras is replaced by BunchSpacingProducer in HBHENoiseFilterResultProducer.
In the default settings, BunchSpacingProducer is enabled, which should automatically switch between Run2 50ns and 25ns settings. However, users will have to manually configure and rerun HBHENoiseFilterResultProducer in case of any Run1 50ns data analysis.
@abdoulline @igv4321 @mariadalfonso
Automatically ported from CMSSW_7_6_X #11789 (original by @dertexaner).
