### PR TITLE
set data processing bunch spacing configs to 50ns for HI

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -21,6 +21,12 @@ def _addLumiProducer(process):
 
     return process
 
+def _overridesFor50ns(process):
+    process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(50)
+    process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
+
+    return process
+
 #gone with the fact that there is no difference between production and development sequence
 #def customiseCommon(process):
 #    return (process)
@@ -93,13 +99,7 @@ def customiseDataRun2Common_25ns(process):
 def customiseDataRun2Common_50nsRunsAfter253000(process):
     process = customiseDataRun2Common_withStage1(process)
 
-    if hasattr(process,'particleFlowClusterECAL'):
-        process.particleFlowClusterECAL.energyCorrector.autoDetectBunchSpacing = False
-        process.particleFlowClusterECAL.energyCorrector.bunchSpacing = cms.int32(50)
-    if hasattr(process,'ecalMultiFitUncalibRecHit'):
-        process.ecalMultiFitUncalibRecHit.algoPSet.useLumiInfoRunHeader = False
-        process.ecalMultiFitUncalibRecHit.algoPSet.bunchSpacing = cms.int32(50)
-
+    process = _overridesFor50ns(process)
     return process
 
 ##############################################################################
@@ -197,6 +197,7 @@ def customisePromptHI(process):
 def customiseRun2CommonHI(process):
     process = customiseDataRun2Common_withStage1(process)
     
+    process = _overridesFor50ns(process)
     # HI Specific additional customizations:
     # from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_Additional_HI
     # process = customiseSimL1EmulatorForPostLS1_Additional_HI(process)

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -434,6 +434,7 @@ RECOEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)
 RECOEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 RECOEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 RECOEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
+RECOEventContent.outputCommands += ['keep int_bunchSpacingProducer_*_*']
 
 RAWRECOEventContent.outputCommands.extend(RECOEventContent.outputCommands)
 RAWRECOEventContent.outputCommands.extend(cms.untracked.vstring(
@@ -464,6 +465,7 @@ AODEventContent.outputCommands.extend(EvtScalersAOD.outputCommands)
 AODEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 AODEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 AODEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
+AODEventContent.outputCommands += ['keep int_bunchSpacingProducer_*_*']
 
 RAWSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 RAWSIMEventContent.outputCommands.extend(SimG4CoreRAW.outputCommands)
@@ -604,6 +606,7 @@ FEVTEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)
 FEVTEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 FEVTEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 FEVTEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
+FEVTEventContent.outputCommands += ['keep int_bunchSpacingProducer_*_*']
 
 FEVTHLTALLEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
 FEVTHLTALLEventContent.outputCommands.append('keep *_*_*_HLT')
@@ -752,4 +755,6 @@ MINIAODSIMEventContent= cms.PSet(
 from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroEventContentMC
 
 MINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
+MINIAODEventContent.outputCommands += ['keep int_bunchSpacingProducer_*_*']
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
+MINIAODSIMEventContent.outputCommands += ['keep int_bunchSpacingProducer_*_*']

--- a/Configuration/StandardSequences/python/PATMC_cff.py
+++ b/Configuration/StandardSequences/python/PATMC_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff import *
 from PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff import *
 from PhysicsTools.PatAlgos.slimming.slimming_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 
 miniAOD=cms.Sequence()

--- a/Configuration/StandardSequences/python/PAT_cff.py
+++ b/Configuration/StandardSequences/python/PAT_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff import *
 from PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff import *
 from PhysicsTools.PatAlgos.slimming.slimming_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 
 miniAOD=cms.Sequence()

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 # no bunchspacing in cosmics
-bunchSpacingProducer.overrideBunchSpacing=true
+bunchSpacingProducer.overrideBunchSpacing=True
 bunchSpacingProducer.bunchSpacingOverride=50
 
 #

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -3,6 +3,11 @@ import FWCore.ParameterSet.Config as cms
 # luminosity
 #
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
+# no bunchspacing in cosmics
+bunchSpacingProducer.overrideBunchSpacing=true
+bunchSpacingProducer.bunchSpacingOverride=50
+
 #
 # tracker
 #
@@ -46,8 +51,8 @@ caloCosmics = cms.Sequence(calolocalreco*ecalClusters)
 caloCosmics_HcalNZS = cms.Sequence(calolocalrecoNZS*ecalClusters)
 muonsLocalRecoCosmics = cms.Sequence(muonlocalreco+muonlocalrecoT0Seg)
 
-localReconstructionCosmics         = cms.Sequence(trackerCosmics*caloCosmics*muonsLocalRecoCosmics*vertexrecoCosmics+lumiProducer)
-localReconstructionCosmics_HcalNZS = cms.Sequence(trackerCosmics*caloCosmics_HcalNZS*muonsLocalRecoCosmics*vertexrecoCosmics +lumiProducer)
+localReconstructionCosmics         = cms.Sequence(bunchSpacingProducer*trackerCosmics*caloCosmics*muonsLocalRecoCosmics*vertexrecoCosmics+lumiProducer)
+localReconstructionCosmics_HcalNZS = cms.Sequence(bunchSpacingProducer*trackerCosmics*caloCosmics_HcalNZS*muonsLocalRecoCosmics*vertexrecoCosmics +lumiProducer)
 
 
 # global reco

--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Tracker
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 from RecoLocalTracker.Configuration.RecoLocalTrackerHeavyIons_cff import *
 from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
 from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
@@ -42,13 +43,13 @@ caloReco = cms.Sequence(ecalLocalRecoSequence*hcalLocalRecoSequence)
 hbhereco = hbheprereco.clone()
 hcalLocalRecoSequence.replace(hbheprereco,hbhereco)
 muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEventPreSplitting+siPixelClusterShapeCachePreSplitting+muonlocalreco)
-localReco = cms.Sequence(offlineBeamSpot*muonReco*caloReco*castorreco)
+localReco = cms.Sequence(bunchSpacingProducer*offlineBeamSpot*muonReco*caloReco*castorreco)
 
 #hbherecoMB = hbheprerecoMB.clone()
 #hcalLocalRecoSequenceNZS.replace(hbheprerecoMB,hbherecoMB)
 
 caloRecoNZS = cms.Sequence(caloReco+hcalLocalRecoSequenceNZS)
-localReco_HcalNZS = cms.Sequence(offlineBeamSpot*muonReco*caloRecoNZS)
+localReco_HcalNZS = cms.Sequence(bunchSpacingProducer*offlineBeamSpot*muonReco*caloRecoNZS)
 
 #--------------------------------------------------------------------------
 # Main Sequence

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 from RecoLocalCalo.Configuration.RecoLocalCalo_cff import *
 from RecoTracker.Configuration.RecoTracker_cff import *
@@ -91,7 +92,7 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
 from FWCore.Modules.logErrorHarvester_cfi import *
 
 # "Export" Section
-reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
+reconstruction         = cms.Sequence(bunchSpacingProducer*localreco*globalreco*highlevelreco*logErrorHarvester)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -79,7 +79,7 @@ private:
   bool autoDetectBunchSpacing_;
   int bunchspacing_;
   edm::InputTag bunchspacingTag_;
-  edm::EDGetTokenT<int> bunchSpacingToken_;
+  edm::EDGetTokenT<unsigned int> bunchSpacingToken_;
   float rhoValue_;
   edm::InputTag rhoTag_;
   edm::EDGetTokenT<double> rhoToken_;
@@ -244,29 +244,9 @@ void EGExtraInfoModifierFromDB::setEvent(const edm::Event& evt) {
   }
   
   if (autoDetectBunchSpacing_) {
-    if (evt.isRealData()) {
-      edm::RunNumber_t run = evt.run();
-      if (run == 178003 ||
-          run == 178004 ||
-          run == 209089 ||
-          run == 209106 ||
-          run == 209109 ||
-          run == 209146 ||
-          run == 209148 ||
-          run == 209151) {
-        bunchspacing_ = 25;
-      }
-      else if (run < 253000) {
-        bunchspacing_ = 50;
-      } 
-      else {
-	bunchspacing_ = 25;
-      }
-    } else {
-      edm::Handle<int> bunchSpacingH;
+      edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacingToken_,bunchSpacingH);
       bunchspacing_ = *bunchSpacingH;
-    }
   }
 
   edm::Handle<double> rhoH;
@@ -329,7 +309,7 @@ void EGExtraInfoModifierFromDB::setConsumes(edm::ConsumesCollector& sumes) {
   vtxToken_ = sumes.consumes<reco::VertexCollection>(vtxTag_);
 
   if (autoDetectBunchSpacing_)
-    bunchSpacingToken_ = sumes.consumes<int>(bunchspacingTag_);
+    bunchSpacingToken_ = sumes.consumes<unsigned int>(bunchspacingTag_);
 
   //setup electrons
   if(!(empty_tag == e_conf.electron_src))

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 regressionModifier = \
     cms.PSet( modifierName    = cms.string('EGExtraInfoModifierFromDB'),  
               autoDetectBunchSpacing = cms.bool(True),
-              bunchSpacingTag = cms.InputTag("addPileupInfo:bunchSpacing"),
+              bunchSpacingTag = cms.InputTag("bunchSpacingProducer"),
               manualBunchSpacing = cms.int32(50),              
               rhoCollection = cms.InputTag("fixedGridRhoFastjetAll"),
               vertexCollection = cms.InputTag("offlinePrimaryVertices"),

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -42,7 +42,7 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   useLumiInfoRunHeader_ = ps.getParameter<bool>("useLumiInfoRunHeader");
   
   if (useLumiInfoRunHeader_) {
-    bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+    bunchSpacing_ = c.consumes<unsigned int>(edm::InputTag("bunchSpacingProducer"));
     bunchSpacingManual_ = 0;
   } else {
     bunchSpacingManual_ = ps.getParameter<int>("bunchSpacing");
@@ -130,35 +130,13 @@ void
 EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
 {
 
-  int bunchspacing = 450;
+  unsigned int bunchspacing = 450;
 
   if (useLumiInfoRunHeader_) {
 
-    if (evt.isRealData()) {
-      edm::RunNumber_t run = evt.run();
-      if (run == 178003 ||
-          run == 178004 ||
-          run == 209089 ||
-          run == 209106 ||
-          run == 209109 ||
-          run == 209146 ||
-          run == 209148 ||
-          run == 209151) {
-        bunchspacing = 25;
-      }
-      else if (run < 253000) {
-        bunchspacing = 50;
-      }
-      else {
-	bunchspacing = 25;
-      }
-    }
-    else {
-      edm::Handle<int> bunchSpacingH;
+      edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacing_,bunchSpacingH);
       bunchspacing = *bunchSpacingH;
-    }
-    
   }
   else {
     bunchspacing = bunchSpacingManual_;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -83,7 +83,7 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
 		int bunchSpacingManual_;
-                edm::EDGetTokenT<int> bunchSpacing_; 
+                edm::EDGetTokenT<unsigned int> bunchSpacing_; 
 
                 // determine which of the samples must actually be used by ECAL local reco
                 edm::ESHandle<EcalSampleMask> sampleMaskHand_;                

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -74,6 +74,11 @@
   <use name="xerces-c"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="BunchSpacingProducer.cc" name="BunchSpacingProducer">
+  <use name="FWCore/PluginManager"/>
+  <use name="DataFormats/Provenance"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
 <library file="ExpressLumiProducer.cc" name="ExpressLumiProducer">
   <use name="RecoLuminosity/LumiProducer"/>
   <use name="FWCore/PluginManager"/>

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -105,7 +105,7 @@ void BunchSpacingProducer::fillDescriptions( edm::ConfigurationDescriptions & de
 {
   edm::ParameterSetDescription desc ;
   desc.add<bool>("overrideBunchSpacing",false); // true for prompt reco
-  desc.add<unsigned int>("bunchSpacingOverride_",25); // override value
+  desc.add<unsigned int>("bunchSpacingOverride",25); // override value
   
   descriptions.add("bunchSpacingProducer",desc) ;
 }

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -1,0 +1,93 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+namespace edm {
+  class EventSetup;
+}
+
+//
+// class declaration
+//
+class BunchSpacingProducer : public edm::stream::EDProducer<> {
+
+public:
+
+  explicit BunchSpacingProducer(const edm::ParameterSet&);
+
+  ~BunchSpacingProducer();
+
+  virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+
+  static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
+  
+private:
+  
+  edm::EDGetTokenT<int> bunchSpacing_;
+};
+
+//
+// constructors and destructor
+//
+
+
+BunchSpacingProducer::
+BunchSpacingProducer::BunchSpacingProducer(const edm::ParameterSet& iConfig)
+{
+  // register your products
+  produces<unsigned int>();
+  bunchSpacing_ = consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+}
+
+BunchSpacingProducer::~BunchSpacingProducer(){ 
+}
+
+//
+// member functions
+//
+void BunchSpacingProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
+{ 
+  unsigned int bunchSpacing=50;
+  unsigned int run=e.run();
+
+  if ( e.isRealData()) {
+    if ( ( run > 252126 && run != 254833 )|| 
+	run == 178003 ||
+	run == 178004 ||
+	run == 209089 ||
+	run == 209106 ||
+	run == 209109 ||
+	run == 209146 ||
+	run == 209148 ||
+	run == 209151) {
+      bunchSpacing = 25;
+    }
+  }
+  else{
+    edm::Handle<int> bunchSpacingH;
+    e.getByToken(bunchSpacing_,bunchSpacingH);
+    bunchSpacing = *bunchSpacingH;
+  }
+
+  std::auto_ptr<unsigned int> pOut1(new unsigned int);
+  *pOut1=bunchSpacing;
+  e.put(pOut1);
+
+}
+
+void BunchSpacingProducer::fillDescriptions( edm::ConfigurationDescriptions & descriptions )
+{
+  edm::ParameterSetDescription desc ;
+
+  descriptions.add("bunchSpacingProducer",desc) ;
+}
+
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(BunchSpacingProducer);

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -47,10 +47,8 @@ BunchSpacingProducer::BunchSpacingProducer(const edm::ParameterSet& iConfig)
   bunchSpacing_ = consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
   overRide_=false;
   if ( iConfig.exists("overrideBunchSpacing") ) {
-    std::cout << "ok parameter eixsts\n";
     overRide_= iConfig.getParameter<bool>("overrideBunchSpacing");
     if ( overRide_) {
-      std::cout << "and its true\n";
       bunchSpacingOverride_=iConfig.getParameter<unsigned int>("bunchSpacingOverride");
     }
   }
@@ -68,7 +66,6 @@ void BunchSpacingProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     std::auto_ptr<unsigned int> pOut1(new unsigned int);
     *pOut1=bunchSpacingOverride_;
     e.put(pOut1);
-    std::cout << "Derived from override " << bunchSpacingOverride_ << std::endl;
     return;
   }
 
@@ -94,7 +91,6 @@ void BunchSpacingProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     bunchSpacing = *bunchSpacingH;
   }
 
-  std::cout << "Derived from run number " << bunchSpacing << std::endl;
   std::auto_ptr<unsigned int> pOut1(new unsigned int);
   *pOut1=bunchSpacing;
   e.put(pOut1);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -30,7 +30,7 @@ class PFClusterEMEnergyCorrector {
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;
   
-  edm::EDGetTokenT<int> bunchSpacing_; 
+  edm::EDGetTokenT<unsigned int> bunchSpacing_; 
   
   edm::EDGetTokenT<EcalRecHitCollection> _recHitsEB;
   edm::EDGetTokenT<EcalRecHitCollection> _recHitsEE;  

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -28,7 +28,7 @@ PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet& 
     autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
 
     if (autoDetectBunchSpacing_) {
-      bunchSpacing_ = cc.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+      bunchSpacing_ = cc.consumes<unsigned int>(edm::InputTag("bunchSpacingProducer"));
       bunchSpacingManual_ = 0;
     }
     else {
@@ -126,30 +126,9 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
   int bunchspacing = 450;  
   
   if (autoDetectBunchSpacing_) {
-    if (evt.isRealData()) {
-      edm::RunNumber_t run = evt.run();
-      if (run == 178003 ||
-          run == 178004 ||
-          run == 209089 ||
-          run == 209106 ||
-          run == 209109 ||
-          run == 209146 ||
-          run == 209148 ||
-          run == 209151) {
-        bunchspacing = 25;
-      }
-      else if (run < 253000) {
-        bunchspacing = 50;
-      } 
-      else {
-	bunchspacing = 25;
-      }
-    }
-    else {
-      edm::Handle<int> bunchSpacingH;
+      edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacing_,bunchSpacingH);
       bunchspacing = *bunchSpacingH;
-    }
   }
   else {
     bunchspacing = bunchSpacingManual_;

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -66,7 +66,7 @@ def customise(process):
             cms.InputTag("interestingEcalDetIdEE"),
             )            
 
-    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
+    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.bunchSpacingProducer * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
 
     process.schedule.append(process.local_digireco)
 


### PR DESCRIPTION
- backport of #11576 to 75X
- force data processing setup for HI Run2 to 50 ns via bunch-spacing override [this is the important bug fix, the rest of the changes are mostly technical]
- use bunchSpacingProducer override for 50 ns for pp run2 data processing setup "50nsRunsAfter253000" aka ppRun2at50ns scenario
- add bunchSpacingProducer to the event content

The new pieces here will be propagated to 76X imminently.

Tests done in 7_5_4:
- short matrix: to check that backport of  bunchSpacingProducer code is done correctly (comparisons show no differences ==> OK)
- run2 2015B and 2015C (134.70\* and 134.80*) workflows to check that setup for these was correct already (comparisons show no differences ==> OK)
- T0 setup processing with ppRun2at50ns of 2015B run to confirm that overrides act correctly (comparisons show no differences ==> OK)
- T0 setup processing with HeavyIonsRun2 of 2015B run (50 ns) to confirm that overrides act correctly (comparisons show no differences ==> OK)
- T0 setup processing with HeavyIonsRun2 of 2015C run (25 ns) to confirm that there are changes in ecal hits and downstream objects (comparisons show  differences ==> OK)
