### PR TITLE
update Method3 with new time slew parametrization and response correction for data and MC

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -128,6 +128,7 @@ def customiseFor10927(process):
             process.DTObjectMapESProducer = cms.ESProducer( 'DTObjectMapESProducer' )
     return process
 
+
 # change RecoTrackRefSelector to stream::EDProducer (PR #10911)
 def customiseFor10911(process):
     if hasattr(process,'hltBSoftMuonMu5L3'):
@@ -135,7 +136,8 @@ def customiseFor10911(process):
         process.hltBSoftMuonMu5L3 = cms.EDProducer("RecoTrackRefSelector", **process.hltBSoftMuonMu5L3.parameters_())
     return process
 
-# Fix MeasurementTrackerEvent configuration in several TrackingRegionProducers (PR 11183)
+
+# fix MeasurementTrackerEvent configuration in several TrackingRegionProducers (PR #11183)
 def customiseFor11183(process):
     def useMTEName(componentName):
         if componentName in ["CandidateSeededTrackingRegionsProducer", "TrackingRegionsFromBeamSpotAndL2Tau"]:
@@ -167,6 +169,14 @@ def customiseFor11183(process):
 
     return process
 
+
+# update Method3 with new time slew parametrization and response correction for data (PR #11091)
+def customizeFor11091(process):
+    # the parameters to be used for data are set in HcalHitReconstructor::fillDescriptions()
+    # the parameters to be used for MC are set in customizeHLTforMC.py 
+    return process
+
+
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
@@ -185,6 +195,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor7794(process)
         process = customiseFor10087(process)
         process = customizeHLTforNewJetCorrectors(process)
+        process = customizeFor11091(process)
     if cmsswVersion >= "CMSSW_7_4":
         process = customiseFor10234(process)
 

--- a/HLTrigger/Configuration/python/customizeHLTforMC.py
+++ b/HLTrigger/Configuration/python/customizeHLTforMC.py
@@ -23,12 +23,8 @@ def customizeHLTforMC(process,_fastSim=False):
     process.hltHbhereco.pedestalSubtractionType = cms.int32( 1 )
     process.hltHbhereco.pedestalUpperLimit      = cms.double( 2.7 ) 
     process.hltHbhereco.timeSlewParsType        = cms.int32( 3 )
-    #old MC
-    process.hltHbhereco.timeSlewPars            = cms.vdouble( 9.27638, -2.05585, 0, 9.27638, -2.05585, 0, 9.27638, -2.05585, 0 ) 
-    process.hltHbhereco.respCorrM3              = cms.double( 1.0 )
-    #new MC once completely implemented
-#    process.hltHbhereco.timeSlewPars            = cms.vdouble( 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 )
-#    process.hltHbhereco.respCorrM3              = cms.double( 0.95 )
+    process.hltHbhereco.timeSlewPars            = cms.vdouble( 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 )
+    process.hltHbhereco.respCorrM3              = cms.double( 0.95 )
 
 
   if _fastSim:


### PR DESCRIPTION
- update Method3 with new time slew parametrization and response correction for data and MC
- customise the HLT for the updates to HCAL method 3
  Automatically ported from CMSSW_7_6_X #11100 (original by @fwyzard).
