### PR TITLE
Revision of snapshotTime handling in HLT

### DIFF
--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -79,7 +79,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                   label      = len(entry) > 3 and entry[3] or None
                   tag        = entry[0]
                   connection = len(entry) > 2 and entry[2] or None
-                  map[ (record, label) ] = (tag, connection)
+                  snapshotTime = len(entry) > 4 and entry[4] or None
+                  map[ (record, label) ] = (tag, connection, snapshotTime)
                 custom_conditions.update( map )
             else:
                 globaltag = autoKey
@@ -109,7 +110,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                 label      = len(entry) > 3 and entry[3] or None
                 tag        = entry[0]
                 connection = len(entry) > 2 and entry[2] or None
-                map[ (record, label) ] = (tag, connection)
+                snapshotTime = len(entry) > 4 and entry[4] or None
+                map[ (record, label) ] = (tag, connection, snapshotTime)
             custom_conditions.update( map )
         elif isinstance(conditions, dict):
           custom_conditions.update( conditions )
@@ -118,7 +120,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # explicit payloads toGet from DB
     if custom_conditions:
-        for ( (record, label), (tag, connection) ) in sorted(custom_conditions.iteritems()):
+        for ( (record, label), (tag, connection, snapshotTime) ) in sorted(custom_conditions.iteritems()):
             payload = cms.PSet()
             payload.record = cms.string( record )
             if label:
@@ -126,6 +128,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             payload.tag = cms.string( tag )
             if connection:
                 payload.connect = cms.string( connection )
+            if snapshotTime:
+                payload.snapshotTime = cms.string( snapshotTime )
             essource.toGet.append( payload )
 
     return essource

--- a/Configuration/AlCa/python/GlobalTag_condDBv1.py
+++ b/Configuration/AlCa/python/GlobalTag_condDBv1.py
@@ -79,7 +79,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                   label      = len(entry) > 3 and entry[3] or None
                   tag        = entry[0]
                   connection = len(entry) > 2 and entry[2] or None
-                  map[ (record, label) ] = (tag, connection)
+                  snapshotTime = len(entry) > 4 and entry[4] or None
+                  map[ (record, label) ] = (tag, connection, snapshotTime)
                 custom_conditions.update( map )
             else:
                 globaltag = autoKey
@@ -109,7 +110,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                 label      = len(entry) > 3 and entry[3] or None
                 tag        = entry[0]
                 connection = len(entry) > 2 and entry[2] or None
-                map[ (record, label) ] = (tag, connection)
+                snapshotTime = len(entry) > 4 and entry[4] or None
+                map[ (record, label) ] = (tag, connection, snapshotTime)
             custom_conditions.update( map )
         elif isinstance(conditions, dict):
           custom_conditions.update( conditions )
@@ -118,7 +120,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # explicit payloads toGet from DB
     if custom_conditions:
-        for ( (record, label), (tag, connection) ) in sorted(custom_conditions.iteritems()):
+        for ( (record, label), (tag, connection, snapshotTime) ) in sorted(custom_conditions.iteritems()):
             payload = cms.PSet()
             payload.record = cms.string( record )
             if label:
@@ -126,6 +128,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             payload.tag = cms.string( tag )
             if connection:
                 payload.connect = cms.string( connection )
+            if snapshotTime:
+                payload.snapshotTime = cms.string (snapshotTime )
             essource.toGet.append( payload )
 
     return essource

--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -1,5 +1,7 @@
 # https://cms-conddb.cern.ch/browser/#search
 
+snapshotTime = "9999-12-31 23:59:59.000"
+
 l1Menus= {
     'Fake'         : 'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc',
     'FULL'         : 'L1Menu_Collisions2015_25nsStage1_v5',
@@ -17,7 +19,7 @@ l1Menus= {
 }
 
 for key,val in l1Menus.iteritems():
-    l1Menus[key] = (val+',L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS',)
+    l1Menus[key] = (val+',L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS,,'+snapshotTime,)
 
 hltGTs = {
 

--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -31,7 +31,7 @@ def Base(process):
 #        process.GlobalTag.connect   = 'frontier://FrontierProd/CMS_CONDITIONS'
 #        process.GlobalTag.pfnPrefix = cms.untracked.string('frontier://Frontie#rProd/')
 #        
-    process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
+#   process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 
     process=ProcessName(process)
 

--- a/HLTrigger/Configuration/python/customizeHLTforALL.py
+++ b/HLTrigger/Configuration/python/customizeHLTforALL.py
@@ -42,7 +42,7 @@ def customizeHLTforAll(process, _customInfo = None):
             if hasattr(process,'GlobalTag'):
                 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
                 process.GlobalTag = GlobalTag(process.GlobalTag, _globalTag, '')
-                process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
+#               process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 
 # inputFile
         if _inputFile[0] == "@":


### PR DESCRIPTION
Revision of snapshotTime handling in HLT: 
no longer use/set a global snapshotTime but move to a per-payload snapshotTime.
