### PR TITLE
Clean up duplicate selection rules (ROOT 6.06)

### DIFF
--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -283,10 +283,6 @@
       ]]>
  </ioread>
 
-  <class name="reco::TrackResiduals" ClassVersion="10">
-   <version ClassVersion="10" checksum="2022291691"/>
-  </class>
-
   <class name="reco::TrackExtraBase" ClassVersion="11">
    <version ClassVersion="10" checksum="3548207838"/>
    <version ClassVersion="11" checksum="3450798337"/>

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -114,7 +114,6 @@
  <class name="std::vector<SiStripMatchedRecHit2D>"/>
  <class name="edmNew::DetSetVector<SiStripMatchedRecHit2D>"/>
  <class name="edm::Wrapper<edmNew::DetSetVector<SiStripMatchedRecHit2D> >"/>
- <class name="std::vector<SiPixelRecHit>"/>
  <class name="edmNew::DetSetVector<SiPixelRecHit>"/>
  <class name="edm::Wrapper<edmNew::DetSetVector<SiPixelRecHit> >"/>
 

--- a/Fireworks/Core/src/classes_def.xml
+++ b/Fireworks/Core/src/classes_def.xml
@@ -59,7 +59,6 @@
   <class name="FWEveText"/>
   <class name="FWEveTextProjected"/>
   <class name="FWEveTextGL"/>
-  <class name="FWInvMassDialog"/>
   <class name="FWGeometryTableViewBase"/>
   <class name="FWGeometryTableView"/>
   <class name="FWOverlapTableView"/>

--- a/RecoLuminosity/LumiProducer/src/classes_def.xml
+++ b/RecoLuminosity/LumiProducer/src/classes_def.xml
@@ -30,8 +30,6 @@
   <class name="HCAL_HLX::LHC_BEAM_CONFIG"/>
   <class name="HCAL_HLX::LHC_FILL_DATA"/>
   <class name="HCAL_HLX::DIP_STRUCT_BASE"/>
-  <class name="HCAL_HLX::LHC_BEAM_MODE_DATA"/>
-  <class name="HCAL_HLX::LHC_BEAM_ENERGY_DATA"/>
   <class name="HCAL_HLX::LHC_BEAM_INTENSITY_DATA"/>
   <class name="HCAL_HLX::LHC_BEAM_FBCT_INTENSITY_DATA"/>
   <class name="HCAL_HLX::BEAM_INFO"/>


### PR DESCRIPTION
```
Warning in <SelectionRules::CheckDuplicates>: Duplicated rule found.
Rule:
                Selected (line 92): Yes
                Attributes:
                name = std::vector<SiPixelRecHit>
                No field sel rules
                No method sel rules
Identical rule already stored:
                Selected (line 117): Yes
                Attributes:
                name = std::vector<SiPixelRecHit>
                No field sel rules
                No method sel rules

Warning in <SelectionRules::CheckDuplicates>: Duplicated rule found.
Rule:
                Selected (line 8): Yes
                Attributes:
                name = reco::TrackResiduals
                No field sel rules
                No method sel rules
Identical rule already stored:
                Selected (line 44): Yes
                Attributes:
                name = reco::TrackResiduals
                No field sel rules
                No method sel rules

Warning in <SelectionRules::CheckDuplicates>: Duplicated rule found.
Rule:
                Selected (line 58): Yes
                Attributes:
                name = FWInvMassDialog
                No field sel rules
                No method sel rules
Identical rule already stored:
                Selected (line 62): Yes
                Attributes:
                name = FWInvMassDialog
                No field sel rules
                No method sel rules

Warning in <SelectionRules::CheckDuplicates>: Duplicated rule found.
Rule:
                Selected (line 15): Yes
                Attributes:
                name = HCAL_HLX::LHC_BEAM_ENERGY_DATA
                No field sel rules
                No method sel rules
Identical rule already stored:
                Selected (line 34): Yes
                Attributes:
                name = HCAL_HLX::LHC_BEAM_ENERGY_DATA
                No field sel rules
                No method sel rules

Warning in <SelectionRules::CheckDuplicates>: Duplicated rule found.
Rule:
                Selected (line 14): Yes
                Attributes:
                name = HCAL_HLX::LHC_BEAM_MODE_DATA
                No field sel rules
                No method sel rules
Identical rule already stored:
                Selected (line 33): Yes
                Attributes:
                name = HCAL_HLX::LHC_BEAM_MODE_DATA
                No field sel rules
                No method sel rules
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
