### PR TITLE
Fix packed gen particle copy and move ctors

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -9,6 +9,8 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Math/interface/deltaPhi.h" 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
 /* #include "DataFormats/Math/interface/PtEtaPhiMass.h" */
 
 //forward declare testing structure
@@ -585,7 +587,7 @@ namespace pat {
     mutable std::atomic<LorentzVector*> p4c_;
     /// vertex position                                                                   
     mutable std::atomic<Point*> vertex_;
-    [[cms::thread_guard("vertex_")]] mutable float dxy_, dz_, dphi_;
+    CMS_THREAD_GUARD(vertex_) mutable float dxy_, dz_, dphi_;
     /// reco::Track                                                                   
     mutable std::atomic<reco::Track*> track_;
     /// PDG identifier                                                                    
@@ -596,7 +598,7 @@ namespace pat {
     reco::VertexRef::key_type pvRefKey_;
 
     /// IP covariance	
-    [[cms::thread_guard("vertex_")]] mutable float dxydxy_, dzdz_, dxydz_,dlambdadz_,dphidxy_,dptdpt_,detadeta_,dphidphi_;
+    CMS_THREAD_GUARD(vertex_) mutable float dxydxy_, dzdz_, dxydz_,dlambdadz_,dphidxy_,dptdpt_,detadeta_,dphidphi_;
     uint8_t packedHits_;
     /// track quality information
     uint8_t normalizedChi2_; 

--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -70,6 +70,10 @@ namespace pat {
 
     PackedGenParticle& operator=(PackedGenParticle&& iOther) {
       if(this != &iOther) {
+        packedPt_ = iOther.packedPt_;
+        packedY_ = iOther.packedY_;
+        packedPhi_ = iOther.packedPhi_;
+        packedM_ = iOther.packedM_;
         if(p4c_) {
           delete p4_.exchange(iOther.p4_.exchange(nullptr));
           delete p4c_.exchange(iOther.p4c_.exchange(nullptr)) ;

--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -45,7 +45,8 @@ namespace pat {
       statusFlags_(c.statusFlags()) { pack(); }
 
     PackedGenParticle(const PackedGenParticle& iOther)
-    : p4_(nullptr),p4c_(nullptr),
+    : packedPt_(iOther.packedPt_), packedY_(iOther.packedY_), packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
+      p4_(nullptr),p4c_(nullptr),
       vertex_(iOther.vertex_), dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_),
       pdgId_(iOther.pdgId_),charge_(iOther.charge_),mother_(iOther.mother_),
       statusFlags_(iOther.statusFlags_) {
@@ -56,7 +57,8 @@ namespace pat {
     }
 
     PackedGenParticle(PackedGenParticle&& iOther)
-    : p4_(nullptr),p4c_(nullptr),
+    : packedPt_(iOther.packedPt_), packedY_(iOther.packedY_), packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
+      p4_(nullptr),p4c_(nullptr),
       vertex_(std::move(iOther.vertex_)), dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_),
       pdgId_(iOther.pdgId_),charge_(iOther.charge_),mother_(std::move(iOther.mother_)),
       statusFlags_(iOther.statusFlags_) {

--- a/DataFormats/PatCandidates/test/testPackedGenParticle.cc
+++ b/DataFormats/PatCandidates/test/testPackedGenParticle.cc
@@ -39,6 +39,10 @@ void testPackedGenParticle::testDefaultConstructor() {
   CPPUNIT_ASSERT(pc.polarP4() == pat::PackedGenParticle::PolarLorentzVector(0,0,0,0));
   CPPUNIT_ASSERT(pc.p4() == pat::PackedGenParticle::LorentzVector(0,0,0,0) );
   CPPUNIT_ASSERT(pc.vertex() == pat::PackedGenParticle::Point(0,0,0));
+  CPPUNIT_ASSERT(pc.packedPt_ == 0);
+  CPPUNIT_ASSERT(pc.packedY_ == 0);
+  CPPUNIT_ASSERT(pc.packedPhi_ == 0);
+  CPPUNIT_ASSERT(pc.packedM_ == 0);
 }
 
 static bool tolerance(double iLHS, double iRHS, double fraction) {
@@ -68,10 +72,18 @@ void testPackedGenParticle::testCopyConstructor() {
   CPPUNIT_ASSERT(copy_pc.polarP4() == pc.polarP4());
   CPPUNIT_ASSERT(copy_pc.p4() == pc.p4());
   CPPUNIT_ASSERT(copy_pc.vertex() == pc.vertex());
+  CPPUNIT_ASSERT(copy_pc.packedPt_ == pc.packedPt_);
+  CPPUNIT_ASSERT(copy_pc.packedY_ == pc.packedY_);
+  CPPUNIT_ASSERT(copy_pc.packedPhi_ == pc.packedPhi_);
+  CPPUNIT_ASSERT(copy_pc.packedM_ == pc.packedM_);
 
   CPPUNIT_ASSERT(&copy_pc.polarP4() != &pc.polarP4());
   CPPUNIT_ASSERT(&copy_pc.p4() != &pc.p4());
   CPPUNIT_ASSERT(&copy_pc.vertex() != &pc.vertex());
+  CPPUNIT_ASSERT(&copy_pc.packedPt_ != &pc.packedPt_);
+  CPPUNIT_ASSERT(&copy_pc.packedY_ != &pc.packedY_);
+  CPPUNIT_ASSERT(&copy_pc.packedPhi_ != &pc.packedPhi_);
+  CPPUNIT_ASSERT(&copy_pc.packedM_ != &pc.packedM_);
 
 }
 


### PR DESCRIPTION
Pr #11706 created explicit copy and move constructors for pat::PackedGenParticle.
Unfortunately, the packed quantities were left out, so they were neither moved nor copied.
This PR fixes that, and also enhances the unit test so that this would have been caught.
This fixes the discrepancy recently seen in PackedGenParticle.
