### PR TITLE
Monitoring service changes for DAQ: rebase (80X)

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -69,7 +69,7 @@ namespace evf{
 	  return (it!=quickReference_.end()) ? (*it).second : 0;
 	}
 	const void* decode(unsigned int index){return decoder_[index];}
-	void fillReserved(void* add, unsigned int i){
+	void fillReserved(const void* add, unsigned int i){
 	  //	  translation_[*name]=current_; 
 	  quickReference_[add]=i; 
 	  if(decoder_.size()<=i)
@@ -77,7 +77,7 @@ namespace evf{
 	  else
 	    decoder_[currentReserved_] = add;
 	}
-	void updateReserved(void* add){
+	void updateReserved(const void* add){
 	  fillReserved(add,currentReserved_);
 	  currentReserved_++;
 	}
@@ -86,7 +86,7 @@ namespace evf{
 	  for(unsigned int i = currentReserved_; i<reserved_; i++)
 	    fillReserved(dummiesForReserved_+i,i);
 	}
-	void update(void* add){
+	void update(const void* add){
 	  //	  translation_[*name]=current_; 
 	  quickReference_[add]=current_; 
 	  decoder_.push_back(add); 

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -21,9 +21,9 @@ using namespace jsoncollector;
 
 constexpr double throughputFactor() {return (1000000)/double(1024*1024);}
 
-#define NRESERVEDMODULES 33
-#define NSPECIALMODULES 7
-#define NRESERVEDPATHS 1
+static const int nReservedModules = 64;
+static const int nSpecialModules = 7;
+static const int nReservedPaths = 1;
 
 namespace evf{
 
@@ -37,7 +37,7 @@ namespace evf{
   FastMonitoringService::FastMonitoringService(const edm::ParameterSet& iPS, 
 				       edm::ActivityRegistry& reg) : 
     MicroStateService(iPS,reg)
-    ,encModule_(NRESERVEDMODULES)
+    ,encModule_(nReservedModules)
     ,nStreams_(0)//until initialized
     ,sleepTime_(iPS.getUntrackedParameter<int>("sleepTime", 1))
     ,fastMonIntervals_(iPS.getUntrackedParameter<unsigned int>("fastMonIntervals", 1))
@@ -88,8 +88,8 @@ namespace evf{
   std::string FastMonitoringService::makePathLegendaJson() {
     Json::Value legendaVector(Json::arrayValue);
     for(int i = 0; i < encPath_[0].current_; i++)
-      legendaVector.append(Json::Value(*((std::string *)(encPath_[0].decode(i)))));
-    Json::Value valReserved(NRESERVEDPATHS);
+      legendaVector.append(Json::Value(*((const std::string *)(encPath_[0].decode(i)))));
+    Json::Value valReserved(nReservedPaths);
     Json::Value pathLegend;
     pathLegend["names"]=legendaVector;
     pathLegend["reserved"]=valReserved;
@@ -101,8 +101,8 @@ namespace evf{
     Json::Value legendaVector(Json::arrayValue);
     for(int i = 0; i < encModule_.current_; i++)
        legendaVector.append(Json::Value(((const edm::ModuleDescription *)(encModule_.decode(i)))->moduleLabel()));
-    Json::Value valReserved(NRESERVEDMODULES);
-    Json::Value valSpecial(NSPECIALMODULES);
+    Json::Value valReserved(nReservedModules);
+    Json::Value valSpecial(nSpecialModules);
     Json::Value valOutputModules(nOutputModules_);
     Json::Value moduleLegend;
     moduleLegend["names"]=legendaVector;

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -88,7 +88,7 @@ namespace evf{
   std::string FastMonitoringService::makePathLegendaJson() {
     Json::Value legendaVector(Json::arrayValue);
     for(int i = 0; i < encPath_[0].current_; i++)
-      legendaVector.append(Json::Value(*((const std::string *)(encPath_[0].decode(i)))));
+      legendaVector.append(Json::Value(*(static_cast<const std::string *>(encPath_[0].decode(i)))));
     Json::Value valReserved(nReservedPaths);
     Json::Value pathLegend;
     pathLegend["names"]=legendaVector;
@@ -100,7 +100,7 @@ namespace evf{
   std::string FastMonitoringService::makeModuleLegendaJson(){
     Json::Value legendaVector(Json::arrayValue);
     for(int i = 0; i < encModule_.current_; i++)
-       legendaVector.append(Json::Value(((const edm::ModuleDescription *)(encModule_.decode(i)))->moduleLabel()));
+       legendaVector.append(Json::Value((static_cast<const edm::ModuleDescription *>(encModule_.decode(i)))->moduleLabel()));
     Json::Value valReserved(nReservedModules);
     Json::Value valSpecial(nSpecialModules);
     Json::Value valOutputModules(nOutputModules_);
@@ -179,7 +179,7 @@ namespace evf{
     macrostate_=FastMonitoringThread::sInit;
 
     for(unsigned int i = 0; i < (mCOUNT); i++)
-      encModule_.updateReserved((void*)(reservedMicroStateNames+i));
+      encModule_.updateReserved(static_cast<const void*>(reservedMicroStateNames+i));
     encModule_.completeReservedWithDummies();
 
     for (unsigned int i=0;i<nStreams_;i++) {
@@ -191,7 +191,7 @@ namespace evf{
 
        //path (mini) state
        encPath_.emplace_back(0);
-       encPath_[i].update((void*)&nopath_);
+       encPath_[i].update(static_cast<const void*>(&nopath_));
        eventCountForPathInit_.push_back(0);
        firstEventId_.push_back(0);
        collectedPathList_.push_back(new std::atomic<bool>(0));
@@ -239,7 +239,6 @@ namespace evf{
                                           << " LS:" << sc.eventID().luminosityBlock() << " " << context;
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
     exceptionInLS_.push_back(sc.eventID().luminosityBlock());
-    //exception_detected_=true; 
   }
 
   void FastMonitoringService::preGlobalEarlyTermination(edm::GlobalContext const& gc, edm::TerminationOrigin to)
@@ -252,7 +251,6 @@ namespace evf{
                                           << gc.luminosityBlockID().luminosityBlock() << " " << context;
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
     exceptionInLS_.push_back(gc.luminosityBlockID().luminosityBlock());
-    //exception_detected_=true; 
   }
 
   void FastMonitoringService::preSourceEarlyTermination(edm::TerminationOrigin to)


### PR DESCRIPTION
Changes in FastMonitoringService:
- C++ style const-correct casts
- void\* --> const void*
- expand to 64 reserved fields in microstatelegend
- static const int instead of preprocessor definitions

this PR is a followup of changes suggested in #12138
