### PR TITLE
Fix the way the folder is handled in SiPixelHLT

### DIFF
--- a/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
@@ -56,7 +56,6 @@
        virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
        virtual void bookMEs(DQMStore::IBooker &);
 
-       std::string topFolderName_;
 
     private:
        edm::ParameterSet conf_;

--- a/DQM/SiPixelMonitorRawData/python/SiPixelMonitorHLT_cfi.py
+++ b/DQM/SiPixelMonitorRawData/python/SiPixelMonitorHLT_cfi.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelHLTSource = cms.EDAnalyzer("SiPixelHLTSource",
-    TopFolderName = cms.string('Pixel'),
+    DirName = cms.untracked.string('Pixel/FEDIntegrity/'),
     RawInput = cms.InputTag("rawDataCollector"),
     ErrorInput = cms.InputTag("siPixelDigis"),
     outputFile = cms.string('Pixel_DQM_HLT.root'),
     saveFile = cms.untracked.bool(False),
-    slowDown = cms.untracked.bool(False),
-    DirName = cms.untracked.string('Pixel/FEDIntegrity/')
+    slowDown = cms.untracked.bool(False)
 )
 
 

--- a/DQM/SiPixelMonitorRawData/src/SiPixelHLTSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelHLTSource.cc
@@ -51,11 +51,11 @@ SiPixelHLTSource::SiPixelHLTSource(const edm::ParameterSet& iConfig) :
   rawin_( consumes<FEDRawDataCollection>( conf_.getParameter<edm::InputTag>( "RawInput" ) ) ),
   errin_( consumes<edm::DetSetVector<SiPixelRawDataError> >( conf_.getParameter<edm::InputTag>( "ErrorInput" ) ) ),
   saveFile( conf_.getUntrackedParameter<bool>("saveFile",false) ),
-  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) )
+  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) ),
+  dirName_( conf_.getUntrackedParameter<string>("DirName","Pixel/FEDIntegrity/") )
 {
   firstRun = true;
   LogInfo ("PixelDQM") << "SiPixelHLTSource::SiPixelHLTSource: Got DQM BackEnd interface"<<endl;
-  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 }
 
 
@@ -153,8 +153,8 @@ void SiPixelHLTSource::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 void SiPixelHLTSource::bookMEs(DQMStore::IBooker & iBooker){
 
   iBooker.cd();
-  iBooker.setCurrentFolder(topFolderName_+"/FEDIntegrity/");
-
+  iBooker.setCurrentFolder(dirName_);
+  
   std::string rawhid;
   std::string errhid;
   // Get collection name and instantiate Histo Id builder


### PR DESCRIPTION
This will take back the Pixel line in the summary map for FEDTest
