### PR TITLE
Mini aodvalidation:  V0

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -29,11 +29,12 @@ from Validation.RecoMuon.muonValidationHLT_cff import *
 from Validation.EventGenerator.BasicGenValidation_cff import *
 # miniAOD
 from Validation.RecoParticleFlow.miniAODValidation_cff import *
+from Validation.RecoEgamma.photonMiniAODValidationSequence_cff import *
 
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
-prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * JetValidationMiniAOD * type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD * METValidationMiniAOD )
+prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * JetValidationMiniAOD * type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD * METValidationMiniAOD )
 
 
 validation = cms.Sequence(cms.SequencePlaceholder("mix")

--- a/Validation/RecoEgamma/plugins/BuildFile.xml
+++ b/Validation/RecoEgamma/plugins/BuildFile.xml
@@ -7,6 +7,8 @@
 <use   name="DataFormats/VertexReco"/>
 <use   name="DataFormats/EgammaReco"/>
 <use   name="DataFormats/EgammaCandidates"/>
+<use   name="DataFormats/HepMCCandidate"/>
+<use   name="DataFormats/PatCandidates"/>
 <use   name="TrackingTools/TransientTrack"/>
 <use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/Records"/>

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -3947,11 +3947,7 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
     
     if ( ( photonEt > 14 &&   newhOverE <0.15 )    ||  ( photonEt > 10 && photonEt < 14 && chargedHadIso <10  ) ) {
       
-      
-      
-      if ( fName_ != "pfPhotonValidator" ) std::cout << " pfPhotonValidator sim pho pt " <<  mcIter->pt() << " reco pho pt " << photonEt << std::endl;
-      
-      
+            
       h_scEta_miniAOD_[0]->Fill( matchingPho->superCluster()->eta() );
       h_scPhi_miniAOD_[0]->Fill( matchingPho->superCluster()->phi() );
       

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -151,6 +151,8 @@ PhotonValidator::PhotonValidator( const edm::ParameterSet& pset )
   hepMC_Token_ = consumes<edm::HepMCProduct>(edm::InputTag("generator"));
   genjets_Token_ = consumes<reco::GenJetCollection>(
       edm::InputTag("ak4GenJets"));
+ 
+  genpartToken_ = consumes<reco::GenParticleCollection>(edm::InputTag( "genParticles" ));
 
   consumes<reco::TrackToTrackingParticleAssociator>(edm::InputTag("trackAssociatorByHitsForPhotonValidation"));
 
@@ -1189,7 +1191,105 @@ void PhotonValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run cons
   
   
     //}
+
+  ///// Histos to allow comparison with miniAOD
+
+  h_scEta_miniAOD_[0] =   iBooker.book1D("scEta_miniAOD"," SC Eta ",etaBin,etaMin, etaMax);
+  h_scPhi_miniAOD_[0] =   iBooker.book1D("scPhi_miniAOD"," SC Phi ",phiBin,phiMin,phiMax);
+  histname = "phoE";
+  h_phoE_miniAOD_[0][0]=iBooker.book1D(histname+"All_miniAOD"," Photon Energy: All ecal ", eBin,eMin, eMax);
+  h_phoE_miniAOD_[0][1]=iBooker.book1D(histname+"Barrel_miniAOD"," Photon Energy: barrel ",eBin,eMin, eMax);
+  h_phoE_miniAOD_[0][2]=iBooker.book1D(histname+"Endcap_miniAOD"," Photon Energy: Endcap ",eBin,eMin, eMax);
   
+  histname = "phoEt";
+  h_phoEt_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD"," Photon Transverse Energy: All ecal ", etBin,etMin, etMax);
+  h_phoEt_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," Photon Transverse Energy: Barrel ",etBin,etMin, etMax);
+  h_phoEt_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," Photon Transverse Energy: Endcap ",etBin,etMin, etMax);
+  
+  
+  histname = "eRes";
+  h_phoERes_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD"," Photon E/E_{true}: All ecal;  E/E_{true} (GeV)", resBin,resMin, resMax);
+  h_phoERes_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","Photon E/E_{true}: Barrel; E/E_{true} (GeV)",resBin,resMin, resMax);
+  h_phoERes_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," Photon E/E_{true}: Endcap; E/E_{true} (GeV)",resBin,resMin, resMax);
+
+  histname = "sigmaEoE";
+  h_phoSigmaEoE_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD","#sigma_{E}/E: All ecal; #sigma_{E}/E", 100,0., 0.08);
+  h_phoSigmaEoE_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","#sigma_{E}/E: Barrel; #sigma_{E}/E",100,0., 0.08);
+  h_phoSigmaEoE_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","#sigma_{E}/E: Endcap, #sigma_{E}/E",100,0., 0.08);
+
+
+  histname = "r9";
+  h_r9_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " r9: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_r9_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," r9: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_r9_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," r9: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "full5x5_r9";
+  h_full5x5_r9_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " r9: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_full5x5_r9_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," r9: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_full5x5_r9_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," r9: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "r1";
+  h_r1_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " e1x5/e5x5: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_r1_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," e1x5/e5x5: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_r1_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," e1x5/e5x5: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "r2";
+  h_r2_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " e2x5/e5x5: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_r2_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," e2x5/e5x5: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_r2_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," e2x5/e5x5: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "hOverE";
+  h_hOverE_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "H/E: All Ecal",100,0., 0.2) ;
+  h_hOverE_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","H/E: Barrel ", 100,0., 0.2) ;
+  h_hOverE_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","H/E: Endcap ", 100,0., 0.2) ;
+  //
+  histname = "newhOverE";
+  h_newhOverE_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "new H/E: All Ecal",100,0., 0.2) ;
+  h_newhOverE_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","new H/E: Barrel ", 100,0., 0.2) ;
+  h_newhOverE_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","new H/E: Endcap ", 100,0., 0.2) ;
+  //
+  histname = "sigmaIetaIeta";
+  h_sigmaIetaIeta_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "sigmaIetaIeta: All Ecal",100,0., 0.1) ;
+  h_sigmaIetaIeta_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","sigmaIetaIeta: Barrel ", 100,0., 0.05) ;
+  h_sigmaIetaIeta_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","sigmaIetaIeta: Endcap ", 100,0., 0.1) ;
+  histname = "full5x5_sigmaIetaIeta";
+  h_full5x5_sigmaIetaIeta_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "Full5x5 sigmaIetaIeta: All Ecal",100,0., 0.1) ;
+  h_full5x5_sigmaIetaIeta_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","Full5x5 sigmaIetaIeta: Barrel ", 100,0., 0.05) ;
+  h_full5x5_sigmaIetaIeta_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","Full5x5 sigmaIetaIeta: Endcap ", 100,0., 0.1) ;
+  //
+  histname = "ecalRecHitSumEtConeDR04";
+  h_ecalRecHitSumEtConeDR04_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "ecalRecHitSumEtDR04: All Ecal",etBin,etMin,20.);
+  h_ecalRecHitSumEtConeDR04_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","ecalRecHitSumEtDR04: Barrel ", etBin,etMin,20.);
+  h_ecalRecHitSumEtConeDR04_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","ecalRecHitSumEtDR04: Endcap ", etBin,etMin,20.);
+  histname = "hcalTowerSumEtConeDR04";
+  h_hcalTowerSumEtConeDR04_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "hcalTowerSumEtConeDR04: All Ecal",etBin,etMin,20.);
+  h_hcalTowerSumEtConeDR04_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","hcalTowerSumEtConeDR04: Barrel ", etBin,etMin,20.);
+  h_hcalTowerSumEtConeDR04_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","hcalTowerSumEtConeDR04: Endcap ", etBin,etMin,20.);
+  //
+  histname = "hcalTowerBcSumEtConeDR04";
+  h_hcalTowerBcSumEtConeDR04_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "hcalTowerBcSumEtConeDR04: All Ecal",etBin,etMin,20.);
+  h_hcalTowerBcSumEtConeDR04_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","hcalTowerBcSumEtConeDR04: Barrel ", etBin,etMin,20.);
+  h_hcalTowerBcSumEtConeDR04_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","hcalTowerBcSumEtConeDR04: Endcap ", etBin,etMin,20.);
+  histname = "isoTrkSolidConeDR04";
+  h_isoTrkSolidConeDR04_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "isoTrkSolidConeDR04: All Ecal",etBin,etMin,etMax*0.1);
+  h_isoTrkSolidConeDR04_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","isoTrkSolidConeDR04: Barrel ", etBin,etMin,etMax*0.1);
+  h_isoTrkSolidConeDR04_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","isoTrkSolidConeDR04: Endcap ", etBin,etMin,etMax*0.1);
+  histname = "nTrkSolidConeDR04";
+  h_nTrkSolidConeDR04_miniAOD_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "nTrkSolidConeDR04: All Ecal",20,0., 20) ;
+  h_nTrkSolidConeDR04_miniAOD_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","nTrkSolidConeDR04: Barrel ", 20,0., 20) ;
+  h_nTrkSolidConeDR04_miniAOD_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","nTrkSolidConeDR04: Endcap ", 20,0., 20) ;
+
+
+  //  Infos from Particle Flow - isolation and ID
+  histname = "chargedHadIso";
+  h_chHadIso_miniAOD_[0]=  iBooker.book1D(histname+"All_miniAOD",   "PF chargedHadIso:  All Ecal",etBin,etMin,20.);
+  h_chHadIso_miniAOD_[1]=  iBooker.book1D(histname+"Barrel_miniAOD",   "PF chargedHadIso:  Barrel",etBin,etMin,20.);
+  h_chHadIso_miniAOD_[2]=  iBooker.book1D(histname+"Endcap_miniAOD",   "PF chargedHadIso:  Endcap",etBin,etMin,20.);
+  histname = "neutralHadIso";
+  h_nHadIso_miniAOD_[0]=  iBooker.book1D(histname+"All_miniAOD",   "PF neutralHadIso:  All Ecal",etBin,etMin,20.);
+  h_nHadIso_miniAOD_[1]=  iBooker.book1D(histname+"Barrel_miniAOD",   "PF neutralHadIso:  Barrel",etBin,etMin,20.);
+  h_nHadIso_miniAOD_[2]=  iBooker.book1D(histname+"Endcap_miniAOD",   "PF neutralHadIso:  Endcap",etBin,etMin,20.);
+  histname = "photonIso";
+  h_phoIso_miniAOD_[0]=  iBooker.book1D(histname+"All_miniAOD",   "PF photonIso:  All Ecal",etBin,etMin,20.);
+  h_phoIso_miniAOD_[1]=  iBooker.book1D(histname+"Barrel_miniAOD",   "PF photonIso:  Barrel",etBin,etMin,20.);
+  h_phoIso_miniAOD_[2]=  iBooker.book1D(histname+"Endcap_miniAOD",   "PF photonIso:  Endcap",etBin,etMin,20.);
+
   iBooker.setCurrentFolder("EgammaV/"+fName_+"/ConversionInfo");
   
   
@@ -1762,6 +1862,11 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
   e.getByToken(hepMC_Token_, hepMC);
   const HepMC::GenEvent *myGenEvent = hepMC->GetEvent();
 
+  Handle<reco::GenParticleCollection> genParticles;
+  e.getByToken( genpartToken_, genParticles );
+
+    
+
 
   // get generated jets
   Handle<reco::GenJetCollection> GenJetsHandle ;
@@ -2080,6 +2185,7 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       mcConvEta_= (*mcPho).vertex().eta();
       mcConvPhi_= (*mcPho).vertex().phi();
 
+
       if ( fabs(mcEta_) > END_HI ) continue;
 
 
@@ -2216,6 +2322,8 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
       if ( ! matched) continue;
 
+
+
       bool  phoIsInBarrel=false;
       bool  phoIsInEndcap=false;
       bool  phoIsInEndcapP=false;
@@ -2264,13 +2372,16 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       const EcalRecHitCollection ecalRecHitCollection = *(ecalRecHitHandle.product());
       float photonE = matchingPho->energy();
       float sigmaEoE =  matchingPho->getCorrectedEnergyError(matchingPho->getCandidateP4type())/matchingPho->energy();
-      float photonEt= matchingPho->energy()/cosh( matchingPho->eta()) ;
+      //float photonEt= matchingPho->energy()/cosh( matchingPho->eta()) ;
+      float photonEt= matchingPho->pt();
       float photonERegr1 = matchingPho->getCorrectedEnergy(reco::Photon::regression1);
       float photonERegr2 = matchingPho->getCorrectedEnergy(reco::Photon::regression2);
       float r9 = matchingPho->r9();
+      //     float full5x5_r9 = matchingPho->full5x5_r9();
       float r1 = matchingPho->r1x5();
       float r2 = matchingPho->r2x5();
       float sigmaIetaIeta =  matchingPho->sigmaIetaIeta();
+      //float full5x5_sieie =  matchingPho->full5x5_sigmaIetaIeta();
       float hOverE = matchingPho->hadronicOverEm();
       float newhOverE = matchingPho->hadTowOverEm();
       float ecalIso = matchingPho->ecalRecHitSumEtConeDR04();
@@ -2285,6 +2396,10 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       float etOutsideMustache = matchingPho->etOutsideMustache();
       int   nClusterOutsideMustache = matchingPho->nClusterOutsideMustache();
       float pfMVA = matchingPho->pfMVA();
+
+
+
+
 
       std::vector< std::pair<DetId, float> >::const_iterator rhIt;
       bool atLeastOneDeadChannel=false;
@@ -3752,6 +3867,182 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       } // end loop over conversions
     } // if !fastSim
   } // end loop over sim jets
+
+  /////// separate loop to compare with miniAOD
+  for ( reco::GenParticleCollection::const_iterator mcIter=genParticles->begin() ; mcIter!=genParticles->end() ; mcIter++ ) {
+    if ( !(mcIter->pdgId() == 22 ) ) continue;
+    if ( !(mcIter->mother()->pdgId()==25) ) continue;
+    if ( fabs(mcIter->eta()) > 2.5 ) continue;
+     
+    float mcPhi= mcIter->phi();
+    float mcEta= mcIter->eta();
+    //mcEta = etaTransformation(mcEta, (*mcPho).primaryVertex().z() );
+    float mcEnergy=mcIter->energy();
+    
+    
+    double dR = 9999999.;
+    float minDr=10000.;
+    int iMatch=-1;
+    bool matched=false;
+    
+    for(unsigned int ipho=0; ipho < photonHandle->size(); ipho++) {
+      reco::PhotonRef pho(reco::PhotonRef(photonHandle, ipho));
+      
+      double dphi = pho->phi()-mcPhi;
+      if (std::fabs(dphi)>CLHEP::pi)
+	{ dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
+      double deta = pho->superCluster()->position().eta()-mcEta;
+      
+      dR = sqrt(pow((deta),2) + pow(dphi,2));
+      if ( dR<0.1 && dR< minDr ) {
+	minDr=dR;
+	iMatch=ipho;
+      }
+    }
+    
+    
+    if ( iMatch >-1)  matched=true;
+    if ( ! matched) continue;
+    
+   
+    reco::PhotonRef matchingPho(reco::PhotonRef(photonHandle, iMatch));
+    
+    bool  phoIsInBarrel=false;
+    bool  phoIsInEndcap=false;
+    
+    float phoEta =  matchingPho->superCluster()->position().eta();  
+    if ( fabs(phoEta) < 1.479) {
+      phoIsInBarrel=true;
+    } else {
+      phoIsInEndcap=true;
+    }	  
+    
+    
+    
+    float photonE = matchingPho->energy();
+    float sigmaEoE =  matchingPho->getCorrectedEnergyError(matchingPho->getCandidateP4type())/matchingPho->energy();
+    float photonEt= matchingPho->energy()/cosh( matchingPho->eta()) ;
+    //	float photonERegr1 = matchingPho->getCorrectedEnergy(reco::Photon::regression1);
+    //float photonERegr2 = matchingPho->getCorrectedEnergy(reco::Photon::regression2);
+    float r9 = matchingPho->r9();
+    float full5x5_r9 = matchingPho->full5x5_r9();
+    float r1 = matchingPho->r1x5();
+    float r2 = matchingPho->r2x5();
+    float sigmaIetaIeta =  matchingPho->sigmaIetaIeta();
+    float full5x5_sieie =  matchingPho->full5x5_sigmaIetaIeta();
+    float hOverE = matchingPho->hadronicOverEm();
+    float newhOverE = matchingPho->hadTowOverEm();
+    float ecalIso = matchingPho->ecalRecHitSumEtConeDR04();
+    float hcalIso = matchingPho->hcalTowerSumEtConeDR04();
+    float newhcalIso = matchingPho->hcalTowerSumEtBcConeDR04();
+    float trkIso =  matchingPho->trkSumPtSolidConeDR04();
+    float nIsoTrk   =  matchingPho->nTrkSolidConeDR04();
+    // PF related quantities
+    float chargedHadIso =  matchingPho->chargedHadronIso();
+    float neutralHadIso =  matchingPho->neutralHadronIso();
+    float photonIso     =  matchingPho->photonIso();
+    //	float etOutsideMustache = matchingPho->etOutsideMustache();
+    //	int   nClusterOutsideMustache = matchingPho->nClusterOutsideMustache();
+    //float pfMVA = matchingPho->pfMVA();
+    
+    if ( ( photonEt > 14 &&   newhOverE <0.15 )    ||  ( photonEt > 10 && photonEt < 14 && chargedHadIso <10  ) ) {
+      
+      
+      
+      if ( fName_ != "pfPhotonValidator" ) std::cout << " pfPhotonValidator sim pho pt " <<  mcIter->pt() << " reco pho pt " << photonEt << std::endl;
+      
+      
+      h_scEta_miniAOD_[0]->Fill( matchingPho->superCluster()->eta() );
+      h_scPhi_miniAOD_[0]->Fill( matchingPho->superCluster()->phi() );
+      
+      h_phoE_miniAOD_[0][0]->Fill( photonE );
+      h_phoEt_miniAOD_[0][0]->Fill( photonEt);
+      
+      h_phoERes_miniAOD_[0][0]->Fill( photonE / mcEnergy );
+      h_phoSigmaEoE_miniAOD_[0][0] -> Fill (sigmaEoE);
+      
+      
+      h_r9_miniAOD_[0][0]->Fill( r9 );
+      h_full5x5_r9_miniAOD_[0][0]->Fill( full5x5_r9 );
+      h_r1_miniAOD_[0][0]->Fill( r1 );
+      h_r2_miniAOD_[0][0]->Fill( r2 );
+      
+      h_sigmaIetaIeta_miniAOD_[0][0]->Fill(sigmaIetaIeta);
+      h_full5x5_sigmaIetaIeta_miniAOD_[0][0]->Fill(full5x5_sieie);
+      h_hOverE_miniAOD_[0][0]->Fill( hOverE );
+      h_newhOverE_miniAOD_[0][0]->Fill( newhOverE );
+      
+      h_ecalRecHitSumEtConeDR04_miniAOD_[0][0]->Fill( ecalIso );
+      h_hcalTowerSumEtConeDR04_miniAOD_[0][0]->Fill( hcalIso );
+      h_hcalTowerBcSumEtConeDR04_miniAOD_[0][0]->Fill( newhcalIso );
+      h_isoTrkSolidConeDR04_miniAOD_[0][0]->Fill( trkIso );
+      h_nTrkSolidConeDR04_miniAOD_[0][0]->Fill( nIsoTrk );
+      
+      //
+      h_chHadIso_miniAOD_[0]-> Fill (chargedHadIso);
+      h_nHadIso_miniAOD_[0]-> Fill (neutralHadIso);
+      h_phoIso_miniAOD_[0]-> Fill (photonIso);
+      
+      //
+      if ( phoIsInBarrel ) {
+	h_phoE_miniAOD_[0][1]->Fill( photonE );
+	h_phoEt_miniAOD_[0][1]->Fill( photonEt);
+	
+	h_phoERes_miniAOD_[0][1]->Fill( photonE / mcEnergy );
+	h_phoSigmaEoE_miniAOD_[0][1] -> Fill (sigmaEoE);
+	    
+	h_r9_miniAOD_[0][1]->Fill( r9 );
+	h_full5x5_r9_miniAOD_[0][1]->Fill( full5x5_r9 );
+	h_r1_miniAOD_[0][1]->Fill( r1 );
+	h_r2_miniAOD_[0][1]->Fill( r2 );
+	h_sigmaIetaIeta_miniAOD_[0][1]->Fill(sigmaIetaIeta);
+	h_full5x5_sigmaIetaIeta_miniAOD_[0][1]->Fill(full5x5_sieie);
+	h_hOverE_miniAOD_[0][1]->Fill( hOverE );
+	h_newhOverE_miniAOD_[0][1]->Fill( newhOverE );
+	h_ecalRecHitSumEtConeDR04_miniAOD_[0][1]->Fill( ecalIso );
+	h_hcalTowerSumEtConeDR04_miniAOD_[0][1]->Fill( hcalIso );
+	h_hcalTowerBcSumEtConeDR04_miniAOD_[0][1]->Fill( newhcalIso );
+	h_isoTrkSolidConeDR04_miniAOD_[0][1]->Fill( trkIso );
+	h_nTrkSolidConeDR04_miniAOD_[0][1]->Fill( nIsoTrk );
+	h_chHadIso_miniAOD_[1]-> Fill (chargedHadIso);
+	h_nHadIso_miniAOD_[1]-> Fill (neutralHadIso);
+	h_phoIso_miniAOD_[1]-> Fill (photonIso);
+	
+      }
+      if ( phoIsInEndcap ) {
+	h_phoE_miniAOD_[0][2]->Fill( photonE );
+	h_phoEt_miniAOD_[0][2]->Fill( photonEt);
+	
+	h_phoERes_miniAOD_[0][2]->Fill( photonE / mcEnergy);
+	h_phoSigmaEoE_miniAOD_[0][2] -> Fill (sigmaEoE);
+	h_r9_miniAOD_[0][2]->Fill( r9 );
+	h_full5x5_r9_miniAOD_[0][2]->Fill( full5x5_r9 );
+	h_r1_miniAOD_[0][2]->Fill( r1 );
+	h_r2_miniAOD_[0][2]->Fill( r2 );
+	h_sigmaIetaIeta_miniAOD_[0][2]->Fill(sigmaIetaIeta);
+	h_full5x5_sigmaIetaIeta_miniAOD_[0][2]->Fill(full5x5_sieie);
+	h_hOverE_miniAOD_[0][2]->Fill( hOverE );
+	h_newhOverE_miniAOD_[0][2]->Fill( newhOverE );
+	h_ecalRecHitSumEtConeDR04_miniAOD_[0][2]->Fill( ecalIso );
+	h_hcalTowerSumEtConeDR04_miniAOD_[0][2]->Fill( hcalIso );
+	h_hcalTowerBcSumEtConeDR04_miniAOD_[0][2]->Fill( newhcalIso );
+	h_isoTrkSolidConeDR04_miniAOD_[0][2]->Fill( trkIso );
+	h_nTrkSolidConeDR04_miniAOD_[0][2]->Fill( nIsoTrk );
+	h_chHadIso_miniAOD_[2]-> Fill (chargedHadIso);
+	h_nHadIso_miniAOD_[2]-> Fill (neutralHadIso);
+	h_phoIso_miniAOD_[2]-> Fill (photonIso);
+	
+      }
+    } // end histos for comparing with miniAOD
+    
+
+
+
+
+    } // end loop over gen photons
+
+
+
 
   h_nPho_->Fill(float(nPho));
 

--- a/Validation/RecoEgamma/plugins/PhotonValidator.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.h
@@ -23,6 +23,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 //#include "RecoEgamma/EgammaTools/interface/ConversionLikelihoodCalculator.h"
 //
 //DQM services
@@ -109,7 +110,7 @@ class PhotonValidator : public DQMEDAnalyzer
   edm::EDGetTokenT<reco::VertexCollection> offline_pvToken_;
   edm::InputTag  bcBarrelCollection_;
   edm::InputTag  bcEndcapCollection_;
-
+  edm::EDGetTokenT<reco::GenParticleCollection> genpartToken_;
 
   edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHits_;
   edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHits_;
@@ -371,6 +372,37 @@ class PhotonValidator : public DQMEDAnalyzer
   MonitorElement* h_SumPtOverPhoPt_ChHad_unCleaned_[3];
   MonitorElement* h_SumPtOverPhoPt_NeuHad_unCleaned_[3];
   MonitorElement* h_SumPtOverPhoPt_Pho_unCleaned_[3];
+
+  /// Histos for comparison with miniAOD content
+  MonitorElement* h_scEta_miniAOD_[2];
+  MonitorElement* h_scPhi_miniAOD_[2];
+
+  MonitorElement* h_r9_miniAOD_[3][3];
+  MonitorElement* h_full5x5_r9_miniAOD_[3][3];
+  MonitorElement* h_sigmaIetaIeta_miniAOD_[3][3];
+  MonitorElement* h_full5x5_sigmaIetaIeta_miniAOD_[3][3];
+  MonitorElement* h_r1_miniAOD_[3][3];
+  MonitorElement* h_r2_miniAOD_[3][3];
+  MonitorElement* h_hOverE_miniAOD_[3][3];
+  MonitorElement* h_newhOverE_miniAOD_[3][3];
+  MonitorElement* h_ecalRecHitSumEtConeDR04_miniAOD_[3][3];
+  MonitorElement* h_hcalTowerSumEtConeDR04_miniAOD_[3][3];
+  MonitorElement* h_hcalTowerBcSumEtConeDR04_miniAOD_[3][3];
+  MonitorElement* h_isoTrkSolidConeDR04_miniAOD_[3][3];
+  MonitorElement* h_nTrkSolidConeDR04_miniAOD_[3][3];
+
+  MonitorElement* h_phoE_miniAOD_[2][3];
+  MonitorElement* h_phoEt_miniAOD_[2][3];
+  MonitorElement* h_phoERes_miniAOD_[3][3];
+  MonitorElement* h_phoSigmaEoE_miniAOD_[3][3];
+
+  // Information from Particle Flow
+  // Isolation
+  MonitorElement* h_chHadIso_miniAOD_[3];
+  MonitorElement* h_nHadIso_miniAOD_[3];
+  MonitorElement* h_phoIso_miniAOD_[3];
+
+
 
 
   /// info per conversion

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
@@ -1,0 +1,377 @@
+#include <memory>
+#include "Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h"
+//
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+//#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ptr.h"
+//#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+//#include "DataFormats/EgammaCandidates/interface/PhotonCore.h"
+//#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TH1F.h"
+#include "TH2F.h"
+
+
+// **********************************************************************
+
+PhotonValidatorMiniAOD::PhotonValidatorMiniAOD( const edm::ParameterSet &iConfig ):
+    outputFileName_( iConfig.getParameter<std::string>( "outputFileName" ) ),
+    photonToken_( consumes<edm::View<pat::Photon> >( iConfig.getUntrackedParameter<edm::InputTag> ( "PhotonTag", edm::InputTag( "slimmedPhotons" ) ) ) ),
+    genpartToken_( consumes<reco::GenParticleCollection>( iConfig.getUntrackedParameter<edm::InputTag> ( "genpartTag", edm::InputTag( "prunedGenParticles" ) ) ) )
+
+{
+  parameters_ = iConfig;
+
+}
+
+
+PhotonValidatorMiniAOD::~PhotonValidatorMiniAOD() {}
+
+
+void PhotonValidatorMiniAOD::bookHistograms( DQMStore::IBooker & iBooker, edm::Run const & run, edm::EventSetup const & es)  {
+
+
+  double eMin = parameters_.getParameter<double>("eMin");
+  double eMax = parameters_.getParameter<double>("eMax");
+  int eBin = parameters_.getParameter<int>("eBin");
+
+  std::cout << "  PhotonValidatorMiniAOD::bookHistogram eMin " << eMin << std::endl;
+
+  double etMin = parameters_.getParameter<double>("etMin");
+  double etMax = parameters_.getParameter<double>("etMax");
+  int etBin = parameters_.getParameter<int>("etBin");
+
+  double resMin = parameters_.getParameter<double>("resMin");
+  double resMax = parameters_.getParameter<double>("resMax");
+  int resBin = parameters_.getParameter<int>("resBin");
+
+  double etaMin = parameters_.getParameter<double>("etaMin");
+  double etaMax = parameters_.getParameter<double>("etaMax");
+  int etaBin = parameters_.getParameter<int>("etaBin");
+ 
+  double phiMin = parameters_.getParameter<double>("phiMin");
+  double phiMax = parameters_.getParameter<double>("phiMax");
+  int    phiBin = parameters_.getParameter<int>("phiBin");
+
+  
+  double r9Min = parameters_.getParameter<double>("r9Min");
+  double r9Max = parameters_.getParameter<double>("r9Max");
+  int r9Bin = parameters_.getParameter<int>("r9Bin");
+
+
+  iBooker.setCurrentFolder("EgammaV/PhotonValidatorMiniAOD/Photons");
+
+  h_scEta_[0] =   iBooker.book1D("scEta_miniAOD"," SC Eta ",etaBin,etaMin, etaMax);
+  h_scPhi_[0] =   iBooker.book1D("scPhi_miniAOD"," SC Phi ",phiBin,phiMin,phiMax);
+
+  std::string histname = " ";
+
+  histname = "phoE";
+  h_phoE_[0][0]=iBooker.book1D(histname+"All_miniAOD"," Photon Energy: All ecal ", eBin,eMin, eMax);
+  h_phoE_[0][1]=iBooker.book1D(histname+"Barrel_miniAOD"," Photon Energy: barrel ",eBin,eMin, eMax);
+  h_phoE_[0][2]=iBooker.book1D(histname+"Endcap_miniAOD"," Photon Energy: Endcap ",eBin,eMin, eMax);
+  
+  histname = "phoEt";
+  h_phoEt_[0][0] = iBooker.book1D(histname+"All_miniAOD"," Photon Transverse Energy: All ecal ", etBin,etMin, etMax);
+  h_phoEt_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," Photon Transverse Energy: Barrel ",etBin,etMin, etMax);
+  h_phoEt_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," Photon Transverse Energy: Endcap ",etBin,etMin, etMax);
+  
+  
+  histname = "eRes";
+  h_phoERes_[0][0] = iBooker.book1D(histname+"All_miniAOD"," Photon E/E_{true}: All ecal;  E/E_{true} (GeV)", resBin,resMin, resMax);
+  h_phoERes_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","Photon E/E_{true}: Barrel; E/E_{true} (GeV)",resBin,resMin, resMax);
+  h_phoERes_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," Photon E/E_{true}: Endcap; E/E_{true} (GeV)",resBin,resMin, resMax);
+
+  histname = "sigmaEoE";
+  h_phoSigmaEoE_[0][0] = iBooker.book1D(histname+"All_miniAOD","#sigma_{E}/E: All ecal; #sigma_{E}/E", 100,0., 0.08);
+  h_phoSigmaEoE_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","#sigma_{E}/E: Barrel; #sigma_{E}/E",100,0., 0.08);
+  h_phoSigmaEoE_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","#sigma_{E}/E: Endcap, #sigma_{E}/E",100,0., 0.08);
+
+
+  histname = "r9";
+  h_r9_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " r9: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_r9_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," r9: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_r9_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," r9: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "full5x5_r9";
+  h_full5x5_r9_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " r9: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_full5x5_r9_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," r9: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_full5x5_r9_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," r9: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "r1";
+  h_r1_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " e1x5/e5x5: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_r1_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," e1x5/e5x5: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_r1_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," e1x5/e5x5: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "r2";
+  h_r2_[0][0] = iBooker.book1D(histname+"All_miniAOD",   " e2x5/e5x5: All Ecal",r9Bin,r9Min, r9Max) ;
+  h_r2_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD"," e2x5/e5x5: Barrel ",r9Bin,r9Min, r9Max) ;
+  h_r2_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD"," e2x5/e5x5: Endcap ",r9Bin,r9Min, r9Max) ;
+  histname = "hOverE";
+  h_hOverE_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "H/E: All Ecal",100,0., 0.2) ;
+  h_hOverE_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","H/E: Barrel ", 100,0., 0.2) ;
+  h_hOverE_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","H/E: Endcap ", 100,0., 0.2) ;
+  //
+  histname = "newhOverE";
+  h_newhOverE_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "new H/E: All Ecal",100,0., 0.2) ;
+  h_newhOverE_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","new H/E: Barrel ", 100,0., 0.2) ;
+  h_newhOverE_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","new H/E: Endcap ", 100,0., 0.2) ;
+  //
+  histname = "sigmaIetaIeta";
+  h_sigmaIetaIeta_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "sigmaIetaIeta: All Ecal",100,0., 0.1) ;
+  h_sigmaIetaIeta_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","sigmaIetaIeta: Barrel ", 100,0., 0.05) ;
+  h_sigmaIetaIeta_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","sigmaIetaIeta: Endcap ", 100,0., 0.1) ;
+  histname = "full5x5_sigmaIetaIeta";
+  h_full5x5_sigmaIetaIeta_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "Full5x5 sigmaIetaIeta: All Ecal",100,0., 0.1) ;
+  h_full5x5_sigmaIetaIeta_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","Full5x5 sigmaIetaIeta: Barrel ", 100,0., 0.05) ;
+  h_full5x5_sigmaIetaIeta_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","Full5x5 sigmaIetaIeta: Endcap ", 100,0., 0.1) ;
+  //
+  histname = "ecalRecHitSumEtConeDR04";
+  h_ecalRecHitSumEtConeDR04_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "ecalRecHitSumEtDR04: All Ecal",etBin,etMin,20.);
+  h_ecalRecHitSumEtConeDR04_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","ecalRecHitSumEtDR04: Barrel ", etBin,etMin,20.);
+  h_ecalRecHitSumEtConeDR04_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","ecalRecHitSumEtDR04: Endcap ", etBin,etMin,20.);
+  histname = "hcalTowerSumEtConeDR04";
+  h_hcalTowerSumEtConeDR04_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "hcalTowerSumEtConeDR04: All Ecal",etBin,etMin,20.);
+  h_hcalTowerSumEtConeDR04_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","hcalTowerSumEtConeDR04: Barrel ", etBin,etMin,20.);
+  h_hcalTowerSumEtConeDR04_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","hcalTowerSumEtConeDR04: Endcap ", etBin,etMin,20.);
+  //
+  histname = "hcalTowerBcSumEtConeDR04";
+  h_hcalTowerBcSumEtConeDR04_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "hcalTowerBcSumEtConeDR04: All Ecal",etBin,etMin,20.);
+  h_hcalTowerBcSumEtConeDR04_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","hcalTowerBcSumEtConeDR04: Barrel ", etBin,etMin,20.);
+  h_hcalTowerBcSumEtConeDR04_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","hcalTowerBcSumEtConeDR04: Endcap ", etBin,etMin,20.);
+  histname = "isoTrkSolidConeDR04";
+  h_isoTrkSolidConeDR04_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "isoTrkSolidConeDR04: All Ecal",etBin,etMin,etMax*0.1);
+  h_isoTrkSolidConeDR04_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","isoTrkSolidConeDR04: Barrel ", etBin,etMin,etMax*0.1);
+  h_isoTrkSolidConeDR04_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","isoTrkSolidConeDR04: Endcap ", etBin,etMin,etMax*0.1);
+  histname = "nTrkSolidConeDR04";
+  h_nTrkSolidConeDR04_[0][0] = iBooker.book1D(histname+"All_miniAOD",   "nTrkSolidConeDR04: All Ecal",20,0., 20) ;
+  h_nTrkSolidConeDR04_[0][1] = iBooker.book1D(histname+"Barrel_miniAOD","nTrkSolidConeDR04: Barrel ", 20,0., 20) ;
+  h_nTrkSolidConeDR04_[0][2] = iBooker.book1D(histname+"Endcap_miniAOD","nTrkSolidConeDR04: Endcap ", 20,0., 20) ;
+
+
+  //  Infos from Particle Flow - isolation and ID
+  histname = "chargedHadIso";
+  h_chHadIso_[0]=  iBooker.book1D(histname+"All_miniAOD",   "PF chargedHadIso:  All Ecal",etBin,etMin,20.);
+  h_chHadIso_[1]=  iBooker.book1D(histname+"Barrel_miniAOD",   "PF chargedHadIso:  Barrel",etBin,etMin,20.);
+  h_chHadIso_[2]=  iBooker.book1D(histname+"Endcap_miniAOD",   "PF chargedHadIso:  Endcap",etBin,etMin,20.);
+  histname = "neutralHadIso";
+  h_nHadIso_[0]=  iBooker.book1D(histname+"All_miniAOD",   "PF neutralHadIso:  All Ecal",etBin,etMin,20.);
+  h_nHadIso_[1]=  iBooker.book1D(histname+"Barrel_miniAOD",   "PF neutralHadIso:  Barrel",etBin,etMin,20.);
+  h_nHadIso_[2]=  iBooker.book1D(histname+"Endcap_miniAOD",   "PF neutralHadIso:  Endcap",etBin,etMin,20.);
+  histname = "photonIso";
+  h_phoIso_[0]=  iBooker.book1D(histname+"All_miniAOD",   "PF photonIso:  All Ecal",etBin,etMin,20.);
+  h_phoIso_[1]=  iBooker.book1D(histname+"Barrel_miniAOD",   "PF photonIso:  Barrel",etBin,etMin,20.);
+  h_phoIso_[2]=  iBooker.book1D(histname+"Endcap_miniAOD",   "PF photonIso:  Endcap",etBin,etMin,20.);
+
+
+
+}
+
+void  PhotonValidatorMiniAOD::endRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {}
+
+
+void
+PhotonValidatorMiniAOD::analyze( const edm::Event &iEvent, const edm::EventSetup &iSetup )
+{
+
+    // ********************************************************************************
+    using namespace edm;
+
+    // access edm objects
+    Handle<View<pat::Photon> > photonsHandle;
+    iEvent.getByToken( photonToken_, photonsHandle );
+    const auto &photons = *photonsHandle;  
+    //
+    Handle<reco::GenParticleCollection> genParticles;
+    iEvent.getByToken( genpartToken_, genParticles );
+
+    
+
+    for ( reco::GenParticleCollection::const_iterator mcIter=genParticles->begin() ; mcIter!=genParticles->end() ; mcIter++ ) {
+        if ( !(mcIter->pdgId() == 22 ) ) continue;
+        if ( !(mcIter->mother()->pdgId()==25) ) continue;
+        if ( fabs(mcIter->eta()) > 2.5 ) continue;
+	//       if ( mcIter->pt() < 5) continue;
+        //        if ( fabs(mcIter->eta()) > 1.4442 && fabs(mcIter->eta()) < 1.566) continue;
+ 
+
+        float mcPhi= mcIter->phi();
+        float mcEta= mcIter->eta();
+        //mcEta = etaTransformation(mcEta, (*mcPho).primaryVertex().z() );
+        float mcEnergy=mcIter->energy();
+
+
+
+
+        double dR = 9999999.;
+        float minDr=10000.;
+        int iMatch=-1;
+	bool matched=false;
+        for( size_t ipho = 0; ipho < photons.size(); ipho++ ) {
+            Ptr<pat::Photon> pho = photons.ptrAt( ipho );
+
+            
+            double dphi = pho->phi()-mcPhi;
+            if (std::fabs(dphi)>CLHEP::pi)
+                { dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
+            double deta = pho->superCluster()->position().eta()-mcEta;
+
+            dR = sqrt(pow((deta),2) + pow(dphi,2));
+	    if ( dR<0.1 && dR< minDr ) {
+	      minDr=dR;
+	      iMatch=ipho;
+	    }
+	}
+
+
+        if ( iMatch >-1)  matched=true;
+	if ( ! matched) continue;
+
+	Ptr<pat::Photon> matchingPho = photons.ptrAt( iMatch );
+
+	bool  phoIsInBarrel=false;
+	bool  phoIsInEndcap=false;
+      
+        float phoEta =  matchingPho->superCluster()->position().eta();  
+        if ( fabs(phoEta) < 1.479) {
+	  phoIsInBarrel=true;
+	} else {
+	  phoIsInEndcap=true;
+	}	  
+	
+
+	
+	float photonE = matchingPho->energy();
+	float sigmaEoE =  matchingPho->getCorrectedEnergyError(matchingPho->getCandidateP4type())/matchingPho->energy();
+	float photonEt= matchingPho->energy()/cosh( matchingPho->eta()) ;
+	//	float photonERegr1 = matchingPho->getCorrectedEnergy(reco::Photon::regression1);
+	//float photonERegr2 = matchingPho->getCorrectedEnergy(reco::Photon::regression2);
+	float r9 = matchingPho->r9();
+	float full5x5_r9 = matchingPho->full5x5_r9();
+	float r1 = matchingPho->r1x5();
+	float r2 = matchingPho->r2x5();
+	float sieie =  matchingPho->sigmaIetaIeta();
+	float full5x5_sieie =  matchingPho->full5x5_sigmaIetaIeta();
+	float hOverE = matchingPho->hadronicOverEm();
+	float newhOverE = matchingPho->hadTowOverEm();
+	float ecalIso = matchingPho->ecalRecHitSumEtConeDR04();
+	float hcalIso = matchingPho->hcalTowerSumEtConeDR04();
+	float newhcalIso = matchingPho->hcalTowerSumEtBcConeDR04();
+	float trkIso =  matchingPho->trkSumPtSolidConeDR04();
+	float nIsoTrk   =  matchingPho->nTrkSolidConeDR04();
+	// PF related quantities
+	float chargedHadIso =  matchingPho->chargedHadronIso();
+	float neutralHadIso =  matchingPho->neutralHadronIso();
+	float photonIso     =  matchingPho->photonIso();
+	//	float etOutsideMustache = matchingPho->etOutsideMustache();
+	//	int   nClusterOutsideMustache = matchingPho->nClusterOutsideMustache();
+	//float pfMVA = matchingPho->pfMVA();
+
+
+	h_scEta_[0]->Fill( matchingPho->superCluster()->eta() );
+	h_scPhi_[0]->Fill( matchingPho->superCluster()->phi() );
+
+	h_phoE_[0][0]->Fill( photonE );
+	h_phoEt_[0][0]->Fill( photonEt);
+	
+	h_phoERes_[0][0]->Fill( photonE / mcEnergy );
+	h_phoSigmaEoE_[0][0] -> Fill (sigmaEoE);
+
+
+	h_r9_[0][0]->Fill( r9 );
+	h_full5x5_r9_[0][0]->Fill( full5x5_r9 );
+	h_r1_[0][0]->Fill( r1 );
+	h_r2_[0][0]->Fill( r2 );
+
+ 	h_sigmaIetaIeta_[0][0]->Fill(sieie);
+	h_full5x5_sigmaIetaIeta_[0][0]->Fill(full5x5_sieie);
+	h_hOverE_[0][0]->Fill( hOverE );
+	h_newhOverE_[0][0]->Fill( newhOverE );
+
+	h_ecalRecHitSumEtConeDR04_[0][0]->Fill( ecalIso );
+	h_hcalTowerSumEtConeDR04_[0][0]->Fill( hcalIso );
+	h_hcalTowerBcSumEtConeDR04_[0][0]->Fill( newhcalIso );
+	h_isoTrkSolidConeDR04_[0][0]->Fill( trkIso );
+	h_nTrkSolidConeDR04_[0][0]->Fill( nIsoTrk );
+
+	//
+	h_chHadIso_[0]-> Fill (chargedHadIso);
+	h_nHadIso_[0]-> Fill (neutralHadIso);
+	h_phoIso_[0]-> Fill (photonIso);
+      
+//
+        if ( phoIsInBarrel ) {
+	  h_phoE_[0][1]->Fill( photonE );
+	  h_phoEt_[0][1]->Fill( photonEt);
+	  h_phoERes_[0][1]->Fill( photonE / mcEnergy );
+	  h_phoSigmaEoE_[0][1] -> Fill (sigmaEoE);
+
+	  h_r9_[0][1]->Fill( r9 );
+	  h_full5x5_r9_[0][1]->Fill( full5x5_r9 );
+	  h_r1_[0][1]->Fill( r1 );
+	  h_r2_[0][1]->Fill( r2 );
+	  h_sigmaIetaIeta_[0][1]->Fill(sieie);
+	  h_full5x5_sigmaIetaIeta_[0][1]->Fill(full5x5_sieie);
+	  h_hOverE_[0][1]->Fill( hOverE );
+	  h_newhOverE_[0][1]->Fill( newhOverE );
+	  h_ecalRecHitSumEtConeDR04_[0][1]->Fill( ecalIso );
+	  h_hcalTowerSumEtConeDR04_[0][1]->Fill( hcalIso );
+	  h_hcalTowerBcSumEtConeDR04_[0][1]->Fill( newhcalIso );
+	  h_isoTrkSolidConeDR04_[0][1]->Fill( trkIso );
+	  h_nTrkSolidConeDR04_[0][1]->Fill( nIsoTrk );
+	  h_chHadIso_[1]-> Fill (chargedHadIso);
+	  h_nHadIso_[1]-> Fill (neutralHadIso);
+	  h_phoIso_[1]-> Fill (photonIso);
+
+	}
+        if ( phoIsInEndcap ) {
+
+
+	  h_phoE_[0][2]->Fill( photonE );
+	  h_phoEt_[0][2]->Fill( photonEt);
+
+	  h_phoERes_[0][2]->Fill( photonE / mcEnergy);
+	  h_phoSigmaEoE_[0][2] -> Fill (sigmaEoE);
+	  h_r9_[0][2]->Fill( r9 );
+	  h_full5x5_r9_[0][2]->Fill( full5x5_r9 );
+	  h_r1_[0][2]->Fill( r1 );
+	  h_r2_[0][2]->Fill( r2 );
+	  h_sigmaIetaIeta_[0][2]->Fill(sieie);
+	  h_full5x5_sigmaIetaIeta_[0][2]->Fill(full5x5_sieie);
+	  h_hOverE_[0][2]->Fill( hOverE );
+	  h_newhOverE_[0][2]->Fill( newhOverE );
+	  h_ecalRecHitSumEtConeDR04_[0][2]->Fill( ecalIso );
+	  h_hcalTowerSumEtConeDR04_[0][2]->Fill( hcalIso );
+	  h_hcalTowerBcSumEtConeDR04_[0][2]->Fill( newhcalIso );
+	  h_isoTrkSolidConeDR04_[0][2]->Fill( trkIso );
+	  h_nTrkSolidConeDR04_[0][2]->Fill( nIsoTrk );
+	  h_chHadIso_[2]-> Fill (chargedHadIso);
+	  h_nHadIso_[2]-> Fill (neutralHadIso);
+	  h_phoIso_[2]-> Fill (photonIso);
+
+	}
+
+
+    } // end loop over gen photons
+
+
+}
+
+
+void  PhotonValidatorMiniAOD::dqmBeginRun (edm::Run const & r, edm::EventSetup const & theEventSetup) {}
+
+

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
@@ -52,8 +52,7 @@ void PhotonValidatorMiniAOD::bookHistograms( DQMStore::IBooker & iBooker, edm::R
   double eMax = parameters_.getParameter<double>("eMax");
   int eBin = parameters_.getParameter<int>("eBin");
 
-  std::cout << "  PhotonValidatorMiniAOD::bookHistogram eMin " << eMin << std::endl;
-
+  
   double etMin = parameters_.getParameter<double>("etMin");
   double etMax = parameters_.getParameter<double>("etMax");
   int etBin = parameters_.getParameter<int>("etBin");

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h
@@ -1,0 +1,128 @@
+#ifndef PhotonValidatorMiniAOD_H
+#define PhotonValidatorMiniAOD_H
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+//#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+//
+//DQM services
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+
+//
+#include <map>
+#include <vector>
+#include <memory>
+/** \class PhotonValidatorMiniAOD
+ **
+ **
+ **  $Id: PhotonValidatorMiniAOD
+ **  \author Nancy Marinelli, U. of Notre Dame, US
+ **
+ ***/
+
+
+// forward declarations
+namespace edm {class HepMCProduct;}
+class TFile;
+class TH1F;
+class TH2F;
+class TProfile;
+class TTree;
+class SimVertex;
+class SimTrack;
+
+
+
+class PhotonValidatorMiniAOD : public DQMEDAnalyzer
+{
+
+ public:
+
+  //
+  explicit PhotonValidatorMiniAOD( const edm::ParameterSet& ) ;
+  virtual ~PhotonValidatorMiniAOD();
+
+
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override;
+  //  virtual void beginJob();
+  virtual void dqmBeginRun( edm::Run const & r, edm::EventSetup const & theEventSetup) override;
+  virtual void endRun (edm::Run const& r, edm::EventSetup const & es) override;
+  void  bookHistograms( DQMStore::IBooker&, edm::Run const &, edm::EventSetup const &) override; 
+
+ private:
+
+  std::string outputFileName_;
+  edm::EDGetTokenT<edm::View<pat::Photon> > photonToken_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genpartToken_;
+
+
+  std::string fName_;
+
+  //  edm::ESHandle<MagneticField> theMF_;
+  edm::ParameterSet parameters_;
+  int verbosity_;
+
+  MonitorElement* h_scEta_[2];
+  MonitorElement* h_scPhi_[2];
+
+  MonitorElement* h_r9_[3][3];
+  MonitorElement* h_full5x5_r9_[3][3];
+  MonitorElement* h_sigmaIetaIeta_[3][3];
+  MonitorElement* h_full5x5_sigmaIetaIeta_[3][3];
+  MonitorElement* h_r1_[3][3];
+  MonitorElement* h_r2_[3][3];
+  MonitorElement* h_hOverE_[3][3];
+  MonitorElement* h_newhOverE_[3][3];
+  MonitorElement* h_ecalRecHitSumEtConeDR04_[3][3];
+  MonitorElement* h_hcalTowerSumEtConeDR04_[3][3];
+  MonitorElement* h_hcalTowerBcSumEtConeDR04_[3][3];
+  MonitorElement* h_isoTrkSolidConeDR04_[3][3];
+  MonitorElement* h_nTrkSolidConeDR04_[3][3];
+
+  MonitorElement* h_phoE_[2][3];
+  MonitorElement* h_phoEt_[2][3];
+  MonitorElement* h_phoERes_[3][3];
+  MonitorElement* h_phoSigmaEoE_[3][3];
+
+  // Information from Particle Flow
+  // Isolation
+  MonitorElement* h_chHadIso_[3];
+  MonitorElement* h_nHadIso_[3];
+  MonitorElement* h_phoIso_[3];
+
+
+
+
+class  sortPhotons
+{
+  public:
+    bool operator () (const pat::PhotonRef& lhs, const pat::PhotonRef & rhs)
+    {
+        return lhs->et() > rhs->et();
+    }
+};
+
+
+
+};
+
+
+
+
+
+
+
+#endif

--- a/Validation/RecoEgamma/plugins/SealModule.cc
+++ b/Validation/RecoEgamma/plugins/SealModule.cc
@@ -3,6 +3,7 @@
 
 #include "Validation/RecoEgamma/plugins/EgammaObjects.h"
 #include "Validation/RecoEgamma/plugins/PhotonValidator.h"
+#include "Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h"
 #include "Validation/RecoEgamma/plugins/TkConvValidator.h"
 #include "Validation/RecoEgamma/plugins/ConversionPostprocessing.h"
 #include "Validation/RecoEgamma/plugins/PhotonPostprocessing.h"
@@ -15,6 +16,7 @@
 
 DEFINE_FWK_MODULE(EgammaObjects);
 DEFINE_FWK_MODULE(PhotonValidator);
+DEFINE_FWK_MODULE(PhotonValidatorMiniAOD);
 DEFINE_FWK_MODULE(TkConvValidator);
 DEFINE_FWK_MODULE(PhotonPostprocessing);
 DEFINE_FWK_MODULE(ConversionPostprocessing);

--- a/Validation/RecoEgamma/python/photonMiniAODValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/photonMiniAODValidationSequence_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoEgamma.photonValidatorMiniAOD_cfi import *
+
+
+photonMiniAODValidationSequence = cms.Sequence(photonValidationMiniAOD)
+
+

--- a/Validation/RecoEgamma/python/photonValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/photonValidatorMiniAOD_cfi.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+photonValidationMiniAOD = cms.EDAnalyzer("PhotonValidatorMiniAOD",
+    ComponentName = cms.string('photonValidationMiniAOD'),
+    outputFileName  = cms.string("output.root"),
+    PhotonTag=cms.untracked.InputTag('slimmedPhotons'),
+    genpartTag=cms.untracked.InputTag('prunedGenParticles'),
+#
+    eBin = cms.int32(100),
+    eMin = cms.double(0.0),
+    eMax = cms.double(500.0),
+#
+    etBin = cms.int32(100),
+    etMax = cms.double(250.),
+    etMin = cms.double(0.0),
+#
+    etaBin = cms.int32(100),
+    etaMin = cms.double(-2.5),
+    etaMax = cms.double(2.5),
+#
+    phiBin = cms.int32(100),
+    phiMin = cms.double(-3.14),
+    phiMax = cms.double(3.14),
+#
+    r9Bin = cms.int32(200),
+    r9Min = cms.double(0.0),
+    r9Max = cms.double(1.1),
+#
+    resBin = cms.int32(100),
+    resMin = cms.double(0.7),
+    resMax = cms.double(1.2)
+#
+
+
+
+)
+
+

--- a/Validation/RecoEgamma/test/PhotonValidator_H130GGgluonfusion.py
+++ b/Validation/RecoEgamma/test/PhotonValidator_H130GGgluonfusion.py
@@ -1,11 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TestPhotonValidator")
-process.load('Configuration/StandardSequences/GeometryPilot2_cff')
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-process.load("RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
+#process.load("RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi")
+#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cfi")
 process.load("SimGeneral.MixingModule.mixNoPU_cfi")
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
@@ -13,8 +11,12 @@ process.load("DQMServices.Components.MEtoEDMConverter_cfi")
 process.load("Validation.RecoEgamma.photonValidationSequence_cff")
 process.load("Validation.RecoEgamma.photonPostprocessing_cfi")
 process.load("Validation.RecoEgamma.conversionPostprocessing_cfi")
+
+
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'START42_V6::All'
+process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_v1'
 
 process.DQMStore = cms.Service("DQMStore");
 process.load("DQMServices.Components.DQMStoreStats_cfi")
@@ -45,31 +47,8 @@ conversionPostprocessing.OuputFileName = tkConversionValidation.OutputFileName
 
 
 process.source = cms.Source("PoolSource",
-noEventSort = cms.untracked.bool(True),
-duplicateCheckMode = cms.untracked.string('noDuplicateCheck'),
-                            
 fileNames = cms.untracked.vstring(
-    '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-RECO/START42_V6-v2/0037/B0E38AE3-444F-E011-8D48-0026189438B1.root',
-    '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-RECO/START42_V6-v2/0032/E0BBE535-BD4E-E011-BFCA-003048678B0C.root',
-    '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-RECO/START42_V6-v2/0032/CA96F351-BA4E-E011-B702-00304867BEE4.root',
-    '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-RECO/START42_V6-v2/0032/4AA4406E-B44E-E011-BF87-00304867929E.root'
-
-
-    ),
-    secondaryFileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0033/6422E6B7-1D4F-E011-9913-002618FDA207.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/EEF45D5C-B44E-E011-9252-001A92811748.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/DA157FC9-B44E-E011-941A-003048678FE0.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/B8DB7DCC-B44E-E011-908B-002354EF3BDB.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/B6F92CB8-BC4E-E011-9DC5-003048678B72.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/A27AC74E-BA4E-E011-813D-001A92971BB4.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/A20609DA-BB4E-E011-803B-001A92810AE0.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/90FF6AF0-BB4E-E011-A3C2-0026189438E0.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/56C312DB-B34E-E011-956B-003048D3C010.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/4C8D35D6-B24E-E011-9151-003048679030.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/4221FF52-B54E-E011-A872-0026189438CC.root',
-        '/store/relval/CMSSW_4_2_0_pre7/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/START42_V6-v2/0032/2AAC7738-BC4E-E011-A35A-00304867BFAA.root'
-
+"/store/relval/CMSSW_7_6_0_pre5/RelValH130GGgluonfusion_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v1-v1/00000/283D2671-4C5C-E511-B601-0025905A60D6.root"
     )
  )
 

--- a/Validation/RecoEgamma/test/validationMiniAOD.csh
+++ b/Validation/RecoEgamma/test/validationMiniAOD.csh
@@ -1,0 +1,775 @@
+##!/bin/csh -x
+#!/bin/csh 
+
+#This script can be used to generate a web page to compare histograms from 
+#two input root files produced using the EDAnalyzers in RecoEgamma/Examples,
+#by running one of:
+#
+#  
+#  #  "Validation/RecoEgamma/test/PhotonValidator_cfg.py
+#
+# The default list of histograms (configurable) is based on version VXX-XX-XX
+# of Validation/RecoEgamma
+#
+#Two files are created by this script: validation.C and validation.html.
+#validation.C should be run inside root to greate a set of gif images
+#which can then be viewed in a web browser using validation.html.
+
+#=============BEGIN CONFIGURATION=================
+
+setenv RUNTYPE Central
+#setenv RUNTYPE Local
+setenv STARTUP True
+setenv FASTSIM False
+setenv UPGRADE True
+## TYPE options: Photons, GEDPhotons
+## ANALYZERNAME options: PhotonValidator, oldpfPhotonValidator, pfPhotonValidator
+#setenv TYPE Photons
+#setenv ANALYZERNAME PhotonValidator
+setenv TYPE GEDPhotons
+setenv ANALYZERNAME1 PhotonValidatorMiniAOD
+setenv ANALYZERNAME2 pfPhotonValidator
+
+
+setenv CMSSWver1 7_6_0
+setenv CMSSWver2 7_6_0
+setenv OLDRELEASE 7_6_0
+setenv NEWRELEASE 7_6_0
+setenv OLDPRERELEASE pre5
+setenv NEWPRERELEASE pre5
+setenv UPGRADEVER  UPG2017
+setenv LHCENERGY   13
+setenv PU False
+setenv PUlevel 25ns
+
+if ( $STARTUP == True &&  $FASTSIM == False && $PU == False && $UPGRADE == True ) then
+setenv OLDGLOBALTAG MCRUN2_74_V7-v1
+setenv NEWGLOBALTAG MCRUN2_74_V7-v2
+else if ( $UPGRADE == True && $PU == True &&  $FASTSIM == False ) then
+setenv OLDGLOBALTAG PU${PUlevel}_76X_mcRun2_asymptotic_v1-v1
+setenv NEWGLOBALTAG PUpmx${PUlevel}_76X_mcRun2_asymptotic_v1-v1
+else if (  $STARTUP == True  && $FASTSIM == True) then
+setenv OLDGLOBALTAG MCRUN2_73_V7_FastSim-v1
+setenv NEWGLOBALTAG MCRUN2_74_V1_FastSim-v1
+ endif
+
+
+
+
+setenv OLDRELEASE ${OLDRELEASE}_${OLDPRERELEASE}
+#setenv OLDRELEASE ${OLDRELEASE}
+setenv NEWRELEASE ${NEWRELEASE}_${NEWPRERELEASE}
+#setenv NEWRELEASE ${NEWRELEASE}
+
+setenv WorkDir1    /afs/cern.ch/user/n/nancy/scratch0/CMSSW/workForMINIAOD/CMSSW_7_6_0_pre5/src/Validation/RecoEgamma/myTest3
+
+#setenv WorkDir1   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver1}/src/Validation/RecoEgamma/test
+#setenv WorkDir2   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver2}_${NEWPRERELEASE}/src/Validation/RecoEgamma/test
+
+#setenv WorkDir1   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver1}_${OLDPRERELEASE}/src/Validation/RecoEgamma/test
+#setenv WorkDir2   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver2}_${NEWPRERELEASE}/src/Validation/RecoEgamma/test
+
+#setenv WorkDir1   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver1}_${OLDPRERELEASE}/src/Validation/RecoEgamma/test
+#setenv WorkDir2   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver2}/src/Validation/RecoEgamma/test
+
+#setenv WorkDir1   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver1}/src/Validation/RecoEgamma/test
+#setenv WorkDir2   /afs/cern.ch/user/n/nancy/scratch0/CMSSW/test/CMSSW_${CMSSWver2}/src/Validation/RecoEgamma/test
+
+#Name of sample (affects output directory name and htmldescription only) 
+
+
+#setenv SAMPLE SingleGammaPt10
+#setenv SAMPLE SingleGammaPt35
+##setenv SAMPLE SingleGammaFlatPt10_100
+setenv SAMPLE H130GGgluonfusion
+#setenv SAMPLE PhotonJets_Pt_10
+#setenv SAMPLE GammaJets_Pt_80_120
+#setenv SAMPLE QCD_Pt_80_120
+
+
+if ( $RUNTYPE == Central ) then
+setenv HISTOPATHNAME_Photons_miniAOD DQMData/Run\ 1/EgammaV/Run\ summary/${ANALYZERNAME1}/Photons
+setenv HISTOPATHNAME_Photons DQMData/Run\ 1/EgammaV/Run\ summary/${ANALYZERNAME2}/Photons
+endif
+
+#==============END BASIC CONFIGURATION==================
+
+
+#Input root trees for the two cases to be compared 
+
+if ($SAMPLE == SingleGammaPt10) then
+
+if ( $RUNTYPE == Local ) then
+setenv OLDFILE ${WorkDir1}/PhotonValidationRelVal${OLDRELEASE}_SingleGammaPt10.root
+setenv NEWFILE ${WorkDir2}/PhotonValidationRelVal${NEWRELEASE}_SingleGammaPt10.root
+else if ( $RUNTYPE == Central &&  $UPGRADE == False ) then
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValSingleGammaPt10_UP15__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQM.root
+else if ( $RUNTYPE == Central && $UPGRADE == True ) then
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValSingleGammaPt10_UP15__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQM.root
+setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValSingleGammaPt10_UP15__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+#setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValSingleGammaPt10_${UPGRADEVER}__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+else 
+setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValSingleGammaPt10_UP15__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+endif
+
+
+
+else if ($SAMPLE == SingleGammaPt35) then 
+
+if ( $RUNTYPE == Local ) then
+setenv OLDFILE ${WorkDir1}/PhotonValidationRelVal${OLDRELEASE}_SingleGammaPt35.root
+setenv NEWFILE ${WorkDir2}/PhotonValidationRelVal${NEWRELEASE}_SingleGammaPt35.root
+else if ( $RUNTYPE == Central &&  $UPGRADE == False ) then
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValSingleGammaPt35_UP15__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQM.root
+else if ( $RUNTYPE == Central && $UPGRADE == True ) then
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValSingleGammaPt35_UP15__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQM.root
+setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValSingleGammaPt35_UP15__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+#setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValSingleGammaPt35_${UPGRADEVER}__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+else 
+#setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValSingleGammaPt35_UP15__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+endif
+
+
+
+
+else if ($SAMPLE == SingleGammaFlatPt10_100) then 
+
+
+if ( $RUNTYPE == Local ) then
+setenv OLDFILE ${WorkDir1}/PhotonValidationRelVal${OLDRELEASE}_SingleGammaFlatPt10To100.root
+setenv NEWFILE ${WorkDir2}/PhotonValidationRelVal${NEWRELEASE}_SingleGammaFlatPt10To100.root
+endif 
+
+
+else if ($SAMPLE == H130GGgluonfusion) then 
+
+
+if ( $RUNTYPE == Local ) then
+setenv OLDFILE ${WorkDir1}/PhotonValidationRelVal${OLDRELEASE}_H130GGgluonfusion.root
+setenv NEWFILE ${WorkDir2}/PhotonValidationRelVal${NEWRELEASE}_H130GGgluonfusion.root
+else if ( $RUNTYPE == Central &&  $UPGRADE == False ) then
+
+
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValH130GGgluonfusion_${UPGRADEVER}_${LHCENERGY}__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQM.root
+
+else if ( $RUNTYPE == Central && $UPGRADE == True ) then
+
+#setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValH130GGgluonfusion_${LHCENERGY}__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQMIO.root
+#setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValH130GGgluonfusion_${LHCENERGY}__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQMIO.root
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
+setenv NEWFILE ${WorkDir1}/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
+else
+setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValH130GGgluonfusion__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQMIO.root
+endif
+
+
+else if ($SAMPLE == PhotonJets_Pt_10) then
+
+if ( $RUNTYPE == Local ) then
+setenv OLDFILE ${WorkDir1}/PhotonValidationRelVal${OLDRELEASE}_PhotonJets_Pt_10.root
+setenv NEWFILE ${WorkDir2}/PhotonValidationRelVal${NEWRELEASE}_PhotonJets_Pt_10.root
+else if ( $RUNTYPE == Central ) then
+
+setenv OLDFILE ${WorkDir1}/DQM_V0001_R000000001__RelValPhotonJets_Pt_10__CMSSW_${OLDRELEASE}-${OLDGLOBALTAG}__DQM.root
+if ( $UPGRADE == True ) then
+setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValPhotonJets_Pt_10_${UPGRADEVER}_${LHCENERGY}__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+else
+setenv NEWFILE ${WorkDir2}/DQM_V0001_R000000001__RelValPhotonJets_Pt_10__CMSSW_${NEWRELEASE}-${NEWGLOBALTAG}__DQM.root
+endif 
+endif
+
+else if ($SAMPLE ==  GammaJets_Pt_80_120) then 
+
+if ( $RUNTYPE == Local ) then
+setenv OLDFILE ${WorkDir1}/PhotonValidationRelVal${OLDRELEASE}_GammaJets_Pt_80_120.root
+setenv NEWFILE ${WorkDir2}/PhotonValidationRelVal${NEWRELEASE}_DQM.root
+endif
+
+else if ($SAMPLE == QCD_Pt_80_120) then 
+
+
+endif
+
+
+
+#Location of output.  The default will put your output in:
+#http://cmsdoc.cern.ch/Physics/egamma/www/validation/
+
+setenv CURRENTDIR $PWD
+setenv OUTPATH /afs/cern.ch/cms/Physics/egamma/www/validation/Photons
+cd $OUTPATH
+setenv NEWRELEASE {$NEWRELEASE}_MiniAOD
+#setenv NEWRELEASE {$NEWRELEASE}
+setenv OLDRELEASE {$OLDRELEASE}
+
+if (! -d $NEWRELEASE) then
+  mkdir $NEWRELEASE
+endif
+setenv OUTPATH $OUTPATH/$NEWRELEASE
+cd $OUTPATH
+
+if (! -d ${TYPE}) then
+  mkdir ${TYPE}
+endif
+setenv OUTPATH $OUTPATH/${TYPE}
+cd  $OUTPATH
+
+if (! -d vs${OLDRELEASE}) then
+  mkdir vs${OLDRELEASE}
+endif
+setenv OUTPATH $OUTPATH/vs${OLDRELEASE}
+
+
+if ( $FASTSIM == True) then 
+setenv OUTDIR $OUTPATH/${SAMPLE}FastSim
+else if ( $FASTSIM == False && $UPGRADE == False && $PU == True ) then 
+setenv OUTDIR $OUTPATH/${SAMPLE}PU
+else if ( $FASTSIM == False && $PU == False && $UPGRADE == False ) then 
+setenv OUTDIR $OUTPATH/${SAMPLE}
+else if ( $SAMPLE == H130GGgluonfusion  && $UPGRADE == True && $PU == True && $FASTSIM == False) then
+setenv OUTDIR $OUTPATH/${SAMPLE}_${LHCENERGY}TeV_PU${PUlevel}
+else if ( $SAMPLE == H130GGgluonfusion  && $UPGRADE == True ) then
+setenv OUTDIR $OUTPATH/${SAMPLE}_${LHCENERGY}TeV
+else if ( $SAMPLE ==  PhotonJets_Pt_10  && $UPGRADE == True ) then
+setenv OUTDIR $OUTPATH/${SAMPLE}_${LHCENERGY}TeV
+else if ( $SAMPLE ==  SingleGammaPt10  && $UPGRADE == True ) then
+setenv OUTDIR $OUTPATH/${SAMPLE}
+else if ( $SAMPLE ==  SingleGammaPt35  && $UPGRADE == True ) then
+setenv OUTDIR $OUTPATH/${SAMPLE}
+endif
+
+
+#else if ( $SAMPLE == H130GGgluonfusion ||  PhotonJets_Pt_10  && $UPGRADE == True ) then
+#if ( $PU == True) then
+#setenv OUTDIR $OUTPATH/${SAMPLE}PU
+#else if ( $PU == False) then
+#setenv OUTDIR $OUTPATH/${SAMPLE}
+#endif
+
+
+
+if (! -d $OUTDIR) then
+  cd $OUTPATH
+  mkdir $OUTDIR
+  cd $OUTDIR
+  mkdir gifs
+endif
+cd $OUTDIR
+
+
+#The list of histograms to be compared for each TYPE can be configured below:
+
+
+if ( $TYPE == Photons ||  $TYPE == GEDPhotons ) then
+
+
+cat > efficiencyForPhotons <<EOF
+
+EOF
+#  recoEffVsEta
+#  recoEffVsPhi
+#  recoEffVsEt
+#  deadChVsEta
+#  deadChVsPhi
+#  deadChVsEt
+
+
+
+cat > scaledhistosForPhotons <<EOF
+  scEta_miniAOD
+  scPhi_miniAOD
+  phoEAll_miniAOD
+  phoEtAll_miniAOD
+  eResAll_miniAOD
+  eResBarrel_miniAOD
+  eResEndcap_miniAOD
+  sigmaEoEBarrel_miniAOD
+  sigmaEoEEndcap_miniAOD
+  isoTrkSolidConeDR04All_miniAOD
+  isoTrkSolidConeDR04Barrel_miniAOD
+  isoTrkSolidConeDR04Endcap_miniAOD
+  nTrkSolidConeDR04All_miniAOD
+  nTrkSolidConeDR04Barrel_miniAOD
+  nTrkSolidConeDR04Endcap_miniAOD
+  r9Barrel_miniAOD
+  r9Endcap_miniAOD
+  full5x5_r9Barrel_miniAOD
+  full5x5_r9Endcap_miniAOD
+  r1Barrel_miniAOD
+  r1Endcap_miniAOD
+  r2Barrel_miniAOD
+  r2Endcap_miniAOD
+  sigmaIetaIetaBarrel_miniAOD
+  sigmaIetaIetaEndcap_miniAOD
+  full5x5_sigmaIetaIetaBarrel_miniAOD
+  full5x5_sigmaIetaIetaEndcap_miniAOD
+  hOverEAll_miniAOD
+  hOverEBarrel_miniAOD
+  hOverEEndcap_miniAOD
+  newhOverEAll_miniAOD
+  newhOverEBarrel_miniAOD
+  newhOverEEndcap_miniAOD
+  hcalTowerSumEtConeDR04Barrel_miniAOD
+  hcalTowerSumEtConeDR04Endcap_miniAOD
+  hcalTowerBcSumEtConeDR04Barrel_miniAOD
+  hcalTowerBcSumEtConeDR04Endcap_miniAOD
+  ecalRecHitSumEtConeDR04Barrel_miniAOD
+  ecalRecHitSumEtConeDR04Endcap_miniAOD
+
+
+EOF
+
+cat > scaledhistosForPhotonsLogScale <<EOF
+  hOverEAll_miniAOD
+  hOverEBarrel_miniAOD
+  hOverEEndcap_miniAOD
+  newhOverEAll_miniAOD
+  newhOverEBarrel_miniAOD
+  newhOverEEndcap_miniAOD
+  hcalTowerSumEtConeDR04Barrel_miniAOD
+  hcalTowerSumEtConeDR04Endcap_miniAOD
+  hcalTowerBcSumEtConeDR04Barrel_miniAOD
+  hcalTowerBcSumEtConeDR04Endcap_miniAOD
+  ecalRecHitSumEtConeDR04Barrel_miniAOD
+  ecalRecHitSumEtConeDR04Endcap_miniAOD
+  r9Barrel_miniAOD
+  r9Endcap_miniAOD
+  full5x5_r9Barrel_miniAOD
+  full5x5_r9Endcap_miniAOD
+  r1Barrel_miniAOD
+  r1Endcap_miniAOD
+  r2Barrel_miniAOD
+  r2Endcap_miniAOD
+  sigmaIetaIetaBarrel_miniAOD
+  sigmaIetaIetaEndcap_miniAOD
+
+
+
+EOF
+
+
+
+
+cat > scaledhistosGEDspecific <<EOF
+  chargedHadIsoBarrel_miniAOD
+  chargedHadIsoEndcap_miniAOD
+  neutralHadIsoBarrel_miniAOD
+  neutralHadIsoEndcap_miniAOD
+  photonIsoBarrel_miniAOD
+  photonIsoEndcap_miniAOD
+
+EOF
+
+
+cat > scaledhistosGEDspecificLogScale <<EOF
+  photonIsoBarrel_miniAOD
+  photonIsoEndcap_miniAOD
+  chargedHadIsoBarrel_miniAOD
+  chargedHadIsoEndcap_miniAOD
+  neutralHadIsoBarrel_miniAOD
+  neutralHadIsoEndcap_miniAOD
+
+
+EOF
+
+
+
+
+endif
+
+#=================END CONFIGURATION=====================
+
+if (-e validation.C) rm validation.C
+touch validation.C
+cat > begin.C <<EOF
+{
+TFile *file_old = TFile::Open("$OLDFILE");
+TFile *file_new = TFile::Open("$NEWFILE");
+
+int nBins = 0;
+float xMin= 0;
+float xMax= 0;
+TH1F* hold;
+TH1F* hnew;
+TH1F* hratio;
+TLine *l;
+Double_t nnew;
+Double_t mnew;
+Double_t mold;
+Double_t nold;
+int scolor=kBlack;
+int rcolor=kPink+8;
+Double_t value;
+
+EOF
+cat begin.C >>& validation.C
+rm begin.C
+
+setenv N 1
+
+
+
+foreach i (`cat scaledhistosForPhotons`)
+  cat > temp$N.C <<EOF
+TCanvas *c$i = new TCanvas("c$i");
+c$i->SetFillColor(10);
+c$i->Divide(1,2);
+c$i->cd(1);
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nBins = $i->GetNbinsX();
+xMin=$i->GetBinLowEdge(1);
+xMax=$i->GetBinLowEdge(nBins)+$i->GetBinWidth(nBins);
+mnew=$i->GetMaximum();
+nnew=$i->GetEntries();
+file_old->cd("$HISTOPATHNAME_Photons");
+hold=new  TH1F("hold"," ",nBins,xMin,xMax);
+hold=$i;
+mold=$i->GetMaximum();
+nold=$i->GetEntries();
+if ( $i==phoEAll_miniAOD ) {  
+$i->GetYaxis()->SetRangeUser(0.,2000.);
+} else if ( $i==r9Barrel_miniAOD ) {
+$i->GetXaxis()->SetRangeUser(0.8,1.);
+$i->GetYaxis()->SetRangeUser(0.,3500);
+} else if ( $i==r9Endcap_miniAOD ) {
+$i->GetXaxis()->SetRangeUser(0.8,1.);
+$i->GetYaxis()->SetRangeUser(0.,1000);
+} else if ( $i==sigmaIetaIetaBarrel_miniAOD ) {
+$i->GetXaxis()->SetRangeUser(0.,0.02);
+}  else if ( $i==sigmaIetaIetaEndcap_miniAOD ) {
+$i->GetXaxis()->SetRangeUser(0.,0.06);
+}  else if ( $i==r2Barrel_miniAOD || $i==r2Endcap_miniAOD) {
+$i->GetXaxis()->SetRangeUser(0.7,1.02);
+} 
+$i->SetStats(1111);
+$i->SetMinimum(0.);
+$i->Draw();
+gPad->Update();
+TPaveStats *os$i = (TPaveStats*)$i->FindObject("stats");
+os$i->SetX1NDC(0.82);
+os$i->SetX2NDC(0.92);
+os$i->SetY1NDC(0.8);
+os$i->SetY2NDC(0.97);
+os$i->SetTextColor(rcolor);
+os$i->SetLineColor(rcolor);
+if ( mnew > mold+sqrt(mold) )  { 
+value=mnew+2*sqrt(mnew);
+$i->SetMaximum(value); 
+}  else { 
+value=mold+2*sqrt(mold);
+$i->SetMaximum(value); 
+}
+$i->SetLineColor(rcolor);
+$i->SetFillColor(rcolor);
+//$i->SetLineWidth(3);
+$i->Draw();
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nnew=$i->GetEntries();
+$i->SetStats(1111);
+$i->SetLineColor(scolor);
+$i->SetMarkerColor(scolor);
+$i->SetMarkerStyle(20);
+$i->SetMarkerSize(0.8);
+hnew=new  TH1F("hnew"," ",nBins,xMin,xMax);
+hnew=$i;
+$i->Draw("e1sames");
+gPad->Update();
+TPaveStats *s$i = (TPaveStats*)$i->FindObject("stats");
+s$i->SetX1NDC(0.82);
+s$i->SetX2NDC(0.92);
+s$i->SetY1NDC(0.55);
+s$i->SetY2NDC(0.72);
+c$i->cd(2);
+hratio=new  TH1F("hratio"," ",nBins,xMin,xMax);
+hratio->Divide(hnew,hold);
+for ( int i=1; i<=hratio->GetNbinsX(); i++ ) {
+float num=hnew->GetBinContent(i);
+float den=hold->GetBinContent(i);
+float dNum=hnew->GetBinError(i);
+float dDen=hold->GetBinError(i);
+float erro=0;
+if ( num!=0 && den!=0) {
+erro= ((1./den)*(1./den)*dNum*dNum) + ((num*num)/(den*den*den*den) * (dDen*dDen));
+erro=sqrt(erro);
+}
+hratio->SetBinError(i, erro);
+}
+hratio->SetStats(0);
+hratio->SetLineColor(1);
+hratio->SetLineWidth(2);
+if ( $i==r9Barrel_miniAOD || $i==r9Endcap_miniAOD ) {
+hratio->GetXaxis()->SetRangeUser(0.8,1.);
+hratio->GetYaxis()->SetRangeUser(0.,2.);
+} else if ( $i==eResAll_miniAOD || $i==eResBarrel_miniAOD || $i==eResEndcap_miniAOD ) {
+hratio->GetYaxis()->SetRangeUser(0.,2.); 
+} else if ( $i==sigmaIetaIetaBarrel_miniAOD ) {
+hratio->GetXaxis()->SetRangeUser(0.,0.02);
+}  else if ( $i==sigmaIetaIetaEndcap_miniAOD ) {
+hratio->GetXaxis()->SetRangeUser(0.,0.06);
+}  else if ( $i==r2Barrel_miniAOD || $i==r2Endcap_miniAOD) {
+hratio->GetXaxis()->SetRangeUser(0.7,1.02);
+hratio->GetYaxis()->SetRangeUser(0.,5.);
+} else {
+hratio->GetYaxis()->SetRangeUser(0.,2.);
+}
+hratio->Draw("e");
+l = new TLine(xMin,1.,xMax,1.);
+l->Draw(); 
+c$i->SaveAs("gifs/$i.gif");
+EOF
+  setenv N `expr $N + 1`
+end
+
+
+foreach i (`cat scaledhistosGEDspecific`)
+  cat > temp$N.C <<EOF
+TCanvas *c$i = new TCanvas("c$i");
+c$i->SetFillColor(10);
+c$i->Divide(1,2);
+c$i->cd(1);
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nBins =$i->GetNbinsX();
+xMin=$i->GetBinLowEdge(1);
+xMax=$i->GetBinLowEdge(nBins)+$i->GetBinWidth(nBins);
+mnew=$i->GetMaximum();
+nnew=$i->GetEntries();
+file_old->cd("$HISTOPATHNAME_Photons");
+hold=new  TH1F("hold"," ",nBins,xMin,xMax);
+hold=$i;
+mold=$i->GetMaximum();
+nold=$i->GetEntries();
+if ( $i==phoEAll_miniAOD ) {  
+$i->GetYaxis()->SetRangeUser(0.,2000.);
+}
+if ($i==chargedHadIsoBarrel_miniAOD || $i==chargedHadIsoBarrel_miniAOD ) {
+$i->GetXaxis()->SetRangeUser(0.,12.);
+}
+$i->SetStats(11111);
+$i->SetMinimum(0.);
+$i->Draw();
+gPad->Update();
+TPaveStats *os2$i = (TPaveStats*)$i->FindObject("stats");
+os2$i->SetTextColor(rcolor);
+os2$i->SetLineColor(rcolor);
+
+if ( mnew > mold+sqrt(mold) )  {
+value=mnew+2*sqrt(mnew); 
+$i->SetMaximum(value); 
+}  else { 
+value=mold+2*sqrt(mold);
+$i->SetMaximum(value); 
+}
+$i->SetLineColor(rcolor);
+$i->SetFillColor(rcolor);
+$i->Draw();
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nnew=$i->GetEntries();
+$i->SetStats(111111);
+$i->SetLineColor(scolor);
+$i->SetMarkerColor(scolor);
+$i->SetMarkerStyle(20);
+$i->SetMarkerSize(0.8);
+hnew=new  TH1F("hnew"," ",nBins,xMin,xMax);
+hnew=$i;
+$i->Draw("e1sames");
+gPad->Update();
+TPaveStats *s2$i = (TPaveStats*)$i->FindObject("stats");
+s2$i->SetY1NDC(.5);
+s2$i->SetY2NDC(.67);
+c$i->cd(2);
+hratio=new  TH1F("hratio"," ",nBins,xMin,xMax);
+hratio->Divide(hnew,hold);
+for ( int i=1; i<=hratio->GetNbinsX(); i++ ) {
+float num=hnew->GetBinContent(i);
+float den=hold->GetBinContent(i);
+float dNum=hnew->GetBinError(i);
+float dDen=hold->GetBinError(i);
+float erro=0;
+if ( num!=0 && den!=0) {
+erro= ((1./den)*(1./den)*dNum*dNum) + ((num*num)/(den*den*den*den) * (dDen*dDen));
+erro=sqrt(erro);
+}
+hratio->SetBinError(i, erro);
+}
+hratio->SetStats(0);
+hratio->SetLineColor(1);
+hratio->SetLineWidth(2);
+hratio->SetMinimum(0.);
+hratio->SetMaximum(4.);
+hratio->Draw("e");
+l = new TLine(xMin,1.,xMax,1.);
+l->Draw(); 
+c$i->SaveAs("gifs/$i.gif");
+EOF
+  setenv N `expr $N + 1`
+end
+
+
+
+foreach i (`cat scaledhistosGEDspecificLogScale`)
+  cat > temp$N.C <<EOF
+TCanvas *cc$i = new TCanvas("cc$i");
+cc$i->cd();
+cc$i->SetFillColor(10);
+cc$i->SetLogy();
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nnew=$i->GetEntries();
+file_old->cd("$HISTOPATHNAME_Photons");
+if ( $i==hcalTowerSumEtConeDR04Barrel_miniAOD ||  $i==hcalTowerSumEtConeDR04Endcap_miniAOD  ) {  
+$i->GetXaxis()->SetRangeUser(0.,10.);
+}
+nold=$i->GetEntries();
+$i->SetStats(1111);
+$i->SetMinimum(1);
+$i->SetLineColor(rcolor);
+$i->SetFillColor(rcolor);
+$i->Draw();
+gPad->Update();
+TPaveStats *os3$i = (TPaveStats*)$i->FindObject("stats");
+os3$i->SetTextColor(rcolor);
+os3$i->SetLineColor(rcolor);
+
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nnew=$i->GetEntries();
+$i->SetStats(11111);
+$i->SetLineColor(scolor);
+$i->SetMarkerColor(scolor);
+$i->SetMarkerStyle(20);
+$i->SetMarkerSize(1);
+$i->Draw("e1sames");
+gPad->Update();
+TPaveStats *s3$i = (TPaveStats*)$i->FindObject("stats");
+s3$i->SetY1NDC(.5);
+s3$i->SetY2NDC(.67);
+cc$i->SaveAs("gifs/log$i.gif");
+EOF
+  setenv N `expr $N + 1`
+end
+
+
+
+
+
+foreach i (`cat scaledhistosForPhotonsLogScale`)
+  cat > temp$N.C <<EOF
+TCanvas *cc$i = new TCanvas("cc$i");
+cc$i->cd();
+cc$i->SetFillColor(10);
+cc$i->SetLogy();
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nnew=$i->GetEntries();
+file_old->cd("$HISTOPATHNAME_Photons");
+if ( $i==hcalTowerSumEtConeDR04Barrel_miniAOD ||  $i==hcalTowerSumEtConeDR04Endcap_miniAOD  ) {  
+$i->GetXaxis()->SetRangeUser(0.,10.);
+}
+nold=$i->GetEntries();
+$i->SetStats(1111);
+$i->SetMinimum(1);
+$i->SetLineColor(rcolor);
+$i->SetFillColor(rcolor);
+$i->Draw();
+gPad->Update();
+TPaveStats *os4$i = (TPaveStats*)$i->FindObject("stats");
+os4$i->SetTextColor(rcolor);
+os4$i->SetLineColor(rcolor);
+file_new->cd("$HISTOPATHNAME_Photons_miniAOD");
+nnew=$i->GetEntries();
+$i->SetStats(11111);
+$i->SetLineColor(scolor);
+$i->SetMarkerColor(scolor);
+$i->SetMarkerStyle(20);
+$i->SetMarkerSize(1);
+$i->Draw("e1sames");
+gPad->Update();
+TPaveStats *s4$i = (TPaveStats*)$i->FindObject("stats");
+s4$i->SetY1NDC(.5);
+s4$i->SetY2NDC(.67);
+cc$i->SaveAs("gifs/log$i.gif");
+EOF
+  setenv N `expr $N + 1`
+end
+
+
+
+setenv NTOT `expr $N - 1`
+setenv N 1
+while ( $N <= $NTOT )
+  cat temp$N.C >>& validation.C
+  rm temp$N.C
+  setenv N `expr $N + 1`
+end
+
+cat > end.C <<EOF
+}
+EOF
+cat end.C >>& validation.C
+rm end.C
+
+
+if  ( $PU == True &&  $FASTSIM == False && $SAMPLE !=  H130GGgluonfusion  && $UPGRADE == True ) then
+#setenv SAMPLE ${SAMPLE}PU
+else if ( $PU == False && $FASTSIM == True) then
+setenv SAMPLE ${SAMPLE}FastSim
+else if ( $SAMPLE == H130GGgluonfusion && $UPGRADE == True && $PU == False  &&  $FASTSIM == False) then
+setenv SAMPLE ${SAMPLE}_${LHCENERGY}TeV
+else if ( $SAMPLE == H130GGgluonfusion && $UPGRADE == True &&  $PU == True  &&  $FASTSIM == False ) then
+setenv SAMPLE ${SAMPLE}_${LHCENERGY}TeV_PU${PUlevel}
+endif
+
+echo $SAMPLE
+
+if (-e validation.html) rm validation.html
+if (-e validationPlotsTemplateForMiniAOD.html) rm validationPlotsTemplateForMiniAOD.html
+cp ${CURRENTDIR}/validationPlotsTemplateForMiniAOD.html validationPlotsTemplateForMiniAOD.html
+touch validation.html
+cat > begin.html <<EOF
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<title>$NEWRELEASE vs $OLDRELEASE $TYPE validation</title>
+</head>
+
+<h1>$NEWRELEASE vs $OLDRELEASE $TYPE validation
+<br>
+ $SAMPLE 
+</h1>
+
+<br>
+In all plots below, $OLDRELEASE is in purple , $NEWRELEASE in black. 
+<br>
+Click on the plots to see them enlarged.
+<br>
+Responsible: N. Marinelli
+<br>
+<br>
+
+
+
+EOF
+cat begin.html >>& validation.html
+rm begin.html
+cat  validationPlotsTemplateForMiniAOD.html >>& validation.html
+rm   validationPlotsTemplateForMiniAOD.html
+
+rm efficiencyForPhotons
+rm scaledhistosForPhotons
+rm scaledhistosForPhotonsLogScale
+rm scaledhistosGEDspecific
+rm scaledhistosGEDspecificLogScale
+
+
+#echo "Now paste the following into your terminal window:"
+#echo ""
+echo "cd $OUTDIR"
+#echo " root -b"
+#echo ".x validation.C"
+#echo ".q"
+#echo "cd $CURRENTDIR"
+#echo ""
+
+
+root -b -l -q validation.C
+cd $CURRENTDIR
+echo "Then you can view your validation plots here:"
+echo "http://cmsdoc.cern.ch/Physics/egamma/www/$OUTPATH/validation.html"

--- a/Validation/RecoEgamma/test/validationPlotsTemplateForMiniAOD.html
+++ b/Validation/RecoEgamma/test/validationPlotsTemplateForMiniAOD.html
@@ -1,0 +1,488 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+  <head>
+    
+    <BODY>
+
+
+      <Table border=4 cellspacing=20  width=100%>
+	<tr>
+	  <td align=center valign=top >
+	    <A HREF="gifs/scEta_miniAOD.gif"><IMG  SRC="gifs/scEta_miniAOD.gif" width=100%></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: Super cluster &eta .
+	      Simulated photons falling in 1.4442 &lt |&eta| &lt  1.566 are excluded.
+	    </font>  
+	  </td>
+	  <td align=center valign=top >
+	    <A HREF="gifs/scPhi_miniAOD.gif"><IMG  SRC="gifs/scPhi_miniAOD.gif" width=100%></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: Super cluster &phi
+	    </font>  
+	  </td>
+	</tr>
+      </table>
+      
+      <Table border=4 cellspacing=20  width=100%>
+	<tr>
+	  <td align=center valign=top >
+	    <A HREF="gifs/phoEAll_miniAOD.gif"><IMG  SRC="gifs/phoEAll_miniAOD.gif" width=100%></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: Photon energy (regression). The distribution is obtained for |&eta| &lt 2.5. 
+	    </font>  
+	  </td>
+	  <td align=center valign=top >
+	    <A HREF="gifs/phoEtAll_miniAOD.gif"><IMG  SRC="gifs/phoEtAll_miniAOD.gif" width=100%></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: Photon transverse energy (regression). The distribution is obtained for |&eta| &lt 2.5. 
+	    </font>  
+	  </td>
+	</tr>
+      </table>
+
+      
+      <table border=4 cellspacing=10  WIDTH=100%>
+	<br><FONT SIZE=4> Standard energy determination
+	</FONT>
+	<tr>
+	  <td align=center valign=top >
+	    <A HREF="gifs/eResAll_miniAOD.gif"><IMG  SRC="gifs/eResAll_miniAOD.gif" width=100% ></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between reconstructed and simulated energy. 
+	      The distribution  is obtained for |&eta| &lt 2.5 
+	    </font>  
+	  </td>
+	  <td align=center valign=top >
+	    <A HREF="gifs/eResBarrel_miniAOD.gif"><IMG  SRC="gifs/eResBarrel_miniAOD.gif" width=100%></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between reconstructed and simulated energy. 
+	      The distribution is for ecal barrel only.
+	    </font>  
+	  </td>
+	  <td align=center valign=top >
+	    <A HREF="gifs/eResEndcap_miniAOD.gif"><IMG  SRC="gifs/eResEndcap_miniAOD.gif" width=100%></A>
+	    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between reconstructed and simulated energy. 
+	      The distribution is for ecal endcaps only.
+	    </font>  
+	  </td>
+	</tr>
+	
+	<table border=4 cellspacing=10 WIDTH=100%>
+	  <tr>
+	    <td align=center valign=top >
+	      <A HREF="gifs/r9Barrel_miniAOD.gif"><IMG  SRC="gifs/r9Barrel_miniAOD.gif" width=100%></A>
+	      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between e3x3 and super cluster energy 
+		The distribution is for ecal barrel only.
+	      </font>  
+	    </td>
+	    <td align=center valign=top >
+	      <A HREF="gifs/logr9Barrel_miniAOD.gif"><IMG  SRC="gifs/logr9Barrel_miniAOD.gif" width=100%></A>
+	      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between e3x3 and super cluster energy 
+		The distribution is for ecal barrel only.
+	      </font>  
+	    </td>
+	    <td align=center valign=top >
+	      <A HREF="gifs/r9Endcap_miniAOD.gif"><IMG  SRC="gifs/r9Endcap_miniAOD.gif" width=100%></A>
+	      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between e3x3 and super cluster energy 
+		The distribution is for ecal endcaps only.
+	      </font>  
+	    </td>
+	    <td align=center valign=top >
+	      <A HREF="gifs/logr9Endcap_miniAOD.gif"><IMG  SRC="gifs/logr9Endcap_miniAOD.gif" width=100%></A>
+	      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: ratio between e3x3 and super cluster energy 
+		The distribution is for ecal endcaps only.
+	      </font>  
+	    </td>
+	  </tr>
+	  
+	  
+	  <table border=4 cellspacing=10 WIDTH=100%>
+	    <tr>
+	      <td align=center valign=top >
+		<A HREF="gifs/r1Barrel_miniAOD.gif"><IMG  SRC="gifs/r1Barrel_miniAOD.gif" width=100%></A>
+		<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e1x5/e5x5
+		  The distribution is for ecal barrel only.
+		</font>  
+	      </td>
+	      <td align=center valign=top >
+		<A HREF="gifs/logr1Barrel_miniAOD.gif"><IMG  SRC="gifs/logr1Barrel_miniAOD.gif" width=100%></A>
+		<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e1x5/e5x5
+		  The distribution is for ecal barrel only.
+		</font>  
+	      </td>
+	      <td align=center valign=top >
+		<A HREF="gifs/r1Endcap_miniAOD.gif"><IMG  SRC="gifs/r1Endcap_miniAOD.gif" width=100%></A>
+		<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e1x5/e5x5
+		  The distribution is for ecal endcaps only.
+		</font>  
+	      </td>
+	      <td align=center valign=top >
+		<A HREF="gifs/logr1Endcap_miniAOD.gif"><IMG  SRC="gifs/logr1Endcap_miniAOD.gif" width=100%></A>
+		<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e1x5/e5x5
+		  The distribution is for ecal endcaps only.
+		</font>  
+	      </td>
+	    </tr>
+	    
+	    
+	    
+	    <table border=4 cellspacing=10 WIDTH=100%>
+	      <tr>
+		<td align=center valign=top >
+		  <A HREF="gifs/r2Barrel_miniAOD.gif"><IMG  SRC="gifs/r2Barrel_miniAOD.gif" width=100%></A>
+		  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e2x5/e5x5 ratio 
+		    The distribution is for ecal barrel only.
+		  </font>  
+		</td>
+		<td align=center valign=top >
+		  <A HREF="gifs/logr2Barrel_miniAOD.gif"><IMG  SRC="gifs/logr2Barrel_miniAOD.gif" width=100%></A>
+		  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e2x5/e5x5 ratio 
+		    The distribution is for ecal barrel only.
+		  </font>  
+		</td>
+		<td align=center valign=top >
+		  <A HREF="gifs/r2Endcap_miniAOD.gif"><IMG  SRC="gifs/r2Endcap_miniAOD.gif" width=100%></A>
+		  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e2x5/e5x5 ratio 
+		    The distribution is for ecal endcaps only.
+		  </font>  
+		</td>
+		<td align=center valign=top >
+		  <A HREF="gifs/logr2Endcap_miniAOD.gif"><IMG  SRC="gifs/logr2Endcap_miniAOD.gif" width=100%></A>
+		  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: e2x5/e5x5 ratio 
+		    The distribution is for ecal endcaps only.
+		  </font>  
+		</td>
+	      </tr>
+	      
+	      
+	      
+	      <table border=4 cellspacing=10 WIDTH=100%>
+		<tr>
+		  <td align=center valign=top >
+		    <A HREF="gifs/sigmaIetaIetaBarrel_miniAOD.gif"><IMG  SRC="gifs/sigmaIetaIetaBarrel_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  sigmaIetaIeta
+		      The distribution is for ecal barrel only.
+		    </font>  
+		  </td>
+		  <td align=center valign=top >
+		    <A HREF="gifs/logsigmaIetaIetaBarrel_miniAOD.gif"><IMG  SRC="gifs/logsigmaIetaIetaBarrel_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  sigmaIetaIeta
+		      The distribution is for ecal barrel only.
+		    </font>  
+		  </td>
+		  <td align=center valign=top >
+		    <A HREF="gifs/sigmaIetaIetaEndcap_miniAOD.gif"><IMG  SRC="gifs/sigmaIetaIetaEndcap_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  sigmaIetaIeta
+		      The distribution is for ecal endcaps only.
+		    </font>  
+		  </td>
+		  <td align=center valign=top >
+		    <A HREF="gifs/logsigmaIetaIetaEndcap_miniAOD.gif"><IMG  SRC="gifs/logsigmaIetaIetaEndcap_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  sigmaIetaIeta
+		      The distribution is for ecal endcaps only.
+		    </font>  
+		  </td>
+		</tr>
+		
+		
+		
+		<table border=4 cellspacing=10 WIDTH=100%>
+		  <tr>
+		    <td align=center valign=top >
+		      <A HREF="gifs/newhOverEBarrel_miniAOD.gif"><IMG  SRC="gifs/newhOverEBarrel_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: new  H/E definition
+			The distribution is for ecal barrel only.
+		      </font>  
+		    </td>
+		    <td align=center valign=top >
+		      <A HREF="gifs/lognewhOverEBarrel_miniAOD.gif"><IMG  SRC="gifs/lognewhOverEBarrel_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: new  H/E definition
+			The distribution is for ecal barrel only.
+		      </font>  
+		    </td>
+		    <td align=center valign=top >
+		      <A HREF="gifs/newhOverEEndcap_miniAOD.gif"><IMG  SRC="gifs/newhOverEEndcap_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: new  H/E definition
+			The distribution is for ecal endcaps only.
+		      </font>  
+		    </td>
+		    <td align=center valign=top >
+		      <A HREF="gifs/lognewhOverEEndcap_miniAOD.gif"><IMG  SRC="gifs/lognewhOverEEndcap_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: new  H/E definition
+			The distribution is for ecal endcaps only.
+		      </font>  
+		    </td>
+		  </tr>
+		  
+		  
+		  
+		  
+		  <table border=4 cellspacing=10 WIDTH=100%>
+		    <tr>
+		      <td align=center valign=top >
+			<A HREF="gifs/hOverEBarrel_miniAOD.gif"><IMG  SRC="gifs/hOverEBarrel_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: old  H/E definition
+			  The distribution is for ecal barrel only.
+			</font>  
+		      </td>
+		      <td align=center valign=top >
+			<A HREF="gifs/loghOverEBarrel_miniAOD.gif"><IMG  SRC="gifs/loghOverEBarrel_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: old  H/E definition
+			  The distribution is for ecal barrel only.
+			</font>  
+		      </td>
+		      <td align=center valign=top >
+			<A HREF="gifs/hOverEEndcap_miniAOD.gif"><IMG  SRC="gifs/hOverEEndcap_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: old  H/E definition
+			  The distribution is for ecal endcaps only.
+			</font>  
+		      </td>
+		      <td align=center valign=top >
+			<A HREF="gifs/loghOverEEndcap_miniAOD.gif"><IMG  SRC="gifs/loghOverEEndcap_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: old  H/E definition
+			  The distribution is for ecal endcaps only.
+			</font>  
+		      </td>
+		    </tr>
+		    
+		    
+		    
+		    <table border=4 cellspacing=10 WIDTH=100%>
+		      <tr>
+			<td align=center valign=top >
+			  <A HREF="gifs/ecalRecHitSumEtConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/ecalRecHitSumEtConeDR04Barrel_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  ecalRecHitSumEtConeDR04
+		      The distribution is for ecal barrel only.
+		    </font>  
+		  </td>
+		  <td align=center valign=top >
+		    <A HREF="gifs/logecalRecHitSumEtConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/logecalRecHitSumEtConeDR04Barrel_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  ecalRecHitSumEtConeDR04
+		      The distribution is for ecal barrel only.
+		    </font>  
+		  </td>
+		  <td align=center valign=top >
+		    <A HREF="gifs/ecalRecHitSumEtConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/ecalRecHitSumEtConeDR04Endcap_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  ecalRecHitSumEtConeDR04
+		      The distribution is for ecal endcaps only.
+		    </font>  
+		  </td>
+		  <td align=center valign=top >
+		    <A HREF="gifs/logecalRecHitSumEtConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/logecalRecHitSumEtConeDR04Endcap_miniAOD.gif" width=100%></A>
+		    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  ecalRecHitSumEtConeDR04
+		      The distribution is for ecal endcaps only.
+		    </font>  
+		  </td>
+		</tr>
+		
+		
+		<table border=4 cellspacing=10 WIDTH=100%>
+		  <tr>
+		    <td align=center valign=top >
+		      <A HREF="gifs/loghcalTowerBcSumEtConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/loghcalTowerBcSumEtConeDR04Barrel_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerBcSumEtConeDR04
+			The distribution is for ecal barrel only.
+		      </font>  
+		    </td>
+		    <td align=center valign=top >
+		      <A HREF="gifs/hcalTowerBcSumEtConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/hcalTowerBcSumEtConeDR04Barrel_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerBcSumEtConeDR04
+			The distribution is for ecal barrel only.
+		      </font>  
+		    </td>
+		    <td align=center valign=top >
+		      <A HREF="gifs/hcalTowerBcSumEtConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/hcalTowerBcSumEtConeDR04Endcap_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerBcSumEtConeDR04
+			The distribution is for ecal endcaps only.
+		      </font>  
+		    </td>
+		    <td align=center valign=top >
+		      <A HREF="gifs/loghcalTowerBcSumEtConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/loghcalTowerBcSumEtConeDR04Endcap_miniAOD.gif" width=100%></A>
+		      <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerBcSumEtConeDR04
+			The distribution is for ecal endcaps only.
+		      </font>  
+		    </td>
+		  </tr>
+		  
+
+		  <table border=4 cellspacing=10 WIDTH=100%>
+		    <tr>
+		      <td align=center valign=top >
+			<A HREF="gifs/hcalTowerSumEtConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/hcalTowerSumEtConeDR04Barrel_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerSumEtConeDR04
+			  The distribution is for ecal barrel only.
+			</font>  
+		      </td>
+		      <td align=center valign=top >
+			<A HREF="gifs/loghcalTowerSumEtConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/loghcalTowerSumEtConeDR04Barrel_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerSumEtConeDR04
+			  The distribution is for ecal barrel only.
+			</font>  
+		      </td>
+		      <td align=center valign=top >
+			<A HREF="gifs/hcalTowerSumEtConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/hcalTowerSumEtConeDR04Endcap_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerSumEtConeDR04
+			  The distribution is for ecal endcaps only.
+			</font>  
+		      </td>
+		      <td align=center valign=top >
+			<A HREF="gifs/loghcalTowerSumEtConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/loghcalTowerSumEtConeDR04Endcap_miniAOD.gif" width=100%></A>
+			<br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:  hcalTowerSumEtConeDR04
+			  The distribution is for ecal endcaps only.
+			</font>  
+		      </td>
+		    </tr>
+		    
+		    
+		    <table border=4 cellspacing=10 WIDTH=100%>
+		      <tr>
+			<td align=center valign=top >
+			  <A HREF="gifs/isoTrkSolidConeDR04All_miniAOD.gif"><IMG  SRC="gifs/isoTrkSolidConeDR04All_miniAOD.gif" width=100%></A>
+			  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:   track Pt sum in SolidConeDR04
+			    The distribution  is obtained for |&eta| &lt 2.5 
+			  </font>  
+			</td>
+			<td align=center valign=top >
+			  <A HREF="gifs/isoTrkSolidConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/isoTrkSolidConeDR04Barrel_miniAOD.gif" width=100%></A>
+			  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:   track Pt sum  in SolidConeDR04
+			    The distribution is for ecal barrel only.
+			  </font>  
+			</td>
+			<td align=center valign=top >
+			  <A HREF="gifs/isoTrkSolidConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/isoTrkSolidConeDR04Endcap_miniAOD.gif" width=100%></A>
+			  <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon: track Pt sum  in SolidConeDR04
+			    The distribution is for ecal endcaps only.
+			  </font>  
+			</td>
+		      </tr>
+		      
+		      
+		      <table border=4 cellspacing=10 WIDTH=100%>
+			<tr>
+			  <td align=center valign=top >
+			    <A HREF="gifs/nTrkSolidConeDR04All_miniAOD.gif"><IMG  SRC="gifs/nTrkSolidConeDR04All_miniAOD.gif" width=100%></A>
+			    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:   number of tracks in SolidConeDR04
+			      The distribution  is obtained for |&eta| &lt 2.5 
+			    </font>  
+			  </td>
+			  <td align=center valign=top >
+			    <A HREF="gifs/nTrkSolidConeDR04Barrel_miniAOD.gif"><IMG  SRC="gifs/nTrkSolidConeDR04Barrel_miniAOD.gif" width=100%></A>
+			    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:   number of tracks in SolidConeDR04
+			      The distribution is for ecal barrel only.
+			    </font>  
+			  </td>
+			  <td align=center valign=top >
+			    <A HREF="gifs/nTrkSolidConeDR04Endcap_miniAOD.gif"><IMG  SRC="gifs/nTrkSolidConeDR04Endcap_miniAOD.gif" width=100%></A>
+			    <br><FONT SIZE=-1>Reconstructed photon matching a simulated photon:   number of tracks in SolidConeDR04
+			      The distribution is for ecal endcaps only.
+			    </font>  
+			  </td>
+			</tr>
+
+
+
+
+			<table border=4 cellspacing=10 WIDTH=100%>
+			  <tr>
+			    <td align=center valign=top >
+			      <A HREF="gifs/photonIsoBarrel_miniAOD.gif"><IMG  SRC="gifs/photonIsoBarrel_miniAOD.gif" width=100%></A>
+			      <br><FONT SIZE=-1>
+				Reconstructed photon matching a simulated photon:   
+				GED based photon isolation.
+				The distribution is for ecal barrel only.
+			      </font>  
+			    </td>
+			    <td align=center valign=top >
+			      <A HREF="gifs/logphotonIsoBarrel_miniAOD.gif"><IMG  SRC="gifs/logphotonIsoBarrel_miniAOD.gif" width=100%></A>
+			      <br><FONT SIZE=-1>
+				Reconstructed photon matching a simulated photon:   
+				GED based photon isolation.
+				The distribution is for ecal barrel only.
+			      </font>  
+			    </td>
+			    <td align=center valign=top >
+			      <A HREF="gifs/photonIsoEndcap_miniAOD.gif"><IMG  SRC="gifs/photonIsoEndcap_miniAOD.gif" width=100%></A>
+			      <br><FONT SIZE=-1>
+				Reconstructed photon matching a simulated photon:  GED based photon isolation.
+				The distribution is for ecal endcaps only.
+			      </font>  
+			    </td>
+			    <td align=center valign=top >
+			      <A HREF="gifs/logphotonIsoEndcap_miniAOD.gif"><IMG  SRC="gifs/logphotonIsoEndcap_miniAOD.gif" width=100%></A>
+			      <br><FONT SIZE=-1>
+				Reconstructed photon matching a simulated photon:  GED based photon isolation.
+				The distribution is for ecal endcaps only.
+			      </font>  
+			    </td>
+			  </tr>
+			  
+			  
+			  <table border=4 cellspacing=10 WIDTH=100%>
+			    <tr>
+			      <td align=center valign=top >
+				<A HREF="gifs/chargedHadIsoBarrel_miniAOD.gif"><IMG  SRC="gifs/chargedHadIsoBarrel_miniAOD.gif" width=100%></A>
+				<br><FONT SIZE=-1>
+				  Reconstructed photon matching a simulated photon:   
+				  GED based photon isolation: contribution from charged hadrons.
+				  The distribution is for ecal barrel only.
+				</font>  
+			      </td>
+			      <td align=center valign=top >
+				<A HREF="gifs/logchargedHadIsoBarrel_miniAOD.gif"><IMG  SRC="gifs/logchargedHadIsoBarrel_miniAOD.gif" width=100%></A>
+				<br><FONT SIZE=-1>
+				  Reconstructed photon matching a simulated photon:   
+				  GED based photon isolation contribution from charged hadrons.
+				  The distribution is for ecal barrel only.
+				</font>  
+			      </td>
+			      <td align=center valign=top >
+				<A HREF="gifs/chargedHadIsoEndcap_miniAOD.gif"><IMG  SRC="gifs/chargedHadIsoEndcap_miniAOD.gif" width=100%></A>
+				<br><FONT SIZE=-1>
+				  Reconstructed photon matching a simulated photon:  GED based photon isolation: contribution from charged hadrons
+				  The distribution is for ecal endcaps only.
+				</font>  
+			      </td>
+			      <td align=center valign=top >
+				<A HREF="gifs/logchargedHadIsoEndcap_miniAOD.gif"><IMG  SRC="gifs/logchargedHadIsoEndcap_miniAOD.gif" width=100%></A>
+				<br><FONT SIZE=-1>
+				  Reconstructed photon matching a simulated photon:  GED based photon isolation: contribution from charged hadrons
+				  The distribution is for ecal endcaps only.
+				</font>  
+			      </td>
+			    </tr>
+			    
+			    
+			    <table border=4 cellspacing=10 WIDTH=100%>
+			      <tr>
+				<td align=center valign=top >
+				  <A HREF="gifs/neutralHadIsoBarrel_miniAOD.gif"><IMG  SRC="gifs/neutralHadIsoBarrel_miniAOD.gif" width=100%></A>
+				  <br><FONT SIZE=-1>
+				    Reconstructed photon matching a simulated photon:   
+				    GED based photon isolation: contribution from neutral hadrons.
+				    The distribution is for ecal barrel only.
+				  </font>  
+				</td>
+				<td align=center valign=top >
+				  <A HREF="gifs/logneutralHadIsoBarrel_miniAOD.gif"><IMG  SRC="gifs/logneutralHadIsoBarrel_miniAOD.gif" width=100%></A>
+				  <br><FONT SIZE=-1>
+				    Reconstructed photon matching a simulated photon:   
+				    GED based photon isolation contribution from neutral hadrons.
+				    The distribution is for ecal barrel only.
+				  </font>  
+				</td>
+				<td align=center valign=top >
+				  <A HREF="gifs/neutralHadIsoEndcap_miniAOD.gif"><IMG  SRC="gifs/neutralHadIsoEndcap_miniAOD.gif" width=100%></A>
+				  <br><FONT SIZE=-1>
+				    Reconstructed photon matching a simulated photon:  GED based photon isolation: contribution from neutral hadrons
+				    The distribution is for ecal endcaps only.
+				  </font>  
+				</td>
+				<td align=center valign=top >
+				  <A HREF="gifs/logneutralHadIsoEndcap_miniAOD.gif"><IMG  SRC="gifs/logneutralHadIsoEndcap_miniAOD.gif" width=100%></A>
+				  <br><FONT SIZE=-1>
+				    Reconstructed photon matching a simulated photon:  GED based photon isolation: contribution from neutral hadrons
+				    The distribution is for ecal endcaps only.
+				  </font>  
+				</td>
+			      </tr>
+
+
+
+			
+
+</BODY>
+</html>


### PR DESCRIPTION
A new analyzer has been deployed in Validation/RecoEgamma and a new sequence to be included in Configuration/StandardSequences/python/Validation_cff.py (also committed). The machinery is meant only for MC miniAOD. It has all been tested with "central" running using runTheMatrix.py --what standard -i all -l 1332 --command=' -n 200'
Automatically ported from CMSSW_7_6_X #11750 (original by @nancymarinelli).
