### PR TITLE
Fix for conddb python tools

### DIFF
--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -310,7 +310,9 @@ class Connection(object):
         '''Tests whether the current DB looks like a valid CMS Conditions one.
         '''
         engine_connection = self.engine.connect()
-        ret = all([self.engine.dialect.has_table(engine_connection, table.__tablename__) for table in [Tag, IOV, Payload, GlobalTag, GlobalTagMap]])
+        #ret = all([self.engine.dialect.has_table(engine_connection, table.__tablename__) for table in [Tag, IOV, Payload, GlobalTag, GlobalTagMap]])
+        # temporarely avoid the check on the GT tables - there are releases in use where C++ does not create these tables.
+        ret = all([self.engine.dialect.has_table(engine_connection, table.__tablename__) for table in [Tag, IOV, Payload]])
         engine_connection.close()
         return ret
 


### PR DESCRIPTION
Fix to support reading from early V2 format, where no GT tables are available.
