### PR TITLE
Use old b-tag training at HLT in 76X

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -184,6 +184,12 @@ def customiseFor11497(process):
         process.CaloTowerTopologyEP = cms.ESProducer( 'CaloTowerTopologyEP' )
     return process
 
+# use old b-tag training for DIGI-RECO campaign in 76X
+def customiseFor12062(process):
+    if hasattr(process,'hltCombinedSecondaryVertexV2'):
+        if process.hltCombinedSecondaryVertexV2.calibrationRecords == cms.vstring('CombinedSVIVFV2RecoVertex','CombinedSVIVFV2PseudoVertex','CombinedSVIVFV2NoVertex'):
+            setattr(process.hltCombinedSecondaryVertexV2,'calibrationRecords', cms.vstring('hltCombinedSVIVFV2RecoVertex','hltCombinedSVIVFV2PseudoVertex','hltCombinedSVIVFV2NoVertex'))
+    return process
 
 def customiseFor12044(process):
     # add a label to indentify the PFProducer calibrations
@@ -191,7 +197,6 @@ def customiseFor12044(process):
       if not 'calibrationsLabel' in module.__dict__:
         module.calibrationsLabel = cms.string('')
     return process
-
 
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
@@ -204,6 +209,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor10911(process)
         process = customiseFor11183(process)
         process = customiseFor11497(process)
+        process = customiseFor12062(process)
         process = customiseFor12044(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)


### PR DESCRIPTION
Starting CMSSW_7_6_0_pre2 (and 75X_mcRun2_asymptotic_v2) both online and offline b-tagging moved to a new training. In details it correspond to BTauGenericMVAJetTagComputerRcd=MVAComputerContainer_75X_JetTags_v2_mc.

The effect is a slight improvement of the performance but, from the HLT point of view, there is a large increase of efficiency and trigger rate.
In the next DIGI-RECO campaign in 76X we want to simulate the trigger as close as possible to the real trigger used in data (in 74X). It means that we want to move back to the online b-taggin to the old training (while the offline b-tagging will continue to use the new training).

This PR adapts the HLT configuration in 76X to use the old b-tag training.
The code will work _only_ on 75X_mcRun2_asymptotic_v9 and later (we need BTauGenericMVAJetTagComputerRcd=MVAComputerContainer_75X_JetTags_v3_mc).

So please approve the PR only when the the new GT will be available.
