### PR TITLE
Add option to print module dependencies on data

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -75,8 +75,10 @@ namespace edm {
     typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
     
-    void modulesDependentUpon(const std::string& iProcessName,
-                              std::vector<const char*>& oModuleLabels) const;
+    void modulesDependentUpon(std::string const& iProcessName,
+                              std::string const& iModuleLabel,
+                              bool iPrint,
+                              std::vector<char const*>& oModuleLabels) const;
 
     void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                          ProductRegistry const& preg,

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -282,6 +282,7 @@ namespace edm {
     std::unique_ptr<SystemTimeKeeper> summaryTimeKeeper_;
 
     bool                           wantSummary_;
+    bool                           printDependencies_;
 
     volatile bool           endpathsAreActive_;
   };

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -92,8 +92,10 @@ namespace edm {
       
       const EDConsumerBase* consumer() const;
       
-      void modulesDependentUpon(const std::string& iProcessName,
-                                std::vector<const char*>& oModuleLabels) const;
+      void modulesDependentUpon(std::string const& iProcessName,
+                                std::string const& iModuleLabel,
+                                bool iPrint,
+                                std::vector<char const*>& oModuleLabels) const;
 
       void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                            ProductRegistry const& preg,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -82,8 +82,10 @@ namespace edm {
       void updateLookup(BranchType iBranchType,
                         ProductHolderIndexHelper const&);
 
-      void modulesDependentUpon(const std::string& iProcessName,
-                                std::vector<const char*>& oModuleLabels) const;
+      void modulesDependentUpon(std::string const& iProcessName,
+                                std::string const& iModuleLabel,
+                                bool iPrint,
+                                std::vector<char const*>& oModuleLabels) const;
 
       void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                            ProductRegistry const& preg,

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -20,6 +20,7 @@
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -379,17 +380,25 @@ namespace {
 }
 
 void
-EDConsumerBase::modulesDependentUpon(const std::string& iProcessName,
-                                     std::vector<const char*>& oModuleLabels) const {
-  std::set<const char*, CharStarComp> uniqueModules;
-  for(unsigned int index=0, iEnd=m_tokenInfo.size();index <iEnd; ++index) {
+EDConsumerBase::modulesDependentUpon(std::string const& iProcessName,
+                                     std::string const& iModuleLabel,
+                                     bool iPrint,
+                                     std::vector<char const*>& oModuleLabels) const {
+  std::set<char const*, CharStarComp> uniqueModules;
+  for(unsigned int index = 0, iEnd = m_tokenInfo.size(); index < iEnd; ++index) {
     auto const& info = m_tokenInfo.get<kLookupInfo>(index);
-    if( not info.m_index.skipCurrentProcess() ) {
-      auto labels = m_tokenInfo.get<kLabels>(index);
-      unsigned int start = labels.m_startOfModuleLabel;
-      const char* processName = &(m_tokenLabels[start+labels.m_deltaToProcessName]);
-      if( (not processName) or processName[0]==0 or
-         iProcessName == processName) {
+    if(not info.m_index.skipCurrentProcess()) {
+      auto const& labels = m_tokenInfo.get<kLabels>(index);
+      unsigned int const start = labels.m_startOfModuleLabel;
+      char const* processName = &(m_tokenLabels[start+labels.m_deltaToProcessName]);
+      if(iPrint) {
+        LogAbsolute("ModuleDependency") << "<ModuleDependency> '" << iModuleLabel << 
+        "' may consume product of type '" << info.m_type.className() << 
+        "' with input tag '" << &(m_tokenLabels[start]) <<
+        ':' << &(m_tokenLabels[start+labels.m_deltaToProductInstance]) <<
+        ':' << processName << "'";;
+      }
+      if((not processName) or processName[0]==0 or iProcessName == processName) {
         uniqueModules.insert(&(m_tokenLabels[start]));
       }
     }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -108,7 +108,7 @@ namespace edm {
     virtual void updateLookup(BranchType iBranchType,
                       ProductHolderIndexHelper const&) = 0;
 
-    virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const = 0;
+    virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels, bool iPrint) const = 0;
 
     virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                                  ProductRegistry const& preg,

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -109,8 +109,8 @@ namespace edm {
     virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) override;
     virtual std::string workerType() const override;
 
-    virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const override {
-      module_->modulesDependentUpon(module_->moduleDescription().processName(),oModuleLabels);
+    virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels, bool iPrint) const override {
+      module_->modulesDependentUpon(module_->moduleDescription().processName(),module_->moduleDescription().moduleLabel(), iPrint, oModuleLabels);
     }
 
     virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -114,10 +114,12 @@ EDAnalyzerAdaptorBase::consumer() const {
 }
 
 void
-EDAnalyzerAdaptorBase::modulesDependentUpon(const std::string& iProcessName,
-                                            std::vector<const char*>& oModuleLabels) const {
+EDAnalyzerAdaptorBase::modulesDependentUpon(std::string const& iProcessName,
+                                            std::string const& iModuleLabel,
+                                            bool iPrint,
+                                            std::vector<char const*>& oModuleLabels) const {
   assert(not m_streamModules.empty());
-  return m_streamModules[0]->modulesDependentUpon(iProcessName, oModuleLabels);
+  return m_streamModules[0]->modulesDependentUpon(iProcessName, iModuleLabel, iPrint, oModuleLabels);
 }
 
 void

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -106,10 +106,12 @@ namespace edm {
 
     template< typename T>
     void
-    ProducingModuleAdaptorBase<T>::modulesDependentUpon(const std::string& iProcessName,
-                                                        std::vector<const char*>& oModuleLabels) const {
+    ProducingModuleAdaptorBase<T>::modulesDependentUpon(std::string const& iProcessName,
+                                                        std::string const& iModuleLabel,
+                                                        bool iPrint,
+                                                        std::vector<char const*>& oModuleLabels) const {
       assert(not m_streamModules.empty());
-      return m_streamModules[0]->modulesDependentUpon(iProcessName, oModuleLabels);
+      return m_streamModules[0]->modulesDependentUpon(iProcessName, iModuleLabel, iPrint, oModuleLabels);
     }
 
     template< typename T>

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -306,3 +306,7 @@
   <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_earlyTerminationSignal.sh"/>
   <use name="FWCore/Utilities"/>
 </bin>
+<bin   name="TestFWCoreFrameworkPrintDependencies" file="TestDriver.cpp">
+  <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_PrintDependencies.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/FWCore/Framework/test/run_PrintDependencies.sh
+++ b/FWCore/Framework/test/run_PrintDependencies.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${LOCAL_TEST_DIR}/testPrintDependencies.py
+
+cmsRun $F1 2>&1 | grep "may consume" >& ${LOCAL_TEST_DIR}/dependencies.txt || die "Failure using $F1" $?
+diff -q ${LOCAL_TEST_DIR}/dependencies.txt ${LOCAL_TEST_DIR}/unit_test_outputs/dependencies.txt || die "dependencies differ" $?
+
+rm -f ${LOCAL_TEST_DIR}/dependencies.txt
+

--- a/FWCore/Framework/test/testPrintDependencies.py
+++ b/FWCore/Framework/test/testPrintDependencies.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTOUTPUT")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.options= cms.untracked.PSet(
+    printDependencies = cms.untracked.bool(True)
+)
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.Thing = cms.EDProducer("ThingProducer")
+
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('file:PoolOutputTest.root')
+)
+
+process.source = cms.Source("EmptySource")
+
+process.p = cms.Path(process.Thing*process.OtherThing)
+process.ep = cms.EndPath(process.output)
+
+

--- a/FWCore/Framework/test/unit_test_outputs/dependencies.txt
+++ b/FWCore/Framework/test/unit_test_outputs/dependencies.txt
@@ -1,0 +1,8 @@
+<ModuleDependency> 'OtherThing' may consume product of type 'std::vector<edmtest::Thing>' with input tag 'Thing::'
+<ModuleDependency> 'output' may consume product of type 'edm::TriggerResults' with input tag 'TriggerResults::TESTOUTPUT'
+<ModuleDependency> 'output' may consume product of type 'std::vector<edmtest::OtherThing>' with input tag 'OtherThing:testUserTag:TESTOUTPUT'
+<ModuleDependency> 'output' may consume product of type 'std::vector<edmtest::Thing>' with input tag 'Thing::TESTOUTPUT'
+<ModuleDependency> 'output' may consume product of type 'std::vector<edmtest::Thing>' with input tag 'Thing:beginLumi:TESTOUTPUT'
+<ModuleDependency> 'output' may consume product of type 'std::vector<edmtest::Thing>' with input tag 'Thing:beginRun:TESTOUTPUT'
+<ModuleDependency> 'output' may consume product of type 'std::vector<edmtest::Thing>' with input tag 'Thing:endLumi:TESTOUTPUT'
+<ModuleDependency> 'output' may consume product of type 'std::vector<edmtest::Thing>' with input tag 'Thing:endRun:TESTOUTPUT'


### PR DESCRIPTION
This is a new feature requested by users in issue #12125  to add an option to cmsRun to print module dependencies in the configuration file to the output log. This PR also adds a unit test for the new feature, and adds some missing const qualifiers to prior code that is relevant to this feature.
