### PR TITLE
Met uncertainties from GT: remove txt file dependency

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -88,10 +88,14 @@ def miniAOD_customizeCommon(process):
     #
     # apply type I + other PFMEt corrections to pat::MET object
     # and estimate systematic uncertainties on MET
+
+    process.selectedPatJetsForMETUnc = process.selectedPatJets.clone()
+    process.selectedPatJetsForMETUnc.cut = cms.string("pt > 15")
+
     from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncForMiniAODProduction
     runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                         jetCollUnskimmed="patJets",
-                                        jetColl="selectedPatJets")
+                                        jetColl="selectedPatJetsForMETUnc")
     
     #caloMET computation
     from PhysicsTools.PatAlgos.tools.metTools import addMETCollection

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -55,9 +55,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         self.addParameter(self._defaultParameters, 'jetCorLabelUpToL3', cms.InputTag('ak4PFCHSL1FastL2L3Corrector'), "Use ak4PFL1FastL2L3Corrector (ak4PFCHSL1FastL2L3Corrector) for PFJets with (without) charged hadron subtraction, ak4CaloL1FastL2L3Corrector for CaloJets", Type=cms.InputTag)
         self.addParameter(self._defaultParameters, 'jetCorLabelL3Res', cms.InputTag('ak4PFCHSL1FastL2L3ResidualCorrector'), "Use ak4PFL1FastL2L3ResidualCorrector (ak4PFCHSL1FastL2L3ResidualCorrector) for PFJets with (without) charged hadron subtraction, ak4CaloL1FastL2L3ResidualCorrector for CaloJets", Type=cms.InputTag)
+
+# the file is used only for local running
         self.addParameter(self._defaultParameters, 'jecUncertaintyFile', 'CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt',
                           "Extra JES uncertainty file", Type=str)
-        self.addParameter(self._defaultParameters, 'jecUncertaintyTag', 'SubTotalMC',
+        self.addParameter(self._defaultParameters, 'jecUncertaintyTag', 'Uncertainty',
                           "JES uncertainty Tag", Type=str)
         
         self.addParameter(self._defaultParameters, 'mvaMetLeptons',["Electrons","Muons"],
@@ -706,7 +708,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 
             shiftedModuleUp = cms.EDProducer(moduleType,
                                              src = objectCollection,
-                                             jetCorrInputFileName = cms.FileInPath(jetUncInfos["jecUncFile"] ), #jecUncertaintyFile),
+##                                             jetCorrInputFileName = cms.FileInPath(jetUncInfos["jecUncFile"] ), #jecUncertaintyFile),
                                              jetCorrUncertaintyTag = cms.string(jetUncInfos["jecUncTag"] ), #jecUncertaintyTag),
                                              addResidualJES = cms.bool(True),
                                              jetCorrLabelUpToL3 = cms.InputTag(jetUncInfos["jCorLabelUpToL3"].value() ), #jetCorrLabelUpToL3.value()),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -57,8 +57,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.addParameter(self._defaultParameters, 'jetCorLabelL3Res', cms.InputTag('ak4PFCHSL1FastL2L3ResidualCorrector'), "Use ak4PFL1FastL2L3ResidualCorrector (ak4PFCHSL1FastL2L3ResidualCorrector) for PFJets with (without) charged hadron subtraction, ak4CaloL1FastL2L3ResidualCorrector for CaloJets", Type=cms.InputTag)
 
 # the file is used only for local running
-        self.addParameter(self._defaultParameters, 'jecUncertaintyFile', 'CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt',
+##        self.addParameter(self._defaultParameters, 'jecUncertaintyFile', 'CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt',
+        self.addParameter(self._defaultParameters, 'jecUncertaintyFile', '',
                           "Extra JES uncertainty file", Type=str)
+##        self.addParameter(self._defaultParameters, 'jecUncertaintyTag', 'SubTotalMC',
         self.addParameter(self._defaultParameters, 'jecUncertaintyTag', 'Uncertainty',
                           "JES uncertainty Tag", Type=str)
         
@@ -705,20 +707,35 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #MM: FIXME MVA
             #if self._parameters["metType"].value == "MVA":
             #    moduleType="ShiftedPFJetProducer"
-                
-            shiftedModuleUp = cms.EDProducer(moduleType,
-                                             src = objectCollection,
-##                                             jetCorrInputFileName = cms.FileInPath(jetUncInfos["jecUncFile"] ), #jecUncertaintyFile),
-                                             jetCorrUncertaintyTag = cms.string(jetUncInfos["jecUncTag"] ), #jecUncertaintyTag),
-                                             addResidualJES = cms.bool(True),
-                                             jetCorrLabelUpToL3 = cms.InputTag(jetUncInfos["jCorLabelUpToL3"].value() ), #jetCorrLabelUpToL3.value()),
-                                             jetCorrLabelUpToL3Res = cms.InputTag(jetUncInfos["jCorLabelL3Res"].value() ), #jetCorrLabelUpToL3Res.value()),
-                                      
-                                             jetCorrPayloadName =  cms.string(jetUncInfos["jCorrPayload"] ),
 
-                                             shiftBy = cms.double(+1.*varyByNsigmas),
-                                             )
-        
+            if jetUncInfos["jecUncFile"] == "":
+
+                shiftedModuleUp = cms.EDProducer(moduleType,
+                                                 src = objectCollection,
+                                                 jetCorrUncertaintyTag = cms.string(jetUncInfos["jecUncTag"] ), #jecUncertaintyTag),
+                                                 addResidualJES = cms.bool(True),
+                                                 jetCorrLabelUpToL3 = cms.InputTag(jetUncInfos["jCorLabelUpToL3"].value() ), #jetCorrLabelUpToL3.value()),
+                                                 jetCorrLabelUpToL3Res = cms.InputTag(jetUncInfos["jCorLabelL3Res"].value() ), #jetCorrLabelUpToL3Res.value()),
+                                                 jetCorrPayloadName =  cms.string(jetUncInfos["jCorrPayload"] ),
+                                                 verbosity = cms.int32(1),
+                                                 shiftBy = cms.double(+1.*varyByNsigmas),
+                                                 )
+            else:
+
+
+                shiftedModuleUp = cms.EDProducer(moduleType,
+                                                 src = objectCollection,
+                                                 jetCorrInputFileName = cms.FileInPath(jetUncInfos["jecUncFile"] ), #jecUncertaintyFile),
+                                                 jetCorrUncertaintyTag = cms.string(jetUncInfos["jecUncTag"] ), #jecUncertaintyTag),
+                                                 addResidualJES = cms.bool(True),
+                                                 jetCorrLabelUpToL3 = cms.InputTag(jetUncInfos["jCorLabelUpToL3"].value() ), #jetCorrLabelUpToL3.value()),
+                                                 jetCorrLabelUpToL3Res = cms.InputTag(jetUncInfos["jCorLabelL3Res"].value() ), #jetCorrLabelUpToL3Res.value()),
+                                                 jetCorrPayloadName =  cms.string(jetUncInfos["jCorrPayload"] ),
+                                                 verbosity = cms.int32(1),
+                                                 shiftBy = cms.double(+1.*varyByNsigmas),
+                                                 )
+
+
         return shiftedModuleUp
 
 
@@ -1424,14 +1441,15 @@ runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
 # miniAOD production ===========================
 def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                         jetCollUnskimmed="patJets",
-                                        jetColl="selectedPatJets",
+                                        jetColl="selectedPatJetsForMETUnc",
                                         photonColl="selectedPatPhotons",
                                         electronColl="selectedPatElectrons",
                                         muonColl="selectedPatMuons",
                                         tauColl="selectedPatTaus",
                                         pfCandColl = "particleFlow",
                                         jetCleaning="LepClean",
-                                        jecUnFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
+##                                        jecUnFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
+                                        jecUnFile="",
                                         recoMetFromPFCs=False,
                                         postfix=""):
 
@@ -1514,7 +1532,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                recoMetFromPFCs=False,
                                jetCorLabelL3=cms.InputTag('ak4PFCHSL1FastL2L3Corrector'),
                                jetCorLabelRes=cms.InputTag('ak4PFCHSL1FastL2L3ResidualCorrector'),
-                               jecUncFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
+##                               jecUncFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
+                               jecUncFile="",
                                postfix=""):
 
     runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -717,7 +717,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                  jetCorrLabelUpToL3 = cms.InputTag(jetUncInfos["jCorLabelUpToL3"].value() ), #jetCorrLabelUpToL3.value()),
                                                  jetCorrLabelUpToL3Res = cms.InputTag(jetUncInfos["jCorLabelL3Res"].value() ), #jetCorrLabelUpToL3Res.value()),
                                                  jetCorrPayloadName =  cms.string(jetUncInfos["jCorrPayload"] ),
-                                                 verbosity = cms.int32(1),
                                                  shiftBy = cms.double(+1.*varyByNsigmas),
                                                  )
             else:
@@ -731,7 +730,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                  jetCorrLabelUpToL3 = cms.InputTag(jetUncInfos["jCorLabelUpToL3"].value() ), #jetCorrLabelUpToL3.value()),
                                                  jetCorrLabelUpToL3Res = cms.InputTag(jetUncInfos["jCorLabelL3Res"].value() ), #jetCorrLabelUpToL3Res.value()),
                                                  jetCorrPayloadName =  cms.string(jetUncInfos["jCorrPayload"] ),
-                                                 verbosity = cms.int32(1),
                                                  shiftBy = cms.double(+1.*varyByNsigmas),
                                                  )
 


### PR DESCRIPTION
MET uncertainties from Jet variation are taken from the Global Tag and not from txt files in the cms-data.
This fix follows report in 
https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1637.html
We aim to have it for the 76X re-processing
@gpetruc @mmarionncern @schoef 
