### PR TITLE
DataFormats/EcalDigi: remove intrusive macros breaking libstdc++

### DIFF
--- a/DataFormats/Common/interface/DataFrameContainer.h
+++ b/DataFormats/Common/interface/DataFrameContainer.h
@@ -11,6 +11,9 @@
 
 class TestDataFrame;
 
+template<typename DigiCollection>
+class TestEcalDigi;
+
 namespace edm {
 
   /** an optitimized container that linearized a "vector of vector".
@@ -187,6 +190,9 @@ namespace edm {
   private:
     //for testing
     friend class ::TestDataFrame;
+
+    template<typename DigiCollection>
+    friend class ::TestEcalDigi;
     
     // subdetector id (as returned by  DetId::subdetId())
     int m_subdetId;

--- a/DataFormats/EcalDigi/test/EcalDigi_t.cpp
+++ b/DataFormats/EcalDigi/test/EcalDigi_t.cpp
@@ -1,11 +1,10 @@
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
 #include <cppunit/extensions/HelperMacros.h>
 
-#define private public
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/Common/interface/DataFrameContainer.h"
-#undef private
+
 #include<vector>
 #include<algorithm>
 #include<boost/function.hpp>


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
