### PR TITLE
Set ROOT histogram fitting to be thread-safe

### DIFF
--- a/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.cc
+++ b/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.cc
@@ -16,6 +16,7 @@
 #include "TROOT.h"
 #include "TH1F.h"
 #include "TF1.h"
+#include "TMinuitMinimizer.h"
 
 /*****************************************************************************/
 HIPixelMedianVtxProducer::HIPixelMedianVtxProducer(const edm::ParameterSet& ps) : 
@@ -29,6 +30,10 @@ HIPixelMedianVtxProducer::HIPixelMedianVtxProducer(const edm::ParameterSet& ps) 
   theFitBinning(ps.getParameter<int>("FitBinsPerCm"))
 {
   produces<reco::VertexCollection>();
+
+  //In order to make fitting ROOT histograms thread safe
+  // one must call this undocumented function
+  TMinuitMinimizer::UseStaticMinuit(false);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
In order to fit different root histograms on different threads one
must call the undocumented function TMinuitMinimizer::UseStaticMinuit
and pass it false.
This will fix crashes seen in the CMSSW_7_6 IBs.
