### PR TITLE
Revert the HCAL method 3 response correction

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforMC.py
+++ b/HLTrigger/Configuration/python/customizeHLTforMC.py
@@ -23,10 +23,10 @@ def customizeHLTforMC(process,_fastSim=False):
     process.hltHbhereco.pedestalSubtractionType = cms.int32( 1 )
     process.hltHbhereco.pedestalUpperLimit      = cms.double( 2.7 ) 
     process.hltHbhereco.timeSlewParsType        = cms.int32( 3 )
-
-    #new MC once completely implemented
+    # new time slew parametrisation
     process.hltHbhereco.timeSlewPars            = cms.vdouble( 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 )
-    process.hltHbhereco.respCorrM3              = cms.double( 0.95 )
+    # old response correction, matching the 2015D 25ns data
+    process.hltHbhereco.respCorrM3              = cms.double( 1.0 )
 
 
   if _fastSim:


### PR DESCRIPTION
Revert the HCAL method 3 response correction to 1.0, to be consistent
with the HLT configuration used in 7.4.x and 2015 25 ns data.

This should NOT be forward-ported to 8.0.x .
