### PR TITLE
Make ClusterMultiplicityFilter multithread safe

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
@@ -4,26 +4,24 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 
 
-class ClusterMultiplicityFilter : public edm::stream::EDFilter<> {
+class ClusterMultiplicityFilter : public edm::global::EDFilter<> {
    public:
       explicit ClusterMultiplicityFilter(const edm::ParameterSet&);
       ~ClusterMultiplicityFilter();
 
    private:
-
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      virtual bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
       const unsigned int maxNumberOfClusters_;
       const edm::InputTag clusterCollectionTag_;
-
-      edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_;
+      const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_;
 
 };
 

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
@@ -18,7 +18,7 @@ class ClusterMultiplicityFilter : public edm::stream::EDFilter<> {
 
    private:
 
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
 
       const unsigned int maxNumberOfClusters_;
       const std::string clusterCollectionLabel_;

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
@@ -21,7 +21,7 @@ class ClusterMultiplicityFilter : public edm::stream::EDFilter<> {
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
 
       const unsigned int maxNumberOfClusters_;
-      const std::string clusterCollectionLabel_;
+      const edm::InputTag clusterCollectionTag_;
 
       edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_;
 

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
@@ -4,23 +4,26 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
 
 
-class ClusterMultiplicityFilter : public edm::EDFilter {
+class ClusterMultiplicityFilter : public edm::stream::EDFilter<> {
    public:
       explicit ClusterMultiplicityFilter(const edm::ParameterSet&);
       ~ClusterMultiplicityFilter();
 
    private:
-      virtual void beginJob() ;
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
 
-      unsigned int maxNumberOfClusters_;
-      std::string clusterCollectionLabel_; 
+      virtual bool filter(edm::Event&, const edm::EventSetup&);
+
+      const unsigned int maxNumberOfClusters_;
+      const std::string clusterCollectionLabel_;
+
+      edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_;
 
 };
 

--- a/RecoLocalTracker/SubCollectionProducers/python/ClusterMultiplicityFilter_cfi.py
+++ b/RecoLocalTracker/SubCollectionProducers/python/ClusterMultiplicityFilter_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 tifClusterFilter = cms.EDFilter("ClusterMultiplicityFilter",
-    MaxNumberOfClusters = cms.untracked.uint32(300),
-    ClusterCollectionLabel = cms.untracked.string('siStripClusters')
+    MaxNumberOfClusters = cms.uint32(300),
+    ClusterCollection = cms.InputTag('siStripClusters')
 )
 
 

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterMultiplicityFilter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterMultiplicityFilter.cc
@@ -20,10 +20,10 @@
 
 
 ClusterMultiplicityFilter::ClusterMultiplicityFilter(const edm::ParameterSet& iConfig) :
-  maxNumberOfClusters_(iConfig.getUntrackedParameter<unsigned int>("MaxNumberOfClusters")),
-  clusterCollectionLabel_(iConfig.getUntrackedParameter<std::string>("ClusterCollectionLabel"))
+  maxNumberOfClusters_(iConfig.getParameter<unsigned int>("MaxNumberOfClusters")),
+  clusterCollectionTag_(iConfig.getParameter<edm::InputTag>("ClusterCollection"))
 {
-  clusters_ = consumes<edmNew::DetSetVector<SiStripCluster> >(edm::InputTag(clusterCollectionLabel_));
+  clusters_ = consumes<edmNew::DetSetVector<SiStripCluster> >(clusterCollectionTag_);
 }
 
 
@@ -41,7 +41,7 @@ bool ClusterMultiplicityFilter::filter(edm::Event& iEvent, const edm::EventSetup
   iEvent.getByToken(clusters_,clusterHandle);
   if( !clusterHandle.isValid() ) {
     throw cms::Exception("CorruptData")
-      << "ClusterMultiplicityFilter requires collection <edm::DetSetVector<SiStripCluster> with label " << clusterCollectionLabel_ << std::endl;
+      << "ClusterMultiplicityFilter requires collection <edm::DetSetVector<SiStripCluster> with label " << clusterCollectionTag_.label() << std::endl;
   }
 
   clusters = clusterHandle.product();

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterMultiplicityFilter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterMultiplicityFilter.cc
@@ -21,9 +21,10 @@
 
 ClusterMultiplicityFilter::ClusterMultiplicityFilter(const edm::ParameterSet& iConfig) :
   maxNumberOfClusters_(iConfig.getParameter<unsigned int>("MaxNumberOfClusters")),
-  clusterCollectionTag_(iConfig.getParameter<edm::InputTag>("ClusterCollection"))
+  clusterCollectionTag_(iConfig.getParameter<edm::InputTag>("ClusterCollection")),
+  clusters_ (consumes<edmNew::DetSetVector<SiStripCluster> >(clusterCollectionTag_))
 {
-  clusters_ = consumes<edmNew::DetSetVector<SiStripCluster> >(clusterCollectionTag_);
+
 }
 
 
@@ -32,7 +33,7 @@ ClusterMultiplicityFilter::~ClusterMultiplicityFilter() {
 
 
 // ------------ method called on each new Event  ------------
-bool ClusterMultiplicityFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool ClusterMultiplicityFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
 
   bool result = true;
 


### PR DESCRIPTION
Small changes to use edm::stream::EDFilter<>, consumes, and edmNew::DetSetVector
