### PR TITLE
Use explicit (preferred) form for numeric literals

### DIFF
--- a/Alignment/MuonAlignmentAlgorithms/scripts/findQualityFiles.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/findQualityFiles.py
@@ -65,13 +65,13 @@ parser.add_option("-m", "--isMC",
 parser.add_option("-s", "--startRun",
                    help="First run number in range.",
                    type="int",
-                   default=0L,
+                   default=0,
                    dest="startRun")
 
 parser.add_option("-e", "--endRun",
                    help="Last run number in range.",
                    type="int",
-                   default=999999999L,
+                   default=999999999,
                    dest="endRun")
 
 parser.add_option("-b", "--minB",
@@ -252,7 +252,7 @@ def getGoodBRuns():
         if v>0:
             print "######## trends ########"
         for x in iov.trendinrange(what,options.startRun-1,options.endRun+1):
-            if v>0 or x[0]==67647L or x[0]==66893L or x[0]==67264L:
+            if v>0 or x[0]==67647 or x[0]==66893 or x[0]==67264:
                 print x[0],x[1] ,x[2], x[2][4], x[2][3]
                 #print x[0],x[1] ,x[2], x[2][4], timeStamptoUTC(x[2][6]), timeStamptoUTC(x[2][7])
             if x[2][4] >= minI and x[2][3] <= maxI:

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -171,7 +171,7 @@ class GenericValidation:
                                                          path, repMap = repMap, repMaps = repMaps)
         for script in self.scriptFiles:
             for scriptwithindex in addIndex(script, self.NJobs):
-                os.chmod(scriptwithindex,0755)
+                os.chmod(scriptwithindex,0o755)
         return self.scriptFiles
 
     def createCrabCfg(self, fileContents, path ):

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -370,7 +370,7 @@ def createMergeScript( path, validations ):
     theFile = open( filePath, "w" )
     theFile.write( replaceByMap( configTemplates.mergeTemplate, repMap ) )
     theFile.close()
-    os.chmod(filePath,0755)
+    os.chmod(filePath,0o755)
     
     return filePath
     

--- a/CalibTracker/SiStripDCS/test/ParseManualO2Olog.py
+++ b/CalibTracker/SiStripDCS/test/ParseManualO2Olog.py
@@ -1308,7 +1308,7 @@ for interval in QueryResults.keys():
         #    print row
         #if row['change_date']==datetime.datetime(2010, 8, 28, 22, 51, 8, 994000):
         #    print row
-        if row['change_date']>datetime.datetime(2010, 8, 28, 22, 44) and row['change_date']<datetime.datetime(2010, 8, 28, 23, 0o5,37):
+        if row['change_date']>datetime.datetime(2010, 8, 28, 22, 44) and row['change_date']<datetime.datetime(2010, 8, 28, 23, 5,37):
             print row    
             
         

--- a/CalibTracker/SiStripDCS/test/ParseManualO2Olog.py
+++ b/CalibTracker/SiStripDCS/test/ParseManualO2Olog.py
@@ -1308,7 +1308,7 @@ for interval in QueryResults.keys():
         #    print row
         #if row['change_date']==datetime.datetime(2010, 8, 28, 22, 51, 8, 994000):
         #    print row
-        if row['change_date']>datetime.datetime(2010, 8, 28, 22, 44) and row['change_date']<datetime.datetime(2010, 8, 28, 23, 05,37):
+        if row['change_date']>datetime.datetime(2010, 8, 28, 22, 44) and row['change_date']<datetime.datetime(2010, 8, 28, 23, 0o5,37):
             print row    
             
         

--- a/CondCore/RunInfoPlugins/test/inspectRunInfo.py
+++ b/CondCore/RunInfoPlugins/test/inspectRunInfo.py
@@ -37,7 +37,7 @@ try :
     print "###(start_current,stop_current,avg_current,max_current,min_current,run_interval_micros) vs runnumber###"
     print iov.trend(what)
     print "########(start_current,stop_current,avg_current,max_current,min_current,run_interval_micros) vs runnumber in a given range########"
-    print iov.trendinrange(what,109441L,109503L)
+    print iov.trendinrange(what,109441,109503)
 except Exception, er :
     print er
 

--- a/CondCore/Utilities/python/upload_popcon.py
+++ b/CondCore/Utilities/python/upload_popcon.py
@@ -402,7 +402,7 @@ class HTTP(object):
 
 def addToTarFile(tarFile, fileobj, arcname):
     tarInfo = tarFile.gettarinfo(fileobj = fileobj, arcname = arcname)
-    tarInfo.mode = 0400
+    tarInfo.mode = 0o400
     tarInfo.uid = tarInfo.gid = tarInfo.mtime = 0
     tarInfo.uname = tarInfo.gname = 'root'
     tarFile.addfile(tarInfo, fileobj)

--- a/DQM/SiStripMonitorClient/scripts/submitDQMOfflineCAF.py
+++ b/DQM/SiStripMonitorClient/scripts/submitDQMOfflineCAF.py
@@ -25,7 +25,7 @@ import smtplib
 # Constants
 
 # numbers
-OCT_rwx_r_r          = 0744
+OCT_rwx_r_r          = 0o744
 LFLOAT_valueMagField = [0.0,2.0,3.0,3.5,3.8,4.0]
 TD_shiftUTC          = datetime.timedelta(hours = 2) # positive for timezones with later time than UTC
 # strings

--- a/DQMOffline/Alignment/test/alcarecoTester.py
+++ b/DQMOffline/Alignment/test/alcarecoTester.py
@@ -114,7 +114,7 @@ class Sample:
       scriptFile = open( scriptPath, "w" )
       scriptFile.write( scriptTemplate%repMap )
       scriptFile.close()
-      os.chmod(scriptPath, 0755)
+      os.chmod(scriptPath, 0o755)
       return scriptPath
    
    def createDQMExtract(self, path):

--- a/DQMServices/StreamerIO/scripts/esMonitoring.py
+++ b/DQMServices/StreamerIO/scripts/esMonitoring.py
@@ -313,7 +313,7 @@ class FDJsonServer(asyncore.file_dispatcher):
             os.unlink(self.fn)
 
         self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        oldmask = os.umask(0077)
+        oldmask = os.umask(0o077)
         try:
             self.bind(self.fn)
             self.listen(5)

--- a/RecoLuminosity/LumiDB/python/pyrootRender.py
+++ b/RecoLuminosity/LumiDB/python/pyrootRender.py
@@ -59,7 +59,7 @@ class batchRender():
         self.__canvas.SaveAs(self.__outfile)
 if __name__=='__main__':
       
-    da = TDatime(2010,0o3,30,13,10,00)
+    da = TDatime(2010,3,30,13,10,00)
     h1f = TH1F("Luminposity","",1000,0.,1000)
     h1f.GetXaxis().SetNdivisions(-503)
     h1f.GetXaxis().SetTimeDisplay(1)

--- a/RecoLuminosity/LumiDB/python/pyrootRender.py
+++ b/RecoLuminosity/LumiDB/python/pyrootRender.py
@@ -59,7 +59,7 @@ class batchRender():
         self.__canvas.SaveAs(self.__outfile)
 if __name__=='__main__':
       
-    da = TDatime(2010,03,30,13,10,00)
+    da = TDatime(2010,0o3,30,13,10,00)
     h1f = TH1F("Luminposity","",1000,0.,1000)
     h1f.GetXaxis().SetNdivisions(-503)
     h1f.GetXaxis().SetTimeDisplay(1)

--- a/RecoLuminosity/LumiDB/test/pyrootLumi.py
+++ b/RecoLuminosity/LumiDB/test/pyrootLumi.py
@@ -16,7 +16,7 @@ class Zhen(tk.Frame):
         #ROOT.gROOT.SetBatch(ROOT.kTRUE)
         ROOT.gStyle.SetOptStat(0)
         
-        da = TDatime(2010,03,30,13,10,00)
+        da = TDatime(2010,0o3,30,13,10,00)
 
         c = TCanvas("Luminosity","",1)
         

--- a/RecoLuminosity/LumiDB/test/pyrootLumi.py
+++ b/RecoLuminosity/LumiDB/test/pyrootLumi.py
@@ -16,7 +16,7 @@ class Zhen(tk.Frame):
         #ROOT.gROOT.SetBatch(ROOT.kTRUE)
         ROOT.gStyle.SetOptStat(0)
         
-        da = TDatime(2010,0o3,30,13,10,00)
+        da = TDatime(2010,3,30,13,10,00)
 
         c = TCanvas("Luminosity","",1)
         

--- a/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
@@ -144,7 +144,7 @@ def createLogFiles(rulesResult, logsDir, wkDay):
             ruleResult = rulesResult[ruleName]
             for package, packageResult in ruleResult:
                 logsDir = join(logDir, package)
-                if not os.path.exists(logsDir): os.makedirs(logsDir, 0755)
+                if not os.path.exists(logsDir): os.makedirs(logsDir, 0o755)
                 file = open(join(logsDir, "log.html"), 'a')
                 file.write('Rule %s'%ruleName)
                 file.write("<br/>")

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -996,7 +996,7 @@ class Plot:
             ROOT.gPad.Update()
             st = h.GetListOfFunctions().FindObject("stats")
             if self._fit:
-                st.SetOptFit(0010)
+                st.SetOptFit(0o010)
                 st.SetOptStat(1001)
             st.SetX1NDC(startingX)
             st.SetX2NDC(startingX+0.3)

--- a/Validation/Tools/python/GenObject.py
+++ b/Validation/Tools/python/GenObject.py
@@ -66,7 +66,7 @@ class GenObject (object):
                                types.string] )
     _defaultValue      = dict ( {types.float  : 0.,
                                  types.int    : 0,
-                                 types.long   : 0L,
+                                 types.long   : 0,
                                  types.string : '""' } )
     _objsDict          = {} # info about GenObjects
     _equivDict         = {} # hold info about 'equivalent' muons


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-3127/#abstract

This turns up a couple of typos related to dates and to ROOT but will not change the results.
