### PR TITLE
Updates for tracker DQM plots, 75X

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -31,7 +31,7 @@ sipixelPhase1Client = cms.EDAnalyzer("SiPixelEDAClient",
 sipixelQTester = cms.EDAnalyzer("QualityTester",
     qtList = cms.untracked.FileInPath('DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml'),
     prescaleFactor = cms.untracked.int32(1),
-    getQualityTestsFromFile = cms.untracked.bool(False),
+    getQualityTestsFromFile = cms.untracked.bool(True),
     label = cms.untracked.string("SiPixelDQMQTests"),
     verboseQT = cms.untracked.bool(False)
 )

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -223,36 +223,36 @@ void SiPixelHitEfficiencySource::bookHistograms(DQMStore::IBooker & iBooker, edm
   //book cluster probability histos for Barrel and Endcap
   iBooker.setCurrentFolder("Pixel/Barrel");
 
-  meClusterProbabilityL1_Plus_  = iBooker.book1D("ClusterProbabilityXY_Layer1_Plus","ClusterProbabilityXY_Layer1_Plus",250,-5,0.1);
+  meClusterProbabilityL1_Plus_  = iBooker.book1D("ClusterProbabilityXY_Layer1_Plus","ClusterProbabilityXY_Layer1_Plus",500,-14,0.1);
   meClusterProbabilityL1_Plus_->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityL1_Minus_ = iBooker.book1D("ClusterProbabilityXY_Layer1_Minus","ClusterProbabilityXY_Layer1_Minus",250,-5,0.1);
+  meClusterProbabilityL1_Minus_ = iBooker.book1D("ClusterProbabilityXY_Layer1_Minus","ClusterProbabilityXY_Layer1_Minus",500,-14,0.1);
   meClusterProbabilityL1_Minus_->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityL2_Plus_  = iBooker.book1D("ClusterProbabilityXY_Layer2_Plus","ClusterProbabilityXY_Layer2_Plus",250,-5,0.1);
+  meClusterProbabilityL2_Plus_  = iBooker.book1D("ClusterProbabilityXY_Layer2_Plus","ClusterProbabilityXY_Layer2_Plus",500,-14,0.1);
   meClusterProbabilityL2_Plus_ ->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityL2_Minus_ = iBooker.book1D("ClusterProbabilityXY_Layer2_Minus","ClusterProbabilityXY_Layer2_Minus",250,-5,0.1);
+  meClusterProbabilityL2_Minus_ = iBooker.book1D("ClusterProbabilityXY_Layer2_Minus","ClusterProbabilityXY_Layer2_Minus",500,-14,0.1);
   meClusterProbabilityL2_Minus_ ->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityL3_Plus_  = iBooker.book1D("ClusterProbabilityXY_Layer3_Plus","ClusterProbabilityXY_Layer3_Plus",250,-5,0.1);
+  meClusterProbabilityL3_Plus_  = iBooker.book1D("ClusterProbabilityXY_Layer3_Plus","ClusterProbabilityXY_Layer3_Plus",500,-14,0.1);
   meClusterProbabilityL3_Plus_->setAxisTitle("Log(ClusterProbability)",1);
  
-  meClusterProbabilityL3_Minus_ = iBooker.book1D("ClusterProbabilityXY_Layer3_Minus","ClusterProbabilityXY_Layer3_Minus",250,-5,0.1);
+  meClusterProbabilityL3_Minus_ = iBooker.book1D("ClusterProbabilityXY_Layer3_Minus","ClusterProbabilityXY_Layer3_Minus",500,-14,0.1);
   meClusterProbabilityL3_Minus_->setAxisTitle("Log(ClusterProbability)",1);
 
   iBooker.setCurrentFolder("Pixel/Endcap");
 
-  meClusterProbabilityD1_Plus_  = iBooker.book1D("ClusterProbabilityXY_Disk1_Plus","ClusterProbabilityXY_Disk1_Plus",250,-5,0.1);
+  meClusterProbabilityD1_Plus_  = iBooker.book1D("ClusterProbabilityXY_Disk1_Plus","ClusterProbabilityXY_Disk1_Plus",500,-14,0.1);
   meClusterProbabilityD1_Plus_ ->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityD1_Minus_ = iBooker.book1D("ClusterProbabilityXY_Disk1_Minus","ClusterProbabilityXY_Disk1_Minus",250,-5,0.1);
+  meClusterProbabilityD1_Minus_ = iBooker.book1D("ClusterProbabilityXY_Disk1_Minus","ClusterProbabilityXY_Disk1_Minus",500,-14,0.1);
   meClusterProbabilityD1_Minus_->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityD2_Plus_  = iBooker.book1D("ClusterProbabilityXY_Disk2_Plus","ClusterProbabilityXY_Disk2_Plus",250,-5,0.1);
+  meClusterProbabilityD2_Plus_  = iBooker.book1D("ClusterProbabilityXY_Disk2_Plus","ClusterProbabilityXY_Disk2_Plus",500,-14,0.1);
   meClusterProbabilityD2_Plus_ ->setAxisTitle("Log(ClusterProbability)",1);
 
-  meClusterProbabilityD2_Minus_ = iBooker.book1D("ClusterProbabilityXY_Disk2_Minus","ClusterProbabilityXY_Disk2_Minus",250,-5,0.1);
+  meClusterProbabilityD2_Minus_ = iBooker.book1D("ClusterProbabilityXY_Disk2_Minus","ClusterProbabilityXY_Disk2_Minus",500,-14,0.1);
   meClusterProbabilityD2_Minus_->setAxisTitle("Log(ClusterProbability)",1);
 
 }

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml
@@ -10,7 +10,7 @@
      <TYPE>ContentsXRange</TYPE> 
      <PARAM name="error">0.80</PARAM> 
      <PARAM name="warning">0.90</PARAM> 
-     <PARAM name="xmin">5.0</PARAM> 
+     <PARAM name="xmin">3.0</PARAM> 
      <PARAM name="xmax">35.0</PARAM> 
 </QTEST>
 <QTEST name="XrangeWithin:Chi2overDoF" activate="true"> 


### PR DESCRIPTION
Correct config for pixel summary report map QTests; update tracking QTest parameter; update pixel cluster probability plot binning. The first two changes are the same as for #12070 (74X).
