### PR TITLE
fixed avgfedDigiOccvsLumi ME

### DIFF
--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -80,9 +80,6 @@
        bool ladOn, layOn, phiOn;
        //forward:
        bool ringOn, bladeOn, diskOn; 
-       int eventNo;
-       int lumSec;
-       int nLumiSecs;
        std::map<uint32_t,SiPixelDigiModule*> thePixelStructure;
 
        int nDP1P1M1;


### PR DESCRIPTION
Fixed for Pixel DQM (online only): FED digi occupancy vs Lumi plot
- starting lumisection now uses the actual LS value, instead of counting from zero
- plot resolution changed from 10 LS to 5 LS (doubling the number of bins)

will this PR be automatically merged for 80X as well?
