### PR TITLE
Add hcal fraction to packed candidates (76X)

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -564,6 +564,11 @@ namespace pat {
     float puppiWeight() const;                          /// Weight from full PUPPI
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
+    // for teh neutral fraction
+    void setHcalFraction(float p);                      /// Set the fraction of Ecal and Hcal needed for HF and neutral hadrons
+    float hcalFraction() const { return hcalFraction_; }    /// Fraction of Ecal and Hcal for HF and neutral hadrons
+
+
   protected:
     friend class ::testPackedCandidate;
 
@@ -582,6 +587,8 @@ namespace pat {
 
     int8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
+    int8_t hcalFraction_;
+
     /// the four vector                                                 
     mutable std::atomic<PolarLorentzVector*> p4_;
     mutable std::atomic<LorentzVector*> p4c_;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -566,7 +566,7 @@ namespace pat {
     
     // for teh neutral fraction
     void setHcalFraction(float p);                      /// Set the fraction of Ecal and Hcal needed for HF and neutral hadrons
-    float hcalFraction() const { return hcalFraction_; }    /// Fraction of Ecal and Hcal for HF and neutral hadrons
+    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons
 
 
   protected:

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -46,6 +46,7 @@ namespace pat {
       packedCovarianceDphiDphi_(0),
       packedPuppiweight_(0),
       packedPuppiweightNoLepDiff_(0),
+      hcalFraction_(0),
       p4_(new PolarLorentzVector(0,0,0,0)), p4c_( new LorentzVector(0,0,0,0)), 
       vertex_(new Point(0,0,0)), dphi_(0), track_(nullptr), pdgId_(0),
       qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()),
@@ -56,6 +57,7 @@ namespace pat {
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
       p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), dphi_(0), 
       track_(nullptr), pdgId_(c.pdgId()), qualityFlags_(0), pvRefProd_(pvRefProd),
@@ -69,6 +71,7 @@ namespace pat {
                               float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
       p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
       vertex_( new Point(vtx) ), dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
       track_(nullptr), pdgId_(pdgId),
@@ -82,6 +85,7 @@ namespace pat {
                               float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
       p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
       p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
       dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
@@ -106,6 +110,7 @@ namespace pat {
       packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      hcalFraction_(iOther.hcalFraction_),
       //Need to trigger unpacking in iOther
       p4_( new PolarLorentzVector(iOther.polarP4() ) ),
       p4c_( new LorentzVector(iOther.p4())), vertex_( new Point(iOther.vertex())),
@@ -131,6 +136,7 @@ namespace pat {
       packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      hcalFraction_(iOther.hcalFraction_),
       p4_( iOther.p4_.exchange(nullptr) ) ,
       p4c_( iOther.p4c_.exchange(nullptr)), vertex_(iOther.vertex_.exchange(nullptr)),
       dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_), 
@@ -164,6 +170,7 @@ namespace pat {
       packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      hcalFraction_=iOther.hcalFraction_;
       //Need to trigger unpacking in iOther
       if(p4_) {
         *p4_ = iOther.polarP4();
@@ -232,6 +239,7 @@ namespace pat {
       packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      hcalFraction_=iOther.hcalFraction_;
       delete p4_.exchange(iOther.p4_.exchange(nullptr));
       delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
       delete vertex_.exchange(iOther.vertex_.exchange(nullptr));

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -313,3 +313,7 @@ void pat::PackedCandidate::setPuppiWeight(float p, float p_nolep) {
 float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
+
+void pat::PackedCandidate::setHcalFraction(float p) {
+  hcalFraction_ = p;
+}

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -315,5 +315,5 @@ float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packed
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
 void pat::PackedCandidate::setHcalFraction(float p) {
-  hcalFraction_ = p;
+  hcalFraction_ = 100*p;
 }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -277,7 +277,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="25">
+  <class name="pat::PackedCandidate" ClassVersion="26">
+    <version ClassVersion="26" checksum="2986327792"/>
     <version ClassVersion="25" checksum="3654469025"/>
     <version ClassVersion="24" checksum="663492232"/>
     <version ClassVersion="23" checksum="559934341"/>

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -248,7 +248,16 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
           outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), PVpos, cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
         }
+
+	// neutrals
+
+	if(abs(cand.pdgId()) == 1 || cand.pdgId() == 2 || cand.pdgId() == 130) {
+	  outPtrP->back().setHcalFraction(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy()));
+	} else {
+	  outPtrP->back().setHcalFraction(-1.);
+	}
 	
+       
         if (puppiWeight.isValid()){
            reco::PFCandidateRef pkref( cands, ic );
                  // outPtrP->back().setPuppiWeight( (*puppiWeight)[pkref]);

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -251,8 +251,8 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
 	// neutrals
 
-	if(abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 2 || abs(cand.pdgId()) == 130) {
-	  outPtrP->back().setHcalFraction(100*(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy())));
+	if(abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
+	  outPtrP->back().setHcalFraction(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy()));
 	} else {
 	  outPtrP->back().setHcalFraction(0);
 	}

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -251,10 +251,10 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
 	// neutrals
 
-	if(abs(cand.pdgId()) == 1 || cand.pdgId() == 2 || cand.pdgId() == 130) {
-	  outPtrP->back().setHcalFraction(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy()));
+	if(abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 2 || abs(cand.pdgId()) == 130) {
+	  outPtrP->back().setHcalFraction(100*(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy())));
 	} else {
-	  outPtrP->back().setHcalFraction(-1.);
+	  outPtrP->back().setHcalFraction(0);
 	}
 	
        


### PR DESCRIPTION
Save hcal energy fraction for pf candidates corresponding to neutral hadrons in the tracker (pdgId 130) or in the HF (pdgId 1). 
The energy fraction is packed with an absolute precision of 1%. We will evaluate later if the precision can be reduced for `CMSSW_8_0_X`, depending on what we'll learn in `CMSSW_7_6_X`.
From @mariadalfonso after discussion with @arizzi and @bachtis 

The branch merges cleanly also in `CMSSW_8_0_X`, if you need a separate PR it can be made.
