### PR TITLE
New GTs for 76X: Updates for MC DR Production and other fixes

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '76X_mcRun1_design_v9',
+    'run1_design'       :   '76X_mcRun1_design_v10',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '76X_mcRun1_realistic_v9',
+    'run1_mc'           :   '76X_mcRun1_realistic_v10',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v9',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v10',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '76X_mcRun1_pA_v9',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v9',
+    'run2_design'       :   '76X_mcRun2_design_v10',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v9',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v10',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v9',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v10',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v9',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v10',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v8',
+    'run1_data'         :   '76X_dataRun1_v9',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v8',
+    'run2_data'         :   '76X_dataRun2_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v8',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v8',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v5',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '76X_mcRun1_design_v8',
+    'run1_design'       :   '76X_mcRun1_design_v9',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '76X_mcRun1_realistic_v8',
+    'run1_mc'           :   '76X_mcRun1_realistic_v9',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v8',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v9',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '76X_mcRun1_pA_v8',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v8',
+    'run2_design'       :   '76X_mcRun2_design_v9',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v8',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v9',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v8',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v9',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v8',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v9',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v7',
+    'run1_data'         :   '76X_dataRun1_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v7',
+    'run2_data'         :   '76X_dataRun2_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v7',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v8',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v7',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v4',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -15,7 +15,7 @@ step1Defaults = {'--relval'      : None, # need to be explicitly set
 step1Up2015Defaults = {'-s' : 'GEN,SIM',
                              '-n'            : 10,
                              '--conditions'  : 'auto:run2_mc',
-                             '--beamspot'    : 'NominalCollision2015',
+                             '--beamspot'    : 'Realistic50ns13TeVCollision',
                              '--datatier'    : 'GEN-SIM',
                              '--eventcontent': 'FEVTDEBUG',
                              '--era'         : 'Run2_25ns'
@@ -534,7 +534,7 @@ step1FastDefaults =merge([{'-s':'GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,L1Reco,R
 step1FastUpg2015Defaults =merge([{'-s':'GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,L1Reco,RECO,EI,HLT:@relval25ns,VALIDATION',
                            '--fast':'',
                            '--conditions'  :'auto:run2_mc_'+autoHLT['relval25ns'],
-                           '--beamspot'    : 'NominalCollision2015',
+                           '--beamspot'    : 'Realistic50ns13TeVCollision',
                            '--era'         :'Run2_25ns',
                            '--eventcontent':'FEVTDEBUGHLT,DQM',
                            '--datatier':'GEN-SIM-DIGI-RECO,DQMIO',

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -44,5 +44,5 @@ VtxSmeared = {
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
 
 }
-VtxSmearedDefaultKey='NominalCollision2015'
+VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='NominalHICollision2015'

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -184,13 +184,6 @@ def customiseFor11497(process):
         process.CaloTowerTopologyEP = cms.ESProducer( 'CaloTowerTopologyEP' )
     return process
 
-# use old b-tag training for DIGI-RECO campaign in 76X
-def customiseFor12062(process):
-    if hasattr(process,'hltCombinedSecondaryVertexV2'):
-        if process.hltCombinedSecondaryVertexV2.calibrationRecords == cms.vstring('CombinedSVIVFV2RecoVertex','CombinedSVIVFV2PseudoVertex','CombinedSVIVFV2NoVertex'):
-            setattr(process.hltCombinedSecondaryVertexV2,'calibrationRecords', cms.vstring('hltCombinedSVIVFV2RecoVertex','hltCombinedSVIVFV2PseudoVertex','hltCombinedSVIVFV2NoVertex'))
-    return process
-
 def customiseFor12044(process):
     # add a label to indentify the PFProducer calibrations
     for module in producers_by_type(process, 'PFProducer'):
@@ -210,7 +203,6 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor11183(process)
         process = customiseFor11497(process)
         process = customiseFor12044(process)
-        process = customiseFor12062(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -184,6 +184,12 @@ def customiseFor11497(process):
         process.CaloTowerTopologyEP = cms.ESProducer( 'CaloTowerTopologyEP' )
     return process
 
+# use old b-tag training for DIGI-RECO campaign in 76X
+def customiseFor12062(process):
+    if hasattr(process,'hltCombinedSecondaryVertexV2'):
+        if process.hltCombinedSecondaryVertexV2.calibrationRecords == cms.vstring('CombinedSVIVFV2RecoVertex','CombinedSVIVFV2PseudoVertex','CombinedSVIVFV2NoVertex'):
+            setattr(process.hltCombinedSecondaryVertexV2,'calibrationRecords', cms.vstring('hltCombinedSVIVFV2RecoVertex','hltCombinedSVIVFV2PseudoVertex','hltCombinedSVIVFV2NoVertex'))
+    return process
 
 def customiseFor12044(process):
     # add a label to indentify the PFProducer calibrations
@@ -191,7 +197,6 @@ def customiseFor12044(process):
       if not 'calibrationsLabel' in module.__dict__:
         module.calibrationsLabel = cms.string('')
     return process
-
 
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
@@ -204,6 +209,8 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor10911(process)
         process = customiseFor11183(process)
         process = customiseFor11497(process)
+        process = customiseFor12044(process)
+        process = customiseFor12062(process)
         process = customiseFor12044(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -211,7 +211,6 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor11497(process)
         process = customiseFor12044(process)
         process = customiseFor12062(process)
-        process = customiseFor12044(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)


### PR DESCRIPTION
# Summary of Changes in the GT
## RunI simulation
- **RunI Ideal scenario** : [76X_mcRun1_design_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_design_v9) as [76X_mcRun1_design_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_design_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_design_v10/76X_mcRun1_design_v8): 
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label .
- **RunI Heavy Ions scenario** : [76X_mcRun1_HeavyIon_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_HeavyIon_v10) as [76X_mcRun1_HeavyIon_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_HeavyIon_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_HeavyIon_v10/76X_mcRun1_HeavyIon_v8): 
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label .
  - introducing HFtowers label for HeavyIonRcd
- **RunI Realistic scenario** : [76X_mcRun1_realistic_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_realistic_v10) as [76X_mcRun1_realistic_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_realistic_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_realistic_v10/76X_mcRun1_realistic_v8): 
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
- **RunI Proton-Lead scenario** : [76X_mcRun1_pA_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_pA_v10) as [76X_mcRun1_pA_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun1_pA_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun1_pA_v10/76X_mcRun1_pA_v8): 
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label .
## RunII simulation
- **RunII Ideal scenario** : [76X_mcRun2_design_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v10) as [76X_mcRun2_design_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_design_v10/76X_mcRun2_design_v8): 
  - added special label for PF hadron calibration for HLT usage, set as in 74X values
  - updated BeamSpot as derived from Realistic 50ns 13 TeV GEN-SIM vertex smearing parameters
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label .
  - updated HCAL dead channel map as in Run2015D
  - updated HCAL LUT Corrections
  - updated HCAL pedestals
  - updated HCAL pedestal width
  - updated JEC for HLT in order to use the same values as data taking in 74X
  - updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
  - updated Pixel dynamic inefficiency, for the 50ns bunch spacing, by using 0.999 values in all modules
  - updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency.
- **RunII Asymptotic scenario** : [76X_mcRun2_asymptotic_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v10) as [76X_mcRun2_asymptotic_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_asymptotic_v10/76X_mcRun2_asymptotic_v8): 
  - added special label for PF hadron calibration for HLT usage, set as in 74X values
  - updated BeamSpot as derived from Realistic 50ns 13 TeV GEN-SIM vertex smearing parameters
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label .
  - updated HCAL dead channel map as in Run2015D
  - updated JEC for HLT in order to use the same values as data taking in 74X
  - updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
  - updated Pixel dynamic inefficiency, for the 50ns bunch spacing, by using 0.999 values in all modules
  - updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency
  - updated Strip bad channels with TOB L3 FED 434 IN and 439 OUT. Computed using Run 258749.
- **RunII Startup scenario** : [76X_mcRun2_startup_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v10) as [76X_mcRun2_startup_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_startup_v10/76X_mcRun2_startup_v8): 
  - added special label for PF hadron calibration for HLT usage, set as in 74X values
  - updated BeamSpot as derived from Realistic 50ns 13 TeV GEN-SIM vertex smearing parameters
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
  - updated HCAL dead channel map as in Run2015D
  - updated JEC for HLT in order to use the same values as data taking in 74X
  - updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
  - updated Pixel dynamic inefficiency, for 50 ns bunch spacing, by using 0.999 values in all modules
  - updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency
  - updated Strip bad channels with every FED IN, computed using Run 251561.
  - updated tracker misalignment scenario based on more realistic estimate of the post-LS1 geometry obtained using Cosmics and 0T collision simulated data.
  - updated muon misalignment scenario closer in performance to 2015 Prompt data. 
- **RunII Heavy Ions scenario** : [76X_mcRun2_HeavyIon_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v10) as [76X_mcRun2_HeavyIon_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v8) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_HeavyIon_v10/76X_mcRun2_HeavyIon_v8): 
  - added special label for PF hadron calibration for HLT usage, set as in 74X values
  - added new label for HFtowers centrality
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
  - updated HCAL dead channel map as in Run2015D
  - updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
  - updated Pixel dynamic inefficiency, for 50 ns bunch spacing, by using 0.999 values in all modules 
  - updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency
  - updated Strip bad channels with TOB L3 FED 434 IN and 439 OUT. Computed using Run 258749.
## RunI data
- **RunI Offline processing** : [76X_dataRun1_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v9) as [76X_dataRun1_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v9/76X_dataRun1_v7): 
  - updating AlCaReco trigger bits to allow for new TkAl Heavy Ion AlCa producers
  - updating DT and CSC and muon Global alignment to latest TB alignment for Run2
  - use of offline tags for CSC bad wires and bad strips
  - merging run1 and run2 EB,EE and ES alignments
  - merging run1 and run2 ECAL time calibration constants
  - updating to latest offline versions for Hcal local reco calibrations
  - introducing tag for L1TCaloParamsRcd
  - updating Pixel LA, Generic Errors and Templates for Run2 IOVs
  - taxonomy change in the Pixel LA tags to avoid use of V1 fully qualified account names
  - updating to latest version offline tags for Strip LA and Noise 
  - updating Tracker Alignment and Surface deformations to latest IOV for Run2.
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
- **RunI HLT processing** : [76X_dataRun1_HLT_frozen_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_HLT_frozen_v9) as [76X_dataRun1_HLT_frozen_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_HLT_frozen_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_HLT_frozen_v9/76X_dataRun1_HLT_frozen_v7): 
  - introducing tag for L1TCaloParamsRcd
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
  - new snapshot time (2015-10-24 13:00:00,000000)
## RunII data
- **RunII Offline processing** : [76X_dataRun2_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v9) as [76X_dataRun2_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v9/76X_dataRun2_v7): 
  - updating AlCaReco trigger bits to allow for new TkAl Heavy Ion AlCa producers
  - updating DT and CSC and muon Global alignment to latest TB for Run2
  - use of offline tags for CSC bad wires and bad strips
  - merging run1 and run2 EB,EE and ES alignments
  - merging run1 and run2 ECAL time calibration constants
  - updating to latest offline versions for Hcal local reco calibrations
  - introducing tag for L1TCaloParamsRcd
  - updating Pixel LA, Generic Errors and Templates for Run2 IOVs
  - taxonomy change in the Pixel LA tags to avoid use of V1 fully qualified account names
  - updating to latest version offline tags for Strip LA and Noise 
  - updating Tracker Alignment and Surface deformations to latest IOV for Run2
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
- **RunII HLT processing** : [76X_dataRun2_HLT_frozen_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_frozen_v9) as [76X_dataRun2_HLT_frozen_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_frozen_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_HLT_frozen_v9/76X_dataRun2_HLT_frozen_v7): 
  - introducing tag for L1TCaloParamsRcd
  - added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
  - adding label HLT for PFCalibrations
  - new snapshot time (2015-10-24 13:00:00,000000)
## Upgrade
- **PhaseI design scenario** : [76X_upgrade2017_design_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v6) as [76X_upgrade2017_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_upgrade2017_design_v6/76X_upgrade2017_design_v4): 
  - added special label for PF hadron calibration for HLT usage, set as in 74X values
  - \* added BTag Jet Taggers with additional keys for CSVV2 trainings for HLT usage, set as in 74X values, through `HLT` label.
  - updated HCAL dead channel map as in Run2015D
  - updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
  - updated Pixel dynamic inefficiency, for the 50ns bunch spacing, by using 0.999 values in all modules
  - updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency

---

Additionally: 
- switched to Realistic 50ns 13 TeV GEN-SIM vertex smearing parameters in the RelVal matrix
- adding #12062 to use old b-tag training at HLT in 76X
