### PR TITLE
METfilters: fix forth bad EE supercluster

### DIFF
--- a/RecoMET/METFilters/python/eeBadScFilter_cfi.py
+++ b/RecoMET/METFilters/python/eeBadScFilter_cfi.py
@@ -16,7 +16,7 @@ eeBadScFilter = cms.EDFilter(
   #coordinates of the crystals in the centre of each bad supercrystal
   # packed into a single integer in the form  iz,ix,iy
   #   for instance -1023023 ->  ix=23, iy=23, iz=-1
-  badscEE        = cms.vint32(-1023023,1048098,-1078063),
+  badscEE        = cms.vint32(-1023023,1048098,-1078063,-1043093),
   taggingMode = cms.bool(False),
   #prints debug info for each supercrystal if set to true
   debug = cms.bool(False),


### PR DESCRIPTION
This PR refine one MET filter adding one bad SC to the list. See finding / validation in 
https://hypernews.cern.ch/HyperNews/CMS/get/ecal-performance/839/2/1.html
We aim to have in the 76 re-reco of the data
@schoef 
