### PR TITLE
Set tight mva value of HI initial step to be equal to highPurity mva value (80X version of #12223)

### DIFF
--- a/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
@@ -18,7 +18,7 @@ hiInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackS
     name = 'hiInitialStepTight',
     preFilterName = 'hiInitialStepLoose',
     useMVA = cms.bool(True),
-    minMVA = cms.double(-0.38)
+    minMVA = cms.double(-0.77)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiInitialStep',


### PR DESCRIPTION
80X version of PR #12223.
This PR changes mva value of 'tight' selection of HI initial step reconstruction. This is a minor fix to prevent confusion and it does not change the event content (because subsequent steps are dependent on 'highPurity', not 'tight' selection)
