### PR TITLE
Fix bug in caching of surface deformations.

### DIFF
--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -195,7 +195,7 @@ public:
   /// and pointers to surface deformations
   virtual int surfaceDeformationIdPairs(std::vector<std::pair<int,SurfaceDeformation*> > &) const = 0;
 
-  /// cache the current position, rotation and other parameters (e.g. surface deformations)
+  /// cache the current position, rotation and other parameters (e.g. surface deformations), also for possible components
   virtual void cacheTransformation();
 
   /// restore the previously cached transformation, also for possible components

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -243,9 +243,18 @@ AlignmentSurfaceDeformations* Alignable::surfaceDeformations( void ) const
  
 void Alignable::cacheTransformation()
 {
+  // first treat itself
   theCachedSurface = theSurface;
   theCachedDisplacement = theDisplacement;
   theCachedRotation = theRotation;
+
+  // now treat components (a clean design would move that to AlignableComposite...)
+  const Alignables comps(this->components());
+
+  for (auto it = comps.begin(); it != comps.end(); ++it) {
+    (*it)->cacheTransformation();
+  }
+
 }
 
 void Alignable::restoreCachedTransformation()


### PR DESCRIPTION
This bug has an effect if the DetUnits of a large tracker structure
that are not listed at all. The net effect of this fix is that omitting
them leaves them and the associated surface deformations unchanged.

This serious bug is discussed in https://indico.cern.ch/event/442138/session/0/contribution/21/attachments/1182456/1712522/talk.pdf

Backport of #12280.
