### PR TITLE
Fix unit tests that require the "startup" autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,4 +1,5 @@
-autoCond = { 
+autoCond = {
+    'startup'           :   'PRE_ST62_V8::All', # this should not be used, only here to be compatible with unit tests 
     'upgrade2017'       :   'DES17_62_V8::All', # 
     'upgrade2019'       :   'DES19_62_V8::All', # 
     'upgradePLS3'       :   'DES23_62_V1::All' # 


### PR DESCRIPTION
A lot of unit tests have been failing recently in SLHCDEV because they expect to be able to use the `startup` tag.  See e.g. #11809 or #11770.  This was taken out in commit https://github.com/cms-sw/cmssw/commit/92a11d05ec452e107f39267632f9164e998d5650, from November 2013.  I'm a little bemused that this hasn't shown up before.  The tag I've used is the last value from then, for the case of unit tests I doubt it matters that the tag is so old.

Submitting to SLHC branch because it should then also be auto-ported to SLHCDEV.

@davidlange6 (original author of commit above), do you think it's okay to add `startup` back, or too risky in case someone inadvertently uses it for any "real" use?  Other options are to change all unit tests to use one of `upgrade2017`, `upgrade2019` or `upgradePLS3`; or to disable unit tests for SLHC and SLHCDEV.  For the former it would clash with the geometry the tests use, the latter option I would think is not desirable.  Could also keep the value but change the name to something like `teststartup`?
