### PR TITLE
Adding label HLT for PFCalibrationRcd

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,13 +10,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v10',
+    'run2_design'       :   '76X_mcRun2_design_v11',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v10',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v11',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v10',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v10',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v11',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '76X_dataRun1_v10',
     # GlobalTag for Run2 data reprocessing
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v6',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -18,9 +18,9 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v10',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v9',
+    'run1_data'         :   '76X_dataRun1_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v9',
+    'run2_data'         :   '76X_dataRun2_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of Changes in the GT
## RunII simulation
- **RunII Ideal scenario** : [76X_mcRun2_design_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v11) as [76X_mcRun2_design_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_design_v11/76X_mcRun2_design_v10):  
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
- **RunII Asymptotic scenario** : [76X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v11) as [76X_mcRun2_asymptotic_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_asymptotic_v11/76X_mcRun2_asymptotic_v10): 
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
- **RunII Startup scenario** : [76X_mcRun2_startup_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v11) as [76X_mcRun2_startup_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_startup_v11/76X_mcRun2_startup_v10): 
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
- **RunII Heavy Ions scenario** : [76X_mcRun2_HeavyIon_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v11) as [76X_mcRun2_HeavyIon_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_HeavyIon_v11/76X_mcRun2_HeavyIon_v10): 
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
## RunI data
- **RunI Offline processing** : [76X_dataRun1_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v10) as [76X_dataRun1_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v10/76X_dataRun1_v9): 
  - added a label for PF hadron calibration specific for HLT usage.
## RunII data
- **RunII Offline processing** : [76X_dataRun2_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v10) as [76X_dataRun2_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v10/76X_dataRun2_v9): 
  - added a label for PF hadron calibration specific for HLT usage
## Upgrade
- **PhaseI design scenario** : [76X_upgrade2017_design_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v7) as [76X_upgrade2017_design_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v6) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_upgrade2017_design_v7/76X_upgrade2017_design_v6): 
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC  

Needed for #12100 to pass `addOn` tests
