### PR TITLE
Take out the era customisations now that L1 comes from GT (76X)

### DIFF
--- a/L1TriggerConfig/L1GtConfigProducers/python/l1GtTriggerMenuXml_cfi.py
+++ b/L1TriggerConfig/L1GtConfigProducers/python/l1GtTriggerMenuXml_cfi.py
@@ -13,12 +13,3 @@ l1GtTriggerMenuXml = cms.ESProducer("L1GtTriggerMenuXmlProducer",
     # XML file for Global Trigger VME configuration (vme.xml)                 
     VmeXmlFile = cms.string('')
 )
-
-#
-# Make changes for Run 2
-#
-from Configuration.StandardSequences.Eras import eras
-# Change the trigger menu depending on whether this is 25ns, 50ns or HI running
-eras.run2_50ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_50nsGct_v1_L1T_Scales_20141121_Imp0_0x1030.xml' )
-eras.run2_25ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )
-eras.run2_HI_specific.toModify( l1GtTriggerMenuXml,   DefXmlFile = 'L1Menu_CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1.xml' )


### PR DESCRIPTION
Back port of the 80X #12116 as requested.

**Description from #12116 copied here for completeness:**
Now that the L1 configuration comes from the Global Tag, era customisations should no longer be required. As far as I'm aware this file is not used anyway, if anyone is using it with `process.load("L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi")` it's because they want to use their own custom menu anyway.
