### PR TITLE
Add castor geometry files with position for 2015

### DIFF
--- a/Geometry/ForwardCommonData/data/dev/castor2015/measured/castor.xml
+++ b/Geometry/ForwardCommonData/data/dev/castor2015/measured/castor.xml
@@ -1,0 +1,1066 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="castor.xml" eval="true">
+        <Constant name="castLength" value="1583.3*mm" />
+        <Constant name="CASTFarTiltAngle" value="0*deg" />
+        <Constant name="CASTNearTiltAngle" value="0*deg" />
+	<Constant name="LGAngleBegin" value="11.6287*deg"/>
+	<Constant name="LGAngleDelta" value="21.74255*deg"/>
+	<Constant name="LGrShift" value="1*mm/tan([castor:LGAngleDelta]/2)"/>
+	<Constant name="LGxShift" value="[castor:LGrShift] * cos([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+	<Constant name="LGyShift" value="[castor:LGrShift] * sin([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+    </ConstantsSection>
+    <RotationSection label="castor.xml">
+        <Rotation name="CASTFarTilt"  thetaX="90*deg+[CASTFarTiltAngle]" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg+[CASTFarTiltAngle]" phiZ="0*deg" />
+        <Rotation name="CASTNearTilt" thetaX="90*deg+[CASTNearTiltAngle]" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg+[CASTNearTiltAngle]" phiZ="0*deg" />
+	<!-- Rotations for the subtraction boxes SubtractBox1/2 used to cut the high-eta edges of the volumes CAEL, CAEA, CAEF, CAHL, CAHA CAHF -->
+	<Rotation name="SubtractBoxRot1"
+		  thetaX ="90*deg" phiX="(22.5+33.75)*deg"
+		  thetaY="90*deg" phiY="(90+22.5+33.75)*deg"
+		  thetaZ="0*deg" phiZ="0*deg"/>
+	<Rotation name="SubtractBoxRot2"
+		  thetaX ="90*deg" phiX="(22.5-33.75)*deg"
+		  thetaY="90*deg" phiY="(90+22.5-33.75)*deg"
+		  thetaZ="0*deg" phiZ="0*deg"/>
+    </RotationSection>
+    <SolidSection label="castor.xml">
+        <!--  -->
+        <!-- main CASTOR volume  -->
+        <!--  -->
+        <Polyhedra name="CASTFar" numSide="4" startPhi="-90.0*deg" deltaPhi="180.0*deg" >
+            <ZSection rMin="39.00*mm"   rMax="40.00*mm"    z="0.0*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="263.2*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="1320.1*mm" />
+            <ZSection rMin="303.20*mm"  rMax="303.20*mm"   z="[castLength]" />
+        </Polyhedra>
+        <Polyhedra name="CASTNear" numSide="4" startPhi="90.0*deg" deltaPhi="180.0*deg" >
+            <ZSection rMin="39.00*mm"   rMax="40.00*mm"    z="0.0*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="263.2*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="1320.1*mm" />
+            <ZSection rMin="303.20*mm"  rMax="303.20*mm"   z="[castLength]" />
+        </Polyhedra>
+        <Polyhedra name="CAST" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="39.00*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="39.00*mm" rMax="303.20*mm" z="1320.1*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="[castLength]"/>
+        </Polyhedra>
+        <!--  -->
+        <!--  -->
+        <!-- 5mm Aluminium, separating EM + H sections -->
+        <Polyhedra name="CAAI" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="45.00*mm" z="5.0*mm"/>
+            <ZSection rMin="139.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="109.5*mm"/>
+        </Polyhedra>
+        <!--  -->
+        <!-- START OF ELECTROMAGNETIC CALO  -->
+        <!--  CASC - StainlessSteel -->
+        <Polyhedra name="CAEC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+        </Polyhedra>
+        <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
+        <!-- CASS sector - Air, 8 copies with deltaPhi=45.0  -->
+        <Polyhedra name="CAES" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+        </Polyhedra>
+        <!-- EM read-out channel  with StainlessSteel size  1 copy -->
+        <Polyhedra name="CAER" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.50*mm"/>
+            <ZSection rMin="92.00*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="155.00*mm"/>
+        </Polyhedra>
+        <!-- Air volume -->
+        <!-- reduced rMin, rMax by (1.mm (StainlessSteel)/tg(22.5)) -1mm = 1.41mm-->
+        <!-- the special X,Y shifts are needed to construct a wall thickness of 1mm. -->
+        <!-- Start the volume below (1.41mm) and then shift upwards in r by (1.41+1)mm.  -->
+	<!-- => wall thickness = deltaR*tan(22.5deg) = 2.41mm*tan(22.5deg) = 1mm -->
+        <!-- Shifts are defined further down the code.  -->
+        <!-- the shifts are: x = (2.41)*cos(22.5) = 2.23, y=...*sin(22.5)=0.92  1 copy     -->
+
+        <Polyhedra name="CERR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="90.09*mm" z="52.50*mm"/>
+            <ZSection rMin="89.59*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="155.00*mm"/>
+        </Polyhedra>
+        <!-- layer    5 copies (5.mm+2mm)/sin(45deg) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
+        <!-- 0.4 mm air gap included -->
+        <!-- CAEL: Tungsten layer, CAEA: air layer, CAEF: AIR -->
+	<!-- The two high-eta corners (in r-phi-plane) of the plates are cut off -->
+	<!-- For that a boolean subtraction with the volumes SubtractBox1 and SubtractBox2 is used. -->
+	<!-- The initial polyhedron without cuts is called "CAEL_helper1". -->
+	<!-- Then the corner with smaller phi is cut with SubtractBox1 and the produced helper-volume with one cut corner is called "CAEL_helper2"-->
+	<!-- At last the volume "CAEL_helper2" is cut again with SubtractBox2 and the final W/Q plate is called CAEL/CAEA/CAEF -->
+
+	<Box name="SubtractBox1" dx="1.9445*mm" dy="10*mm" dz="40*mm"/>
+	<Box name="SubtractBox2" dx="1.9445*mm" dy="10*mm" dz="40*mm"/>
+
+	<Polyhedra name="CAEL_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="48.89*mm" z="11.30*mm"/>
+            <ZSection rMin="130.79*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="113.80*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEL_helper2">
+	  <rSolid name="castor:CAEL_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEL">
+	  <rSolid name="castor:CAEL_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <Polyhedra name="CAEA_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="41.82*mm" z="4.23*mm"/>
+            <ZSection rMin="137.86*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="106.73*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEA_helper2">
+	  <rSolid name="castor:CAEA_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEA">
+	  <rSolid name="castor:CAEA_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<Polyhedra name="CAEF_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="41.42*mm" z="3.83*mm"/>
+            <ZSection rMin="138.26*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="106.33*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEF_helper2">
+	  <rSolid name="castor:CAEF_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEF">
+	  <rSolid name="castor:CAEF_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <!-- shape to be used for Intersection to create C3TF,C4TF semi-trapezoid solids   -->
+        <!-- box defined from center of box (rotated therefore x!=x_global) -->
+        <!-- dz=Height of plate/2 + 3 mm (arbitrary) ; dy = plate width/2 -->
+	<Box name="C2EF" dz="76.890*mm" dy="(29.79)*mm" dx="1.495*mm"/>
+        <IntersectionSolid name="castor:C3EF">
+            <rSolid name="castor:CAEF"/>
+            <rSolid name="castor:C2EF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="93.75198195*mm" y="6.57782247*mm" z="53.6642067*mm"/>
+        </IntersectionSolid>
+        <IntersectionSolid name="castor:C4EF">
+            <rSolid name="castor:CAEF"/>
+            <rSolid name="castor:C2EF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="70.94403509*mm" y="61.64098148*mm" z="53.66420678*mm"/>
+        </IntersectionSolid>
+        <!--  -->
+        <!-- tree with HADRONIC calorimeter 1 copy 8x14x7x(10.5) -->
+        <!--  -->
+        <!--  -->
+        <Polyhedra name="CAHC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+        </Polyhedra>
+        <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
+        <!-- CAHS sector - Air, 8 copies with deltaPhi=45.0  -->
+        <Polyhedra name="CAHS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+        </Polyhedra>
+        <!-- HAD read-out channel  with StainlessSteel size  12 copies -->
+        <Polyhedra name="CAHR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="141.00*mm" z="101.0*mm"/>
+            <ZSection rMin="76.40*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="238.4*mm"/>
+        </Polyhedra>
+        <!-- reduced rMin,rMax by (1.mm (StainlessSteel)/tg(22.5)) -1mm = 1.41mm-->
+        <!-- the special X,Y shifts are needed (see CERR) -->
+        <Polyhedra name="CHRR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="139.59*mm" z="102.00*mm"/>
+            <ZSection rMin="73.99*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="238.40*mm"/>
+        </Polyhedra>
+        <!-- layer    7 copies (10.+4.+0.4)/sin(45deg)=20.2  (14.14+5.66+0.60) -->
+	<!-- tungsten layer -->
+        <Polyhedra name="CAHL_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="58.79*mm" z="21.20*mm"/>
+            <ZSection rMin="154.79*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="157.60*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHL_helper2">
+	  <rSolid name="castor:CAHL_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHL">
+	  <rSolid name="castor:CAHL_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<!-- quartz volume layer where wrapping (here simply air?) is included?-->
+        <Polyhedra name="CAHA_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="44.65*mm" z="7.06*mm"/>
+            <ZSection rMin="168.93*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="143.46*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHA_helper2">
+	  <rSolid name="castor:CAHA_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHA">
+	  <rSolid name="castor:CAHA_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<!-- quartz volume without wrapping where will be intersected -->
+        <Polyhedra name="CAHF_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="44.25*mm" z="6.66*mm"/>
+            <ZSection rMin="169.33*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="143.06*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHF_helper2">
+	  <rSolid name="castor:CAHF_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHF">
+	  <rSolid name="castor:CAHF_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <!--  -->
+        <!--  -->
+        <!-- shape to be used for Intersection to create C3TF,C4TF solids   -->
+        <Box name="C2HF" dz="100.865*mm" dy="36.35*mm" dx="2.980*mm"/>
+        <IntersectionSolid name="castor:C3HF">
+            <rSolid name="castor:CAHF"/>
+            <rSolid name="castor:C2HF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="110.861741*mm" y="6.71078*mm" z="69.9071*mm"/>
+        </IntersectionSolid>
+        <IntersectionSolid name="castor:C4HF">
+            <rSolid name="castor:CAHF"/>
+            <rSolid name="castor:C2HF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="83.13641*mm" y="73.645852*mm" z="69.9071*mm"/>
+        </IntersectionSolid>
+        <!--  -->
+        <!-- tree with EM dead material  1 copy 8x2  -->
+        <!--  -->
+        <Polyhedra name="CEDC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="247.50*mm" z="207.5*mm"/>
+            <ZSection rMin="200.20*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="366.2*mm"/>
+        </Polyhedra>
+        <!-- one sector  8 copies -->
+        <Polyhedra name="CEDS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="247.50*mm" z="207.5*mm"/>
+            <ZSection rMin="200.20*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="366.2*mm"/>
+        </Polyhedra>
+        <!-- read-out channel  2 copies -->
+        <Polyhedra name="CEDR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="196.00*mm" z="156.0*mm"/>
+            <ZSection rMin="251.70*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="314.7*mm"/>
+        </Polyhedra>
+        <!-- compartment with Air lightguide (1 mm wall strength) (external part)  1 copy -->
+        <Polyhedra name="CEAL" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+            <ZSection rMin="67.6913*mm" rMax="67.6913*mm" z="13.50*mm"/>
+            <ZSection rMin="67.6913*mm" rMax="98.829*mm" z="39.5*mm"/>
+            <ZSection rMin="105.2413*mm" rMax="149.9623*mm" z="82.27*mm"/>
+            <ZSection rMin="149.9623*mm" rMax="149.9623*mm" z="133.27*mm"/>
+        </Polyhedra>
+        <!-- Air compartment in CEAL (lightguide) (internal part of LG)  1 copy -->
+        <Polyhedra name="CEAI" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+           <ZSection rMin="62.48432*mm" rMax="62.48432*mm" z="14.50*mm"/>
+           <ZSection rMin="62.48432*mm" rMax="91.22937*mm" z="38.50*mm"/>
+           <ZSection rMin="101.78906*mm" rMax="144.75532*mm" z="83.27*mm"/>
+           <ZSection rMin="144.75532*mm" rMax="144.75532*mm" z="132.27*mm"/>
+        </Polyhedra>
+        <!-- Air volume to be filled by PMT  1 copy -->
+        <!-- volume for PMT's -->
+        <!-- Air volume to be filled by PMT box   1 copy -->
+        <Polyhedra name="CEEL" numSide="1" startPhi="19.4709*deg" deltaPhi="6.0582*deg">
+            <ZSection rMin="226.771*mm" rMax="226.771*mm" z="214.771*mm"/>
+            <ZSection rMin="226.771*mm" rMax="250.771*mm" z="238.771*mm"/>
+            <ZSection rMin="258.271*mm" rMax="282.271*mm" z="270.271*mm"/>
+            <ZSection rMin="282.271*mm" rMax="282.271*mm" z="294.271*mm"/>
+        </Polyhedra>
+        <!-- -->
+        <!--  -->
+        <!-- tree with Hadronic dead material  1 copy 8x12 -->
+        <!--  -->
+        <Polyhedra name="CHDC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="366.2*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="1453.4*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="1578.2*mm"/>
+        </Polyhedra>
+        <!-- one sector  8 copies -->
+        <!-- radius of LG + PMT housing = 124.8 mm -->
+        <Polyhedra name="CHDS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="366.2*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="1453.4*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="1578.2*mm"/>
+        </Polyhedra>
+        <!-- read-out channel  12 copies -->
+        <Polyhedra name="CHDR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="279.40*mm" z="342.4*mm"/>
+            <ZSection rMin="217.60*mm" rMax="303.20*mm" z="381.6*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="467.2*mm"/>
+        </Polyhedra>
+        <!--  Aluminium (1mm) compartment with Air lightguide (external part)  1 copy -->
+        <Polyhedra name="CHAL" numSide="1" startPhi="7.1364*deg" deltaPhi="30.7273*deg">
+            <ZSection rMin="45.1808*mm" rMax="45.1808*mm" z="21.65*mm"/>
+            <ZSection rMin="45.1808*mm" rMax="83.2830*mm" z="48.65*mm"/>
+            <ZSection rMin="64.6976*mm" rMax="119.3108*mm" z="74.13*mm"/>
+            <ZSection rMin="119.3108*mm" rMax="119.3108*mm" z="145.43*mm"/>
+        </Polyhedra>
+        <Polyhedra name="CHAI" numSide="1" startPhi="7.1364*deg" deltaPhi="30.7273*deg">
+            <ZSection rMin="43.5074*mm" rMax="43.5074*mm" z="22.15*mm"/>
+            <ZSection rMin="43.5074*mm" rMax="80.1985*mm" z="48.15*mm"/>
+            <ZSection rMin="63.7902*mm" rMax="117.6374*mm" z="74.63*mm"/>
+            <ZSection rMin="117.6374*mm" rMax="117.6374*mm" z="144.93*mm"/>
+        </Polyhedra>
+        <!-- Air volume to be filled by PMT  1 copy -->
+        <!-- volume for PMT's -->
+        <Polyhedra name="CHEL" numSide="1" startPhi="19.5531*deg" deltaPhi="5.89386*deg">
+            <ZSection rMin="252.53*mm" rMax="252.53*mm" z="239.53*mm"/>
+            <ZSection rMin="252.53*mm" rMax="278.53*mm" z="264.53*mm"/>
+            <ZSection rMin="277.20*mm" rMax="303.20*mm" z="290.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="316.2*mm"/>
+        </Polyhedra>
+    </SolidSection>
+    <!--  -->
+    <!-- MATERIALS -->
+    <LogicalPartSection label="castor.xml">
+        <!--  -->
+        <!--  -->
+        <LogicalPart name="CAST" category="unspecified">
+            <rSolid name="CAST"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CASTFar" category="unspecified">
+            <rSolid name="CASTFar"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CASTNear" category="unspecified">
+            <rSolid name="CASTNear"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- -->
+        <!--  Aluminium separation of EM+H sections  -->
+        <LogicalPart name="CAAI" category="unspecified">
+            <rSolid name="CAAI"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- -->
+        <!--  Materials for EM calorimeter -->
+        <!-- -->
+        <LogicalPart name="CAEC" category="unspecified">
+            <rSolid name="CAEC"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAES" category="unspecified">
+            <rSolid name="CAES"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAER" category="unspecified">
+            <rSolid name="CAER"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CERR" category="unspecified">
+            <rSolid name="CERR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+	<LogicalPart name="CAEL" category="unspecified">
+            <rSolid name="CAEL"/>
+            <rMaterial name="materials:Tungsten"/>
+	</LogicalPart>
+        <LogicalPart name="CAEA" category="unspecified">
+            <rSolid name="CAEA"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAEF" category="unspecified">
+            <rSolid name="CAEF"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- quartz plates -->
+        <LogicalPart name="C3EF" category="unspecified">
+            <rSolid name="C3EF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <LogicalPart name="C4EF" category="unspecified">
+            <rSolid name="C4EF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <!-- dead volume materials -->
+        <LogicalPart name="CEDC" category="unspecified">
+            <rSolid name="CEDC"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEDS" category="unspecified">
+            <rSolid name="CEDS"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEDR" category="unspecified">
+            <rSolid name="CEDR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEAL" category="unspecified">
+            <rSolid name="CEAL"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="CEAI" category="unspecified">
+            <rSolid name="CEAI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEEL" category="unspecified">
+            <rSolid name="CEEL"/>
+            <rMaterial name="materials:Castor_Electronics averag"/>
+        </LogicalPart>
+        <!-- materials for HAD section -->
+        <LogicalPart name="CAHC" category="unspecified">
+            <rSolid name="CAHC"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAHS" category="unspecified">
+            <rSolid name="CAHS"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAHR" category="unspecified">
+            <rSolid name="CAHR"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CHRR" category="unspecified">
+            <rSolid name="CHRR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAHL" category="unspecified">
+            <rSolid name="CAHL"/>
+            <rMaterial name="materials:Tungsten"/>
+        </LogicalPart>
+        <LogicalPart name="CAHA" category="unspecified">
+            <rSolid name="CAHA"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAHF" category="unspecified">
+            <rSolid name="CAHF"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="C3HF" category="unspecified">
+            <rSolid name="C3HF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <LogicalPart name="C4HF" category="unspecified">
+            <rSolid name="C4HF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <!-- materials for the dead HAD volumes -->
+        <LogicalPart name="CHDC" category="unspecified">
+            <rSolid name="CHDC"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHDS" category="unspecified">
+            <rSolid name="CHDS"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHDR" category="unspecified">
+            <rSolid name="CHDR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHAL" category="unspecified">
+            <rSolid name="CHAL"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="CHAI" category="unspecified">
+            <rSolid name="CHAI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHEL" category="unspecified">
+            <rSolid name="CHEL"/>
+            <rMaterial name="materials:Castor_Electronics averag"/>
+        </LogicalPart>
+        <!--  -->
+    </LogicalPartSection>
+    <PosPartSection label="castor.xml">
+        <!--  -->
+        <!--  -->
+        <!-- main CASTOR volume inside polycone "forward:Castor" -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="forward:CastorB"/>
+            <rChild name="castor:CASTFar"/>
+            <rRotation name="castor:CASTFarTilt"/>
+            <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
+            <!-- the tilt is defined so that the face position center face position does not change-->
+            <Translation x="5.41*mm - [castor:castLength]*sin([castor:CASTFarTiltAngle])"
+			 y="-5.56*mm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="forward:CastorB"/>
+            <rChild name="castor:CASTNear"/>
+            <rRotation name="castor:CASTNearTilt"/>
+            <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
+            <!-- the tilt is defined so that the face position center face position does not change-->
+            <Translation x="2.49*mm - [castor:castLength]*sin([castor:CASTNearTiltAngle])"
+			 y="-2.35*mm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
+        </PosPart>
+
+        <PosPart copyNumber="2">
+            <rParent name="castor:CASTNear"/>
+            <rChild name="castor:CAST"/>
+            <rRotation name="rotations:R090"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="-0.1*mm" />
+        </PosPart>
+
+        <PosPart copyNumber="3">
+            <rParent name="castor:CASTFar"/>
+            <rChild name="castor:CAST"/>
+            <rRotation name="rotations:R270"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="-0.1*mm" />
+        </PosPart>
+        <!--  -->
+        <!-- Aluminium volume between EM & HAD sections : 1 copy  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="103.1*mm"/>
+        </PosPart>
+        <!-- EM calorimeter  1 copy -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAEC"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="0.1*mm"/>
+        </PosPart>
+        <!-- HADRONIC calorimeter 1 copy  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAHC"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="108.1*mm"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- one EM-sector 4 copies in each half-->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <!--  -->
+        <!-- HADRONIC part sector :  4 copies in each half-->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- EM read-out channels, 2 copies 5 layers each -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAES"/>
+            <rChild name="castor:CAER"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAES"/>
+            <rChild name="castor:CAER"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="51.5*mm"/>
+        </PosPart>
+        <!-- reduced rmin, rmax volume  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAER"/>
+            <rChild name="castor:CERR"/>
+            <rRotation name="rotations:000D"/>
+	    <Translation x="2.41*cos(22.5*deg)*mm" y="2.41*sin(22.5*deg)*mm" z="0.0*mm"/>
+
+        </PosPart>
+        <!--  -->
+        <!-- HAD read-out channel  12 copies include 5 layers -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="101.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="202.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="303.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="404.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="505.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="606.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="707.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="808.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="909.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1010.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1111.0*mm"/>
+        </PosPart>
+        <!-- reduced rmin, rmax volumes -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHR"/>
+            <rChild name="castor:CHRR"/>
+            <rRotation name="rotations:000D"/>
+	    <Translation x="2.41*cos(22.5*deg)*mm" y="2.41*sin(22.5*deg)*mm" z="0.0*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- EM layers :   5 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="10.30*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="20.60*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="30.90*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="41.20*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- HAD layers : 5 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="20.20*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="40.40*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="60.60*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="80.80*mm"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- EM section: Air-Paper-Quartz volumes 1 by 1 by 1 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEL"/>
+            <rChild name="castor:CAEA"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="7.07*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEA"/>
+            <rChild name="castor:CAEF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.2*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEF"/>
+            <rChild name="castor:C3EF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEF"/>
+            <rChild name="castor:C4EF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <!-- HAD sampling unit : Air-Paper-Quartz volumes 1 by 1 by 1 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHL"/>
+            <rChild name="castor:CAHA"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="14.14*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHA"/>
+            <rChild name="castor:CAHF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.28142*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHF"/>
+            <rChild name="castor:C3HF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHF"/>
+            <rChild name="castor:C4HF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- copies for dead material -->
+        <!-- EM dead material -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CEDC"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDS"/>
+            <rChild name="castor:CEDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDS"/>
+            <rChild name="castor:CEDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="51.5*mm"/>
+        </PosPart>
+        <!-- HAD dead volumes -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CHDC"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="101.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="202.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="303.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="404.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="505.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="606.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="707.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="808.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="909.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1010.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1111.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="283.5002*mm" y="85.037*mm" z="239.2853*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="260.5945*mm" y="140.33465*mm" z="239.2853*mm"/>
+        </PosPart>
+	<!-- shift back by rShift in direction of axis -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEAL"/>
+            <rChild name="castor:CEAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[castor:LGxShift]"
+			 y="[castor:LGyShift]"
+			 z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="11.4525*mm" y="-27.6488*mm" z="-13.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-11.4525*mm" y="27.6488*mm" z="-13.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="289.1883*mm" y="79.7934*mm" z="404.6267*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="260.9096*mm" y="148.0646*mm" z="404.6267*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHAL"/>
+            <rChild name="castor:CHAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="1.5460*mm" y="0.6404*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="14.1393*mm" y="-34.1354*mm" z="109.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-14.1393*mm" y="34.1354*mm" z="109.5*mm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/ForwardCommonData/data/dev/castor2015/systMinus/castor.xml
+++ b/Geometry/ForwardCommonData/data/dev/castor2015/systMinus/castor.xml
@@ -1,0 +1,1066 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="castor.xml" eval="true">
+        <Constant name="castLength" value="1583.3*mm" />
+        <Constant name="CASTFarTiltAngle" value="0*deg" />
+        <Constant name="CASTNearTiltAngle" value="0*deg" />
+	<Constant name="LGAngleBegin" value="11.6287*deg"/>
+	<Constant name="LGAngleDelta" value="21.74255*deg"/>
+	<Constant name="LGrShift" value="1*mm/tan([castor:LGAngleDelta]/2)"/>
+	<Constant name="LGxShift" value="[castor:LGrShift] * cos([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+	<Constant name="LGyShift" value="[castor:LGrShift] * sin([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+    </ConstantsSection>
+    <RotationSection label="castor.xml">
+        <Rotation name="CASTFarTilt"  thetaX="90*deg+[CASTFarTiltAngle]" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg+[CASTFarTiltAngle]" phiZ="0*deg" />
+        <Rotation name="CASTNearTilt" thetaX="90*deg+[CASTNearTiltAngle]" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg+[CASTNearTiltAngle]" phiZ="0*deg" />
+	<!-- Rotations for the subtraction boxes SubtractBox1/2 used to cut the high-eta edges of the volumes CAEL, CAEA, CAEF, CAHL, CAHA CAHF -->
+	<Rotation name="SubtractBoxRot1"
+		  thetaX ="90*deg" phiX="(22.5+33.75)*deg"
+		  thetaY="90*deg" phiY="(90+22.5+33.75)*deg"
+		  thetaZ="0*deg" phiZ="0*deg"/>
+	<Rotation name="SubtractBoxRot2"
+		  thetaX ="90*deg" phiX="(22.5-33.75)*deg"
+		  thetaY="90*deg" phiY="(90+22.5-33.75)*deg"
+		  thetaZ="0*deg" phiZ="0*deg"/>
+    </RotationSection>
+    <SolidSection label="castor.xml">
+        <!--  -->
+        <!-- main CASTOR volume  -->
+        <!--  -->
+        <Polyhedra name="CASTFar" numSide="4" startPhi="-90.0*deg" deltaPhi="180.0*deg" >
+            <ZSection rMin="39.00*mm"   rMax="40.00*mm"    z="0.0*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="263.2*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="1320.1*mm" />
+            <ZSection rMin="303.20*mm"  rMax="303.20*mm"   z="[castLength]" />
+        </Polyhedra>
+        <Polyhedra name="CASTNear" numSide="4" startPhi="90.0*deg" deltaPhi="180.0*deg" >
+            <ZSection rMin="39.00*mm"   rMax="40.00*mm"    z="0.0*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="263.2*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="1320.1*mm" />
+            <ZSection rMin="303.20*mm"  rMax="303.20*mm"   z="[castLength]" />
+        </Polyhedra>
+        <Polyhedra name="CAST" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="39.00*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="39.00*mm" rMax="303.20*mm" z="1320.1*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="[castLength]"/>
+        </Polyhedra>
+        <!--  -->
+        <!--  -->
+        <!-- 5mm Aluminium, separating EM + H sections -->
+        <Polyhedra name="CAAI" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="45.00*mm" z="5.0*mm"/>
+            <ZSection rMin="139.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="109.5*mm"/>
+        </Polyhedra>
+        <!--  -->
+        <!-- START OF ELECTROMAGNETIC CALO  -->
+        <!--  CASC - StainlessSteel -->
+        <Polyhedra name="CAEC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+        </Polyhedra>
+        <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
+        <!-- CASS sector - Air, 8 copies with deltaPhi=45.0  -->
+        <Polyhedra name="CAES" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+        </Polyhedra>
+        <!-- EM read-out channel  with StainlessSteel size  1 copy -->
+        <Polyhedra name="CAER" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.50*mm"/>
+            <ZSection rMin="92.00*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="155.00*mm"/>
+        </Polyhedra>
+        <!-- Air volume -->
+        <!-- reduced rMin, rMax by (1.mm (StainlessSteel)/tg(22.5)) -1mm = 1.41mm-->
+        <!-- the special X,Y shifts are needed to construct a wall thickness of 1mm. -->
+        <!-- Start the volume below (1.41mm) and then shift upwards in r by (1.41+1)mm.  -->
+	<!-- => wall thickness = deltaR*tan(22.5deg) = 2.41mm*tan(22.5deg) = 1mm -->
+        <!-- Shifts are defined further down the code.  -->
+        <!-- the shifts are: x = (2.41)*cos(22.5) = 2.23, y=...*sin(22.5)=0.92  1 copy     -->
+
+        <Polyhedra name="CERR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="90.09*mm" z="52.50*mm"/>
+            <ZSection rMin="89.59*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="155.00*mm"/>
+        </Polyhedra>
+        <!-- layer    5 copies (5.mm+2mm)/sin(45deg) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
+        <!-- 0.4 mm air gap included -->
+        <!-- CAEL: Tungsten layer, CAEA: air layer, CAEF: AIR -->
+	<!-- The two high-eta corners (in r-phi-plane) of the plates are cut off -->
+	<!-- For that a boolean subtraction with the volumes SubtractBox1 and SubtractBox2 is used. -->
+	<!-- The initial polyhedron without cuts is called "CAEL_helper1". -->
+	<!-- Then the corner with smaller phi is cut with SubtractBox1 and the produced helper-volume with one cut corner is called "CAEL_helper2"-->
+	<!-- At last the volume "CAEL_helper2" is cut again with SubtractBox2 and the final W/Q plate is called CAEL/CAEA/CAEF -->
+
+	<Box name="SubtractBox1" dx="1.9445*mm" dy="10*mm" dz="40*mm"/>
+	<Box name="SubtractBox2" dx="1.9445*mm" dy="10*mm" dz="40*mm"/>
+
+	<Polyhedra name="CAEL_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="48.89*mm" z="11.30*mm"/>
+            <ZSection rMin="130.79*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="113.80*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEL_helper2">
+	  <rSolid name="castor:CAEL_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEL">
+	  <rSolid name="castor:CAEL_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <Polyhedra name="CAEA_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="41.82*mm" z="4.23*mm"/>
+            <ZSection rMin="137.86*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="106.73*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEA_helper2">
+	  <rSolid name="castor:CAEA_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEA">
+	  <rSolid name="castor:CAEA_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<Polyhedra name="CAEF_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="41.42*mm" z="3.83*mm"/>
+            <ZSection rMin="138.26*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="106.33*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEF_helper2">
+	  <rSolid name="castor:CAEF_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEF">
+	  <rSolid name="castor:CAEF_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <!-- shape to be used for Intersection to create C3TF,C4TF semi-trapezoid solids   -->
+        <!-- box defined from center of box (rotated therefore x!=x_global) -->
+        <!-- dz=Height of plate/2 + 3 mm (arbitrary) ; dy = plate width/2 -->
+	<Box name="C2EF" dz="76.890*mm" dy="(29.79)*mm" dx="1.495*mm"/>
+        <IntersectionSolid name="castor:C3EF">
+            <rSolid name="castor:CAEF"/>
+            <rSolid name="castor:C2EF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="93.75198195*mm" y="6.57782247*mm" z="53.6642067*mm"/>
+        </IntersectionSolid>
+        <IntersectionSolid name="castor:C4EF">
+            <rSolid name="castor:CAEF"/>
+            <rSolid name="castor:C2EF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="70.94403509*mm" y="61.64098148*mm" z="53.66420678*mm"/>
+        </IntersectionSolid>
+        <!--  -->
+        <!-- tree with HADRONIC calorimeter 1 copy 8x14x7x(10.5) -->
+        <!--  -->
+        <!--  -->
+        <Polyhedra name="CAHC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+        </Polyhedra>
+        <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
+        <!-- CAHS sector - Air, 8 copies with deltaPhi=45.0  -->
+        <Polyhedra name="CAHS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+        </Polyhedra>
+        <!-- HAD read-out channel  with StainlessSteel size  12 copies -->
+        <Polyhedra name="CAHR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="141.00*mm" z="101.0*mm"/>
+            <ZSection rMin="76.40*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="238.4*mm"/>
+        </Polyhedra>
+        <!-- reduced rMin,rMax by (1.mm (StainlessSteel)/tg(22.5)) -1mm = 1.41mm-->
+        <!-- the special X,Y shifts are needed (see CERR) -->
+        <Polyhedra name="CHRR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="139.59*mm" z="102.00*mm"/>
+            <ZSection rMin="73.99*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="238.40*mm"/>
+        </Polyhedra>
+        <!-- layer    7 copies (10.+4.+0.4)/sin(45deg)=20.2  (14.14+5.66+0.60) -->
+	<!-- tungsten layer -->
+        <Polyhedra name="CAHL_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="58.79*mm" z="21.20*mm"/>
+            <ZSection rMin="154.79*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="157.60*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHL_helper2">
+	  <rSolid name="castor:CAHL_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHL">
+	  <rSolid name="castor:CAHL_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<!-- quartz volume layer where wrapping (here simply air?) is included?-->
+        <Polyhedra name="CAHA_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="44.65*mm" z="7.06*mm"/>
+            <ZSection rMin="168.93*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="143.46*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHA_helper2">
+	  <rSolid name="castor:CAHA_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHA">
+	  <rSolid name="castor:CAHA_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<!-- quartz volume without wrapping where will be intersected -->
+        <Polyhedra name="CAHF_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="44.25*mm" z="6.66*mm"/>
+            <ZSection rMin="169.33*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="143.06*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHF_helper2">
+	  <rSolid name="castor:CAHF_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHF">
+	  <rSolid name="castor:CAHF_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <!--  -->
+        <!--  -->
+        <!-- shape to be used for Intersection to create C3TF,C4TF solids   -->
+        <Box name="C2HF" dz="100.865*mm" dy="36.35*mm" dx="2.980*mm"/>
+        <IntersectionSolid name="castor:C3HF">
+            <rSolid name="castor:CAHF"/>
+            <rSolid name="castor:C2HF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="110.861741*mm" y="6.71078*mm" z="69.9071*mm"/>
+        </IntersectionSolid>
+        <IntersectionSolid name="castor:C4HF">
+            <rSolid name="castor:CAHF"/>
+            <rSolid name="castor:C2HF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="83.13641*mm" y="73.645852*mm" z="69.9071*mm"/>
+        </IntersectionSolid>
+        <!--  -->
+        <!-- tree with EM dead material  1 copy 8x2  -->
+        <!--  -->
+        <Polyhedra name="CEDC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="247.50*mm" z="207.5*mm"/>
+            <ZSection rMin="200.20*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="366.2*mm"/>
+        </Polyhedra>
+        <!-- one sector  8 copies -->
+        <Polyhedra name="CEDS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="247.50*mm" z="207.5*mm"/>
+            <ZSection rMin="200.20*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="366.2*mm"/>
+        </Polyhedra>
+        <!-- read-out channel  2 copies -->
+        <Polyhedra name="CEDR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="196.00*mm" z="156.0*mm"/>
+            <ZSection rMin="251.70*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="314.7*mm"/>
+        </Polyhedra>
+        <!-- compartment with Air lightguide (1 mm wall strength) (external part)  1 copy -->
+        <Polyhedra name="CEAL" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+            <ZSection rMin="67.6913*mm" rMax="67.6913*mm" z="13.50*mm"/>
+            <ZSection rMin="67.6913*mm" rMax="98.829*mm" z="39.5*mm"/>
+            <ZSection rMin="105.2413*mm" rMax="149.9623*mm" z="82.27*mm"/>
+            <ZSection rMin="149.9623*mm" rMax="149.9623*mm" z="133.27*mm"/>
+        </Polyhedra>
+        <!-- Air compartment in CEAL (lightguide) (internal part of LG)  1 copy -->
+        <Polyhedra name="CEAI" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+           <ZSection rMin="62.48432*mm" rMax="62.48432*mm" z="14.50*mm"/>
+           <ZSection rMin="62.48432*mm" rMax="91.22937*mm" z="38.50*mm"/>
+           <ZSection rMin="101.78906*mm" rMax="144.75532*mm" z="83.27*mm"/>
+           <ZSection rMin="144.75532*mm" rMax="144.75532*mm" z="132.27*mm"/>
+        </Polyhedra>
+        <!-- Air volume to be filled by PMT  1 copy -->
+        <!-- volume for PMT's -->
+        <!-- Air volume to be filled by PMT box   1 copy -->
+        <Polyhedra name="CEEL" numSide="1" startPhi="19.4709*deg" deltaPhi="6.0582*deg">
+            <ZSection rMin="226.771*mm" rMax="226.771*mm" z="214.771*mm"/>
+            <ZSection rMin="226.771*mm" rMax="250.771*mm" z="238.771*mm"/>
+            <ZSection rMin="258.271*mm" rMax="282.271*mm" z="270.271*mm"/>
+            <ZSection rMin="282.271*mm" rMax="282.271*mm" z="294.271*mm"/>
+        </Polyhedra>
+        <!-- -->
+        <!--  -->
+        <!-- tree with Hadronic dead material  1 copy 8x12 -->
+        <!--  -->
+        <Polyhedra name="CHDC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="366.2*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="1453.4*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="1578.2*mm"/>
+        </Polyhedra>
+        <!-- one sector  8 copies -->
+        <!-- radius of LG + PMT housing = 124.8 mm -->
+        <Polyhedra name="CHDS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="366.2*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="1453.4*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="1578.2*mm"/>
+        </Polyhedra>
+        <!-- read-out channel  12 copies -->
+        <Polyhedra name="CHDR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="279.40*mm" z="342.4*mm"/>
+            <ZSection rMin="217.60*mm" rMax="303.20*mm" z="381.6*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="467.2*mm"/>
+        </Polyhedra>
+        <!--  Aluminium (1mm) compartment with Air lightguide (external part)  1 copy -->
+        <Polyhedra name="CHAL" numSide="1" startPhi="7.1364*deg" deltaPhi="30.7273*deg">
+            <ZSection rMin="45.1808*mm" rMax="45.1808*mm" z="21.65*mm"/>
+            <ZSection rMin="45.1808*mm" rMax="83.2830*mm" z="48.65*mm"/>
+            <ZSection rMin="64.6976*mm" rMax="119.3108*mm" z="74.13*mm"/>
+            <ZSection rMin="119.3108*mm" rMax="119.3108*mm" z="145.43*mm"/>
+        </Polyhedra>
+        <Polyhedra name="CHAI" numSide="1" startPhi="7.1364*deg" deltaPhi="30.7273*deg">
+            <ZSection rMin="43.5074*mm" rMax="43.5074*mm" z="22.15*mm"/>
+            <ZSection rMin="43.5074*mm" rMax="80.1985*mm" z="48.15*mm"/>
+            <ZSection rMin="63.7902*mm" rMax="117.6374*mm" z="74.63*mm"/>
+            <ZSection rMin="117.6374*mm" rMax="117.6374*mm" z="144.93*mm"/>
+        </Polyhedra>
+        <!-- Air volume to be filled by PMT  1 copy -->
+        <!-- volume for PMT's -->
+        <Polyhedra name="CHEL" numSide="1" startPhi="19.5531*deg" deltaPhi="5.89386*deg">
+            <ZSection rMin="252.53*mm" rMax="252.53*mm" z="239.53*mm"/>
+            <ZSection rMin="252.53*mm" rMax="278.53*mm" z="264.53*mm"/>
+            <ZSection rMin="277.20*mm" rMax="303.20*mm" z="290.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="316.2*mm"/>
+        </Polyhedra>
+    </SolidSection>
+    <!--  -->
+    <!-- MATERIALS -->
+    <LogicalPartSection label="castor.xml">
+        <!--  -->
+        <!--  -->
+        <LogicalPart name="CAST" category="unspecified">
+            <rSolid name="CAST"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CASTFar" category="unspecified">
+            <rSolid name="CASTFar"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CASTNear" category="unspecified">
+            <rSolid name="CASTNear"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- -->
+        <!--  Aluminium separation of EM+H sections  -->
+        <LogicalPart name="CAAI" category="unspecified">
+            <rSolid name="CAAI"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- -->
+        <!--  Materials for EM calorimeter -->
+        <!-- -->
+        <LogicalPart name="CAEC" category="unspecified">
+            <rSolid name="CAEC"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAES" category="unspecified">
+            <rSolid name="CAES"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAER" category="unspecified">
+            <rSolid name="CAER"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CERR" category="unspecified">
+            <rSolid name="CERR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+	<LogicalPart name="CAEL" category="unspecified">
+            <rSolid name="CAEL"/>
+            <rMaterial name="materials:Tungsten"/>
+	</LogicalPart>
+        <LogicalPart name="CAEA" category="unspecified">
+            <rSolid name="CAEA"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAEF" category="unspecified">
+            <rSolid name="CAEF"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- quartz plates -->
+        <LogicalPart name="C3EF" category="unspecified">
+            <rSolid name="C3EF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <LogicalPart name="C4EF" category="unspecified">
+            <rSolid name="C4EF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <!-- dead volume materials -->
+        <LogicalPart name="CEDC" category="unspecified">
+            <rSolid name="CEDC"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEDS" category="unspecified">
+            <rSolid name="CEDS"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEDR" category="unspecified">
+            <rSolid name="CEDR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEAL" category="unspecified">
+            <rSolid name="CEAL"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="CEAI" category="unspecified">
+            <rSolid name="CEAI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEEL" category="unspecified">
+            <rSolid name="CEEL"/>
+            <rMaterial name="materials:Castor_Electronics averag"/>
+        </LogicalPart>
+        <!-- materials for HAD section -->
+        <LogicalPart name="CAHC" category="unspecified">
+            <rSolid name="CAHC"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAHS" category="unspecified">
+            <rSolid name="CAHS"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAHR" category="unspecified">
+            <rSolid name="CAHR"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CHRR" category="unspecified">
+            <rSolid name="CHRR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAHL" category="unspecified">
+            <rSolid name="CAHL"/>
+            <rMaterial name="materials:Tungsten"/>
+        </LogicalPart>
+        <LogicalPart name="CAHA" category="unspecified">
+            <rSolid name="CAHA"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAHF" category="unspecified">
+            <rSolid name="CAHF"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="C3HF" category="unspecified">
+            <rSolid name="C3HF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <LogicalPart name="C4HF" category="unspecified">
+            <rSolid name="C4HF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <!-- materials for the dead HAD volumes -->
+        <LogicalPart name="CHDC" category="unspecified">
+            <rSolid name="CHDC"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHDS" category="unspecified">
+            <rSolid name="CHDS"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHDR" category="unspecified">
+            <rSolid name="CHDR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHAL" category="unspecified">
+            <rSolid name="CHAL"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="CHAI" category="unspecified">
+            <rSolid name="CHAI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHEL" category="unspecified">
+            <rSolid name="CHEL"/>
+            <rMaterial name="materials:Castor_Electronics averag"/>
+        </LogicalPart>
+        <!--  -->
+    </LogicalPartSection>
+    <PosPartSection label="castor.xml">
+        <!--  -->
+        <!--  -->
+        <!-- main CASTOR volume inside polycone "forward:Castor" -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="forward:CastorB"/>
+            <rChild name="castor:CASTFar"/>
+            <rRotation name="castor:CASTFarTilt"/>
+            <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
+            <!-- the tilt is defined so that the face position center face position does not change-->
+            <Translation x="6.61*mm - [castor:castLength]*sin([castor:CASTFarTiltAngle])"
+			 y="-6.76*mm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="forward:CastorB"/>
+            <rChild name="castor:CASTNear"/>
+            <rRotation name="castor:CASTNearTilt"/>
+            <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
+            <!-- the tilt is defined so that the face position center face position does not change-->
+            <Translation x="4.66*mm - [castor:castLength]*sin([castor:CASTNearTiltAngle])"
+			 y="-4.52*mm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
+        </PosPart>
+
+        <PosPart copyNumber="2">
+            <rParent name="castor:CASTNear"/>
+            <rChild name="castor:CAST"/>
+            <rRotation name="rotations:R090"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="-0.1*mm" />
+        </PosPart>
+
+        <PosPart copyNumber="3">
+            <rParent name="castor:CASTFar"/>
+            <rChild name="castor:CAST"/>
+            <rRotation name="rotations:R270"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="-0.1*mm" />
+        </PosPart>
+        <!--  -->
+        <!-- Aluminium volume between EM & HAD sections : 1 copy  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="103.1*mm"/>
+        </PosPart>
+        <!-- EM calorimeter  1 copy -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAEC"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="0.1*mm"/>
+        </PosPart>
+        <!-- HADRONIC calorimeter 1 copy  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAHC"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="108.1*mm"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- one EM-sector 4 copies in each half-->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <!--  -->
+        <!-- HADRONIC part sector :  4 copies in each half-->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- EM read-out channels, 2 copies 5 layers each -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAES"/>
+            <rChild name="castor:CAER"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAES"/>
+            <rChild name="castor:CAER"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="51.5*mm"/>
+        </PosPart>
+        <!-- reduced rmin, rmax volume  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAER"/>
+            <rChild name="castor:CERR"/>
+            <rRotation name="rotations:000D"/>
+	    <Translation x="2.41*cos(22.5*deg)*mm" y="2.41*sin(22.5*deg)*mm" z="0.0*mm"/>
+
+        </PosPart>
+        <!--  -->
+        <!-- HAD read-out channel  12 copies include 5 layers -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="101.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="202.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="303.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="404.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="505.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="606.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="707.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="808.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="909.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1010.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1111.0*mm"/>
+        </PosPart>
+        <!-- reduced rmin, rmax volumes -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHR"/>
+            <rChild name="castor:CHRR"/>
+            <rRotation name="rotations:000D"/>
+	    <Translation x="2.41*cos(22.5*deg)*mm" y="2.41*sin(22.5*deg)*mm" z="0.0*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- EM layers :   5 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="10.30*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="20.60*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="30.90*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="41.20*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- HAD layers : 5 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="20.20*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="40.40*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="60.60*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="80.80*mm"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- EM section: Air-Paper-Quartz volumes 1 by 1 by 1 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEL"/>
+            <rChild name="castor:CAEA"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="7.07*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEA"/>
+            <rChild name="castor:CAEF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.2*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEF"/>
+            <rChild name="castor:C3EF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEF"/>
+            <rChild name="castor:C4EF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <!-- HAD sampling unit : Air-Paper-Quartz volumes 1 by 1 by 1 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHL"/>
+            <rChild name="castor:CAHA"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="14.14*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHA"/>
+            <rChild name="castor:CAHF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.28142*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHF"/>
+            <rChild name="castor:C3HF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHF"/>
+            <rChild name="castor:C4HF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- copies for dead material -->
+        <!-- EM dead material -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CEDC"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDS"/>
+            <rChild name="castor:CEDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDS"/>
+            <rChild name="castor:CEDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="51.5*mm"/>
+        </PosPart>
+        <!-- HAD dead volumes -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CHDC"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="101.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="202.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="303.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="404.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="505.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="606.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="707.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="808.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="909.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1010.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1111.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="283.5002*mm" y="85.037*mm" z="239.2853*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="260.5945*mm" y="140.33465*mm" z="239.2853*mm"/>
+        </PosPart>
+	<!-- shift back by rShift in direction of axis -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEAL"/>
+            <rChild name="castor:CEAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[castor:LGxShift]"
+			 y="[castor:LGyShift]"
+			 z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="11.4525*mm" y="-27.6488*mm" z="-13.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-11.4525*mm" y="27.6488*mm" z="-13.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="289.1883*mm" y="79.7934*mm" z="404.6267*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="260.9096*mm" y="148.0646*mm" z="404.6267*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHAL"/>
+            <rChild name="castor:CHAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="1.5460*mm" y="0.6404*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="14.1393*mm" y="-34.1354*mm" z="109.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-14.1393*mm" y="34.1354*mm" z="109.5*mm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/ForwardCommonData/data/dev/castor2015/systPlus/castor.xml
+++ b/Geometry/ForwardCommonData/data/dev/castor2015/systPlus/castor.xml
@@ -1,0 +1,1066 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="castor.xml" eval="true">
+        <Constant name="castLength" value="1583.3*mm" />
+        <Constant name="CASTFarTiltAngle" value="0*deg" />
+        <Constant name="CASTNearTiltAngle" value="0*deg" />
+	<Constant name="LGAngleBegin" value="11.6287*deg"/>
+	<Constant name="LGAngleDelta" value="21.74255*deg"/>
+	<Constant name="LGrShift" value="1*mm/tan([castor:LGAngleDelta]/2)"/>
+	<Constant name="LGxShift" value="[castor:LGrShift] * cos([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+	<Constant name="LGyShift" value="[castor:LGrShift] * sin([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+    </ConstantsSection>
+    <RotationSection label="castor.xml">
+        <Rotation name="CASTFarTilt"  thetaX="90*deg+[CASTFarTiltAngle]" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg+[CASTFarTiltAngle]" phiZ="0*deg" />
+        <Rotation name="CASTNearTilt" thetaX="90*deg+[CASTNearTiltAngle]" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg+[CASTNearTiltAngle]" phiZ="0*deg" />
+	<!-- Rotations for the subtraction boxes SubtractBox1/2 used to cut the high-eta edges of the volumes CAEL, CAEA, CAEF, CAHL, CAHA CAHF -->
+	<Rotation name="SubtractBoxRot1"
+		  thetaX ="90*deg" phiX="(22.5+33.75)*deg"
+		  thetaY="90*deg" phiY="(90+22.5+33.75)*deg"
+		  thetaZ="0*deg" phiZ="0*deg"/>
+	<Rotation name="SubtractBoxRot2"
+		  thetaX ="90*deg" phiX="(22.5-33.75)*deg"
+		  thetaY="90*deg" phiY="(90+22.5-33.75)*deg"
+		  thetaZ="0*deg" phiZ="0*deg"/>
+    </RotationSection>
+    <SolidSection label="castor.xml">
+        <!--  -->
+        <!-- main CASTOR volume  -->
+        <!--  -->
+        <Polyhedra name="CASTFar" numSide="4" startPhi="-90.0*deg" deltaPhi="180.0*deg" >
+            <ZSection rMin="39.00*mm"   rMax="40.00*mm"    z="0.0*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="263.2*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="1320.1*mm" />
+            <ZSection rMin="303.20*mm"  rMax="303.20*mm"   z="[castLength]" />
+        </Polyhedra>
+        <Polyhedra name="CASTNear" numSide="4" startPhi="90.0*deg" deltaPhi="180.0*deg" >
+            <ZSection rMin="39.00*mm"   rMax="40.00*mm"    z="0.0*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="263.2*mm" />
+            <ZSection rMin="39.00*mm"   rMax="303.20*mm"   z="1320.1*mm" />
+            <ZSection rMin="303.20*mm"  rMax="303.20*mm"   z="[castLength]" />
+        </Polyhedra>
+        <Polyhedra name="CAST" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="39.00*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="39.00*mm" rMax="303.20*mm" z="1320.1*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="[castLength]"/>
+        </Polyhedra>
+        <!--  -->
+        <!--  -->
+        <!-- 5mm Aluminium, separating EM + H sections -->
+        <Polyhedra name="CAAI" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="45.00*mm" z="5.0*mm"/>
+            <ZSection rMin="139.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="109.5*mm"/>
+        </Polyhedra>
+        <!--  -->
+        <!-- START OF ELECTROMAGNETIC CALO  -->
+        <!--  CASC - StainlessSteel -->
+        <Polyhedra name="CAEC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+        </Polyhedra>
+        <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
+        <!-- CASS sector - Air, 8 copies with deltaPhi=45.0  -->
+        <Polyhedra name="CAES" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+        </Polyhedra>
+        <!-- EM read-out channel  with StainlessSteel size  1 copy -->
+        <Polyhedra name="CAER" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.50*mm"/>
+            <ZSection rMin="92.00*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="155.00*mm"/>
+        </Polyhedra>
+        <!-- Air volume -->
+        <!-- reduced rMin, rMax by (1.mm (StainlessSteel)/tg(22.5)) -1mm = 1.41mm-->
+        <!-- the special X,Y shifts are needed to construct a wall thickness of 1mm. -->
+        <!-- Start the volume below (1.41mm) and then shift upwards in r by (1.41+1)mm.  -->
+	<!-- => wall thickness = deltaR*tan(22.5deg) = 2.41mm*tan(22.5deg) = 1mm -->
+        <!-- Shifts are defined further down the code.  -->
+        <!-- the shifts are: x = (2.41)*cos(22.5) = 2.23, y=...*sin(22.5)=0.92  1 copy     -->
+
+        <Polyhedra name="CERR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="90.09*mm" z="52.50*mm"/>
+            <ZSection rMin="89.59*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="155.00*mm"/>
+        </Polyhedra>
+        <!-- layer    5 copies (5.mm+2mm)/sin(45deg) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
+        <!-- 0.4 mm air gap included -->
+        <!-- CAEL: Tungsten layer, CAEA: air layer, CAEF: AIR -->
+	<!-- The two high-eta corners (in r-phi-plane) of the plates are cut off -->
+	<!-- For that a boolean subtraction with the volumes SubtractBox1 and SubtractBox2 is used. -->
+	<!-- The initial polyhedron without cuts is called "CAEL_helper1". -->
+	<!-- Then the corner with smaller phi is cut with SubtractBox1 and the produced helper-volume with one cut corner is called "CAEL_helper2"-->
+	<!-- At last the volume "CAEL_helper2" is cut again with SubtractBox2 and the final W/Q plate is called CAEL/CAEA/CAEF -->
+
+	<Box name="SubtractBox1" dx="1.9445*mm" dy="10*mm" dz="40*mm"/>
+	<Box name="SubtractBox2" dx="1.9445*mm" dy="10*mm" dz="40*mm"/>
+
+	<Polyhedra name="CAEL_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="48.89*mm" z="11.30*mm"/>
+            <ZSection rMin="130.79*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="113.80*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEL_helper2">
+	  <rSolid name="castor:CAEL_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEL">
+	  <rSolid name="castor:CAEL_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <Polyhedra name="CAEA_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="41.82*mm" z="4.23*mm"/>
+            <ZSection rMin="137.86*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="106.73*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEA_helper2">
+	  <rSolid name="castor:CAEA_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEA">
+	  <rSolid name="castor:CAEA_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<Polyhedra name="CAEF_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="41.42*mm" z="3.83*mm"/>
+            <ZSection rMin="138.26*mm" rMax="141.09*mm" z="103.50*mm"/>
+            <ZSection rMin="141.09*mm" rMax="141.09*mm" z="106.33*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAEF_helper2">
+	  <rSolid name="castor:CAEF_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAEF">
+	  <rSolid name="castor:CAEF_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <!-- shape to be used for Intersection to create C3TF,C4TF semi-trapezoid solids   -->
+        <!-- box defined from center of box (rotated therefore x!=x_global) -->
+        <!-- dz=Height of plate/2 + 3 mm (arbitrary) ; dy = plate width/2 -->
+	<Box name="C2EF" dz="76.890*mm" dy="(29.79)*mm" dx="1.495*mm"/>
+        <IntersectionSolid name="castor:C3EF">
+            <rSolid name="castor:CAEF"/>
+            <rSolid name="castor:C2EF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="93.75198195*mm" y="6.57782247*mm" z="53.6642067*mm"/>
+        </IntersectionSolid>
+        <IntersectionSolid name="castor:C4EF">
+            <rSolid name="castor:CAEF"/>
+            <rSolid name="castor:C2EF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="70.94403509*mm" y="61.64098148*mm" z="53.66420678*mm"/>
+        </IntersectionSolid>
+        <!--  -->
+        <!-- tree with HADRONIC calorimeter 1 copy 8x14x7x(10.5) -->
+        <!--  -->
+        <!--  -->
+        <Polyhedra name="CAHC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+        </Polyhedra>
+        <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
+        <!-- CAHS sector - Air, 8 copies with deltaPhi=45.0  -->
+        <Polyhedra name="CAHS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+        </Polyhedra>
+        <!-- HAD read-out channel  with StainlessSteel size  12 copies -->
+        <Polyhedra name="CAHR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="141.00*mm" z="101.0*mm"/>
+            <ZSection rMin="76.40*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="238.4*mm"/>
+        </Polyhedra>
+        <!-- reduced rMin,rMax by (1.mm (StainlessSteel)/tg(22.5)) -1mm = 1.41mm-->
+        <!-- the special X,Y shifts are needed (see CERR) -->
+        <Polyhedra name="CHRR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="139.59*mm" z="102.00*mm"/>
+            <ZSection rMin="73.99*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="238.40*mm"/>
+        </Polyhedra>
+        <!-- layer    7 copies (10.+4.+0.4)/sin(45deg)=20.2  (14.14+5.66+0.60) -->
+	<!-- tungsten layer -->
+        <Polyhedra name="CAHL_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="58.79*mm" z="21.20*mm"/>
+            <ZSection rMin="154.79*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="157.60*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHL_helper2">
+	  <rSolid name="castor:CAHL_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHL">
+	  <rSolid name="castor:CAHL_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<!-- quartz volume layer where wrapping (here simply air?) is included?-->
+        <Polyhedra name="CAHA_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="44.65*mm" z="7.06*mm"/>
+            <ZSection rMin="168.93*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="143.46*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHA_helper2">
+	  <rSolid name="castor:CAHA_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHA">
+	  <rSolid name="castor:CAHA_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<!-- quartz volume without wrapping where will be intersected -->
+        <Polyhedra name="CAHF_helper1" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="38.59*mm" rMax="38.59*mm" z="1.00*mm"/>
+            <ZSection rMin="38.59*mm" rMax="44.25*mm" z="6.66*mm"/>
+            <ZSection rMin="169.33*mm" rMax="174.99*mm" z="137.40*mm"/>
+            <ZSection rMin="174.99*mm" rMax="174.99*mm" z="143.06*mm"/>
+        </Polyhedra>
+	<SubtractionSolid name="castor:CAHF_helper2">
+	  <rSolid name="castor:CAHF_helper1"/>
+	  <rSolid name="castor:SubtractBox1"/>
+	  <rRotation name="castor:SubtractBoxRot1"/>
+	  <Translation x="(37.59/cos(22.5*deg))*mm" y="0.*mm" z="1.*mm"/>
+	</SubtractionSolid>
+	<SubtractionSolid name="castor:CAHF">
+	  <rSolid name="castor:CAHF_helper2"/>
+	  <rSolid name="castor:SubtractBox2"/>
+	  <rRotation name="castor:SubtractBoxRot2"/>
+	  <Translation x="37.59*cos(45*deg)/cos(22.5*deg)*mm" y="2*37.59*sin(22.5*deg)*mm" z="1.*mm"/>
+	</SubtractionSolid>
+        <!--  -->
+        <!--  -->
+        <!-- shape to be used for Intersection to create C3TF,C4TF solids   -->
+        <Box name="C2HF" dz="100.865*mm" dy="36.35*mm" dx="2.980*mm"/>
+        <IntersectionSolid name="castor:C3HF">
+            <rSolid name="castor:CAHF"/>
+            <rSolid name="castor:C2HF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="110.861741*mm" y="6.71078*mm" z="69.9071*mm"/>
+        </IntersectionSolid>
+        <IntersectionSolid name="castor:C4HF">
+            <rSolid name="castor:CAHF"/>
+            <rSolid name="castor:C2HF"/>
+            <rRotation name="rotations:CARM"/>
+            <Translation x="83.13641*mm" y="73.645852*mm" z="69.9071*mm"/>
+        </IntersectionSolid>
+        <!--  -->
+        <!-- tree with EM dead material  1 copy 8x2  -->
+        <!--  -->
+        <Polyhedra name="CEDC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="247.50*mm" z="207.5*mm"/>
+            <ZSection rMin="200.20*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="366.2*mm"/>
+        </Polyhedra>
+        <!-- one sector  8 copies -->
+        <Polyhedra name="CEDS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="247.50*mm" z="207.5*mm"/>
+            <ZSection rMin="200.20*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="366.2*mm"/>
+        </Polyhedra>
+        <!-- read-out channel  2 copies -->
+        <Polyhedra name="CEDR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="196.00*mm" z="156.0*mm"/>
+            <ZSection rMin="251.70*mm" rMax="303.20*mm" z="263.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="314.7*mm"/>
+        </Polyhedra>
+        <!-- compartment with Air lightguide (1 mm wall strength) (external part)  1 copy -->
+        <Polyhedra name="CEAL" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+            <ZSection rMin="67.6913*mm" rMax="67.6913*mm" z="13.50*mm"/>
+            <ZSection rMin="67.6913*mm" rMax="98.829*mm" z="39.5*mm"/>
+            <ZSection rMin="105.2413*mm" rMax="149.9623*mm" z="82.27*mm"/>
+            <ZSection rMin="149.9623*mm" rMax="149.9623*mm" z="133.27*mm"/>
+        </Polyhedra>
+        <!-- Air compartment in CEAL (lightguide) (internal part of LG)  1 copy -->
+        <Polyhedra name="CEAI" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+           <ZSection rMin="62.48432*mm" rMax="62.48432*mm" z="14.50*mm"/>
+           <ZSection rMin="62.48432*mm" rMax="91.22937*mm" z="38.50*mm"/>
+           <ZSection rMin="101.78906*mm" rMax="144.75532*mm" z="83.27*mm"/>
+           <ZSection rMin="144.75532*mm" rMax="144.75532*mm" z="132.27*mm"/>
+        </Polyhedra>
+        <!-- Air volume to be filled by PMT  1 copy -->
+        <!-- volume for PMT's -->
+        <!-- Air volume to be filled by PMT box   1 copy -->
+        <Polyhedra name="CEEL" numSide="1" startPhi="19.4709*deg" deltaPhi="6.0582*deg">
+            <ZSection rMin="226.771*mm" rMax="226.771*mm" z="214.771*mm"/>
+            <ZSection rMin="226.771*mm" rMax="250.771*mm" z="238.771*mm"/>
+            <ZSection rMin="258.271*mm" rMax="282.271*mm" z="270.271*mm"/>
+            <ZSection rMin="282.271*mm" rMax="282.271*mm" z="294.271*mm"/>
+        </Polyhedra>
+        <!-- -->
+        <!--  -->
+        <!-- tree with Hadronic dead material  1 copy 8x12 -->
+        <!--  -->
+        <Polyhedra name="CHDC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="366.2*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="1453.4*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="1578.2*mm"/>
+        </Polyhedra>
+        <!-- one sector  8 copies -->
+        <!-- radius of LG + PMT housing = 124.8 mm -->
+        <Polyhedra name="CHDS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="366.2*mm"/>
+            <ZSection rMin="178.40*mm" rMax="303.20*mm" z="1453.4*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="1578.2*mm"/>
+        </Polyhedra>
+        <!-- read-out channel  12 copies -->
+        <Polyhedra name="CHDR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="241.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="279.40*mm" z="342.4*mm"/>
+            <ZSection rMin="217.60*mm" rMax="303.20*mm" z="381.6*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="467.2*mm"/>
+        </Polyhedra>
+        <!--  Aluminium (1mm) compartment with Air lightguide (external part)  1 copy -->
+        <Polyhedra name="CHAL" numSide="1" startPhi="7.1364*deg" deltaPhi="30.7273*deg">
+            <ZSection rMin="45.1808*mm" rMax="45.1808*mm" z="21.65*mm"/>
+            <ZSection rMin="45.1808*mm" rMax="83.2830*mm" z="48.65*mm"/>
+            <ZSection rMin="64.6976*mm" rMax="119.3108*mm" z="74.13*mm"/>
+            <ZSection rMin="119.3108*mm" rMax="119.3108*mm" z="145.43*mm"/>
+        </Polyhedra>
+        <Polyhedra name="CHAI" numSide="1" startPhi="7.1364*deg" deltaPhi="30.7273*deg">
+            <ZSection rMin="43.5074*mm" rMax="43.5074*mm" z="22.15*mm"/>
+            <ZSection rMin="43.5074*mm" rMax="80.1985*mm" z="48.15*mm"/>
+            <ZSection rMin="63.7902*mm" rMax="117.6374*mm" z="74.63*mm"/>
+            <ZSection rMin="117.6374*mm" rMax="117.6374*mm" z="144.93*mm"/>
+        </Polyhedra>
+        <!-- Air volume to be filled by PMT  1 copy -->
+        <!-- volume for PMT's -->
+        <Polyhedra name="CHEL" numSide="1" startPhi="19.5531*deg" deltaPhi="5.89386*deg">
+            <ZSection rMin="252.53*mm" rMax="252.53*mm" z="239.53*mm"/>
+            <ZSection rMin="252.53*mm" rMax="278.53*mm" z="264.53*mm"/>
+            <ZSection rMin="277.20*mm" rMax="303.20*mm" z="290.2*mm"/>
+            <ZSection rMin="303.20*mm" rMax="303.20*mm" z="316.2*mm"/>
+        </Polyhedra>
+    </SolidSection>
+    <!--  -->
+    <!-- MATERIALS -->
+    <LogicalPartSection label="castor.xml">
+        <!--  -->
+        <!--  -->
+        <LogicalPart name="CAST" category="unspecified">
+            <rSolid name="CAST"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CASTFar" category="unspecified">
+            <rSolid name="CASTFar"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CASTNear" category="unspecified">
+            <rSolid name="CASTNear"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- -->
+        <!--  Aluminium separation of EM+H sections  -->
+        <LogicalPart name="CAAI" category="unspecified">
+            <rSolid name="CAAI"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- -->
+        <!--  Materials for EM calorimeter -->
+        <!-- -->
+        <LogicalPart name="CAEC" category="unspecified">
+            <rSolid name="CAEC"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAES" category="unspecified">
+            <rSolid name="CAES"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAER" category="unspecified">
+            <rSolid name="CAER"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CERR" category="unspecified">
+            <rSolid name="CERR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+	<LogicalPart name="CAEL" category="unspecified">
+            <rSolid name="CAEL"/>
+            <rMaterial name="materials:Tungsten"/>
+	</LogicalPart>
+        <LogicalPart name="CAEA" category="unspecified">
+            <rSolid name="CAEA"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAEF" category="unspecified">
+            <rSolid name="CAEF"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- quartz plates -->
+        <LogicalPart name="C3EF" category="unspecified">
+            <rSolid name="C3EF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <LogicalPart name="C4EF" category="unspecified">
+            <rSolid name="C4EF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <!-- dead volume materials -->
+        <LogicalPart name="CEDC" category="unspecified">
+            <rSolid name="CEDC"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEDS" category="unspecified">
+            <rSolid name="CEDS"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEDR" category="unspecified">
+            <rSolid name="CEDR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEAL" category="unspecified">
+            <rSolid name="CEAL"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="CEAI" category="unspecified">
+            <rSolid name="CEAI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CEEL" category="unspecified">
+            <rSolid name="CEEL"/>
+            <rMaterial name="materials:Castor_Electronics averag"/>
+        </LogicalPart>
+        <!-- materials for HAD section -->
+        <LogicalPart name="CAHC" category="unspecified">
+            <rSolid name="CAHC"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAHS" category="unspecified">
+            <rSolid name="CAHS"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CAHR" category="unspecified">
+            <rSolid name="CAHR"/>
+            <rMaterial name="materials:StainlessSteel"/>
+        </LogicalPart>
+        <LogicalPart name="CHRR" category="unspecified">
+            <rSolid name="CHRR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAHL" category="unspecified">
+            <rSolid name="CAHL"/>
+            <rMaterial name="materials:Tungsten"/>
+        </LogicalPart>
+        <LogicalPart name="CAHA" category="unspecified">
+            <rSolid name="CAHA"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CAHF" category="unspecified">
+            <rSolid name="CAHF"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="C3HF" category="unspecified">
+            <rSolid name="C3HF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <LogicalPart name="C4HF" category="unspecified">
+            <rSolid name="C4HF"/>
+            <rMaterial name="materials:Quartz"/>
+        </LogicalPart>
+        <!-- materials for the dead HAD volumes -->
+        <LogicalPart name="CHDC" category="unspecified">
+            <rSolid name="CHDC"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHDS" category="unspecified">
+            <rSolid name="CHDS"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHDR" category="unspecified">
+            <rSolid name="CHDR"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHAL" category="unspecified">
+            <rSolid name="CHAL"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="CHAI" category="unspecified">
+            <rSolid name="CHAI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="CHEL" category="unspecified">
+            <rSolid name="CHEL"/>
+            <rMaterial name="materials:Castor_Electronics averag"/>
+        </LogicalPart>
+        <!--  -->
+    </LogicalPartSection>
+    <PosPartSection label="castor.xml">
+        <!--  -->
+        <!--  -->
+        <!-- main CASTOR volume inside polycone "forward:Castor" -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="forward:CastorB"/>
+            <rChild name="castor:CASTFar"/>
+            <rRotation name="castor:CASTFarTilt"/>
+            <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
+            <!-- the tilt is defined so that the face position center face position does not change-->
+            <Translation x="4.21*mm - [castor:castLength]*sin([castor:CASTFarTiltAngle])"
+			 y="-4.36*mm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="forward:CastorB"/>
+            <rChild name="castor:CASTNear"/>
+            <rRotation name="castor:CASTNearTilt"/>
+            <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
+            <!-- the tilt is defined so that the face position center face position does not change-->
+            <Translation x="0.32*mm - [castor:castLength]*sin([castor:CASTNearTiltAngle])"
+			 y="-0.18*mm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
+        </PosPart>
+
+        <PosPart copyNumber="2">
+            <rParent name="castor:CASTNear"/>
+            <rChild name="castor:CAST"/>
+            <rRotation name="rotations:R090"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="-0.1*mm" />
+        </PosPart>
+
+        <PosPart copyNumber="3">
+            <rParent name="castor:CASTFar"/>
+            <rChild name="castor:CAST"/>
+            <rRotation name="rotations:R270"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="-0.1*mm" />
+        </PosPart>
+        <!--  -->
+        <!-- Aluminium volume between EM & HAD sections : 1 copy  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="103.1*mm"/>
+        </PosPart>
+        <!-- EM calorimeter  1 copy -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAEC"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="0.1*mm"/>
+        </PosPart>
+        <!-- HADRONIC calorimeter 1 copy  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CAHC"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*cm" y="0.0*cm" z="108.1*mm"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- one EM-sector 4 copies in each half-->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAEC"/>
+            <rChild name="castor:CAES"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <!--  -->
+        <!-- HADRONIC part sector :  4 copies in each half-->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAHC"/>
+            <rChild name="castor:CAHS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- EM read-out channels, 2 copies 5 layers each -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAES"/>
+            <rChild name="castor:CAER"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAES"/>
+            <rChild name="castor:CAER"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="51.5*mm"/>
+        </PosPart>
+        <!-- reduced rmin, rmax volume  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAER"/>
+            <rChild name="castor:CERR"/>
+            <rRotation name="rotations:000D"/>
+	    <Translation x="2.41*cos(22.5*deg)*mm" y="2.41*sin(22.5*deg)*mm" z="0.0*mm"/>
+
+        </PosPart>
+        <!--  -->
+        <!-- HAD read-out channel  12 copies include 5 layers -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="101.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="202.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="303.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="404.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="505.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="606.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="707.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="808.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="909.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1010.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="castor:CAHS"/>
+            <rChild name="castor:CAHR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1111.0*mm"/>
+        </PosPart>
+        <!-- reduced rmin, rmax volumes -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHR"/>
+            <rChild name="castor:CHRR"/>
+            <rRotation name="rotations:000D"/>
+	    <Translation x="2.41*cos(22.5*deg)*mm" y="2.41*sin(22.5*deg)*mm" z="0.0*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- EM layers :   5 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="10.30*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="20.60*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="30.90*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CERR"/>
+            <rChild name="castor:CAEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="41.20*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- HAD layers : 5 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="20.20*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="40.40*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="60.60*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CHRR"/>
+            <rChild name="castor:CAHL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="80.80*mm"/>
+        </PosPart>
+        <!--  -->
+        <!--  -->
+        <!-- EM section: Air-Paper-Quartz volumes 1 by 1 by 1 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEL"/>
+            <rChild name="castor:CAEA"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="7.07*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEA"/>
+            <rChild name="castor:CAEF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.2*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEF"/>
+            <rChild name="castor:C3EF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAEF"/>
+            <rChild name="castor:C4EF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <!-- HAD sampling unit : Air-Paper-Quartz volumes 1 by 1 by 1 copies -->
+        <!--  -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHL"/>
+            <rChild name="castor:CAHA"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="14.14*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHA"/>
+            <rChild name="castor:CAHF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.28142*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHF"/>
+            <rChild name="castor:C3HF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAHF"/>
+            <rChild name="castor:C4HF"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.000*mm"/>
+        </PosPart>
+        <!--  -->
+        <!-- copies for dead material -->
+        <!-- EM dead material -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CEDC"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CEDC"/>
+            <rChild name="castor:CEDS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDS"/>
+            <rChild name="castor:CEDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDS"/>
+            <rChild name="castor:CEDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="51.5*mm"/>
+        </PosPart>
+        <!-- HAD dead volumes -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CAST"/>
+            <rChild name="castor:CHDC"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:000D"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R045"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R090"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHDC"/>
+            <rChild name="castor:CHDS"/>
+            <rRotation name="rotations:R135"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="101.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="202.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="303.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="404.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="505.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="606.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="707.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="808.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="909.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1010.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="castor:CHDS"/>
+            <rChild name="castor:CHDR"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="1111.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="283.5002*mm" y="85.037*mm" z="239.2853*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="260.5945*mm" y="140.33465*mm" z="239.2853*mm"/>
+        </PosPart>
+	<!-- shift back by rShift in direction of axis -->
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEAL"/>
+            <rChild name="castor:CEAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[castor:LGxShift]"
+			 y="[castor:LGyShift]"
+			 z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="11.4525*mm" y="-27.6488*mm" z="-13.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CEDR"/>
+            <rChild name="castor:CEEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-11.4525*mm" y="27.6488*mm" z="-13.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="289.1883*mm" y="79.7934*mm" z="404.6267*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHAL"/>
+            <rRotation name="rotations:CABK"/>
+            <Translation x="260.9096*mm" y="148.0646*mm" z="404.6267*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHAL"/>
+            <rChild name="castor:CHAI"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="1.5460*mm" y="0.6404*mm" z="0.0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="14.1393*mm" y="-34.1354*mm" z="109.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="castor:CHDR"/>
+            <rChild name="castor:CHEL"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-14.1393*mm" y="34.1354*mm" z="109.5*mm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>


### PR DESCRIPTION
This PR is complementary to the other two recent PRs for CASTOR (#10259,  #10216).
The changed add 3 castor.xml files:
1. One with the measured position by the positioning sensors
2. Same as (1) plus an upward shift within the sys uncertainty
3. Same as (2) but with downward shift.

The files are in separate folders. Hope this is OK but simple renaming could not be done because of the namespace "castor:" used by DDL.

FSQ Group wants to request simulations with these files.
Thank you.
Automatically ported from CMSSW_7_6_X #11730 (original by @cbaus).
