### PR TITLE
Removed LazyGetter from SiPixelClusterShapeCache

### DIFF
--- a/DataFormats/SiPixelCluster/src/SiPixelClusterShapeCache.cc
+++ b/DataFormats/SiPixelCluster/src/SiPixelClusterShapeCache.cc
@@ -3,9 +3,6 @@
 
 SiPixelClusterShapeData::~SiPixelClusterShapeData() {}
 
-SiPixelClusterShapeCache::LazyGetter::LazyGetter() {}
-SiPixelClusterShapeCache::LazyGetter::~LazyGetter() {}
-
 SiPixelClusterShapeCache::~SiPixelClusterShapeCache() {}
 
 void SiPixelClusterShapeCache::checkRef(const ClusterRef& ref) const {


### PR DESCRIPTION
The original LazyGetter implementation was not thread-safe and the
facility was never used in production. Removing the code avoids
accidently trying to switch on that facility.
The SiPixelClusterShapeCacheProducer was also switch from a stream
producer to a global producer.
