### PR TITLE
Add full5x5 shower shape block to non-GED photons producer

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -359,6 +359,19 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float sigmaIetaIeta = sqrt(locCov[0]);
     float r9 =e3x3/(scRef->rawEnergy());
 
+    float full5x5_maxXtal =   noZS::EcalClusterTools::eMax( *(scRef->seed()), &(*hits) );
+    //AA
+    //Change these to consider severity level of hits
+    float full5x5_e1x5    =   noZS::EcalClusterTools::e1x5(  *(scRef->seed()), &(*hits), &(*topology));
+    float full5x5_e2x5    =   noZS::EcalClusterTools::e2x5Max(  *(scRef->seed()), &(*hits), &(*topology));
+    float full5x5_e3x3    =   noZS::EcalClusterTools::e3x3(  *(scRef->seed()), &(*hits), &(*topology));
+    float full5x5_e5x5    =   noZS::EcalClusterTools::e5x5( *(scRef->seed()), &(*hits), &(*topology));
+    std::vector<float> full5x5_cov =  noZS::EcalClusterTools::covariances( *(scRef->seed()), &(*hits), &(*topology), geometry);
+    std::vector<float> full5x5_locCov =  noZS::EcalClusterTools::localCovariances( *(scRef->seed()), &(*hits), &(*topology));
+
+    float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);
+    float full5x5_sigmaIetaIeta = sqrt(full5x5_locCov[0]);
+
     // compute position of ECAL shower
     math::XYZPoint caloPosition;
     if (r9>minR9) {
@@ -404,7 +417,18 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     showerShape.hcalDepth1OverEcalBc = hcalDepth1OverEcalBc;
     showerShape.hcalDepth2OverEcalBc = hcalDepth2OverEcalBc;
     showerShape.hcalTowersBehindClusters =  TowersBehindClus;
-    newCandidate.setShowerShapeVariables ( showerShape ); 
+    newCandidate.setShowerShapeVariables ( showerShape );
+
+    /// fill full5x5 shower shape block
+    reco::Photon::ShowerShape  full5x5_showerShape;
+    full5x5_showerShape.e1x5= full5x5_e1x5;
+    full5x5_showerShape.e2x5= full5x5_e2x5;
+    full5x5_showerShape.e3x3= full5x5_e3x3;
+    full5x5_showerShape.e5x5= full5x5_e5x5;
+    full5x5_showerShape.maxEnergyXtal =  full5x5_maxXtal;
+    full5x5_showerShape.sigmaEtaEta =    full5x5_sigmaEtaEta;
+    full5x5_showerShape.sigmaIetaIeta =  full5x5_sigmaIetaIeta;
+    newCandidate.full5x5_setShowerShapeVariables ( full5x5_showerShape );
 
     /// get ecal photon specific corrected energy 
     /// plus values from regressions     and store them in the Photon


### PR DESCRIPTION
75X backport of #12085
HI noticed that for photons produced with the "standard" photon producer, the full5x5 shower shape info was missing.

HI absolutely needs this info for photon ID purposes in run2 analyses, as we plan on using "standard" photons for run2 analyses.

@ttrk @mandrenguyen @yetkinyilmaz 

We would like to request that this be included in the release used for HI data taking, potentially 7_5_3_patch2 or something similar. Apologies for not catching this error earlier. 
