### PR TITLE
MuonAnalysis/MomentumScaleCalibration: remove intrusive macros breaking libstdc++

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/interface/BackgroundHandler.h
+++ b/MuonAnalysis/MomentumScaleCalibration/interface/BackgroundHandler.h
@@ -17,6 +17,9 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+// Unit test for testing BackgroundHandler
+class TestBackgroundHandler;
+
 /**
  * This class is used to handle the different background functions for the
  * different regions. <br>
@@ -28,6 +31,9 @@
  */
 class BackgroundHandler
 {
+  // For tests
+  friend class TestBackgroundHandler;
+
 public:
   BackgroundHandler( const std::vector<int> & identifiers,
                      const std::vector<double> & leftWindowBorders,

--- a/MuonAnalysis/MomentumScaleCalibration/interface/CrossSectionHandler.h
+++ b/MuonAnalysis/MomentumScaleCalibration/interface/CrossSectionHandler.h
@@ -21,8 +21,14 @@
 #include "TString.h"
 #include "TMinuit.h"
 
+// Unit test for testing CrossSectionHandler
+class TestCrossSectionHandler;
+
 class CrossSectionHandler
 {
+  // For tests
+  friend class TestCrossSectionHandler;
+
 public:
   CrossSectionHandler(const std::vector<double> & crossSection, const std::vector<int> & resfind) :
     parNum_(0),

--- a/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestBackgroundHandler.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestBackgroundHandler.cc
@@ -11,11 +11,7 @@
 #include <iterator>
 #include <boost/foreach.hpp>
 
-#define private public
-#define protected public
 #include "MuonAnalysis/MomentumScaleCalibration/interface/BackgroundHandler.h"
-#undef private
-#undef protected
 
 #ifndef TestBackgroundHandler_cc
 #define TestBackgroundHandler_cc

--- a/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestCrossSectionHandler.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/UnitTests/TestCrossSectionHandler.cc
@@ -11,11 +11,7 @@
 #include <iterator>
 #include <boost/foreach.hpp>
 
-#define private public
-#define protected public
 #include "MuonAnalysis/MomentumScaleCalibration/interface/CrossSectionHandler.h"
-#undef private
-#undef protected
 
 #ifndef TestCrossSectionHandler_cc
 #define TestCrossSectionHandler_cc


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
