### PR TITLE
75X - Fix for handling of rare cases of CSC CFEB data corruptions with incorrect 16 samples flag reporting

### DIFF
--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -36,7 +36,12 @@ CSCCFEBData::CSCCFEBData(unsigned number, unsigned short * buf, uint16_t format_
 	theSliceStarts.push_back(std::pair<int, bool>(pos, true));
 	// it will just be an array of CSCCFEBTimeSlices, so we'll
 	// grab the number of time slices from the first good one
-	maxSamples =   goodSlice->sixteenSamples() ? 16 : 8;
+	// !!! VB - Limit maximum number of CFEB samples to 8. 
+	// !!!      In Run2 rare CFEB data corruptions were causing RECO problems with mistakenly setting 16 samples flags
+	// !!!      Will need another fix in case of CSC switch to 16 samples readout
+	// maxSamples =   goodSlice->sixteenSamples() ? 16 : 8;
+	if (goodSlice->sixteenSamples()) LogTrace ("CSCCFEBData|CSCRawToDigi")
+          << "CFEB DATA slice " << theNumberOfSamples << " 16 samples flag is detected";
 	pos += goodSlice->sizeInWords();
       } 
       else {


### PR DESCRIPTION
75X - Fix for handling of rare cases of CSC CFEB data corruptions with incorrect 16 samples flag reporting.
- Limit CSC CFEB maximum expected and unpacked samples to 8, to prevent CSC RECO assertion failures, when CFEBs send corrupted data with 16 samples flag set. 
  Refer to https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1395.html thread.
  74X - PR #12186 
