### PR TITLE
Fireworks/Core: remove intrusive macros breaking libstdc++

### DIFF
--- a/Fireworks/Core/interface/FWEventItem.h
+++ b/Fireworks/Core/interface/FWEventItem.h
@@ -161,6 +161,8 @@ public:
    // ---------- member functions ---------------------------
    void setEvent(const edm::EventBase* iEvent);
 
+   void setData(const edm::ObjectWithDict& ) const;
+
    void getPrimaryData() const;
    const FWGeometry* getGeom() const;
    FWProxyBuilderConfiguration* getConfig() const { return m_proxyBuilderConfig; }
@@ -217,7 +219,6 @@ private:
    //FWEventItem(const FWEventItem&); // stop default
 
    //const FWEventItem& operator=(const FWEventItem&); // stop default
-   void setData(const edm::ObjectWithDict& ) const;
 
    void runFilter();
    void handleChange();

--- a/Fireworks/Core/test/unittest_changemanager.cc
+++ b/Fireworks/Core/test/unittest_changemanager.cc
@@ -19,9 +19,7 @@
 
 // user include files
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 

--- a/Fireworks/Core/test/unittest_modelexpressionselector.cc
+++ b/Fireworks/Core/test/unittest_modelexpressionselector.cc
@@ -19,9 +19,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
 
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
 

--- a/Fireworks/Core/test/unittest_selectionmanager.cc
+++ b/Fireworks/Core/test/unittest_selectionmanager.cc
@@ -22,9 +22,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
-#define private public
 #include "Fireworks/Core/interface/FWEventItem.h"
-#undef private
 
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
 


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
