### PR TITLE
Add a consume to fix DumpFedRawDataProduct from crashing.

### DIFF
--- a/DataFormats/FEDRawData/test/DumpFEDRawDataProduct.cc
+++ b/DataFormats/FEDRawData/test/DumpFEDRawDataProduct.cc
@@ -30,6 +30,7 @@ namespace test{
     DumpFEDRawDataProduct(const ParameterSet& pset){
       std::vector<int> ids;
       label_ = pset.getUntrackedParameter<std::string>("label","source");
+      consumes<FEDRawDataCollection>(label_);
       ids=pset.getUntrackedParameter<std::vector<int> >("feds",std::vector<int>());
       dumpPayload_=pset.getUntrackedParameter<bool>("dumpPayload",false);
       for (std::vector<int>::iterator i=ids.begin(); i!=ids.end(); i++) 


### PR DESCRIPTION
This analyzer is used to debug the L1T unpacking development.  It would be nice to have it fixed.  Should this also be added to the 8_0_X branch?
