### PR TITLE
corrected wrong cfi file called for PhaseIPixel tag in dumpSimGeometry_cfg.py

### DIFF
--- a/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
@@ -43,7 +43,7 @@ def simGeoLoad(score):
        process.load('Configuration.Geometry.GeometryExtended2019Reco_cff')
   
     elif score == "PhaseIPixel":
-       process.load('Geometry.CMSCommonData.GeometryExtendedPhaseIPixel_cfi')
+       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi')
 
     elif score == "Phase1_R34F16":
         process.load('Geometry.CMSCommonData.Phase1_R34F16_cmsSimIdealGeometryXML_cff')

--- a/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
@@ -45,21 +45,13 @@ def simGeoLoad(score):
     elif score == "PhaseIPixel":
        process.load('Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi')
 
-    elif score == "Phase1_R34F16":
-        process.load('Geometry.CMSCommonData.Phase1_R34F16_cmsSimIdealGeometryXML_cff')
  
-    elif score == "Phase2Tk":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometryPhase2TkBEXML_cfi')
-
     elif score == "2023Muon":
        process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
 
     elif score == "2023":
        process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
-        
-    elif score == "SLHC":
-        process.load('SLHCUpgradeSimulations.Geometry.Phase1_R30F12_HCal_cmsSimIdealGeometryXML_cff')
-        
+                
     elif score == "DB":
         process.load("Configuration.StandardSequences.GeometryDB_cff")
         process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")


### PR DESCRIPTION
In dumpSimGeometry_cfg.py, the wrong cfi.py file was being loaded for the PhaseIPixel tag; I have changed it to the correct filename.
