### PR TITLE
add missing-, inactive-, valid-hits and clusterChargePerCm TkMaps

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -51,13 +51,12 @@ SiStripMonitorCluster.TH1MainDiagonalPosition.globalswitchon=False
 SiStripMonitorCluster.TH1StripNoise2ApvCycle.globalswitchon=True
 SiStripMonitorCluster.TH1StripNoise3ApvCycle.globalswitchon=True
 SiStripMonitorCluster.TH1TotalNumberOfClusters.subdetswitchon = True
+SiStripMonitorCluster.TH1TotalNumberOfClusters.xmax = cms.double(1999.5)
 SiStripMonitorCluster.ClusterHisto = True
-SiStripMonitorCluster.TH1NClusStrip.Nbinsx = cms.int32(200)
-SiStripMonitorCluster.TH1NClusStrip.xmax = cms.double(3999.5)
+SiStripMonitorCluster.TH1NClusStrip.Nbinsx = cms.int32(100)
+SiStripMonitorCluster.TH1NClusStrip.xmax = cms.double(1999.5)
 SiStripMonitorCluster.TH1NClusPx.Nbinsx = cms.int32(100)
 SiStripMonitorCluster.TH1NClusPx.xmax = cms.double(999.5)
-SiStripMonitorCluster.TH1TotalNumberOfClusters.Nbinx = cms.int32(100)
-SiStripMonitorCluster.TH1TotalNumberOfClusters.xmax = cms.double(1999.5)
 
 # SiStripMonitorTrack ####
 # Clone for Cosmic Tracks
@@ -67,10 +66,10 @@ SiStripMonitorTrack_cosmicTk.TrackProducer = 'cosmictrackfinderP5'
 SiStripMonitorTrack_cosmicTk.Mod_On        = False
 
 # Clone for CKF Tracks
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
 SiStripMonitorTrack_ckf.TrackProducer      = 'ctfWithMaterialTracksP5'
 SiStripMonitorTrack_ckf.Mod_On             = False
+SiStripMonitorTrack_ckf.TH1nClustersOff.xmax = cms.double(1999.5)
 
 # Clone for Road Search  Tracks
 #import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
@@ -85,7 +84,6 @@ MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_c
 MonitorTrackResiduals_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5'
 MonitorTrackResiduals_cosmicTk.Mod_On              = False
 # Clone for CKF Tracks
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
 MonitorTrackResiduals_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
 MonitorTrackResiduals_ckf.trajectoryInput          = 'ctfWithMaterialTracksP5'
 MonitorTrackResiduals_ckf.Mod_On                   = False
@@ -105,7 +103,6 @@ TrackMon_cosmicTk.FolderName                       = 'Tracking/TrackParameters'
 TrackMon_cosmicTk.doSeedParameterHistos            = True
 
 # Clone for CKF Tracks
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
 TrackMon_ckf = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
 TrackMon_ckf.TrackProducer                         = 'ctfWithMaterialTracksP5'
 TrackMon_ckf.AlgoName                              = 'CKFTk'
@@ -121,7 +118,6 @@ TrackMon_ckf.doSeedParameterHistos                 = True
 #TrackMon_rs.doSeedParameterHistos                  = True
 
 # Clone for Beam Halo Muon Tracks
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
 TrackMon_bhmuon = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
 TrackMon_bhmuon.TrackProducer                      = 'ctfWithMaterialTracksBeamHaloMuon'
 TrackMon_bhmuon.AlgoName                           = 'BHMuonTk'
@@ -151,7 +147,6 @@ TrackEffMon_ckf.FolderName                         = 'Tracking/TrackParameters/T
 #TrackEffMon_rs.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
 
 # Clone for Beam Halo  Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
 TrackEffMon_bhmuon = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
 TrackEffMon_bhmuon.TKTrackCollection               = 'ctfWithMaterialTracksBeamHaloMuon'
 TrackEffMon_bhmuon.AlgoName                        = 'BHMuonTk'

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -20,7 +20,7 @@ SiStripMonitorDigi.TProfDigiApvCycle.subdetswitchon = True
 # APV shots monitoring
 SiStripMonitorDigi.TkHistoMapNApvShots_On = True 
 SiStripMonitorDigi.TkHistoMapNStripApvShots_On= True
-SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= True
+SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= False
 
 SiStripMonitorDigi.TH1NApvShots.subdetswitchon = True
 SiStripMonitorDigi.TH1NApvShots.globalswitchon = True
@@ -51,12 +51,13 @@ SiStripMonitorCluster.TH1MainDiagonalPosition.globalswitchon=False
 SiStripMonitorCluster.TH1StripNoise2ApvCycle.globalswitchon=True
 SiStripMonitorCluster.TH1StripNoise3ApvCycle.globalswitchon=True
 SiStripMonitorCluster.TH1TotalNumberOfClusters.subdetswitchon = True
-SiStripMonitorCluster.TH1TotalNumberOfClusters.xmax = cms.double(1999.5)
 SiStripMonitorCluster.ClusterHisto = True
-SiStripMonitorCluster.TH1NClusStrip.Nbinsx = cms.int32(100)
-SiStripMonitorCluster.TH1NClusStrip.xmax = cms.double(1999.5)
+SiStripMonitorCluster.TH1NClusStrip.Nbinsx = cms.int32(200)
+SiStripMonitorCluster.TH1NClusStrip.xmax = cms.double(3999.5)
 SiStripMonitorCluster.TH1NClusPx.Nbinsx = cms.int32(100)
 SiStripMonitorCluster.TH1NClusPx.xmax = cms.double(999.5)
+SiStripMonitorCluster.TH1TotalNumberOfClusters.Nbinx = cms.int32(100)
+SiStripMonitorCluster.TH1TotalNumberOfClusters.xmax = cms.double(1999.5)
 
 # SiStripMonitorTrack ####
 # Clone for Cosmic Tracks
@@ -66,10 +67,10 @@ SiStripMonitorTrack_cosmicTk.TrackProducer = 'cosmictrackfinderP5'
 SiStripMonitorTrack_cosmicTk.Mod_On        = False
 
 # Clone for CKF Tracks
+import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
 SiStripMonitorTrack_ckf.TrackProducer      = 'ctfWithMaterialTracksP5'
 SiStripMonitorTrack_ckf.Mod_On             = False
-SiStripMonitorTrack_ckf.TH1nClustersOff.xmax = cms.double(1999.5)
 
 # Clone for Road Search  Tracks
 #import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
@@ -84,6 +85,7 @@ MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_c
 MonitorTrackResiduals_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5'
 MonitorTrackResiduals_cosmicTk.Mod_On              = False
 # Clone for CKF Tracks
+import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
 MonitorTrackResiduals_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
 MonitorTrackResiduals_ckf.trajectoryInput          = 'ctfWithMaterialTracksP5'
 MonitorTrackResiduals_ckf.Mod_On                   = False
@@ -103,6 +105,7 @@ TrackMon_cosmicTk.FolderName                       = 'Tracking/TrackParameters'
 TrackMon_cosmicTk.doSeedParameterHistos            = True
 
 # Clone for CKF Tracks
+import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
 TrackMon_ckf = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
 TrackMon_ckf.TrackProducer                         = 'ctfWithMaterialTracksP5'
 TrackMon_ckf.AlgoName                              = 'CKFTk'
@@ -118,6 +121,7 @@ TrackMon_ckf.doSeedParameterHistos                 = True
 #TrackMon_rs.doSeedParameterHistos                  = True
 
 # Clone for Beam Halo Muon Tracks
+import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
 TrackMon_bhmuon = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
 TrackMon_bhmuon.TrackProducer                      = 'ctfWithMaterialTracksBeamHaloMuon'
 TrackMon_bhmuon.AlgoName                           = 'BHMuonTk'
@@ -147,6 +151,7 @@ TrackEffMon_ckf.FolderName                         = 'Tracking/TrackParameters/T
 #TrackEffMon_rs.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
 
 # Clone for Beam Halo  Tracks
+import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
 TrackEffMon_bhmuon = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
 TrackEffMon_bhmuon.TKTrackCollection               = 'ctfWithMaterialTracksBeamHaloMuon'
 TrackEffMon_bhmuon.AlgoName                        = 'BHMuonTk'

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -36,7 +36,7 @@ SiStripMonitorDigi.TProfGlobalNShots.globalswitchon = True
 # SiStripMonitorCluster ####
 from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
 SiStripMonitorClusterBPTX = SiStripMonitorCluster.clone()
-SiStripMonitorClusterBPTX.Mod_On = True #False
+SiStripMonitorClusterBPTX.Mod_On = False
 SiStripMonitorClusterBPTX.TH1TotalNumberOfClusters.subdetswitchon   = True
 SiStripMonitorClusterBPTX.TProfClustersApvCycle.subdetswitchon      = True
 SiStripMonitorClusterBPTX.TProfTotalNumberOfClusters.subdetswitchon = True 

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -20,7 +20,7 @@ SiStripMonitorDigi.TProfDigiApvCycle.subdetswitchon = True
 # APV shots monitoring
 SiStripMonitorDigi.TkHistoMapNApvShots_On = True 
 SiStripMonitorDigi.TkHistoMapNStripApvShots_On= True
-SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= True
+SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= False
 SiStripMonitorDigi.TH1NApvShots.subdetswitchon = True
 SiStripMonitorDigi.TH1NApvShots.globalswitchon = True
 SiStripMonitorDigi.TH1ChargeMedianApvShots.subdetswitchon = True
@@ -36,7 +36,7 @@ SiStripMonitorDigi.TProfGlobalNShots.globalswitchon = True
 # SiStripMonitorCluster ####
 from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
 SiStripMonitorClusterBPTX = SiStripMonitorCluster.clone()
-SiStripMonitorClusterBPTX.Mod_On = False
+SiStripMonitorClusterBPTX.Mod_On = True #False
 SiStripMonitorClusterBPTX.TH1TotalNumberOfClusters.subdetswitchon   = True
 SiStripMonitorClusterBPTX.TProfClustersApvCycle.subdetswitchon      = True
 SiStripMonitorClusterBPTX.TProfTotalNumberOfClusters.subdetswitchon = True 

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
@@ -115,7 +115,13 @@ process.siStripOfflineAnalyser = cms.EDAnalyzer("SiStripOfflineDQM",
     cms.PSet(mapName=cms.untracked.string('StoNCorrOnTrack')),
     cms.PSet(mapName=cms.untracked.string('NApvShots'),mapMax=cms.untracked.double(-1.),logScale=cms.untracked.bool(True)),
     cms.PSet(mapName=cms.untracked.string('NApvShots'),logScale=cms.untracked.bool(True),psuMap=cms.untracked.bool(True),loadLVCabling=cms.untracked.bool(True),TopModules=cms.untracked.bool(True)),
-    cms.PSet(mapName=cms.untracked.string('MedianChargeApvShots'),mapMax=cms.untracked.double(-1.)),
+    #cms.PSet(mapName=cms.untracked.string('MedianChargeApvShots'),mapMax=cms.untracked.double(-1.)),
+    #cms.PSet(mapName=cms.untracked.string('ClusterCharge'),mapMax=cms.untracked.double(-1.)),
+    cms.PSet(mapName=cms.untracked.string('NumberMissingHits')),
+    cms.PSet(mapName=cms.untracked.string('ChargePerCMfromTrack')),
+    cms.PSet(mapName=cms.untracked.string('ChargePerCMfromOrigin')),
+    cms.PSet(mapName=cms.untracked.string('NumberValidHits')),
+     cms.PSet(mapName=cms.untracked.string('NumberInactiveHits'))
     )
 )
 

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -142,6 +142,7 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
 
   // TkHistoMap added
   TkHistoMap* tkmapcluster; 
+  TkHistoMap* tkmapclusterch;
 
   int runNb, eventNb;
   int firstEvent;
@@ -186,6 +187,7 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
   bool globalswitchcstripvscpix;
   bool globalswitchMultiRegions;
   bool clustertkhistomapon;
+  bool clusterchtkhistomapon;
   bool createTrendMEs;
   bool trendVsLs_;
   bool globalswitchnclusvscycletimeprof2don;

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
@@ -19,6 +19,8 @@ SiStripCalZeroBiasMonitorCluster.ClusterLabel = cms.string('')
 
 SiStripCalZeroBiasMonitorCluster.TkHistoMap_On = cms.bool(False)
 
+SiStripCalZeroBiasMonitorCluster.ClusterChTkHistoMap_On = cms.bool(False)
+
 SiStripCalZeroBiasMonitorCluster.TopFolderName = cms.string('AlcaReco/SiStrip')
 
 SiStripCalZeroBiasMonitorCluster.BPTXfilter     = cms.PSet()

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -15,6 +15,8 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
     ClusterLabel = cms.string(''),
 
     TkHistoMap_On = cms.bool(True),
+
+    ClusterChTkHistoMap_On = cms.bool(False),
                                      
     TopFolderName = cms.string('SiStrip'),
 
@@ -79,7 +81,7 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         Nbinx          = cms.int32(11),
         xmin           = cms.double(-0.5),
         xmax           = cms.double(10.5),
-        layerswitchon  = cms.bool(False),
+        layerswitchon  = cms.bool(True),#False
         moduleswitchon = cms.bool(True)
     ),
     TH1ClusterStoN = cms.PSet(
@@ -145,9 +147,9 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
     ),
 
     TH1TotalNumberOfClusters = cms.PSet(
-        Nbinx          = cms.int32(100),
+        Nbinx          = cms.int32(80),
         xmin           = cms.double(-0.5),
-        xmax           = cms.double(14999.5),
+        xmax           = cms.double(15999.5),
         subdetswitchon = cms.bool(False)
     ),
                                        
@@ -213,10 +215,10 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         ),
                                        
     MultiplicityRegions = cms.PSet(
-        k0 = cms.double(0.097),  # k from linear fit of the diagonal default 0.13
+        k0 = cms.double(0.13),  # k from linear fit of the diagonal default 0.13
         q0 = cms.double(300),   # +/- variation of y axis intercept default 300
         dk0 = cms.double(40),   #+/- variation of k0 (in %) to contain the diagonal zone defoult 40
-        MaxClus = cms.double(26000), #Divide Region 2 and Region 3  default 20000
+        MaxClus = cms.double(20000), #Divide Region 2 and Region 3  default 20000
         MinPix = cms.double(50)  # minimum number of Pix clusters to flag events with zero Si clusters default 50
         ),
                                        

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -16,7 +16,7 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
 
     TkHistoMap_On = cms.bool(True),
 
-    ClusterChTkHistoMap_On = cms.bool(False),
+    ClusterChTkHistoMap_On = cms.bool(True),
                                      
     TopFolderName = cms.string('SiStrip'),
 
@@ -81,7 +81,7 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         Nbinx          = cms.int32(11),
         xmin           = cms.double(-0.5),
         xmax           = cms.double(10.5),
-        layerswitchon  = cms.bool(True),#False
+        layerswitchon  = cms.bool(False),
         moduleswitchon = cms.bool(True)
     ),
     TH1ClusterStoN = cms.PSet(
@@ -147,9 +147,9 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
     ),
 
     TH1TotalNumberOfClusters = cms.PSet(
-        Nbinx          = cms.int32(80),
+        Nbinx          = cms.int32(100),
         xmin           = cms.double(-0.5),
-        xmax           = cms.double(15999.5),
+        xmax           = cms.double(14999.5),
         subdetswitchon = cms.bool(False)
     ),
                                        
@@ -215,10 +215,10 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         ),
                                        
     MultiplicityRegions = cms.PSet(
-        k0 = cms.double(0.13),  # k from linear fit of the diagonal default 0.13
+        k0 = cms.double(0.097),  # k from linear fit of the diagonal default 0.13
         q0 = cms.double(300),   # +/- variation of y axis intercept default 300
         dk0 = cms.double(40),   #+/- variation of k0 (in %) to contain the diagonal zone defoult 40
-        MaxClus = cms.double(20000), #Divide Region 2 and Region 3  default 20000
+        MaxClus = cms.double(26000), #Divide Region 2 and Region 3  default 20000
         MinPix = cms.double(50)  # minimum number of Pix clusters to flag events with zero Si clusters default 50
         ),
                                        

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -162,6 +162,7 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
   globalswitchnclusvscycletimeprof2don = ParametersNclusVsCycleTimeProf2D.getParameter<bool>("globalswitchon");
 
   clustertkhistomapon = conf_.getParameter<bool>("TkHistoMap_On");
+  clusterchtkhistomapon = conf_.getParameter<bool>("ClusterChTkHistoMap_On");
   createTrendMEs = conf_.getParameter<bool>("CreateTrendMEs");
   trendVsLs_ = conf_.getParameter<bool>("TrendVsLS");
   Mod_On_ = conf_.getParameter<bool>("Mod_On");
@@ -251,6 +252,12 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
 	tkmapcluster = new TkHistoMap(ibooker , topFolderName_,"TkHMap_NumberOfCluster",0.,true);
       else tkmapcluster = new TkHistoMap(ibooker , topFolderName_+"/TkHistoMap","TkHMap_NumberOfCluster",0.,false);
     }
+
+    if (clusterchtkhistomapon) {
+      if ( (topFolderName_ == "SiStrip") or (std::string::npos != topFolderName_.find("HLT")) )
+        tkmapclusterch = new TkHistoMap(ibooker , topFolderName_,"TkHMap_ClusterCharge",0.,true);
+      else tkmapclusterch = new TkHistoMap(ibooker , topFolderName_+"/TkHistoMap","TkHMap_ClusterCharge",0.,false);
+   } 
 
     // loop over detectors and book MEs
     edm::LogInfo("SiStripTkDQM|SiStripMonitorCluster")<<"nr. of activeDets:  "<<activeDets.size();
@@ -586,6 +593,7 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 	  (mod_single.NumberOfClusters)->Fill(0.); // no clusters for this detector module,fill histogram with 0
 	}
 	if(clustertkhistomapon) tkmapcluster->fill(detid,0.);
+        if(clusterchtkhistomapon) tkmapclusterch->fill(detid,0.);
 	if (found_layer_me && layerswitchnumclusterprofon) layer_single.LayerNumberOfClusterProfile->Fill(iDet, 0.0);
 	continue; // no clusters for this detid => jump to next step of loop
       }
@@ -624,6 +632,8 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 	short cluster_width    = ampls.size();
 	// add nr of strips of this cluster to total nr. of clusterized strips
 	total_clusterized_strips = total_clusterized_strips + cluster_width;
+
+        if(clusterchtkhistomapon) tkmapclusterch->fill(detid,static_cast<float>(clusterIter->charge()));
 
 	// cluster signal and noise from the amplitudes
 	float cluster_signal = 0.0;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -126,9 +126,11 @@ private:
   std::string topFolderName_;
   
   //******* TkHistoMaps
-  TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack;  
+  TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack, *tkhisto_ClChPerCMfromTrack;  
+  TkHistoMap *tkhisto_ClChPerCMfromOrigin, *tkhisto_NumMissingHits, *tkhisto_NumberInactiveHits, *tkhisto_NumberValidHits;
   //******** TkHistoMaps
- 
+  int numTracks;
+
   struct ModMEs{  
     MonitorElement* ClusterStoNCorr;
     MonitorElement* ClusterCharge;
@@ -211,6 +213,7 @@ private:
   bool HistoFlag_On_;
   bool ring_flag;
   bool TkHistoMap_On_;
+  bool clchCMoriginTkHmap_On_;
 
   std::string TrackProducer_;
   std::string TrackLabel_;

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -22,7 +22,8 @@ SiStripMonitorTrack = cms.EDAnalyzer(
     OffHisto_On   = cms.bool(True),
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),
-    TkHistoMap_On = cms.bool(True),   
+    TkHistoMap_On = cms.bool(True),
+    clchCMoriginTkHmap_On = cms.bool(False),    
     
     ClusterConditions = cms.PSet( On       = cms.bool(False),
                                   minStoN  = cms.double(0.0),
@@ -36,9 +37,9 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                              xmax  = cms.double(1999.5)
                              ),   
 
-    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(100),
+    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(200),
                              xmin  = cms.double(-0.5),
-                             xmax  = cms.double(14999.5)
+                             xmax  = cms.double(3999.5)
                              ),
     
     TH1ClusterCharge = cms.PSet(

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -22,9 +22,9 @@ SiStripMonitorTrack = cms.EDAnalyzer(
     OffHisto_On   = cms.bool(True),
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),
-    TkHistoMap_On = cms.bool(True),
-    clchCMoriginTkHmap_On = cms.bool(False),    
-    
+    TkHistoMap_On = cms.bool(True),   
+    clchCMoriginTkHmap_On = cms.bool(False),   
+ 
     ClusterConditions = cms.PSet( On       = cms.bool(False),
                                   minStoN  = cms.double(0.0),
                                   maxStoN  = cms.double(2000.0),
@@ -37,9 +37,9 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                              xmax  = cms.double(1999.5)
                              ),   
 
-    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(200),
+    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(100),
                              xmin  = cms.double(-0.5),
-                             xmax  = cms.double(3999.5)
+                             xmax  = cms.double(14999.5)
                              ),
     
     TH1ClusterCharge = cms.PSet(


### PR DESCRIPTION
valid, missing and inactive recHit TrackerHistoMaps added. 
inclusiveClusterCharge, ClusterChargePerCMfromOrigin and ClusterChargePerCMfromTrack TkHistoMaps also added.
inclusiveClusterCharge and ClusterChargePerCMfromTrack configurable.
SiStripDQM_OfflineTkMap_Template_cfg_DB.py updated to create the corresponding new TkMaps
