### PR TITLE
PR for adding the cfi of HITrackClusterRemover.cc for ConfDB use in 76 (same as #12220)

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/python/HITrackClusterRemover_cfi.py
+++ b/RecoLocalTracker/SubCollectionProducers/python/HITrackClusterRemover_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+HITrackClusterRemover = cms.EDProducer( "HITrackClusterRemover",
+     clusterLessSolution = cms.bool(True),
+     trajectories = cms.InputTag("hltHIGlobalPrimTracks"),
+     oldClusterRemovalInfo = cms.InputTag( "" ),
+     overrideTrkQuals = cms.InputTag( 'hltHIIter0TrackSelection','hiInitialStep' ),
+     TrackQuality = cms.string('highPurity'),
+     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+     pixelClusters = cms.InputTag("hltHISiPixelClusters"),
+     stripClusters = cms.InputTag("hltHITrackingSiStripRawToClustersFacility"),
+     Common = cms.PSet(
+         maxChi2 = cms.double(9.0),
+     ),
+     Strip = cms.PSet(
+        # Yen-Jie's mod to preserve merged clusters
+        maxSize = cms.uint32(2),
+        maxChi2 = cms.double(9.0)
+     )
+)
+

--- a/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
@@ -146,6 +146,7 @@ HITrackClusterRemover::HITrackClusterRemover(const ParameterSet& iConfig):
     stripRecHits_(doStripChargeCheck_ ? iConfig.getParameter<std::string>("stripRecHits") : std::string("siStripMatchedRecHits")),
     pixelRecHits_(doPixelChargeCheck_ ? iConfig.getParameter<std::string>("pixelRecHits") : std::string("siPixelRecHits"))
 {
+  mergeOld_ = mergeOld_ && iConfig.getParameter<InputTag>("oldClusterRemovalInfo").label()!="";
   if (iConfig.exists("overrideTrkQuals"))
     overrideTrkQuals_.push_back(consumes<edm::ValueMap<int> >(iConfig.getParameter<InputTag>("overrideTrkQuals")));
   if (iConfig.exists("clusterLessSolution"))


### PR DESCRIPTION
Hello,

We would ask to PR the following modification in order to be able to use the HITrackClusterRemover
in ConfDB for HLT tracking. The PR consist of the corresponding cfi file and a small modification in the producer as a protection in case of null string in the oldClusterRemovalInfo.

Same as  #12220 
Thanks, Cheers, Gian Michele
