### PR TITLE
3prong1pi0 new dms

### DIFF
--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
@@ -59,6 +59,14 @@ decayMode_3Prong0Pi0 = cms.PSet(
     minMass = cms.double(0.8),
     maxMass = cms.string("1.5")
 )
+decayMode_3Prong1Pi0 = cms.PSet( #suggestions made by CV
+    nCharged = cms.uint32(3),
+    nPiZeros = cms.uint32(1),
+    nTracksMin = cms.uint32(2),
+    nChargedPFCandsMin = cms.uint32(1),
+    minMass = cms.double(0.9),
+    maxMass = cms.string("1.6")
+)
 
 hpsSelectionDiscriminator = cms.EDProducer(
     "PFRecoTauDiscriminationByHPSSelection",
@@ -72,7 +80,8 @@ hpsSelectionDiscriminator = cms.EDProducer(
         decayMode_1Prong2Pi0,
         decayMode_2Prong0Pi0,
         decayMode_2Prong1Pi0,
-        decayMode_3Prong0Pi0
+        decayMode_3Prong0Pi0,
+	decayMode_3Prong1Pi0
     ),
     requireTauChargedHadronsToBeChargedPFCands = cms.bool(False),
     # CV: require at least one pixel hit for the sum of all tracks

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -67,6 +67,13 @@ combinatoricDecayModeConfigs = cms.PSet(
         nPiZeros = cms.uint32(0),
         maxTracks = cms.uint32(6),
         maxPiZeros = cms.uint32(0),
+    ),
+    config3prong1pi0 = cms.PSet( # suggestions made by CV
+        # Three prong one pizero mode
+        nCharged = cms.uint32(3),
+        nPiZeros = cms.uint32(1),
+        maxTracks = cms.uint32(6),
+        maxPiZeros = cms.uint32(3),
     )
 )
 
@@ -82,7 +89,8 @@ _combinatoricTauConfig = cms.PSet(
         combinatoricDecayModeConfigs.config1prong2pi0,
         combinatoricDecayModeConfigs.config2prong0pi0,
         combinatoricDecayModeConfigs.config2prong1pi0,
-        combinatoricDecayModeConfigs.config3prong0pi0
+        combinatoricDecayModeConfigs.config3prong0pi0,
+	combinatoricDecayModeConfigs.config3prong1pi0
     ),
     signalConeSize = cms.string("max(min(0.1, 3.0/pt()), 0.05)"),
     minAbsPhotonSumPt_insideSignalCone = cms.double(2.5),


### PR DESCRIPTION
Adding 3prong1pi0 decay mode to new tau ID DMs
Automatically ported from CMSSW_7_6_X #11766 (original by @cms-tau-pog).
