### PR TITLE
add a label to indentify the PFProducer calibrations

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+# reusable functions
+def producers_by_type(process, type):
+    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type == type)
+
+
 # Update to replace old jet corrector mechanism
 from HLTrigger.Configuration.customizeHLTforNewJetCorrectors import customizeHLTforNewJetCorrectors
 
@@ -54,9 +59,6 @@ def customiseFor8356(process):
         vertexCollection = cms.InputTag( "pixelVertices" ),
         input = cms.InputTag( 'hltL2Muons','UpdatedAtVtx' )
     )
-
-    def producers_by_type(process, type):
-    	return (module for module in process._Process__producers.values() if module._TypedParameterizable__type == type)
 
     for l3MPModule in producers_by_type(process, 'L3MuonProducer'):
 	if hasattr(l3MPModule, 'GlbRefitterParameters'):
@@ -175,11 +177,21 @@ def customiseFor11183(process):
 
     return process
 
+
 def customiseFor11497(process):
     # Take care of CaloTowerTopology
     if not hasattr(process,'CaloTowerTopologyEP'):
         process.CaloTowerTopologyEP = cms.ESProducer( 'CaloTowerTopologyEP' )
     return process
+
+
+def customiseFor12044(process):
+    # add a label to indentify the PFProducer calibrations
+    for module in producers_by_type(process, 'PFProducer'):
+      if not 'calibrationsLabel' in module.__dict__:
+        module.calibrationsLabel = cms.string('')
+    return process
+
 
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
@@ -192,6 +204,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor10911(process)
         process = customiseFor11183(process)
         process = customiseFor11497(process)
+        process = customiseFor12044(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -263,7 +263,10 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
   // fToRead =  iConfig.getUntrackedParameter<vector<string> >("toRead");
 
   useCalibrationsFromDB_
-    = iConfig.getParameter<bool>("useCalibrationsFromDB");    
+    = iConfig.getParameter<bool>("useCalibrationsFromDB");
+
+  if (useCalibrationsFromDB_)
+    calibrationsLabel_ = iConfig.getParameter<std::string>("calibrationsLabel");
 
   boost::shared_ptr<PFEnergyCalibration> 
     calibration( new PFEnergyCalibration() ); 
@@ -424,11 +427,11 @@ PFProducer::beginRun(const edm::Run & run,
   */
 
   if ( useCalibrationsFromDB_ ) { 
-  // Read the PFCalibration functions from the global tags.
+    // read the PFCalibration functions from the global tags
     edm::ESHandle<PerformancePayload> perfH;
-    es.get<PFCalibrationRcd>().get(perfH);
-    
-    const PerformancePayloadFromTFormula *pfCalibrations = static_cast< const PerformancePayloadFromTFormula *>(perfH.product());
+    es.get<PFCalibrationRcd>().get(calibrationsLabel_, perfH);
+
+    PerformancePayloadFromTFormula const * pfCalibrations = static_cast< const PerformancePayloadFromTFormula *>(perfH.product());
     
     pfAlgo_->thePFEnergyCalibration()->setCalibrationFunctions(pfCalibrations);
   }

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.h
@@ -102,7 +102,7 @@ class PFProducer : public edm::stream::EDProducer<> {
 
   // Take PF cluster calibrations from Global Tag ?
   bool useCalibrationsFromDB_;
-
+  std::string calibrationsLabel_;
 
   bool postHFCleaning_;
   // Name of the calibration functions to read from the database

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
@@ -176,6 +176,7 @@ particleFlowEGamma = cms.EDProducer("PFEGammaProducer",
 
     # ECAL/HCAL PF cluster calibration : take it from global tag ?
     useCalibrationsFromDB = cms.bool(True),
+    calibrationsLabel = cms.string(''),
 
     # calibration parameters for HF:
     calibHF_use = cms.bool(False),

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cfi.py
@@ -215,6 +215,7 @@ particleFlowTmp = cms.EDProducer("PFProducer",
 
     # ECAL/HCAL PF cluster calibration : take it from global tag ?
     useCalibrationsFromDB = cms.bool(True),
+    calibrationsLabel = cms.string(''),
 
     # calibration parameters for HF:
     calibHF_use = cms.bool(False),


### PR DESCRIPTION
This would be used to allow different PFCluster calibrations for online (HLT) and offline reconstruction.
The default is to use an empty label, which should be equivalent to not using any label.
