### PR TITLE
Remove intrusive macros breaking libstdc++

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -141,8 +141,18 @@ class SiStripLorentzAngle;
 class PixelGeomDetUnit;
 class StripGeomDetUnit;
 
+// Function for testing ClusterShapeHitFilter
+namespace test {
+  namespace ClusterShapeHitFilterTest {
+    int test();
+  }
+}
+
 class ClusterShapeHitFilter
 {
+  // For tests
+  friend int test::ClusterShapeHitFilterTest::test();
+
  public:
 
   struct PixelData {

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeHitFilter_t.cpp
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeHitFilter_t.cpp
@@ -1,49 +1,57 @@
 // ClusterShapeHitFilter test
-#define private public
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-#undef private
 
 #include <iostream>
 #include <cassert>
+
+namespace test {
+  namespace ClusterShapeHitFilterTest {    
+    int test() {
+      const std::string use_PixelShapeFile("RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par");
+    
+      ClusterShapeHitFilter filter;
+      filter.PixelShapeFile = &use_PixelShapeFile;
+      filter.loadPixelLimits();
+      filter.loadStripLimits();
+    
+      const float out = 10e12;
+      const float eps = 0.01;
+      std::cout << "dump strip limits" << std::endl;
+      for (int i=0; i!=StripKeys::N+1; i++) {
+        assert(!filter.stripLimits[i].isInside(out));
+        assert(!filter.stripLimits[i].isInside(-out));
+        std::cout << i << ": ";
+        float const * p = filter.stripLimits[i].data[0];
+        if (p[1]<1.e9) {
+          assert(filter.stripLimits[i].isInside(p[0]+eps));
+          assert(filter.stripLimits[i].isInside(p[3]-eps));
+        }
+        for (int j=0;j!=4; ++j)
+          std::cout << p[j] << ", ";
+        std::cout << std::endl;
+      }
+    
+      const std::pair<float,float> out1(out,out), out2(-out,-out);
+      std::cout << "\ndump pixel limits" << std::endl;
+      for (int i=0; i!=PixelKeys::N+1; i++) {
+        assert(!filter.pixelLimits[i].isInside(out1));
+        assert(!filter.pixelLimits[i].isInside(out2));
+        std::cout << i << ": ";
+        float const * p = filter.pixelLimits[i].data[0][0];
+        if (p[1]<1.e9) {
+          assert(filter.pixelLimits[i].isInside(std::pair<float,float>(p[0]+eps,p[3]-eps)));
+          assert(filter.pixelLimits[i].isInside(std::pair<float,float>(p[5]-eps,p[6]+eps)));
+        }
+        for (int j=0;j!=8; ++j)
+          std::cout << p[j] << ", ";
+        std::cout << std::endl;
+      }
+    
+      return 0;
+    }
+  }
+}
+
 int main() {
-  const std::string use_PixelShapeFile("RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par");
-
-  ClusterShapeHitFilter filter;
-  filter.PixelShapeFile = &use_PixelShapeFile;
-  filter.loadPixelLimits();
-  filter.loadStripLimits();
-
-  const float out = 10e12;
-  const float eps = 0.01;
-  std::cout << "dump strip limits" << std::endl;
-  for (int i=0; i!=StripKeys::N+1; i++) {
-    assert(!filter.stripLimits[i].isInside(out));
-    assert(!filter.stripLimits[i].isInside(-out));
-    std::cout << i << ": ";
-    float const * p = filter.stripLimits[i].data[0];
-    if (p[1]<1.e9) {
-      assert(filter.stripLimits[i].isInside(p[0]+eps));
-      assert(filter.stripLimits[i].isInside(p[3]-eps));
-    }
-    for (int j=0;j!=4; ++j)
-      std::cout << p[j] << ", ";
-    std::cout << std::endl;
-  }
-
-  const std::pair<float,float> out1(out,out), out2(-out,-out);
-  std::cout << "\ndump pixel limits" << std::endl;
-  for (int i=0; i!=PixelKeys::N+1; i++) {
-    assert(!filter.pixelLimits[i].isInside(out1));
-    assert(!filter.pixelLimits[i].isInside(out2));
-    std::cout << i << ": ";
-    float const * p = filter.pixelLimits[i].data[0][0];
-    if (p[1]<1.e9) {
-      assert(filter.pixelLimits[i].isInside(std::pair<float,float>(p[0]+eps,p[3]-eps)));
-      assert(filter.pixelLimits[i].isInside(std::pair<float,float>(p[5]-eps,p[6]+eps)));
-    }
-    for (int j=0;j!=8; ++j)
-      std::cout << p[j] << ", ";
-    std::cout << std::endl;
-  }
-
+  return test::ClusterShapeHitFilterTest::test();
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.h
@@ -23,8 +23,21 @@
 class TrackingRegion;
 class OrderedHitPair;
 
+// Function for testing ThirdHitPredictionFromInvParabola
+namespace test {
+  namespace PixelTriplets_InvPrbl_prec {
+    int test();
+  }
+  namespace PixelTriplets_InvPrbl_t {
+    int test();
+  }
+}
+
 
 class ThirdHitPredictionFromInvParabola {
+  // For tests
+  friend int test::PixelTriplets_InvPrbl_prec::test();
+  friend int test::PixelTriplets_InvPrbl_t::test();
 
 public:
   using Scalar=double;

--- a/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_prec.cpp
+++ b/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_prec.cpp
@@ -1,42 +1,46 @@
-#define private public
 #include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc"
-#undef private
 
 #include<iostream>
 #include<string>
 
-
-int main(int n, const char **) {
-  if (n<2) return 0; // protect testing
-  std::string c("++Constr");
-  std::string r("++R");
-  std::string a;
-  double par[7];
-  double q[2];
-  while(std::cin) {
-    ThirdHitPredictionFromInvParabola pred;
-    std::cin >> a;
-    if (a==c) { 
-      for ( auto & p : par ) std::cin >> p;
-      pred =ThirdHitPredictionFromInvParabola(par[0],par[1],par[2],par[3],par[4],par[5],par[6]);
-      std::cout << "ip min, max " <<  pred.theIpRangePlus.min() << " " << pred.theIpRangePlus.max()
-		<< "  " <<  pred.theIpRangeMinus.min() << " " << pred.theIpRangeMinus.max()  << std::endl;
-    }
-    else if (a==r) {
-      std::cin >> q[0] >> q[1];
-      {
-	auto rp = pred.rangeRPhi(q[0],1);
-	auto rn = pred.rangeRPhi(q[0],-1);
-	std::cout << "range " << rp.min() << " " << rp.max()
-		  << " " << rn.min() << " " << rn.max() << std::endl;
+namespace test {
+  namespace PixelTriplets_InvPrbl_prec {
+    int test() {
+      std::string c("++Constr");
+      std::string r("++R");
+      std::string a;
+      double par[7];
+      double q[2];
+      while(std::cin) {
+        ThirdHitPredictionFromInvParabola pred;
+        std::cin >> a;
+        if (a==c) { 
+          for ( auto & p : par ) std::cin >> p;
+          pred =ThirdHitPredictionFromInvParabola(par[0],par[1],par[2],par[3],par[4],par[5],par[6]);
+          std::cout << "ip min, max " <<  pred.theIpRangePlus.min() << " " << pred.theIpRangePlus.max()
+    		<< "  " <<  pred.theIpRangeMinus.min() << " " << pred.theIpRangeMinus.max()  << std::endl;
+        }
+        else if (a==r) {
+          std::cin >> q[0] >> q[1];
+          {
+    	auto rp = pred.rangeRPhi(q[0],1);
+    	auto rn = pred.rangeRPhi(q[0],-1);
+    	std::cout << "range " << rp.min() << " " << rp.max()
+    		  << " " << rn.min() << " " << rn.max() << std::endl;
+          }
+          {
+    	auto rp = pred.rangeRPhi(q[1],1);
+    	auto rn = pred.rangeRPhi(q[1],-1);
+    	std::cout << "range " << rp.min() << " " << rp.max()
+    		  << " " << rn.min() << " " << rn.max() << std::endl;
+          }
+        }
       }
-      {
-	auto rp = pred.rangeRPhi(q[1],1);
-	auto rn = pred.rangeRPhi(q[1],-1);
-	std::cout << "range " << rp.min() << " " << rp.max()
-		  << " " << rn.min() << " " << rn.max() << std::endl;
-      }
+        return 0;
     }
   }
-    return 0;
+}
+
+int main() {
+  return test::PixelTriplets_InvPrbl_prec::test();
 }

--- a/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_t.cpp
+++ b/RecoPixelVertexing/PixelTriplets/test/PixelTriplets_InvPrbl_t.cpp
@@ -1,6 +1,4 @@
-#define private public
 #include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc"
-#undef private
 
 #include <cmath>
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
@@ -87,46 +85,53 @@ void newCode(const GlobalPoint & P1, const GlobalPoint & P2) {
 
 }
 
+namespace test {
+  namespace PixelTriplets_InvPrbl_t {
+    int test() {
+    
+      GlobalPoint P1(3., 4., 7.);
+      GlobalPoint P2(-2., 5., 7.);
+    
+      oldCode(P1,P2);
+      newCode(P1,P2);
+    
+      oldCode(P2,P1);
+      newCode(P2,P1);
+    
+      {
+      ThirdHitPredictionFromInvParabola pred(P1,P2,0.2,0.05,0.1);
+      std::cout << "ip min, max " <<  pred.theIpRangePlus.min() << " " << pred.theIpRangePlus.max()
+    	    << "  " <<  pred.theIpRangeMinus.min() << " " << pred.theIpRangeMinus.max()  << std::endl;
+      std::cout << "A,B +pos " << pred.coeffA(0.1) << " " <<  pred.coeffB(0.1) << std::endl;
+      std::cout << "A,B -pos " << pred.coeffA(-0.1) << " " <<  pred.coeffB(-0.1) << std::endl;
+    
+      auto rp = pred.rangeRPhi(5.,1);
+      auto rn = pred.rangeRPhi(5.,-1);
+      std::cout << "range " << rp.min() << " " << rp.max()
+    	    << " " << rn.min() << " " << rn.max() << std::endl;
+      }
+    
+      ThirdHitPredictionFromInvParabola pred(-1.092805, 4.187564, -2.361283, 7.892722, 0.111413, 0.019043, 0.032000);
+      std::cout << "ip min, max " <<  pred.theIpRangePlus.min() << " " << pred.theIpRangePlus.max()
+    	    << "  " <<  pred.theIpRangeMinus.min() << " " << pred.theIpRangeMinus.max()  << std::endl;
+      {
+      auto rp = pred.rangeRPhi(11.4356,1);
+      auto rn = pred.rangeRPhi(11.4356,-1);
+      std::cout << "range " << rp.min() << " " << rp.max()
+    	    << " " << rn.min() << " " << rn.max() << std::endl;
+      }
+      {
+      auto rp = pred.rangeRPhi(13.2131,1);
+      auto rn = pred.rangeRPhi(13.2131,-1);
+      std::cout << "range " << rp.min() << " " << rp.max()
+    	    << " " << rn.min() << " " << rn.max() << std::endl;
+      }
+    
+      return 0;
+    }
+  }
+}
 
 int main() {
-
-  GlobalPoint P1(3., 4., 7.);
-  GlobalPoint P2(-2., 5., 7.);
-
-  oldCode(P1,P2);
-  newCode(P1,P2);
-
-  oldCode(P2,P1);
-  newCode(P2,P1);
-
-  {
-  ThirdHitPredictionFromInvParabola pred(P1,P2,0.2,0.05,0.1);
-  std::cout << "ip min, max " <<  pred.theIpRangePlus.min() << " " << pred.theIpRangePlus.max()
-	    << "  " <<  pred.theIpRangeMinus.min() << " " << pred.theIpRangeMinus.max()  << std::endl;
-  std::cout << "A,B +pos " << pred.coeffA(0.1) << " " <<  pred.coeffB(0.1) << std::endl;
-  std::cout << "A,B -pos " << pred.coeffA(-0.1) << " " <<  pred.coeffB(-0.1) << std::endl;
-
-  auto rp = pred.rangeRPhi(5.,1);
-  auto rn = pred.rangeRPhi(5.,-1);
-  std::cout << "range " << rp.min() << " " << rp.max()
-	    << " " << rn.min() << " " << rn.max() << std::endl;
-  }
-
-  ThirdHitPredictionFromInvParabola pred(-1.092805, 4.187564, -2.361283, 7.892722, 0.111413, 0.019043, 0.032000);
-  std::cout << "ip min, max " <<  pred.theIpRangePlus.min() << " " << pred.theIpRangePlus.max()
-	    << "  " <<  pred.theIpRangeMinus.min() << " " << pred.theIpRangeMinus.max()  << std::endl;
-  {
-  auto rp = pred.rangeRPhi(11.4356,1);
-  auto rn = pred.rangeRPhi(11.4356,-1);
-  std::cout << "range " << rp.min() << " " << rp.max()
-	    << " " << rn.min() << " " << rn.max() << std::endl;
-  }
-  {
-  auto rp = pred.rangeRPhi(13.2131,1);
-  auto rn = pred.rangeRPhi(13.2131,-1);
-  std::cout << "range " << rp.min() << " " << rp.max()
-	    << " " << rn.min() << " " << rn.max() << std::endl;
-  }
-
-  return 0;
+  return test::PixelTriplets_InvPrbl_t::test();
 }

--- a/TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h
+++ b/TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h
@@ -15,7 +15,15 @@
  *     the z-coordinates on the 2 tracks are the closest is chosen. 
  */
 
+// Function for testing ClosestApproachInRPhi
+namespace test {
+  namespace ClosestApproachInRPhi_t {
+    int test();
+  }
+}
+
 class ClosestApproachInRPhi GCC11_FINAL : public ClosestApproachOnHelices {
+  friend int test::ClosestApproachInRPhi_t::test();
 
 public:
 

--- a/TrackingTools/PatternTools/test/ClosestApproachInRPhi_t.cpp
+++ b/TrackingTools/PatternTools/test/ClosestApproachInRPhi_t.cpp
@@ -1,7 +1,5 @@
-#define private public
 #include "TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixHelix.h"
-#undef private
 
 // #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -64,85 +62,92 @@ void compute(GlobalTrajectoryParameters const & gtp1, GlobalTrajectoryParameters
   }
 }
 
+namespace test {
+  namespace ClosestApproachInRPhi_t {
+    int test() {
+    
+      MagneticField * field = new ConstMagneticField;
+    
+      {
+        // going back and forth gtp2 should be identical to gpt1....
+        GlobalPoint gp1(1,0,0);
+        GlobalVector gv1(1,1,-1);
+        GlobalTrajectoryParameters gtp1(gp1,gv1,1,field);
+        double bz = field->inTesla(gp1).z() * 2.99792458e-3;
+        GlobalPoint np(0.504471,    -0.498494,     0.497014);
+        GlobalTrajectoryParameters gtpN = ClosestApproachInRPhi::newTrajectory(np,gtp1,bz);
+        GlobalTrajectoryParameters gtp2 = ClosestApproachInRPhi::newTrajectory(gp1,gtpN,bz);
+        std::cout << gtp1 << std::endl;
+        std::cout << gtpN << std::endl;
+        std::cout << gtp2 << std::endl;
+        std::cout << std::endl;
+      }
+    
+    
+      {
+        std::cout <<"opposite sign, same direction, same origin: the two circles are tangent to each other at gp1\n" << std::endl;
+        GlobalPoint gp1(0,0,0);
+        GlobalVector gv1(1,1,1);
+        GlobalTrajectoryParameters gtp1(gp1,gv1,1,field);
+        
+        GlobalPoint gp2(0,0,0);
+        GlobalVector gv2(1,1,-1);
+        GlobalTrajectoryParameters gtp2(gp2,gv2,-1,field);
+        
+        compute(gtp1,gtp2);
+        std::cout << std::endl;
+    
+      }
+      {
+         std::cout <<" not crossing: the pcas are on the line connecting the two centers\n"
+    	       <<"the momenta at the respective pcas shall be parallel as they are perpendicular to the same line\n"
+    	       <<"(the one connecting the two centers)\n" << std::endl;
+        GlobalPoint gp1(-1,0,0);
+        GlobalVector gv1(1,1,1);
+        GlobalTrajectoryParameters gtp1(gp1,gv1,-1,field);
+        
+        GlobalPoint gp2(1,0,0);
+        GlobalVector gv2(1,1,-1);
+        GlobalTrajectoryParameters gtp2(gp2,gv2,1,field);
+        
+        compute(gtp1,gtp2);
+       std::cout << std::endl;
+      }
+      {
+        std::cout <<"crossing (only opposite changes w.r.t. previous)\n" << std::endl;
+        GlobalPoint gp1(-1,0,0);
+        GlobalVector gv1(1,1,1);
+        GlobalTrajectoryParameters gtp1(gp1,gv1,1,field);
+       
+        GlobalPoint gp2(1,0,0);
+        GlobalVector gv2(1,1,-1);
+        GlobalTrajectoryParameters gtp2(gp2,gv2,-1,field);
+    
+        compute(gtp1,gtp2);
+        std::cout << std::endl;
+      }
+    
+      {
+        std::cout <<"crossing\n" << std::endl;
+        GlobalPoint gp1(-1,0,0);
+        GlobalVector gv1(1,1,1);
+        GlobalTrajectoryParameters gtp1(gp1,gv1,-1,field);
+        
+        GlobalPoint gp2(1,0,0);
+        GlobalVector gv2(-1,1,-1);
+        GlobalTrajectoryParameters gtp2(gp2,gv2,1,field);
+        
+        compute(gtp1,gtp2);
+       std::cout << std::endl;
+      }
+    
+    
+      return 0;
+    
+    }
+  }
+}
 
 int main() {
-
-  MagneticField * field = new ConstMagneticField;
-
-  {
-    // going back and forth gtp2 should be identical to gpt1....
-    GlobalPoint gp1(1,0,0);
-    GlobalVector gv1(1,1,-1);
-    GlobalTrajectoryParameters gtp1(gp1,gv1,1,field);
-    double bz = field->inTesla(gp1).z() * 2.99792458e-3;
-    GlobalPoint np(0.504471,    -0.498494,     0.497014);
-    GlobalTrajectoryParameters gtpN = ClosestApproachInRPhi::newTrajectory(np,gtp1,bz);
-    GlobalTrajectoryParameters gtp2 = ClosestApproachInRPhi::newTrajectory(gp1,gtpN,bz);
-    std::cout << gtp1 << std::endl;
-    std::cout << gtpN << std::endl;
-    std::cout << gtp2 << std::endl;
-    std::cout << std::endl;
-  }
-
-
-  {
-    std::cout <<"opposite sign, same direction, same origin: the two circles are tangent to each other at gp1\n" << std::endl;
-    GlobalPoint gp1(0,0,0);
-    GlobalVector gv1(1,1,1);
-    GlobalTrajectoryParameters gtp1(gp1,gv1,1,field);
-    
-    GlobalPoint gp2(0,0,0);
-    GlobalVector gv2(1,1,-1);
-    GlobalTrajectoryParameters gtp2(gp2,gv2,-1,field);
-    
-    compute(gtp1,gtp2);
-    std::cout << std::endl;
-
-  }
-  {
-     std::cout <<" not crossing: the pcas are on the line connecting the two centers\n"
-	       <<"the momenta at the respective pcas shall be parallel as they are perpendicular to the same line\n"
-	       <<"(the one connecting the two centers)\n" << std::endl;
-    GlobalPoint gp1(-1,0,0);
-    GlobalVector gv1(1,1,1);
-    GlobalTrajectoryParameters gtp1(gp1,gv1,-1,field);
-    
-    GlobalPoint gp2(1,0,0);
-    GlobalVector gv2(1,1,-1);
-    GlobalTrajectoryParameters gtp2(gp2,gv2,1,field);
-    
-    compute(gtp1,gtp2);
-   std::cout << std::endl;
-  }
-  {
-    std::cout <<"crossing (only opposite changes w.r.t. previous)\n" << std::endl;
-    GlobalPoint gp1(-1,0,0);
-    GlobalVector gv1(1,1,1);
-    GlobalTrajectoryParameters gtp1(gp1,gv1,1,field);
-   
-    GlobalPoint gp2(1,0,0);
-    GlobalVector gv2(1,1,-1);
-    GlobalTrajectoryParameters gtp2(gp2,gv2,-1,field);
-
-    compute(gtp1,gtp2);
-    std::cout << std::endl;
-  }
-
-  {
-    std::cout <<"crossing\n" << std::endl;
-    GlobalPoint gp1(-1,0,0);
-    GlobalVector gv1(1,1,1);
-    GlobalTrajectoryParameters gtp1(gp1,gv1,-1,field);
-    
-    GlobalPoint gp2(1,0,0);
-    GlobalVector gv2(-1,1,-1);
-    GlobalTrajectoryParameters gtp2(gp2,gv2,1,field);
-    
-    compute(gtp1,gtp2);
-   std::cout << std::endl;
-  }
-
-
-  return 0;
-
+  return test::ClosestApproachInRPhi_t::test();
 }


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
