### PR TITLE
Added generated HT (genHT) EDFilter module

### DIFF
--- a/GeneratorInterface/GenFilters/python/genHTFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/genHTFilter_cfi.py
@@ -1,0 +1,11 @@
+#Configuration file fragment used for GenHTFilter module (GeneratorInterface/GenFilters/src/GenHTFilter.cc) initalisation
+#genHTFilter_cfi GeneratorInterface/GenFilters/python/genHTFilter_cfi.py
+
+import FWCore.ParameterSet.Config as cms
+
+genHTFilter = cms.EDFilter("GenHTFilter",
+   src = cms.InputTag("ak4GenJets"), #GenJet collection as input
+   jetPtCut = cms.double(30.0), #GenJet pT cut for HT
+   jetEtaCut = cms.double(4.5), #GenJet eta cut for HT
+   genHTcut = cms.double(160.0) #GenHT cut
+)

--- a/GeneratorInterface/GenFilters/src/GenHTFilter.cc
+++ b/GeneratorInterface/GenFilters/src/GenHTFilter.cc
@@ -1,0 +1,88 @@
+/*
+Package:    GeneralInterface/GenFilters/GenHTFilter
+Class:      GenHTFilter
+
+class GenHTFilter GenHTFilter.cc GeneratorInterface/GenFilters/src/GenHTFilter.cc
+
+Description: EDFilter which firstly calculates the generated HT (genHT) from GenJets (given a HT definition) and then filters the events on the generator level (given a certain genHT cut).  
+
+Implementation: 
+
+The following input parameters are used (found in the genHTFilter_cfi configuration file fragment used for module initalisation): 
+  src = cms.InputTag("X") : GenJet collection label as input
+  jetPtCut = cms.double(#) : GenJet pT cut for HT
+  jetEtaCut = cms.double(#) : GenJet eta cut for HT
+  genHTcut = cms.double(#) : GenHT cut
+
+Original Author:  Mateusz Zarucki
+         Created:  Oct 2015
+*/
+
+//System include files
+#include <memory>
+#include <vector> 
+
+//User include files
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h" 
+
+#include "DataFormats/Common/interface/Handle.h" 
+#include "DataFormats/JetReco/interface/GenJetCollection.h" 
+ 
+//Class declaration
+class GenHTFilter : public edm::EDFilter 
+{
+   public:
+      explicit GenHTFilter(const edm::ParameterSet&);
+      ~GenHTFilter();
+
+   private:
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      
+      //Member data 
+      edm::EDGetTokenT<reco::GenJetCollection> token_;
+      double jetPtCut_, jetEtaCut_, genHTcut_;
+};
+
+//Constructor
+GenHTFilter::GenHTFilter(const edm::ParameterSet& params):
+   token_(consumes<reco::GenJetCollection>(params.getParameter<edm::InputTag>("src"))),
+   jetPtCut_(params.getParameter<double>("jetPtCut")),
+   jetEtaCut_(params.getParameter<double>("jetEtaCut")),
+   genHTcut_(params.getParameter<double>("genHTcut")){}
+
+//Destructor
+GenHTFilter::~GenHTFilter(){}
+
+bool GenHTFilter::filter(edm::Event& evt, const edm::EventSetup& params)
+{
+   using namespace std;
+   using namespace edm;
+   using namespace reco;
+   
+   //Read GenJets Collection from Event
+   edm::Handle<reco::GenJetCollection> generatedJets;
+   evt.getByToken(token_, generatedJets);
+   
+   //Loop over all jets in Event and calculate genHT
+   double genHT = 0.0;
+   for(std::vector<reco::GenJet>::const_iterator it = generatedJets->begin(); it != generatedJets->end(); ++it)
+   {
+      const reco::GenJet& gjet = *it;
+      
+      //Add GenJet pt to genHT if GenJet complies with given HT definition
+      if(gjet.pt() > jetPtCut_ && abs(gjet.eta()) < jetEtaCut_) 
+      {
+         genHT += gjet.pt();
+      }
+   }
+   return (genHT > genHTcut_); //Return boolean whether genHT passes cut value
+}
+
+// Define module as a plug-in
+DEFINE_FWK_MODULE(GenHTFilter);


### PR DESCRIPTION
EDFilter module which takes a GenJet collection as input, calculates the generated HT (genHT) based on a HT definition (GenJet pt and GenJet eta cuts as input parameters) and returns a boolean based on whether the genHT passes the genHT cut (also input parameter).
