### PR TITLE
use dedicated calibrations at HLT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -18,9 +18,9 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v10',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v9',
+    'run1_data'         :   '76X_dataRun1_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v9',
+    'run2_data'         :   '76X_dataRun2_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -184,12 +184,14 @@ def customiseFor11497(process):
         process.CaloTowerTopologyEP = cms.ESProducer( 'CaloTowerTopologyEP' )
     return process
 
+
 def customiseFor12044(process):
     # add a label to indentify the PFProducer calibrations
     for module in producers_by_type(process, 'PFProducer'):
       if not 'calibrationsLabel' in module.__dict__:
-        module.calibrationsLabel = cms.string('')
+        module.calibrationsLabel = cms.string('HLT')
     return process
+
 
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -1,8 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 # reusable functions
-def producers_by_type(process, type):
-    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type == type)
+def producers_by_type(process, *types):
+    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
+
+def esproducers_by_type(process, *types):
+    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
 
 
 # Update to replace old jet corrector mechanism
@@ -193,6 +196,14 @@ def customiseFor12044(process):
     return process
 
 
+def customiseFor12062(process):
+    # add a label to indentify the b-tagging calibrations
+    for module in esproducers_by_type(process, 'CombinedSecondaryVertexESProducer'):
+      if not 'recordLabel' in module.__dict__:
+        module.recordLabel = cms.string('HLT')
+    return process
+
+
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
@@ -205,6 +216,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor11183(process)
         process = customiseFor11497(process)
         process = customiseFor12044(process)
+        process = customiseFor12062(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)

--- a/RecoBTag/CTagging/python/candidateCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi.py
+++ b/RecoBTag/CTagging/python/candidateCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi.py
@@ -16,6 +16,7 @@ candidateCombinedSecondaryVertexSoftLeptonCvsLComputer = cms.ESProducer(
       'CombinedSVRecoVertexSoftElectronCvsL', 
       'CombinedSVPseudoVertexSoftElectronCvsL', 
       'CombinedSVNoVertexSoftElectronCvsL'),
+   recordLabel = cms.string(''),
    categoryVariableName = cms.string('vertexLeptonCategory')
 )
 

--- a/RecoBTag/Combined/python/candidateCombinedMVAComputer_cfi.py
+++ b/RecoBTag/Combined/python/candidateCombinedMVAComputer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 candidateCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 	useCategories = cms.bool(False),
 	calibrationRecord = cms.string('CombinedMVA'),
+        recordLabel = cms.string(''),
 	jetTagComputers = cms.VPSet(
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTag/Combined/python/candidateNegativeCombinedMVAComputer_cfi.py
+++ b/RecoBTag/Combined/python/candidateNegativeCombinedMVAComputer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 candidateNegativeCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 	useCategories = cms.bool(False),
 	calibrationRecord = cms.string('CombinedMVA'),
+        recordLabel = cms.string(''),
 	jetTagComputers = cms.VPSet(
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTag/Combined/python/candidatePositiveCombinedMVAComputer_cfi.py
+++ b/RecoBTag/Combined/python/candidatePositiveCombinedMVAComputer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 candidatePositiveCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 	useCategories = cms.bool(False),
 	calibrationRecord = cms.string('CombinedMVA'),
+        recordLabel = cms.string(''),
 	jetTagComputers = cms.VPSet(
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTag/Combined/python/combinedMVAComputer_cfi.py
+++ b/RecoBTag/Combined/python/combinedMVAComputer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 combinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 	useCategories = cms.bool(False),
 	calibrationRecord = cms.string('CombinedMVA'),
+        recordLabel = cms.string(''),
 	jetTagComputers = cms.VPSet(
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTag/Combined/python/negativeCombinedMVAComputer_cfi.py
+++ b/RecoBTag/Combined/python/negativeCombinedMVAComputer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 negativeCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 	useCategories = cms.bool(False),
 	calibrationRecord = cms.string('CombinedMVA'),
+        recordLabel = cms.string(''),
 	jetTagComputers = cms.VPSet(
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTag/Combined/python/positiveCombinedMVAComputer_cfi.py
+++ b/RecoBTag/Combined/python/positiveCombinedMVAComputer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 positiveCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 	useCategories = cms.bool(False),
 	calibrationRecord = cms.string('CombinedMVA'),
+        recordLabel = cms.string(''),
 	jetTagComputers = cms.VPSet(
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTag/ImpactParameter/python/impactParameterMVAComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/impactParameterMVAComputer_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 # impactParameterMVAComputer btag computer
 impactParameterMVAComputer = cms.ESProducer("GenericMVAJetTagESProducer",
     useCategories = cms.bool(False),
-    calibrationRecord = cms.string('ImpactParameterMVA')
+    calibrationRecord = cms.string('ImpactParameterMVA'),
+    recordLabel = cms.string('')
 )
-
-

--- a/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexComputer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexComputer_cfi.py
@@ -9,5 +9,6 @@ candidateCombinedSecondaryVertexComputer = cms.ESProducer("CandidateCombinedSeco
                 'CombinedSVRecoVertex',
                 'CombinedSVPseudoVertex',
                 'CombinedSVNoVertex'),
+        recordLabel = cms.string(''),
         categoryVariableName = cms.string('vertexCategory')
 )

--- a/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexSoftLeptonComputer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexSoftLeptonComputer_cfi.py
@@ -15,6 +15,7 @@ candidateCombinedSecondaryVertexSoftLeptonComputer = cms.ESProducer("CandidateCo
 		'CombinedSVRecoVertexSoftElectron', 
 		'CombinedSVPseudoVertexSoftElectron', 
 		'CombinedSVNoVertexSoftElectron'),
+        recordLabel = cms.string(''),
 	categoryVariableName = cms.string('vertexLeptonCategory')
 )
 

--- a/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexV2Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexV2Computer_cfi.py
@@ -9,5 +9,6 @@ candidateCombinedSecondaryVertexV2Computer = cms.ESProducer("CandidateCombinedSe
                'CombinedSVIVFV2RecoVertex', 
                'CombinedSVIVFV2PseudoVertex', 
                'CombinedSVIVFV2NoVertex'),
+        recordLabel = cms.string(''),
         categoryVariableName = cms.string('vertexCategory')
 )

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexComputer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexComputer_cfi.py
@@ -9,5 +9,6 @@ combinedSecondaryVertexComputer = cms.ESProducer("CombinedSecondaryVertexESProdu
 		'CombinedSVRecoVertex', 
 		'CombinedSVPseudoVertex', 
 		'CombinedSVNoVertex'),
+        recordLabel = cms.string(''),
 	categoryVariableName = cms.string('vertexCategory')
 )

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexSoftLeptonComputer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexSoftLeptonComputer_cfi.py
@@ -15,6 +15,7 @@ combinedSecondaryVertexSoftLeptonComputer = cms.ESProducer("CombinedSecondaryVer
 		'CombinedSVRecoVertexSoftElectron', 
 		'CombinedSVPseudoVertexSoftElectron', 
 		'CombinedSVNoVertexSoftElectron'),
+        recordLabel = cms.string(''),
 	categoryVariableName = cms.string('vertexLeptonCategory')
 )
 

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexV2Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexV2Computer_cfi.py
@@ -9,5 +9,6 @@ combinedSecondaryVertexV2Computer = cms.ESProducer("CombinedSecondaryVertexESPro
 		'CombinedSVIVFV2RecoVertex', 
 		'CombinedSVIVFV2PseudoVertex', 
 		'CombinedSVIVFV2NoVertex'),
+        recordLabel = cms.string(''),
 	categoryVariableName = cms.string('vertexCategory')
 )

--- a/RecoBTag/SecondaryVertex/python/ghostTrackComputer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/ghostTrackComputer_cfi.py
@@ -9,5 +9,6 @@ ghostTrackComputer = cms.ESProducer("GhostTrackESProducer",
 		'GhostTrackRecoVertex', 
 		'GhostTrackPseudoVertex', 
 		'GhostTrackNoVertex'),
+        recordLabel = cms.string(''),
 	categoryVariableName = cms.string('vertexCategory')
 )

--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
@@ -28,8 +28,9 @@ class GenericMVAJetTagComputer : public JetTagComputer {
 	taggingVariables(const TagInfoHelper &info) const;
 
     private:
-	std::auto_ptr<TagInfoMVACategorySelector> categorySelector;
-	GenericMVAComputerCache computerCache;
+	std::auto_ptr<TagInfoMVACategorySelector> categorySelector_;
+	GenericMVAComputerCache computerCache_;
+        std::string recordLabel_;
 };
 
 #endif // RecoBTau_JetTagComputer_GenericMVAJetTagComputer_h

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -39,7 +39,8 @@ getCalibrationLabels(const edm::ParameterSet &params,
 
 GenericMVAJetTagComputer::GenericMVAJetTagComputer(
 					const edm::ParameterSet &params) :
-	computerCache(getCalibrationLabels(params, categorySelector))
+	computerCache_(getCalibrationLabels(params, categorySelector_)),
+        recordLabel_(params.getParameter<std::string>("recordLabel"))
 {
 }
 
@@ -53,11 +54,11 @@ void GenericMVAJetTagComputer::initialize(const JetTagComputerRecord & record) {
 
 	// retrieve MVAComputer calibration container
 	edm::ESHandle<Calibration::MVAComputerContainer> calibHandle;
-	dependentRecord.get(calibHandle);
+	dependentRecord.get(recordLabel_, calibHandle);
 	const Calibration::MVAComputerContainer *calib = calibHandle.product();
 
 	// check for updates
-	computerCache.update(calib);
+	computerCache_.update(calib);
 }
 
 float GenericMVAJetTagComputer::discriminator(const TagInfoHelper &info) const
@@ -66,13 +67,13 @@ float GenericMVAJetTagComputer::discriminator(const TagInfoHelper &info) const
 
 	// retrieve index of computer in case categories are used
 	int index = 0;
-	if (categorySelector.get()) {
-		index = categorySelector->findCategory(variables);
+	if (categorySelector_.get()) {
+		index = categorySelector_->findCategory(variables);
 		if (index < 0)
 			return -10.0;
 	}
 
-	GenericMVAComputer const* computer = computerCache.getComputer(index);
+	GenericMVAComputer const* computer = computerCache_.getComputer(index);
 
 	if (!computer)
 		return -10.0;


### PR DESCRIPTION
- modify the GenericMVAJetTagComputers adding a label to choose calibrations
- customise the CombinedSecondaryVertexESProducer to read b-tagging calibrations with the "HLT" label
- customise the PFProducer to read the PF calibrations with the "HLT" label
