### PR TITLE
Faster muon shower info filler to fix slow prompt reco issue

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -103,7 +103,6 @@ class MuonShowerInformationFiller {
     std::vector<const GeomDet*> dtPositionToDets(const GlobalPoint&) const;
     std::vector<const GeomDet*> cscPositionToDets(const GlobalPoint&) const;
     MuonRecHitContainer findPerpCluster(MuonRecHitContainer& muonRecHits) const;
-    MuonRecHitContainer findPhiCluster(MuonRecHitContainer&, const GlobalPoint&) const;
     TransientTrackingRecHit::ConstRecHitContainer findThetaCluster(TransientTrackingRecHit::ConstRecHitContainer&, const GlobalPoint&) const;
     TransientTrackingRecHit::ConstRecHitContainer hitsFromSegments(const GeomDet*,edm::Handle<DTRecSegment4DCollection>, edm::Handle<CSCSegmentCollection>) const;
     std::vector<const GeomDet*> getCompatibleDets(const reco::Track&) const;

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -808,10 +808,15 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
        << theAllStationHits.at(2) << " "
        << theAllStationHits.at(3) << endl;
 
+  //station shower sizes
+  MuonTransientTrackingRecHit::MuonRecHitContainer muonRecHitsPhiBest;
+  TransientTrackingRecHit::ConstRecHitContainer muonRecHitsThetaTemp, muonRecHitsThetaBest;
   // send station hits to the clustering algorithm
   for ( int stat = 0; stat != 4; stat++ ) {
     const size_t nhit = muonRecHits[stat].size();
     if (nhit < 2) continue; // Require at least 2 hits
+    muonRecHitsPhiBest.clear();
+    muonRecHitsPhiBest.reserve(nhit);
 
     // Cluster seeds by global position phi. Best cluster is chosen to give greatest dphi
     // Sort by phi (complexity = NLogN with enough memory, or = NLog^2N for insufficient mem)
@@ -829,11 +834,9 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
     }
 
     //station shower sizes
-    MuonTransientTrackingRecHit::MuonRecHitContainer muonRecHitsPhiBest;
     double dphimax = 0;
     if ( clUppers.empty() ) {
       // No gaps - there is only one cluster. Take all of them
-      muonRecHitsPhiBest.reserve(muonRecHits[stat].size());
       const double refPhi = muonRecHits[stat].at(0)->globalPosition().phi();
       double dphilo = 0, dphihi = 0;
       for ( auto& hit : muonRecHits[stat] ) {
@@ -894,10 +897,8 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
       }
 
      //for theta
-     TransientTrackingRecHit::ConstRecHitContainer muonRecHitsThetaBest;
      if (!muonCorrelatedHits.at(stat).empty()) {
 
-       TransientTrackingRecHit::ConstRecHitContainer muonRecHitsThetaTemp;
        float dthetamax = 0;
        for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator iseed = muonCorrelatedHits.at(stat).begin(); iseed != muonCorrelatedHits.at(stat).end(); ++iseed) {
            if (!(*iseed)->isValid()) continue;


### PR DESCRIPTION
This PR reduces algorithm complexity in MuonShowerInformationFiller by reducing un-necessary series of sorting while build largest cluster of rechits to a muon.
Timing performance can be improved for events with large number of muon hits.

Previous algorithm collects nearby hits by sorting rechits in increasing order or abs(deltaPhi), and do the sorting for every rechits in the vector. Clustering can be done by just fining large gaps after sorting by phi. 

This may give a partial solution to the long prompt reco timing issue in the following HN.
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1392.html
x20 total time reduction was observed for one most problematic event mentioned in the HN.

(to be confirmed/cross-checked) Original code does sorting[2] inside a loop[1]. This may introduce random behavior (or random infinite-like loop). New code is free from this problem.
[1] https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc#L850-L862
[2] https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc#L289
