### PR TITLE
fix for unit test: do not call unit test with full path

### DIFF
--- a/FWCore/Framework/test/run_statemachine.sh
+++ b/FWCore/Framework/test/run_statemachine.sh
@@ -7,7 +7,7 @@
 #LOCAL_TMP_DIR=/uscms_data/d1/wdd/CMSSW_1_8_0_pre2/tmp/slc4_ia32_gcc345
 #LOCAL_TEST_DIR=/uscms_data/d1/wdd/CMSSW_1_8_0_pre2/src/FWCore/Framework/test
 
-exe=${LOCALRT}/test/${SCRAM_ARCH}/TestFWCoreFrameworkStatemachine
+exe=TestFWCoreFrameworkStatemachine
 input=${LOCAL_TEST_DIR}/unit_test_outputs/statemachine_
 output=statemachine_output_
 reference_output=${LOCAL_TEST_DIR}/unit_test_outputs/statemachine_output_


### PR DESCRIPTION
No need to run unit test with full path. unit test might not be in dev area e.g. when we run tests for IBs.
- For normal dev environment, when developer run "scram build runtests" then <LOCALRT>/test/<arch> is already in PATH.
- In IB test env, IB tests scripts also add CMSSW_RELEASE_BASE/test/<arch> in PATH
