### PR TITLE
Removed static analyzer errors from RecoLocalTracker

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplateSplit.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplateSplit.cc
@@ -395,8 +395,6 @@ int SiStripTemplateSplit::StripTempSplit(int id, float cotalpha, float cotbeta, 
 // uncertainty and final correction depend upon charge bin 	   
 	   
 		bias = templ.xavgc2m(binq);
-		k = std::min(minbink, minbinj);
-		j = std::max(minbink, minbinj);
 		xrec1 = (0.125f*(minbink-xcbin)+BSHX-(float)shiftx+originx)*xsize - bias;
 		xrec2 = (0.125f*(minbinj-xcbin)+BSHX-(float)shiftx+originx)*xsize - bias;
 		sigmax = sqrt2x*templ.xrmsc2m(binqerr);

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTemplate.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTemplate.cc
@@ -126,7 +126,7 @@ StripCPEfromTemplate::localParameters( const SiStripCluster& cluster,
       //else 
       //cout << "Do not use templates for strip modules other than IB1, IB2, OB1 and OB2" << endl;
       
-      StripGeomDetUnit* stripdet = (StripGeomDetUnit*)(&det);
+      const StripGeomDetUnit* stripdet = (const StripGeomDetUnit*)(&det);
  
       if ( (id  > -9999999) && !(stripdet == 0) )
 	{

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
@@ -677,7 +677,6 @@ void TrackClusterSplitter::splitCluster<SiStripCluster> (const SiStripClusterWit
 			    }
 			  
 			  currentChannel = linkiter->channel();
-			  currentAmpl = rawAmpl;
 			}
 		      
 		      // Now deal with this new DigiSimLink


### PR DESCRIPTION
SiStripTemplateSplit.cc
Unused variables

StripCPEfromTemplate.cc
Unnecessary const cast

TrackClusterSplitter.cc
This currentAmpl value is not used (it is set to another value at around line 710)
