### PR TITLE
Fixed package dependency problem in DQMOffline/Trigger/plugins

### DIFF
--- a/DQMOffline/Trigger/plugins/BuildFile.xml
+++ b/DQMOffline/Trigger/plugins/BuildFile.xml
@@ -16,7 +16,7 @@
 <use   name="RecoEgamma/EgammaHLTAlgos"/>
 <use   name="HLTrigger/HLTcore"/>
 <use   name="CondFormats/DataRecord"/>
-<use   name="DQM/HLTEvF"/>
+<use   name="DQMServices/Core"/>
 <use   name="root"/>
 <use   name="roofit"/>
 <use   name="boost"/>


### PR DESCRIPTION
The DQMOffline/Trigger/plugins/BuildFile.xml had a dependency on
DQM/HLTEvF which was where the package was getting all its necessary
DQM related dependencies. However, DQM/HLTEvF recently was changed
to no longer have a BuildFile.xml so all the needed 3rd party DQM
dependencies were now missing from DQMOffline/Trigger/plugins. This
change adds in the proper dependency on DQMServices/Core.
