### PR TITLE
Replaced synchronization types according to the new policy. 

### DIFF
--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -104,11 +104,11 @@ namespace cond {
       template <typename T>
       IOVEditor createIov( const std::string& tag, 
 			   cond::TimeType timeType, 
-			   cond::SynchronizationType synchronizationType=cond::OFFLINE );
+			   cond::SynchronizationType synchronizationType=cond::SYNCH_ANY );
       IOVEditor createIov( const std::string& payloadType, 
 			   const std::string& tag, 
 			   cond::TimeType timeType,
-			   cond::SynchronizationType synchronizationType=cond::OFFLINE );
+			   cond::SynchronizationType synchronizationType=cond::SYNCH_ANY );
 
       IOVEditor createIov( const std::string& payloadType, 
 			   const std::string& tag, 
@@ -118,7 +118,7 @@ namespace cond {
 
       IOVEditor createIovForPayload( const Hash& payloadHash, 
 				     const std::string& tag, cond::TimeType timeType,
-				     cond::SynchronizationType synchronizationType=cond::OFFLINE );
+				     cond::SynchronizationType synchronizationType=cond::SYNCH_ANY );
 
       void clearIov( const std::string& tag );
       

--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -29,11 +29,15 @@ namespace cond {
 								 "Validated" };
 
   typedef enum { 
-    SYNCHRONIZATION_UNKNOWN = -1,
-    OFFLINE=0, 
-    HLT, 
-    PROMPT, 
-    PCL 
+    SYNCH_ANY = 0,
+    SYNCH_VALIDATION,
+    SYNCH_OFFLINE,
+    SYNCH_MC,
+    SYNCH_RUNMC,
+    SYNCH_HLT, 
+    SYNCH_EXPRESS,
+    SYNCH_PROMPT, 
+    SYNCH_PCL 
   } SynchronizationType;
 
   std::string synchronizationTypeNames( SynchronizationType type );

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -19,7 +19,7 @@ namespace cond {
       boost::posix_time::ptime snapshotTime;
       cond::TimeType timeType;
       std::string payloadType;
-      cond::SynchronizationType synchronizationType = cond::OFFLINE;
+      cond::SynchronizationType synchronizationType;
       cond::Time_t endOfValidity;
       cond::Time_t lastValidatedTime;
       // iov data
@@ -197,7 +197,7 @@ namespace cond {
     }
     
     cond::SynchronizationType IOVProxy::synchronizationType() const {
-      return m_data.get() ? m_data->synchronizationType : cond::SYNCHRONIZATION_UNKNOWN;
+      return m_data.get() ? m_data->synchronizationType : cond::SYNCH_ANY;
     }
 
     cond::Time_t IOVProxy::endOfValidity() const {

--- a/CondCore/CondDB/src/Types.cc
+++ b/CondCore/CondDB/src/Types.cc
@@ -29,18 +29,23 @@ namespace cond {
     lastValidatedTime = time::MIN_VAL;
   }
 
-  static std::pair<const char *, SynchronizationType> s_synchronizationTypeArray[] = { std::make_pair("Offline", OFFLINE),
-                                                                                       std::make_pair("HLT", HLT),
-                                                                                       std::make_pair("Prompt", PROMPT),
-                                                                                       std::make_pair("PCL", PCL) };
+  static std::pair<const char *, SynchronizationType> s_synchronizationTypeArray[] = { std::make_pair("any", SYNCH_ANY),
+										       std::make_pair("validation", SYNCH_VALIDATION),
+										       std::make_pair("offline", SYNCH_OFFLINE),
+										       std::make_pair("mc", SYNCH_MC),
+										       std::make_pair("runmc", SYNCH_RUNMC),
+										       std::make_pair("hlt", SYNCH_HLT),
+										       std::make_pair("express", SYNCH_EXPRESS),
+										       std::make_pair("prompt", SYNCH_PROMPT),
+										       std::make_pair("pcl", SYNCH_PCL) };
+
   std::string synchronizationTypeNames(SynchronizationType type) {
     return s_synchronizationTypeArray[type].first;
   }
 
   SynchronizationType synchronizationTypeFromName( const std::string& name ){
     for (auto const &i : s_synchronizationTypeArray)
-      if (name.compare(i.first))
-        return i.second;
+      if (name.compare(i.first)==0) return i.second;
     throwException( "SynchronizationType \""+name+"\" is unknown.","synchronizationTypeFromName");
   }
 

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -11,6 +11,8 @@
 <bin file="testReadWritePayloads.cpp" name="testReadWritePayloads">
 </bin>
 
+<bin   file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">
+</bin>
 <bin   file="testConditionDatabase_1.cpp" name="testConditionDatabase_1">
 </bin>
 

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -222,7 +222,7 @@ cond::service::PoolDBOutputService::createNewIOV( const std::string& firstPayloa
 
   try{
     // FIX ME: synchronization type and description have to be passed as the other parameters?
-    cond::persistency::IOVEditor editor = m_session.createIov( payloadType, myrecord.m_tag, myrecord.m_timetype, cond::OFFLINE ); 
+    cond::persistency::IOVEditor editor = m_session.createIov( payloadType, myrecord.m_tag, myrecord.m_timetype, cond::SYNCH_ANY ); 
     editor.setDescription( "New Tag" );
     editor.insert( firstSinceTime, firstPayloadId );
     editor.flush();
@@ -264,7 +264,7 @@ cond::service::PoolDBOutputService::createNewIOV( const std::string& firstPayloa
   std::string payloadType("");
   try{
     // FIX ME: synchronization type and description have to be passed as the other parameters?
-    cond::persistency::IOVEditor editor = m_session.createIovForPayload( firstPayloadId, myrecord.m_tag, myrecord.m_timetype, cond::OFFLINE ); 
+    cond::persistency::IOVEditor editor = m_session.createIovForPayload( firstPayloadId, myrecord.m_tag, myrecord.m_timetype, cond::SYNCH_ANY ); 
     editor.setDescription( "New Tag" );
     payloadType = editor.payloadType();
     editor.insert( firstSinceTime, firstPayloadId );


### PR DESCRIPTION
The 'synchronization' types used originally to control the iov setting for the condition uploads, will be now used more widely to categorise the tag w/s to the target workflows. 
The insertion policy will be different depending on this type. The new policy has been implemented.
This is required by the new DropBox.
