### PR TITLE
Adding label HLT for PFCalibrationRcd

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -18,9 +18,9 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v10',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v9',
+    'run1_data'         :   '76X_dataRun1_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v9',
+    'run2_data'         :   '76X_dataRun2_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of Changes in the GT
## RunI data
- **RunI Offline processing** : [76X_dataRun1_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v10) as [76X_dataRun1_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v10/76X_dataRun1_v9): 
  - added a label for PF hadron calibration specific for HLT usage.
## RunII data
- **RunII Offline processing** : [76X_dataRun2_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v10) as [76X_dataRun2_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v10/76X_dataRun2_v9): 
  - added a label for PF hadron calibration specific for HLT usage

Needed for #12100 to pass `addOn` tests
