### PR TITLE
Fix race condition in DAQ modules when exception is thrown in event processing (only affecting multithreading) - 76X

### DIFF
--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -217,7 +217,7 @@ namespace evf{
     if (to==edm::TerminationOrigin::ExceptionFromThisContext) context =  " FromThisContext ";
     if (to==edm::TerminationOrigin::ExceptionFromAnotherContext) context =  " FromAnotherContext";
     if (to==edm::TerminationOrigin::ExternalSignal) context = " FromExternalSignal";
-    edm::LogInfo("FastMonitoringService") << " STREAM " << sc.streamID().value() << " earlyTermination -: ID:"<< sc.eventID() 
+    edm::LogWarning("FastMonitoringService") << " STREAM " << sc.streamID().value() << " earlyTermination -: ID:"<< sc.eventID() 
                                           << " LS:" << sc.eventID().luminosityBlock() << " " << context;
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
     exceptionInLS_.push_back(sc.eventID().luminosityBlock());
@@ -230,7 +230,7 @@ namespace evf{
     if (to==edm::TerminationOrigin::ExceptionFromThisContext) context =  " FromThisContext ";
     if (to==edm::TerminationOrigin::ExceptionFromAnotherContext) context =  " FromAnotherContext";
     if (to==edm::TerminationOrigin::ExternalSignal) context = " FromExternalSignal";
-    edm::LogInfo("FastMonitoringService") << " GLOBAL " << "earlyTermination -: LS:"
+    edm::LogWarning("FastMonitoringService") << " GLOBAL " << "earlyTermination -: LS:"
                                           << gc.luminosityBlockID().luminosityBlock() << " " << context;
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
     exceptionInLS_.push_back(gc.luminosityBlockID().luminosityBlock());
@@ -243,7 +243,7 @@ namespace evf{
     if (to==edm::TerminationOrigin::ExceptionFromThisContext) context =  " FromThisContext ";
     if (to==edm::TerminationOrigin::ExceptionFromAnotherContext) context =  " FromAnotherContext";
     if (to==edm::TerminationOrigin::ExternalSignal) context = " FromExternalSignal";
-    edm::LogInfo("FastMonitoringService") << " SOURCE " << "earlyTermination -: " << context;
+    edm::LogWarning("FastMonitoringService") << " SOURCE " << "earlyTermination -: " << context;
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
     exception_detected_=true; 
   }
@@ -357,34 +357,32 @@ namespace evf{
               throw cms::Exception("FastMonitoringService") << "Internal error: got null pointer from FastMonitor";
 	  processedEventsPerLumi_[lumi] = std::pair<unsigned int,bool>(lumiProcessedJptr->value(),false);
 
-	  {
-	    auto itr = sourceEventsReport_.find(lumi);
-	    if (itr==sourceEventsReport_.end()) {
-              //check if exception has been thrown (in case of Global/Stream early termination, for this LS)
-              bool exception_detected = exception_detected_;
-              for (auto ex : exceptionInLS_)
-                if (lumi == ex) exception_detected=true;
+          //checking if exception has been thrown (in case of Global/Stream early termination, for this LS)
+          bool exception_detected = exception_detected_;
+          for (auto ex : exceptionInLS_)
+            if (lumi == ex) exception_detected=true;
 
-              if (edm::shutdown_flag || exception_detected) {
-                edm::LogInfo("FastMonitoringService") << "Run interrupted. Skip writing EoL information -: "
-                                                      << processedEventsPerLumi_[lumi].first << " events were processed in LUMI " << lumi;
-                //this will prevent output modules from producing json file for possibly incomplete lumi
-                processedEventsPerLumi_[lumi].first=0;
-                processedEventsPerLumi_[lumi].second=true;
-                return;
-              }
-              //disable this exception, so service can be used standalone (will be thrown if output module asks for this information)
-              //throw cms::Exception("FastMonitoringService") << "SOURCE did not send update for lumi block. LUMI -:" << lumi;
+          if (edm::shutdown_flag || exception_detected) {
+            edm::LogInfo("FastMonitoringService") << "Run interrupted. Skip writing EoL information -: "
+                                                  << processedEventsPerLumi_[lumi].first << " events were processed in LUMI " << lumi;
+            //this will prevent output modules from producing json file for possibly incomplete lumi
+            processedEventsPerLumi_[lumi].first=0;
+            processedEventsPerLumi_[lumi].second=true;
+            //disable this exception, so service can be used standalone (will be thrown if output module asks for this information)
+            //throw cms::Exception("FastMonitoringService") << "SOURCE did not send update for lumi block. LUMI -:" << lumi;
+            return;
+
+          }
+
+	  auto itr = sourceEventsReport_.find(lumi);
+	  if (itr!=sourceEventsReport_.end()) {
+	    if (itr->second!=processedEventsPerLumi_[lumi].first) {
+	      throw cms::Exception("FastMonitoringService") << "MISMATCH with SOURCE update. LUMI -: "
+                                                            << lumi
+                                                            << ", events(processed):" << processedEventsPerLumi_[lumi].first
+                                                            << " events(source):" << itr->second;
 	    }
-	    else {
-	      if (itr->second!=processedEventsPerLumi_[lumi].first) {
-		throw cms::Exception("FastMonitoringService") << "MISMATCH with SOURCE update. LUMI -: "
-                                                              << lumi
-                                                              << ", events(processed):" << processedEventsPerLumi_[lumi].first
-                                                              << " events(source):" << itr->second;
-	      }
-	      sourceEventsReport_.erase(itr);
-	    }
+	    sourceEventsReport_.erase(itr);
 	  }
 	  edm::LogInfo("FastMonitoringService")	<< "Statistics for lumisection -: lumi = " << lumi << " events = "
 			                        << lumiProcessedJptr->value() << " time = " << usecondsForLumi/1000000


### PR DESCRIPTION
Port of #12200 (75X).

A rare race condition occurs when exception is thrown during processing of last few events in a file and LS. In this case, another thread can already request next event from the source. If next event belongs to the next LS, input source reports to the FastMonitoringService a total number of events in previous LS.

Normally in case of exception, we skip writing JSON stream output (catching exception action callback in the FastMonitoringService), and subsequently hltd assigns missing events as error events to close micro-merge of that LS. However, suppression was not happening after input source already reported the total number of events to the FastMonitoringService. This lead to incomplete micromerge for some streams. The problem is present only in multithreading, as in the single-threaded mode source can get a request for next event before exception on currently processed event is thrown (i.e. event requests are aborted and run/LS get closed).

In this update, JSON output is suppressed if exception has been thrown, regardless of input source report.
