### PR TITLE
Revision of snapshotTime handling in HLT and new Run2 MC GT with ES fixes

### DIFF
--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -79,7 +79,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                   label      = len(entry) > 3 and entry[3] or None
                   tag        = entry[0]
                   connection = len(entry) > 2 and entry[2] or None
-                  map[ (record, label) ] = (tag, connection)
+                  snapshotTime = len(entry) > 4 and entry[4] or None
+                  map[ (record, label) ] = (tag, connection, snapshotTime)
                 custom_conditions.update( map )
             else:
                 globaltag = autoKey
@@ -109,7 +110,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                 label      = len(entry) > 3 and entry[3] or None
                 tag        = entry[0]
                 connection = len(entry) > 2 and entry[2] or None
-                map[ (record, label) ] = (tag, connection)
+                snapshotTime = len(entry) > 4 and entry[4] or None
+                map[ (record, label) ] = (tag, connection, snapshotTime)
             custom_conditions.update( map )
         elif isinstance(conditions, dict):
           custom_conditions.update( conditions )
@@ -118,7 +120,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # explicit payloads toGet from DB
     if custom_conditions:
-        for ( (record, label), (tag, connection) ) in sorted(custom_conditions.iteritems()):
+        for ( (record, label), (tag, connection, snapshotTime) ) in sorted(custom_conditions.iteritems()):
             payload = cms.PSet()
             payload.record = cms.string( record )
             if label:
@@ -126,6 +128,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             payload.tag = cms.string( tag )
             if connection:
                 payload.connect = cms.string( connection )
+            if snapshotTime:
+                payload.snapshotTime = cms.string( snapshotTime )
             essource.toGet.append( payload )
 
     return essource

--- a/Configuration/AlCa/python/GlobalTag_condDBv1.py
+++ b/Configuration/AlCa/python/GlobalTag_condDBv1.py
@@ -79,7 +79,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                   label      = len(entry) > 3 and entry[3] or None
                   tag        = entry[0]
                   connection = len(entry) > 2 and entry[2] or None
-                  map[ (record, label) ] = (tag, connection)
+                  snapshotTime = len(entry) > 4 and entry[4] or None
+                  map[ (record, label) ] = (tag, connection, snapshotTime)
                 custom_conditions.update( map )
             else:
                 globaltag = autoKey
@@ -109,7 +110,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                 label      = len(entry) > 3 and entry[3] or None
                 tag        = entry[0]
                 connection = len(entry) > 2 and entry[2] or None
-                map[ (record, label) ] = (tag, connection)
+                snapshotTime = len(entry) > 4 and entry[4] or None
+                map[ (record, label) ] = (tag, connection, snapshotTime)
             custom_conditions.update( map )
         elif isinstance(conditions, dict):
           custom_conditions.update( conditions )
@@ -118,7 +120,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # explicit payloads toGet from DB
     if custom_conditions:
-        for ( (record, label), (tag, connection) ) in sorted(custom_conditions.iteritems()):
+        for ( (record, label), (tag, connection, snapshotTime) ) in sorted(custom_conditions.iteritems()):
             payload = cms.PSet()
             payload.record = cms.string( record )
             if label:
@@ -126,6 +128,8 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             payload.tag = cms.string( tag )
             if connection:
                 payload.connect = cms.string( connection )
+            if snapshotTime:
+                payload.snapshotTime = cms.string (snapshotTime )
             essource.toGet.append( payload )
 
     return essource

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,13 +10,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v10',
+    'run2_design'       :   '76X_mcRun2_design_v11',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v10',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v11',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v10',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v10',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v11',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '76X_dataRun1_v9',
     # GlobalTag for Run2 data reprocessing
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v6',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -1,25 +1,29 @@
 # https://cms-conddb.cern.ch/browser/#search
 
-snapshotTime = "9999-12-31 23:59:59.000"
+#default value for all L1T menus
+connectionString = "frontier://FrontierProd/CMS_CONDITIONS"
+l1MenuRecord = "L1GtTriggerMenuRcd"
+l1MenuLabel = ""
+
+#The snapshot time has been set as starting point as the one of PR 12095.
+#Next time you change the customisations, change also the snapshot time in the affected tuple,
+#and leave unchanged the snapshot times for the other tuples.
 
 l1Menus= {
-    'Fake'         : 'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc',
-    'FULL'         : 'L1Menu_Collisions2015_25nsStage1_v5',
-    'GRun'         : 'L1Menu_Collisions2015_25nsStage1_v5',
-    '25ns14e33_v1' : 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030',
-    '25ns14e33_v3' : 'L1Menu_Collisions2015_25nsStage1_v4',
-    '25ns14e33_v4' : 'L1Menu_Collisions2015_25nsStage1_v5',
-    'HIon'         : 'L1Menu_CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1',
-    'PIon'         : 'L1Menu_Collisions2015_25nsStage1_v5',
-    '50nsGRun'     : 'L1Menu_Collisions2015_50nsGct_v4',
-    '50ns_5e33_v1' : 'L1Menu_Collisions2015_50nsGct_v1_L1T_Scales_20141121_Imp0_0x1030',
-    '50ns_5e33_v3' : 'L1Menu_Collisions2015_50nsGct_v4',
-    'LowPU'        : 'L1Menu_Collisions2015_lowPU_v4',
-    '25nsLowPU'    : 'L1Menu_Collisions2015_lowPU_25nsStage1_v6',
+    'Fake'         : ( ','.join( [ 'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    'FULL'         : ( ','.join( [ 'L1Menu_Collisions2015_25nsStage1_v5', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    'GRun'         : ( ','.join( [ 'L1Menu_Collisions2015_25nsStage1_v5', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '25ns14e33_v1' : ( ','.join( [ 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '25ns14e33_v3' : ( ','.join( [ 'L1Menu_Collisions2015_25nsStage1_v4', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '25ns14e33_v4' : ( ','.join( [ 'L1Menu_Collisions2015_25nsStage1_v5', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    'HIon'         : ( ','.join( [ 'L1Menu_CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    'PIon'         : ( ','.join( [ 'L1Menu_Collisions2015_25nsStage1_v5', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '50nsGRun'     : ( ','.join( [ 'L1Menu_Collisions2015_50nsGct_v4', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '50ns_5e33_v1' : ( ','.join( [ 'L1Menu_Collisions2015_50nsGct_v1_L1T_Scales_20141121_Imp0_0x1030', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '50ns_5e33_v3' : ( ','.join( [ 'L1Menu_Collisions2015_50nsGct_v4', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    'LowPU'        : ( ','.join( [ 'L1Menu_Collisions2015_lowPU_v4', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
+    '25nsLowPU'    : ( ','.join( [ 'L1Menu_Collisions2015_lowPU_25nsStage1_v6', l1MenuRecord, connectionString, l1MenuLabel, "2015-10-26 12:00:00.000"] ), ),
 }
-
-for key,val in l1Menus.iteritems():
-    l1Menus[key] = (val+',L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS,,'+snapshotTime,)
 
 hltGTs = {
 

--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -1,5 +1,7 @@
 # https://cms-conddb.cern.ch/browser/#search
 
+snapshotTime = "9999-12-31 23:59:59.000"
+
 l1Menus= {
     'Fake'         : 'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc',
     'FULL'         : 'L1Menu_Collisions2015_25nsStage1_v5',
@@ -17,7 +19,7 @@ l1Menus= {
 }
 
 for key,val in l1Menus.iteritems():
-    l1Menus[key] = (val+',L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS',)
+    l1Menus[key] = (val+',L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS,,'+snapshotTime,)
 
 hltGTs = {
 

--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -31,7 +31,7 @@ def Base(process):
 #        process.GlobalTag.connect   = 'frontier://FrontierProd/CMS_CONDITIONS'
 #        process.GlobalTag.pfnPrefix = cms.untracked.string('frontier://Frontie#rProd/')
 #        
-    process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
+#   process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 
     process=ProcessName(process)
 

--- a/HLTrigger/Configuration/python/customizeHLTforALL.py
+++ b/HLTrigger/Configuration/python/customizeHLTforALL.py
@@ -42,7 +42,7 @@ def customizeHLTforAll(process, _customInfo = None):
             if hasattr(process,'GlobalTag'):
                 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
                 process.GlobalTag = GlobalTag(process.GlobalTag, _globalTag, '')
-                process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
+#               process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 
 # inputFile
         if _inputFile[0] == "@":


### PR DESCRIPTION
# Summary of Changes for HLT Testing

Revision of snapshotTime handling in HLT: no longer use/set a global `snapshotTime` but move to a per-payload `snapshotTime`, set to the time of PR #12095 
# Summary of Changes in the GT

Originally in #12114 commit https://github.com/mmusich/cmssw/commit/bee66c2e63f42f434e9cd95740d37c49a7e6ffef
## RunII Simulation
- RunII Ideal scenario : 76X_mcRun2_design_v11 as 76X_mcRun2_design_v10 with the following changes:
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
- RunII Asymptotic scenario : 76X_mcRun2_asymptotic_v11 as 76X_mcRun2_asymptotic_v10 with the following changes:
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
- RunII Startup scenario : 76X_mcRun2_startup_v11 as 76X_mcRun2_startup_v10 with the following changes:
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
- RunII Heavy Ions scenario : 76X_mcRun2_HeavyIon_v11 as 76X_mcRun2_HeavyIon_v10 with the following changes:
  - updated Preshower bad channels as per Run2015D
  - updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
  - updated Preshower Zero suppression thresholds with 6 ADC
