### PR TITLE
add ctagging discriminators in the default PAT content, small improvement to test script

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -47,10 +47,10 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("softPFMuonBJetTags"),
         cms.InputTag("softPFElectronBJetTags"),
         cms.InputTag("pfCombinedMVABJetTags"),
-        cms.InputTag("pfCombinedMVAV2BJetTags")
-        #CTagging -- temporary commented out waiting for RelVals
-        ## cms.InputTag('pfCombinedCvsLJetTags'),
-        ## cms.InputTag('pfCombinedCvsBJetTags')
+        cms.InputTag("pfCombinedMVAV2BJetTags"),
+        #CTagging
+        cms.InputTag('pfCombinedCvsLJetTags'),
+        cms.InputTag('pfCombinedCvsBJetTags')
     ),
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -400,7 +400,7 @@ class AddJetCollection(ConfigToolBase):
                 process.load("RecoBTag.SecondaryVertex.secondaryVertex_cff")
                 process.load("RecoBTag.SoftLepton.softLepton_cff")
                 process.load("RecoBTag.Combined.combinedMVA_cff")
-                process.load("RecoBTag.CTagging.cTagging_cff")
+                process.load("RecoBTag.CTagging.RecoCTagging_cff")
             #addESProducers(process,'RecoBTag.Configuration.RecoBTag_cff')
             import RecoBTag.Configuration.RecoBTag_cff as btag
             import RecoJets.JetProducers.caTopTaggers_cff as toptag

--- a/RecoBTag/CTagging/test/test_discriminator_presence.py
+++ b/RecoBTag/CTagging/test/test_discriminator_presence.py
@@ -3,9 +3,15 @@ import pprint
 import sys
 from DataFormats.FWLite import Events, Handle
 ROOT.gROOT.SetBatch()
+from argparse import ArgumentParser
 
-events = Events('validate_ctag_pat.root')
-jet_labels = ["selectedPatJets"]#, "selectedPatJetsAK4PF", "selectedPatJetsAK8PFCHSSoftDropSubjets"]
+parser = ArgumentParser()
+parser.add_argument('file')
+parser.add_argument('collections', default=['slimmedJets'], nargs='*')
+args = parser.parse_args()
+
+events = Events(args.file)
+jet_labels = args.collections
 tested_discriminators = ['pfCombinedCvsLJetTags', 'pfCombinedCvsBJetTags']
 
 evt = events.__iter__().next()


### PR DESCRIPTION
Just one commit that was scheduled to happen once the AOD RelVals with ctagging were available. Tested with

```
PhysicsTools/PatAlgos/test//runAsyncTests.pl --all
```

and with runTheMatrix, no patological sign.
