### PR TITLE
Adding a vertex smearing configution for pp at 5 TeV

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -42,6 +42,7 @@ VtxSmeared = {
     'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi',
     'Realistic50ns13TeVCollisionZeroTesla': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollisionZeroTesla_cfi',
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
+    'Nominal5TeVpp2015Collision':    'IOMC.EventVertexGenerators.VtxSmearedNominal5TeVpp2015Collision_cfi',
 
 }
 VtxSmearedDefaultKey='NominalCollision2015'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominal5TeVpp2015Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominal5TeVpp2015Collision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Nominal5TeVpp2015VtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Nominal5TeVpp2015VtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -533,7 +533,7 @@ Nominal5TeVpp2015VtxSmearingParameters = cms.PSet(
     Alpha = cms.double(0.0),
     SigmaZ = cms.double(5.5),
     TimeOffset = cms.double(0.0),
-    X0 = cms.double(0.0322),
-    Y0 = cms.double(0.),
-    Z0 = cms.double(0.)
+    X0 = cms.double(0.1044),
+    Y0 = cms.double(0.1676),
+    Z0 = cms.double(0.6707)
 )

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -524,3 +524,16 @@ UpdatedHICollision2015VtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.16973),
     Z0 = cms.double(-1.2230)
 )
+
+# Estimate for 2015 pp collisions at 5.02 TeV, based on feedback from accelerator:  beta* ~ 400cm, normalized emittance = 2.5 um, SigmaZ similar to RunIIWinter15GS
+Nominal5TeVpp2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(400.0),
+    Emittance = cms.double(1.0e-07),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.5),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0322),
+    Y0 = cms.double(0.),
+    Z0 = cms.double(0.)
+)


### PR DESCRIPTION
Expected beam conditions for the pp run at 5 TeV that will take place in about 4 weeks.
Same as #12040 #12047 #12049 
