### PR TITLE
Reco changes for centralityBin in DQM

### DIFF
--- a/DQM/Physics/python/CentralityDQM_cfi.py
+++ b/DQM/Physics/python/CentralityDQM_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 CentralityDQM = cms.EDAnalyzer(
     "CentralityDQM",
     centralitycollection = cms.InputTag("hiCentrality"),
+    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
     vertexcollection = cms.InputTag("hiSelectedVertex"),
     eventplanecollection= cms.InputTag("hiEvtPlane")
-
     )

--- a/DQM/Physics/src/CentralityDQM.cc
+++ b/DQM/Physics/src/CentralityDQM.cc
@@ -31,8 +31,15 @@ CentralityDQM::CentralityDQM(const edm::ParameterSet& ps) {
   edm::LogInfo("CentralityDQM") << " Starting CentralityDQM "
                                 << "\n";
 
+
+
+
   centralityTag_ = ps.getParameter<InputTag>("centralitycollection");
   centralityToken = consumes<reco::Centrality>(centralityTag_);
+
+  centralityBinTag_ = (ps.getParameter<edm::InputTag> ("centralitybincollection"));
+  centralityBinToken = consumes<int>(centralityBinTag_);
+
 
   vertexTag_ = ps.getParameter<InputTag>("vertexcollection");
   vertexToken = consumes<std::vector<reco::Vertex> >(vertexTag_);
@@ -62,27 +69,27 @@ void CentralityDQM::bookHistograms(DQMStore::IBooker& bei, edm::Run const&,
 
   h_hiNpix = bei.book1D("h_hiNpix", "h_hiNpix", 750, 0, 75000);
   h_hiNpixelTracks =
-      bei.book1D("h_hiNpixelTracks", "hiNpixelTracks", 500, 0, 5000);
+    bei.book1D("h_hiNpixelTracks", "hiNpixelTracks", 500, 0, 5000);
   h_hiNtracks = bei.book1D("h_hiNtracks", "h_hiNtracks", 500, 0, 5000);
   h_hiNtracksPtCut =
-      bei.book1D("h_hiNtracksPtCut", "h_hiNtracksPtCut", 500, 0, 5000);
+    bei.book1D("h_hiNtracksPtCut", "h_hiNtracksPtCut", 500, 0, 5000);
   h_hiNtracksEtaCut =
-      bei.book1D("h_hiNtracksEtaCut", "h_hiNtracksEtaCut", 500, 0, 5000);
+    bei.book1D("h_hiNtracksEtaCut", "h_hiNtracksEtaCut", 500, 0, 5000);
   h_hiNtracksEtaPtCut =
-      bei.book1D("h_hiNtracksEtaPtCut", "h_hiNtracksEtaPtCut", 500, 0, 5000);
-
+    bei.book1D("h_hiNtracksEtaPtCut", "h_hiNtracksEtaPtCut", 500, 0, 5000);
+  
   h_hiHF = bei.book1D("h_hiHF", "h_hiHF", 900, 0, 9000);
   h_hiHFplus = bei.book1D("h_hiHFplus", "h_hiHFplus", 900, 0, 9000);
   h_hiHFminus = bei.book1D("h_hiHFminus", "h_hiHFminus", 900, 0, 9000);
   h_hiHFplusEta4 = bei.book1D("h_hiHFplusEta4", "h_hiHFplusEta4", 900, 0, 9000);
   h_hiHFminusEta4 =
-      bei.book1D("h_hiHFminusEta4", "h_hiHFminusEta4", 900, 0, 9000);
-
+    bei.book1D("h_hiHFminusEta4", "h_hiHFminusEta4", 900, 0, 9000);
+  
   h_hiHFhit = bei.book1D("h_hiHFhit", "h_hiHFhit", 3000, 0, 300000);
   h_hiHFhitPlus = bei.book1D("h_hiHFhitPlus", "h_hiHFhitPlus", 2000, 0, 200000);
   h_hiHFhitMinus =
-      bei.book1D("h_hiHFhitMinus", "h_hiHFhitMinus", 2000, 0, 200000);
-
+    bei.book1D("h_hiHFhitMinus", "h_hiHFhitMinus", 2000, 0, 200000);
+  
   h_hiEB = bei.book1D("h_hiEB", "h_hiEB", 600, 0, 6000);
   h_hiET = bei.book1D("h_hiET", "h_hiET", 600, 0, 6000);
   h_hiEE = bei.book1D("h_hiEE", "h_hiEE", 600, 0, 6000);
@@ -91,10 +98,12 @@ void CentralityDQM::bookHistograms(DQMStore::IBooker& bei, edm::Run const&,
   h_hiZDC = bei.book1D("h_hiZDC", "h_hiZDC", 600, 0, 6000);
   h_hiZDCplus = bei.book1D("h_hiZDCplus", "h_hiZDCplus", 600, 0, 6000);
   h_hiZDCminus = bei.book1D("h_hiZDCminus", "h_hiZDCminus", 600, 0, 6000);
-
+  
   h_vertex_x = bei.book1D("h_vertex_x", "h_vertex_x", 400, -4, 4);
   h_vertex_y = bei.book1D("h_vertex_y", "h_vertex_y", 400, -4, 4);
   h_vertex_z = bei.book1D("h_vertex_z", "h_vertex_z", 400, -40, 40);
+  
+  h_cent_bin = bei.book1D("h_cent_bin", "h_cent_bin", 200, 0, 200);
 
   Double_t psirange = 4;
   bei.setCurrentFolder("Physics/Centrality/EventPlane/");
@@ -112,7 +121,7 @@ void CentralityDQM::bookHistograms(DQMStore::IBooker& bei, edm::Run const&,
   h_ep_HFm3 = bei.book1D("h_ep_HFm3", "h_ep_HFm3", 800,-psirange,psirange);
   h_ep_HFp3 = bei.book1D("h_ep_HFp3", "h_ep_HFp3", 800,-psirange,psirange);
   h_ep_trackmid3 = bei.book1D("h_ep_trackmid3", "h_ep_trackmid3", 800,-psirange,psirange);
-
+  
 }
 
 //
@@ -120,17 +129,26 @@ void CentralityDQM::bookHistograms(DQMStore::IBooker& bei, edm::Run const&,
 //
 void CentralityDQM::analyze(const edm::Event& iEvent,
                             const edm::EventSetup& iSetup) {
-
+  
   using namespace edm;
   edm::Handle<reco::Centrality> cent;
   iEvent.getByToken(centralityToken, cent);  //_centralitytag comes from the cfg
+  
+  edm::Handle<int> cbin;
+  iEvent.getByToken(centralityBinToken, cbin);
+  
   // as an inputTag and is
   //"hiCentrality"
   edm::Handle<reco::EvtPlaneCollection> ep;
   iEvent.getByToken(eventplaneToken, ep);
 
-  if (!cent.isValid()) return;
+  //  if (!cent.isValid()) return;
+  if(cent.isValid()){
+  int hibin = *cbin;
+  
+  //  std::cout<<  " ------------------------------------- "  << hibin << std::endl;
 
+  h_cent_bin->Fill(hibin);
   h_hiNpix->Fill(cent->multiplicityPixel());
   h_hiNpixelTracks->Fill(cent->NpixelTracks());
   h_hiNtracks->Fill(cent->Ntracks());  //
@@ -159,31 +177,35 @@ void CentralityDQM::analyze(const edm::Event& iEvent,
   h_hiEB->Fill(cent->EtEBSum());
   h_hiET->Fill(cent->EtMidRapiditySum());
 
+
+
   edm::Handle<std::vector<reco::Vertex> > vertex;
   iEvent.getByToken(vertexToken, vertex);
   h_vertex_x->Fill(vertex->begin()->x());
   h_vertex_y->Fill(vertex->begin()->y());
   h_vertex_z->Fill(vertex->begin()->z());
+  }
 
   if (ep.isValid()){ 
-
   EvtPlaneCollection::const_iterator rp = ep->begin();
-  h_ep_HFm1->Fill(rp[HFm1].angle());
-  h_ep_HFp1->Fill(rp[HFp1].angle());
-  h_ep_trackm1->Fill(rp[trackm1].angle());
-  h_ep_trackp1->Fill(rp[trackp1].angle());
-  h_ep_castor1->Fill(rp[Castor1].angle());
 
-  h_ep_HFm2->Fill(rp[HFm2].angle());
-  h_ep_HFp2->Fill(rp[HFp2].angle());
-  h_ep_trackmid2->Fill(rp[trackmid2].angle());
-  h_ep_trackm2->Fill(rp[trackm2].angle());
-  h_ep_trackp2->Fill(rp[trackp2].angle());
-  h_ep_castor2->Fill(rp[Castor2].angle());
+  h_ep_HFm1->Fill(rp[HFm1].angle(0));
+  h_ep_HFp1->Fill(rp[HFp1].angle(0));
+  h_ep_trackm1->Fill(rp[trackm1].angle(0));
+  h_ep_trackp1->Fill(rp[trackp1].angle(0));
+  h_ep_castor1->Fill(rp[Castor1].angle(0));
 
-  h_ep_HFm3->Fill(rp[HFm3].angle());
-  h_ep_HFp3->Fill(rp[HFp3].angle());
-  h_ep_trackmid3->Fill(rp[trackmid3].angle());
-}
 
+  h_ep_HFm2->Fill(rp[HFm2].angle(0));
+  h_ep_HFp2->Fill(rp[HFp2].angle(0));
+  h_ep_trackmid2->Fill(rp[trackmid2].angle(0));
+  h_ep_trackm2->Fill(rp[trackm2].angle(0));
+  h_ep_trackp2->Fill(rp[trackp2].angle(0));
+  h_ep_castor2->Fill(rp[Castor2].angle(0));
+
+  h_ep_HFm3->Fill(rp[HFm3].angle(0));
+  h_ep_HFp3->Fill(rp[HFp3].angle(0));
+  h_ep_trackmid3->Fill(rp[trackmid3].angle(0));
+
+  }
 }

--- a/DQM/Physics/src/CentralityDQM.cc
+++ b/DQM/Physics/src/CentralityDQM.cc
@@ -30,10 +30,7 @@ CentralityDQM::CentralityDQM(const edm::ParameterSet& ps) {
 
   edm::LogInfo("CentralityDQM") << " Starting CentralityDQM "
                                 << "\n";
-
-
-
-
+                                
   centralityTag_ = ps.getParameter<InputTag>("centralitycollection");
   centralityToken = consumes<reco::Centrality>(centralityTag_);
 

--- a/DQM/Physics/src/CentralityDQM.h
+++ b/DQM/Physics/src/CentralityDQM.h
@@ -48,6 +48,11 @@ class CentralityDQM : public DQMEDAnalyzer {
 
   edm::InputTag  eventplaneTag_;
   edm::EDGetTokenT<reco::EvtPlaneCollection> eventplaneToken;
+  
+  edm::InputTag centralityBinTag_;
+  edm::EDGetTokenT<int> centralityBinToken;
+  edm::Handle<int>centralityBin_;
+
 
   ///////////////////////////
   // Histograms
@@ -80,6 +85,8 @@ class CentralityDQM : public DQMEDAnalyzer {
   MonitorElement* h_vertex_x;
   MonitorElement* h_vertex_y;
   MonitorElement* h_vertex_z;
+
+  MonitorElement* h_cent_bin;
 
   MonitorElement* h_ep_HFm1;
   MonitorElement* h_ep_HFp1;

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -25,6 +25,7 @@ from RecoHI.Configuration.Reconstruction_hiPF_cff import *
 
 # Heavy Ion Event Characterization
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import *
+from RecoHI.HiCentralityAlgos.CentralityBin_cfi import *
 from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import *
 from RecoHI.HiEvtPlaneAlgos.HiEvtPlane_cfi import *
 
@@ -42,6 +43,7 @@ globalRecoPbPb = cms.Sequence(hiTracking_wSplitting
                               * hiEgammaSequence
                               * hiParticleFlowReco
                               * hiCentrality
+                              * centralityBin
                               * hiClusterCompatibility
                               * hiEvtPlane
                               * hcalnoise
@@ -57,6 +59,7 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               * hiEgammaSequence
                                               * hiParticleFlowReco
                                               * hiCentrality
+                                              * centralityBin
                                               * hiClusterCompatibility
                                               * hiEvtPlane
                                               * hcalnoise

--- a/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
+++ b/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
@@ -2,15 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 RecoHiCentralityFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
-
 RecoHiCentralityRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
-
 RecoHiCentralityAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )


### PR DESCRIPTION
To include centralityBin distribution in the DQM monitoring. For this,  changes are requested  in the HI reco sequence 

> Reconstruction_HI_cff.py
> RecoHiCentrality_EventContent_cff.py
> and in the 
> CentralityDQM module.
> CentralityDQM_cfi.py
