### PR TITLE
New FED modes handled in SiStrip unpacker

### DIFF
--- a/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
@@ -95,19 +95,27 @@ namespace sistrip {
   static const char unknownApvReadoutMode_[]   = "UnknownApvReadoutMode";
   static const char undefinedApvReadoutMode_[] = "UndefinedApvReadoutMode";
 
-  static const char apvPeakMode_[] = "ApvPeakMode";
+  static const char apvPeakMode_[]  = "ApvPeakMode";
   static const char apvDeconMode_[] = "ApvDeconMode";
   static const char apvMultiMode_[] = "ApvMultiMode";
 
   static const char unknownFedReadoutMode_[]   = "UnknownFedReadoutMode";
   static const char undefinedFedReadoutMode_[] = "UndefinedFedReadoutMode";
 
-  static const char fedScopeMode_[]     = "FedScopeMode";
-  static const char fedVirginRaw_[]     = "FedVirginRaw";
-  static const char fedProcRaw_[]       = "FedProcessedRaw";
-  static const char fedZeroSuppr_[]     = "FedZeroSuppressed";
-  static const char fedZeroSupprLite_[] = "FedZeroSupprressedLite";
-  static const char fedPreMixRaw_[]     = "FedPreMixRaw";
+  static const char fedScopeMode_[]            = "FedScopeMode";
+  static const char fedVirginRaw_[]            = "FedVirginRaw";
+  static const char fedProcRaw_[]              = "FedProcessedRaw";
+  static const char fedZeroSuppr_[]            = "FedZeroSuppressed";
+  static const char fedZeroSupprCMO_[]         = "FedZeroSuppressedCMOverride";
+  static const char fedZeroSupprLite_[]        = "FedZeroSupprressedLite";
+  static const char fedZeroSupprLiteCMO_[]     = "FedZeroSuppressedLiteCMOverride";
+  static const char fedZeroSupprLite8TT_[]     = "FedZeroSuppressedLite8TT";
+  static const char fedZeroSupprLite8TTCMO_[]  = "FedZeroSuppressedLite8TTCMOverride";
+  static const char fedZeroSupprLite8TB_[]     = "FedZeroSuppressedLite8TB";
+  static const char fedZeroSupprLite8TBCMO_[]  = "FedZeroSuppressedLite8TBCMOverride";
+  static const char fedZeroSupprLite8BB_[]     = "FedZeroSuppressedLite8BB";
+  static const char fedZeroSupprLite8BBCMO_[]  = "FedZeroSuppressedLite8BBCMOverride";
+  static const char fedPreMixRaw_[]            = "FedPreMixRaw";
   
   // -------------------- Enumerators --------------------
   
@@ -119,13 +127,20 @@ namespace sistrip {
   };
   
   enum FedReadoutMode { UNKNOWN_FED_READOUT_MODE = sistrip::unknown_,
-			UNDEFINED_FED_READOUT_MODE = sistrip::invalid_,
-			FED_SCOPE_MODE = 1, 
-			FED_VIRGIN_RAW = 2, 
-			FED_PROC_RAW = 6, 
-			FED_ZERO_SUPPR = 10,
-			FED_ZERO_SUPPR_LITE = 12,
-			FED_PREMIX_RAW = 15
+                        UNDEFINED_FED_READOUT_MODE = sistrip::invalid_,
+                        FED_SCOPE_MODE = 1, 
+                        FED_VIRGIN_RAW = 2, 
+                        FED_PROC_RAW = 6, 
+                        FED_ZERO_SUPPR = 10,
+                        FED_ZERO_SUPPR_LITE = 3,
+                        FED_ZERO_SUPPR_LITE_CMO = 4,
+                        FED_ZERO_SUPPR_LITE8_TT = 12,
+                        FED_ZERO_SUPPR_LITE8_TT_CMO = 8,
+                        FED_ZERO_SUPPR_LITE8_TB = 5,
+                        FED_ZERO_SUPPR_LITE8_TB_CMO = 7,
+                        FED_ZERO_SUPPR_LITE8_BB = 9,
+                        FED_ZERO_SUPPR_LITE8_BB_CMO = 11,
+                        FED_PREMIX_RAW = 15
   };
 
   enum FedReadoutPath { UNKNOWN_FED_READOUT_PATH = sistrip::unknown_,

--- a/DataFormats/SiStripCommon/src/SiStripEnumsAndStrings.cc
+++ b/DataFormats/SiStripCommon/src/SiStripEnumsAndStrings.cc
@@ -252,6 +252,13 @@ std::string SiStripEnumsAndStrings::fedReadoutMode( const sistrip::FedReadoutMod
   else if ( mode == sistrip::FED_PROC_RAW ) { return sistrip::fedProcRaw_; }
   else if ( mode == sistrip::FED_ZERO_SUPPR ) { return sistrip::fedZeroSuppr_; }
   else if ( mode == sistrip::FED_ZERO_SUPPR_LITE ) { return sistrip::fedZeroSupprLite_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE_CMO ) { return sistrip::fedZeroSupprLiteCMO_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE8_TT ) { return sistrip::fedZeroSupprLite8TT_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE8_TT_CMO ) { return sistrip::fedZeroSupprLite8TTCMO_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE8_TB ) { return sistrip::fedZeroSupprLite8TB_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE8_TB_CMO ) { return sistrip::fedZeroSupprLite8TBCMO_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE8_BB ) { return sistrip::fedZeroSupprLite8BB_; }
+  else if ( mode == sistrip::FED_ZERO_SUPPR_LITE8_BB_CMO ) { return sistrip::fedZeroSupprLite8BBCMO_; }
   else if ( mode == sistrip::UNDEFINED_FED_READOUT_MODE ) { return sistrip::undefinedFedReadoutMode_; }
   else { return sistrip::unknownFedReadoutMode_; }
 }
@@ -264,6 +271,13 @@ sistrip::FedReadoutMode SiStripEnumsAndStrings::fedReadoutMode( const std::strin
   else if ( mode.find( sistrip::fedProcRaw_ ) != std::string::npos ) { return sistrip::FED_PROC_RAW; } 
   else if ( mode.find( sistrip::fedZeroSuppr_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR; } 
   else if ( mode.find( sistrip::fedZeroSupprLite_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE; } 
+  else if ( mode.find( sistrip::fedZeroSupprLiteCMO_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE_CMO; }
+  else if ( mode.find( sistrip::fedZeroSupprLite8TT_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE8_TT; }
+  else if ( mode.find( sistrip::fedZeroSupprLite8TTCMO_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE8_TT_CMO; }
+  else if ( mode.find( sistrip::fedZeroSupprLite8TB_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE8_TB; }
+  else if ( mode.find( sistrip::fedZeroSupprLite8TBCMO_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE8_TB_CMO; }
+  else if ( mode.find( sistrip::fedZeroSupprLite8BB_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE8_BB; }
+  else if ( mode.find( sistrip::fedZeroSupprLite8BBCMO_ ) != std::string::npos ) { return sistrip::FED_ZERO_SUPPR_LITE8_BB_CMO; }
   else if ( mode.find( sistrip::undefinedFedReadoutMode_ ) != std::string::npos ) { return sistrip::UNDEFINED_FED_READOUT_MODE; } 
   else if ( mode.empty() ) { return sistrip::UNDEFINED_FED_READOUT_MODE; } 
   else { return sistrip::UNKNOWN_FED_READOUT_MODE; }

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -40,22 +40,49 @@ namespace sistrip {
   enum FEDReadoutMode { READOUT_MODE_INVALID=INVALID,
                         READOUT_MODE_SCOPE=0x1,
                         READOUT_MODE_VIRGIN_RAW=0x2,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE10=0x3,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE=0x4,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT=0x5,
                         READOUT_MODE_PROC_RAW=0x6,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE=0x7,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE=0x8,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT=0x9,
                         READOUT_MODE_ZERO_SUPPRESSED=0xA,
-                        READOUT_MODE_ZERO_SUPPRESSED_LITE=0xC,
+                        READOUT_MODE_ZERO_SUPPRESSED_FAKE=0xB,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE8=0xC,
+                        READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE=0xD,
                         READOUT_MODE_SPY=0xE,
-			READOUT_MODE_PREMIX_RAW=0xF //0x8?
+                        READOUT_MODE_PREMIX_RAW=0xF
                       };
 
-  static const uint8_t PACKET_CODE_SCOPE = 0xE5;
-  static const uint8_t PACKET_CODE_VIRGIN_RAW = 0xE6;
-  static const uint8_t PACKET_CODE_PROC_RAW = 0xF2;
-  static const uint8_t PACKET_CODE_ZERO_SUPPRESSED = 0xEA;
+  enum FEDLegacyReadoutMode { READOUT_MODE_LEGACY_INVALID=INVALID,
+                              READOUT_MODE_LEGACY_SCOPE=0x1,
+                              READOUT_MODE_LEGACY_VIRGIN_RAW_REAL=0x2,
+                              READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE=0x3,
+                              READOUT_MODE_LEGACY_PROC_RAW_REAL=0x6,
+                              READOUT_MODE_LEGACY_PROC_RAW_FAKE=0x7,
+                              READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL=0xA,
+                              READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE=0xB,
+                              READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL=0xC,
+                              READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE=0xD,
+                              READOUT_MODE_LEGACY_SPY=0xE,
+                              READOUT_MODE_LEGACY_PREMIX_RAW=0xF
+                            };
 
-  //enum values are values which appear in buffer. DO NOT CHANGE!
-  enum FEDDataType { DATA_TYPE_REAL=0,
-                     DATA_TYPE_FAKE=1
-                   };
+  static const uint8_t PACKET_CODE_SCOPE = 0xE1;
+  static const uint8_t PACKET_CODE_VIRGIN_RAW = 0xE6;
+  static const uint8_t PACKET_CODE_VIRGIN_RAW10 = 0x86; 
+  static const uint8_t PACKET_CODE_VIRGIN_RAW8_BOTBOT = 0xC6; //FIXME need to implement this!
+  static const uint8_t PACKET_CODE_VIRGIN_RAW8_TOPBOT = 0xA6;
+  static const uint8_t PACKET_CODE_PROC_RAW = 0xF2;
+  static const uint8_t PACKET_CODE_PROC_RAW10 = 0x92; //FIXME need to implement this!
+  static const uint8_t PACKET_CODE_PROC_RAW8_BOTBOT = 0xCA;
+  static const uint8_t PACKET_CODE_PROC_RAW8_TOPBOT = 0xB2;
+  static const uint8_t PACKET_CODE_ZERO_SUPPRESSED = 0xEA;
+  static const uint8_t PACKET_CODE_ZERO_SUPPRESSED_LITE10 = 0x8A;
+  static const uint8_t PACKET_CODE_ZERO_SUPPRESSED_LITE8 = 0xEA;
+  static const uint8_t PACKET_CODE_ZERO_SUPPRESSED_LITE8_BOTBOT = 0xCA;
+  static const uint8_t PACKET_CODE_ZERO_SUPPRESSED_LITE8_TOPBOT = 0xAA;
 
   //enum values are values which appear in buffer. DO NOT CHANGE!
   //see http://cmsdoc.cern.ch/cms/TRIDAS/horizontal/RUWG/DAQ_IF_guide/DAQ_IF_guide.html
@@ -114,8 +141,8 @@ namespace sistrip {
   //to make enums printable
   std::ostream& operator<<(std::ostream& os, const FEDBufferFormat& value);
   std::ostream& operator<<(std::ostream& os, const FEDHeaderType& value);
+  std::ostream& operator<<(std::ostream& os, const FEDLegacyReadoutMode& value);
   std::ostream& operator<<(std::ostream& os, const FEDReadoutMode& value);
-  std::ostream& operator<<(std::ostream& os, const FEDDataType& value);
   std::ostream& operator<<(std::ostream& os, const FEDDAQEventType& value);
   std::ostream& operator<<(std::ostream& os, const FEDTTSBits& value);
   std::ostream& operator<<(std::ostream& os, const FEDBufferState& value);
@@ -124,7 +151,6 @@ namespace sistrip {
   FEDBufferFormat fedBufferFormatFromString(const std::string& bufferFormatString);
   FEDHeaderType fedHeaderTypeFromString(const std::string& headerTypeString);
   FEDReadoutMode fedReadoutModeFromString(const std::string& readoutModeString);
-  FEDDataType fedDataTypeFromString(const std::string& dataTypeString);
   FEDDAQEventType fedDAQEventTypeFromString(const std::string& daqEventTypeString);
 
   //
@@ -267,7 +293,7 @@ namespace sistrip {
       FEDHeaderType headerType() const;
       uint8_t trackerEventTypeNibble() const;
       FEDReadoutMode readoutMode() const;
-      FEDDataType dataType() const;
+      FEDLegacyReadoutMode legacyReadoutMode() const;
       uint8_t apveAddress() const;
       uint8_t apvAddressErrorRegister() const;
       bool majorityAddressErrorForFEUnit(const uint8_t internalFEUnitNum) const;
@@ -285,7 +311,6 @@ namespace sistrip {
       TrackerSpecialHeader& setBufferFormat(const FEDBufferFormat newBufferFormat);
       TrackerSpecialHeader& setHeaderType(const FEDHeaderType headerType);
       TrackerSpecialHeader& setReadoutMode(const FEDReadoutMode readoutMode);
-      TrackerSpecialHeader& setDataType(const FEDDataType dataType);
       TrackerSpecialHeader& setAPVEAddress(const uint8_t address);
       TrackerSpecialHeader& setAPVEAddressErrorRegister(const uint8_t addressErrorRegister);
       TrackerSpecialHeader& setAPVAddressErrorForFEUnit(const uint8_t internalFEUnitNum, const bool error);
@@ -294,8 +319,7 @@ namespace sistrip {
       TrackerSpecialHeader& setFEOverflowRegister(const uint8_t feOverflowRegister);
       TrackerSpecialHeader& setFEOverflowForFEUnit(const uint8_t internalFEUnitNum, const bool overflow);
       TrackerSpecialHeader& setFEDStatusRegister(const FEDStatusRegister fedStatusRegister);
-      TrackerSpecialHeader(const FEDBufferFormat bufferFormat, const FEDReadoutMode readoutMode,
-                           const FEDHeaderType headerType, const FEDDataType dataType,
+      TrackerSpecialHeader(const FEDBufferFormat bufferFormat, const FEDReadoutMode readoutMode, const FEDHeaderType headerType,
                            const uint8_t address = 0x00, const uint8_t addressErrorRegister = 0x00,
                            const uint8_t feEnableRegister = 0xFF, const uint8_t feOverflowRegister = 0x00,
                            const FEDStatusRegister fedStatusRegister = FEDStatusRegister());
@@ -303,7 +327,6 @@ namespace sistrip {
       void setBufferFormatByte(const FEDBufferFormat newBufferFormat);
       void setHeaderTypeNibble(const uint8_t value);
       void setReadoutModeBits(const uint8_t value);
-      void setDataTypeBit(const bool value);
       enum byteIndicies { FEDSTATUS=0, FEOVERFLOW=2, FEENABLE=3, ADDRESSERROR=4, APVEADDRESS=5, BUFFERTYPE=6, BUFFERFORMAT=7 };
       //copy of header, 32 bit word swapped if needed
       uint8_t specialHeader_[8];
@@ -523,10 +546,10 @@ namespace sistrip {
       const uint8_t* data() const;
       size_t offset() const;
       uint16_t cmMedian(const uint8_t apvIndex) const;
-    private:
-      friend class FEDBuffer;
       //third byte of channel data for normal FED channels
       uint8_t packetCode() const;
+    private:
+      friend class FEDBuffer;
       const uint8_t* data_;
       size_t offset_;
       uint16_t length_;
@@ -565,8 +588,9 @@ namespace sistrip {
       //methods to get info from the tracker special header
       FEDBufferFormat bufferFormat() const;
       FEDHeaderType headerType() const;
+      FEDLegacyReadoutMode legacyReadoutMode() const;
       FEDReadoutMode readoutMode() const;
-      FEDDataType dataType() const;
+      uint8_t packetCode(bool legacy=false, const uint8_t internalFEDChannelNum=0) const;
       uint8_t apveAddress() const;
       bool majorityAddressErrorForFEUnit(const uint8_t internalFEUnitNum) const;
       bool feEnabled(const uint8_t internalFEUnitNum) const;
@@ -740,14 +764,9 @@ namespace sistrip {
   
   inline void TrackerSpecialHeader::setReadoutModeBits(const uint8_t value)
     {
-      specialHeader_[BUFFERTYPE] = ( (specialHeader_[BUFFERTYPE] & (~0x0E)) | (value & 0x0E) );
+      specialHeader_[BUFFERTYPE] = ( (specialHeader_[BUFFERTYPE] & (~0x0F)) | (value & 0x0F) );
     }
       
-  inline void TrackerSpecialHeader::setDataTypeBit(const bool value)
-    {
-      specialHeader_[BUFFERTYPE] = ( (specialHeader_[BUFFERTYPE] & (~0x01)) | (value ? 0x01 : 0x00) );
-    }
-  
   inline TrackerSpecialHeader& TrackerSpecialHeader::setAPVEAddress(const uint8_t address)
     {
       specialHeader_[APVEADDRESS] = address;
@@ -1422,14 +1441,69 @@ namespace sistrip {
       return specialHeader_.headerType();
     }
   
+  inline FEDLegacyReadoutMode FEDBufferBase::legacyReadoutMode() const
+    {
+      return specialHeader_.legacyReadoutMode();
+    }
+
   inline FEDReadoutMode FEDBufferBase::readoutMode() const
     {
       return specialHeader_.readoutMode();
     }
-  
-  inline FEDDataType FEDBufferBase::dataType() const
+
+  inline uint8_t FEDBufferBase::packetCode(bool legacy, const uint8_t internalFEDChannelNum) const
     {
-      return specialHeader_.dataType();
+      if (legacy) {
+        FEDLegacyReadoutMode mode = legacyReadoutMode();
+        switch(mode) {
+        case READOUT_MODE_LEGACY_SCOPE:
+          return PACKET_CODE_SCOPE;
+        case READOUT_MODE_LEGACY_VIRGIN_RAW_REAL:
+        case READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE:
+          return PACKET_CODE_VIRGIN_RAW;
+        case READOUT_MODE_LEGACY_PROC_RAW_REAL:
+        case READOUT_MODE_LEGACY_PROC_RAW_FAKE:
+          return PACKET_CODE_PROC_RAW;
+        case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL:
+        case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE:
+          return PACKET_CODE_ZERO_SUPPRESSED;
+        case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL:
+        case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE:
+        case READOUT_MODE_LEGACY_PREMIX_RAW:
+        case READOUT_MODE_LEGACY_SPY:
+        case READOUT_MODE_LEGACY_INVALID:
+        default:
+          return 0;
+        }
+      } else {
+        FEDReadoutMode mode = readoutMode();
+        switch(mode) {
+        case READOUT_MODE_SCOPE:
+          return PACKET_CODE_SCOPE;
+        case READOUT_MODE_VIRGIN_RAW:
+          return channel(internalFEDChannelNum).packetCode();
+        case READOUT_MODE_PROC_RAW:
+          return PACKET_CODE_PROC_RAW;
+        case READOUT_MODE_ZERO_SUPPRESSED:
+          return PACKET_CODE_ZERO_SUPPRESSED;
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+          return PACKET_CODE_ZERO_SUPPRESSED_LITE10;
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+          return PACKET_CODE_ZERO_SUPPRESSED_LITE8_BOTBOT;
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
+          return PACKET_CODE_ZERO_SUPPRESSED_LITE8_TOPBOT;
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+        case READOUT_MODE_PREMIX_RAW:
+        case READOUT_MODE_SPY:
+        case READOUT_MODE_INVALID:
+        default:
+          return 0;
+        }
+      }
     }
   
   inline uint8_t FEDBufferBase::apveAddress() const

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -32,7 +32,7 @@ namespace sistrip {
         //get the 10bit value to be used for raw modes
         uint16_t getSample(const uint16_t sampleNumber) const;
         //get the 8 bit value to be used for ZS modes, converting it as the FED does if specified in constructor
-        uint8_t get8BitSample(const uint16_t sampleNumber) const;
+        uint8_t get8BitSample(const uint16_t sampleNumber, const FEDReadoutMode mode) const;
         uint16_t get10BitSample(const uint16_t sampleNumber) const;
         void setSample(const uint16_t sampleNumber, const uint16_t adcValue);
         //setting value directly is equivalent to get and set Sample but without length check
@@ -93,10 +93,10 @@ namespace sistrip {
                                 const FEDStripData::ChannelData& data, const bool channelEnabled, const bool reorderData) const;
       //fill the vector with channel data for zero suppressed modes
       void fillZeroSuppressedChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
-      void fillZeroSuppressedLiteChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
-       void fillPreMixRawChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
+      void fillZeroSuppressedLiteChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled, const FEDReadoutMode mode) const;
+      void fillPreMixRawChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
      //add the ZS cluster data for the channel to the end of the vector
-      void fillClusterData(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data) const;
+      void fillClusterData(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const FEDReadoutMode mode) const;
       void fillClusterDataPreMixMode(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data) const;
       std::vector<bool> feUnitsEnabled_;
       std::vector<bool> channelsEnabled_;
@@ -113,8 +113,7 @@ namespace sistrip {
                          const FEDReadoutMode readoutMode = READOUT_MODE_ZERO_SUPPRESSED,
                          const FEDHeaderType headerType = HEADER_TYPE_FULL_DEBUG,
                          const FEDBufferFormat bufferFormat = BUFFER_FORMAT_OLD_SLINK,
-                         const FEDDAQEventType evtType = DAQ_EVENT_TYPE_PHYSICS,
-                         const FEDDataType dataType = DATA_TYPE_FAKE);
+                         const FEDDAQEventType evtType = DAQ_EVENT_TYPE_PHYSICS);
       //methods to get and set the defaults
       uint32_t getL1ID() const;
       uint16_t getBXID() const;
@@ -122,14 +121,12 @@ namespace sistrip {
       FEDHeaderType getHeaderType() const;
       FEDBufferFormat getBufferFormat() const;
       FEDDAQEventType getDAQEventType() const;
-      FEDDataType getFEDDataType() const;
       FEDBufferGenerator& setL1ID(const uint32_t newL1ID);
       FEDBufferGenerator& setBXID(const uint16_t newBXID);
       FEDBufferGenerator& setReadoutMode(const FEDReadoutMode newReadoutMode);
       FEDBufferGenerator& setHeaderType(const FEDHeaderType newHeaderType);
       FEDBufferGenerator& setBufferFormat(const FEDBufferFormat newBufferFormat);
       FEDBufferGenerator& setDAQEventType(const FEDDAQEventType newDAQEventType);
-      FEDBufferGenerator& setFEDDataType(const FEDDataType newFEDDataType);
       //disabled FE units produce no data at all
       //disabled channels have headers but data is all zeros (raw modes) or have no clusters (ZS)
       bool getFEUnitEnabled(const uint8_t internalFEUnitNumber) const;
@@ -234,11 +231,30 @@ namespace sistrip {
     return data_[sampleNumber];
   }
   
-  inline uint8_t FEDStripData::ChannelData::get8BitSample(const uint16_t sampleNumber) const
+  inline uint8_t FEDStripData::ChannelData::get8BitSample(const uint16_t sampleNumber, const FEDReadoutMode mode) const
   {
-    if (dataIs8Bit_) return (0xFF & getSample(sampleNumber));
+    uint16_t sample = getSample(sampleNumber);
+    // one start shifting the word
+    switch (mode) {
+      case READOUT_MODE_ZERO_SUPPRESSED:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+        break;
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
+        sample = (sample>>1);
+        break;
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+        sample = (sample>>2);
+        break;
+      default:
+        throw cms::Exception("FEDBufferGenerator") << "Invalid readout mode requested for 8-bit sample retrieval";
+    }
+    if (dataIs8Bit_) {
+      return (0xFF & sample);
+    }
     else {
-      const uint16_t sample = getSample(sampleNumber);
       if (sample < 0xFE) return sample;
       else if (sample == 0x3FF) return 0xFF;
       else return 0xFE;
@@ -330,11 +346,6 @@ namespace sistrip {
       return defaultDAQHeader_.eventType();
     }
   
-  inline FEDDataType FEDBufferGenerator::getFEDDataType() const
-    {
-      return defaultTrackerSpecialHeader_.dataType();
-    }
-  
   inline FEDBufferGenerator& FEDBufferGenerator::setL1ID(const uint32_t newL1ID)
     {
       defaultDAQHeader_.setL1ID(newL1ID);
@@ -368,12 +379,6 @@ namespace sistrip {
   inline FEDBufferGenerator& FEDBufferGenerator::setDAQEventType(const FEDDAQEventType newDAQEventType)
     {
       defaultDAQHeader_.setEventType(newDAQEventType);
-      return *this;
-    }
-  
-  inline FEDBufferGenerator& FEDBufferGenerator::setFEDDataType(const FEDDataType newFEDDataType)
-    {
-      defaultTrackerSpecialHeader_.setDataType(newFEDDataType);
       return *this;
     }
   

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -34,12 +34,20 @@ namespace sistrip {
 
     
     switch(mode_) {
-    case READOUT_MODE_ZERO_SUPPRESSED_LITE: rawdigi_ = false; break;
-    case READOUT_MODE_ZERO_SUPPRESSED:      rawdigi_ = false; break;
-    case READOUT_MODE_PREMIX_RAW:      rawdigi_ = false; break; 
-    case READOUT_MODE_VIRGIN_RAW:      rawdigi_ = true; break;
-    case READOUT_MODE_PROC_RAW:        rawdigi_ = true; break;
-    case READOUT_MODE_SCOPE:           rawdigi_ = true; break;
+    case READOUT_MODE_ZERO_SUPPRESSED:                         rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_FAKE:                    rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10:                  rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:       rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8:                   rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:        rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:            rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE: rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:            rawdigi_ = false; break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE: rawdigi_ = false; break;
+    case READOUT_MODE_PREMIX_RAW:                              rawdigi_ = false; break; 
+    case READOUT_MODE_VIRGIN_RAW:                              rawdigi_ = true; break;
+    case READOUT_MODE_PROC_RAW:                                rawdigi_ = true; break;
+    case READOUT_MODE_SCOPE:                                   rawdigi_ = true; break;
     case READOUT_MODE_INVALID: {
       if( edm::isDebugEnabled()) {
 	edm::LogWarning("DigiToRawModule") 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.cc
@@ -34,6 +34,7 @@ namespace sistrip {
     token_ = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel"));
     int16_t appended_bytes = pset.getParameter<int>("AppendedBytes");
     int16_t trigger_fed_id = pset.getParameter<int>("TriggerFedId");
+    bool legacy_unpacker = pset.getParameter<bool>("LegacyUnpacker");
     bool use_daq_register = pset.getParameter<bool>("UseDaqRegister");
     bool using_fed_key = pset.getParameter<bool>("UseFedKey");
     bool unpack_bad_channels = pset.getParameter<bool>("UnpackBadChannels");
@@ -49,6 +50,7 @@ namespace sistrip {
     uint32_t errorThreshold = pset.getParameter<unsigned int>("ErrorThreshold");
 
     rawToDigi_ = new sistrip::RawToDigiUnpacker( appended_bytes, fed_buffer_dump_freq, fed_event_dump_freq, trigger_fed_id, using_fed_key, unpack_bad_channels, mark_missing_feds, errorThreshold);
+    rawToDigi_->legacy(legacy_unpacker);
     rawToDigi_->quiet(quiet);
     rawToDigi_->useDaqRegister( use_daq_register ); 
     rawToDigi_->extractCm(extractCm_);

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -63,6 +63,8 @@ namespace sistrip {
 
     inline void doAPVEmulatorCheck( bool );
 
+    inline void legacy( bool );
+
   private:
     
     /// fill DetSetVectors using registries
@@ -128,6 +130,7 @@ namespace sistrip {
     bool extractCm_;    
     bool doFullCorruptBufferChecks_;
     bool doAPVEmulatorCheck_;
+    bool legacy_;
     uint32_t errorThreshold_;
     
     /// registries
@@ -167,13 +170,7 @@ sistrip::FedBufferFormat sistrip::RawToDigiUnpacker::fedBufferFormat( const uint
 
 sistrip::FedReadoutMode sistrip::RawToDigiUnpacker::fedReadoutMode( const uint16_t& register_value ) 
 {
-  if ( ((register_value>>1)&0x7) == 0x0 ) { return sistrip::FED_SCOPE_MODE; }
-  else if ( ((register_value>>1)&0x7) == 0x1 ) { return sistrip::FED_VIRGIN_RAW; }
-  else if ( ((register_value>>1)&0x7) == 0x3 ) { return sistrip::FED_PROC_RAW; }
-  else if ( ((register_value>>1)&0x7) == 0x5 ) { return sistrip::FED_ZERO_SUPPR; }
-  else if ( ((register_value>>1)&0x7) == 0x6 ) { return sistrip::FED_ZERO_SUPPR_LITE; }
-  else if ( ((register_value>>1)&0x7) == 0x7 ) { return sistrip::FED_PREMIX_RAW; } //new mode
-  else { return sistrip::UNKNOWN_FED_READOUT_MODE; }
+  return static_cast<sistrip::FedReadoutMode>(register_value&0xF);
 }
 
 void sistrip::RawToDigiUnpacker::quiet( bool quiet ) { quiet_ = quiet; }
@@ -185,6 +182,8 @@ void sistrip::RawToDigiUnpacker::extractCm( bool extract_cm ) { extractCm_ = ext
 void sistrip::RawToDigiUnpacker::doFullCorruptBufferChecks( bool do_full_corrupt_buffer_checks ) { doFullCorruptBufferChecks_ = do_full_corrupt_buffer_checks; }
 
 void sistrip::RawToDigiUnpacker::doAPVEmulatorCheck( bool do_APVEmulator_check) { doAPVEmulatorCheck_ = do_APVEmulator_check; }
+
+void sistrip::RawToDigiUnpacker::legacy( bool legacy ) { legacy_ = legacy; }
 
 #endif // EventFilter_SiStripRawToDigi_SiStripRawToDigiUnpacker_H
 

--- a/EventFilter/SiStripRawToDigi/python/ExcludedFEDListProducer_cfi.py
+++ b/EventFilter/SiStripRawToDigi/python/ExcludedFEDListProducer_cfi.py
@@ -2,4 +2,4 @@ import FWCore.ParameterSet.Config as cms
 import EventFilter.SiStripRawToDigi.siStripExcludedFEDListProducer_cfi
 
 SiStripExcludedFEDListProducer = EventFilter.SiStripRawToDigi.siStripExcludedFEDListProducer_cfi.siStripExcludedFEDListProducer.clone()
-SiStripExcludedFEDListProduce.ProductLabel = cms.InputTag("rawDataCollector")
+SiStripExcludedFEDListProducer.ProductLabel = cms.InputTag("rawDataCollector")

--- a/EventFilter/SiStripRawToDigi/python/SiStripDigis_cfi.py
+++ b/EventFilter/SiStripRawToDigi/python/SiStripDigis_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 siStripDigis = cms.EDProducer(
     "SiStripRawToDigiModule",
     ProductLabel      = cms.InputTag('rawDataCollector'),
+    LegacyUnpacker    = cms.bool(False),
     AppendedBytes     = cms.int32(0),
     UseDaqRegister    = cms.bool(False),
     UseFedKey         = cms.bool(False),

--- a/EventFilter/SiStripRawToDigi/python/test/SiStripTrivialDigiSource_cfi.py
+++ b/EventFilter/SiStripRawToDigi/python/test/SiStripTrivialDigiSource_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-DigiSource = cms.EDFilter(
+DigiSource = cms.EDProducer(
     "SiStripTrivialDigiSource",
     MeanOccupancy = cms.untracked.double(1.0),
     RmsOccupancy = cms.untracked.double(0.1),

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -9,7 +9,7 @@
 
 namespace sistrip {
 
-  FEDBuffer::FEDBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool allowBadBuffer)
+  FEDBuffer::FEDBuffer(const uint8_t* fedBuffer, const uint16_t fedBufferSize, const bool allowBadBuffer)
     : FEDBufferBase(fedBuffer,fedBufferSize,allowBadBuffer,false)
   {
     channels_.reserve(FEDCH_PER_FED);
@@ -59,7 +59,7 @@ namespace sistrip {
       //if there was a problem either rethrow the exception or just mark channel pointers NULL
       if (!allowBadBuffer) throw;
       else {
-        channels_.insert(channels_.end(),size_t(FEDCH_PER_FED-validChannels_),FEDChannel(payloadPointer_,0,0));
+        channels_.insert(channels_.end(),uint16_t(FEDCH_PER_FED-validChannels_),FEDChannel(payloadPointer_,0,0));
       }
     }
   }
@@ -74,21 +74,31 @@ namespace sistrip {
     uint16_t minLength;
     switch (readoutMode()) {
     case READOUT_MODE_ZERO_SUPPRESSED:
+    case READOUT_MODE_ZERO_SUPPRESSED_FAKE:
       minLength = 7;
       break;
-    case READOUT_MODE_ZERO_SUPPRESSED_LITE:
     case READOUT_MODE_PREMIX_RAW:
+      minLength = 2;
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
       minLength = 2;
       break;
     default:
       minLength = 3;
       break;
     }
-    size_t offsetBeginningOfChannel = 0;
-    for (size_t i = 0; i < FEDCH_PER_FED; i++) {
+    uint16_t offsetBeginningOfChannel = 0;
+    for (uint16_t i = 0; i < FEDCH_PER_FED; i++) {
       //if FE unit is not enabled then skip rest of FE unit adding NULL pointers
       if unlikely( !(fePresent(i/FEDCH_PER_FEUNIT) && feEnabled(i/FEDCH_PER_FEUNIT)) ) {
-	channels_.insert(channels_.end(),size_t(FEDCH_PER_FEUNIT),FEDChannel(payloadPointer_,0,0));
+	channels_.insert(channels_.end(),uint16_t(FEDCH_PER_FEUNIT),FEDChannel(payloadPointer_,0,0));
 	i += FEDCH_PER_FEUNIT-1;
 	validChannels_ += FEDCH_PER_FEUNIT;
 	continue;
@@ -131,7 +141,7 @@ namespace sistrip {
       }
 
       validChannels_++;
-      const size_t offsetEndOfChannel = offsetBeginningOfChannel+channelLength;
+      const uint16_t offsetEndOfChannel = offsetBeginningOfChannel+channelLength;
       //add padding if necessary and calculate offset for begining of next channel
       if (!( (i+1) % FEDCH_PER_FEUNIT )) {
 	uint8_t numPaddingBytes = 8 - (offsetEndOfChannel % 8);
@@ -199,7 +209,7 @@ namespace sistrip {
     if (!checkChannelLengths()) return false;
   
     //payload length from length of data buffer
-    const size_t payloadLengthInWords = payloadLength_/8;
+    const uint16_t payloadLengthInWords = payloadLength_/8;
   
     //find channel length
     //find last enabled FE unit
@@ -207,11 +217,11 @@ namespace sistrip {
     while ( !(fePresent(lastEnabledFeUnit) && feEnabled(lastEnabledFeUnit)) && lastEnabledFeUnit!=0 ) lastEnabledFeUnit--;
     //last channel is last channel on last enabled FE unit
     const FEDChannel& lastChannel = channels_[internalFEDChannelNum(lastEnabledFeUnit,FEDCH_PER_FEUNIT-1)];
-    const size_t offsetLastChannel = lastChannel.offset();
-    const size_t offsetEndOfChannelData = offsetLastChannel+lastChannel.length();
-    const size_t channelDataLength = offsetEndOfChannelData;
+    const uint16_t offsetLastChannel = lastChannel.offset();
+    const uint16_t offsetEndOfChannelData = offsetLastChannel+lastChannel.length();
+    const uint16_t channelDataLength = offsetEndOfChannelData;
     //channel length in words is length in bytes rounded up to nearest word
-    size_t channelDataLengthInWords = channelDataLength/8;
+    uint16_t channelDataLengthInWords = channelDataLength/8;
     if (channelDataLength % 8) channelDataLengthInWords++;
   
     //check lengths match
@@ -379,30 +389,6 @@ namespace sistrip {
     return summary.str();
   }
 
-  uint8_t FEDBuffer::getCorrectPacketCode() const
-  {
-    switch(readoutMode()) {
-    case READOUT_MODE_SCOPE:
-      return PACKET_CODE_SCOPE;
-      break;
-    case READOUT_MODE_VIRGIN_RAW:
-      return PACKET_CODE_VIRGIN_RAW;
-      break;
-    case READOUT_MODE_PROC_RAW:
-      return PACKET_CODE_PROC_RAW;
-      break;
-    case READOUT_MODE_ZERO_SUPPRESSED:
-      return PACKET_CODE_ZERO_SUPPRESSED;
-      break;
-    case READOUT_MODE_ZERO_SUPPRESSED_LITE:
-    case READOUT_MODE_PREMIX_RAW:
-    case READOUT_MODE_SPY:
-    case READOUT_MODE_INVALID:
-    default:
-      return 0;
-    }
-  }
-
   uint8_t FEDBuffer::nFEUnitsPresent() const
   {
     uint8_t result = 0;
@@ -435,8 +421,33 @@ namespace sistrip {
     throw cms::Exception("FEDBuffer") << ss.str();
   }
 
+  void FEDBSChannelUnpacker::throwBadChannelLength(const uint16_t length)
+  {
+    std::ostringstream ss;
+    ss << "Channel length is invalid. "
+       << "Channel length is " << uint16_t(length) << "."
+       << std::endl;
+    throw cms::Exception("FEDBuffer") << ss.str();
+  }
 
+  void FEDBSChannelUnpacker::throwBadWordLength(const uint16_t word_length)
+  {
+    std::ostringstream ss;
+    ss << "Word length is invalid. "
+       << "Word length is " << word_length << "."
+       << std::endl;
+    throw cms::Exception("FEDBuffer") << ss.str();
+  }
 
+  void FEDBSChannelUnpacker::throwUnorderedData(const uint8_t currentStrip, const uint8_t firstStripOfNewCluster)
+  {
+    std::ostringstream ss;
+    ss << "First strip of new cluster is not greater than last strip of previous cluster. "
+       << "Last strip of previous cluster is " << uint16_t(currentStrip) << ". "
+       << "First strip of new cluster is " << uint16_t(firstStripOfNewCluster) << "."
+       << std::endl;
+    throw cms::Exception("FEDBuffer") << ss.str();
+  }
 
   void FEDZSChannelUnpacker::throwBadChannelLength(const uint16_t length)
   {

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -130,6 +130,31 @@ namespace sistrip {
     return os;
   }
 
+  std::ostream& operator<<(std::ostream& os, const FEDLegacyReadoutMode& value)
+  {
+    switch (value) {
+    case READOUT_MODE_LEGACY_SCOPE:                     os << "(L) Scope mode"; break;
+    case READOUT_MODE_LEGACY_VIRGIN_RAW_REAL:           os << "(L) Virgin raw (real)"; break;
+    case READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE:           os << "(L) Virgin raw (fake)"; break;
+    case READOUT_MODE_LEGACY_PROC_RAW_REAL:             os << "(L) Processed raw (real)"; break;
+    case READOUT_MODE_LEGACY_PROC_RAW_FAKE:             os << "(L) Processed raw (fake)"; break;
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL:      os << "(L) Zero suppressed (real)"; break;
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE:      os << "(L) Zero suppressed (fake)"; break;
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL: os << "(L) Zero suppressed lite (real)"; break;
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE: os << "(L) Zero suppressed lite (fake)"; break;
+    case READOUT_MODE_LEGACY_SPY:                       os << "(L) Spy channel"; break;
+    case READOUT_MODE_LEGACY_PREMIX_RAW:                os << "(L) PreMix raw"; break;
+    case READOUT_MODE_LEGACY_INVALID:                   os << "(L) Invalid"; break;
+    default:
+      os << "(L) Unrecognized";
+      os << " (";
+      printHexValue(value,os);
+      os << ")";
+      break;
+    }
+    return os;
+  }
+
   std::ostream& operator<<(std::ostream& os, const FEDReadoutMode& value)
   {
     switch (value) {
@@ -145,36 +170,44 @@ namespace sistrip {
     case READOUT_MODE_ZERO_SUPPRESSED:
       os << "Zero suppressed";
       break;
-    case READOUT_MODE_ZERO_SUPPRESSED_LITE:
+    case READOUT_MODE_ZERO_SUPPRESSED_FAKE:
+      os << "Zero suppressed (fake)";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
       os << "Zero suppressed lite";
       break;
     case READOUT_MODE_SPY:
       os << "Spy channel";
+      break;
+    /*case READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE:
+      os << "Zero suppressed CM Override";
+      break;*/
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+      os << "Zero suppressed lite CM Override";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+      os << "Zero suppressed lite (8 bit, top-stripped)";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+      os << "Zero suppressed lite CM Override (8 bit, top-stripped)";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+      os << "Zero suppressed lite (8 bit, bottom-stripped)";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+      os << "Zero suppressed lite CM Override (8 bit, bottom-stripped)";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+      os << "Zero suppressed lite (8 bit, top/bottom-stripped)";
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
+      os << "Zero suppressed lite CM Override (8 bit, top/bottom-stripped)";
       break;
     case READOUT_MODE_PREMIX_RAW:
       os << "PreMix raw";
       break;
     case READOUT_MODE_INVALID:
       os << "Invalid";
-      break;
-    default:
-      os << "Unrecognized";
-      os << " (";
-      printHexValue(value,os);
-      os << ")";
-      break;
-    }
-    return os;
-  }
-
-  std::ostream& operator<<(std::ostream& os, const FEDDataType& value)
-  {
-    switch (value) {
-    case DATA_TYPE_REAL:
-      os << "Real data";
-      break;
-    case DATA_TYPE_FAKE:
-      os << "Fake data";
       break;
     default:
       os << "Unrecognized";
@@ -365,7 +398,24 @@ namespace sistrip {
     if ( (readoutModeString == "READOUT_MODE_ZERO_SUPPRESSED_LITE") ||
          (readoutModeString == "ZERO_SUPPRESSED_LITE") ||
          (readoutModeString == "Zero suppressed lite") ) {
-      return READOUT_MODE_ZERO_SUPPRESSED_LITE;
+      return READOUT_MODE_ZERO_SUPPRESSED_LITE10;
+    }
+    if ( (readoutModeString == "READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE") ||
+         (readoutModeString == "ZERO_SUPPRESSED_CMOVERRIDE") ||
+         (readoutModeString == "ZERO_SUPPRESSED_CMO") ||
+         (readoutModeString == "Zero suppressed CM Override") ) {
+      return READOUT_MODE_ZERO_SUPPRESSED;
+    }
+    if ( (readoutModeString == "READOUT_MODE_ZERO_SUPPRESSED_LITE_CMOVERRIDE") ||
+         (readoutModeString == "ZERO_SUPPRESSED_LITE_CMO") ||
+         (readoutModeString == "ZERO_SUPPRESSED_LITE_CMOVERRIDE") ||
+         (readoutModeString == "Zero suppressed lite CM Override") ) {
+      return READOUT_MODE_ZERO_SUPPRESSED_LITE10;
+    }
+    if ( (readoutModeString == "READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT") ||
+         (readoutModeString == "ZERO_SUPPRESSED_LITE8_TOPBOT") ||
+         (readoutModeString == "Zero suppressed lite8 TobBot") ){
+      return READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT;
     }
     if ( (readoutModeString == "READOUT_MODE_PREMIX_RAW") ||
          (readoutModeString == "PREMIX_RAW") ||
@@ -379,24 +429,6 @@ namespace sistrip {
     }
     //if it was none of the above then return invalid
     return READOUT_MODE_INVALID;
-  }
-  
-  FEDDataType fedDataTypeFromString(const std::string& dataTypeString)
-  {
-    if ( (dataTypeString == "REAL") ||
-         (dataTypeString == "DATA_TYPE_REAL") ||
-         (dataTypeString == "Real data") ) {
-      return DATA_TYPE_REAL;
-    }
-    if ( (dataTypeString == "FAKE") ||
-         (dataTypeString == "DATA_TYPE_FAKE") ||
-         (dataTypeString == "Fake data") ) {
-      return DATA_TYPE_FAKE;
-    }
-    //if it was none of the above then throw an exception (there is no invalid value for the data type since it is represented as a single bit in the buffer)
-    std::ostringstream ss;
-    ss << "Trying to convert to a FEDDataType from an invalid string: " << dataTypeString;
-    throw cms::Exception("FEDDataType") << ss.str();
   }
   
   FEDDAQEventType fedDAQEventTypeFromString(const std::string& daqEventTypeString)
@@ -653,6 +685,25 @@ namespace sistrip {
     else return HEADER_TYPE_INVALID;
   }
 
+  FEDLegacyReadoutMode TrackerSpecialHeader::legacyReadoutMode() const
+  {
+    const uint8_t eventTypeNibble = trackerEventTypeNibble();
+    const uint8_t mode = (eventTypeNibble & 0xF);
+    switch(mode) {
+    case READOUT_MODE_LEGACY_VIRGIN_RAW_REAL:
+    case READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE:
+    case READOUT_MODE_LEGACY_PROC_RAW_REAL:
+    case READOUT_MODE_LEGACY_PROC_RAW_FAKE:
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL:
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE:
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL:
+    case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE:
+      return FEDLegacyReadoutMode(mode);
+    default:
+      return READOUT_MODE_LEGACY_INVALID;
+    }
+  }
+
   FEDReadoutMode TrackerSpecialHeader::readoutMode() const
   {
     const uint8_t eventTypeNibble = trackerEventTypeNibble();
@@ -662,29 +713,29 @@ namespace sistrip {
     if (eventTypeNibble == READOUT_MODE_PREMIX_RAW) return FEDReadoutMode(eventTypeNibble);
     //if not then ignore the last bit which indicates if it is real or fake
     else {
-      const uint8_t mode = (eventTypeNibble & 0xE);
+      const uint8_t mode = (eventTypeNibble & 0xF);
       switch(mode) {
       case READOUT_MODE_VIRGIN_RAW:
       case READOUT_MODE_PROC_RAW:
       case READOUT_MODE_ZERO_SUPPRESSED:
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE:
+      case READOUT_MODE_ZERO_SUPPRESSED_FAKE:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+      //case READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
       case READOUT_MODE_SPY:
-	return FEDReadoutMode(mode);
+        return FEDReadoutMode(mode);
       default:
-	return READOUT_MODE_INVALID;
+        return READOUT_MODE_INVALID;
       }
-    }   
+    }
   }
 
-  FEDDataType TrackerSpecialHeader::dataType() const
-  {
-    const uint8_t eventTypeNibble = trackerEventTypeNibble();
-    //if it is scope mode then it is always real
-    if (eventTypeNibble == READOUT_MODE_SCOPE) return DATA_TYPE_REAL;
-    //in other modes it is the lowest order bit of event type nibble
-    else return FEDDataType(eventTypeNibble & 0x1);
-  }
-  
   TrackerSpecialHeader& TrackerSpecialHeader::setBufferFormat(const FEDBufferFormat newBufferFormat)
   {
     //check if order in buffer is different
@@ -737,18 +788,24 @@ namespace sistrip {
     case READOUT_MODE_SCOPE:
       //scope mode is always real
       setReadoutModeBits(readoutMode);
-      setDataTypeBit(true);
     case READOUT_MODE_VIRGIN_RAW:
     case READOUT_MODE_PROC_RAW:
-    case READOUT_MODE_ZERO_SUPPRESSED:
-    case READOUT_MODE_ZERO_SUPPRESSED_LITE:
     case READOUT_MODE_SPY:
+    case READOUT_MODE_ZERO_SUPPRESSED:
+    case READOUT_MODE_ZERO_SUPPRESSED_FAKE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
       setReadoutModeBits(readoutMode);
       break;
     case READOUT_MODE_PREMIX_RAW:
       //special mode for simulation
       setReadoutModeBits(readoutMode);
-      setDataTypeBit(true);
       break;
     default:
       std::ostringstream ss;
@@ -757,23 +814,6 @@ namespace sistrip {
       throw cms::Exception("FEDBuffer") << ss.str();
     }
     return *this;
-  }
-  
-  TrackerSpecialHeader& TrackerSpecialHeader::setDataType(const FEDDataType dataType)
-  {
-    //if mode is scope then this bit can't be changed
-    if (readoutMode() == READOUT_MODE_SCOPE) return *this;
-    switch (dataType) {
-    case DATA_TYPE_REAL:
-    case DATA_TYPE_FAKE:
-      setDataTypeBit(dataType);
-      return *this;
-    default:
-      std::ostringstream ss;
-      ss << "Invalid data type: ";
-      printHex(&dataType,1,ss);
-      throw cms::Exception("FEDBuffer") << ss.str();
-    }
   }
   
   TrackerSpecialHeader& TrackerSpecialHeader::setAPVAddressErrorForFEUnit(const uint8_t internalFEUnitNum, const bool error)
@@ -801,7 +841,7 @@ namespace sistrip {
   }
   
   TrackerSpecialHeader::TrackerSpecialHeader(const FEDBufferFormat bufferFormat, const FEDReadoutMode readoutMode,
-                                             const FEDHeaderType headerType, const FEDDataType dataType,
+                                             const FEDHeaderType headerType,
                                              const uint8_t address, const uint8_t addressErrorRegister,
                                              const uint8_t feEnableRegister, const uint8_t feOverflowRegister,
                                              const FEDStatusRegister fedStatusRegister)
@@ -813,7 +853,6 @@ namespace sistrip {
     setBufferFormatByte(bufferFormat);
     setReadoutMode(readoutMode);
     setHeaderType(headerType);
-    setDataType(dataType);
     setAPVEAddress(address);
     setAPVEAddressErrorRegister(addressErrorRegister);
     setFEEnableRegister(feEnableRegister);
@@ -1305,7 +1344,6 @@ namespace sistrip {
     os << "Source ID: " << daqSourceID() << std::endl;
     os << "Header type: " << headerType() << std::endl;
     os << "Readout mode: " << readoutMode() << std::endl;
-    os << "Data type: " << dataType() << std::endl;
     os << "DAQ event type: " << daqEventType() << std::endl;
     os << "TTS state: " << daqTTSState() << std::endl;
     os << "L1 ID: " << daqLvl1ID() << std::endl;

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
@@ -124,10 +124,18 @@ namespace sistrip {
       fillRawChannelBuffer(channelBuffer,PACKET_CODE_PROC_RAW,data,channelEnabled,false);
       break;
     case READOUT_MODE_ZERO_SUPPRESSED:
+    //case READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE:
       fillZeroSuppressedChannelBuffer(channelBuffer,data,channelEnabled);
       break;
-    case READOUT_MODE_ZERO_SUPPRESSED_LITE:
-      fillZeroSuppressedLiteChannelBuffer(channelBuffer,data,channelEnabled);
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
+      fillZeroSuppressedLiteChannelBuffer(channelBuffer,data,channelEnabled,mode);
       break;
     case READOUT_MODE_PREMIX_RAW:
       fillPreMixRawChannelBuffer(channelBuffer,data,channelEnabled);
@@ -182,7 +190,8 @@ namespace sistrip {
     }
     //if channel is not empty
     //add space for channel length
-    channelBuffer->push_back(0xFF); channelBuffer->push_back(0xFF);
+    channelBuffer->push_back(0xFF);
+    channelBuffer->push_back(0xFF);
     //packet code
     channelBuffer->push_back(PACKET_CODE_ZERO_SUPPRESSED);
     //add medians
@@ -192,7 +201,7 @@ namespace sistrip {
     channelBuffer->push_back(medians.second & 0xFF);
     channelBuffer->push_back((medians.second & 0x300) >> 8);
     //clusters
-    fillClusterData(channelBuffer,data);
+    fillClusterData(channelBuffer,data,READOUT_MODE_ZERO_SUPPRESSED);
     //set length
     const uint16_t length = channelBuffer->size();
     (*channelBuffer)[0] = (length & 0xFF);
@@ -201,7 +210,8 @@ namespace sistrip {
   
   void FEDBufferPayloadCreator::fillZeroSuppressedLiteChannelBuffer(std::vector<uint8_t>* channelBuffer,
                                                                    const FEDStripData::ChannelData& data,
-                                                                   const bool channelEnabled) const
+                                                                   const bool channelEnabled,
+                                                                   const FEDReadoutMode mode) const
   {
     channelBuffer->reserve(50);
     //if channel is disabled then create empty channel header and return
@@ -213,10 +223,11 @@ namespace sistrip {
     }
     //if channel is not empty
     //add space for channel length
-    channelBuffer->push_back(0xFF); channelBuffer->push_back(0xFF);
+    channelBuffer->push_back(0xFF);
+    channelBuffer->push_back(0xFF);
     //clusters
-    fillClusterData(channelBuffer,data);
-    //set length
+    fillClusterData(channelBuffer,data,mode);
+    //set fibre length
     const uint16_t length = channelBuffer->size();
     (*channelBuffer)[0] = (length & 0xFF);
     (*channelBuffer)[1] = ((length & 0x300) >> 8);
@@ -257,32 +268,56 @@ namespace sistrip {
     (*channelBuffer)[1] = ((length & 0x300) >> 8);
   }
   
-  void FEDBufferPayloadCreator::fillClusterData(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data) const
+  void FEDBufferPayloadCreator::fillClusterData(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const FEDReadoutMode mode) const
   {
     uint16_t clusterSize = 0;
     const uint16_t nSamples = data.size();
+    uint16_t size;
+    switch (mode) {
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+      case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+        size = 2; break;
+      default:
+        size = 1; break;
+    }
     for( uint16_t strip = 0; strip < nSamples; ++strip) {
-      const uint8_t adc = data.get8BitSample(strip);
+      uint16_t adc;
+      switch (mode) {
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+          adc = data.get10BitSample(strip); break;
+        default:
+          adc = data.get8BitSample(strip,mode); break;
+      }
 
       if(adc) {
 	if( clusterSize==0 || strip == STRIPS_PER_APV ) { 
 	  if(clusterSize) { 
-	    *(channelBuffer->end() - clusterSize - 1) = clusterSize ; 
+	    *(channelBuffer->end() - size*clusterSize - 1) = clusterSize ; 
 	    clusterSize = 0; 
 	  }
 	  channelBuffer->push_back(strip); 
 	  channelBuffer->push_back(0); //clustersize	  
 	}
-	channelBuffer->push_back(adc);
+        switch (mode) {
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+	    channelBuffer->push_back(adc & 0xFF);
+            channelBuffer->push_back((adc & 0x0300) >> 8);
+            break;
+          default:
+            channelBuffer->push_back(adc & 0xFF);
+            break;
+        }
 	++clusterSize;
       }
 
       else if(clusterSize) { 
-	*(channelBuffer->end() - clusterSize - 1) = clusterSize ; 
+	*(channelBuffer->end() - size*clusterSize - 1) = clusterSize ; 
 	clusterSize = 0; 
       }
     }
-    if(clusterSize) *(channelBuffer->end() - clusterSize - 1) = clusterSize ;
+    if(clusterSize) *(channelBuffer->end() - size*clusterSize - 1) = clusterSize ;
   }
 
   void FEDBufferPayloadCreator::fillClusterDataPreMixMode(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data) const
@@ -322,10 +357,10 @@ namespace sistrip {
   FEDBufferGenerator::FEDBufferGenerator(const uint32_t l1ID, const uint16_t bxID,
                                          const std::vector<bool>& feUnitsEnabled, const std::vector<bool>& channelsEnabled,
                                          const FEDReadoutMode readoutMode, const FEDHeaderType headerType, const FEDBufferFormat bufferFormat,
-                                         const FEDDAQEventType evtType, const FEDDataType dataType)
+                                         const FEDDAQEventType evtType)
     : defaultDAQHeader_(l1ID,bxID,0,evtType),
       defaultDAQTrailer_(0,0),
-      defaultTrackerSpecialHeader_(bufferFormat,readoutMode,headerType,dataType),
+      defaultTrackerSpecialHeader_(bufferFormat,readoutMode,headerType),
       defaultFEHeader_(FEDFEHeader::newFEHeader(headerType)),
       feUnitsEnabled_(feUnitsEnabled),
       channelsEnabled_(channelsEnabled)

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripClusterValidator.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripClusterValidator.cc
@@ -27,6 +27,13 @@ SiStripClusterValidator::SiStripClusterValidator(const edm::ParameterSet& conf)
      << "\""
      << std::endl;
   header_ = ss.str();
+  if (dsvnew_) {
+    consumes< edmNew::DetSetVector<SiStripCluster> >( collection1Tag_ );
+    consumes< edmNew::DetSetVector<SiStripCluster> >( collection2Tag_ );
+  } else {
+    consumes< edm::DetSetVector<SiStripCluster> >( collection1Tag_ );
+    consumes< edm::DetSetVector<SiStripCluster> >( collection2Tag_ );
+  }
 }
 
 SiStripClusterValidator::~SiStripClusterValidator()

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.cc
@@ -58,6 +58,11 @@ void SiStripTrivialDigiAnalysis::print( stringstream& ss ) {
 SiStripDigiAnalyzer::SiStripDigiAnalyzer( const edm::ParameterSet& pset ) :
   inputModuleLabel_( pset.getParameter<string>( "InputModuleLabel" ) )
 {
+  consumes< edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "VirginRaw"));
+  consumes< edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "ProcessedRaw"));
+  consumes< edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "ScopeMode"));
+  consumes< edm::DetSetVector<SiStripDigi> >(edm::InputTag(inputModuleLabel_, "ZeroSuppressed"));
+  consumes< SiStripEventSummary >(inputModuleLabel_);
   LogDebug("SiStripDigiAnalyzer")
     << "[SiStripDigiAnalyzer::SiStripDigiAnalyzer]"
     << " Constructing object...";
@@ -207,5 +212,4 @@ void SiStripDigiAnalyzer::analyze( const edm::Event& event, const edm::EventSetu
       
     } // channel loop
   } // fed loop
-  
 }

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiValidator.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiValidator.cc
@@ -28,6 +28,11 @@ SiStripDigiValidator::SiStripDigiValidator(const edm::ParameterSet& conf)
      << "\""
      << std::endl;
   header_ = ss.str();
+  
+  mayConsume< edm::DetSetVector<SiStripDigi> >( tag1_ );
+  mayConsume< edm::DetSetVector<SiStripRawDigi> >( tag1_ );
+  mayConsume< edm::DetSetVector<SiStripDigi> >( tag2_ );
+  mayConsume< edm::DetSetVector<SiStripRawDigi> >( tag2_ );
 }
 
 SiStripDigiValidator::~SiStripDigiValidator()

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -25,6 +25,7 @@ SiStripFEDRawDataAnalyzer::SiStripFEDRawDataAnalyzer( const edm::ParameterSet& p
     << "[SiStripFEDRawDataAnalyzer::"
     << __func__ << "]"
     << "Constructing object...";
+  consumes<FEDRawDataCollection>( label_ );
 }
 
 // -----------------------------------------------------------------------------
@@ -221,7 +222,7 @@ void SiStripFEDRawDataAnalyzer::analyze( const edm::Event& event, const edm::Eve
 
 	if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED && sistrip::FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(buffer->channel(ichan)).hasData()) channels_with_data[ifed].push_back(ichan);
 
-	else if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE && sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(ichan)).hasData()) channels_with_data[ifed].push_back(ichan);
+	else if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 && sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(ichan)).hasData()) channels_with_data[ifed].push_back(ichan);
 	
 	else if ( mode == sistrip::READOUT_MODE_VIRGIN_RAW && sistrip::FEDRawChannelUnpacker::virginRawModeUnpacker(buffer->channel(ichan)).hasData()) channels_with_data[ifed].push_back(ichan);
 	

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -331,7 +331,7 @@ try {
     const sistrip::FEDReadoutMode mode = buffer->readoutMode();
     
     
-    if likely(mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE ) { 
+    if likely(mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 ) { 
 	
 	try {
 	  // create unpacker
@@ -355,9 +355,28 @@ try {
 	  }                                               
 	  continue;
 	}
-      } else {
+    } else if likely(mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE8 ) {
+
+      try {
+        // create unpacker
+        sistrip::FEDZSChannelUnpacker unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(fedCh));
+
+        // unpack
+        clusterizer.addFed(unpacker,ipair,record);
+      } catch (edmNew::CapacityExaustedException) {
+        throw;
+      } catch (const cms::Exception& e) {
+          if (edm::isDebugEnabled()) {
+            std::ostringstream ss;
+            ss << "Unordered clusters for channel " << fedCh << " on FED " << fedId << ": " << e.what();
+            edm::LogWarning(sistrip::mlRawToCluster_) << ss.str();
+          }
+          continue;
+        }
+
+    } else {
       
-      if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED ) { 
+      if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED or mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_FAKE ) { 
 	try {
 	  // create unpacker
 	  sistrip::FEDZSChannelUnpacker unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(buffer->channel(fedCh));


### PR DESCRIPTION
The FED FE packet codes has been reorganized to leave room to new modes (e.g. VR 10bit, ZS 8bit, ...). The SiStripRawToDigiUnpacker was hence modified to match these changes.
In an attempt to restore the previous unpacking behaviour a boolean has been introduced in the siStripDigis PSet to switch between the legacy modes and the new ones (siStripDigis.LegacyUnpacker = cms.bool(False)).
For more information on the requirements and new specifications, see https://its.cern.ch/jira/browse/CMSTRACK-127
