### PR TITLE
Take Stage 1 trigger out of 50ns era

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -13,11 +13,6 @@ class Eras (object):
         self.run2_HI_specific = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
         self.stage2L1Trigger = cms.Modifier()
-        # Implementation note: When this was first started, stage1L1Trigger wasn't in all
-        # of the eras. Now that it is, it could in theory be dropped if all changes are
-        # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to
-        # "run2_common" over the whole python tree). In practice, I don't think it's worth
-        # it, and this also gives the flexibilty to take it out easily.
         
         # This era should not be set by the user with the "--era" command, it's
         # activated automatically if the "--fast" command is used.
@@ -31,7 +26,7 @@ class Eras (object):
         self.Run1 = cms.Modifier()
         # The various Run2 scenarios for 2015 startup.
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
-        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific, self.stage1L1Trigger )
+        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
         # Future Run 2 scenarios.
         self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger )


### PR DESCRIPTION
The Stage 1 trigger should never have been in the 50ns era, this takes it out.  It originally came about because at some stage the Stage 1 customisations were added to the `customisePostLS1_50ns` customisation function (see [SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py#L9](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py#L9)), and the eras were just copied from them.

I'm moderately sure all trigger configuration comes from the Global Tag now, so I don't think this will change anything in the comparisons.  It's better to get the code to reflect reality though so as not to confuse future maintainers.

Submitting this for 7_6_X - I'm assuming if merged it also automatically gets applied to 8_0_X.  If not let me know and I'll put in a separate PR.

@mulhearn, @davidlange6 
