### PR TITLE
Fix heavy ion relval tests

### DIFF
--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoostReversed_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoostReversed_cff.py
@@ -4,6 +4,6 @@ from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("MixBoostEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
-                            mixLabel = cms.InputTag("mix","generatorunsmeared"),
+                            mixLabel = cms.InputTag("mix","generatorSmeared"),
                             Beta=cms.double(0.434)                          
                             )

--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoost_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoost_cff.py
@@ -4,6 +4,6 @@ from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("MixBoostEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
-                            mixLabel = cms.InputTag("mix","generatorunsmeared"),
+                            mixLabel = cms.InputTag("mix","generatorSmeared"),
                             Beta=cms.double(-0.434)
                             )

--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatchHI_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatchHI_cff.py
@@ -4,5 +4,5 @@ from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("MixEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
-                            mixLabel = cms.InputTag("mix","generatorunsmeared")
+                            mixLabel = cms.InputTag("mix","generatorSmeared")
                             )

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -101,7 +101,7 @@ GenParticleProducer::GenParticleProducer( const ParameterSet & cfg ) :
     produces<vector<int> >().setBranchAlias( alias + "BarCodes" );
   }
 
-  if(useCF_) mixToken_ = mayConsume<CrossingFrame<HepMCProduct> >(InputTag(cfg.getParameter<std::string>( "mix" ),"generatorunsmeared"));
+  if(useCF_) mixToken_ = mayConsume<CrossingFrame<HepMCProduct> >(InputTag(cfg.getParameter<std::string>( "mix" ),"generatorSmeared"));
   else srcToken_ = mayConsume<HepMCProduct>(cfg.getParameter<InputTag>( "src" ));
 }
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -135,15 +135,15 @@ namespace edm {
             branchesActivate(TypeID(typeid(HepMCProduct)).friendlyClassName(),std::string(""),tag,label);
             bool makeCrossingFrame = pset.getUntrackedParameter<bool>("makeCrossingFrame", false);
             if(makeCrossingFrame) {
-              workersObjects_.push_back(new MixingWorker<HepMCProduct>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
+              workersObjects_.push_back(new MixingWorker<HepMCProduct>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF,tags));
               produces<CrossingFrame<HepMCProduct> >(label);
             }
 	    consumes<HepMCProduct>(tag);
 
             LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
             //            std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
-            if(tags.size()>1) {
-              InputTag fallbackTag = tags[1];
+            for(size_t i = 1; i < tags.size(); ++i) { 
+              InputTag fallbackTag = tags[i];
               std::string fallbackLabel;
               branchesActivate(TypeID(typeid(HepMCProduct)).friendlyClassName(),std::string(""),fallbackTag,fallbackLabel);
               mayConsume<HepMCProduct>(fallbackTag);

--- a/SimGeneral/MixingModule/plugins/MixingWorker.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.cc
@@ -11,48 +11,48 @@ namespace edm {
   template <>
   void MixingWorker<HepMCProduct>::addPileups(const EventPrincipal& ep, ModuleCallingContext const* mcc, unsigned int eventNr) {
     // HepMCProduct does not come as a vector....
-    std::shared_ptr<Wrapper<HepMCProduct> const> shPtr = getProductByTag<HepMCProduct>(ep, tag_, mcc);
-    if(!shPtr) {
-       shPtr = getProductByTag<HepMCProduct>(ep, InputTag("generator"), mcc);
-    }
-    if (shPtr) {
-      LogDebug("MixingModule") <<"HepMC pileup objects  added, eventNr "<<eventNr << " Tag " << tag_ << std::endl;
-      crFrame_->setPileupPtr(shPtr);
-      crFrame_->addPileups(*shPtr->product());
+    for(InputTag const& tag : allTags_) {
+      std::shared_ptr<Wrapper<HepMCProduct> const> shPtr = getProductByTag<HepMCProduct>(ep, tag, mcc);
+      if(shPtr) {
+        LogDebug("MixingModule") << "HepMC pileup objects  added, eventNr " << eventNr << " Tag " << tag << std::endl;
+        crFrame_->setPileupPtr(shPtr);
+        crFrame_->addPileups(*shPtr->product());
+        break;
+      }
     }
   }
 
   template <>
   void MixingWorker<HepMCProduct>::addSignals(const Event &e) { 
     //HepMC - here the interface is different!!!
+    bool got = false;
     Handle<HepMCProduct>  result_t;
-    bool got = e.getByLabel(tag_,result_t);
-    if (got) {
-      LogDebug("MixingModule") <<" adding HepMCProduct from signal event  with "<<tag_;
-      crFrame_->addSignals(result_t.product(),e.id());  
-    } else {
-      LogInfo("MixingModule") <<"!!!!!!! Did not get any signal data for HepMCProduct with "<<tag_;
+    for(InputTag const& tag : allTags_) {
+      bool got = e.getByLabel(tag, result_t);
+      if (got) {
+        LogDebug("MixingModule") << "adding HepMCProduct from signal event  with " << tag;
+        crFrame_->addSignals(result_t.product(), e.id());  
+        break;
+      }
+    }
+    if(!got) {
+      LogInfo("MixingModule") << "!!!!!!! Did not get any signal data for HepMCProduct with " << allTags_[0];
     }
   }
   
   template <>
   bool MixingWorker<HepMCProduct>::checkSignal(const Event &e) {   
-          bool got;
-	  InputTag t;
-	  
+          bool got = false;
 	  Handle<HepMCProduct> result_t;
-	  got = e.getByLabel(tag_,result_t);
-	  t = InputTag(tag_.label(),tag_.instance());
-          if(!got) {
-	     got = e.getByLabel(InputTag("generator","unsmeared"),result_t);
+          for(InputTag const& tag : allTags_) {
+	    got = e.getByLabel(tag, result_t);
+            if(got) {
+	      InputTag t = InputTag(tag.label(), tag.instance());
+	      LogInfo("MixingModule") <<" Will create a CrossingFrame for HepMCProduct with "
+                                      << " with InputTag= "<< t.encode();
+              break;
+            }
           }
-	  
-	  if (got) {
-	       LogInfo("MixingModule") <<" Will create a CrossingFrame for HepMCProduct with "
-	  			       << " with InputTag= "<< t.encode();
-          }
-				       
 	  return got;
   }
-      
 }//namespace edm

--- a/SimGeneral/MixingModule/plugins/MixingWorker.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.cc
@@ -28,7 +28,7 @@ namespace edm {
     bool got = false;
     Handle<HepMCProduct>  result_t;
     for(InputTag const& tag : allTags_) {
-      bool got = e.getByLabel(tag, result_t);
+      got = e.getByLabel(tag, result_t);
       if (got) {
         LogDebug("MixingModule") << "adding HepMCProduct from signal event  with " << tag;
         crFrame_->addSignals(result_t.product(), e.id());  

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -50,9 +50,13 @@ namespace edm
         subdet_(std::string(" ")),
         label_(std::string(" ")),
         labelCF_(std::string(" ")),
-        maxNbSources_(5) {
-	    tag_=InputTag();
-	    tagSignal_=InputTag();
+        maxNbSources_(5),
+	tag_(),
+	tagSignal_(),
+        allTags_(),
+        crFrame_(nullptr),
+        secSourceCF_(nullptr)
+        {
 	}
 
       /*Normal constructor*/ 
@@ -69,7 +73,32 @@ namespace edm
 	labelCF_(labelCF),
 	maxNbSources_(maxNbSources),
 	tag_(tag),
-	tagSignal_(tagCF)
+	tagSignal_(tagCF),
+        allTags_(),
+        crFrame_(nullptr),
+        secSourceCF_(nullptr)
+	{
+	}
+
+       /*constructor for HepMCproduct case*/  
+      MixingWorker(int minBunch,int maxBunch, int bunchSpace,
+		   std::string subdet,std::string label,
+		   std::string labelCF,int maxNbSources, InputTag& tag,
+		   InputTag& tagCF,
+		   std::vector<InputTag> const& tags) : 
+	MixingWorkerBase(),
+	minBunch_(minBunch),
+	maxBunch_(maxBunch),
+	bunchSpace_(bunchSpace),
+	subdet_(subdet),
+	label_(label),
+	labelCF_(labelCF),
+	maxNbSources_(maxNbSources),
+	tag_(tag),
+	tagSignal_(tagCF),
+        allTags_(tags),
+        crFrame_(nullptr),
+        secSourceCF_(nullptr)
 	{
 	}
 
@@ -131,7 +160,6 @@ namespace edm
 	LogDebug("MixingModule") <<" CF was put for type "<<typeid(T).name()<<" with "<<label_;
       }
 
-
       // When using mixed secondary source 
       // Copy the data from the PCrossingFrame to the CrossingFrame
       virtual void copyPCrossingFrame(const PCrossingFrame<T> *PCF);
@@ -146,6 +174,7 @@ namespace edm
       unsigned int const maxNbSources_;
       InputTag tag_;
       InputTag tagSignal_;
+      std::vector<InputTag> allTags_; // for HepMCProduct
 
       CrossingFrame<T> * crFrame_;
       PCrossingFrame<T> * secSourceCF_;

--- a/SimGeneral/MixingModule/python/HiEventMixing_cff.py
+++ b/SimGeneral/MixingModule/python/HiEventMixing_cff.py
@@ -30,7 +30,7 @@ mixGen = cms.EDProducer("MixingModule",
 
     mixObjects = cms.PSet(
         mixHepMC = cms.PSet(
-            input = cms.VInputTag(cms.InputTag("generator","unsmeared"),cms.InputTag("generator")),
+            input = cms.VInputTag(cms.InputTag("generatorSmeared","",cms.InputTag.skipCurrentProcess()),cms.InputTag("generator","unsmeared"),cms.InputTag("generator","",cms.InputTag.skipCurrentProcess())),
             makeCrossingFrame = cms.untracked.bool(True),
             type = cms.string('HepMCProduct')
             )

--- a/SimGeneral/MixingModule/python/HiMixGEN_cff.py
+++ b/SimGeneral/MixingModule/python/HiMixGEN_cff.py
@@ -29,7 +29,7 @@ mix = cms.EDProducer("MixingModule",
 
     mixObjects = cms.PSet(
         mixHepMC = cms.PSet(
-            input = cms.VInputTag(cms.InputTag("generator","unsmeared"),cms.InputTag("generator")),
+            input = cms.VInputTag(cms.InputTag("generatorSmeared","",cms.InputTag.skipCurrentProcess()),cms.InputTag("generator","unsmeared"),cms.InputTag("generator","",cms.InputTag.skipCurrentProcess())),
             makeCrossingFrame = cms.untracked.bool(True),
             type = cms.string('HepMCProduct')
             )

--- a/SimMuon/GEMDigitizer/python/customizeGEMDigi.py
+++ b/SimMuon/GEMDigitizer/python/customizeGEMDigi.py
@@ -95,7 +95,7 @@ mixObjects_dt_csc_rpc_trk =  cms.PSet(
         subdets = cms.vstring()
     ),
     mixHepMC = cms.PSet(
-        input = cms.VInputTag(cms.InputTag("generator")),
+        input = cms.VInputTag(cms.InputTag("generatorSmeared"),cms.InputTag("generator")),
         makeCrossingFrame = cms.untracked.bool(True),
         type = cms.string('HepMCProduct')
     ),


### PR DESCRIPTION
These are bug fixes for the failures of relvals 300.0, 301.0, and 302.0 in 7_6_X and 8_0_X.
These are bug fixes, so they are being submitted to 7_6_X.
There are three parts to the fixes:
1) Generalize the mixing module (mainly MixingWorker) to handle multiple labels at once for HepMCProduct, as the heavy ion smearer uses a smeared HepMCProduct from pileup to smear the unsmeared HepMCProduct from the signal. Do this so that the labels are not hard coded, but taken from the configuration files.
2) Fix heavy ion specific configurations to use the correct labels.
3) Fix one other config file ( SimMuon/GEMDigitizer/python/customizeGEMDigi.py) to properly handle backward compatibility.
