### PR TITLE
ADC region reduced to 100 for strip ClusterStoNCorr summaries.

### DIFF
--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -68,9 +68,9 @@ SiStripMonitorTrack = cms.EDAnalyzer(
     TH1ClusterStoNCorr = cms.PSet( 
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
-        Nbinx = cms.int32(200),
+        Nbinx = cms.int32(100),
         xmin  = cms.double(-0.5),
-        xmax  = cms.double(199.5)
+        xmax  = cms.double(99.5)
      ),
 
     TH1ClusterStoNCorrMod = cms.PSet(


### PR DESCRIPTION
The ADC region of ClusterStoNCorr summaries for SiStrip is reduced from 0~200 to 0~100.

reference for 74X: #12081 
