### PR TITLE
Set class version number to 2 for CastorShowerLibraryInfo

### DIFF
--- a/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
@@ -31,7 +31,7 @@ class SLBin: public TObject {
              unsigned int        NBins;
              unsigned int        NEvtPerBin;
              std::vector<double> Bins;
-    ClassDef(SLBin,1);
+    ClassDef(SLBin,2);
 };
 
 class CastorShowerLibraryInfo : public TObject {
@@ -48,7 +48,7 @@ class CastorShowerLibraryInfo : public TObject {
     SLBin Eta;
     SLBin Phi;
 
-    ClassDef(CastorShowerLibraryInfo,1);
+    ClassDef(CastorShowerLibraryInfo,2);
     
   };
 

--- a/SimDataFormats/CaloHit/src/classes_def.xml
+++ b/SimDataFormats/CaloHit/src/classes_def.xml
@@ -13,10 +13,12 @@
   <class name="CastorShowerEvent" ClassVersion="2">
    <version ClassVersion="2" checksum="802334252"/>
   </class>
-  <class name="CastorShowerLibraryInfo" ClassVersion="1">
+  <class name="CastorShowerLibraryInfo" ClassVersion="2">
+   <version ClassVersion="2" checksum="3924826676"/>
    <version ClassVersion="1" checksum="3924826676"/>
   </class>
-  <class name="SLBin" ClassVersion="1">
+  <class name="SLBin" ClassVersion="2">
+   <version ClassVersion="2" checksum="1661681871"/>
    <version ClassVersion="1" checksum="1661681871"/>
   </class>
   <class name="HFShowerLibraryEventInfo" ClassVersion="10">


### PR DESCRIPTION
Philippe Canal stated that using version 1 for this case is inappropriate
and 2 should be used instead. The number 1 is reserved for 'unversioned'
classes.
