### PR TITLE
Add eras for 2016 and Run 1 (76X)

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -12,6 +12,7 @@ class Eras (object):
         self.run2_50ns_specific = cms.Modifier()
         self.run2_HI_specific = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
+        self.stage2L1Trigger = cms.Modifier()
         # Implementation note: When this was first started, stage1L1Trigger wasn't in all
         # of the eras. Now that it is, it could in theory be dropped if all changes are
         # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -23,7 +23,13 @@ class Eras (object):
         # activated automatically if the "--fast" command is used.
         self.fastSim = cms.Modifier()
         
+        #
         # These are the eras that the user should specify
+        #
+        # Run1 currently does nothing. It's useful to use as a no-operation era commands when scripting,
+        # but also retains the flexibility to add Run1 specific commands at a later date.
+        self.Run1 = cms.Modifier()
+        # The various Run2 scenarios for 2015 startup.
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific, self.stage1L1Trigger )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -27,6 +27,8 @@ class Eras (object):
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific, self.stage1L1Trigger )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+        # Future Run 2 scenarios.
+        self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger )
         
         # The only thing this collection is used for is for cmsDriver to
         # warn the user if they specify an era that is discouraged from being


### PR DESCRIPTION
As requested this is a back port of #12023 for 7_6_X.  There was some discussion on there about changing era names, but then it was merged so I assume everything is okay.  If not please comment here.

**The description for #12023 copied here for completeness:**
This adds a `Run2_2016` era that uses the stage 2 trigger. The `stage2L1Trigger` sub-era component of it is currently empty, but I'm expecting trigger experts to apply the correct commands.

A `Run1` era is also added. This is foreseen as a no-operation era to help with scripting cmsDriver commands (e.g. `--era=$MY_ERA`). However, it also adds the flexibility to add customisation changes at a later date.

Both of these additions were discussed in the 20/Oct/2015 release planning meeting.
