### PR TITLE
CondFormats/Common: remove intrusive macros breaking libstdc++

### DIFF
--- a/CondFormats/Common/interface/SmallWORMDict.h
+++ b/CondFormats/Common/interface/SmallWORMDict.h
@@ -13,6 +13,12 @@
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 
+// Function for testing SmallWORMDict
+namespace test {
+  namespace SmallWORMDict {
+    int test();
+  }
+}
 
 namespace cond {
 
@@ -21,6 +27,8 @@ namespace cond {
  */
 
   class SmallWORMDict {
+    friend int test::SmallWORMDict::test();
+
   public:
     SmallWORMDict();
     ~SmallWORMDict();

--- a/CondFormats/Common/interface/UpdateStamp.h
+++ b/CondFormats/Common/interface/UpdateStamp.h
@@ -7,6 +7,11 @@
 #include <string>
 
 
+// Unit test class for UpdateStamp
+namespace {
+  class TestUpdateStamp;
+}
+
 namespace cond {
   
   /** class to "stamp" a new version of an updateble persistent object
@@ -14,6 +19,8 @@ namespace cond {
       no history in mantained at the moment
    */
   class UpdateStamp {
+    friend class ::TestUpdateStamp;
+
   public:
     // constrcutor creates and invalid stamp
     UpdateStamp();

--- a/CondFormats/Common/test/SmallWORMDict_t.cpp
+++ b/CondFormats/Common/test/SmallWORMDict_t.cpp
@@ -1,57 +1,62 @@
-#define private public
 #include "CondFormats/Common/interface/SmallWORMDict.h"
-#undef private
-
 
 #include <iostream>
 
+namespace test {
+  namespace SmallWORMDict {
+    int test() {
+    
+      std::vector<std::string> dict;
+      size_t tot=0;
+      dict.push_back("Sneezy");
+      tot+=dict.back().size();
+      dict.push_back("Sleepy");
+      tot+=dict.back().size();
+      dict.push_back("Dopey");
+      tot+=dict.back().size();
+      dict.push_back("Doc");
+      tot+=dict.back().size();
+      dict.push_back("Happy");
+      tot+=dict.back().size();
+      dict.push_back("Bashful");
+      tot+=dict.back().size();
+      dict.push_back("Grumpy");
+      tot+=dict.back().size();
+      
+      cond::SmallWORMDict  worm(dict);
+    
+    
+      std::cout << dict.size() << " " << worm.m_index.size() << std::endl;
+      std::cout << tot << " " << worm.m_data.size() << std::endl;
+      std::copy(worm.m_index.begin(),worm.m_index.end(),
+    	    std::ostream_iterator<int>(std::cout," "));
+      std::cout << std::endl;
+      std::copy(worm.m_data.begin(),worm.m_data.end(),
+    	    std::ostream_iterator<char>(std::cout,""));
+      std::cout << std::endl;
+    
+      cond::SmallWORMDict::Frame f = worm[2];
+      std::copy(f.b,f.b+f.l,
+    	    std::ostream_iterator<char>(std::cout,""));
+      std::cout << std::endl;
+      
+      int i = worm.index("Doc");
+      f = worm[i];
+      std::copy(f.b,f.b+f.l,
+    	    std::ostream_iterator<char>(std::cout,""));
+      std::cout << " at " << i<< std::endl;
+    
+      f = *worm.find("Sleepy");
+      std::copy(f.b,f.b+f.l,
+    	    std::ostream_iterator<char>(std::cout,""));
+      std::cout << " at " << f.ind << std::endl;
+    
+    return 0;
+    
+    }
+  }
+}
+
 int main() {
-
-  std::vector<std::string> dict;
-  size_t tot=0;
-  dict.push_back("Sneezy");
-  tot+=dict.back().size();
-  dict.push_back("Sleepy");
-  tot+=dict.back().size();
-  dict.push_back("Dopey");
-  tot+=dict.back().size();
-  dict.push_back("Doc");
-  tot+=dict.back().size();
-  dict.push_back("Happy");
-  tot+=dict.back().size();
-  dict.push_back("Bashful");
-  tot+=dict.back().size();
-  dict.push_back("Grumpy");
-  tot+=dict.back().size();
-  
-  cond::SmallWORMDict  worm(dict);
-
-
-  std::cout << dict.size() << " " << worm.m_index.size() << std::endl;
-  std::cout << tot << " " << worm.m_data.size() << std::endl;
-  std::copy(worm.m_index.begin(),worm.m_index.end(),
-	    std::ostream_iterator<int>(std::cout," "));
-  std::cout << std::endl;
-  std::copy(worm.m_data.begin(),worm.m_data.end(),
-	    std::ostream_iterator<char>(std::cout,""));
-  std::cout << std::endl;
-
-  cond::SmallWORMDict::Frame f = worm[2];
-  std::copy(f.b,f.b+f.l,
-	    std::ostream_iterator<char>(std::cout,""));
-  std::cout << std::endl;
-  
-  int i = worm.index("Doc");
-  f = worm[i];
-  std::copy(f.b,f.b+f.l,
-	    std::ostream_iterator<char>(std::cout,""));
-  std::cout << " at " << i<< std::endl;
-
-  f = *worm.find("Sleepy");
-  std::copy(f.b,f.b+f.l,
-	    std::ostream_iterator<char>(std::cout,""));
-  std::cout << " at " << f.ind << std::endl;
-
-return 0;
-
+  return test::SmallWORMDict::test();
 }

--- a/CondFormats/Common/test/UpdateStamp_t.cpp
+++ b/CondFormats/Common/test/UpdateStamp_t.cpp
@@ -1,17 +1,13 @@
 #include <cppunit/extensions/HelperMacros.h>
 
-//#include "boost/intrusive_ptr.hpp"
-
-#define private public
 #include "CondFormats/Common/interface/UpdateStamp.h"
-#undef private
 #include "CondFormats/Common/interface/TimeConversions.h"
 
 namespace {
 
-   class Test: public CppUnit::TestFixture
+   class TestUpdateStamp: public CppUnit::TestFixture
    {
-	 CPPUNIT_TEST_SUITE(Test);
+	 CPPUNIT_TEST_SUITE(TestUpdateStamp);
 	 CPPUNIT_TEST(construct);
 	 CPPUNIT_TEST(stamp);
 	 CPPUNIT_TEST_SUITE_END();
@@ -23,14 +19,14 @@ namespace {
 
    };
 
-  void Test::construct() {
+  void TestUpdateStamp::construct() {
     cond::UpdateStamp object;
     CPPUNIT_ASSERT(-1==object.m_revision);
     CPPUNIT_ASSERT(0==object.m_timestamp);
     CPPUNIT_ASSERT("not stamped"==object.m_comment);
   }
 
-  void Test::stamp() {
+  void TestUpdateStamp::stamp() {
     cond::UpdateStamp object;
     cond::Time_t otime = cond::time::now();
     {
@@ -60,8 +56,5 @@ namespace {
 
 }
 
-CPPUNIT_TEST_SUITE_REGISTRATION(Test);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestUpdateStamp);
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
-
-
-


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
