### PR TITLE
MiniAOD event content updates for 76X

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -58,6 +58,7 @@ MicroEventContent = cms.PSet(
         'keep *_TriggerResults_*_*', # for MET filters (a catch all for the moment, but ideally it should be only the current process)
         'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
+        'keep recoCSCHaloData_CSCHaloData_*_*',
         'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
         'keep *_caTopTagInfosPAT_*_*'
     )

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -58,6 +58,7 @@ MicroEventContent = cms.PSet(
         'keep *_TriggerResults_*_*', # for MET filters (a catch all for the moment, but ideally it should be only the current process)
         'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
+        'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
         'keep *_caTopTagInfosPAT_*_*'
     )
 )

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -37,10 +37,13 @@ MicroEventContent = cms.PSet(
         'keep *_offlineSlimmedPrimaryVertices_*_*',
         'keep patPackedCandidates_packedPFCandidates_*_*',
 
+        'keep *_bunchSpacingProducer_*_*',
+
         #'keep double_fixedGridRho*__*',
         'keep double_fixedGridRhoAll__*',
         'keep double_fixedGridRhoFastjetAll__*',
         'keep double_fixedGridRhoFastjetAllCalo__*',
+        'keep double_fixedGridRhoFastjetCentral_*_*',
         'keep double_fixedGridRhoFastjetCentralCalo__*',
         'keep double_fixedGridRhoFastjetCentralChargedPileUp__*',
         'keep double_fixedGridRhoFastjetCentralNeutral__*',

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -17,3 +17,4 @@ from PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi      import *
 from PhysicsTools.PatAlgos.slimming.metFilterPaths_cff   import *
 from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import *
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi  import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import bunchSpacingProducer


### PR DESCRIPTION
Include a few extra quantities on miniAOD:
- bunch spacing
- rho in the central part of the detector, added to reco in #11875 
- some inputs to MET filters, to allow a retuning of the filters for Moriond

there will be another PR adding a few other bools to the CSCHaloData format, but that won't conflict with this PR

should we save the bunch spacing also on AOD? 
even if it can be recomputed easily, it may be convenient to have it stored anyway (e.g. for people using fwlite), and the disk size cost is zero.

the branch merges also cleanly in 8_0_X: should I make a separate PR or is the auto-forward-port enabled between 7_6_X and 8_0_X?

@mariadalfonso @arizzi
