### PR TITLE
Use preferred form of not-equal since python 3 eliminates <>

### DIFF
--- a/DQM/HcalMonitorModule/python/hcal_dqm_sourceclient-file_cfg.py
+++ b/DQM/HcalMonitorModule/python/hcal_dqm_sourceclient-file_cfg.py
@@ -96,7 +96,7 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 
 # Set collector host to machine where gui output to be collected
 process.DQM.collectorHost = 'lxplus305'
-if (host<>None):
+if (host!=None):
     process.DQM.collectorHost = host
 process.DQM.collectorPort = 9190
 process.dqmSaver.convention = 'Online'

--- a/DQM/HcalMonitorTasks/python/HcalMonitorTasks_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalMonitorTasks_cfi.py
@@ -74,7 +74,7 @@ def SetTaskParams(process,param, value):
     # Tries to set all task parameter 'param' to the value 'value'
     newval=value
     isstring=False
-    if (newval<>True and newval<>False):
+    if (newval!=True and newval!=False):
         try:
             newval=string.atoi(newval)
         except:

--- a/EventFilter/HcalRawToDigi/test/GetBadEvents.py
+++ b/EventFilter/HcalRawToDigi/test/GetBadEvents.py
@@ -29,9 +29,9 @@ def GetBadCrabEvents(crabdir=None,prefix=None,verbose=False):
         ###print f
         temp=open(os.path.join(newdir,f),'r').readlines()
         for line in temp:
-            if prefix<>None and not line.startswith(prefix):
+            if prefix!=None and not line.startswith(prefix):
                 continue
-            if prefix<>None:
+            if prefix!=None:
                 thisline=string.strip(string.split(line,prefix)[1])
             else:
                 thisline=string.strip(line)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -266,7 +266,7 @@ class LuminosityBlockRange(_ParameterTypeBase):
         if self.__end < self.__start:
             raise RuntimeError('LuminosityBlockRange '+str(self.__start)+':'+str(self.__startSub)+'-'+str(self.__end)+':'+str(self.__endSub)+' out of order')
         # 0 luminosity block number is a special case that means no limit
-        if self.__end == self.__start and (self.__endSub <> 0 and self.__endSub < self.__startSub):
+        if self.__end == self.__start and (self.__endSub != 0 and self.__endSub < self.__startSub):
             raise RuntimeError('LuminosityBlockRange '+str(self.__start)+':'+str(self.__startSub)+'-'+str(self.__end)+':'+str(self.__endSub)+' out of order')
     def start(self):
         return self.__start
@@ -340,7 +340,7 @@ class EventRange(_ParameterTypeBase):
         if self.__end < self.__start or (self.__end == self.__start and self.__endLumi < self.__startLumi):
             raise RuntimeError('EventRange '+str(self.__start)+':'+str(self.__startLumi)+':'+str(self.__startSub)+'-'+str(self.__end)+':'+str(self.__endLumi)+':'+str(self.__endSub)+' out of order')
         # 0 event number is a special case that means no limit
-        if self.__end == self.__start and self.__endLumi == self.__startLumi and (self.__endSub <> 0 and self.__endSub < self.__startSub):
+        if self.__end == self.__start and self.__endLumi == self.__startLumi and (self.__endSub != 0 and self.__endSub < self.__startSub):
             raise RuntimeError('EventRange '+str(self.__start)+':'+str(self.__startLumi)+':'+str(self.__startSub)+'-'+str(self.__end)+':'+str(self.__endLumi)+':'+str(self.__endSub)+' out of order')
     def start(self):
         return self.__start
@@ -462,11 +462,11 @@ class InputTag(_ParameterTypeBase):
     def _isValid(value):
         return True
     def __cmp__(self,other):
-        v = self.__moduleLabel <> other.__moduleLabel
+        v = self.__moduleLabel != other.__moduleLabel
         if not v:
-            v= self.__productInstance <> other.__productInstance
+            v= self.__productInstance != other.__productInstance
             if not v:
-                v=self.__processName <> other.__processName
+                v=self.__processName != other.__processName
         return v
     def value(self):
         "Return the string rep"
@@ -538,9 +538,9 @@ class ESInputTag(_ParameterTypeBase):
     def _isValid(value):
         return True
     def __cmp__(self,other):
-        v = self.__moduleLabel <> other.__moduleLabel
+        v = self.__moduleLabel != other.__moduleLabel
         if not v:
-            v= self.__data <> other.__data
+            v= self.__data != other.__data
         return v
     def value(self):
         "Return the string rep"

--- a/RecoLocalCalo/HcalRecAlgos/test/test_RecHitReflagger_cfg.py
+++ b/RecoLocalCalo/HcalRecAlgos/test/test_RecHitReflagger_cfg.py
@@ -82,14 +82,14 @@ for i in range(len(process.hcalRecAlgos.SeverityLevels)):  # loop over each seve
     severitylevels.append(process.hcalRecAlgos.SeverityLevels[i].Level.value())  # store severity value
     flagvec=process.hcalRecAlgos.SeverityLevels[i].RecHitFlags.value()  # Get vector of rechit flags for this severity level
     flaglevel=process.hcalRecAlgos.SeverityLevels[i].Level.value()
-    if "UserDefinedBit0" in flagvec and flaglevel<>10:  # remove HFLongShort from its default position
+    if "UserDefinedBit0" in flagvec and flaglevel!=10:  # remove HFLongShort from its default position
         flagvec.remove("UserDefinedBit0")
         process.hcalRecAlgos.SeverityLevels[i].RecHitFlags=flagvec
         print "Removed 'UserDefinedBit0' from severity level %i"%(process.hcalRecAlgos.SeverityLevels[i].Level.value())
     if (flaglevel==NewSevLevel):  # Set UserDefinedBit0 severity to 10, which will exclude such rechits from CaloTower
         print "FOUND LEVEL %i!"%NewSevLevel
         if "UserDefinedBit0" not in flagvec:
-            if (flagvec<>['']):
+            if (flagvec!=['']):
                 flagvec.append("UserDefinedBit0")
             else:
                 flagvec=["UserDefinedBit0"]

--- a/Validation/EcalClusters/test/macro/plotEffSigmaVsET.py
+++ b/Validation/EcalClusters/test/macro/plotEffSigmaVsET.py
@@ -38,7 +38,7 @@ file.write(header)
 
 for i in ("emCorr_et", "em_et"):
     for j in range(0, len(eta1)):
-        if variable[j] <> i:
+        if variable[j] != i:
             continue
         bin = str(int((float(eta1[j]) + float(eta2[j]))/2))
         file.write("  h_" + i + "->SetBinContent(" + bin + ", " + effS[j] + ");\n")

--- a/Validation/EcalClusters/test/macro/plotEffSigmaVsEta.py
+++ b/Validation/EcalClusters/test/macro/plotEffSigmaVsEta.py
@@ -38,7 +38,7 @@ file.write(header)
 
 for i in ("emCorr_et", "em_et"):
     for j in range(0, len(eta1)):
-        if variable[j] <> i:
+        if variable[j] != i:
             continue
         bin = str(int((float(eta1[j]) + float(eta2[j]))*50))
         file.write("  h_" + i + "->SetBinContent(" + bin + ", " + effS[j] + ");\n")

--- a/Validation/EcalClusters/test/macro/plotMeanVsET.py
+++ b/Validation/EcalClusters/test/macro/plotMeanVsET.py
@@ -34,7 +34,7 @@ file.write(header)
 
 for i in ("emCorr_et", "em_et"):
     for j in range(0, len(eta1)):
-        if variable[j] <> i:
+        if variable[j] != i:
             continue
         bin = str(int((float(eta1[j]) + float(eta2[j]))/2))
         file.write("  h_" + i + "->SetBinContent(" + bin + ", " + mean[j] + ");\n")

--- a/Validation/EcalClusters/test/macro/plotMeanVsEta.py
+++ b/Validation/EcalClusters/test/macro/plotMeanVsEta.py
@@ -34,7 +34,7 @@ file.write(header)
 
 for i in ("emCorr_et", "em_et"):
     for j in range(0, len(eta1)):
-        if variable[j] <> i:
+        if variable[j] != i:
             continue
         bin = str(int((float(eta1[j]) + float(eta2[j]))*50))
         file.write("  h_" + i + "->SetBinContent(" + bin + ", " + mean[j] + ");\n")


### PR DESCRIPTION
@Dr15Jones said 8_0_X would be a decent place to start getting rid of old python that is not compatible with python 3 but works fine in 2.6/2.7.
