### PR TITLE
Add Phase1 pixel and Phase2 (2023) eras

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -13,6 +13,7 @@ class Eras (object):
         self.run2_HI_specific = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
         self.stage2L1Trigger = cms.Modifier()
+        self.phase1Pixel = cms.Modifier()
         # Implementation note: When this was first started, stage1L1Trigger wasn't in all
         # of the eras. Now that it is, it could in theory be dropped if all changes are
         # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to
@@ -35,6 +36,10 @@ class Eras (object):
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
         # Future Run 2 scenarios.
         self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger )
+        self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel )
+        # Scenarios further afield.
+        # Phase2Dev is everything for the 2023 (2026?) detector that works so far in this release.
+        self.Phase2Dev = cms.Modifier()
         
         # The only thing this collection is used for is for cmsDriver to
         # warn the user if they specify an era that is discouraged from being


### PR DESCRIPTION
Add a `Run2_2017` era that includes the Phase 1 pixel detector; and a `Phase2Dev` era for every Phase2 component that currently works in 76X.  I'm not entirely convinced by the name `Phase2Dev`, if anyone wants it changed please comment here.

Put in on 7_6_X, not sure if it should be 8_0_X only?

Currently no changes added to either scenario, I thought integration would be easier if that was done in separate pull requests.  Note that this includes #12124 otherwise there would probably be merge conflicts (EDIT - now no longer true; decoupled from #12124).
