### PR TITLE
Change cMVAv2 range in DQM to [-1,1]

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -8,6 +8,7 @@ from DQMOffline.RecoB.bTagTrackCountingAnalysis_cff import *
 from DQMOffline.RecoB.bTagTrackProbabilityAnalysis_cff import *
 from DQMOffline.RecoB.bTagTrackBProbabilityAnalysis_cff import *
 from DQMOffline.RecoB.bTagGenericAnalysis_cff import *
+from DQMOffline.RecoB.bTagSymmetricAnalysis_cff import *
 from DQMOffline.RecoB.bTagSimpleSVAnalysis_cff import *
 from DQMOffline.RecoB.bTagSoftLeptonAnalysis_cff import *
 from DQMOffline.RecoB.bTagSoftLeptonByPtAnalysis_cff import *
@@ -102,7 +103,7 @@ bTagCommonBlock = cms.PSet(
             folder = cms.string("combMVA")
         ),
         cms.PSet(
-            bTagGenericAnalysisBlock,
+            bTagSymmetricAnalysisBlock,
             label = cms.InputTag("pfCombinedMVAV2BJetTags"),
             folder = cms.string("combMVAV2")
         ),

--- a/DQMOffline/RecoB/python/bTagSymmetricAnalysis_cff.py
+++ b/DQMOffline/RecoB/python/bTagSymmetricAnalysis_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+# For discriminators with output in the range [-1,1]
+bTagSymmetricAnalysisBlock = cms.PSet(
+    parameters = cms.PSet(
+        discriminatorStart = cms.double(-1.011),
+        nBinEffPur = cms.int32(200),
+        # the constant b-efficiency for the differential plots versus pt and eta
+        effBConst = cms.double(0.5),
+        endEffPur = cms.double(1.005),
+        discriminatorEnd = cms.double(1.011),
+        startEffPur = cms.double(0.005)
+    )
+)
+
+


### PR DESCRIPTION
After [PR#11685](https://github.com/cms-sw/cmssw/pull/11685), the output of the cMVAv2 discriminator
will be between -1 and 1 so default bTagGenericAnalysis configuration should not be used.

This PR adds a configuration parameters for discriminators with output range [-1,1], named bTagSymmetricAnalysis and changes bTagCommon to use it as default for cMVAv2.

I have verified that everything works as expected using runTheMatrix.py.
