### PR TITLE
replacing 2012 relval with 2015 relval for reduced matrix tests

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
                      4.22, #cosmic data
                      1000, #data+prompt
                      1001, #data+express
-                     4.53, #2012B Photon data
+                     134.911, #2015D Photon data
                      140.53, #2011 HI data
                      1330, #Run2 MC Zmm
                      135.4 #Run 2 Zee ttbar


### PR DESCRIPTION
Replacing data wf 4.53 (2012 photon relval) with data wf 134.911 (2015 photon relval) for reduced matrix tests.
Same as #12293 
