### PR TITLE
Remove *TSchemaHelper* classes from the dictionary

### DIFF
--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -192,10 +192,6 @@
   <version ClassVersion="10" checksum="2903606143"/>
  </class>
 
- <class name="ROOT::TSchemaHelper" ClassVersion="10">
-  <version ClassVersion="10" checksum="3064700282"/>
- </class>
- <class name="std::vector<ROOT::TSchemaHelper>"/>
  <class name="std::vector<TFormula*>"/>
 
  <class name="edm::ThinnedAssociationBranches"/>


### PR DESCRIPTION
ROOT commit (8a44438d5707dd96eeab5fbf9a928378f92f07ce) renamed
`ROOT::TSchemaHelper` to `ROOT::Internal::TSchemaHelper`.

Christopher Jones checked the package history and it looks like
`TSchemaHelper` was just a victim of the original pattern being way to
inclusive. It also seems not to be used by CMSSW.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
