### PR TITLE
Reload calogeometry for every event: 

### DIFF
--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -90,11 +90,12 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
   bool ECALEmatched =false;
   bool HCALmatched =false;
 
-  if(!geo){
-    edm::ESHandle<CaloGeometry> pGeo;
-    TheSetup.get<CaloGeometryRecord>().get(pGeo);
-    geo = pGeo.product();
-  }
+  //  if(!geo){
+  geo = 0;
+  edm::ESHandle<CaloGeometry> pGeo;
+  TheSetup.get<CaloGeometryRecord>().get(pGeo);
+  geo = pGeo.product();
+  //}
   bool trkmuunvetoisdefault = false; //Pb with low pt tracker muons that veto good csc segments/halo triggers. 
   //Test to "unveto" low pt trk muons. 
   //For now, we just recalculate everything without the veto and add an extra set of variables to the class CSCHaloData. 


### PR DESCRIPTION
geo object seems to change its memory address between runs, leading to segmentation fault from time to time, the change should hopefully fix this. 

Apologies for again another iteration related to the CSCHaloFilter... 
