### PR TITLE
Add enum to PackedCandidate and functions to MiniFloatConverter to aid validation

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -376,6 +376,11 @@ namespace pat {
     }
     /// set impact parameters covariance
 
+    // Note: mask is also the maximum value
+    enum trackHitShiftsAndMasks {
+      trackPixelHitsMask = 7,
+      trackStripHitsMask = 31, trackStripHitsShift = 3
+    };
     virtual void setTrackProperties( const reco::Track & tk, const reco::Track::CovarianceMatrix & covariance) {
       dxydxy_ = covariance(3,3);
       dxydz_ = covariance(3,4);
@@ -388,10 +393,10 @@ namespace pat {
 
       normalizedChi2_ = tk.normalizedChi2();
       int numberOfPixelHits_ = tk.hitPattern().numberOfValidPixelHits();
-      if (numberOfPixelHits_ > 7) numberOfPixelHits_ = 7;
+      if (numberOfPixelHits_ > trackPixelHitsMask) numberOfPixelHits_ = trackPixelHitsMask;
       int numberOfStripHits_ = tk.hitPattern().numberOfValidHits() - numberOfPixelHits_;
-      if (numberOfStripHits_ > 31) numberOfStripHits_ = 31;
-      packedHits_ = (numberOfPixelHits_&0x7) | (numberOfStripHits_ << 3);
+      if (numberOfStripHits_ > trackStripHitsMask) numberOfStripHits_ = trackStripHitsMask;
+      packedHits_ = (numberOfPixelHits_&trackPixelHitsMask) | (numberOfStripHits_ << trackStripHitsShift);
       packBoth();
     }
 
@@ -399,8 +404,8 @@ namespace pat {
 	setTrackProperties(tk,tk.covariance());
     }	
  
-    int numberOfPixelHits() const { return packedHits_ & 0x7; }
-    int numberOfHits() const { return (packedHits_ >> 3) + numberOfPixelHits(); }
+    int numberOfPixelHits() const { return packedHits_ & trackPixelHitsMask; }
+    int numberOfHits() const { return (packedHits_ >> trackStripHitsShift) + numberOfPixelHits(); }
 	
     /// vertex position
     virtual const Point & vertex() const { maybeUnpackBoth(); return *vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }

--- a/DataFormats/PatCandidates/interface/libminifloat.h
+++ b/DataFormats/PatCandidates/interface/libminifloat.h
@@ -45,6 +45,48 @@ class MiniFloatConverter {
             conv.i32&=mask;
             return conv.flt;
         }
+
+        inline static float max() {
+            union { float flt; uint32_t i32; } conv;
+            conv.i32 = 0x477fe000; // = mantissatable[offsettable[0x1e]+0x3ff]+exponenttable[0x1e]
+            return conv.flt;
+        }
+
+        // Maximum float32 value that gets rounded to max()
+        inline static float max32RoundedToMax16() {
+            union { float flt; uint32_t i32; } conv;
+            // 2^16 in float32 is the first to result inf in float16, so
+            // 2^16-1 is the last float32 to result max() in float16
+            conv.i32 = (0x8f<<23) - 1;
+            return conv.flt;
+        }
+
+        inline static float min() {
+            union { float flt; uint32_t i32; } conv;
+            conv.i32 = 0x38800000; // = mantissatable[offsettable[1]+0]+exponenttable[1]
+            return conv.flt;
+        }
+
+        // Minimum float32 value that gets rounded to min()
+        inline static float min32RoundedToMin16() {
+            union { float flt; uint32_t i32; } conv;
+            // 2^-14-1 in float32 is the first to result denormalized in float16, so
+            // 2^-14 is the first float32 to result min() in float16
+            conv.i32 = (0x71<<23);
+            return conv.flt;
+        }
+
+        inline static float denorm_min() {
+            union { float flt; uint32_t i32; } conv;
+            conv.i32 = 0x33800000; // mantissatable[offsettable[0]+1]+exponenttable[0]
+            return conv.flt;
+        }
+
+        inline static bool isdenorm(uint16_t h) {
+            // if exponent is zero (sign-bit excluded of course) and mantissa is not zero
+            return ((h >> 10) & 0x1f) == 0 && (h & 0x3ff) != 0;
+        }
+
     private:
         CMS_THREAD_SAFE static uint32_t mantissatable[2048];
         CMS_THREAD_SAFE static uint32_t exponenttable[64];

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -169,8 +169,8 @@ void pat::PackedCandidate::unpackTrk() const {
     m(4,3)=dxydz_;
     m(4,4)=dzdz_;
     math::RhoEtaPhiVector p3(p4_.load()->pt(),p4_.load()->eta(),phiAtVtx());
-    int numberOfPixelHits = packedHits_ & 0x7 ;
-    int numberOfHits = (packedHits_>>3) + numberOfPixelHits;
+    int numberOfPixelHits = packedHits_ & trackPixelHitsMask ;
+    int numberOfHits = (packedHits_>>trackStripHitsShift) + numberOfPixelHits;
 
     int ndof = numberOfHits+numberOfPixelHits-5;
     reco::HitPattern hp, hpExpIn;

--- a/DataFormats/PatCandidates/test/BuildFile.xml
+++ b/DataFormats/PatCandidates/test/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/PatCandidates"/>
-<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testPackedGenParticle.cc,testRunner.cpp"/>
+<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testPackedGenParticle.cc,testMiniFloat.cpp,testRunner.cpp"/>
 <bin   name="testKinResolutions" file="testKinParametrizations.cc,testKinResolutions.cc,testRunner.cpp">
   <flags   NO_TESTRUN="1"/>
 </bin>

--- a/DataFormats/PatCandidates/test/testMiniFloat.cpp
+++ b/DataFormats/PatCandidates/test/testMiniFloat.cpp
@@ -1,0 +1,115 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <iostream>
+
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
+class testMiniFloat : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testMiniFloat);
+
+  CPPUNIT_TEST(testIsDenorm);
+  CPPUNIT_TEST(testMax);
+  CPPUNIT_TEST(testMax32RoundedToMax16);
+  CPPUNIT_TEST(testMin);
+  CPPUNIT_TEST(testMin32RoundedToMin16);
+  CPPUNIT_TEST(testDenormMin);
+
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void testIsDenorm();
+  void testMax() ;
+  void testMax32RoundedToMax16();
+  void testMin();
+  void testMin32RoundedToMin16();
+  void testDenormMin();
+
+private:
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testMiniFloat);
+
+void testMiniFloat::testIsDenorm() {
+  // all float16s with zero exponent and non-zero mantissa are denormals, test here the boundaries
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(1));
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(1 | (1<<15))); // negative 1
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(0x3ff));
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(0x3ff) | (1<<15)); // negative full-1 mantissa
+
+  // Test also boundary cases for float16 not being denormal
+  CPPUNIT_ASSERT(!MiniFloatConverter::isdenorm(0));
+  CPPUNIT_ASSERT(!MiniFloatConverter::isdenorm(0x400)); // exponent 1, zero mantissa
+  CPPUNIT_ASSERT(!MiniFloatConverter::isdenorm(0x400 | (1<<15))); // negative exponent 1, zero mantissa
+}
+
+void testMiniFloat::testMax() {
+  // 0x1f exponent is for inf, so 0x1e is the maximum
+  // in maximum mantissa all bits are 1
+  const uint16_t minifloatmax = (0x1e << 10) | 0x3ff;
+  CPPUNIT_ASSERT(MiniFloatConverter::max() == MiniFloatConverter::float16to32(minifloatmax));
+
+  // adding 1ulp(16) to max should give inf
+  const uint16_t minifloatinf = minifloatmax + 1;
+  CPPUNIT_ASSERT(edm::isNotFinite(MiniFloatConverter::float16to32(minifloatinf)));
+}
+
+void testMiniFloat::testMax32RoundedToMax16() {
+  // max32RoundedToMax16() -> float16 -> float32 should give max()
+  CPPUNIT_ASSERT(MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(MiniFloatConverter::max32RoundedToMax16())) == MiniFloatConverter::max());
+
+  // max32RoundedToMax16() + 1ulp(32) should give inf(16)
+  union { float flt; uint32_t i32; } conv;
+  conv.flt = MiniFloatConverter::max32RoundedToMax16();
+  conv.i32 += 1;
+  const float max32PlusUlp32RoundedTo16 = MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(conv.flt));
+  CPPUNIT_ASSERT(edm::isNotFinite(max32PlusUlp32RoundedTo16));
+}
+
+void testMiniFloat::testMin() {
+  // 1 exponent, and 0 mantissa gives the smallest non-denormalized number of float16
+  CPPUNIT_ASSERT(MiniFloatConverter::min() == MiniFloatConverter::float16to32(1 << 10));
+
+  // subtracting 1ulp(16) from min should give denormalized float16
+  const uint16_t minifloat_denorm = MiniFloatConverter::float32to16(MiniFloatConverter::min()) - 1;
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(minifloat_denorm));
+
+  // subtracking 1ulp(32) from min should also give denormalized float16 (both crop and round)
+  union { float flt; uint32_t i32; } conv;
+  conv.flt = MiniFloatConverter::min();
+  conv.i32 -= 1;
+  const uint16_t min32MinusUlp32CroppedTo16 = MiniFloatConverter::float32to16crop(conv.flt);
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(min32MinusUlp32CroppedTo16));
+  const uint16_t min32MinusUlp32RoundedTo16 = MiniFloatConverter::float32to16round(conv.flt);
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(min32MinusUlp32RoundedTo16));
+}
+
+void testMiniFloat::testMin32RoundedToMin16() {
+  // min32RoundedToMin16() -> float16 -> float32 should be the same as min()
+  CPPUNIT_ASSERT(MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(MiniFloatConverter::min32RoundedToMin16())) == MiniFloatConverter::min());
+
+  // min32RoundedToMax16() - 1ulp(32) should give denormalized float16
+  union { float flt; uint32_t i32; } conv;
+  conv.flt = MiniFloatConverter::min32RoundedToMin16();
+  conv.i32 -= 1;
+  const uint16_t min32MinusUlp32RoundedTo16 = MiniFloatConverter::float32to16(conv.flt);
+  CPPUNIT_ASSERT(MiniFloatConverter::isdenorm(min32MinusUlp32RoundedTo16));
+}
+
+void testMiniFloat::testDenormMin() {
+  // zero exponent, and 0x1 in mantissa gives the smallest number of float16
+  CPPUNIT_ASSERT(MiniFloatConverter::denorm_min() == MiniFloatConverter::float16to32(1));
+
+  // subtracting 1ulp(16) from denorm_min should give 0 float32
+  CPPUNIT_ASSERT(MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(MiniFloatConverter::denorm_min()) - 1) == 0.f);
+
+  // subtracking 1ulp(32) from denorm_min should also give 0 float32
+  union { float flt; uint32_t i32; } conv;
+  conv.flt = MiniFloatConverter::denorm_min();
+  conv.i32 -= 1;
+  const float min32MinusUlp32RoundedTo16 = MiniFloatConverter::float16to32(MiniFloatConverter::float32to16round(conv.flt));
+  CPPUNIT_ASSERT(min32MinusUlp32RoundedTo16 == 0.f);
+  const float min32MinusUlp32CroppedTo16 = MiniFloatConverter::float16to32(MiniFloatConverter::float32to16crop(conv.flt));
+  CPPUNIT_ASSERT(min32MinusUlp32CroppedTo16 == 0.f);
+}


### PR DESCRIPTION
This PR changes PackedCandidate to use enum instead of magic constants for track hit masks and shifts, and adds bunch of `std::numeric_limits` style functions to MiniFloatConverter (+unit tests for those). I need both for upcoming improvements in PackedCandidateTrackValidator (which I prefer to integrate separately to show that the changes here do not affect results).

Tested in 760pre3 and rebased on top of CMSSW_8_0_X_2015-10-28-1100. No changes expected in monitored quantities.

@rovere @VinInn @arizzi @gpetruc 
