### PR TITLE
CalibCalorimetry/EcalLaserAnalyzer: uncomment ClassDef

### DIFF
--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/PulseFitWithFunction.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/PulseFitWithFunction.h
@@ -79,7 +79,7 @@ class PulseFitWithFunction: public TObject
   
   
 
-  //  ClassDef(PulseFitWithFunction,1)     //!< The processed part of the class is persistant
+  ClassDef(PulseFitWithFunction,1)     //!< The processed part of the class is persistant
 } ;
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/PulseFitWithShape.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/PulseFitWithShape.h
@@ -44,7 +44,7 @@ class PulseFitWithShape: public TObject
   int     fNum_samp_after_max  ; // number of samples after  maximum sample
  
   
-  // ClassDef(PulseFitWithShape,1)     //!< The processed part of the class is persistant
+  ClassDef(PulseFitWithShape,1)     //!< The processed part of the class is persistant
 
 } ;
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TAPDPulse.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TAPDPulse.h
@@ -58,7 +58,7 @@ class TAPDPulse: public TObject
   double getPedestal();
   double* getAdcWithoutPedestal();
   void setPresamples(int);
-  //ClassDef(TAPDPulse,1)
+  ClassDef(TAPDPulse,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TFParams.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TFParams.h
@@ -93,6 +93,6 @@ double fitpj(double **, double *,double ** , double noise_val, int debug) ;
  double mixShape( Double_t *, Double_t * ) ;
  double computePulseWidth( int, double, double) ;
 
- //  ClassDef( TFParams, 1 ) 
+ ClassDef( TFParams, 1 ) 
 };
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMarkov.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMarkov.h
@@ -27,7 +27,7 @@ class TMarkov: public TObject
   double getPeakValue(int i) const { return peak[i]; }
   int getBinMax() const { return imax; }
 
-  //  ClassDef(TMarkov,1)
+  ClassDef(TMarkov,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
@@ -76,7 +76,7 @@ class TMatacq: public TObject
   double getWidth80() {return width80;}
   double getSlide() {return slidingmean;}
 
-  //  ClassDef(TMatacq,1)
+  ClassDef(TMatacq,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMem.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMem.h
@@ -29,7 +29,7 @@ class TMem: public TObject
   bool isMemRelevant(int);
   int Mem(int, int);
 
-  //ClassDef(TMem,1)
+  ClassDef(TMem,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMom.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMom.h
@@ -61,7 +61,7 @@ class TMom: public TObject
   double getMax();
   std::vector<double> getPeak();
 
-  //  ClassDef(TMom,1)
+  ClassDef(TMom,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNCor.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNCor.h
@@ -28,7 +28,7 @@ class TPNCor: public TObject
   double corParams[iSizeGain][iSizePar];
   int isFileOK;
   
-  //  ClassDef(TPNCor,1)
+  ClassDef(TPNCor,1)
     
 
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h
@@ -35,7 +35,7 @@ class TPNFit: public TObject
   double getAmpl() {return ampl;}
   double getTimax() {return timeatmax;}
 
-  //  ClassDef(TPNFit,1)
+  ClassDef(TPNFit,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNPulse.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNPulse.h
@@ -40,7 +40,7 @@ class TPNPulse: public TObject
   double getPedestal();
   double* getAdcWithoutPedestal();
   void setPresamples(int);
-  //ClassDef(TPNPulse,1)
+  ClassDef(TPNPulse,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
@@ -86,7 +86,7 @@ public :
 
   double inverms  ( int, double xx[matdim][matdim], double yy[matdim][matdim] );
 
-  //  ClassDef( TSFit, 1 )
+  ClassDef( TSFit, 1 )
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h
@@ -75,7 +75,7 @@ class TShapeAnalysis: public TObject
   std::vector<double> getVals(int);
   std::vector<double> getInitVals(int);
 
-  //  ClassDef(TShapeAnalysis,1)
+  ClassDef(TShapeAnalysis,1)
 };
 
 #endif


### PR DESCRIPTION
Having classes based on `TObject` without `ClassDef` creates issues while
creating a dictionary. According to CVS these files were introduced 6
years and 4 months ago and already had `ClassDef` commented out. If we
do not need to store (I/O) then we need to set `ClassVersionID` to **0**.

CVS history: http://cvs.web.cern.ch/cvs/cgi-bin/viewcvs.cgi/CMSSW/CalibCalorimetry/EcalLaserAnalyzer/interface/
ROOT `ClassDef` documentation: https://root.cern.ch/root/Using.html

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
Automatically ported from CMSSW_7_6_X #11787 (original by @davidlt).
