### PR TITLE
Support multiple subprocesses

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -230,8 +230,8 @@ namespace edm {
 
     void setupSignal();
 
-    bool hasSubProcess() const {
-      return subProcess_.get() != 0;
+    bool hasSubProcesses() const {
+      return subProcesses_.get() != nullptr && !subProcesses_->empty();
     }
 
     void possiblyContinueAfterForkChildFailure();
@@ -269,7 +269,7 @@ namespace edm {
     ProcessContext                                processContext_;
     PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
     std::auto_ptr<Schedule>                       schedule_;
-    std::auto_ptr<SubProcess>                     subProcess_;
+    std::unique_ptr<std::vector<SubProcess> >     subProcesses_;
     std::unique_ptr<HistoryAppender>            historyAppender_;
 
     std::unique_ptr<FileBlock>                    fb_;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -127,7 +127,7 @@ namespace edm {
              ExceptionToActionTable const& actions,
              std::shared_ptr<ActivityRegistry> areg,
              std::shared_ptr<ProcessConfiguration> processConfiguration,
-             const ParameterSet* subProcPSet,
+             bool hasSubprocesses,
              PreallocationConfiguration const& config,
              ProcessContext const* processContext);
 

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -46,7 +46,7 @@ namespace edm {
 
     std::auto_ptr<Schedule>
     initSchedule(ParameterSet& parameterSet,
-                 ParameterSet const* subProcessPSet,
+                 bool hasSubprocesses,
                  PreallocationConfiguration const& iAllocConfig,
                  ProcessContext const*);
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -362,7 +362,7 @@ namespace edm {
                      ExceptionToActionTable const& actions,
                      std::shared_ptr<ActivityRegistry> areg,
                      std::shared_ptr<ProcessConfiguration> processConfiguration,
-                     const ParameterSet* subProcPSet,
+                     bool hasSubprocesses,
                      PreallocationConfiguration const& prealloc,
                      ProcessContext const* processContext) :
   //Only create a resultsInserter if there is a trigger path
@@ -376,7 +376,7 @@ namespace edm {
     assert(0<prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
     for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
-      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(resultsInserter_,moduleRegistry_,proc_pset,tns,prealloc,preg,branchIDListHelper,actions,areg,processConfiguration,nullptr==subProcPSet,StreamID{i},processContext));
+      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(resultsInserter_,moduleRegistry_,proc_pset,tns,prealloc,preg,branchIDListHelper,actions,areg,processConfiguration,!hasSubprocesses,StreamID{i},processContext));
     }
     
     //TriggerResults are injected automatically by StreamSchedules and are

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -129,7 +129,7 @@ namespace edm {
 
   std::auto_ptr<Schedule>
   ScheduleItems::initSchedule(ParameterSet& parameterSet,
-                              ParameterSet const* subProcessPSet,
+                              bool hasSubprocesses,
                               PreallocationConfiguration const& config,
                               ProcessContext const* processContext) {
     std::auto_ptr<Schedule> schedule(
@@ -141,7 +141,7 @@ namespace edm {
                      *act_table_,
                      actReg_,
                      processConfiguration_,
-                     subProcessPSet,
+                     hasSubprocesses,
                      config,
                      processContext));
     return schedule;

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -59,7 +59,7 @@ namespace edm {
       esp_(),
       schedule_(),
       parentToChildPhID_(),
-      subProcess_(),
+      subProcesses_(),
       processParameterSet_(),
       productSelectorRules_(parameterSet, "outputCommands", "OutputModule"),
       productSelector_(),
@@ -106,9 +106,9 @@ namespace edm {
       processParameterSet_->addUntrackedParameter<ParameterSet>(maxLumis, topLevelParameterSet.getUntrackedParameterSet(maxLumis));
     }
 
-    // If this process has a subprocess, pop the subprocess parameter set out of the process parameter set
-
-    std::shared_ptr<ParameterSet> subProcessParameterSet(popSubProcessParameterSet(*processParameterSet_).release());
+    // If there are subprocesses, pop the subprocess parameter sets out of the process parameter set
+    std::unique_ptr<std::vector<ParameterSet> > subProcessVParameterSet(popSubProcessVParameterSet(*processParameterSet_));
+    bool hasSubProcesses = subProcessVParameterSet.get() != nullptr;
   
     ScheduleItems items(*parentProductRegistry, *this);
     actReg_ = items.actReg_;
@@ -120,7 +120,7 @@ namespace edm {
     ServiceToken iToken;
 
     // get any configured services.
-    std::auto_ptr<std::vector<ParameterSet> > serviceSets = processParameterSet_->popVParameterSet(std::string("services")); 
+    std::unique_ptr<std::vector<ParameterSet> > serviceSets = processParameterSet_->popVParameterSet(std::string("services")); 
 
     ServiceToken newToken = items.initServices(*serviceSets, *processParameterSet_, token, iLegacy, false);
     parentActReg.connectToSubProcess(*items.actReg_);
@@ -143,7 +143,7 @@ namespace edm {
     thinnedAssociationsHelper_->updateFromParentProcess(parentThinnedAssociationsHelper, keepAssociation, droppedBranchIDToKeptBranchID_);
 
     // intialize the Schedule
-    schedule_ = items.initSchedule(*processParameterSet_,subProcessParameterSet.get(),preallocConfig,&processContext_);
+    schedule_ = items.initSchedule(*processParameterSet_,hasSubProcesses,preallocConfig,&processContext_);
 
     // set the items
     act_table_ = std::move(items.act_table_);
@@ -165,18 +165,24 @@ namespace edm {
       ep->postModuleDelayedGetSignal_.connect(std::cref(items.actReg_->postModuleEventDelayedGetSignal_));
       principalCache_.insert(ep);
     }
-    if(subProcessParameterSet) {
-      subProcess_.reset(new SubProcess(*subProcessParameterSet,
-                                       topLevelParameterSet,
-                                       preg_,
-                                       branchIDListHelper_,
-                                       *thinnedAssociationsHelper_,
-                                       esController,
-                                       *items.actReg_,
-                                       newToken,
-                                       iLegacy,
-                                       preallocConfig,
-                                       &processContext_));
+    if(hasSubProcesses) {
+      if(subProcesses_ == nullptr) {
+        subProcesses_ = std::make_unique<std::vector<SubProcess> >();
+      }
+      subProcesses_->reserve(subProcessVParameterSet->size());
+      for(auto& subProcessPSet : *subProcessVParameterSet) {
+        subProcesses_->emplace_back(subProcessPSet,
+                                    topLevelParameterSet,
+                                    preg_,
+                                    branchIDListHelper_,
+                                    *thinnedAssociationsHelper_,
+                                    esController,
+                                    *items.actReg_,
+                                    newToken,
+                                    iLegacy,
+                                    preallocConfig,
+                                    &processContext_);
+       }
     }
   }
 
@@ -202,7 +208,11 @@ namespace edm {
     pathsAndConsumesOfModules_.initialize(schedule_.get(), preg_);
     actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
     schedule_->beginJob(*preg_);
-    if(subProcess_.get()) subProcess_->doBeginJob();
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doBeginJob();
+      }
+    }
   }
 
   void
@@ -210,7 +220,11 @@ namespace edm {
     ServiceRegistry::Operate operate(serviceToken_);
     ExceptionCollector c("Multiple exceptions were thrown while executing endJob. An exception message follows for each.");
     schedule_->endJob(c);
-    if(subProcess_.get()) c.call([this](){ this->subProcess_->doEndJob();});
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        c.call([&subProcess](){ subProcess.doEndJob();});
+      }
+    }
     if(c.hasThrown()) {
       c.rethrow();
     }
@@ -289,7 +303,11 @@ namespace edm {
         }
       }
     }
-    if(subProcess_.get()) subProcess_->fixBranchIDListsForEDAliases(droppedBranchIDToKeptBranchID);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.fixBranchIDListsForEDAliases(droppedBranchIDToKeptBranchID);
+      }
+    }
   }
 
   void
@@ -332,7 +350,11 @@ namespace edm {
     propagateProducts(InEvent, principal, ep);
     typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Traits;
     schedule_->processOneEvent<Traits>(ep.streamID().value(),ep, esp_->eventSetup());
-    if(subProcess_.get()) subProcess_->doEvent(ep);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doEvent(ep);
+      }
+    }
     ep.clearEventPrincipal();
   }
 
@@ -361,7 +383,11 @@ namespace edm {
     propagateProducts(InRun, principal, rp);
     typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
     schedule_->processOneGlobal<Traits>(rp, esp_->eventSetupForInstance(ts));
-    if(subProcess_.get()) subProcess_->doBeginRun(rp, ts);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doBeginRun(rp, ts);
+      }
+    }
   }
 
   void
@@ -376,7 +402,11 @@ namespace edm {
     propagateProducts(InRun, principal, rp);
     typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
     schedule_->processOneGlobal<Traits>(rp, esp_->eventSetupForInstance(ts), cleaningUpAfterException);
-    if(subProcess_.get()) subProcess_->doEndRun(rp, ts, cleaningUpAfterException);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doEndRun(rp, ts, cleaningUpAfterException);
+      }
+    }
   }
 
   void
@@ -385,7 +415,11 @@ namespace edm {
     std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
     assert(it != parentToChildPhID_.end());
     schedule_->writeRun(principalCache_.runPrincipal(it->second, runNumber), &processContext_);
-    if(subProcess_.get()) subProcess_->writeRun(it->second, runNumber);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.writeRun(it->second, runNumber);
+      }
+    }
   }
 
   void
@@ -393,7 +427,11 @@ namespace edm {
     std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
     assert(it != parentToChildPhID_.end());
     principalCache_.deleteRun(it->second, runNumber);
-    if(subProcess_.get()) subProcess_->deleteRunFromCache(it->second, runNumber);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.deleteRunFromCache(it->second, runNumber);
+      }
+    }
   }
 
   void
@@ -416,7 +454,11 @@ namespace edm {
     propagateProducts(InLumi, principal, lbp);
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
     schedule_->processOneGlobal<Traits>(lbp, esp_->eventSetupForInstance(ts));
-    if(subProcess_.get()) subProcess_->doBeginLuminosityBlock(lbp, ts);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doBeginLuminosityBlock(lbp, ts);
+      }
+    }
   }
 
   void
@@ -431,7 +473,11 @@ namespace edm {
     propagateProducts(InLumi, principal, lbp);
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
     schedule_->processOneGlobal<Traits>(lbp, esp_->eventSetupForInstance(ts), cleaningUpAfterException);
-    if(subProcess_.get()) subProcess_->doEndLuminosityBlock(lbp, ts, cleaningUpAfterException);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doEndLuminosityBlock(lbp, ts, cleaningUpAfterException);
+      }
+    }
   }
 
   void
@@ -440,7 +486,11 @@ namespace edm {
     std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
     assert(it != parentToChildPhID_.end());
     schedule_->writeLumi(principalCache_.lumiPrincipal(it->second, runNumber, lumiNumber), &processContext_);
-    if(subProcess_.get()) subProcess_->writeLumi(it->second, runNumber, lumiNumber);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.writeLumi(it->second, runNumber, lumiNumber);
+      }
+    }
   }
 
   void
@@ -448,21 +498,33 @@ namespace edm {
     std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
     assert(it != parentToChildPhID_.end());
     principalCache_.deleteLumi(it->second, runNumber, lumiNumber);
-      if(subProcess_.get()) subProcess_->deleteLumiFromCache(it->second, runNumber, lumiNumber);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.deleteLumiFromCache(it->second, runNumber, lumiNumber);
+      }
+    }
   }
   
   void
   SubProcess::doBeginStream(unsigned int iID) {
     ServiceRegistry::Operate operate(serviceToken_);
     schedule_->beginStream(iID);
-    if(subProcess_.get()) subProcess_->doBeginStream(iID);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doBeginStream(iID);
+      }
+    }
   }
 
   void
   SubProcess::doEndStream(unsigned int iID) {
     ServiceRegistry::Operate operate(serviceToken_);
     schedule_->endStream(iID);
-    if(subProcess_.get()) subProcess_->doEndStream(iID);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.doEndStream(iID);
+      }
+    }
   }
 
   void
@@ -472,7 +534,11 @@ namespace edm {
       RunPrincipal& rp = *principalCache_.runPrincipalPtr();
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
       schedule_->processOneStream<Traits>(id,rp, esp_->eventSetupForInstance(ts));
-      if(subProcess_.get()) subProcess_->doStreamBeginRun(id,rp, ts);
+      if(hasSubProcesses()) {
+        for(auto& subProcess : *subProcesses_) {
+          subProcess.doStreamBeginRun(id,rp, ts);
+        }
+      }
     }
   }
   
@@ -483,7 +549,11 @@ namespace edm {
       RunPrincipal& rp = *principalCache_.runPrincipalPtr();
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
       schedule_->processOneStream<Traits>(id,rp, esp_->eventSetupForInstance(ts),cleaningUpAfterException);
-      if(subProcess_.get()) subProcess_->doStreamEndRun(id,rp, ts,cleaningUpAfterException);
+      if(hasSubProcesses()) {
+        for(auto& subProcess : *subProcesses_) {
+          subProcess.doStreamEndRun(id,rp, ts,cleaningUpAfterException);
+        }
+      }
     }
   }
   
@@ -494,7 +564,11 @@ namespace edm {
       LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
       schedule_->processOneStream<Traits>(id,lbp, esp_->eventSetupForInstance(ts));
-      if(subProcess_.get()) subProcess_->doStreamBeginLuminosityBlock(id,lbp, ts);
+      if(hasSubProcesses()) {
+        for(auto& subProcess : *subProcesses_) {
+          subProcess.doStreamBeginLuminosityBlock(id,lbp, ts);
+        }
+      }
     }
   }
   
@@ -505,7 +579,11 @@ namespace edm {
       LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Traits;
       schedule_->processOneStream<Traits>(id,lbp, esp_->eventSetupForInstance(ts),cleaningUpAfterException);
-      if(subProcess_.get()) subProcess_->doStreamEndLuminosityBlock(id,lbp, ts,cleaningUpAfterException);
+      if(hasSubProcesses()) {
+        for(auto& subProcess : *subProcesses_) {
+          subProcess.doStreamEndLuminosityBlock(id,lbp, ts,cleaningUpAfterException);
+        }
+      }
     }
   }
 
@@ -543,8 +621,10 @@ namespace edm {
 
   void SubProcess::updateBranchIDListHelper(BranchIDLists const& branchIDLists) {
     branchIDListHelper_->updateFromParent(branchIDLists);
-    if(subProcess_.get()) {
-      subProcess_->updateBranchIDListHelper(branchIDListHelper_->branchIDLists());
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists());
+      }
     }
   }
 
@@ -553,19 +633,21 @@ namespace edm {
   SubProcess::respondToOpenInputFile(FileBlock const& fb) {
     ServiceRegistry::Operate operate(serviceToken_);
     schedule_->respondToOpenInputFile(fb);
-    if(subProcess_.get()) subProcess_->respondToOpenInputFile(fb);
+    if(hasSubProcesses()) {
+      for(auto& subProcess : *subProcesses_) {
+        subProcess.respondToOpenInputFile(fb);
+      }
+    }
   }
 
   // free function
-  std::auto_ptr<ParameterSet>
-  popSubProcessParameterSet(ParameterSet& parameterSet) {
+  std::unique_ptr<std::vector<ParameterSet> >
+  popSubProcessVParameterSet(ParameterSet& parameterSet) {
     std::vector<std::string> subProcesses = parameterSet.getUntrackedParameter<std::vector<std::string> >("@all_subprocesses");
     if(!subProcesses.empty()) {
-      assert(subProcesses.size() == 1U);
-      assert(subProcesses[0] == "@sub_process");
-      return parameterSet.popParameterSet(subProcesses[0]);
+      return parameterSet.popVParameterSet("subProcesses");
     }
-    return std::auto_ptr<ParameterSet>(nullptr);
+    return std::unique_ptr<std::vector<ParameterSet> >(nullptr);
   }
 }
 

--- a/FWCore/Framework/test/test_subProcessDeleteEarly_cfg.py
+++ b/FWCore/Framework/test/test_subProcessDeleteEarly_cfg.py
@@ -33,4 +33,4 @@ process2.tester2 = cms.EDAnalyzer("DeleteEarlyCheckDeleteAnalyzer",
                                 expectedValues = cms.untracked.vuint32(1,3,5))
 process2.p = cms.Path(process2.reader+process2.tester2)
 
-process.add_(cms.SubProcess(process2))
+process.addSubProcess(cms.SubProcess(process2))

--- a/FWCore/Integration/test/EventHistory_SubProcess_cfg.py
+++ b/FWCore/Integration/test/EventHistory_SubProcess_cfg.py
@@ -36,7 +36,7 @@ process.ep1 = cms.EndPath(process.out)
 
 process2 = cms.Process("SECOND")
 
-process.subProcess = cms.SubProcess(process2)
+process.addSubProcess(cms.SubProcess(process2))
 
 process2.intdeque = cms.EDProducer("IntDequeProducer",
     count = cms.int32(12),
@@ -82,11 +82,11 @@ process2.sched = cms.Schedule(process2.f55, process2.f75, process2.ep2)
 
 process3 = cms.Process("THIRD")
 
-process2.subProcess = cms.SubProcess(process3,
+process2.addSubProcess(cms.SubProcess(process3,
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('f55')
     )
-)
+))
 
 process3.intdeque = cms.EDProducer("IntDequeProducer",
     count = cms.int32(12),
@@ -123,7 +123,7 @@ process3.epother = cms.EndPath(process3.outother)
 
 process4 = cms.Process("FOURTH")
 
-process3.subProcess = cms.SubProcess(process4)
+process3.addSubProcess(cms.SubProcess(process4))
 
 process4.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testEventHistory_4.root')
@@ -133,7 +133,7 @@ process4.ep4 = cms.EndPath(process4.out)
 
 process5 = cms.Process("FIFTH")
 
-process4.subProcess = cms.SubProcess(process5)
+process4.addSubProcess(cms.SubProcess(process5))
 
 process5.out = cms.OutputModule("PoolOutputModule",
     SelectEvents = cms.untracked.PSet(
@@ -146,11 +146,11 @@ process5.ep4 = cms.EndPath(process5.out)
 
 process6 = cms.Process("SIXTH")
 
-process5.subProcess = cms.SubProcess(process6,
+process5.addSubProcess(cms.SubProcess(process6,
     SelectEvents = cms.untracked.PSet(
        SelectEvents = cms.vstring('f55:SECOND','f75:SECOND')
     )
-)
+))
 
 process6.historytest = cms.EDAnalyzer("HistoryAnalyzer",
     # Why does the filter module (from step 3) pass 56 events, when I
@@ -263,7 +263,7 @@ process6.ep63 = cms.EndPath(process6.analyzerOnEndPath*process6.out2*process6.ou
 
 process7 = cms.Process("SEVENTH")
 
-process6.subProcess = cms.SubProcess(process7)
+process6.addSubProcess(cms.SubProcess(process7))
 
 process7.dummyproducerxxx = cms.EDProducer("IntProducer",
     ivalue = cms.int32(2)

--- a/FWCore/Integration/test/ThinningTestSubProcess_cfg.py
+++ b/FWCore/Integration/test/ThinningTestSubProcess_cfg.py
@@ -338,14 +338,14 @@ process.endPath = cms.EndPath(process.out)
 # ---------------------------------------------------------------
 
 secondProcess = cms.Process("SECOND")
-process.subProcess = cms.SubProcess(secondProcess,
+process.addSubProcess(cms.SubProcess(secondProcess,
     outputCommands = cms.untracked.vstring(
         'keep *',
         'drop *_thinningThingProducerM_*_*',
         'drop *_thinningThingProducerN_*_*',
         'drop *_thinningThingProducerO_*_*',
     )
-)
+))
 
 secondProcess.testSecondA = cms.EDAnalyzer("ThinningTestAnalyzer",
     parentTag = cms.InputTag('thingProducer'),
@@ -408,7 +408,7 @@ secondProcess.endPath = cms.EndPath(secondProcess.out)
 # ---------------------------------------------------------------
 
 thirdProcess = cms.Process("THIRD")
-secondProcess.subProcess = cms.SubProcess(thirdProcess,
+secondProcess.addSubProcess(cms.SubProcess(thirdProcess,
     outputCommands = cms.untracked.vstring(
         'keep *',
         'drop *_thingProducer_*_*',
@@ -421,7 +421,7 @@ secondProcess.subProcess = cms.SubProcess(thirdProcess,
         'drop *_aliasM_*_*',
         'drop *_aliasN_*_*',
     )
-)
+))
 
 thirdProcess.testThirdA = cms.EDAnalyzer("ThinningTestAnalyzer",
     parentTag = cms.InputTag('thingProducer'),

--- a/FWCore/Integration/test/readSubProcessOutput_cfg.py
+++ b/FWCore/Integration/test/readSubProcessOutput_cfg.py
@@ -145,12 +145,12 @@ process.ep = cms.EndPath(process.out)
 
 
 read2Process = cms.Process("READ2")
-process.subProcess = cms.SubProcess(read2Process,
+process.addSubProcess(cms.SubProcess(read2Process,
     outputCommands = cms.untracked.vstring(
         "keep *", 
         "drop *_putInt2_*_*"
     )
-)
+))
 
 read2Process.getInt = cms.EDAnalyzer("TestFindProduct",
   inputTags = cms.untracked.VInputTag(

--- a/FWCore/Integration/test/ref_merge_subprocess_cfg.py
+++ b/FWCore/Integration/test/ref_merge_subprocess_cfg.py
@@ -7,7 +7,7 @@ process.source = cms.Source("PoolSource",
                             )
 
 testProcess = cms.Process("TEST")
-process.subProcess = cms.SubProcess(testProcess)
+process.addSubProcess(cms.SubProcess(testProcess))
 
 testProcess.a = cms.EDProducer("IntProducer",
                            ivalue = cms.int32(1))
@@ -24,7 +24,7 @@ testProcess.p = cms.Path(testProcess.a)
 testProcess.e = cms.EndPath(testProcess.tester*testProcess.out)
 
 testProcessA = cms.Process("TESTA")
-testProcess.subProcess = cms.SubProcess(testProcessA)
+testProcess.addSubProcess(cms.SubProcess(testProcessA))
 
 testProcessA.a = cms.EDProducer("IntProducer",
                            ivalue = cms.int32(1))

--- a/FWCore/Integration/test/testConsumesInfo_cfg.py
+++ b/FWCore/Integration/test/testConsumesInfo_cfg.py
@@ -107,12 +107,12 @@ process.e = cms.EndPath(process.out)
 process.p1ep2 = cms.EndPath()
 
 copyProcess = cms.Process("COPY")
-process.subProcess = cms.SubProcess(copyProcess,
+process.addSubProcess(cms.SubProcess(copyProcess,
     outputCommands = cms.untracked.vstring(
         "keep *",
         "drop *_intProducerA_*_*"
     )
-)
+))
 
 copyProcess.intVectorProducer = cms.EDProducer("IntVectorProducer",
   count = cms.int32(9),

--- a/FWCore/Integration/test/testGetBy1_cfg.py
+++ b/FWCore/Integration/test/testGetBy1_cfg.py
@@ -87,9 +87,9 @@ process.p = cms.Path(process.intProducer * process.a1 * process.a2 * process.a3)
 process.e = cms.EndPath(process.out)
 
 copyProcess = cms.Process("COPY")
-process.subProcess = cms.SubProcess(copyProcess,
+process.addSubProcess(cms.SubProcess(copyProcess,
     outputCommands = cms.untracked.vstring(
         "keep *", 
         "drop *_intProducerA_*_*"
     )
-)
+))

--- a/FWCore/Integration/test/testSubProcessEventSetup1_cfg.py
+++ b/FWCore/Integration/test/testSubProcessEventSetup1_cfg.py
@@ -118,7 +118,7 @@ process.path1 = cms.Path(process.esTestAnalyzerB*process.esTestAnalyzerK)
 # function to be called.
 
 process1 = cms.Process("TEST1")
-process.subProcess = cms.SubProcess(process1)
+process.addSubProcess(cms.SubProcess(process1))
 
 process1.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -215,7 +215,7 @@ process1.path1 = cms.Path(process1.esTestAnalyzerB*process1.esTestAnalyzerK)
 # Shows the esTestProducerB is not shared.
 
 process2 = cms.Process("TEST2")
-process1.subProcess = cms.SubProcess(process2)
+process1.addSubProcess(cms.SubProcess(process2))
 
 process2.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -312,7 +312,7 @@ process2.path1 = cms.Path(process2.esTestAnalyzerB*process2.esTestAnalyzerK)
 # Shows the esTestProducerB is not shared.
 
 process3 = cms.Process("TEST3")
-process2.subProcess = cms.SubProcess(process3)
+process2.addSubProcess(cms.SubProcess(process3))
 
 process3.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -382,7 +382,7 @@ process3.path1 = cms.Path(process3.esTestAnalyzerB)
 
 
 process4 = cms.Process("TEST4")
-process3.subProcess = cms.SubProcess(process4)
+process3.addSubProcess(cms.SubProcess(process4))
 
 process4.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -453,7 +453,7 @@ process4.path1 = cms.Path(process4.esTestAnalyzerB)
 
 
 process5 = cms.Process("TEST5")
-process4.subProcess = cms.SubProcess(process5)
+process4.addSubProcess(cms.SubProcess(process5))
 
 process5.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -518,7 +518,7 @@ process5.path1 = cms.Path(process5.esTestAnalyzerB)
 
 
 process6 = cms.Process("TEST6")
-process5.subProcess = cms.SubProcess(process6)
+process5.addSubProcess(cms.SubProcess(process6))
 
 process6.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -592,7 +592,7 @@ process6.path1 = cms.Path(process6.esTestAnalyzerB)
 
 
 process7 = cms.Process("TEST7")
-process6.subProcess = cms.SubProcess(process7)
+process6.addSubProcess(cms.SubProcess(process7))
 
 process7.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -667,7 +667,7 @@ process7.path1 = cms.Path(process7.esTestAnalyzerB)
 # get for events 1 to 6.
 
 process8 = cms.Process("TEST8")
-process7.subProcess = cms.SubProcess(process8)
+process7.addSubProcess(cms.SubProcess(process8))
 
 process8.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -730,7 +730,7 @@ process8.path1 = cms.Path(process8.esTestAnalyzerB)
 # record G. Does not do the get for events 1 to 7.
 
 process9 = cms.Process("TEST9")
-process8.subProcess = cms.SubProcess(process9)
+process8.addSubProcess(cms.SubProcess(process9))
 
 process9.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
@@ -800,7 +800,7 @@ process9.path1 = cms.Path(process9.esTestAnalyzerB)
 # Shows the esTestProducerB is not shared.
 
 process10 = cms.Process("TEST10")
-process9.subProcess = cms.SubProcess(process10)
+process9.addSubProcess(cms.SubProcess(process10))
 
 process10.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),

--- a/FWCore/Integration/test/testSubProcessEventSetup_cfg.py
+++ b/FWCore/Integration/test/testSubProcessEventSetup_cfg.py
@@ -78,7 +78,7 @@ process.path1 = cms.Path(process.esTestAnalyzerA*process.esTestAnalyzerAZ)
 # previous process.
 
 process1 = cms.Process("TEST1")
-process.subProcess = cms.SubProcess(process1)
+process.addSubProcess(cms.SubProcess(process1))
 
 process1.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -118,7 +118,7 @@ process1.path1 = cms.Path(process1.esTestAnalyzerA)
 # because of a difference in a tracked parameter
 
 process2 = cms.Process("TEST2")
-process1.subProcess = cms.SubProcess(process2)
+process1.addSubProcess(cms.SubProcess(process2))
 
 process2.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -160,7 +160,7 @@ process2.path1 = cms.Path(process2.esTestAnalyzerA)
 # Data is not gotten on event 3.
 
 process3 = cms.Process("TEST3")
-process2.subProcess = cms.SubProcess(process3)
+process2.addSubProcess(cms.SubProcess(process3))
 
 process3.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -203,7 +203,7 @@ process3.path1 = cms.Path(process3.esTestAnalyzerA)
 # exactly. No data gotten on event 4 and 5.
 
 process4 = cms.Process("TEST4")
-process3.subProcess = cms.SubProcess(process4)
+process3.addSubProcess(cms.SubProcess(process4))
 
 process4.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -250,7 +250,7 @@ process4.path1 = cms.Path(process4.esTestAnalyzerA*process4.esTestAnalyzerAZ)
 # not anything earlier. No data gotten on events 4, 5, and 6.
 
 process5 = cms.Process("TEST5")
-process4.subProcess = cms.SubProcess(process5)
+process4.addSubProcess(cms.SubProcess(process5))
 
 process5.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -298,7 +298,7 @@ process5.path1 = cms.Path(process5.esTestAnalyzerA*process5.esTestAnalyzerAZ)
 # No data gotten on event 7
 
 process6 = cms.Process("TEST6")
-process5.subProcess = cms.SubProcess(process6)
+process5.addSubProcess(cms.SubProcess(process6))
 
 process6.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -334,7 +334,7 @@ process6.path1 = cms.Path(process6.esTestAnalyzerA)
 # gotten on event 8.
 
 process7 = cms.Process("TEST7")
-process6.subProcess = cms.SubProcess(process7)
+process6.addSubProcess(cms.SubProcess(process7))
 
 process7.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -374,7 +374,7 @@ process7.path1 = cms.Path(process7.esTestAnalyzerA)
 # difference. No data gotten on event 1 to 4.
 
 process8 = cms.Process("TEST8")
-process7.subProcess = cms.SubProcess(process8)
+process7.addSubProcess(cms.SubProcess(process8))
 
 process8.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -415,7 +415,7 @@ process8.path1 = cms.Path(process8.esTestAnalyzerA)
 # same record. No data gotten on event 1 to 5.
 
 process9 = cms.Process("TEST9")
-process8.subProcess = cms.SubProcess(process9)
+process8.addSubProcess(cms.SubProcess(process9))
 
 process9.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -448,7 +448,7 @@ process9.path1 = cms.Path(process9.esTestAnalyzerA)
 # same record. No data gotten on event 1 to 6.
 
 process10 = cms.Process("TEST10")
-process9.subProcess = cms.SubProcess(process10)
+process9.addSubProcess(cms.SubProcess(process10))
 
 process10.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -493,7 +493,7 @@ process10.path1 = cms.Path(process10.esTestAnalyzerA)
 # same record has a differing configuration. No data gotten on event 1 to 7.
 
 process11 = cms.Process("TEST11")
-process10.subProcess = cms.SubProcess(process11)
+process10.addSubProcess(cms.SubProcess(process11))
 
 process11.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),
@@ -533,7 +533,7 @@ process11.path1 = cms.Path(process11.esTestAnalyzerA)
 # because the emptyESSourceZ has a differing configuration.
 
 process12 = cms.Process("TEST12")
-process11.subProcess = cms.SubProcess(process12)
+process11.addSubProcess(cms.SubProcess(process12))
 
 process12.emptyESSourceA = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordA"),

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
@@ -1,4 +1,6 @@
 Sharing ESSource: class=DoodadESSource label=''
 Sharing ESSource: class=DoodadESSource label=''
+Sharing ESSource: class=DoodadESSource label=''
 got data of type "edmtest::Doodad" with name "abcd" in record GadgetRcd
+got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -32,6 +32,22 @@
 ++++ finished: constructing module with label 'dependsOnNoPut' id = 15
 ++++ starting: constructing module with label 'out' id = 16
 ++++ finished: constructing module with label 'out' id = 16
+++++ starting: constructing module with label 'TriggerResults' id = 17
+++++ finished: constructing module with label 'TriggerResults' id = 17
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 18
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 18
+++++ starting: constructing module with label 'test' id = 19
+++++ finished: constructing module with label 'test' id = 19
+++++ starting: constructing module with label 'testmerge' id = 20
+++++ finished: constructing module with label 'testmerge' id = 20
+++++ starting: constructing module with label 'get' id = 21
+++++ finished: constructing module with label 'get' id = 21
+++++ starting: constructing module with label 'getInt' id = 22
+++++ finished: constructing module with label 'getInt' id = 22
+++++ starting: constructing module with label 'dependsOnNoPut' id = 23
+++++ finished: constructing module with label 'dependsOnNoPut' id = 23
+++++ starting: constructing module with label 'out' id = 24
+++++ finished: constructing module with label 'out' id = 24
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
 ++ starting: begin job
@@ -70,6 +86,23 @@
 ++++ finished: begin job for module with label 'out' id = 16
 ++++ starting: begin job for module with label 'TriggerResults' id = 9
 ++++ finished: begin job for module with label 'TriggerResults' id = 9
+++ starting: begin job
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 18
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 18
+++++ starting: begin job for module with label 'test' id = 19
+++++ finished: begin job for module with label 'test' id = 19
+++++ starting: begin job for module with label 'testmerge' id = 20
+++++ finished: begin job for module with label 'testmerge' id = 20
+++++ starting: begin job for module with label 'get' id = 21
+++++ finished: begin job for module with label 'get' id = 21
+++++ starting: begin job for module with label 'getInt' id = 22
+++++ finished: begin job for module with label 'getInt' id = 22
+++++ starting: begin job for module with label 'dependsOnNoPut' id = 23
+++++ finished: begin job for module with label 'dependsOnNoPut' id = 23
+++++ starting: begin job for module with label 'out' id = 24
+++++ finished: begin job for module with label 'out' id = 24
+++++ starting: begin job for module with label 'TriggerResults' id = 17
+++++ finished: begin job for module with label 'TriggerResults' id = 17
 ++ finished: begin job
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
@@ -103,6 +136,22 @@
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 9
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 16
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++ starting: begin stream for module: stream = 0 label = 'test' id = 19
+++++ finished: begin stream for module: stream = 0 label = 'test' id = 19
+++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 20
+++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 20
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 21
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 21
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 22
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 22
+++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 17
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 17
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 24
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 24
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -147,6 +196,24 @@
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 1 : time = 1
+++++ starting: global begin run 1 : time = 1
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin run for module: label = 'test' id = 19
+++++++ finished: global begin run for module: label = 'test' id = 19
+++++++ starting: global begin run for module: label = 'testmerge' id = 20
+++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 21
+++++++ finished: global begin run for module: label = 'get' id = 21
+++++++ starting: global begin run for module: label = 'getInt' id = 22
+++++++ finished: global begin run for module: label = 'getInt' id = 22
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin run for module: label = 'out' id = 24
+++++++ finished: global begin run for module: label = 'out' id = 24
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
+++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
@@ -184,6 +251,22 @@
 ++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -229,6 +312,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
@@ -267,6 +368,22 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
@@ -325,6 +442,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: source event
@@ -387,6 +532,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
@@ -447,6 +620,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
@@ -505,6 +706,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
@@ -545,6 +774,22 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
@@ -586,6 +831,24 @@
 ++++++ finished: global end lumi for module: label = 'out' id = 16
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -631,6 +894,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
@@ -669,6 +950,22 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
@@ -727,6 +1024,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: source event
@@ -789,6 +1114,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
@@ -849,6 +1202,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
@@ -907,6 +1288,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
@@ -947,6 +1356,22 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
@@ -988,6 +1413,24 @@
 ++++++ finished: global end lumi for module: label = 'out' id = 16
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1033,6 +1476,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
@@ -1070,6 +1531,22 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1131,6 +1608,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
@@ -1189,6 +1694,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
@@ -1228,6 +1761,22 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
@@ -1271,6 +1820,24 @@
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
 ++++ starting: end run: stream = 0 run = 1 time = 0
@@ -1308,6 +1875,22 @@
 ++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 16
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end run for module: stream = 0 label = 'test' id = 19
+++++++ finished: end run for module: stream = 0 label = 'test' id = 19
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end run for module: stream = 0 label = 'get' id = 21
+++++++ finished: end run for module: stream = 0 label = 'get' id = 21
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'out' id = 24
+++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: global end run 1 : time = 50000001
 ++++ finished: global end run 1 : time = 50000001
@@ -1351,6 +1934,24 @@
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 9
 ++++ finished: global end run 1 : time = 0
+++++ starting: global end run 1 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end run for module: label = 'test' id = 19
+++++++ finished: global end run for module: label = 'test' id = 19
+++++++ starting: global end run for module: label = 'testmerge' id = 20
+++++++ finished: global end run for module: label = 'testmerge' id = 20
+++++++ starting: global end run for module: label = 'get' id = 21
+++++++ finished: global end run for module: label = 'get' id = 21
+++++++ starting: global end run for module: label = 'getInt' id = 22
+++++++ finished: global end run for module: label = 'getInt' id = 22
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end run for module: label = 'out' id = 24
+++++++ finished: global end run for module: label = 'out' id = 24
+++++++ starting: global end run for module: label = 'TriggerResults' id = 17
+++++++ finished: global end run for module: label = 'TriggerResults' id = 17
+++++ finished: global end run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 2 : time = 55000001
@@ -1395,6 +1996,24 @@
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 2 : time = 55000001
+++++ starting: global begin run 2 : time = 55000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin run for module: label = 'test' id = 19
+++++++ finished: global begin run for module: label = 'test' id = 19
+++++++ starting: global begin run for module: label = 'testmerge' id = 20
+++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 21
+++++++ finished: global begin run for module: label = 'get' id = 21
+++++++ starting: global begin run for module: label = 'getInt' id = 22
+++++++ finished: global begin run for module: label = 'getInt' id = 22
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin run for module: label = 'out' id = 24
+++++++ finished: global begin run for module: label = 'out' id = 24
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
+++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
@@ -1432,6 +2051,22 @@
 ++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1477,6 +2112,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
@@ -1515,6 +2168,22 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
@@ -1573,6 +2242,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: source event
@@ -1635,6 +2332,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
@@ -1695,6 +2420,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
@@ -1753,6 +2506,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
@@ -1793,6 +2574,22 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
@@ -1834,6 +2631,24 @@
 ++++++ finished: global end lumi for module: label = 'out' id = 16
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1879,6 +2694,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
@@ -1917,6 +2750,22 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
@@ -1975,6 +2824,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: source event
@@ -2037,6 +2914,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
@@ -2097,6 +3002,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
@@ -2155,6 +3088,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
@@ -2195,6 +3156,22 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
@@ -2236,6 +3213,24 @@
 ++++++ finished: global end lumi for module: label = 'out' id = 16
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2281,6 +3276,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
@@ -2318,6 +3331,22 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
@@ -2379,6 +3408,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
@@ -2437,6 +3494,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
@@ -2476,6 +3561,22 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
@@ -2519,6 +3620,24 @@
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
 ++++ starting: end run: stream = 0 run = 2 time = 0
@@ -2556,6 +3675,22 @@
 ++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 16
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end run for module: stream = 0 label = 'test' id = 19
+++++++ finished: end run for module: stream = 0 label = 'test' id = 19
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end run for module: stream = 0 label = 'get' id = 21
+++++++ finished: end run for module: stream = 0 label = 'get' id = 21
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'out' id = 24
+++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: global end run 2 : time = 100000001
 ++++ finished: global end run 2 : time = 100000001
@@ -2599,6 +3734,24 @@
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 9
 ++++ finished: global end run 2 : time = 0
+++++ starting: global end run 2 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end run for module: label = 'test' id = 19
+++++++ finished: global end run for module: label = 'test' id = 19
+++++++ starting: global end run for module: label = 'testmerge' id = 20
+++++++ finished: global end run for module: label = 'testmerge' id = 20
+++++++ starting: global end run for module: label = 'get' id = 21
+++++++ finished: global end run for module: label = 'get' id = 21
+++++++ starting: global end run for module: label = 'getInt' id = 22
+++++++ finished: global end run for module: label = 'getInt' id = 22
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end run for module: label = 'out' id = 24
+++++++ finished: global end run for module: label = 'out' id = 24
+++++++ starting: global end run for module: label = 'TriggerResults' id = 17
+++++++ finished: global end run for module: label = 'TriggerResults' id = 17
+++++ finished: global end run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 3 : time = 105000001
@@ -2643,6 +3796,24 @@
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 3 : time = 105000001
+++++ starting: global begin run 3 : time = 105000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin run for module: label = 'test' id = 19
+++++++ finished: global begin run for module: label = 'test' id = 19
+++++++ starting: global begin run for module: label = 'testmerge' id = 20
+++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 21
+++++++ finished: global begin run for module: label = 'get' id = 21
+++++++ starting: global begin run for module: label = 'getInt' id = 22
+++++++ finished: global begin run for module: label = 'getInt' id = 22
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin run for module: label = 'out' id = 24
+++++++ finished: global begin run for module: label = 'out' id = 24
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
+++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
@@ -2680,6 +3851,22 @@
 ++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2725,6 +3912,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
@@ -2763,6 +3968,22 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
@@ -2821,6 +4042,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: source event
@@ -2883,6 +4132,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
@@ -2943,6 +4220,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
@@ -3001,6 +4306,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
@@ -3041,6 +4374,22 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
@@ -3082,6 +4431,24 @@
 ++++++ finished: global end lumi for module: label = 'out' id = 16
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -3127,6 +4494,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
@@ -3165,6 +4550,22 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
@@ -3223,6 +4624,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: source event
@@ -3285,6 +4714,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
@@ -3345,6 +4802,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
@@ -3403,6 +4888,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
@@ -3443,6 +4956,22 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
@@ -3484,6 +5013,24 @@
 ++++++ finished: global end lumi for module: label = 'out' id = 16
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -3529,6 +5076,24 @@
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 19
+++++++ finished: global begin lumi for module: label = 'test' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 22
+++++++ finished: global begin lumi for module: label = 'getInt' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global begin lumi for module: label = 'out' id = 24
+++++++ finished: global begin lumi for module: label = 'out' id = 24
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
@@ -3566,6 +5131,22 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3627,6 +5208,34 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
@@ -3685,6 +5294,34 @@
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
@@ -3724,6 +5361,22 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
@@ -3767,6 +5420,24 @@
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
 ++++ starting: end run: stream = 0 run = 3 time = 0
@@ -3804,6 +5475,22 @@
 ++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 16
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 16
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end run for module: stream = 0 label = 'test' id = 19
+++++++ finished: end run for module: stream = 0 label = 'test' id = 19
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
+++++++ starting: end run for module: stream = 0 label = 'get' id = 21
+++++++ finished: end run for module: stream = 0 label = 'get' id = 21
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'out' id = 24
+++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: global end run 3 : time = 150000001
 ++++ finished: global end run 3 : time = 150000001
@@ -3847,6 +5534,24 @@
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 9
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 9
 ++++ finished: global end run 3 : time = 0
+++++ starting: global end run 3 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end run for module: label = 'test' id = 19
+++++++ finished: global end run for module: label = 'test' id = 19
+++++++ starting: global end run for module: label = 'testmerge' id = 20
+++++++ finished: global end run for module: label = 'testmerge' id = 20
+++++++ starting: global end run for module: label = 'get' id = 21
+++++++ finished: global end run for module: label = 'get' id = 21
+++++++ starting: global end run for module: label = 'getInt' id = 22
+++++++ finished: global end run for module: label = 'getInt' id = 22
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end run for module: label = 'out' id = 24
+++++++ finished: global end run for module: label = 'out' id = 24
+++++++ starting: global end run for module: label = 'TriggerResults' id = 17
+++++++ finished: global end run for module: label = 'TriggerResults' id = 17
+++++ finished: global end run 3 : time = 0
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 3
@@ -3879,6 +5584,22 @@
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 9
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 16
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 16
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++ starting: end stream for module: stream = 0 label = 'test' id = 19
+++++ finished: end stream for module: stream = 0 label = 'test' id = 19
+++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 20
+++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 20
+++++ starting: end stream for module: stream = 0 label = 'get' id = 21
+++++ finished: end stream for module: stream = 0 label = 'get' id = 21
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 22
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 22
+++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 17
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 17
+++++ starting: end stream for module: stream = 0 label = 'out' id = 24
+++++ finished: end stream for module: stream = 0 label = 'out' id = 24
 ++++ starting: end job for module with label 'thingWithMergeProducer' id = 2
 ++++ finished: end job for module with label 'thingWithMergeProducer' id = 2
 ++++ starting: end job for module with label 'get' id = 3
@@ -3911,4 +5632,20 @@
 ++++ finished: end job for module with label 'out' id = 16
 ++++ starting: end job for module with label 'TriggerResults' id = 9
 ++++ finished: end job for module with label 'TriggerResults' id = 9
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 18
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 18
+++++ starting: end job for module with label 'test' id = 19
+++++ finished: end job for module with label 'test' id = 19
+++++ starting: end job for module with label 'testmerge' id = 20
+++++ finished: end job for module with label 'testmerge' id = 20
+++++ starting: end job for module with label 'get' id = 21
+++++ finished: end job for module with label 'get' id = 21
+++++ starting: end job for module with label 'getInt' id = 22
+++++ finished: end job for module with label 'getInt' id = 22
+++++ starting: end job for module with label 'dependsOnNoPut' id = 23
+++++ finished: end job for module with label 'dependsOnNoPut' id = 23
+++++ starting: end job for module with label 'out' id = 24
+++++ finished: end job for module with label 'out' id = 24
+++++ starting: end job for module with label 'TriggerResults' id = 17
+++++ finished: end job for module with label 'TriggerResults' id = 17
 ++ finished: end job

--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -244,11 +244,11 @@ namespace edm {
 
     ParameterSet const& registerIt();
 
-    std::auto_ptr<ParameterSet> popParameterSet(std::string const& name);
+    std::unique_ptr<ParameterSet> popParameterSet(std::string const& name);
     void eraseSimpleParameter(std::string const& name);
     void eraseOrSetUntrackedParameterSet(std::string const& name);
 
-    std::auto_ptr<std::vector<ParameterSet> > popVParameterSet(std::string const& name);
+    std::unique_ptr<std::vector<ParameterSet> > popVParameterSet(std::string const& name);
 
     typedef std::map<std::string, Entry> table;
     table const& tbl() const {return tbl_;}

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -102,7 +102,7 @@ class Process(object):
     def __init__(self,name,*Mods):
         """The argument 'name' will be the name applied to this Process
             Can optionally pass as additional arguments cms.Modifier instances
-            which will be used ot modify the Process as it is built
+            that will be used to modify the Process as it is built
             """
         self.__dict__['_Process__name'] = name
         if not name.isalnum():
@@ -111,7 +111,7 @@ class Process(object):
         self.__dict__['_Process__producers'] = {}
         self.__dict__['_Process__source'] = None
         self.__dict__['_Process__looper'] = None
-        self.__dict__['_Process__subProcess'] = None
+        self.__dict__['_Process__subProcesses'] = []
         self.__dict__['_Process__schedule'] = None
         self.__dict__['_Process__analyzers'] = {}
         self.__dict__['_Process__outputmodules'] = {}
@@ -170,7 +170,7 @@ class Process(object):
 
 
     def filters_(self):
-        """returns a dict of the filters which have been added to the Process"""
+        """returns a dict of the filters that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__filters)
     filters = property(filters_, doc="dictionary containing the filters for the process")
     def name_(self):
@@ -181,49 +181,47 @@ class Process(object):
         self.__dict__['_Process__name'] = name
     process = property(name_,setName_, doc="name of the process")
     def producers_(self):
-        """returns a dict of the producers which have been added to the Process"""
+        """returns a dict of the producers that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__producers)
     producers = property(producers_,doc="dictionary containing the producers for the process")
     def source_(self):
-        """returns the source which has been added to the Process or None if none have been added"""
+        """returns the source that has been added to the Process or None if none have been added"""
         return self.__source
     def setSource_(self,src):
         self._placeSource('source',src)
     source = property(source_,setSource_,doc='the main source or None if not set')
     def looper_(self):
-        """returns the looper which has been added to the Process or None if none have been added"""
+        """returns the looper that has been added to the Process or None if none have been added"""
         return self.__looper
     def setLooper_(self,lpr):
         self._placeLooper('looper',lpr)
     looper = property(looper_,setLooper_,doc='the main looper or None if not set')
-    def subProcess_(self):
-        """returns the sub-process which has been added to the Process or None if none have been added"""
-        return self.__subProcess
-    def setSubProcess_(self,lpr):
-        self._placeSubProcess('subProcess',lpr)
-    subProcess = property(subProcess_,setSubProcess_,doc='the SubProcess or None if not set')
+    def subProcesses_(self):
+        """returns a list of the subProcesses that have been added to the Process"""
+        return self.__subProcesses
+    subProcesses = property(subProcesses_,doc='the SubProcesses that have been added to the Process')
     def analyzers_(self):
-        """returns a dict of the analyzers which have been added to the Process"""
+        """returns a dict of the analyzers that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__analyzers)
     analyzers = property(analyzers_,doc="dictionary containing the analyzers for the process")
     def outputModules_(self):
-        """returns a dict of the output modules which have been added to the Process"""
+        """returns a dict of the output modules that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__outputmodules)
     outputModules = property(outputModules_,doc="dictionary containing the output_modules for the process")
     def paths_(self):
-        """returns a dict of the paths which have been added to the Process"""
+        """returns a dict of the paths that have been added to the Process"""
         return DictTypes.SortedAndFixedKeysDict(self.__paths)
     paths = property(paths_,doc="dictionary containing the paths for the process")
     def endpaths_(self):
-        """returns a dict of the endpaths which have been added to the Process"""
+        """returns a dict of the endpaths that have been added to the Process"""
         return DictTypes.SortedAndFixedKeysDict(self.__endpaths)
     endpaths = property(endpaths_,doc="dictionary containing the endpaths for the process")
     def sequences_(self):
-        """returns a dict of the sequences which have been added to the Process"""
+        """returns a dict of the sequences that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__sequences)
     sequences = property(sequences_,doc="dictionary containing the sequences for the process")
     def schedule_(self):
-        """returns the schedule which has been added to the Process or None if none have been added"""
+        """returns the schedule that has been added to the Process or None if none have been added"""
         return self.__schedule
     def setPartialSchedule_(self,sch,label):
         if label == "schedule":
@@ -243,19 +241,19 @@ class Process(object):
         self.__dict__['_Process__schedule'] = sch
     schedule = property(schedule_,setSchedule_,doc='the schedule or None if not set')
     def services_(self):
-        """returns a dict of the services which have been added to the Process"""
+        """returns a dict of the services that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__services)
     services = property(services_,doc="dictionary containing the services for the process")
     def es_producers_(self):
-        """returns a dict of the esproducers which have been added to the Process"""
+        """returns a dict of the esproducers that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__esproducers)
     es_producers = property(es_producers_,doc="dictionary containing the es_producers for the process")
     def es_sources_(self):
-        """returns a the es_sources which have been added to the Process"""
+        """returns a the es_sources that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__essources)
     es_sources = property(es_sources_,doc="dictionary containing the es_sources for the process")
     def es_prefers_(self):
-        """returns a dict of the es_prefers which have been added to the Process"""
+        """returns a dict of the es_prefers that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__esprefers)
     es_prefers = property(es_prefers_,doc="dictionary containing the es_prefers for the process")
     def aliases_(self):
@@ -263,11 +261,11 @@ class Process(object):
         return DictTypes.FixedKeysDict(self.__aliases)
     aliases = property(aliases_,doc="dictionary containing the aliases for the process")
     def psets_(self):
-        """returns a dict of the PSets which have been added to the Process"""
+        """returns a dict of the PSets that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__psets)
     psets = property(psets_,doc="dictionary containing the PSets for the process")
     def vpsets_(self):
-        """returns a dict of the VPSets which have been added to the Process"""
+        """returns a dict of the VPSets that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__vpsets)
     vpsets = property(vpsets_,doc="dictionary containing the PSets for the process")
 
@@ -308,7 +306,7 @@ class Process(object):
             self.__dict__[name]=value
             return
         if not isinstance(value,_ConfigureComponent):
-            raise TypeError("can only assign labels to an object which inherits from '_ConfigureComponent'\n"
+            raise TypeError("can only assign labels to an object that inherits from '_ConfigureComponent'\n"
                             +"an instance of "+str(type(value))+" will not work - requested label is "+name)
         if not isinstance(value,_Labelable) and not isinstance(value,Source) and not isinstance(value,Looper) and not isinstance(value,Schedule):
             if name == value.type_():
@@ -408,7 +406,7 @@ class Process(object):
                 pass
 
     def add_(self,value):
-        """Allows addition of components which do not have to have a label, e.g. Services"""
+        """Allows addition of components that do not have to have a label, e.g. Services"""
         if not isinstance(value,_ConfigureComponent):
             raise TypeError
         if not isinstance(value,_Unlabelable):
@@ -502,10 +500,10 @@ class Process(object):
         self.__dict__['_Process__looper'] = mod
         self.__dict__[mod.type_()] = mod
     def _placeSubProcess(self,name,mod):
-        if name != 'subProcess':
-            raise ValueError("The label '"+name+"' can not be used for a SubProcess.  Only 'subProcess' is allowed.")
         self.__dict__['_Process__subProcess'] = mod
         self.__dict__[mod.type_()] = mod
+    def addSubProcess(self,mod):
+        self.__subProcesses.append(mod)
     def _placeService(self,typeName,mod):
         self._place(typeName, mod, self.__services)
         self.__dict__[typeName]=mod
@@ -514,7 +512,7 @@ class Process(object):
         module = __import__(moduleName)
         self.extend(sys.modules[moduleName])
     def extend(self,other,items=()):
-        """Look in other and find types which we can use"""
+        """Look in other and find types that we can use"""
         # enable explicit check to avoid overwriting of existing objects
         self.__dict__['_Process__InExtendCall'] = True
 
@@ -524,7 +522,7 @@ class Process(object):
             if name.startswith('_'):
                 continue
             item = getattr(other,name)
-            if name == "source" or name == "looper" or name == "subProcess":
+            if name == "source" or name == "looper":
                 # In these cases 'item' could be None if the specific object was not defined
                 if item is not None:
                     self.__setattr__(name,item)
@@ -543,7 +541,7 @@ class Process(object):
             elif isinstance(item,ProcessFragment):
                 self.extend(item)
 
-        #now create a sequence which uses the newly made items
+        #now create a sequence that uses the newly made items
         for name in seqs.iterkeys():
             seq = seqs[name]
             #newSeq = seq.copy()
@@ -583,9 +581,10 @@ class Process(object):
             config += options.indentation()+"source = "+self.source_().dumpConfig(options)
         if self.looper_():
             config += options.indentation()+"looper = "+self.looper_().dumpConfig(options)
-        if self.subProcess_():
-            config += options.indentation()+"subProcess = "+self.subProcess_().dumpConfig(options)
 
+        config+=self._dumpConfigNamedList(self.subProcesses_(),
+                                  'subProcess',
+                                  options)
         config+=self._dumpConfigNamedList(self.producers_().iteritems(),
                                   'module',
                                   options)
@@ -641,6 +640,11 @@ class Process(object):
         for item in self.es_prefers_().itervalues():
             result +=options.indentation()+'es_prefer '+item.targetLabel_()+' = '+item.dumpConfig(options)
         return result
+    def _dumpPythonSubProcesses(self, l, options):
+        returnValue = ''
+        for item in l:
+            returnValue += item.dumpPython(options)+'\n\n'
+        return returnValue
     def _dumpPythonList(self, d, options):
         returnValue = ''
         if isinstance(d, DictTypes.SortedKeysDict):
@@ -703,8 +707,7 @@ class Process(object):
             result += "process.source = "+self.source_().dumpPython(options)
         if self.looper_():
             result += "process.looper = "+self.looper_().dumpPython()
-        if self.subProcess_():
-            result += self.subProcess_().dumpPython(options)
+        result+=self._dumpPythonSubProcesses(self.subProcesses_(), options)
         result+=self._dumpPythonList(self.producers_(), options)
         result+=self._dumpPythonList(self.filters_() , options)
         result+=self._dumpPythonList(self.analyzers_(), options)
@@ -758,6 +761,19 @@ class Process(object):
         # alphabetical order is easier to compare with old language
         l.sort()
         parameterSet.addVString(tracked, label, l)
+    def _insertSubProcessesInto(self, parameterSet, label, itemList, tracked):
+        l = []
+        subprocs = []
+        for value in itemList:
+          name = value.getProcessName()
+          newLabel = value.nameInProcessDesc_(name)
+          l.append(newLabel)
+          pset = value.getSubProcessPSet(parameterSet)
+          subprocs.append(pset)
+        # alphabetical order is easier to compare with old language
+        l.sort()
+        parameterSet.addVString(tracked, label, l)
+        parameterSet.addVPSet(False,"subProcesses",subprocs)
     def _insertPaths(self, processPSet):
         scheduledPaths = []
         triggerPaths = []
@@ -800,7 +816,7 @@ class Process(object):
         processPSet.addVString(False, "@filters_on_endpaths", endpathValidator.filtersOnEndpaths)
 
     def prune(self,verbose=False,keepUnresolvedSequencePlaceholders=False):
-        """ Remove clutter from the process which we think is unnecessary:
+        """ Remove clutter from the process that we think is unnecessary:
         tracked PSets, VPSets and unused modules and sequences. If a Schedule has been set, then Paths and EndPaths
         not in the schedule will also be removed, along with an modules and sequences used only by
         those removed Paths and EndPaths."""
@@ -905,7 +921,7 @@ class Process(object):
         self._insertManyInto(adaptor, "@all_modules", all_modules, True)
         self._insertOneInto(adaptor,  "@all_sources", self.source_(), True)
         self._insertOneInto(adaptor,  "@all_loopers", self.looper_(), True)
-        self._insertOneInto(adaptor,  "@all_subprocesses", self.subProcess_(), False)
+        self._insertSubProcessesInto(adaptor, "@all_subprocesses", self.subProcesses_(), False)
         self._insertManyInto(adaptor, "@all_esmodules", self.es_producers_(), True)
         self._insertManyInto(adaptor, "@all_essources", self.es_sources_(), True)
         self._insertManyInto(adaptor, "@all_esprefers", self.es_prefers_(), True)
@@ -935,7 +951,7 @@ class Process(object):
              process.prefer("JuicerProducer")
            In addition, you can pass as a labelled arguments the name of the Record you wish to
            prefer where the type passed is a cms.vstring and that vstring can contain the
-           name of the C++ types in the Record which are being preferred, e.g.,
+           name of the C++ types in the Record that are being preferred, e.g.,
               #prefer all data in record 'OrangeRecord' from 'juicer'
               process.prefer("juicer", OrangeRecord=cms.vstring())
            or
@@ -1034,10 +1050,10 @@ class FilteredStream(dict):
     def __getattr__(self,attr):
         return self[attr]
 
-class SubProcess(_ConfigureComponent,_Unlabelable):
+class SubProcess(_Unlabelable):
    """Allows embedding another process within a parent process. This allows one to 
    chain processes together directly in one cmsRun job rather than having to run
-   separate jobs which are connected via a temporary file.
+   separate jobs that are connected via a temporary file.
    """
    def __init__(self,process, SelectEvents = untracked.PSet(), outputCommands = untracked.vstring()):
       """
@@ -1056,8 +1072,10 @@ class SubProcess(_ConfigureComponent,_Unlabelable):
       out += self.__process.dumpPython()
       out += "childProcess = process\n"
       out += "process = parentProcess"+str(hash(self))+"\n"
-      out += "process.subProcess = cms.SubProcess( process = childProcess, SelectEvents = "+self.__SelectEvents.dumpPython(options) +", outputCommands = "+self.__outputCommands.dumpPython(options) +")\n"
+      out += "process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = "+self.__SelectEvents.dumpPython(options) +", outputCommands = "+self.__outputCommands.dumpPython(options) +"))"
       return out
+   def getProcessName(self):
+      return self.__process.name_()
    def process(self):
       return self.__process
    def SelectEvents(self):
@@ -1067,20 +1085,20 @@ class SubProcess(_ConfigureComponent,_Unlabelable):
    def type_(self):
       return 'subProcess'
    def nameInProcessDesc_(self,label):
-      return '@sub_process'
+      return label
    def _place(self,label,process):
       process._placeSubProcess('subProcess',self)
-   def insertInto(self,parameterSet, newlabel):
+   def getSubProcessPSet(self,parameterSet):
       topPSet = parameterSet.newPSet()
       self.__process.fillProcessDesc(topPSet)
       subProcessPSet = parameterSet.newPSet()
       self.__SelectEvents.insertInto(subProcessPSet,"SelectEvents")
       self.__outputCommands.insertInto(subProcessPSet,"outputCommands")
       subProcessPSet.addPSet(False,"process",topPSet)
-      parameterSet.addPSet(False,self.nameInProcessDesc_("subProcess"), subProcessPSet)
+      return subProcessPSet
 
 class _ParameterModifier(object):
-  """Helper class for Modifier which takes key/value pairs and uses them to reset parameters of the object"""
+  """Helper class for Modifier that takes key/value pairs and uses them to reset parameters of the object"""
   def __init__(self,args):
     self.__args = args
   def __call__(self,obj):
@@ -1091,7 +1109,7 @@ class Modifier(object):
   """This class is used to define standard modifications to a Process.
   An instance of this class is declared to denote a specific modification,e.g. era2017 could
   reconfigure items in a process to match our expectation of running in 2017. Once declared,
-  these Modifier instances are imported into a configuration and items which need to be modified
+  these Modifier instances are imported into a configuration and items that need to be modified
   are then associated with the Modifier and with the action to do the modification.
   The registered modifications will only occur if the Modifier was passed to 
   the cms.Process' constructor.
@@ -1100,15 +1118,15 @@ class Modifier(object):
     self.__processModifiers = []
     self.__chosen = False
   def makeProcessModifier(self,func):
-    """This is used to create a ProcessModifer which can perform actions on the process as a whole.
-       This takes as argument a callable object (e.g. function) which takes as its sole argument an instance of Process.
+    """This is used to create a ProcessModifer that can perform actions on the process as a whole.
+       This takes as argument a callable object (e.g. function) that takes as its sole argument an instance of Process.
        In order to work, the value returned from this function must be assigned to a uniquely named variable.
     """
     return ProcessModifier(self,func)
   def toModify(self,obj, func=None,**kw):
     """This is used to register an action to be performed on the specific object. Two different forms are allowed
     Form 1: A callable object (e.g. function) can be passed as the second. This callable object is expected to take one argument
-    which will be the object passed in as the first argument.
+    that will be the object passed in as the first argument.
     Form 2: A list of parameter name, value pairs can be passed
        mod.toModify(foo, fred=cms.int32(7), barney = cms.double(3.14))
     """
@@ -1167,7 +1185,7 @@ if __name__=="__main__":
     import copy
     
     class TestMakePSet(object):
-        """Has same interface as the C++ object which creates PSets
+        """Has same interface as the C++ object that creates PSets
         """
         def __init__(self):
             self.values = dict()
@@ -1747,7 +1765,7 @@ process.prefer("juicer",
             subProcess.a = EDProducer("A")
             subProcess.p = Path(subProcess.a)
             subProcess.add_(Service("Foo"))
-            process.add_( SubProcess(subProcess) )
+            process.addSubProcess(SubProcess(subProcess))
             d = process.dumpPython()
             equalD ="""import FWCore.ParameterSet.Config as cms
 
@@ -1769,17 +1787,18 @@ process.Foo = cms.Service("Foo")
 
 childProcess = process
 process = parentProcess
-process.subProcess = cms.SubProcess( process = childProcess, SelectEvents = cms.untracked.PSet(
+process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.untracked.PSet(
 
-), outputCommands = cms.untracked.vstring())
+), outputCommands = cms.untracked.vstring()))
+
 """
-            equalD = equalD.replace("parentProcess","parentProcess"+str(hash(process.subProcess)))
+            equalD = equalD.replace("parentProcess","parentProcess"+str(hash(process.subProcesses_()[0])))
             self.assertEqual(d,equalD)
             p = TestMakePSet()
-            process.subProcess.insertInto(p,"dummy")
-            self.assertEqual((True,['a']),p.values["@sub_process"][1].values["process"][1].values['@all_modules'])
-            self.assertEqual((True,['p']),p.values["@sub_process"][1].values["process"][1].values['@paths'])
-            self.assertEqual({'@service_type':(True,'Foo')}, p.values["@sub_process"][1].values["process"][1].values["services"][1][0].values)
+            process.fillProcessDesc(p)
+            self.assertEqual((True,['a']),p.values["subProcesses"][1][0].values["process"][1].values['@all_modules'])
+            self.assertEqual((True,['p']),p.values["subProcesses"][1][0].values["process"][1].values['@paths'])
+            self.assertEqual({'@service_type':(True,'Foo')}, p.values["subProcesses"][1][0].values["process"][1].values["services"][1][0].values)
         def testRefToPSet(self):
             proc = Process("test")
             proc.top = PSet(a = int32(1))

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -141,11 +141,11 @@ namespace edm {
     return *this;
   }
 
-  std::auto_ptr<ParameterSet> ParameterSet::popParameterSet(std::string const& name) {
+  std::unique_ptr<ParameterSet> ParameterSet::popParameterSet(std::string const& name) {
     assert(!isRegistered());
     psettable::iterator it = psetTable_.find(name);
     assert(it != psetTable_.end());
-    std::auto_ptr<ParameterSet> pset(new ParameterSet);
+    std::unique_ptr<ParameterSet> pset = std::make_unique<ParameterSet>();
     std::swap(*pset, it->second.psetForUpdate());
     psetTable_.erase(it);
     return pset;
@@ -170,11 +170,11 @@ namespace edm {
     }
   }
 
-  std::auto_ptr<std::vector<ParameterSet> > ParameterSet::popVParameterSet(std::string const& name) {
+  std::unique_ptr<std::vector<ParameterSet> > ParameterSet::popVParameterSet(std::string const& name) {
     assert(!isRegistered());
     vpsettable::iterator it = vpsetTable_.find(name);
     assert(it != vpsetTable_.end());
-    std::auto_ptr<std::vector<ParameterSet> > vpset(new std::vector<ParameterSet>);
+    std::unique_ptr<std::vector<ParameterSet> > vpset = std::make_unique<std::vector<ParameterSet> >();
     std::swap(*vpset, it->second.vpsetForUpdate());
     vpsetTable_.erase(it);
     return vpset;

--- a/FWCore/ServiceRegistry/src/ServiceRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ServiceRegistry.cc
@@ -81,7 +81,7 @@ namespace edm {
       std::shared_ptr<ParameterSet> params;
       makeParameterSets(config, params);
 
-      std::auto_ptr<std::vector<ParameterSet> > serviceSets = params->popVParameterSet(std::string("services"));
+      std::unique_ptr<std::vector<ParameterSet> > serviceSets = params->popVParameterSet(std::string("services"));
       //create the services
       return ServiceToken(ServiceRegistry::createSet(*serviceSets));
    }

--- a/IOPool/Input/test/PoolAliasSubProcessTestStep1_cfg.py
+++ b/IOPool/Input/test/PoolAliasSubProcessTestStep1_cfg.py
@@ -40,10 +40,10 @@ process.ep = cms.EndPath(process.output)
 
 analysisProcess = cms.Process("TESTANALYSIS")
 
-process.subProcess = cms.SubProcess(analysisProcess,
+process.addSubProcess(cms.SubProcess(analysisProcess,
    # Optional SelectEvents parameter can go here.
    #outputCommands = cms.untracked.vstring("drop *")
-   outputCommands = cms.untracked.vstring("keep *", "drop *_Thing_*_TESTPROD")
+   outputCommands = cms.untracked.vstring("keep *", "drop *_Thing_*_TESTPROD"))
 )
 
 # Configuration file for PoolInputTest


### PR DESCRIPTION
This PR enhances the "SubProcess" class in the framework so that the main process or a subprocess can have multiple subprocesses. Currently, it can have just one.
The previous syntax used for subprocesses in python config files is not compatible with multiple subprocesses, so the new syntax is:

  process2 = cms.Process("Whatever") 
  process.addSubProcess(cms.SubProcess(process2))

All existing uses of SubProcess in CMSSW were modified to use the new syntax. There were no such uses outside the framework.

This is being submitted to 8_0_X because it is new development, and it is my understanding that 7_6_X is now closed to new development. If this is wanted in 7_6_X, it can easily be backported.
