### PR TITLE
Remove intrusive macros breaking libstdc++

### DIFF
--- a/MagneticField/Engine/test/testMagneticField.cc
+++ b/MagneticField/Engine/test/testMagneticField.cc
@@ -466,7 +466,6 @@ void testMagneticField::fillFromTable(string inputFile, vector<GlobalPoint>& p, 
 }
 
 
-#define private public
 #include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
 
 // Get the pointer of the volume containing a point

--- a/MagneticField/GeomBuilder/test/stubs/MagGeometryAnalyzer.cc
+++ b/MagneticField/GeomBuilder/test/stubs/MagGeometryAnalyzer.cc
@@ -12,27 +12,22 @@
 #include "MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include "MagneticField/Layers/interface/MagVerbosity.h"
-
-//dirty hack
-#define private public
 #include "MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.h"
 #include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
-#undef public
 
 #include <iostream>
 #include <vector>
 
 using namespace std;
 
-class MagGeometryAnalyzer : public edm::EDAnalyzer {
+class testMagGeometryAnalyzer : public edm::EDAnalyzer {
  public:
   /// Constructor
-  MagGeometryAnalyzer(const edm::ParameterSet& pset) {};
+  testMagGeometryAnalyzer(const edm::ParameterSet& pset) {};
 
   /// Destructor
-  virtual ~MagGeometryAnalyzer() {};
+  virtual ~testMagGeometryAnalyzer() {};
 
   /// Perform the real analysis
   void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
@@ -46,7 +41,7 @@ class MagGeometryAnalyzer : public edm::EDAnalyzer {
 
 using namespace edm;
 
-void MagGeometryAnalyzer::analyze(const edm::Event & event, const edm::EventSetup& eventSetup) {
+void testMagGeometryAnalyzer::analyze(const edm::Event & event, const edm::EventSetup& eventSetup) {
 
   ESHandle<MagneticField> magfield;
   eventSetup.get<IdealMagneticFieldRecord>().get(magfield);
@@ -79,7 +74,7 @@ void MagGeometryAnalyzer::analyze(const edm::Event & event, const edm::EventSetu
 #include "VolumeGridTester.h"
 
 
-void MagGeometryAnalyzer::testGrids(const vector<MagVolume6Faces const*>& bvol) {
+void testMagGeometryAnalyzer::testGrids(const vector<MagVolume6Faces const*>& bvol) {
   static map<string,int> nameCalls;
 
   for (vector<MagVolume6Faces const*>::const_iterator i=bvol.begin();
@@ -100,4 +95,4 @@ void MagGeometryAnalyzer::testGrids(const vector<MagVolume6Faces const*>& bvol) 
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE(MagGeometryAnalyzer);
+DEFINE_FWK_MODULE(testMagGeometryAnalyzer);

--- a/MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h
+++ b/MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h
@@ -11,7 +11,15 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/VolumeBasedEngine/interface/MagGeometry.h"
 
+// Class for testing VolumeBasedMagneticField
+class testMagneticField;
+class testMagGeometryAnalyzer;
+
 class VolumeBasedMagneticField : public MagneticField {
+  // For tests
+  friend class testMagneticField;
+  friend class testMagGeometryAnalyzer;
+
  public:
   //  VolumeBasedMagneticField(const DDCompactView & cpv);
   VolumeBasedMagneticField( int geomVersion,


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
