### PR TITLE
FWCore/Utilities: remove intrusive macros breaking libstdc++

### DIFF
--- a/FWCore/Utilities/interface/RunningAverage.h
+++ b/FWCore/Utilities/interface/RunningAverage.h
@@ -4,10 +4,20 @@
 #include <algorithm>
 #include <array>
 
+// Function for testing RunningAverage
+namespace test {
+  namespace running_average {
+    int test();
+  }
+}
+
 namespace edm {
 // keeps the running average of the last N entries
 // thread safe, fast: does not garantee precise update in case of collision
   class RunningAverage {
+    // For tests
+    friend int ::test::running_average::test();
+
   public:
     static constexpr int N = 16;  // better be a power of 2
     explicit RunningAverage(unsigned int k=4) : m_mean(N*k), m_curr(0) {

--- a/FWCore/Utilities/test/RunningAverage_t.cpp
+++ b/FWCore/Utilities/test/RunningAverage_t.cpp
@@ -1,6 +1,4 @@
-#define private public
 #include "FWCore/Utilities/interface/RunningAverage.h"
-#undef private
 
 namespace {
 
@@ -17,57 +15,64 @@ namespace {
 #include <algorithm>
 #include <type_traits>
 
-int main() {
-
-
-  //tbb::task_scheduler_init init;  // Automatic number of threads
-  tbb::task_scheduler_init init(tbb::task_scheduler_init::default_num_threads());  // Explicit number of threads
-
-  // std::random_device rd;
-  std::mt19937 e2; // (rd());
-  std::normal_distribution<> normal_dist(1000., 200.);
-
-
-
-  thread_local std::vector<float> v;  
-
-  
-
-  int kk=0;
-
-
-  int n=2000;
-
-  int res[n];
-  int qq[n]; for (auto & y:qq) y = std::max(0.,normal_dist(e2));
-
-  auto theLoop = [&](int i) {
-    kk++;
-    v.reserve(res[i]=localRA.upper());
-    v.resize(qq[i]);
-    localRA.update(v.size());
-    decltype(v) t;
-    swap(v,t);
-  };
-
-
-  tbb::parallel_for(
-		    tbb::blocked_range<size_t>(0,n),
-		    [&](const tbb::blocked_range<size_t>& r) {
-		      for (size_t i=r.begin();i<r.end();++i) theLoop(i);
+namespace test {
+  namespace running_average {
+    int test() {
+    
+    
+      //tbb::task_scheduler_init init;  // Automatic number of threads
+      tbb::task_scheduler_init init(tbb::task_scheduler_init::default_num_threads());  // Explicit number of threads
+    
+      // std::random_device rd;
+      std::mt19937 e2; // (rd());
+      std::normal_distribution<> normal_dist(1000., 200.);
+    
+    
+    
+      thread_local std::vector<float> v;  
+    
+      
+    
+      int kk=0;
+    
+    
+      int n=2000;
+    
+      int res[n];
+      int qq[n]; for (auto & y:qq) y = std::max(0.,normal_dist(e2));
+    
+      auto theLoop = [&](int i) {
+        kk++;
+        v.reserve(res[i]=localRA.upper());
+        v.resize(qq[i]);
+        localRA.update(v.size());
+        decltype(v) t;
+        swap(v,t);
+      };
+    
+    
+      tbb::parallel_for(
+    		    tbb::blocked_range<size_t>(0,n),
+    		    [&](const tbb::blocked_range<size_t>& r) {
+    		      for (size_t i=r.begin();i<r.end();++i) theLoop(i);
+        }
+      );
+    
+    
+      auto mm = std::max_element(res,res+n);
+      std::cout << kk << ' ' << localRA.m_curr << ' ' << localRA.mean() << std::endl;
+      for (auto & i : localRA.m_buffer) std::cout << i << ' ';
+      std::cout << std::endl;
+      std::cout << std::accumulate(res,res+n,0)/n 
+    	    << ' ' << *std::min_element(res+16,res+n) << ',' << *mm << std::endl;
+    
+      return 0;
+    
+    
     }
-  );
-
-
-  auto mm = std::max_element(res,res+n);
-  std::cout << kk << ' ' << localRA.m_curr << ' ' << localRA.mean() << std::endl;
-  for (auto & i : localRA.m_buffer) std::cout << i << ' ';
-  std::cout << std::endl;
-  std::cout << std::accumulate(res,res+n,0)/n 
-	    << ' ' << *std::min_element(res+16,res+n) << ',' << *mm << std::endl;
-
-  return 0;
-
-
+  }
 }
 
+int main() {
+  return ::test::running_average::test();
+}


### PR DESCRIPTION
We cannot redefine 'private' and 'protected' keywords via macros to e.g.
'public'. This is extremely intrusive and breaks encapsulation.

This does not work anymore with new libstdc++ libraries, because foward
delcaration of struct is implicitly private and then implementation is
under explicit private clause. Redefining 'private' only change one of
them thus creating compile-time errors in sstream.

Details in PR65899 (GCC BZ). It's WONTFIX.

Such cleanups are required for GCC 5 and above.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
