### PR TITLE
New Global Tags with cleanup and fixes for all scenarios; Reco changes for centralityBin in DQM; Heavy ion common alignment producer

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using JpsiMuMu events
+OutALCARECOTkAlJpsiMuMuHI_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlJpsiMuMuHI')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_ALCARECOTkAlJpsiMuMuHI_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+	'keep *_hiSelectedVertex_*_*')
+)
+
+import copy
+OutALCARECOTkAlJpsiMuMuHI = copy.deepcopy(OutALCARECOTkAlJpsiMuMuHI_noDrop)
+OutALCARECOTkAlJpsiMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_cff.py
@@ -1,0 +1,20 @@
+# AlCaReco for track based alignment using Jpsi->mumu events in heavy ion data
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_cff import *
+
+ALCARECOTkAlJpsiMuMuHIHLT = ALCARECOTkAlJpsiMuMuHLT.clone(
+    eventSetupPathsKey = 'TkAlJpsiMuMuHI'
+)
+
+ALCARECOTkAlJpsiMuMuHIDCSFilter = ALCARECOTkAlJpsiMuMuDCSFilter.clone()
+
+ALCARECOTkAlJpsiMuMuHIGoodMuons = ALCARECOTkAlJpsiMuMuGoodMuons.clone()
+
+ALCARECOTkAlJpsiMuMuHI = ALCARECOTkAlJpsiMuMu.clone(
+     src = 'hiGeneralTracks'
+)
+
+ALCARECOTkAlJpsiMuMuHI.GlobalSelector.muonSource = 'ALCARECOTkAlJpsiMuMuHIGoodMuons'
+
+seqALCARECOTkAlJpsiMuMuHI = cms.Sequence(ALCARECOTkAlJpsiMuMuHIHLT+ALCARECOTkAlJpsiMuMuHIDCSFilter+ALCARECOTkAlJpsiMuMuHIGoodMuons+ALCARECOTkAlJpsiMuMuHI)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_cff.py
@@ -13,4 +13,7 @@ ALCARECOTkAlMinBiasHI = ALCARECOTkAlMinBias.clone(
      src = 'hiGeneralTracks'
 )
 
+ALCARECOTkAlMinBiasHI.trackQualities = cms.vstring("highPurity")
+#ALCARECOTkAlMinBiasHI.pMin = 3.0 ##GeV
+
 seqALCARECOTkAlMinBiasHI = cms.Sequence(ALCARECOTkAlMinBiasHIHLT+ALCARECOTkAlMinBiasHIDCSFilter+ALCARECOTkAlMinBiasHI)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using MuonIsolated events
+OutALCARECOTkAlMuonIsolatedHI_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolatedHI')
+    ),
+    outputCommands = cms.untracked.vstring( 
+        'keep *_ALCARECOTkAlMuonIsolatedHI_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+	'keep *_hiSelectedVertex_*_*')
+)
+
+import copy
+OutALCARECOTkAlMuonIsolatedHI = copy.deepcopy(OutALCARECOTkAlMuonIsolatedHI_noDrop)
+OutALCARECOTkAlMuonIsolatedHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_cff.py
@@ -1,0 +1,33 @@
+# AlCaReco for track based alignment using isolated muon tracks
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_cff import *
+
+ALCARECOTkAlMuonIsolatedHIHLT = ALCARECOTkAlMuonIsolatedHLT.clone(
+    eventSetupPathsKey = 'TkAlMuonIsolated'
+    )
+
+ALCARECOTkAlMuonIsolatedHIDCSFilter = ALCARECOTkAlMuonIsolatedDCSFilter.clone()
+
+ALCARECOTkAlMuonIsolatedHIGoodMuons = ALCARECOTkAlMuonIsolatedGoodMuons.clone()
+ALCARECOTkAlMuonIsolatedHIRelCombIsoMuons = ALCARECOTkAlMuonIsolatedRelCombIsoMuons.clone(
+    src = 'ALCARECOTkAlMuonIsolatedHIGoodMuons'
+)
+
+ALCARECOTkAlMuonIsolatedHI = ALCARECOTkAlMuonIsolated.clone(
+    src = 'hiGeneralTracks'
+)
+
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.muonSource = 'ALCARECOTkAlMuonIsolatedHIRelCombIsoMuons'
+# Isolation is shifted to the muon preselection, and then applied intrinsically if applyGlobalMuonFilter = True
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.applyIsolationtest = False
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.minJetDeltaR = 0.1
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.applyGlobalMuonFilter = True
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.jetIsoSource = cms.InputTag("iterativeConePu5CaloJets")
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.jetCountSource = cms.InputTag("iterativeConePu5CaloJets")
+
+ALCARECOTkAlMuonIsolatedHI.TwoBodyDecaySelector.applyMassrangeFilter = False
+ALCARECOTkAlMuonIsolatedHI.TwoBodyDecaySelector.applyChargeFilter = False
+ALCARECOTkAlMuonIsolatedHI.TwoBodyDecaySelector.applyAcoplanarityFilter = False
+
+seqALCARECOTkAlMuonIsolatedHI = cms.Sequence(ALCARECOTkAlMuonIsolatedHIHLT+ALCARECOTkAlMuonIsolatedHIDCSFilter+ALCARECOTkAlMuonIsolatedHIGoodMuons+ALCARECOTkAlMuonIsolatedHIRelCombIsoMuons+ALCARECOTkAlMuonIsolatedHI)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using UpsilonMuMu events
+OutALCARECOTkAlUpsilonMuMuHI_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMuHI')
+    ),
+    outputCommands = cms.untracked.vstring( 
+        'keep *_ALCARECOTkAlUpsilonMuMuHI_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+	'keep *_hiSelectedVertex_*_*')
+)
+
+import copy
+OutALCARECOTkAlUpsilonMuMuHI = copy.deepcopy(OutALCARECOTkAlUpsilonMuMuHI_noDrop)
+OutALCARECOTkAlUpsilonMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_cff.py
@@ -1,0 +1,22 @@
+# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion data
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
+
+ALCARECOTkAlUpsilonMuMuHIHLT = ALCARECOTkAlUpsilonMuMuHLT.clone(
+    eventSetupPathsKey = 'TkAlUpsilonMuMuHI'
+)
+
+ALCARECOTkAlUpsilonMuMuHIDCSFilter = ALCARECOTkAlUpsilonMuMuDCSFilter.clone()
+
+ALCARECOTkAlUpsilonMuMuHIGoodMuons = ALCARECOTkAlUpsilonMuMuGoodMuons.clone()
+ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons = ALCARECOTkAlUpsilonMuMuRelCombIsoMuons.clone()
+ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons.src = 'ALCARECOTkAlUpsilonMuMuHIGoodMuons'
+ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons.cut = '(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.3'
+
+ALCARECOTkAlUpsilonMuMuHI = ALCARECOTkAlUpsilonMuMu.clone(
+     src = 'hiGeneralTracks'
+)
+ALCARECOTkAlUpsilonMuMuHI.GlobalSelector.muonSource = 'ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons'
+
+seqALCARECOTkAlUpsilonMuMuHI = cms.Sequence(ALCARECOTkAlUpsilonMuMuHIHLT+ALCARECOTkAlUpsilonMuMuHIDCSFilter+ALCARECOTkAlUpsilonMuMuHIGoodMuons+ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons+ALCARECOTkAlUpsilonMuMuHI)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using ZMuMu events
+OutALCARECOTkAlZMuMuHI_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlZMuMuHI')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_ALCARECOTkAlZMuMuHI_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+	'keep *_hiSelectedVertex_*_*')
+)
+
+import copy
+OutALCARECOTkAlZMuMuHI = copy.deepcopy(OutALCARECOTkAlZMuMuHI_noDrop)
+OutALCARECOTkAlZMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_cff.py
@@ -1,0 +1,21 @@
+# AlCaReco for track based alignment using Z->mumu events in heavy ion data
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
+
+ALCARECOTkAlZMuMuHIHLT = ALCARECOTkAlZMuMuHLT.clone(
+    eventSetupPathsKey = 'TkAlZMuMuHI'
+)
+
+ALCARECOTkAlZMuMuHIDCSFilter = ALCARECOTkAlZMuMuDCSFilter.clone()
+
+ALCARECOTkAlZMuMuHIGoodMuons = ALCARECOTkAlZMuMuGoodMuons.clone()
+ALCARECOTkAlZMuMuHIRelCombIsoMuons = ALCARECOTkAlZMuMuRelCombIsoMuons.clone()
+ALCARECOTkAlZMuMuHIRelCombIsoMuons.src = 'ALCARECOTkAlZMuMuHIGoodMuons'
+
+ALCARECOTkAlZMuMuHI = ALCARECOTkAlZMuMu.clone(
+     src = 'hiGeneralTracks'
+)
+ALCARECOTkAlZMuMuHI.GlobalSelector.muonSource = 'ALCARECOTkAlZMuMuHIRelCombIsoMuons'
+
+seqALCARECOTkAlZMuMuHI = cms.Sequence(ALCARECOTkAlZMuMuHIHLT+ALCARECOTkAlZMuMuHIDCSFilter+ALCARECOTkAlZMuMuHIGoodMuons+ALCARECOTkAlZMuMuHIRelCombIsoMuons+ALCARECOTkAlZMuMuHI)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '75X_mcRun1_design_v5',
+    'run1_design'       :   '75X_mcRun1_design_v7',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '75X_mcRun1_realistic_v5',
+    'run1_mc'           :   '75X_mcRun1_realistic_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v5',
+    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v7',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '75X_mcRun1_pA_v5',
+    'run1_mc_pa'        :   '75X_mcRun1_pA_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v7',
+    'run2_design'       :   '75X_mcRun2_design_v10',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v6',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v9',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v7',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v10',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v7',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v6',
+    'run1_data'         :   '75X_dataRun1_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v6',
+    'run2_data'         :   '75X_dataRun2_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v3',
+    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v2',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 ###############################################################
 # AlCaReco for track based alignment using ZMuMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_Output_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_Output_cff import *
 # AlCaReco for track based alignment using Cosmic muon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsInCollisions_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics_Output_cff import *
@@ -15,12 +16,15 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0THLT_Output_cff impor
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlLAS_Output_cff import *
 # AlCaReco for track based alignment using isoMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_Output_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_Output_cff import *
 # AlCaReco for track based alignment using isoMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedPA_Output_cff import *
 # AlCaReco for track based alignment using J/Psi events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_Output_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMuHI_Output_cff import *
 # AlCaReco for track based alignment using Upsilon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_Output_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuHI_Output_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBiasHI_Output_cff import *

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -858,7 +858,7 @@ steps['REPACKHID']=merge([{'--scenario':'HeavyIons',
                          '--eventcontent':'REPACKRAW'},
                         steps['RECOD']])
 steps['RECOHID10']=merge([{'--scenario':'HeavyIons',
-                         '-s':'RAW2DIGI,L1Reco,RECO,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBiasHI+HcalCalMinBias,DQM',
+                         '-s':'RAW2DIGI,L1Reco,RECO,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBiasHI+TkAlUpsilonMuMuHI+TkAlZMuMuHI+TkAlMuonIsolatedHI+TkAlJpsiMuMuHI+HcalCalMinBias,DQM',
                          '--datatier':'RECO,DQMIO',
                          '--eventcontent':'RECO,DQM','-n':30},
                         steps['RECOD']])

--- a/Configuration/StandardSequences/python/AlCaRecoStreamsHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreamsHeavyIons_cff.py
@@ -8,7 +8,7 @@ import FWCore.ParameterSet.Config as cms
 # Tracker Alignment
 ###############################################################
 # AlCaReco for track based alignment using ZMuMu events
-from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_cff import *
 # AlCaReco for track based alignment using Cosmic muon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsInCollisions_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics_cff import *
@@ -16,11 +16,11 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsHLT_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0T_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0THLT_cff import *
 # AlCaReco for track based alignment using isoMu events
-from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_cff import *
 # AlCaReco for track based alignment using J/Psi events
-from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMuHI_cff import *
 # AlCaReco for track based alignment using Upsilon events
-from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuHI_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBiasHI_cff import *
 
@@ -99,10 +99,10 @@ from DQMOffline.Configuration.AlCaRecoDQMHI_cff import *
 
 # AlCaReco path definitions:
 
-pathALCARECOTkAlZMuMu = cms.Path(seqALCARECOTkAlZMuMu*ALCARECOTkAlZMuMuDQM)
-pathALCARECOTkAlMuonIsolated = cms.Path(seqALCARECOTkAlMuonIsolated*ALCARECOTkAlMuonIsolatedDQM)
-pathALCARECOTkAlJpsiMuMu = cms.Path(seqALCARECOTkAlJpsiMuMu*ALCARECOTkAlJpsiMuMuDQM)
-pathALCARECOTkAlUpsilonMuMu = cms.Path(seqALCARECOTkAlUpsilonMuMu*ALCARECOTkAlUpsilonMuMuDQM)
+pathALCARECOTkAlZMuMuHI = cms.Path(seqALCARECOTkAlZMuMuHI*ALCARECOTkAlZMuMuHIDQM)
+pathALCARECOTkAlMuonIsolatedHI = cms.Path(seqALCARECOTkAlMuonIsolatedHI*ALCARECOTkAlMuonIsolatedHIDQM)
+pathALCARECOTkAlJpsiMuMuHI = cms.Path(seqALCARECOTkAlJpsiMuMuHI*ALCARECOTkAlJpsiMuMuHIDQM)
+pathALCARECOTkAlUpsilonMuMuHI = cms.Path(seqALCARECOTkAlUpsilonMuMuHI*ALCARECOTkAlUpsilonMuMuHIDQM)
 pathALCARECOTkAlMinBiasHI = cms.Path(seqALCARECOTkAlMinBiasHI*ALCARECOTkAlMinBiasHIDQM)
 pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
@@ -148,7 +148,7 @@ from Configuration.EventContent.AlCaRecoOutput_cff import *
 
 
 ALCARECOStreamTkAlMinBiasHI = cms.FilteredStream(
-	responsible = 'Andreas Mussgiller',
+	responsible = 'James Castle',
 	name = 'TkAlMinBiasHI',
 	paths  = (pathALCARECOTkAlMinBiasHI),
 	content = OutALCARECOTkAlMinBiasHI.outputCommands,
@@ -156,39 +156,39 @@ ALCARECOStreamTkAlMinBiasHI = cms.FilteredStream(
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
-ALCARECOStreamTkAlMuonIsolated = cms.FilteredStream(
-	responsible = 'Andreas Mussgiller',
-	name = 'TkAlMuonIsolated',
-	paths  = (pathALCARECOTkAlMuonIsolated),
-	content = OutALCARECOTkAlMuonIsolated.outputCommands,
-	selectEvents = OutALCARECOTkAlMuonIsolated.SelectEvents,
+ALCARECOStreamTkAlMuonIsolatedHI = cms.FilteredStream(
+	responsible = 'James Castle',
+	name = 'TkAlMuonIsolatedHI',
+	paths  = (pathALCARECOTkAlMuonIsolatedHI),
+	content = OutALCARECOTkAlMuonIsolatedHI.outputCommands,
+	selectEvents = OutALCARECOTkAlMuonIsolatedHI.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
-ALCARECOStreamTkAlZMuMu = cms.FilteredStream(
-	responsible = 'Andreas Mussgiller',
-	name = 'TkAlZMuMu',
-	paths  = (pathALCARECOTkAlZMuMu),
-	content = OutALCARECOTkAlZMuMu.outputCommands,
-	selectEvents = OutALCARECOTkAlZMuMu.SelectEvents,
+ALCARECOStreamTkAlZMuMuHI = cms.FilteredStream(
+	responsible = 'James Castle',
+	name = 'TkAlZMuMuHI',
+	paths  = (pathALCARECOTkAlZMuMuHI),
+	content = OutALCARECOTkAlZMuMuHI.outputCommands,
+	selectEvents = OutALCARECOTkAlZMuMuHI.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
-ALCARECOStreamTkAlJpsiMuMu = cms.FilteredStream(
-	responsible = 'Andreas Mussgiller',
-	name = 'TkAlJpsiMuMu',
-	paths  = (pathALCARECOTkAlJpsiMuMu),
-	content = OutALCARECOTkAlJpsiMuMu.outputCommands,
-	selectEvents = OutALCARECOTkAlJpsiMuMu.SelectEvents,
+ALCARECOStreamTkAlJpsiMuMuHI = cms.FilteredStream(
+	responsible = 'James Castle',
+	name = 'TkAlJpsiMuMuHI',
+	paths  = (pathALCARECOTkAlJpsiMuMuHI),
+	content = OutALCARECOTkAlJpsiMuMuHI.outputCommands,
+	selectEvents = OutALCARECOTkAlJpsiMuMuHI.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
-ALCARECOStreamTkAlUpsilonMuMu = cms.FilteredStream(
-	responsible = 'Andreas Mussgiller',
-	name = 'TkAlUpsilonMuMu',
-	paths  = (pathALCARECOTkAlUpsilonMuMu),
-	content = OutALCARECOTkAlUpsilonMuMu.outputCommands,
-	selectEvents = OutALCARECOTkAlUpsilonMuMu.SelectEvents,
+ALCARECOStreamTkAlUpsilonMuMuHI = cms.FilteredStream(
+	responsible = 'James Castle',
+	name = 'TkAlUpsilonMuMuHI',
+	paths  = (pathALCARECOTkAlUpsilonMuMuHI),
+	content = OutALCARECOTkAlUpsilonMuMuHI.outputCommands,
+	selectEvents = OutALCARECOTkAlUpsilonMuMuHI.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 

--- a/DQM/Physics/python/CentralityDQM_cfi.py
+++ b/DQM/Physics/python/CentralityDQM_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 CentralityDQM = cms.EDAnalyzer(
     "CentralityDQM",
     centralitycollection = cms.InputTag("hiCentrality"),
+    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
     vertexcollection = cms.InputTag("hiSelectedVertex"),
     eventplanecollection= cms.InputTag("hiEvtPlane")
-
     )

--- a/DQM/Physics/src/CentralityDQM.h
+++ b/DQM/Physics/src/CentralityDQM.h
@@ -48,6 +48,11 @@ class CentralityDQM : public DQMEDAnalyzer {
 
   edm::InputTag  eventplaneTag_;
   edm::EDGetTokenT<reco::EvtPlaneCollection> eventplaneToken;
+  
+  edm::InputTag centralityBinTag_;
+  edm::EDGetTokenT<int> centralityBinToken;
+  edm::Handle<int>centralityBin_;
+
 
   ///////////////////////////
   // Histograms
@@ -80,6 +85,8 @@ class CentralityDQM : public DQMEDAnalyzer {
   MonitorElement* h_vertex_x;
   MonitorElement* h_vertex_y;
   MonitorElement* h_vertex_z;
+
+  MonitorElement* h_cent_bin;
 
   MonitorElement* h_ep_HFm1;
   MonitorElement* h_ep_HFp1;

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -58,6 +58,40 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import ALCARECOTkAl
 ALCARECOTkAlZMuMuDQM = cms.Sequence( ALCARECOTkAlZMuMuTrackingDQM + ALCARECOTkAlZMuMuTkAlDQM )
 
 #########################################################
+#############---  TkAlZMuMuHI ---########################
+#########################################################
+__selectionName = 'TkAlZMuMuHI'
+ALCARECOTkAlZMuMuHITrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
+    primaryVertex = cms.InputTag('hiSelectedVertex'),
+)
+
+ALCARECOTkAlZMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
+    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" ),
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_cff import ALCARECOTkAlZMuMuHIHLT
+#ALCARECOTkAlZMuMuHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*Mu.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlZMuMuHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlZMuMuDQM = cms.Sequence( ALCARECOTkAlZMuMuTrackingDQM + ALCARECOTkAlZMuMuTkAlDQM + ALCARECOTkAlZMuMuHLTDQM)
+ALCARECOTkAlZMuMuHIDQM = cms.Sequence( ALCARECOTkAlZMuMuHITrackingDQM + ALCARECOTkAlZMuMuHITkAlDQM )
+
+#########################################################
 #############---  TkAlJpsiMuMu ---#######################
 #########################################################
 __selectionName = 'TkAlJpsiMuMu'
@@ -92,6 +126,45 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_cff import ALCARECOT
 #ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM + ALCARECOTkAlJpsiMuMuHLTDQM)
 ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM )
 
+#########################################################
+#############---  TkAlJpsiMuMuHI ---#####################
+#########################################################
+__selectionName = 'TkAlJpsiMuMuHI'
+ALCARECOTkAlJpsiMuMuHITrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
+    primaryVertex = cms.InputTag('hiSelectedVertex'),
+# margins and settings
+    TrackPtMax = 50
+)
+
+ALCARECOTkAlJpsiMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
+    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" ),
+# margins and settings
+    MassMin = 2.5,
+    MassMax = 4.0,
+    TrackPtMax = 50
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMuHI_cff import ALCARECOTkAlJpsiMuMuHIHLT
+#ALCARECOTkAlJpsiMuMuHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*Mu.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlJpsiMuMuHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM + ALCARECOTkAlJpsiMuMuHLTDQM)
+ALCARECOTkAlJpsiMuMuHIDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuHITrackingDQM + ALCARECOTkAlJpsiMuMuHITkAlDQM )
 
 ############################################################
 #############---  TkAlUpsilonMuMu ---#######################
@@ -127,7 +200,45 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import ALCARE
 #ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuHLTDQM)
 ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM )
 
+############################################################
+#############---  TkAlUpsilonMuMuHI ---#####################
+############################################################
+__selectionName = 'TkAlUpsilonMuMuHI'
+ALCARECOTkAlUpsilonMuMuHITrackingDQM = ALCARECOTkAlJpsiMuMuHITrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
+    primaryVertex = cms.InputTag('hiSelectedVertex'),
+# margins and settings
+    TrackPtMax = 50
+)
 
+ALCARECOTkAlUpsilonMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
+    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" ),
+# margins and settings
+    MassMin = 8.,
+    MassMax = 10,
+    TrackPtMax = 50
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuHI_cff import ALCARECOTkAlUpsilonMuMuHIHLT
+#ALCARECOTkAlUpsilonMuMuHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*Mu.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlUpsilonMuMuHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuHLTDQM)
+ALCARECOTkAlUpsilonMuMuHIDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuHITrackingDQM + ALCARECOTkAlUpsilonMuMuHITkAlDQM )
 
 #########################################################
 #############---  TkAlBeamHalo ---#######################
@@ -282,6 +393,41 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_cff import ALCAR
 #ALCARECOTkAlMuonIsolatedDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedTrackingDQM + ALCARECOTkAlMuonIsolatedTkAlDQM+ALCARECOTkAlMuonIsolatedHLTDQM)
 ALCARECOTkAlMuonIsolatedDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedTrackingDQM + ALCARECOTkAlMuonIsolatedTkAlDQM )
 
+#############################################################
+#############---  TkAlMuonIsolatedHI ---#####################
+#############################################################
+__selectionName = 'TkAlMuonIsolatedHI'
+ALCARECOTkAlMuonIsolatedHITrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
+    primaryVertex = cms.InputTag('hiSelectedVertex'),
+# margins and settings
+    TkSizeBin = 16,
+    TkSizeMin = -0.5,
+    TkSizeMax = 15.5
+)
+ALCARECOTkAlMuonIsolatedHITkAlDQM = ALCARECOTkAlMinBiasTkAlDQM.clone(
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
+    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" )
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_cff import ALCARECOTkAlMuonIsolatedHIHLT
+#ALCARECOTkAlMuonIsolatedHIHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*L1.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlMuonIsolatedHIHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlMuonIsolatedHIDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedHITrackingDQM + ALCARECOTkAlMuonIsolatedHITkAlDQM+ALCARECOTkAlMuonIsolatedHIHLTDQM)
+ALCARECOTkAlMuonIsolatedHIDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedHITrackingDQM + ALCARECOTkAlMuonIsolatedHITkAlDQM )
 
 ####################################################
 #############---  TkAlLAS ---#######################

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -25,6 +25,7 @@ from RecoHI.Configuration.Reconstruction_hiPF_cff import *
 
 # Heavy Ion Event Characterization
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import *
+from RecoHI.HiCentralityAlgos.CentralityBin_cfi import *
 from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import *
 from RecoHI.HiEvtPlaneAlgos.HiEvtPlane_cfi import *
 
@@ -42,6 +43,7 @@ globalRecoPbPb = cms.Sequence(hiTracking_wSplitting
                               * hiEgammaSequence
                               * hiParticleFlowReco
                               * hiCentrality
+                              * centralityBin
                               * hiClusterCompatibility
                               * hiEvtPlane
                               * hcalnoise
@@ -57,6 +59,7 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               * hiEgammaSequence
                                               * hiParticleFlowReco
                                               * hiCentrality
+                                              * centralityBin
                                               * hiClusterCompatibility
                                               * hiEvtPlane
                                               * hcalnoise

--- a/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
+++ b/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
@@ -2,15 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 RecoHiCentralityFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
-
 RecoHiCentralityRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
-
 RecoHiCentralityAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )


### PR DESCRIPTION
Adding Heavy-Ion specific Tracker Alignment AlCaReco producers for 75X, originally in #12030 by @jrcastle

To include centralityBin distribution in the DQM monitoring. For this, changes are requested in the HI reco sequence

```
Reconstruction_HI_cff.py
RecoHiCentrality_EventContent_cff.py
```

and in the Centrality DQM module

```
CentralityDQM_cfi.py
```

Originally in #12002 by @smdogra 

New Global Tags for all supported scenario.
Run1 ideal simulation: 75X_mcRun1_design_v7: As 75X_mcRun1_design_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated PF hadron calibration based on latest 75X analysis.

Run1 realistic simulation: 75X_mcRun1_realistic_v7: As 75X_mcRun1_realistic_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated PF hadron calibration based on latest 75X analysis.

Run1 HeavyIon simulation: 75X_mcRun1_HeavyIon_v7: As 75X_mcRun1_HeavyIon_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- added HFtowers label for centrality
- updated PF hadron calibration based on latest 75X analysis.

Run1 proton-lead simulation: 75X_mcRun1_pA_v7: As 75X_mcRun1_pA_v5 with the following changes:
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated PF hadron calibration based on latest 75X analysis.

Run2 design simulation: 75X_mcRun2_design_v10: As 75X_mcRun2_design_v7 with the following changes:
- added L1T Calorimeter parameters
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated Jet Probability calibration with the results produced on top of Spring15 DIGI-RECO campaign
- updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
- updated Preshower Zero suppression thresholds with 6 ADC
- updated HCAL dead channel map as in Run2015D
- updated HCAL pedestals
- updated HCAL pedestal widths
- updated set of Jet Energy Corrections from Summer15 campaign, in 25 ns bunch spacing
- updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
- updated PF hadron calibration based on latest 75X analysis
- updated Pixel dynamic inefficiency for 50 ns bunch spacing by using 0.999 values in all modules
- updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency.

Run2 startup simulation: 75X_mcRun2_startup_v9: As 75X_mcRun2_startup_v6 with the following changes:
- added L1T Calorimeter parameters
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated Jet Probability calibration with the results produced on top of Spring15 DIGI-RECO campaign
- updated Preshower bad channels as per Run2015D
- updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
- updated Preshower Zero suppression thresholds with 6 ADC
- updated HCAL dead channel map as in Run2015D
- updated HCAL pedestals
- updated HCAL pedestal widths
- updated set of Jet Energy Corrections from Summer15 campaign, in 25 ns bunch spacing
- updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
- updated PF hadron calibration based on latest 75X analysis
- updated Pixel dynamic inefficiency for 50 ns bunch spacing by using 0.999 values in all modules
- updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency.

Run2 asymptotic simulation: 75X_mcRun2_asymptotic_v10: As 75X_mcRun2_asymptotic_v9 with the following changes:
- added L1T Calorimeter parameters
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated Jet Probability calibration with the results produced on top of Spring15 DIGI-RECO campaign
- updated Preshower bad channels as per Run2015D
- updated Preshower pedestals as per pedestal run in low gain taken in Run2015D
- updated Preshower Zero suppression thresholds with 6 ADC
- updated HCAL dead channel map as in Run2015D
- updated HCAL pedestals
- updated HCAL pedestal widths
- updated set of Jet Energy Corrections from Summer15 campaign, in 25 ns bunch spacing
- updated L1T RPC configuration accounting for the changes that were done in July 2015 at p5
- updated PF hadron calibration based on latest 75X analysis
- updated Pixel dynamic inefficiency for 50 ns bunch spacing by using 0.999 values in all modules
- updated Strip Gain from MIP cluster charge counting, fixing a 10% deficiency.

Run2 HeavyIon simulation: 75X_mcRun2_HeavyIon_v7: As 75X_mcRun2_HeavyIon_v5 with the following changes:
- added L1T Calorimeter parameters
- added new label for HFtowers centrality
- taxonomy changes for DT reconstruction uncertainties, ECAL inter calibration errors, ECAL electronics map
- updated Jet Probability calibration with the results produced on top of Spring15 DIGI-RECO campaign.
- updated PF hadron calibration based on latest 75X analysis
- updated Pixel dynamic inefficiency for 50 ns bunch spacing by using 0.999 values in all modules

Run1 data: 75X_dataRun1_v8: As 75X_dataRun1_v6 with:
- updated AlcaReco Trigger bits to allow TkAl HI producers to run
- technical taxonomy change to get rid of fully qualified v1 account names in the tag names for several records
- updated DT,CSC and Global muon alignment for 2015
- updated CSC bad strips and bad wires
- updated EB,EE and ES alignments
- updated Ecal timing
- updated ECAL pulse shapes with an offline tag with 2 IOVs: the former for Run1, the latter for Run2
- updated Hcal gains, LongReco params, MCparams and Response corrections
- updated JEC to Summer V2 version
- added tag for L1TCaloParamsRcd
- updated PF hadron calibration with the latest version from dedicated MC studies.
- updated SiPixel Lorentz angle,templates and generic errors for 2015
- updated SiStrip noise
- move SiStrip FedCabling,Latency, Pedestals and Thresholds to Prompt tags
- updated Tracker alignment and surface deformations.

Run2 data: 75X_dataRun2_v8 As 75X_dataRun2_v6 with:
- updated AlcaReco Trigger bits to allow TkAl HI producers to run
- technical taxonomy change to get rid of fully qualified v1 account names in the tag names for several records
- updated DT,CSC and Global muon alignment for 2015
- updated CSC bad strips and bad wires
- updated EB,EE and ES alignments
- updated Ecal timing
- updated ECAL pulse shapes with an offline tag with 2 IOVs: the former for Run1, the latter for Run2
- updated Hcal gains, LongReco params, MCparams and Response corrections
- updated JEC to Summer V2 version
- added tag for L1TCaloParamsRcd
- updated PF hadron calibration with the latest version from dedicated MC studies.
- updated SiPixel Lorentz angle,templates and generic errors for 2015
- updated SiStrip noise
- move SiStrip FedCabling,Latency, Pedestals and Thresholds to Prompt tags
- updated Tracker alignment and surface deformations.

Run1 HLT: 75X_dataRun1_HLT_frozen_v4
As 75X_dataRun1_HLT_frozen_v3 (snapshot 2015-10-30 10:23:00 UTC) with the following changes:
- added tag for L1TCaloParamsRcd
- technical taxonomy change to get rid of fully qualified v1 account names in the tag names for several records
- updated PF hadron calibration with the latest version from dedicated MC studies.

Run2 HLT: 75X_dataRun2_HLT_frozen_v4: As 75X_dataRun2_HLT_frozen_v3 (snapshot 2015-10-30 10:23:00 UTC) with the following changes:
- added tag for L1TCaloParamsRcd
- technical taxonomy change to get rid of fully qualified v1 account names in the tag names for several records
- updated PF hadron calibration with the latest version from dedicated MC studies.
