### PR TITLE
Hcal det id protect again invalid IDs in digitizer

### DIFF
--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -31,6 +31,7 @@ class HcalBaseSignalGenerator;
 class HcalShapes;
 class PCaloHit;
 class PileUpEventPrincipal;
+class HcalTopology;
 
 namespace edm {
   class ConsumesCollector;
@@ -61,7 +62,7 @@ public:
   void setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
-  void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHits, edm::Handle<std::vector<PCaloHit> > const& zdcHits, int bunchCrossing, CLHEP::HepRandomEngine*);
+  void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHits, edm::Handle<std::vector<PCaloHit> > const& zdcHits, int bunchCrossing, CLHEP::HepRandomEngine*, const HcalTopology *h);
 
   /// some hits in each subdetector, just for testing purposes
   void fillFakeHits();

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -444,7 +444,7 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const
       HcalDetId hid(id);
       
       //      if ( id.subdetId()==2 && hid.ietaAbs()<16 ) edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
-      if ( htopoP->validHcal(hid) ) edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
+      if ( !htopoP->validHcal(hid) ) edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
       else
 	hcalHits.push_back(hcalHitsOrig[i]);
     }

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -431,11 +431,23 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
 
 }
 
-void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHandle, edm::Handle<std::vector<PCaloHit> > const& zdcHandle, int bunchCrossing, CLHEP::HepRandomEngine* engine) {
+void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHandle, edm::Handle<std::vector<PCaloHit> > const& zdcHandle, int bunchCrossing, CLHEP::HepRandomEngine* engine, const HcalTopology *htopoP) {
 
   // Step A: pass in inputs, and accumulate digirs
   if(isHCAL) {
-    std::vector<PCaloHit> hcalHits = *hcalHandle.product();
+    std::vector<PCaloHit> hcalHitsOrig = *hcalHandle.product();
+    std::vector<PCaloHit> hcalHits;
+    hcalHits.reserve(hcalHitsOrig.size());
+
+    for ( unsigned int i=0; i< hcalHitsOrig.size(); i++) {
+      DetId id(hcalHitsOrig[i].id());
+      HcalDetId hid(id);
+      
+      //      if ( id.subdetId()==2 && hid.ietaAbs()<16 ) edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
+      if ( htopoP->validHcal(hid) ) edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
+      else
+	hcalHits.push_back(hcalHitsOrig[i]);
+    }
     //evaluate darkening before relabeling
     if(m_HEDarkening || m_HFRecalibration){
       darkening(hcalHits);
@@ -490,7 +502,11 @@ void HcalDigitizer::accumulate(edm::Event const& e, edm::EventSetup const& event
   e.getByLabel(hcalTag, hcalHandle);
   isHCAL = hcalHandle.isValid();
 
-  accumulateCaloHits(hcalHandle, zdcHandle, 0, engine);
+  edm::ESHandle<HcalTopology> htopo;
+  eventSetup.get<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology *htopoP=htopo.product();
+
+  accumulateCaloHits(hcalHandle, zdcHandle, 0, engine, htopoP);
 }
 
 void HcalDigitizer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& eventSetup, CLHEP::HepRandomEngine* engine) {
@@ -505,7 +521,11 @@ void HcalDigitizer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup co
   e.getByLabel(hcalTag, hcalHandle);
   isHCAL = hcalHandle.isValid();
 
-  accumulateCaloHits(hcalHandle, zdcHandle, e.bunchCrossing(), engine);
+  edm::ESHandle<HcalTopology> htopo;
+  eventSetup.get<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology *htopoP=htopo.product();
+
+  accumulateCaloHits(hcalHandle, zdcHandle, e.bunchCrossing(), engine, htopoP);
 }
 
 void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup, CLHEP::HepRandomEngine* engine) {


### PR DESCRIPTION
this avoids recently seen crashes in fastsim pileup tests where an invalid hcal det id got into the pileup sample. The real fix is to address that, but meanwhile, as it is a rare event, this PR should avoid the issue..
