### PR TITLE
  Replace mark-and-delete at next merge algorithm in DQMStore (76x)

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -735,7 +735,7 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
     }
 
     // after saving per LS, delete the old LS global histograms.
-    dbe_->markForDeletion(enableMultiThread_ ? irun : 0, ilumi);
+    dbe_->deleteUnusedLumiHistograms(enableMultiThread_ ? irun : 0, ilumi);
   }
 }
 

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -629,7 +629,7 @@ class DQMStore
 					      uint32_t streamId,
 					      uint32_t moduleId);
 
-  void markForDeletion(uint32_t run, uint32_t lumi);
+  void deleteUnusedLumiHistograms(uint32_t run, uint32_t lumi);
  private:
 
   // ---------------- Miscellaneous -----------------------------

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
@@ -23,10 +23,6 @@
 #include <TString.h>
 #include <TSystem.h>
 
-#include <openssl/md5.h>
-#include <boost/iostreams/device/mapped_file.hpp>
-#include <boost/filesystem.hpp>
-
 using namespace dqm;
 
 DQMFileSaverBase::DQMFileSaverBase(const edm::ParameterSet &ps) {
@@ -72,10 +68,10 @@ DQMFileSaverBase::DQMFileSaverBase(const edm::ParameterSet &ps) {
 
 DQMFileSaverBase::~DQMFileSaverBase() {}
 
-void DQMFileSaverBase::beginJob() {}
-
 std::shared_ptr<NoCache> DQMFileSaverBase::globalBeginRun(
     const edm::Run &r, const edm::EventSetup &) const {
+
+  this->initRun();  
 
   return nullptr;
 }
@@ -103,11 +99,10 @@ void DQMFileSaverBase::globalEndLuminosityBlock(const edm::LuminosityBlock &iLS,
   fp.lumi_ = ilumi;
   fp.run_ = irun;
 
-  edm::Service<DQMStore> store;
-
   this->saveLumi(fp);
 
-  store->markForDeletion(store->mtEnabled() ? irun : 0, ilumi);
+  edm::Service<DQMStore> store;
+  store->deleteUnusedLumiHistograms(store->mtEnabled() ? irun : 0, ilumi);
 }
 
 void DQMFileSaverBase::globalEndRun(const edm::Run &iRun,
@@ -122,8 +117,6 @@ void DQMFileSaverBase::globalEndRun(const edm::Run &iRun,
   // empty
   this->saveRun(fp);
 }
-
-void DQMFileSaverBase::endJob(void) {}
 
 void DQMFileSaverBase::postForkReacquireResources(
     unsigned int childIndex, unsigned int numberOfChildren) {
@@ -145,7 +138,7 @@ void DQMFileSaverBase::postForkReacquireResources(
   initial_fp_.child_ = std::string(buffer);
 }
 
-const std::string DQMFileSaverBase::filename(FileParameters fp, bool useLumi) {
+const std::string DQMFileSaverBase::filename(const FileParameters& fp, bool useLumi) {
   char buf[256];
   if (useLumi) {
     snprintf(buf, 256, "%s_V%04d_%s_R%09ld_L%09ld%s", fp.producer_.c_str(),
@@ -162,99 +155,6 @@ const std::string DQMFileSaverBase::filename(FileParameters fp, bool useLumi) {
   fs::path file(buf);
 
   return (path / file).string();
-}
-
-// file metadata saving stuff
-boost::property_tree::ptree
-DQMFileSaverBase::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, evf::FastMonitoringService *fms)
-{
-  namespace bpt = boost::property_tree;
-  namespace bfs = boost::filesystem;
-
-  bpt::ptree pt;
-
-  int hostnameReturn;
-  char host[32];
-  hostnameReturn = gethostname(host ,sizeof(host));
-  if (hostnameReturn == -1)
-    throw cms::Exception("fillJson")
-          << "Internal error, cannot get host name";
-
-  int pid = getpid();
-  std::ostringstream oss_pid;
-  oss_pid << pid;
-
-  // Stat the data file: if not there, throw
-  struct stat dataFileStat;
-  if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
-    throw cms::Exception("fillJson")
-          << "Internal error, cannot get data file: "
-          << dataFilePathName;
-  // Extract only the data file name from the full path
-  std::string dataFileName = bfs::path(dataFilePathName).filename().string();
-  // The availability test of the FastMonitoringService was done in the ctor.
-  bpt::ptree data;
-  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination;
-
-  processedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Processed events
-  acceptedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Accepted events, same as processed for our purposes
-
-  errorEvents.put("", 0); // Error events
-  bitmask.put("", 0); // Bitmask of abs of CMSSW return code
-  fileList.put("", dataFileName); // Data file the information refers to
-  fileSize.put("", dataFileStat.st_size); // Size in bytes of the data file
-  inputFiles.put("", ""); // We do not care about input files!
-  fileAdler32.put("", -1); // placeholder to match output json definition
-  transferDestination.put("", transferDestinationStr); // SM Transfer destination field
-
-  data.push_back(std::make_pair("", processedEvents));
-  data.push_back(std::make_pair("", acceptedEvents));
-  data.push_back(std::make_pair("", errorEvents));
-  data.push_back(std::make_pair("", bitmask));
-  data.push_back(std::make_pair("", fileList));
-  data.push_back(std::make_pair("", fileSize));
-  data.push_back(std::make_pair("", inputFiles));
-  data.push_back(std::make_pair("", fileAdler32));
-  data.push_back(std::make_pair("", transferDestination));
-
-  pt.add_child("data", data);
-
-  if (fms == nullptr) {
-    pt.put("definition", "/fakeDefinition.jsn");
-  } else {
-    // The availability test of the EvFDaqDirector Service was done in the ctor.
-    bfs::path outJsonDefName(edm::Service<evf::EvFDaqDirector>()->baseRunDir()); //we assume this file is written bu the EvF Output module
-    outJsonDefName /= (std::string("output_") + oss_pid.str() + std::string(".jsd"));
-    pt.put("definition", outJsonDefName.string());
-  }
-
-  char sourceInfo[64]; //host and pid information
-  sprintf(sourceInfo, "%s_%d", host, pid);
-  pt.put("source", sourceInfo);
-
-  return pt;
-}
-
-const std::string DQMFileSaverBase::fillOrigin(const std::string filename,
-                                  const std::string final_filename) {
-
-    // format.origin (one line):
-    //   md5:d566a34b27f48d507150a332b189398b 294835 final_filename.root
-
-    unsigned char md5[MD5_DIGEST_LENGTH];
-
-    boost::iostreams::mapped_file_source fp(filename);
-
-    MD5((unsigned char *)fp.data(), fp.size(), md5);
-
-    std::ostringstream hash;
-    for (int i = 0; i < MD5_DIGEST_LENGTH; ++i) {
-      hash << std::hex << std::setfill('0') << std::setw(2) << (int)(md5[i]);
-    }
-
-    std::ostringstream out;
-    out << "md5:" << hash.str() << " " << fp.size() << " " << final_filename;
-    return out.str();
 }
 
 void DQMFileSaverBase::saveJobReport(const std::string &filename) const

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.h
@@ -45,38 +45,34 @@ class DQMFileSaverBase
   };
 
  protected:
-  virtual void beginJob(void);
+  //virtual void beginJob(void) const override final;
+  //virtual void endJob(void) const override final;
+
   virtual std::shared_ptr<NoCache> globalBeginRun(
-      const edm::Run &, const edm::EventSetup &) const;
+      const edm::Run &, const edm::EventSetup &) const override final;
+
   virtual std::shared_ptr<NoCache> globalBeginLuminosityBlock(
-      const edm::LuminosityBlock &, const edm::EventSetup &) const;
+      const edm::LuminosityBlock &, const edm::EventSetup &) const override final;
+
   virtual void analyze(edm::StreamID, const edm::Event &e,
-                       const edm::EventSetup &) const;
+                       const edm::EventSetup &) const override final;
+
   virtual void globalEndLuminosityBlock(const edm::LuminosityBlock &,
-                                        const edm::EventSetup &) const;
-  virtual void globalEndRun(const edm::Run &, const edm::EventSetup &) const;
-  virtual void endJob(void);
+                                        const edm::EventSetup &) const override final ;
+  virtual void globalEndRun(const edm::Run &, const edm::EventSetup &) const override final;
+
   virtual void postForkReacquireResources(unsigned int childIndex,
                                           unsigned int numberOfChildren);
 
-  // these two should be overwritten
-  // in some cases, hsitograms are deleted after saving
+  // these method (and only these) should be overriden
   // so we need to call all file savers
-  virtual void saveLumi(FileParameters fp) const {};
-  virtual void saveRun(FileParameters fp) const {};
+  virtual void initRun(void) const {};
+  virtual void saveLumi(const FileParameters& fp) const {};
+  virtual void saveRun(const FileParameters& fp) const {};
 
-  static const std::string filename(FileParameters fp, bool useLumi = false);
+  static const std::string filename(const FileParameters& fp, bool useLumi = false);
 
-  // also used by the JsonWritingTimedPoolOutputModule,
-  // fms will be nullptr in such case
-  static boost::property_tree::ptree fillJson(
-      int run, int lumi, const std::string &dataFilePathName, const std::string transferDestinationStr,
-      evf::FastMonitoringService *fms);
-
-  static const std::string fillOrigin(const std::string filename,
-                                  const std::string final_filename);
-
-  // utilities
+    // utilities
   void logFileAction(const std::string& msg, const std::string& fileName) const;
   void saveJobReport(const std::string &filename) const;
 

--- a/DQMServices/FileIO/plugins/DQMFileSaverOnline.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverOnline.h
@@ -17,9 +17,12 @@ class DQMFileSaverOnline : public DQMFileSaverBase {
   DQMFileSaverOnline(const edm::ParameterSet &ps);
   ~DQMFileSaverOnline();
 
+  static const std::string fillOrigin(const std::string filename,
+                                  const std::string final_filename);
+
  protected:
-  virtual void saveLumi(FileParameters fp) const;
-  virtual void saveRun(FileParameters fp) const;
+  virtual void saveLumi(const FileParameters& fp) const override;
+  virtual void saveRun(const FileParameters& fp) const override;
 
  protected:
   int backupLumiCount_;

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -1,0 +1,192 @@
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DQMFileSaverPB.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <utility>
+#include <TString.h>
+#include <TSystem.h>
+
+#include <openssl/md5.h>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+
+using namespace dqm;
+
+DQMFileSaverPB::DQMFileSaverPB(const edm::ParameterSet &ps)
+    : DQMFileSaverBase(ps) {
+
+  fakeFilterUnitMode_ = ps.getUntrackedParameter<bool>("fakeFilterUnitMode", false);
+  streamLabel_ = ps.getUntrackedParameter<std::string>("streamLabel", "streamDQMHistograms");
+
+  transferDestination_ = "";
+}
+
+DQMFileSaverPB::~DQMFileSaverPB() {}
+
+void DQMFileSaverPB::initRun() const {
+  if (!fakeFilterUnitMode_) {
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel_);
+  } 
+}
+
+void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
+  // get from DAQ2 services where to store the files according to their format
+  namespace bpt = boost::property_tree;
+
+  std::string openJsonFilePathName;
+  std::string jsonFilePathName;
+  std::string openHistoFilePathName;
+  std::string histoFilePathName;
+
+  evf::FastMonitoringService *fms = nullptr;
+  edm::Service<DQMStore> store;
+
+  // create the files names
+  if (fakeFilterUnitMode_) {
+    std::string runDir = str(boost::format("%s/run%06d") % fp.path_ % fp.run_);
+    std::string baseName = str(boost::format("%s/run%06d_ls%04d_%s") % runDir % fp.run_ % fp.lumi_ % streamLabel_ );
+
+    boost::filesystem::create_directories(runDir);
+
+    jsonFilePathName = baseName + ".jsn";
+    openJsonFilePathName = jsonFilePathName + ".open";
+
+    histoFilePathName = baseName + ".pb";
+    openHistoFilePathName = histoFilePathName + ".open";
+  } else {
+    openJsonFilePathName = edm::Service<evf::EvFDaqDirector>()->getOpenOutputJsonFilePath(fp.lumi_, streamLabel_);
+    jsonFilePathName = edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(fp.lumi_, streamLabel_);
+
+    openHistoFilePathName = edm::Service<evf::EvFDaqDirector>()->getOpenProtocolBufferHistogramFilePath(fp.lumi_, streamLabel_);
+    histoFilePathName = edm::Service<evf::EvFDaqDirector>()->getProtocolBufferHistogramFilePath(fp.lumi_, streamLabel_);
+  
+    fms = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
+  }
+
+  if (fms ? fms->getEventsProcessedForLumi(fp.lumi_) : true) {
+    // Save the file in the open directory.
+    store->savePB(openHistoFilePathName, "",
+      store->mtEnabled() ? fp.run_ : 0,
+      fp.lumi_,
+      true);
+
+    // Now move the the data and json files into the output directory.
+    ::rename(openHistoFilePathName.c_str(), histoFilePathName.c_str());
+  }
+
+  // Write the json file in the open directory.
+  bpt::ptree pt = fillJson(fp.run_, fp.lumi_, histoFilePathName, transferDestination_, fms);
+  write_json(openJsonFilePathName, pt);
+  ::rename(openJsonFilePathName.c_str(), jsonFilePathName.c_str());
+}
+
+void DQMFileSaverPB::saveRun(const FileParameters& fp) const {
+  // no saving for the run
+}
+
+boost::property_tree::ptree
+DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, evf::FastMonitoringService *fms)
+{
+  namespace bpt = boost::property_tree;
+  namespace bfs = boost::filesystem;
+  
+  bpt::ptree pt;
+
+  int hostnameReturn;
+  char host[32];
+  hostnameReturn = gethostname(host ,sizeof(host));
+  if (hostnameReturn == -1)
+    throw cms::Exception("fillJson")
+          << "Internal error, cannot get host name";
+  
+  int pid = getpid();
+  std::ostringstream oss_pid;
+  oss_pid << pid;
+
+  int nProcessed = fms ? (fms->getEventsProcessedForLumi(lumi)) : -1;
+
+  // Stat the data file: if not there, throw
+  std::string dataFileName;
+  struct stat dataFileStat;
+  dataFileStat.st_size=0;
+  if (nProcessed) {
+    if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
+      throw cms::Exception("fillJson")
+            << "Internal error, cannot get data file: "
+            << dataFilePathName;
+    // Extract only the data file name from the full path
+    dataFileName = bfs::path(dataFilePathName).filename().string();
+  }
+  // The availability test of the FastMonitoringService was done in the ctor.
+  bpt::ptree data;
+  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination;
+
+  processedEvents.put("", nProcessed); // Processed events
+  acceptedEvents.put("", nProcessed); // Accepted events, same as processed for our purposes
+
+  errorEvents.put("", 0); // Error events
+  bitmask.put("", 0); // Bitmask of abs of CMSSW return code
+  fileList.put("", dataFileName); // Data file the information refers to
+  fileSize.put("", dataFileStat.st_size); // Size in bytes of the data file
+  inputFiles.put("", ""); // We do not care about input files!
+  fileAdler32.put("", -1); // placeholder to match output json definition
+  transferDestination.put("", transferDestinationStr); // SM Transfer destination field
+
+  data.push_back(std::make_pair("", processedEvents));
+  data.push_back(std::make_pair("", acceptedEvents));
+  data.push_back(std::make_pair("", errorEvents));
+  data.push_back(std::make_pair("", bitmask));
+  data.push_back(std::make_pair("", fileList));
+  data.push_back(std::make_pair("", fileSize));
+  data.push_back(std::make_pair("", inputFiles));
+  data.push_back(std::make_pair("", fileAdler32));
+  data.push_back(std::make_pair("", transferDestination));
+
+  pt.add_child("data", data);
+
+  if (fms == nullptr) {
+    pt.put("definition", "/fakeDefinition.jsn");
+  } else {
+    // The availability test of the EvFDaqDirector Service was done in the ctor.
+    bfs::path outJsonDefName(edm::Service<evf::EvFDaqDirector>()->baseRunDir()); //we assume this file is written bu the EvF Output module
+    outJsonDefName /= (std::string("output_") + oss_pid.str() + std::string(".jsd"));
+    pt.put("definition", outJsonDefName.string());
+  }
+
+  char sourceInfo[64]; //host and pid information
+  sprintf(sourceInfo, "%s_%d", host, pid);
+  pt.put("source", sourceInfo);
+
+  return pt;
+}
+
+
+void DQMFileSaverPB::fillDescriptions(
+    edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.setComment("Saves histograms from DQM store, HLT->pb workflow.");
+
+  desc.addUntracked<bool>("fakeFilterUnitMode", false)->setComment(
+      "If set, EvFDaqDirector is emulated and not used.");
+
+  desc.addUntracked<std::string>("streamLabel", "streamDQMHistograms")->setComment(
+      "Label of the stream.");
+
+  DQMFileSaverBase::fillDescription(desc);
+  descriptions.add("saver", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DQMFileSaverPB);

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.h
@@ -1,0 +1,41 @@
+#ifndef DQMSERVICES_COMPONENTS_DQMFILESAVERPB_H
+#define DQMSERVICES_COMPONENTS_DQMFILESAVERPB_H
+
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include <sys/time.h>
+#include <string>
+#include <mutex>
+
+#include "DQMFileSaverBase.h"
+
+namespace dqm {
+
+class DQMFileSaverPB : public DQMFileSaverBase {
+ public:
+  DQMFileSaverPB(const edm::ParameterSet &ps);
+  ~DQMFileSaverPB();
+
+  // used by the JsonWritingTimedPoolOutputModule,
+  // fms will be nullptr in such case
+  static boost::property_tree::ptree fillJson(
+      int run, int lumi, const std::string &dataFilePathName, const std::string transferDestinationStr,
+      evf::FastMonitoringService *fms);
+
+ protected:
+  virtual void initRun() const override;
+  virtual void saveLumi(const FileParameters& fp) const override;
+  virtual void saveRun(const FileParameters& fp) const override;
+
+  bool fakeFilterUnitMode_;
+  std::string streamLabel_;
+  mutable std::string transferDestination_;
+
+ public:
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+};
+
+}  // dqm namespace
+
+#endif  // DQMSERVICES_COMPONENTS_DQMFILESAVERPB_H

--- a/DQMServices/FileIO/python/DQMFileSaverPB_cfi.py
+++ b/DQMServices/FileIO/python/DQMFileSaverPB_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+# DQM file saver module
+dqmSaver = cms.EDAnalyzer("DQMFileSaverPB",
+    # Name of the producer.
+    producer = cms.untracked.string('DQM'),
+    # Directory in which to save the files.
+    path = cms.untracked.string('./'),
+
+    # Tag, used in the filename as the third term.
+    tag = cms.untracked.string('UNKNOWN'),
+
+    # Control reference saving (default / skip / qtests / all)
+    referenceHandling = cms.untracked.string('all'),
+    # Control which references are saved for qtests (default: STATUS_OK)
+    referenceRequireStatus = cms.untracked.int32(100),
+
+    # If set, EvFDaqDirector is emulated and not used
+    fakeFilterUnitMode = cms.untracked.bool(false),
+    # Label of the stream
+    streamLabel = cms.untracked.string("streamDQMHistograms"),
+)


### PR DESCRIPTION
Additionally, the DQMStore will now acquire locks for writing files.

This PR also add a new file saver for HLT->PB (DQMFileSaverPB).
Which should replace DQMFileSaver in the near future.

(Discussion: https://github.com/cms-sw/cmssw/pull/11086)
Automatically ported from CMSSW_7_6_X #11251 (original by @dmitrijus).
