### PR TITLE
Modification to #11868 (configuring flat BS + DQM GUI)

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -57,7 +57,7 @@ class MatrixInjector(object):
             self.wmagent = 'cmsweb.cern.ch'
 
         if not self.dqmgui:
-            self.dqmgui="https://cmsweb.cern.ch/dqm/relval;https://cmsweb-testbed.cern.ch/dqm/relval"
+            self.dqmgui="https://cmsweb.cern.ch/dqm/relval"
         #couch stuff
         self.couch = 'https://'+self.wmagent+'/couchdb'
 # self.couchDB = 'reqmgr_config_cache'

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -858,48 +858,73 @@ def fastsimDefault(process):
 def fastsimPhase2(process):
     return fastCustomisePhase2(process)
 
-def bsStudyStep1(process):
-    process.VtxSmeared.MaxZ = 11.0
-    process.VtxSmeared.MinZ = -11.0
+def bsStudyStep1(process,length):
+    process.VtxSmeared.MaxZ = length
+    process.VtxSmeared.MinZ = -length
     return process
 
-def bsStudyStep2(process):
+def bsStudyStep2(process,length):
     process.initialStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
         precise = cms.bool(True),
         originRadius = cms.double(0.02),
-        originHalfLength = cms.double(11.0),#nSigmaZ = cms.double(4.0),
+        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         ptMin = cms.double(0.7)
         )
     process.highPtTripletStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
         precise = cms.bool(True),
         originRadius = cms.double(0.02),
-        originHalfLength = cms.double(11.0),#nSigmaZ = cms.double(4.0),
+        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         ptMin = cms.double(0.7)
         )
     process.lowPtQuadStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
         precise = cms.bool(True),
         originRadius = cms.double(0.02),
-        originHalfLength = cms.double(11.0),#nSigmaZ = cms.double(4.0),
+        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         ptMin = cms.double(0.2)
         )
     process.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
         precise = cms.bool(True),
         originRadius = cms.double(0.015),
-        originHalfLength = cms.double(11.0),#nSigmaZ = cms.double(4.0),
+        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         ptMin = cms.double(0.35)
         )
     process.detachedQuadStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
         precise = cms.bool(True),
         originRadius = cms.double(0.5),
-        originHalfLength = cms.double(11.0),#nSigmaZ = cms.double(4.0),
+        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         ptMin = cms.double(0.3)
         )
     return process
+
+def customise_bsStudyStep1_11(process):
+    process=bsStudyStep1(process,11.0)
+    return process
+    
+def customise_bsStudyStep2_11(process):
+    process=bsStudyStep2(process,11.0)
+    return process
+
+def customise_bsStudyStep1_15(process):
+    process=bsStudyStep1(process,15.0)
+    return process
+    
+def customise_bsStudyStep2_15(process):
+    process=bsStudyStep2(process,15.0)
+    return process
+
+def customise_bsStudyStep1_20(process):
+    process=bsStudyStep1(process,20.0)
+    return process
+    
+def customise_bsStudyStep2_20(process):
+    process=bsStudyStep2(process,20.0)
+    return process
+
 
 def customise_noPixelDataloss(process):
     return cNoPixDataloss(process)

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -858,71 +858,66 @@ def fastsimDefault(process):
 def fastsimPhase2(process):
     return fastCustomisePhase2(process)
 
-def bsStudyStep1(process,length):
-    process.VtxSmeared.MaxZ = length
-    process.VtxSmeared.MinZ = -length
+def bsStudy(process,length):
+    if hasattr(process,"VtxSmeared") :
+        try:
+            process.VtxSmeared.MaxZ = length
+            process.VtxSmeared.MinZ = -length
+        except TypeError as error:
+            raise TypeError( str(error)+". Are you using '--beamspot Flat'? This customisation only works the Flat beamspot." )
+
+    if hasattr(process,"initialStepSeeds") :
+        process.initialStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
+            precise = cms.bool(True),
+            originRadius = cms.double(0.02),
+            originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
+            beamSpot = cms.InputTag("offlineBeamSpot"),
+            ptMin = cms.double(0.7)
+            )
+    if hasattr(process,"highPtTripletStepSeeds") :
+        process.highPtTripletStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
+            precise = cms.bool(True),
+            originRadius = cms.double(0.02),
+            originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
+            beamSpot = cms.InputTag("offlineBeamSpot"),
+            ptMin = cms.double(0.7)
+            )
+    if hasattr(process,"lowPtQuadStepSeeds") :
+        process.lowPtQuadStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
+            precise = cms.bool(True),
+            originRadius = cms.double(0.02),
+            originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
+            beamSpot = cms.InputTag("offlineBeamSpot"),
+            ptMin = cms.double(0.2)
+            )
+    if hasattr(process,"lowPtTripletStepSeeds") :
+        process.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
+            precise = cms.bool(True),
+            originRadius = cms.double(0.015),
+            originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
+            beamSpot = cms.InputTag("offlineBeamSpot"),
+            ptMin = cms.double(0.35)
+            )
+    if hasattr(process,"detachedQuadStepSeeds") :
+        process.detachedQuadStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
+            precise = cms.bool(True),
+            originRadius = cms.double(0.5),
+            originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
+            beamSpot = cms.InputTag("offlineBeamSpot"),
+            ptMin = cms.double(0.3)
+            )
     return process
 
-def bsStudyStep2(process,length):
-    process.initialStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
-        precise = cms.bool(True),
-        originRadius = cms.double(0.02),
-        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
-        beamSpot = cms.InputTag("offlineBeamSpot"),
-        ptMin = cms.double(0.7)
-        )
-    process.highPtTripletStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
-        precise = cms.bool(True),
-        originRadius = cms.double(0.02),
-        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
-        beamSpot = cms.InputTag("offlineBeamSpot"),
-        ptMin = cms.double(0.7)
-        )
-    process.lowPtQuadStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
-        precise = cms.bool(True),
-        originRadius = cms.double(0.02),
-        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
-        beamSpot = cms.InputTag("offlineBeamSpot"),
-        ptMin = cms.double(0.2)
-        )
-    process.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
-        precise = cms.bool(True),
-        originRadius = cms.double(0.015),
-        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
-        beamSpot = cms.InputTag("offlineBeamSpot"),
-        ptMin = cms.double(0.35)
-        )
-    process.detachedQuadStepSeeds.RegionFactoryPSet.RegionPSet = cms.PSet(
-        precise = cms.bool(True),
-        originRadius = cms.double(0.5),
-        originHalfLength = cms.double(length),#nSigmaZ = cms.double(4.0),
-        beamSpot = cms.InputTag("offlineBeamSpot"),
-        ptMin = cms.double(0.3)
-        )
-    return process
-
-def customise_bsStudyStep1_11(process):
-    process=bsStudyStep1(process,11.0)
+def customise_bsStudy_11(process):
+    process=bsStudy(process,11.0)
     return process
     
-def customise_bsStudyStep2_11(process):
-    process=bsStudyStep2(process,11.0)
-    return process
-
-def customise_bsStudyStep1_15(process):
-    process=bsStudyStep1(process,15.0)
+def customise_bsStudy_15(process):
+    process=bsStudy(process,15.0)
     return process
     
-def customise_bsStudyStep2_15(process):
-    process=bsStudyStep2(process,15.0)
-    return process
-
-def customise_bsStudyStep1_20(process):
-    process=bsStudyStep1(process,20.0)
-    return process
-    
-def customise_bsStudyStep2_20(process):
-    process=bsStudyStep2(process,20.0)
+def customise_bsStudy_20(process):
+    process=bsStudy(process,20.0)
     return process
 
 


### PR DESCRIPTION
This is a slight change to pull request #11868, where the `bsStudyStep1` and `bsStudyStep2` functions are merged into one `bsStudy` function, with `hasattr` guards to select the right parts.  This should make it easier to use.

I'll start the auto tests, but they don't use the new customisation functions so I've already tested privately with:

```
cmsDriver.py FourMuPt_1_200_cfi --conditions PH2_1K_FB_V6::All -n 10 --eventcontent FEVTDEBUG --relval 10000,100 -s GEN,SIM --datatier GEN-SIM --beamspot Flat --customise RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon,SLHCUpgradeSimulations/Configuration/combinedCustoms.customise_bsStudy_15 --geometry Extended2023HGCalMuon,Extended2023HGCalMuonReco --magField 38T_PostLS1 --no_exec --fileout file:step1.root
cmsDriver.py step2 --conditions PH2_1K_FB_V6::All -n 10 --eventcontent FEVTDEBUGHLT -s DIGI:pdigi_valid,L1,DIGI2RAW --datatier GEN-SIM-DIGI-RAW --customise RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon,SLHCUpgradeSimulations/Configuration/combinedCustoms.customise_bsStudy_15 --geometry Extended2023HGCalMuon,Extended2023HGCalMuonReco --magField 38T_PostLS1 --no_exec --filein file:step1.root --fileout file:step2.root
cmsDriver.py step3 --conditions PH2_1K_FB_V6::All -n 10 --eventcontent RECOSIM -s RAW2DIGI,L1Reco,RECO --datatier GEN-SIM-RECO --customise RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon,SLHCUpgradeSimulations/Configuration/combinedCustoms.customise_bsStudy_15 --geometry Extended2023HGCalMuon,Extended2023HGCalMuonReco --magField 38T_PostLS1 --no_exec --filein file:step2.root --fileout file:step3.root
```

(basically upgrade workflow 15600 but with `customise_bsStudy_15` customisation and the beamspot set to `Flat`).  And:

```
runTheMatrix.py -w upgrade -l 12200 --command="--beamspot Flat --customise SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon,SLHCUpgradeSimulations/Configuration/combinedCustoms.customise_bsStudy_15"
```

(`cust_2023HGCalMuon` has to be respecified, since the new customise command overrides the original).  Everything runs fine and the correct parameters are changed.

@boudoul 
