### PR TITLE
DataFormats/TrackerRecHit2D: clean Clang override warnings

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/FastSingleTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastSingleTrackerRecHit.h
@@ -23,12 +23,12 @@ class FastSingleTrackerRecHit : public FastTrackerRecHit {
 
     virtual FastSingleTrackerRecHit * clone() const GCC11_OVERRIDE  {FastSingleTrackerRecHit * p =  new FastSingleTrackerRecHit( * this); p->load(); return p;}
 
-    size_t                       nIds()                    const { return 1;}
-    int32_t                      id(size_t i =0)           const { return i == 0 ? id_ : -1;}
-    int32_t                      eventId(size_t i = 0)     const { return i == 0 ? eventId_ : -1;}
-    size_t                       nSimTrackIds()            const { return simTrackIds_.size();}                             ///< see addSimTrackId(int32_t simTrackId)
-    int32_t                      simTrackId(size_t i)      const { return i < simTrackIds_.size() ? simTrackIds_[i] : -1;}  ///< see addSimTrackId(int32_t simTrackId)
-    int32_t                      simTrackEventId(size_t i) const { return i < simTrackIds_.size() ? eventId_ : -1;}  ///< see addSimTrackId(int32_t simTrackId)
+    size_t                       nIds()                    const override { return 1;}
+    int32_t                      id(size_t i =0)           const override { return i == 0 ? id_ : -1;}
+    int32_t                      eventId(size_t i = 0)     const override { return i == 0 ? eventId_ : -1;}
+    size_t                       nSimTrackIds()            const override { return simTrackIds_.size();}                             ///< see addSimTrackId(int32_t simTrackId)
+    int32_t                      simTrackId(size_t i)      const override { return i < simTrackIds_.size() ? simTrackIds_[i] : -1;}  ///< see addSimTrackId(int32_t simTrackId)
+    int32_t                      simTrackEventId(size_t i) const override { return i < simTrackIds_.size() ? eventId_ : -1;}  ///< see addSimTrackId(int32_t simTrackId)
 
 
     /// add an id number to the list of id numbers of SimTracks from which the hit originates
@@ -43,7 +43,7 @@ class FastSingleTrackerRecHit : public FastTrackerRecHit {
     /// set the hit's event number
     /// there is in principle no reason to play with this variable outside the PU mixing modules
     /// see Adjuster::doTheOffset(int bunchSpace, int bcr, TrackingRecHitCollection & trackingrechits, unsigned int evtNr, int vertexOffset)
-    void setEventId(int32_t eventId)    {eventId_ = eventId;}
+    void setEventId(int32_t eventId) override {eventId_ = eventId;}
 
     private:
 

--- a/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
@@ -61,7 +61,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 	, recHitCombinationIndex_(-1)
 	{store();}
 
-    virtual FastTrackerRecHit * clone() const {FastTrackerRecHit * p =  new FastTrackerRecHit( * this); p->load(); return p;}
+    virtual FastTrackerRecHit * clone() const override {FastTrackerRecHit * p =  new FastTrackerRecHit( * this); p->load(); return p;}
 
     /// Steers behaviour of hit in track fit.
     /// Hit is interpreted as 1D or 2D depending on value of is2D_
@@ -73,7 +73,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 
     /// Steers behaviour of hit in track fit.
     /// FastSim hit smearing assumes
-    virtual bool canImproveWithTrack() const {return false;}
+    virtual bool canImproveWithTrack() const override {return false;}
 
     /* getters */
 
@@ -99,15 +99,15 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 
     /// bogus function : 
     /// implement purely virtual function of TrackingRecHit
-    virtual std::vector<const TrackingRecHit*> recHits() const { return std::vector<TrackingRecHit const*>();}
+    virtual std::vector<const TrackingRecHit*> recHits() const override { return std::vector<TrackingRecHit const*>();}
 
     /// bogus function : 
     /// implement purely virtual function of TrackingRecHit
-    virtual std::vector<TrackingRecHit*> recHits()  { return std::vector<TrackingRecHit*>();}
+    virtual std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>();}
  
     /// bogus function : 
     /// implement purely virutal function of BaseTrackerRecHit
-    OmniClusterRef const & firstClusterRef() const;
+    OmniClusterRef const & firstClusterRef() const override;
 
     /// fastsim's way to check whether 2 single hits share sim-information or not
     /// hits are considered to share sim-information if 
@@ -118,7 +118,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
     // - FastSiStripMatchedRecHit::sharesInput
     // - FastProjectedSiStripRecHit2D::sharesInput
     inline bool sameId(const FastTrackerRecHit * other,size_t i=0,size_t j = 0) const {return id(i) == other->id(j) && eventId(i) == other->eventId(j);}
-    inline bool sharesInput(const TrackingRecHit * other,SharedInputType what) const {
+    inline bool sharesInput(const TrackingRecHit * other,SharedInputType what) const override {
 
 	// cast other hit
 	if(!trackerHitRTTI::isFast(*other) )


### PR DESCRIPTION
13 Clang warnings popup while building `DataFormats/TrackerRecHit2D`
dictionary with ROOT 6.04 and above. Example:

```
warning: 'recHits' overrides a member function but is not marked
'override' [-Winconsistent-missing-override]
```

The patch cleans all 13 warnings.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
