### PR TITLE
Adding H->inv paths to the HLT Higgs dqm

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -160,6 +160,10 @@ hltHiggsPostHtaunu = hltHiggsPostProcessor.clone()
 hltHiggsPostHtaunu.subDirs = ['HLT/Higgs/Htaunu']
 hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
 
+hltHiggsPostVBFHToInv = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHToInv.subDirs = ['HLT/Higgs/VBFHToInv']
+hltHiggsPostVBFHToInv.efficiencyProfile = efficiency_strings
+
 
 efficiency_strings_TTHbbej = []
 #add the summary plots
@@ -340,28 +344,6 @@ efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 hltHiggsPostMSSMHbb = hltHiggsPostProcessor.clone()
 hltHiggsPostMSSMHbb.subDirs = ['HLT/Higgs/MSSMHbb']
 hltHiggsPostMSSMHbb.efficiencyProfile = efficiency_strings
-
-#Specific plots for VBFHToInv
-#Jet plots
-NminOneCuts = _config.VBFHToInv.NminOneCuts
-if NminOneCuts:
-    for iCut in range(0,len(NminOneCuts)):
-        if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            plot_types.append(NminOneCutNames[iCut])
-
-efficiency_strings = []
-for type in plot_types:
-    for obj in obj_types:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-
-hltHiggsPostVBFHToInv = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHToInv.subDirs = ['HLT/Higgs/VBFHToInv']
-hltHiggsPostVBFHToInv.efficiencyProfile = efficiency_strings
-
 
 hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHWW+

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -340,6 +340,29 @@ efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 hltHiggsPostMSSMHbb = hltHiggsPostProcessor.clone()
 hltHiggsPostMSSMHbb.subDirs = ['HLT/Higgs/MSSMHbb']
 hltHiggsPostMSSMHbb.efficiencyProfile = efficiency_strings
+
+#Specific plots for VBFHToInv
+#Jet plots
+NminOneCuts = _config.VBFHToInv.NminOneCuts
+if NminOneCuts:
+    for iCut in range(0,len(NminOneCuts)):
+        if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
+            plot_types.append(NminOneCutNames[iCut])
+
+efficiency_strings = []
+for type in plot_types:
+    for obj in obj_types:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
+
+efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
+
+hltHiggsPostVBFHToInv = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHToInv.subDirs = ['HLT/Higgs/VBFHToInv']
+hltHiggsPostVBFHToInv.efficiencyProfile = efficiency_strings
+
+
 hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHWW+
         hltHiggsPostHZZ+
@@ -357,7 +380,8 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHiggsDalitz+
         hltHiggsPostX4b+
         hltHiggsPostWHToENuBB+
-        hltHiggsPostMSSMHbb
+        hltHiggsPostMSSMHbb+
+        hltHiggsPostVBFHToInv
 )
 
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -412,8 +412,6 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         recPFMETLabel = cms.string("pfMet"), 
-        jetTagLabel  = cms.string("pfCombinedSecondaryVertexV2BJetTags"), # needed for NminOneCuts
         minCandidates = cms.uint32(2),
-        NminOneCuts = cms.untracked.vdouble(3.5, 600, 0, 0, 0 , 0, 0, 0, 80, 40, 40), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ), 
 )

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "HggControlPaths", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH","WHToENuBB","MSSMHbb"), 
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "HggControlPaths", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH","WHToENuBB","MSSMHbb","VBFHToInv"),
     histDirectory  = cms.string("HLT/Higgs"),
     
     # -- The instance name of the reco::GenParticles collection -
@@ -400,6 +400,20 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         jetTagLabel  = cms.string("combinedInclusiveSecondaryVertexV2BJetTags"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(3),
-        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.941, 0.941 , 0.00, 0, 0, 0, 100, 100, 0.0, 0.0),
+        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.941, 0.941 , 0.00, 0, 0, 0, 100, 100, 0.0, 0.0), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ),
+        
+    VBFHToInv  = cms.PSet( 
+        hltPathsToCheck = cms.vstring(
+            "HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu140_v",
+            "HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu80_v",
+            "HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu140_JetIdCleaned_v",
+            "HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu80_JetIdCleaned_v" 
+            ),
+        recJetLabel  = cms.string("ak4PFJetsCHS"),
+        recPFMETLabel = cms.string("pfMet"), 
+        jetTagLabel  = cms.string("pfCombinedSecondaryVertexV2BJetTags"), # needed for NminOneCuts
+        minCandidates = cms.uint32(2),
+        NminOneCuts = cms.untracked.vdouble(3.5, 600, 0, 0, 0 , 0, 0, 0, 80, 40, 40), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        ), 
 )

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -133,6 +133,30 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
                         <<  (9 + _minCandidates) << ".";
             exit(-1);
         }
+        if( (_NminOneCuts[0] || _NminOneCuts[1]) &&  _minCandidates  < 4 )
+        {
+            edm::LogError("HiggsValidation") << "In HLTHiggsSubAnalysis::HLTHiggsSubAnalysis, " 
+                        << "Incoherence found in the python configuration file!!\nThe SubAnalysis '" 
+                        << _analysisname << "' has a vector NminOneCuts with a dEtaqq of mqq cut on the least b-tagged jets of the first 4 jets while only requiring " 
+                        <<  _minCandidates << " jets.";
+            exit(-1);
+        }
+        if( _NminOneCuts[5] && _minCandidates < 3 )
+        {
+            edm::LogError("HiggsValidation") << "In HLTHiggsSubAnalysis::HLTHiggsSubAnalysis, " 
+                        << "Incoherence found in the python configuration file!!\nThe SubAnalysis '" 
+                        << _analysisname << "' has a vector NminOneCuts with a CSV3 cut while only requiring " 
+                        <<  _minCandidates << " jets.";
+            exit(-1);
+        }
+        if( (_NminOneCuts[2] || _NminOneCuts[4]) &&  _minCandidates < 2 )
+        {
+            edm::LogError("HiggsValidation") << "In HLTHiggsSubAnalysis::HLTHiggsSubAnalysis, " 
+                        << "Incoherence found in the python configuration file!!\nThe SubAnalysis '" 
+                        << _analysisname << "' has a vector NminOneCuts with a dPhibb or CSV2 cut using the second most b-tagged jet while only requiring " 
+                        <<  _minCandidates << " jet.";
+            exit(-1);
+        }
         for(std::vector<double>::const_iterator it = _NminOneCuts.begin(); it != _NminOneCuts.end(); ++it)
         {
             if( *it ) {

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -23,6 +23,7 @@
 #include "HLTriggerOffline/Higgs/src/MatchStruct.cc"
 
 #include "TPRegexp.h"
+#include "TRegexp.h"
 #include "TString.h"
 
 #include<set>
@@ -754,7 +755,8 @@ const std::vector<unsigned int> HLTHiggsSubAnalysis::getObjectsType(const std::s
            continue;
         }
         if( ( objtriggernames[i] == EVTColContainer::CALOMET && (TString(hltPath).Contains("PFMET") || TString(hltPath).Contains("MHT") ) ) || // fix for PFMET
-        (objtriggernames[i] == EVTColContainer::PFJET && TString(hltPath).Contains("JetIdCleaned")) ) // fix for Htaunu
+        (objtriggernames[i] == EVTColContainer::PFJET && TString(hltPath).Contains("JetIdCleaned") && ! TString(hltPath).Contains(TRegexp("Jet[^I]"))) || // fix for Htaunu
+        (objtriggernames[i] == EVTColContainer::MUON && TString(hltPath).Contains("METNoMu")) ) // fix for VBFHToInv
         {
             continue;
         }


### PR DESCRIPTION
Backport of #11636

Adding paths to the dqm:
"HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu140_v",
"HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu80_v",
"HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu140_JetIdCleaned_v",
"HLT_DiPFJet40_DEta3p5_MJJ600_PFMETNoMu80_JetIdCleaned_v" 

The naming of these paths required an additional fix in the code as well.
