### PR TITLE
Updates for tracker DQM plots, 74X

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -31,7 +31,7 @@ sipixelPhase1Client = cms.EDAnalyzer("SiPixelEDAClient",
 sipixelQTester = cms.EDAnalyzer("QualityTester",
     qtList = cms.untracked.FileInPath('DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml'),
     prescaleFactor = cms.untracked.int32(1),
-    getQualityTestsFromFile = cms.untracked.bool(False),
+    getQualityTestsFromFile = cms.untracked.bool(True),
     label = cms.untracked.string("SiPixelDQMQTests"),
     verboseQT = cms.untracked.bool(False)
 )

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml
@@ -10,7 +10,7 @@
      <TYPE>ContentsXRange</TYPE> 
      <PARAM name="error">0.80</PARAM> 
      <PARAM name="warning">0.90</PARAM> 
-     <PARAM name="xmin">5.0</PARAM> 
+     <PARAM name="xmin">3.0</PARAM> 
      <PARAM name="xmax">35.0</PARAM> 
 </QTEST>
 <QTEST name="XrangeWithin:Chi2overDoF" activate="true"> 


### PR DESCRIPTION
Correct config for pixel summary report map QTests; update tracking QTest parameter. The fix for the pixel summary report map (where at the moment the quality tests are configured incorrectly), is important to have as soon as possible so that these plots make sense in the Offline DQM.
