### PR TITLE
Raw iso pt sum rework

### DIFF
--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -84,8 +84,26 @@ pfTausProducer.src = cms.InputTag("pfTausProducerSansRefs")
 pfTausDiscriminationByDecayModeFinding = hpsPFTauDiscriminationByDecayModeFinding.clone()
 pfTausDiscriminationByDecayModeFinding.PFTauProducer="pfTausProducer"
 
-pfTausDiscriminationByIsolation= hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits.clone()
-pfTausDiscriminationByIsolation.PFTauProducer="pfTausProducer"
+pfTausDiscriminationByIsolation= pfRecoTauDiscriminationByIsolation.clone(
+     PFTauProducer = cms.InputTag('pfTausProducer'),
+     ApplyDiscriminationByECALIsolation = cms.bool(True),
+     ApplyDiscriminationByTrackerIsolation = cms.bool(True),
+     applySumPtCut = cms.bool(False),
+     applyDeltaBetaCorrection = cms.bool(True),
+     applyPhotonPtSumOutsideSignalConeCut = cms.bool(True),
+     deltaBetaFactor = cms.string('0.2000'),
+     deltaBetaPUTrackPtCutOverride = cms.double(0.5),
+     maximumSumPtCut = cms.double(2.5),
+     storeRawSumPt = cms.bool(True),
+     storeRawPUsumPt = cms.bool(False),     
+     customOuterCone = PFRecoTauPFJetInputs.isolationConeSize,
+     isoConeSizeForDeltaBeta = cms.double(0.8),
+     verbosity = cms.int32(0),
+     applyOccupancyCut = cms.bool(False)
+)   
+
+
+
 
 pfTausrequireDecayMode = cms.PSet(
     BooleanOperator = cms.string("and"),

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -18,6 +18,8 @@ from RecoTauTag.RecoTau.PFRecoTauDiscriminationAgainstMuon2_cfi                 
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationAgainstMuonMVA_cfi                   import *
 
 from RecoTauTag.RecoTau.RecoTauDiscriminantCutMultiplexer_cfi import *
+from RecoTauTag.RecoTau.RecoTauDiscriminantSimpleCut_cfi      import *
+
 
 # Load helper functions to change the source of the discriminants
 from RecoTauTag.RecoTau.TauDiscriminatorTools import *
@@ -66,6 +68,25 @@ hpsPFTauDiscriminationByLooseIsolation = pfRecoTauDiscriminationByIsolation.clon
     ApplyDiscriminationByECALIsolation = True,
     applyOccupancyCut = True
 )
+
+
+#AJ's attempt to redo the isoPtSums using RecoTauDiscriminantSimpleCut
+
+#hpsPFTauDiscriminationByLooseIsolation = recoTauDiscriminantSimpleCut.clone( 
+#    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+#    Prediscriminants = requireDecayMode.clone(),    
+#    rawIsoPtSum = cms.InputTag('pfRecoTauDiscriminationByIsolation'),
+#    cut = cms.double(2.5),
+#    ApplyDiscriminationByTrackerIsolation = False,
+#    ApplyDiscriminationByECALIsolation = True,
+#    applyOccupancyCut = True
+#)
+
+
+
+
+
+
 hpsPFTauDiscriminationByLooseIsolation.Prediscriminants.preIso = cms.PSet(
     Producer = cms.InputTag("hpsPFTauDiscriminationByLooseChargedIsolation"),
     cut = cms.double(0.5))
@@ -106,7 +127,7 @@ hpsPFTauDiscriminationByVLooseIsolationDBSumPtCorr = hpsPFTauDiscriminationByVLo
     isoConeSizeForDeltaBeta = 0.8,
     deltaBetaFactor = "%0.4f"%(0.0123/0.1687),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
 )
 hpsPFTauDiscriminationByVLooseIsolationDBSumPtCorr.maximumSumPtCut = hpsPFTauDiscriminationByVLooseIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -116,7 +137,7 @@ hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr = hpsPFTauDiscriminationByLoos
     isoConeSizeForDeltaBeta = 0.8,
     deltaBetaFactor = "%0.4f"%(0.0123/0.1687),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
 )
 hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr.maximumSumPtCut = hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -126,7 +147,7 @@ hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr = hpsPFTauDiscriminationByMed
     isoConeSizeForDeltaBeta = 0.8,
     deltaBetaFactor = "%0.4f"%(0.0462/0.1687),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
 )
 hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.maximumSumPtCut = hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -136,7 +157,7 @@ hpsPFTauDiscriminationByTightIsolationDBSumPtCorr = hpsPFTauDiscriminationByTigh
     isoConeSizeForDeltaBeta = 0.8,
     deltaBetaFactor = "%0.4f"%(ak4dBetaCorrection),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
 )
 hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.maximumSumPtCut = hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -152,7 +173,7 @@ hpsPFTauDiscriminationByVLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminat
     ApplyDiscriminationByECALIsolation = True,
     deltaBetaFactor = "%0.4f"%((0.09/0.25)*(ak4dBetaCorrection)),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
     maximumSumPtCut = 3.5,
     Prediscriminants = requireDecayMode.clone()
 )
@@ -164,7 +185,7 @@ hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
     ApplyDiscriminationByECALIsolation = True,
     deltaBetaFactor = "%0.4f"%(ak4dBetaCorrection),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
     maximumSumPtCut = 2.5,
     Prediscriminants = requireDecayMode.clone()
 )
@@ -193,7 +214,7 @@ hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminat
     ApplyDiscriminationByECALIsolation = True,
     deltaBetaFactor = "%0.4f"%(ak4dBetaCorrection),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
     maximumSumPtCut = 1.5,
     Prediscriminants = requireDecayMode.clone()
 )
@@ -205,7 +226,7 @@ hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
     ApplyDiscriminationByECALIsolation = True,
     deltaBetaFactor = "%0.4f"%(ak4dBetaCorrection),
     applyOccupancyCut = False,
-    applySumPtCut = True,
+    applySumPtCut = False,
     maximumSumPtCut = 0.8,
     Prediscriminants = requireDecayMode.clone()
 )
@@ -528,6 +549,60 @@ hpsPFTauDiscriminationByDeadECALElectronRejection = pfRecoTauDiscriminationAgain
     Prediscriminants = requireDecayMode.clone()
 )
 
+
+#AJ's attempt to redo the isoPtSums using RecoTauDiscriminantSimpleCut
+
+printEventContent = cms.EDAnalyzer('EventContentAnalyzer')
+
+hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits = pfRecoTauDiscriminationByIsolation.clone(
+     PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+     Prediscriminants = requireDecayMode.clone(),
+     ApplyDiscriminationByECALIsolation = cms.bool(True),
+     ApplyDiscriminationByTrackerIsolation = cms.bool(True),
+     applySumPtCut = cms.bool(False),
+     applyDeltaBetaCorrection = cms.bool(True),
+     applyPhotonPtSumOutsideSignalConeCut = cms.bool(True),
+     deltaBetaFactor = cms.string('0.2000'),
+     deltaBetaPUTrackPtCutOverride = cms.double(0.5),
+     maximumSumPtCut = cms.double(2.5),
+     storeRawSumPt = cms.bool(True),
+     storeRawPUsumPt = cms.bool(False),     
+     customOuterCone = PFRecoTauPFJetInputs.isolationConeSize,
+     isoConeSizeForDeltaBeta = cms.double(0.8),
+     verbosity = cms.int32(0),
+     applyOccupancyCut = cms.bool(False)
+)
+
+hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits = recoTauDiscriminantSimpleCut.clone( 
+    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    Prediscriminants = requireDecayMode.clone(),    
+    applySumPtCut = cms.bool(False),
+    cut = cms.double(2.5),
+    maximumSumPtCut = cms.double(6.0),
+    rawIsoPtSum = cms.InputTag('hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits')
+)
+
+hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits = recoTauDiscriminantSimpleCut.clone( 
+    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    Prediscriminants = requireDecayMode.clone(),    
+    applySumPtCut = cms.bool(False),
+    cut = cms.double(1.5),
+    maximumSumPtCut = cms.double(6.0),
+    rawIsoPtSum = cms.InputTag('hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits')
+)
+
+hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits = recoTauDiscriminantSimpleCut.clone( 
+    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    Prediscriminants = requireDecayMode.clone(),    
+    applySumPtCut = cms.bool(False),
+    cut = cms.double(0.8),
+    maximumSumPtCut = cms.double(6.0),
+    rawIsoPtSum = cms.InputTag('hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits')
+)
+
+
+
+'''
 #Define new sequence that is using smaller number on hits cut
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.clone()
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits = hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.clone()
@@ -544,12 +619,14 @@ hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits = hpsPFTauDiscrimin
     applySumPtCut = False,
     storeRawSumPt = cms.bool(True)
 )
+'''
+
 
 hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3Hits = cms.Sequence(
+    hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits*
     hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits*
     hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits*
-    hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits*
-    hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits
+    hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits
 )
 
 hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits.clone(
@@ -907,3 +984,4 @@ produceAndDiscriminateHPSPFTaus = cms.Sequence(
 
     hpsPFTauMVAIsolation2Seq
 )
+

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantSimpleCut.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantSimpleCut.cc
@@ -12,27 +12,10 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
-#include "CondFormats/PhysicsToolsObjects/interface/PhysicsTGraphPayload.h"
-#include "CondFormats/DataRecord/interface/PhysicsTGraphPayloadRcd.h"
-#include "CondFormats/PhysicsToolsObjects/interface/PhysicsTFormulaPayload.h"
-#include "CondFormats/DataRecord/interface/PhysicsTFormulaPayloadRcd.h"
-
-#include "TMath.h"
-#include "TGraph.h"
-#include "TFormula.h"
-#include "TFile.h"
-
 
 
 #include <functional>
-#include "DataFormats/Candidate/interface/LeafCandidate.h"
-#include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
-#include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
-#include "RecoTauTag/RecoTau/interface/ConeTools.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 
 
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantSimpleCut.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantSimpleCut.cc
@@ -1,0 +1,93 @@
+/*
+ * RecoTauDiscriminantSimpleCut
+ *
+ * Author: A.J. Johnson, Colorado
+ *
+ * Apply a cut on the raw isolation pT-sum, given by the discriminator specified via the 'rawIsoPtSum' InputTag,
+ * to compute Loose, Medium and Tight working-point discriminators.
+ *
+ */
+#include <boost/foreach.hpp>
+#include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "CondFormats/PhysicsToolsObjects/interface/PhysicsTGraphPayload.h"
+#include "CondFormats/DataRecord/interface/PhysicsTGraphPayloadRcd.h"
+#include "CondFormats/PhysicsToolsObjects/interface/PhysicsTFormulaPayload.h"
+#include "CondFormats/DataRecord/interface/PhysicsTFormulaPayloadRcd.h"
+
+#include "TMath.h"
+#include "TGraph.h"
+#include "TFormula.h"
+#include "TFile.h"
+
+
+
+#include <functional>
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
+#include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
+#include "RecoTauTag/RecoTau/interface/ConeTools.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+
+
+using namespace reco;
+using namespace edm;
+
+class RecoTauDiscriminantSimpleCut : public PFTauDiscriminationProducerBase 
+{
+ public:
+  explicit RecoTauDiscriminantSimpleCut(const edm::ParameterSet& pset);
+
+  ~RecoTauDiscriminantSimpleCut();
+  double discriminate(const reco::PFTauRef&) const override;
+  void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+  
+ private:
+
+  double cutValue;
+
+  edm::InputTag rawIsoPtSum_;
+  edm::Handle<reco::PFTauDiscriminator> rawIsoPtSumHandle_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> rawIsoPtSum_token;
+
+};
+
+RecoTauDiscriminantSimpleCut::RecoTauDiscriminantSimpleCut(const edm::ParameterSet& cfg)
+  : PFTauDiscriminationProducerBase(cfg)
+{
+  
+  rawIsoPtSum_ = cfg.getParameter<edm::InputTag>("rawIsoPtSum");
+  rawIsoPtSum_token = consumes<reco::PFTauDiscriminator>(rawIsoPtSum_);
+  cutValue = cfg.getParameter<double>("cut");
+
+}
+
+RecoTauDiscriminantSimpleCut::~RecoTauDiscriminantSimpleCut()
+{
+}
+
+void RecoTauDiscriminantSimpleCut::beginEvent(const edm::Event& evt, const edm::EventSetup& es) 
+{
+  evt.getByToken(rawIsoPtSum_token, rawIsoPtSumHandle_);
+}
+
+double
+RecoTauDiscriminantSimpleCut::discriminate(const reco::PFTauRef& tau) const
+{
+  double disc_result = (*rawIsoPtSumHandle_)[tau];
+
+  // See if the discriminator passes our cuts
+  bool passesCut = false;
+  passesCut = (disc_result < cutValue);
+
+  return passesCut;
+}
+
+DEFINE_FWK_MODULE(RecoTauDiscriminantSimpleCut);
+

--- a/RecoTauTag/RecoTau/python/RecoTauDiscriminantSimpleCut_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauDiscriminantSimpleCut_cfi.py
@@ -1,0 +1,30 @@
+'''
+
+Multiplex a cut on a PFTauDiscriminator using another PFTauDiscriminator as the
+index.
+
+Used by the anti-electron MVA, which needs to choose what cut to apply on the
+MVA output depending on what the category is.
+
+'''
+
+import FWCore.ParameterSet.Config as cms
+
+recoTauDiscriminantSimpleCut = cms.EDProducer(
+    "RecoTauDiscriminantSimpleCut",
+    PFTauProducer = cms.InputTag("hpsPFTauProducer"),
+ 
+    Prediscriminants = cms.PSet(
+     BooleanOperator = cms.string('and'),
+     decayMode = cms.PSet(
+        Producer = cms.InputTag("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),
+        cut = cms.double(0.5)
+     )
+    ),
+
+
+    rawIsoPtSum  = cms.InputTag(''),
+    cut = cms.double(0.),
+    maximumSumPtCut = cms.double(6.0),
+    applySumPtCut = cms.bool(False)
+)


### PR DESCRIPTION
Rebase of reworking of raw iso pt sum calculation to 8_0_X. No changes to reco quantities are anticipated - this is a simple fix that calculates the pt sum for isolation once and stores it so that it may be used for each iso WP, rather than have each iso WP calculate the pt sum separately.
