### PR TITLE
Add centrality bin in 75X and Jet DQM update

### DIFF
--- a/DQM/Physics/python/CentralityDQM_cfi.py
+++ b/DQM/Physics/python/CentralityDQM_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 CentralityDQM = cms.EDAnalyzer(
     "CentralityDQM",
     centralitycollection = cms.InputTag("hiCentrality"),
+    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
     vertexcollection = cms.InputTag("hiSelectedVertex"),
     eventplanecollection= cms.InputTag("hiEvtPlane")
-
     )

--- a/DQM/Physics/src/CentralityDQM.h
+++ b/DQM/Physics/src/CentralityDQM.h
@@ -48,6 +48,11 @@ class CentralityDQM : public DQMEDAnalyzer {
 
   edm::InputTag  eventplaneTag_;
   edm::EDGetTokenT<reco::EvtPlaneCollection> eventplaneToken;
+  
+  edm::InputTag centralityBinTag_;
+  edm::EDGetTokenT<int> centralityBinToken;
+  edm::Handle<int>centralityBin_;
+
 
   ///////////////////////////
   // Histograms
@@ -80,6 +85,8 @@ class CentralityDQM : public DQMEDAnalyzer {
   MonitorElement* h_vertex_x;
   MonitorElement* h_vertex_y;
   MonitorElement* h_vertex_z;
+
+  MonitorElement* h_cent_bin;
 
   MonitorElement* h_ep_HFm1;
   MonitorElement* h_ep_HFp1;

--- a/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h
@@ -74,6 +74,9 @@
 
 
 const Int_t MAXPARTICLE = 10000;
+const Double_t BarrelEta = 2.0;
+const Double_t EndcapEta = 3.0;
+const Double_t ForwardEta = 5.0;
 
 class MonitorElement;
 
@@ -91,7 +94,6 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
   
   edm::InputTag   mInputCollection;
   edm::InputTag   mInputPFCandCollection;
-  edm::InputTag   centrality;
   
   std::string     mOutputFile;
   std::string     JetType;
@@ -101,6 +103,14 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
   double          mReverseEnergyFractionThreshold;
   double          mRThreshold;
   std::string     JetCorrectionService;
+
+  edm::InputTag centralityTag_;
+  edm::EDGetTokenT<reco::Centrality> centralityToken;
+  edm::Handle<reco::Centrality> centrality_;
+
+  edm::InputTag centralityBinTag_;
+  edm::EDGetTokenT<int> centralityBinToken;
+  edm::Handle<int>centralityBin_;
 
   //Tokens
   edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
@@ -115,7 +125,6 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
 
   edm::EDGetTokenT<edm::ValueMap<reco::VoronoiBackground>> backgrounds_;
   edm::EDGetTokenT<std::vector<float>> backgrounds_value_;
-  edm::EDGetTokenT<reco::Centrality> centralityToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex> > hiVertexToken_;
 
   MonitorElement *mNPFpart;
@@ -124,7 +133,93 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
   MonitorElement *mPFPhi;
   MonitorElement *mPFVsPt;
   MonitorElement *mPFVsPtInitial;
+  MonitorElement *mPFVsPtInitial_HF; //MZ
+
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_100_95; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_95_90; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_90_85; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_85_80; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_80_75; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_75_70; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_70_65; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_65_60; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_60_55; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_55_50; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_50_45; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_45_40; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_40_35; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_35_30; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_30_25; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_25_20; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_20_15; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_15_10; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_10_5; //MZ
+  MonitorElement *mPFVsPtInitial_Barrel_Centrality_5_0; //MZ
+
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_100_95; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_95_90; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_90_85; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_85_80; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_80_75; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_75_70; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_70_65; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_65_60; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_60_55; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_55_50; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_50_45; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_45_40; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_40_35; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_35_30; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_30_25; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_25_20; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_20_15; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_15_10; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_10_5; //MZ
+  MonitorElement *mPFVsPtInitial_EndCap_Centrality_5_0; //MZ
+
+  MonitorElement *mPFVsPtInitial_HF_Centrality_100_95; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_95_90; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_90_85; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_85_80; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_80_75; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_75_70; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_70_65; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_65_60; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_60_55; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_55_50; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_50_45; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_45_40; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_40_35; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_35_30; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_30_25; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_25_20; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_20_15; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_15_10; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_10_5; //MZ
+  MonitorElement *mPFVsPtInitial_HF_Centrality_5_0; //MZ
+
   MonitorElement *mPFArea;
+  MonitorElement *mPFDeltaR; //MZ
+  MonitorElement *mPFDeltaR_Scaled_R; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_20To30; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_30To50; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_50To80; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_80To120; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_120To180; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_180To300; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFpT_300ToInf; //MZ
+  
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_20To30; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_30To50; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_50To80; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_80To120; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_120To180; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_180To300; //MZ
+  MonitorElement *mPFDeltaR_pTCorrected_PFVsInitialpT_300ToInf; //MZ
+
+  MonitorElement *mPFVsPtInitialDeltaR_pTCorrected; //MZ
+  MonitorElement *mPFVsPtDeltaR_pTCorrected; //MZ
   MonitorElement *mNCalopart;
   MonitorElement *mCaloPt;
   MonitorElement *mCaloEta;
@@ -288,6 +383,42 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
   MonitorElement* mNJets;
   MonitorElement* mNJets_40;
 
+  MonitorElement* mPFCandpT_vs_eta_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_vs_eta_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_vs_eta_electron; // pf id - 2
+  MonitorElement* mPFCandpT_vs_eta_muon; // pf id - 3
+  MonitorElement* mPFCandpT_vs_eta_photon; // pf id - 4
+  MonitorElement* mPFCandpT_vs_eta_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_vs_eta_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_vs_eta_EME_inHF; // pf id - 7
+  
+  MonitorElement* mPFCandpT_Barrel_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_Barrel_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_Barrel_electron; // pf id - 2
+  MonitorElement* mPFCandpT_Barrel_muon; // pf id - 3
+  MonitorElement* mPFCandpT_Barrel_photon; // pf id - 4
+  MonitorElement* mPFCandpT_Barrel_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_Barrel_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_Barrel_EME_inHF; // pf id - 7
+
+  MonitorElement* mPFCandpT_Endcap_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_Endcap_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_Endcap_electron; // pf id - 2
+  MonitorElement* mPFCandpT_Endcap_muon; // pf id - 3
+  MonitorElement* mPFCandpT_Endcap_photon; // pf id - 4
+  MonitorElement* mPFCandpT_Endcap_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_Endcap_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_Endcap_EME_inHF; // pf id - 7
+
+  MonitorElement* mPFCandpT_Forward_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_Forward_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_Forward_electron; // pf id - 2
+  MonitorElement* mPFCandpT_Forward_muon; // pf id - 3
+  MonitorElement* mPFCandpT_Forward_photon; // pf id - 4
+  MonitorElement* mPFCandpT_Forward_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_Forward_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_Forward_EME_inHF; // pf id - 7
+
   // Parameters
 
   bool            isCaloJet;
@@ -298,6 +429,8 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
   static const Int_t etaBins_ = 15;
 
   static const Int_t nedge_pseudorapidity = etaBins_ + 1;
+
+  
 
 
 };

--- a/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons_matching.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons_matching.h
@@ -125,6 +125,12 @@ class JetAnalyzer_HeavyIons_matching : public DQMEDAnalyzer {
   MonitorElement * mNeutralEmEnergy_Jet1_unmatched;
   MonitorElement * mChargedMuEnergy_Jet1_unmatched;
 
+  MonitorElement * mChargedHadEnergyFraction_Jet1_unmatched;
+  MonitorElement * mNeutralHadEnergyFraction_Jet1_unmatched;
+  MonitorElement * mPhotonEnergyFraction_Jet1_unmatched;
+  MonitorElement * mElectronEnergyFraction_Jet1_unmatched;
+  MonitorElement * mMuonEnergyFraction_Jet1_unmatched;
+  
   MonitorElement * mHadEnergy_Jet2_unmatched;
   MonitorElement * mEmEnergy_Jet2_unmatched;
   MonitorElement * mChargedHadronEnergy_Jet2_unmatched;
@@ -133,6 +139,13 @@ class JetAnalyzer_HeavyIons_matching : public DQMEDAnalyzer {
   MonitorElement * mNeutralEmEnergy_Jet2_unmatched;
   MonitorElement * mChargedMuEnergy_Jet2_unmatched;
 
+  MonitorElement * mChargedHadEnergyFraction_Jet2_unmatched;
+  MonitorElement * mNeutralHadEnergyFraction_Jet2_unmatched;
+  MonitorElement * mPhotonEnergyFraction_Jet2_unmatched;
+  MonitorElement * mElectronEnergyFraction_Jet2_unmatched;
+  MonitorElement * mMuonEnergyFraction_Jet2_unmatched;
+
+  
   struct MyJet{
     int   id;
     float pt;

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -4,16 +4,16 @@ from DQMOffline.JetMET.jetDQMConfig_cff import *      # parameters for all jet a
 from DQMOffline.JetMET.jetMETDQMCleanup_cff import *  # parameters for event cleanup
 
 jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
-    JetType = cms.string('calo'),#pf, calo or jpt
-    JetCorrections = cms.InputTag("dqmAk4CaloL2L3ResidualCorrector"),
-    jetsrc = cms.InputTag("ak4CaloJets"),
-    METCollectionLabel     = cms.InputTag("caloMet"),
-    muonsrc = cms.InputTag("muons"),
-    l1algoname = cms.string("L1Tech_BPTX_plus_AND_minus.v0"),
-    filljetHighLevel =cms.bool(False),
-    #
-    #
-    #
+                                                JetType = cms.string('calo'),#pf, calo or jpt
+                                                JetCorrections = cms.InputTag("dqmAk4CaloL2L3ResidualCorrector"),
+                                                jetsrc = cms.InputTag("ak4CaloJets"),
+                                                METCollectionLabel     = cms.InputTag("caloMet"),
+                                                muonsrc = cms.InputTag("muons"),
+                                                l1algoname = cms.string("L1Tech_BPTX_plus_AND_minus.v0"),
+                                                filljetHighLevel =cms.bool(False),
+                                                #
+                                                #
+                                                #
     highPtJetTrigger = cms.PSet(
         andOr         = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
@@ -23,64 +23,64 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
         andOrHlt       = cms.bool( True ),
         errorReplyHlt  = cms.bool( False ),
     ),
-    lowPtJetTrigger = cms.PSet(
-        andOr         = cms.bool( False ),
-        dbLabel        = cms.string("JetMETDQMTrigger"),
-        hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
-        hltDBKey       = cms.string( 'jetmet_lowptjet' ),
-        hltPaths       = cms.vstring( 'HLT_Jet60_v','HLT_Jet60_v6','HLT_Jet60_v7','HLT_Jet60_v8' ), 
-        andOrHlt       = cms.bool( True ),
-        errorReplyHlt  = cms.bool( False ),
-    ),
+                                                lowPtJetTrigger = cms.PSet(
+                                                    andOr         = cms.bool( False ),
+                                                    dbLabel        = cms.string("JetMETDQMTrigger"),
+                                                    hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
+                                                    hltDBKey       = cms.string( 'jetmet_lowptjet' ),
+                                                    hltPaths       = cms.vstring( 'HLT_Jet60_v','HLT_Jet60_v6','HLT_Jet60_v7','HLT_Jet60_v8' ), 
+                                                    andOrHlt       = cms.bool( True ),
+                                                    errorReplyHlt  = cms.bool( False ),
+                                                ),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
-    processname                = cms.string("HLT"),
+                                                processname                = cms.string("HLT"),
 
     #
-    # Jet-related
-    #   
+                                                # Jet-related
+                                                #   
 
     JetCleaningFlag            = cms.untracked.bool(False),       
 
     runcosmics                 = cms.untracked.bool(False),                
-                                
+                                                
     #Cleanup parameters
     CleaningParameters = cleaningParameters.clone(
         bypassAllPVChecks = cms.bool(True),
-        ),
+    ),
 
     #for JPT and CaloJetID  
     InputJetIDValueMap         = cms.InputTag("ak4JetID"), 
-    #options for Calo and JPT: LOOSE,LOOSE_AOD,TIGHT,MINIMAL
-    #for PFJets: LOOSE,TIGHT
+                                                #options for Calo and JPT: LOOSE,LOOSE_AOD,TIGHT,MINIMAL
+                                                #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
-    #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: FIRSTDATA
+                                                #options for Calo and JPT: PURE09,DQM09,CRAFT08
+                                                #for PFJets: FIRSTDATA
     JetIDVersion               = cms.string("PURE09"),
-    #
-    #actually done only for PFJets at the moment
+                                                #
+                                                #actually done only for PFJets at the moment
     InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","fullDiscriminant"),
-    InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedDiscriminant"),
-    InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","fullId"),
-    InputCutPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedId"),
+                                                InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedDiscriminant"),
+                                                InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","fullId"),
+                                                InputCutPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedId"),
 
     InputQGMultiplicity = cms.InputTag("QGTagger", "mult"),
-    InputQGLikelihood = cms.InputTag("QGTagger", "qgLikelihood"),
-    InputQGPtDToken = cms.InputTag("QGTagger", "ptD"),
-    InputQGAxis2 = cms.InputTag("QGTagger", "axis2"),
+                                                InputQGLikelihood = cms.InputTag("QGTagger", "qgLikelihood"),
+                                                InputQGPtDToken = cms.InputTag("QGTagger", "ptD"),
+                                                InputQGAxis2 = cms.InputTag("QGTagger", "axis2"),
 
     fillCHShistos =cms.bool(False),
-    #
-    # For jetAnalysis
-    #
+                                                #
+                                                # For jetAnalysis
+                                                #
     jetAnalysis = jetDQMParameters.clone(),
 
     #
-    # DCS
-    #                             
+                                                # DCS
+                                                #                             
     DCSFilterForJetMonitoring = cms.PSet(
-      DetectorTypes = cms.untracked.string("ecal:hbhe:hf"),
-      #DebugOn = cms.untracked.bool(True),
+        DetectorTypes = cms.untracked.string("ecal:hbhe:hf"),
+        #DebugOn = cms.untracked.bool(True),
       alwaysPass = cms.untracked.bool(False)
     )
 )
@@ -95,12 +95,12 @@ jetDQMAnalyzerAk4CaloCleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
         ptThreshold = cms.double(20.),
         asymmetryThirdJetCut = cms.double(30),
         balanceThirdJetCut   = cms.double(0.2), 
-       )  
+    )  
 )
 
 jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     CleaningParameters = cleaningParameters.clone(
-       bypassAllPVChecks  = cms.bool(False),
+        bypassAllPVChecks  = cms.bool(False),
     ),
     #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
@@ -115,8 +115,8 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     #jetsrc = cms.InputTag("ak4PFJetsCHS"),
     filljetHighLevel  = cms.bool(False),
     DCSFilterForJetMonitoring = cms.PSet(
-      DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
-      #DebugOn = cms.untracked.bool(True),
+        DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
+        #DebugOn = cms.untracked.bool(True),
       alwaysPass = cms.untracked.bool(False)
     )
 )
@@ -129,7 +129,7 @@ jetDQMAnalyzerAk4PFCleaned=jetDQMAnalyzerAk4PFUncleaned.clone(
         ptThreshold = cms.double(20.),
         asymmetryThirdJetCut = cms.double(30),
         balanceThirdJetCut = cms.double(0.2),
-        ),
+    ),
     METCollectionLabel     = cms.InputTag("pfMet"),
 )
 
@@ -138,6 +138,7 @@ jetDQMAnalyzerAk4PFCHSCleaned=jetDQMAnalyzerAk4PFCleaned.clone(
     JetCorrections = cms.InputTag("dqmAk4PFCHSL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJetsCHS"),
     METCollectionLabel     = cms.InputTag("pfMETT1"),
+    #actually done only for PFJets at the moment
     InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorCHSDQM","fullDiscriminant"),
     InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorCHSDQM","cutbasedDiscriminant"),
     InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorCHSDQM","fullId"),
@@ -149,7 +150,7 @@ jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD=jetDQMAnalyzerAk4PFUncleaned.clone(
     filljetHighLevel =cms.bool(True),
     CleaningParameters = cleaningParameters.clone(
         vertexCollection    = cms.InputTag( "goodOfflinePrimaryVerticesDQMforMiniAOD" ),
-        ),
+    ),
     JetType = cms.string('miniaod'),#pf, calo or jpt
     jetsrc = cms.InputTag("slimmedJets"),
     METCollectionLabel     = cms.InputTag("slimmedMETs"),
@@ -158,7 +159,7 @@ jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD=jetDQMAnalyzerAk4PFUncleaned.clone(
 jetDQMAnalyzerAk4PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCleaned.clone(
     CleaningParameters = cleaningParameters.clone(
         vertexCollection    = cms.InputTag( "goodOfflinePrimaryVerticesDQMforMiniAOD" ),
-        ),
+    ),
     JetType = cms.string('miniaod'),#pf, calo or jpt
     jetsrc = cms.InputTag("slimmedJets"),
 )
@@ -168,7 +169,7 @@ jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     CleaningParameters = cleaningParameters.clone(
         bypassAllPVChecks  = cms.bool(False),
         vertexCollection = cms.InputTag( "hiSelectedVertex" ),
-        ),
+    ),
     JetType = cms.string('calo'),#pf, calo or jpt
     JetCorrections = cms.InputTag(""),# no jet correction available yet?
     jetsrc = cms.InputTag("iterativeConePu5CaloJets"),
@@ -183,157 +184,168 @@ jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
 
 
 jetDQMAnalyzerAkVs3PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Vs'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akVs3PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Vs'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akVs3PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 jetDQMAnalyzerAkPU3Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Pu'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akPu3CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Pu'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akPu3CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkPU4Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Pu'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akPu4CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)                                    
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Pu'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akPu4CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)                                    
 )
 
 jetDQMAnalyzerAkPU5Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Pu'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akPu5CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Pu'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akPu5CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkPU3PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Pu'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akPu3PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Pu'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akPu3PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkPU4PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Pu'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akPu4PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Pu'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akPu4PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkPU5PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Pu'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akPu5PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Pu'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akPu5PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkVs2Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Vs'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akVs2CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Vs'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akVs2CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkVs3Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Vs'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akVs3CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Vs'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akVs3CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkVs4Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Vs'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akVs4CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Vs'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akVs4CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkVs5Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                      JetType = cms.untracked.string('calo'),
-                                      UEAlgo = cms.untracked.string('Vs'),
-                                      OutputFile = cms.untracked.string(''),
-                                      src = cms.InputTag("akVs5CaloJets"),
-                                      PFcands = cms.InputTag("particleFlowTmp"),
-                                      Background = cms.InputTag("voronoiBackgroundCalo"),
-                                      centrality = cms.InputTag("hiCentrality"),
-                                      JetCorrections = cms.string(""),
-                                      recoJetPtThreshold = cms.double(10),        
-                                      RThreshold = cms.double(0.3),
-                                      reverseEnergyFractionThreshold = cms.double(0.5)
+                                         JetType = cms.untracked.string('calo'),
+                                         UEAlgo = cms.untracked.string('Vs'),
+                                         OutputFile = cms.untracked.string(''),
+                                         src = cms.InputTag("akVs5CaloJets"),
+                                         PFcands = cms.InputTag("particleFlowTmp"),
+                                         Background = cms.InputTag("voronoiBackgroundCalo"),
+                                         centralitycollection = cms.InputTag("hiCentrality"),
+                                         centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                         JetCorrections = cms.string(""),
+                                         recoJetPtThreshold = cms.double(10),        
+                                         RThreshold = cms.double(0.3),
+                                         reverseEnergyFractionThreshold = cms.double(0.5)
 )
 '''
 jetDQMAnalyzerAkVs6Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
@@ -383,49 +395,52 @@ jetDQMAnalyzerAkVs2PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
 '''
 
 jetDQMAnalyzerAkVs3PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Vs'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akVs3PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                    #srcRho = cms.InputTag("akVs3PFJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Vs'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akVs3PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       #srcRho = cms.InputTag("akVs3PFJets","rho"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 
 jetDQMAnalyzerAkVs4PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Vs'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akVs4PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                    #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Vs'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akVs4PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 
 jetDQMAnalyzerAkVs5PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
-                                    JetType = cms.untracked.string('pf'),
-                                    UEAlgo = cms.untracked.string('Vs'),
-                                    OutputFile = cms.untracked.string(''),
-                                    src = cms.InputTag("akVs5PFJets"),
-                                    PFcands = cms.InputTag("particleFlowTmp"),
-                                    Background = cms.InputTag("voronoiBackgroundPF"),
-                                      #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
-                                    JetCorrections = cms.string(""),
-                                    recoJetPtThreshold = cms.double(10),        
-                                    RThreshold = cms.double(0.3),
-                                    reverseEnergyFractionThreshold = cms.double(0.5)
+                                       JetType = cms.untracked.string('pf'),
+                                       UEAlgo = cms.untracked.string('Vs'),
+                                       OutputFile = cms.untracked.string(''),
+                                       src = cms.InputTag("akVs5PFJets"),
+                                       PFcands = cms.InputTag("particleFlowTmp"),
+                                       Background = cms.InputTag("voronoiBackgroundPF"),
+                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
+                                       centralitycollection = cms.InputTag("hiCentrality"),
+                                       centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
+                                       JetCorrections = cms.string(""),
+                                       recoJetPtThreshold = cms.double(10),        
+                                       RThreshold = cms.double(0.3),
+                                       reverseEnergyFractionThreshold = cms.double(0.5)
 )
 '''
 jetDQMAnalyzerAkVs6PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons",
@@ -468,35 +483,35 @@ jetDQMMatchAkPu3CaloAkVs3Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                recoJetPtThreshold = cms.double(20.),
                                                recoDelRMatch = cms.double(0.2),
                                                recoJetEtaCut = cms.double(2.0)
-                                           )
+)
 jetDQMMatchAkPu3PFAkVs3PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu3PFJets"),
-                                               src_Jet2 = cms.InputTag("akVs3PFJets"),
-                                               Jet1     = cms.untracked.string("PuPF"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                           src_Jet1 = cms.InputTag("akPu3PFJets"),
+                                           src_Jet2 = cms.InputTag("akVs3PFJets"),
+                                           Jet1     = cms.untracked.string("PuPF"),
+                                           Jet2     = cms.untracked.string("VsPF"),
+                                           recoJetPtThreshold = cms.double(20.),
+                                           recoDelRMatch = cms.double(0.2),
+                                           recoJetEtaCut = cms.double(2.0)
+)
 
 jetDQMMatchAkPu3CaloAkPu3PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu3CaloJets"),
-                                               src_Jet2 = cms.InputTag("akPu3PFJets"),
-                                               Jet1     = cms.untracked.string("PuCalo"),
-                                               Jet2     = cms.untracked.string("PuPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akPu3CaloJets"),
+                                             src_Jet2 = cms.InputTag("akPu3PFJets"),
+                                             Jet1     = cms.untracked.string("PuCalo"),
+                                             Jet2     = cms.untracked.string("PuPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 jetDQMMatchAkVs3CaloAkVs3PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akVs3CaloJets"),
-                                               src_Jet2 = cms.InputTag("akVs3PFJets"),
-                                               Jet1     = cms.untracked.string("VsCalo"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akVs3CaloJets"),
+                                             src_Jet2 = cms.InputTag("akVs3PFJets"),
+                                             Jet1     = cms.untracked.string("VsCalo"),
+                                             Jet2     = cms.untracked.string("VsPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 
 jetDQMMatchAkPu4CaloAkVs4Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                src_Jet1 = cms.InputTag("akPu4CaloJets"),
@@ -506,35 +521,35 @@ jetDQMMatchAkPu4CaloAkVs4Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                recoJetPtThreshold = cms.double(20.),
                                                recoDelRMatch = cms.double(0.2),
                                                recoJetEtaCut = cms.double(2.0)
-                                           )
+)
 jetDQMMatchAkPu4PFAkVs4PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu4PFJets"),
-                                               src_Jet2 = cms.InputTag("akVs4PFJets"),
-                                               Jet1     = cms.untracked.string("PuPF"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                           src_Jet1 = cms.InputTag("akPu4PFJets"),
+                                           src_Jet2 = cms.InputTag("akVs4PFJets"),
+                                           Jet1     = cms.untracked.string("PuPF"),
+                                           Jet2     = cms.untracked.string("VsPF"),
+                                           recoJetPtThreshold = cms.double(20.),
+                                           recoDelRMatch = cms.double(0.2),
+                                           recoJetEtaCut = cms.double(2.0)
+)
 
 jetDQMMatchAkPu4CaloAkPu4PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu4CaloJets"),
-                                               src_Jet2 = cms.InputTag("akPu4PFJets"),
-                                               Jet1     = cms.untracked.string("PuCalo"),
-                                               Jet2     = cms.untracked.string("PuPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akPu4CaloJets"),
+                                             src_Jet2 = cms.InputTag("akPu4PFJets"),
+                                             Jet1     = cms.untracked.string("PuCalo"),
+                                             Jet2     = cms.untracked.string("PuPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 jetDQMMatchAkVs4CaloAkVs4PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akVs4CaloJets"),
-                                               src_Jet2 = cms.InputTag("akVs4PFJets"),
-                                               Jet1     = cms.untracked.string("VsCalo"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akVs4CaloJets"),
+                                             src_Jet2 = cms.InputTag("akVs4PFJets"),
+                                             Jet1     = cms.untracked.string("VsCalo"),
+                                             Jet2     = cms.untracked.string("VsPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 jetDQMMatchAkPu5CaloAkVs5Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                src_Jet1 = cms.InputTag("akPu5CaloJets"),
                                                src_Jet2 = cms.InputTag("akVs5CaloJets"),
@@ -543,35 +558,35 @@ jetDQMMatchAkPu5CaloAkVs5Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                recoJetPtThreshold = cms.double(20.),
                                                recoDelRMatch = cms.double(0.2),
                                                recoJetEtaCut = cms.double(2.0)
-                                           )
+)
 jetDQMMatchAkPu5PFAkVs5PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu5PFJets"),
-                                               src_Jet2 = cms.InputTag("akVs5PFJets"),
-                                               Jet1     = cms.untracked.string("PuPF"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                           src_Jet1 = cms.InputTag("akPu5PFJets"),
+                                           src_Jet2 = cms.InputTag("akVs5PFJets"),
+                                           Jet1     = cms.untracked.string("PuPF"),
+                                           Jet2     = cms.untracked.string("VsPF"),
+                                           recoJetPtThreshold = cms.double(20.),
+                                           recoDelRMatch = cms.double(0.2),
+                                           recoJetEtaCut = cms.double(2.0)
+)
 
 jetDQMMatchAkPu5CaloAkPu5PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu5CaloJets"),
-                                               src_Jet2 = cms.InputTag("akPu5PFJets"),
-                                               Jet1     = cms.untracked.string("PuCalo"),
-                                               Jet2     = cms.untracked.string("PuPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akPu5CaloJets"),
+                                             src_Jet2 = cms.InputTag("akPu5PFJets"),
+                                             Jet1     = cms.untracked.string("PuCalo"),
+                                             Jet2     = cms.untracked.string("PuPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 jetDQMMatchAkVs5CaloAkVs5PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akVs5CaloJets"),
-                                               src_Jet2 = cms.InputTag("akVs5PFJets"),
-                                               Jet1     = cms.untracked.string("VsCalo"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akVs5CaloJets"),
+                                             src_Jet2 = cms.InputTag("akVs5PFJets"),
+                                             Jet1     = cms.untracked.string("VsCalo"),
+                                             Jet2     = cms.untracked.string("VsPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 jetDQMMatchAkPu2CaloAkVs2Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                src_Jet1 = cms.InputTag("akPu2CaloJets"),
                                                src_Jet2 = cms.InputTag("akVs2CaloJets"),
@@ -580,32 +595,32 @@ jetDQMMatchAkPu2CaloAkVs2Calo = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
                                                recoJetPtThreshold = cms.double(20.),
                                                recoDelRMatch = cms.double(0.2),
                                                recoJetEtaCut = cms.double(2.0)
-                                           )
+)
 jetDQMMatchAkPu2PFAkVs2PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu2PFJets"),
-                                               src_Jet2 = cms.InputTag("akVs2PFJets"),
-                                               Jet1     = cms.untracked.string("PuPF"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                           src_Jet1 = cms.InputTag("akPu2PFJets"),
+                                           src_Jet2 = cms.InputTag("akVs2PFJets"),
+                                           Jet1     = cms.untracked.string("PuPF"),
+                                           Jet2     = cms.untracked.string("VsPF"),
+                                           recoJetPtThreshold = cms.double(20.),
+                                           recoDelRMatch = cms.double(0.2),
+                                           recoJetEtaCut = cms.double(2.0)
+)
 
 jetDQMMatchAkPu2CaloAkPu2PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akPu2CaloJets"),
-                                               src_Jet2 = cms.InputTag("akPu2PFJets"),
-                                               Jet1     = cms.untracked.string("PuCalo"),
-                                               Jet2     = cms.untracked.string("PuPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akPu2CaloJets"),
+                                             src_Jet2 = cms.InputTag("akPu2PFJets"),
+                                             Jet1     = cms.untracked.string("PuCalo"),
+                                             Jet2     = cms.untracked.string("PuPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)
 jetDQMMatchAkVs2CaloAkVs2PF = cms.EDAnalyzer("JetAnalyzer_HeavyIons_matching",
-                                               src_Jet1 = cms.InputTag("akVs2CaloJets"),
-                                               src_Jet2 = cms.InputTag("akVs2PFJets"),
-                                               Jet1     = cms.untracked.string("VsCalo"),
-                                               Jet2     = cms.untracked.string("VsPF"),
-                                               recoJetPtThreshold = cms.double(20.),
-                                               recoDelRMatch = cms.double(0.2),
-                                               recoJetEtaCut = cms.double(2.0)
-                                           )
+                                             src_Jet1 = cms.InputTag("akVs2CaloJets"),
+                                             src_Jet2 = cms.InputTag("akVs2PFJets"),
+                                             Jet1     = cms.untracked.string("VsCalo"),
+                                             Jet2     = cms.untracked.string("VsPF"),
+                                             recoJetPtThreshold = cms.double(20.),
+                                             recoDelRMatch = cms.double(0.2),
+                                             recoJetEtaCut = cms.double(2.0)
+)

--- a/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
@@ -1,10 +1,10 @@
 //
 // Jet Analyzer class for heavy ion jets. for DQM jet analysis monitoring 
 // For CMSSW_7_4_X, especially reading background subtracted jets 
-// author: Raghav Kunnawalkam Elayavalli,
+// author: Raghav Kunnawalkam Elayavalli, Mohammed Zakaria (co Author)
 //         Jan 12th 2015 
 //         Rutgers University, email: raghav.k.e at CERN dot CH 
-//
+//         UIC, email: mzakaria @ CERN dot CH
 
 
 #include "DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h"
@@ -18,7 +18,6 @@ using namespace std;
 JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
   mInputCollection               (iConfig.getParameter<edm::InputTag>       ("src")),
   mInputPFCandCollection         (iConfig.getParameter<edm::InputTag>       ("PFcands")),
-  centrality                     (iConfig.getParameter<edm::InputTag>       ("centrality")),
   mOutputFile                    (iConfig.getUntrackedParameter<std::string>("OutputFile","")),
   JetType                        (iConfig.getUntrackedParameter<std::string>("JetType")),
   UEAlgo                         (iConfig.getUntrackedParameter<std::string>("UEAlgo")),
@@ -49,19 +48,112 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
   caloCandViewToken_ = consumes<reco::CandidateView>(edm::InputTag("towerMaker"));
   backgrounds_ = consumes<edm::ValueMap<reco::VoronoiBackground> >(Background);  
   backgrounds_value_ = consumes<std::vector<float> >(Background);
-  centralityToken_ = consumes<reco::Centrality>(centrality);
+                                  
+  centralityTag_ = iConfig.getParameter<InputTag>("centralitycollection");
+  centralityToken = consumes<reco::Centrality>(centralityTag_);
+
+  centralityBinTag_ = (iConfig.getParameter<edm::InputTag> ("centralitybincollection"));
+  centralityBinToken = consumes<int>(centralityBinTag_);
+
   hiVertexToken_ = consumes<std::vector<reco::Vertex> >(edm::InputTag("hiSelectedVertex"));
-  
+
   // need to initialize the PF cand histograms : which are also event variables 
   if(isPFJet){
-
     mNPFpart = 0;
     mPFPt = 0;
     mPFEta = 0;
     mPFPhi = 0;
     mPFVsPt = 0;
     mPFVsPtInitial = 0;
+    mPFVsPtInitial_HF = 0;
+    mPFVsPtInitial_Barrel_Centrality_100_95 = 0;
+    mPFVsPtInitial_Barrel_Centrality_95_90 = 0;
+    mPFVsPtInitial_Barrel_Centrality_90_85 = 0;
+    mPFVsPtInitial_Barrel_Centrality_85_80 = 0;
+    mPFVsPtInitial_Barrel_Centrality_80_75 = 0;
+    mPFVsPtInitial_Barrel_Centrality_75_70 = 0;
+    mPFVsPtInitial_Barrel_Centrality_70_65 = 0;
+    mPFVsPtInitial_Barrel_Centrality_65_60 = 0;
+    mPFVsPtInitial_Barrel_Centrality_60_55 = 0;
+    mPFVsPtInitial_Barrel_Centrality_55_50 = 0;
+    mPFVsPtInitial_Barrel_Centrality_50_45 = 0;
+    mPFVsPtInitial_Barrel_Centrality_45_40 = 0;
+    mPFVsPtInitial_Barrel_Centrality_40_35 = 0;
+    mPFVsPtInitial_Barrel_Centrality_35_30 = 0;
+    mPFVsPtInitial_Barrel_Centrality_30_25 = 0;
+    mPFVsPtInitial_Barrel_Centrality_25_20 = 0;
+    mPFVsPtInitial_Barrel_Centrality_20_15 = 0;
+    mPFVsPtInitial_Barrel_Centrality_15_10 = 0;
+    mPFVsPtInitial_Barrel_Centrality_10_5 = 0;
+    mPFVsPtInitial_Barrel_Centrality_5_0 = 0;
+
+    mPFVsPtInitial_EndCap_Centrality_100_95 = 0;
+    mPFVsPtInitial_EndCap_Centrality_95_90 = 0;
+    mPFVsPtInitial_EndCap_Centrality_90_85 = 0;
+    mPFVsPtInitial_EndCap_Centrality_85_80 = 0;
+    mPFVsPtInitial_EndCap_Centrality_80_75 = 0;
+    mPFVsPtInitial_EndCap_Centrality_75_70 = 0;
+    mPFVsPtInitial_EndCap_Centrality_70_65 = 0;
+    mPFVsPtInitial_EndCap_Centrality_65_60 = 0;
+    mPFVsPtInitial_EndCap_Centrality_60_55 = 0;
+    mPFVsPtInitial_EndCap_Centrality_55_50 = 0;
+    mPFVsPtInitial_EndCap_Centrality_50_45 = 0;
+    mPFVsPtInitial_EndCap_Centrality_45_40 = 0;
+    mPFVsPtInitial_EndCap_Centrality_40_35 = 0;
+    mPFVsPtInitial_EndCap_Centrality_35_30 = 0;
+    mPFVsPtInitial_EndCap_Centrality_30_25 = 0;
+    mPFVsPtInitial_EndCap_Centrality_25_20 = 0;
+    mPFVsPtInitial_EndCap_Centrality_20_15 = 0;
+    mPFVsPtInitial_EndCap_Centrality_15_10 = 0;
+    mPFVsPtInitial_EndCap_Centrality_10_5 = 0;
+    mPFVsPtInitial_EndCap_Centrality_5_0 = 0;
+
+    mPFVsPtInitial_HF_Centrality_100_95 = 0;
+    mPFVsPtInitial_HF_Centrality_95_90 = 0;
+    mPFVsPtInitial_HF_Centrality_90_85 = 0;
+    mPFVsPtInitial_HF_Centrality_85_80 = 0;
+    mPFVsPtInitial_HF_Centrality_80_75 = 0;
+    mPFVsPtInitial_HF_Centrality_75_70 = 0;
+    mPFVsPtInitial_HF_Centrality_70_65 = 0;
+    mPFVsPtInitial_HF_Centrality_65_60 = 0;
+    mPFVsPtInitial_HF_Centrality_60_55 = 0;
+    mPFVsPtInitial_HF_Centrality_55_50 = 0;
+    mPFVsPtInitial_HF_Centrality_50_45 = 0;
+    mPFVsPtInitial_HF_Centrality_45_40 = 0;
+    mPFVsPtInitial_HF_Centrality_40_35 = 0;
+    mPFVsPtInitial_HF_Centrality_35_30 = 0;
+    mPFVsPtInitial_HF_Centrality_30_25 = 0;
+    mPFVsPtInitial_HF_Centrality_25_20 = 0;
+    mPFVsPtInitial_HF_Centrality_20_15 = 0;
+    mPFVsPtInitial_HF_Centrality_15_10 = 0;
+    mPFVsPtInitial_HF_Centrality_10_5 = 0;
+    mPFVsPtInitial_HF_Centrality_5_0 = 0;
+
     mPFArea = 0;
+    mPFDeltaR = 0; 
+    mPFDeltaR_Scaled_R = 0; 
+
+    mPFDeltaR_pTCorrected = 0; 
+    mPFDeltaR_pTCorrected_PFpT_20To30 = 0; 
+    mPFDeltaR_pTCorrected_PFpT_30To50 = 0; 
+    mPFDeltaR_pTCorrected_PFpT_50To80 = 0; 
+    mPFDeltaR_pTCorrected_PFpT_80To120 = 0; 
+    mPFDeltaR_pTCorrected_PFpT_120To180 = 0; 
+    mPFDeltaR_pTCorrected_PFpT_180To300 = 0; 
+    mPFDeltaR_pTCorrected_PFpT_300ToInf = 0;  
+
+    mPFDeltaR_pTCorrected_PFVsInitialpT_20To30 = 0;  
+    mPFDeltaR_pTCorrected_PFVsInitialpT_30To50 = 0;  
+    mPFDeltaR_pTCorrected_PFVsInitialpT_50To80 = 0;  
+    mPFDeltaR_pTCorrected_PFVsInitialpT_80To120 = 0; 
+    mPFDeltaR_pTCorrected_PFVsInitialpT_120To180 = 0;
+    mPFDeltaR_pTCorrected_PFVsInitialpT_180To300 = 0;
+    mPFDeltaR_pTCorrected_PFVsInitialpT_300ToInf = 0;
+
+
+    mPFVsPtInitialDeltaR_pTCorrected = 0; 
+    mPFVsPtDeltaR_pTCorrected = 0; 
+
     mSumPFVsPt = 0;
     mSumPFVsPtInitial = 0;
     mSumPFPt = 0;
@@ -77,7 +169,7 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumPFVsPtInitial_HF = 0;
     mSumPFVsPt_HF = 0;
     mSumPFPt_HF = 0;
-   
+
     mSumPFVsPtInitial_n5p191_n2p650 = 0;
     mSumPFVsPtInitial_n2p650_n2p043 = 0;
     mSumPFVsPtInitial_n2p043_n1p740 = 0;
@@ -125,7 +217,43 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumPFPt_1p740_2p043 = 0;
     mSumPFPt_2p043_2p650 = 0;
     mSumPFPt_2p650_5p191 = 0;
-  
+
+    mPFCandpT_vs_eta_Unknown = 0; // pf id 0
+    mPFCandpT_vs_eta_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_vs_eta_electron = 0; // pf id - 2
+    mPFCandpT_vs_eta_muon = 0; // pf id - 3
+    mPFCandpT_vs_eta_photon = 0; // pf id - 4
+    mPFCandpT_vs_eta_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_vs_eta_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_vs_eta_EME_inHF = 0; // pf id - 7
+     
+    mPFCandpT_Barrel_Unknown = 0; // pf id 0
+    mPFCandpT_Barrel_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_Barrel_electron = 0; // pf id - 2
+    mPFCandpT_Barrel_muon = 0; // pf id - 3
+    mPFCandpT_Barrel_photon = 0; // pf id - 4
+    mPFCandpT_Barrel_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_Barrel_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_Barrel_EME_inHF = 0; // pf id - 7
+
+    mPFCandpT_Endcap_Unknown = 0; // pf id 0
+    mPFCandpT_Endcap_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_Endcap_electron = 0; // pf id - 2
+    mPFCandpT_Endcap_muon = 0; // pf id - 3
+    mPFCandpT_Endcap_photon = 0; // pf id - 4
+    mPFCandpT_Endcap_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_Endcap_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_Endcap_EME_inHF = 0; // pf id - 7
+
+    mPFCandpT_Forward_Unknown = 0; // pf id 0
+    mPFCandpT_Forward_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_Forward_electron = 0; // pf id - 2
+    mPFCandpT_Forward_muon = 0; // pf id - 3
+    mPFCandpT_Forward_photon = 0; // pf id - 4
+    mPFCandpT_Forward_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_Forward_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_Forward_EME_inHF = 0; // pf id - 7
+      
   }
   if(isCaloJet){
     mNCalopart = 0;
@@ -135,7 +263,7 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
     mCaloVsPt = 0;
     mCaloVsPtInitial = 0;
     mCaloArea = 0;
-    
+
     mSumCaloVsPt = 0;
     mSumCaloVsPtInitial = 0;
     mSumCaloPt = 0;
@@ -151,7 +279,7 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumCaloVsPtInitial_HF = 0;
     mSumCaloVsPt_HF = 0;
     mSumCaloPt_HF = 0;
-   
+
     mSumCaloVsPtInitial_n5p191_n2p650 = 0;
     mSumCaloVsPtInitial_n2p650_n2p043 = 0;
     mSumCaloVsPtInitial_n2p043_n1p740 = 0;
@@ -199,18 +327,17 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumCaloPt_1p740_2p043 = 0;
     mSumCaloPt_2p043_2p650 = 0;
     mSumCaloPt_2p650_5p191 = 0;
-  
+
   }
 
   mSumpt = 0;
-  
+
   // Events variables
   mNvtx         = 0;
   mHF           = 0;
 
   // added Jan 12th 2015
 
-  
   // Jet parameters
   mEta          = 0;
   mPhi          = 0;
@@ -224,206 +351,330 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
   mNJets_40     = 0;
   mNJets        = 0;
 
- 
+
 }
-   
+
 void JetAnalyzer_HeavyIons::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & iRun,edm::EventSetup const &) 
-  {
+{
 
-    ibooker.setCurrentFolder("JetMET/HIJetValidation/"+mInputCollection.label());
+  ibooker.setCurrentFolder("JetMET/HIJetValidation/"+mInputCollection.label());
+
+  double edge_pseudorapidity[etaBins_ +1] = {-5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522, 0.522, 0.783, 1.131, 1.479, 1.740, 2.043, 2.650, 5.191 };
+
+  TH2F *h2D_etabins_vs_pt2 = new TH2F("h2D_etabins_vs_pt2",";#eta;sum p_{T}^{2}",etaBins_,edge_pseudorapidity,10000,0,10000);
+  TH2F *h2D_etabins_vs_pt = new TH2F("h2D_etabins_vs_pt",";#eta;sum p_{T}",etaBins_,edge_pseudorapidity,10000,-1000,1000);
+  TH2F *h2D_pfcand_etabins_vs_pt = new TH2F("h2D_etabins_vs_pt",";#eta;sum p_{T}",etaBins_,edge_pseudorapidity,300, 0, 300);
+
+  if(isPFJet){
+
+    mNPFpart         = ibooker.book1D("NPFpart","No of particle flow candidates",1000,0,1000);
+    mPFPt            = ibooker.book1D("PFPt","PF candidate p_{T}",10000,-500,500);
+    mPFEta           = ibooker.book1D("PFEta","PF candidate #eta",120,-6,6);
+    mPFPhi           = ibooker.book1D("PFPhi","PF candidate #phi",70,-3.5,3.5);
+    mPFVsPt          = ibooker.book1D("PFVsPt","Vs PF candidate p_{T}",1000,-500,500);
+    mPFVsPtInitial   = ibooker.book1D("PFVsPtInitial","Vs background subtracted PF candidate p_{T}",1000,-500,500);
+    mPFVsPtInitial_HF   = ibooker.book2D("PFVsPtInitial_HF","Vs background subtracted PF candidate p_{T} versus HF", 600,0,6000,1000,-500,500);
+
+    mPFVsPtInitial_Barrel_Centrality_100_95   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_100_95","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW100And95 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_95_90   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_95_90","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW95And90 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_90_85   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_90_85","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW90And85 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_85_80   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_85_80","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW85And80 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_80_75   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_80_75","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW80And75 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_75_70   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_75_70","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW75And70 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_70_65   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_70_65","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW70And65 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_65_60   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_65_60","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW65And60 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_60_55   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_60_55","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW60And55 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_55_50   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_55_50","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW55And50 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_50_45   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_50_45","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW50And45 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_45_40   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_45_40","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW45And40 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_40_35   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_40_35","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW40And35 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_35_30   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_35_30","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW35And30 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_30_25   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_30_25","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW30And25 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_25_20   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_25_20","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW25And20 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_20_15   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_20_15","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW20And15 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_15_10   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_15_10","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW15And10 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_10_5   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_10_5","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW10And05 Barrel",1000,-100,100);
+    mPFVsPtInitial_Barrel_Centrality_5_0   = ibooker.book1D("mPFVsPtInitial_Barrel_Centrality_5_0","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW05And00 Barrel",1000,-100,100);
+
+    mPFVsPtInitial_EndCap_Centrality_100_95   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_100_95","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW100And95 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_95_90   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_95_90","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW95And90 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_90_85   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_90_85","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW90And85 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_85_80   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_85_80","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW85And80 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_80_75   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_80_75","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW80And75 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_75_70   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_75_70","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW75And70 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_70_65   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_70_65","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW70And65 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_65_60   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_65_60","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW65And60 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_60_55   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_60_55","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW60And55 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_55_50   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_55_50","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW55And50 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_50_45   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_50_45","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW50And45 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_45_40   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_45_40","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW45And40 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_40_35   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_40_35","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW40And35 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_35_30   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_35_30","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW35And30 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_30_25   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_30_25","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW30And25 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_25_20   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_25_20","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW25And20 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_20_15   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_20_15","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW20And15 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_15_10   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_15_10","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW15And10 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_10_5   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_10_5","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW10And05 EndCap",1000,-100,100);
+    mPFVsPtInitial_EndCap_Centrality_5_0   = ibooker.book1D("mPFVsPtInitial_EndCap_Centrality_5_0","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW05And00 EndCap",1000,-100,100);
+
+    mPFVsPtInitial_HF_Centrality_100_95   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_100_95","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW100And95 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_95_90   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_95_90","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW95And90 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_90_85   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_90_85","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW90And85 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_85_80   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_85_80","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW85And80 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_80_75   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_80_75","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW80And75 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_75_70   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_75_70","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW75And70 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_70_65   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_70_65","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW70And65 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_65_60   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_65_60","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW65And60 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_60_55   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_60_55","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW60And55 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_55_50   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_55_50","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW55And50 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_50_45   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_50_45","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW50And45 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_45_40   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_45_40","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW45And40 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_40_35   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_40_35","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW40And35 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_35_30   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_35_30","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW35And30 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_30_25   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_30_25","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW30And25 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_25_20   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_25_20","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW25And20 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_20_15   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_20_15","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW20And15 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_15_10   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_15_10","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW15And10 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_10_5   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_10_5","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW10And05 HF",1000,-100,100);
+    mPFVsPtInitial_HF_Centrality_5_0   = ibooker.book1D("mPFVsPtInitial_HF_Centrality_5_0","Vs background subtracted PF candidate p_{T} versus HF Energy Dist. BTW05And00 HF",1000,-100,100);
+
+    mPFArea          = ibooker.book1D("PFArea","VS PF candidate area",100,0,4);
+    mPFDeltaR          = ibooker.book1D("PFDeltaR","VS PF candidate DeltaR",100,0,4); //MZ
+    mPFDeltaR_Scaled_R          = ibooker.book1D("PFDeltaR_Scaled_R","VS PF candidate DeltaR Divided by DeltaR square",100,0,4); //MZ
+    mPFDeltaR_pTCorrected          = ibooker.book1D("PFDeltaR_pTCorrected","VS PF candidate DeltaR time pFpT over jet pT",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_20To30          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_20_30","VS PF candidate DeltaR time pFpT over jet pT for PFpT 20 to 30 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_30To50          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_30_50","VS PF candidate DeltaR time pFpT over jet pT for PFpT 30 to 50 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_50To80          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_50_80","VS PF candidate DeltaR time pFpT over jet pT for PFpT 50 to 80 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_80To120          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_80_120","VS PF candidate DeltaR time pFpT over jet pT for PFpT 80 to 120 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_120To180          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_120_180","VS PF candidate DeltaR time pFpT over jet pT for PFpT 120 to 180 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_180To300          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_180_300","VS PF candidate DeltaR time pFpT over jet pT for PFpT 180 to 300 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFpT_300ToInf          = ibooker.book1D("PFDeltaR_pTCorrected_PFpT_300_Inf","VS PF candidate DeltaR time pFpT over jet pT for PFpT 300 to Inf GeV",100,0,4); //MZ
+
+    mPFDeltaR_pTCorrected_PFVsInitialpT_20To30          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_20_30","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 20 to 30 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFVsInitialpT_30To50          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_30_50","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 30 to 50 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFVsInitialpT_50To80          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_50_80","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 50 to 80 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFVsInitialpT_80To120          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_80_120","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 80 to 120 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFVsInitialpT_120To180          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_120_180","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 120 to 180 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFVsInitialpT_180To300          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_180_300","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 180 to 300 GeV",100,0,4); //MZ
+    mPFDeltaR_pTCorrected_PFVsInitialpT_300ToInf          = ibooker.book1D("PFVsInitialDeltaR_pTCorrected_PFpT_300_Inf","VS PF candidate DeltaR time pFVsInitiaal pT over jet pT for PFpT 300 to Inf GeV",100,0,4); //MZ
+
+
+    mPFVsPtInitialDeltaR_pTCorrected         = ibooker.book1D("PFVsPtInitialDeltaR_pTCorrected","VS PF Initial candidate DeltaR time pFpTInitial over jet pT",100,0,4); //MZ
+    mPFVsPtDeltaR_pTCorrected         = ibooker.book1D("PFVsPtDeltaR_pTCorrected","VS PF candidate DeltaR time pFpT over jet pT",100,0,4); //MZ
+
+    mSumPFVsPt       = ibooker.book1D("SumPFVsPt","Sum of final PF VS p_{T}",1000,-10000,10000);
+    mSumPFVsPtInitial= ibooker.book1D("SumPFVsPtInitial","Sum PF VS p_{T} after subtraction",1000,-10000,10000);
+    mSumPFPt         = ibooker.book1D("SumPFPt","Sum of initial PF p_{T}",1000,-10000,10000);
+    mSumPFVsPt_eta   = ibooker.book2D("SumPFVsPt_etaBins",h2D_etabins_vs_pt);
+    mSumPFVsPtInitial_eta   = ibooker.book2D("SumPFVsPtInitial_etaBins",h2D_etabins_vs_pt);
+    mSumPFPt_eta     = ibooker.book2D("SumPFPt_etaBins",h2D_etabins_vs_pt);
+
+    mSumSquaredPFVsPt       = ibooker.book1D("SumSquaredPFVsPt","Sum PF Vs p_{T} square",10000,0,10000);
+    mSumSquaredPFVsPtInitial= ibooker.book1D("SumSquaredPFVsPtInitial","Sum PF Vs p_{T} square after subtraction ",10000,0,10000);
+    mSumSquaredPFPt         = ibooker.book1D("SumSquaredPFPt","Sum of initial PF p_{T} squared",10000,0,10000);
+    mSumSquaredPFVsPt_eta   = ibooker.book2D("SumSquaredPFVsPt_etaBins",h2D_etabins_vs_pt2);
+    mSumSquaredPFVsPtInitial_eta   = ibooker.book2D("SumSquaredPFVsPtInitial_etaBins",h2D_etabins_vs_pt2);
+    mSumSquaredPFPt_eta     = ibooker.book2D("SumSquaredPFPt_etaBins",h2D_etabins_vs_pt2);
+
+    mSumPFVsPtInitial_HF    = ibooker.book2D("SumPFVsPtInitial_HF","HF Energy (y axis) vs Sum PF Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumPFVsPt_HF    = ibooker.book2D("SumPFVsPt_HF","HF energy (y axis) vs Sum PF Vs p_{T} final (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumPFPt_HF    = ibooker.book2D("SumPFPt_HF","HF energy (y axis) vs Sum initial PF p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
+
+    mSumPFVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumPFVsPtInitial_n5p191_n2p650","Sum PFVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumPFVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumPFVsPtInitial_n2p650_n2p043","Sum PFVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumPFVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumPFVsPtInitial_n2p043_n1p740","Sum PFVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumPFVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumPFVsPtInitial_n1p740_n1p479","Sum PFVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumPFVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumPFVsPtInitial_n1p479_n1p131","Sum PFVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumPFVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumPFVsPtInitial_n1p131_n0p783","Sum PFVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumPFVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p783_n0p522","Sum PFVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumPFVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p522_0p522","Sum PFVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumPFVsPtInitial_0p522_0p783 = ibooker.book1D("mSumPFVsPtInitial_0p522_0p783","Sum PFVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumPFVsPtInitial_0p783_1p131 = ibooker.book1D("mSumPFVsPtInitial_0p783_1p131","Sum PFVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumPFVsPtInitial_1p131_1p479 = ibooker.book1D("mSumPFVsPtInitial_1p131_1p479","Sum PFVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumPFVsPtInitial_1p479_1p740 = ibooker.book1D("mSumPFVsPtInitial_1p479_1p740","Sum PFVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumPFVsPtInitial_1p740_2p043 = ibooker.book1D("mSumPFVsPtInitial_1p740_2p043","Sum PFVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumPFVsPtInitial_2p043_2p650 = ibooker.book1D("mSumPFVsPtInitial_2p043_2p650","Sum PFVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumPFVsPtInitial_2p650_5p191 = ibooker.book1D("mSumPFVsPtInitial_2p650_5p191","Sum PFVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mSumPFVsPt_n5p191_n2p650 = ibooker.book1D("mSumPFVsPt_n5p191_n2p650","Sum PFVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumPFVsPt_n2p650_n2p043 = ibooker.book1D("mSumPFVsPt_n2p650_n2p043","Sum PFVsPt  variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumPFVsPt_n2p043_n1p740 = ibooker.book1D("mSumPFVsPt_n2p043_n1p740","Sum PFVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumPFVsPt_n1p740_n1p479 = ibooker.book1D("mSumPFVsPt_n1p740_n1p479","Sum PFVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumPFVsPt_n1p479_n1p131 = ibooker.book1D("mSumPFVsPt_n1p479_n1p131","Sum PFVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumPFVsPt_n1p131_n0p783 = ibooker.book1D("mSumPFVsPt_n1p131_n0p783","Sum PFVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumPFVsPt_n0p783_n0p522 = ibooker.book1D("mSumPFVsPt_n0p783_n0p522","Sum PFVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumPFVsPt_n0p522_0p522 = ibooker.book1D("mSumPFVsPt_n0p522_0p522","Sum PFVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumPFVsPt_0p522_0p783 = ibooker.book1D("mSumPFVsPt_0p522_0p783","Sum PFVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumPFVsPt_0p783_1p131 = ibooker.book1D("mSumPFVsPt_0p783_1p131","Sum PFVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumPFVsPt_1p131_1p479 = ibooker.book1D("mSumPFVsPt_1p131_1p479","Sum PFVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumPFVsPt_1p479_1p740 = ibooker.book1D("mSumPFVsPt_1p479_1p740","Sum PFVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumPFVsPt_1p740_2p043 = ibooker.book1D("mSumPFVsPt_1p740_2p043","Sum PFVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumPFVsPt_2p043_2p650 = ibooker.book1D("mSumPFVsPt_2p043_2p650","Sum PFVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumPFVsPt_2p650_5p191 = ibooker.book1D("mSumPFVsPt_2p650_5p191","Sum PFVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mSumPFPt_n5p191_n2p650 = ibooker.book1D("mSumPFPt_n5p191_n2p650","Sum PFPt  in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumPFPt_n2p650_n2p043 = ibooker.book1D("mSumPFPt_n2p650_n2p043","Sum PFPt  in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumPFPt_n2p043_n1p740 = ibooker.book1D("mSumPFPt_n2p043_n1p740","Sum PFPt  in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumPFPt_n1p740_n1p479 = ibooker.book1D("mSumPFPt_n1p740_n1p479","Sum PFPt  in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumPFPt_n1p479_n1p131 = ibooker.book1D("mSumPFPt_n1p479_n1p131","Sum PFPt  in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumPFPt_n1p131_n0p783 = ibooker.book1D("mSumPFPt_n1p131_n0p783","Sum PFPt  in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumPFPt_n0p783_n0p522 = ibooker.book1D("mSumPFPt_n0p783_n0p522","Sum PFPt  in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumPFPt_n0p522_0p522 = ibooker.book1D("mSumPFPt_n0p522_0p522","Sum PFPt  in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumPFPt_0p522_0p783 = ibooker.book1D("mSumPFPt_0p522_0p783","Sum PFPt  in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumPFPt_0p783_1p131 = ibooker.book1D("mSumPFPt_0p783_1p131","Sum PFPt  in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumPFPt_1p131_1p479 = ibooker.book1D("mSumPFPt_1p131_1p479","Sum PFPt  in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumPFPt_1p479_1p740 = ibooker.book1D("mSumPFPt_1p479_1p740","Sum PFPt  in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumPFPt_1p740_2p043 = ibooker.book1D("mSumPFPt_1p740_2p043","Sum PFPt  in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumPFPt_2p043_2p650 = ibooker.book1D("mSumPFPt_2p043_2p650","Sum PFPt  in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumPFPt_2p650_5p191 = ibooker.book1D("mSumPFPt_2p650_5p191","Sum PFPt  in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mPFCandpT_vs_eta_Unknown = ibooker.book2D("PF_cand_X_unknown",h2D_pfcand_etabins_vs_pt); // pf id 0
+    mPFCandpT_vs_eta_ChargedHadron = ibooker.book2D("PF_cand_chargedHad",h2D_pfcand_etabins_vs_pt); // pf id - 1 
+    mPFCandpT_vs_eta_electron = ibooker.book2D("PF_cand_electron",h2D_pfcand_etabins_vs_pt); // pf id - 2
+    mPFCandpT_vs_eta_muon = ibooker.book2D("PF_cand_muon",h2D_pfcand_etabins_vs_pt); // pf id - 3
+    mPFCandpT_vs_eta_photon = ibooker.book2D("PF_cand_photon",h2D_pfcand_etabins_vs_pt); // pf id - 4
+    mPFCandpT_vs_eta_NeutralHadron = ibooker.book2D("PF_cand_neutralHad",h2D_pfcand_etabins_vs_pt); // pf id - 5
+    mPFCandpT_vs_eta_HadE_inHF = ibooker.book2D("PF_cand_HadEner_inHF",h2D_pfcand_etabins_vs_pt); // pf id - 6
+    mPFCandpT_vs_eta_EME_inHF = ibooker.book2D("PF_cand_EMEner_inHF",h2D_pfcand_etabins_vs_pt); // pf id - 7
+
+    mPFCandpT_Barrel_Unknown = ibooker.book1D("mPFCandpT_Barrel_Unknown",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id  - 0
+    mPFCandpT_Barrel_ChargedHadron = ibooker.book1D("mPFCandpT_Barrel_ChargedHadron",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 1 
+    mPFCandpT_Barrel_electron = ibooker.book1D("mPFCandpT_Barrel_electron",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 2
+    mPFCandpT_Barrel_muon = ibooker.book1D("mPFCandpT_Barrel_muon",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 3
+    mPFCandpT_Barrel_photon = ibooker.book1D("mPFCandpT_Barrel_photon",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 4
+    mPFCandpT_Barrel_NeutralHadron = ibooker.book1D("mPFCandpT_Barrel_NeutralHadron",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 5
+    mPFCandpT_Barrel_HadE_inHF = ibooker.book1D("mPFCandpT_Barrel_HadE_inHF",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 6
+    mPFCandpT_Barrel_EME_inHF = ibooker.book1D("mPFCandpT_Barrel_EME_inHF",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 7
     
-    double edge_pseudorapidity[etaBins_ +1] = {-5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522, 0.522, 0.783, 1.131, 1.479, 1.740, 2.043, 2.650, 5.191 };
+    mPFCandpT_Endcap_Unknown = ibooker.book1D("mPFCandpT_Endcap_Unknown",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 0
+    mPFCandpT_Endcap_ChargedHadron = ibooker.book1D("mPFCandpT_Endcap_ChargedHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 1 
+    mPFCandpT_Endcap_electron = ibooker.book1D("mPFCandpT_Endcap_electron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 2
+    mPFCandpT_Endcap_muon = ibooker.book1D("mPFCandpT_Endcap_muon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 3
+    mPFCandpT_Endcap_photon = ibooker.book1D("mPFCandpT_Endcap_photon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 4
+    mPFCandpT_Endcap_NeutralHadron = ibooker.book1D("mPFCandpT_Endcap_NeutralHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 5
+    mPFCandpT_Endcap_HadE_inHF = ibooker.book1D("mPFCandpT_Endcap_HadE_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 6
+    mPFCandpT_Endcap_EME_inHF = ibooker.book1D("mPFCandpT_Endcap_EME_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 7
 
-    TH2F *h2D_etabins_vs_pt2 = new TH2F("h2D_etabins_vs_pt2","etaBins (x axis), sum pt^{2} (y axis)",etaBins_,edge_pseudorapidity,10000,0,10000);
-    TH2F *h2D_etabins_vs_pt = new TH2F("h2D_etabins_vs_pt","etaBins (x axis), sum pt (y axis)",etaBins_,edge_pseudorapidity,10000,-1000,1000);
-    
-    if(isPFJet){
-
-      mNPFpart         = ibooker.book1D("NPFpart","No of particle flow candidates",1000,0,10000);
-      mPFPt            = ibooker.book1D("PFPt","PF candidate p_{T}",1000,-5000,5000);
-      mPFEta           = ibooker.book1D("PFEta","PF candidate #eta",120,-6,6);
-      mPFPhi           = ibooker.book1D("PFPhi","PF candidate #phi",70,-3.5,3.5);
-      mPFVsPt          = ibooker.book1D("PFVsPt","Vs PF candidate p_{T}",1000,-5000,5000);
-      mPFVsPtInitial   = ibooker.book1D("PFVsPtInitial","Vs background subtracted PF candidate p_{T}",1000,-5000,5000);
-      mPFArea          = ibooker.book1D("PFArea","VS PF candidate area",100,0,4);
-      
-      mSumPFVsPt       = ibooker.book1D("SumPFVsPt","Sum of final PF VS p_{T}",1000,-10000,10000);
-      mSumPFVsPtInitial= ibooker.book1D("SumPFVsPtInitial","Sum PF VS p_{T} after subtraction",1000,-10000,10000);
-      mSumPFPt         = ibooker.book1D("SumPFPt","Sum of initial PF p_{T}",1000,-10000,10000);
-      mSumPFVsPt_eta   = ibooker.book2D("SumPFVsPt_etaBins",h2D_etabins_vs_pt);
-      mSumPFVsPtInitial_eta   = ibooker.book2D("SumPFVsPtInitial_etaBins",h2D_etabins_vs_pt);
-      mSumPFPt_eta     = ibooker.book2D("SumPFPt_etaBins",h2D_etabins_vs_pt);
-
-      mSumSquaredPFVsPt       = ibooker.book1D("SumSquaredPFVsPt","Sum PF Vs p_{T} square",10000,0,10000);
-      mSumSquaredPFVsPtInitial= ibooker.book1D("SumSquaredPFVsPtInitial","Sum PF Vs p_{T} square after subtraction ",10000,0,10000);
-      mSumSquaredPFPt         = ibooker.book1D("SumSquaredPFPt","Sum of initial PF p_{T} squared",10000,0,10000);
-      mSumSquaredPFVsPt_eta   = ibooker.book2D("SumSquaredPFVsPt_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredPFVsPtInitial_eta   = ibooker.book2D("SumSquaredPFVsPtInitial_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredPFPt_eta     = ibooker.book2D("SumSquaredPFPt_etaBins",h2D_etabins_vs_pt2);
-
-      mSumPFVsPtInitial_HF    = ibooker.book2D("SumPFVsPtInitial_HF","HF Energy (y axis) vs Sum PF Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumPFVsPt_HF    = ibooker.book2D("SumPFVsPt_HF","HF energy (y axis) vs Sum PF Vs p_{T} final (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumPFPt_HF    = ibooker.book2D("SumPFPt_HF","HF energy (y axis) vs Sum initial PF p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
-    
-      mSumPFVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumPFVsPtInitial_n5p191_n2p650","Sum PFVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumPFVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumPFVsPtInitial_n2p650_n2p043","Sum PFVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumPFVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumPFVsPtInitial_n2p043_n1p740","Sum PFVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumPFVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumPFVsPtInitial_n1p740_n1p479","Sum PFVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumPFVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumPFVsPtInitial_n1p479_n1p131","Sum PFVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumPFVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumPFVsPtInitial_n1p131_n0p783","Sum PFVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumPFVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p783_n0p522","Sum PFVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumPFVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p522_0p522","Sum PFVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumPFVsPtInitial_0p522_0p783 = ibooker.book1D("mSumPFVsPtInitial_0p522_0p783","Sum PFVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumPFVsPtInitial_0p783_1p131 = ibooker.book1D("mSumPFVsPtInitial_0p783_1p131","Sum PFVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumPFVsPtInitial_1p131_1p479 = ibooker.book1D("mSumPFVsPtInitial_1p131_1p479","Sum PFVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumPFVsPtInitial_1p479_1p740 = ibooker.book1D("mSumPFVsPtInitial_1p479_1p740","Sum PFVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumPFVsPtInitial_1p740_2p043 = ibooker.book1D("mSumPFVsPtInitial_1p740_2p043","Sum PFVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumPFVsPtInitial_2p043_2p650 = ibooker.book1D("mSumPFVsPtInitial_2p043_2p650","Sum PFVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumPFVsPtInitial_2p650_5p191 = ibooker.book1D("mSumPFVsPtInitial_2p650_5p191","Sum PFVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-
-      mSumPFVsPt_n5p191_n2p650 = ibooker.book1D("mSumPFVsPt_n5p191_n2p650","Sum PFVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumPFVsPt_n2p650_n2p043 = ibooker.book1D("mSumPFVsPt_n2p650_n2p043","Sum PFVsPt  variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumPFVsPt_n2p043_n1p740 = ibooker.book1D("mSumPFVsPt_n2p043_n1p740","Sum PFVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumPFVsPt_n1p740_n1p479 = ibooker.book1D("mSumPFVsPt_n1p740_n1p479","Sum PFVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumPFVsPt_n1p479_n1p131 = ibooker.book1D("mSumPFVsPt_n1p479_n1p131","Sum PFVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumPFVsPt_n1p131_n0p783 = ibooker.book1D("mSumPFVsPt_n1p131_n0p783","Sum PFVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumPFVsPt_n0p783_n0p522 = ibooker.book1D("mSumPFVsPt_n0p783_n0p522","Sum PFVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumPFVsPt_n0p522_0p522 = ibooker.book1D("mSumPFVsPt_n0p522_0p522","Sum PFVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumPFVsPt_0p522_0p783 = ibooker.book1D("mSumPFVsPt_0p522_0p783","Sum PFVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumPFVsPt_0p783_1p131 = ibooker.book1D("mSumPFVsPt_0p783_1p131","Sum PFVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumPFVsPt_1p131_1p479 = ibooker.book1D("mSumPFVsPt_1p131_1p479","Sum PFVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumPFVsPt_1p479_1p740 = ibooker.book1D("mSumPFVsPt_1p479_1p740","Sum PFVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumPFVsPt_1p740_2p043 = ibooker.book1D("mSumPFVsPt_1p740_2p043","Sum PFVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumPFVsPt_2p043_2p650 = ibooker.book1D("mSumPFVsPt_2p043_2p650","Sum PFVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumPFVsPt_2p650_5p191 = ibooker.book1D("mSumPFVsPt_2p650_5p191","Sum PFVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-
-      mSumPFPt_n5p191_n2p650 = ibooker.book1D("mSumPFPt_n5p191_n2p650","Sum PFPt  in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumPFPt_n2p650_n2p043 = ibooker.book1D("mSumPFPt_n2p650_n2p043","Sum PFPt  in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumPFPt_n2p043_n1p740 = ibooker.book1D("mSumPFPt_n2p043_n1p740","Sum PFPt  in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumPFPt_n1p740_n1p479 = ibooker.book1D("mSumPFPt_n1p740_n1p479","Sum PFPt  in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumPFPt_n1p479_n1p131 = ibooker.book1D("mSumPFPt_n1p479_n1p131","Sum PFPt  in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumPFPt_n1p131_n0p783 = ibooker.book1D("mSumPFPt_n1p131_n0p783","Sum PFPt  in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumPFPt_n0p783_n0p522 = ibooker.book1D("mSumPFPt_n0p783_n0p522","Sum PFPt  in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumPFPt_n0p522_0p522 = ibooker.book1D("mSumPFPt_n0p522_0p522","Sum PFPt  in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumPFPt_0p522_0p783 = ibooker.book1D("mSumPFPt_0p522_0p783","Sum PFPt  in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumPFPt_0p783_1p131 = ibooker.book1D("mSumPFPt_0p783_1p131","Sum PFPt  in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumPFPt_1p131_1p479 = ibooker.book1D("mSumPFPt_1p131_1p479","Sum PFPt  in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumPFPt_1p479_1p740 = ibooker.book1D("mSumPFPt_1p479_1p740","Sum PFPt  in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumPFPt_1p740_2p043 = ibooker.book1D("mSumPFPt_1p740_2p043","Sum PFPt  in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumPFPt_2p043_2p650 = ibooker.book1D("mSumPFPt_2p043_2p650","Sum PFPt  in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumPFPt_2p650_5p191 = ibooker.book1D("mSumPFPt_2p650_5p191","Sum PFPt  in the eta range 2.650 to 5.191",1000,-5000,5000);
-     
-      
-    }
-
-    if(isCaloJet){
-
-      mNCalopart         = ibooker.book1D("NCalopart","No of particle flow candidates",1000,0,10000);
-      mCaloPt            = ibooker.book1D("CaloPt","Calo candidate p_{T}",1000,-5000,5000);
-      mCaloEta           = ibooker.book1D("CaloEta","Calo candidate #eta",120,-6,6);
-      mCaloPhi           = ibooker.book1D("CaloPhi","Calo candidate #phi",70,-3.5,3.5);
-      mCaloVsPt          = ibooker.book1D("CaloVsPt","Vs Calo candidate p_{T}",1000,-5000,5000);
-      mCaloVsPtInitial   = ibooker.book1D("CaloVsPtInitial","Vs background subtracted Calo candidate p_{T}",1000,-5000,5000);
-      mCaloArea          = ibooker.book1D("CaloArea","VS Calo candidate area",100,0,4);
-      
-      mSumCaloVsPt       = ibooker.book1D("SumCaloVsPt","Sum of final Calo VS p_{T} ",1000,-10000,10000);
-      mSumCaloVsPtInitial= ibooker.book1D("SumCaloVsPtInitial","Sum Calo VS p_{T} after subtraction",1000,-10000,10000);
-      mSumCaloPt         = ibooker.book1D("SumCaloPt","Sum Calo p_{T}",1000,-10000,10000);
-      mSumCaloVsPt_eta   = ibooker.book2D("SumCaloVsPt_etaBins",h2D_etabins_vs_pt);
-      mSumCaloVsPtInitial_eta   = ibooker.book2D("SumCaloVsPtInitial_etaBins",h2D_etabins_vs_pt);
-      mSumCaloPt_eta     = ibooker.book2D("SumCaloPt_etaBins",h2D_etabins_vs_pt);
-      
-      mSumSquaredCaloVsPt       = ibooker.book1D("SumSquaredCaloVsPt","Sum of final Calo VS p_{T} squared",10000,0,10000);
-      mSumSquaredCaloVsPtInitial= ibooker.book1D("SumSquaredCaloVsPtInitial","Sum of subtracted Calo VS p_{T} squared",10000,0,10000);
-      mSumSquaredCaloPt         = ibooker.book1D("SumSquaredCaloPt","Sum of initial Calo tower p_{T} squared",10000,0,10000);
-      mSumSquaredCaloVsPt_eta   = ibooker.book2D("SumSquaredCaloVsPt_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredCaloVsPtInitial_eta   = ibooker.book2D("SumSquaredCaloVsPtInitial_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredCaloPt_eta     = ibooker.book2D("SumSquaredCaloPt_etaBins",h2D_etabins_vs_pt2);
-
-      mSumCaloVsPtInitial_HF    = ibooker.book2D("SumCaloVsPtInitial_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumCaloVsPt_HF    = ibooker.book2D("SumCaloVsPt_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumCaloPt_HF    = ibooker.book2D("SumCaloPt_HF","HF Energy (y axis) vs Sum Calo tower p_{T}",1000,-1000,1000,1000,0,10000);
-    
-      mSumCaloVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPtInitial_n5p191_n2p650","Sum CaloVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumCaloVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPtInitial_n2p650_n2p043","Sum CaloVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumCaloVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPtInitial_n2p043_n1p740","Sum CaloVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumCaloVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPtInitial_n1p740_n1p479","Sum CaloVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumCaloVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPtInitial_n1p479_n1p131","Sum CaloVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumCaloVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPtInitial_n1p131_n0p783","Sum CaloVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumCaloVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p783_n0p522","Sum CaloVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumCaloVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p522_0p522","Sum CaloVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumCaloVsPtInitial_0p522_0p783 = ibooker.book1D("mSumCaloVsPtInitial_0p522_0p783","Sum CaloVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumCaloVsPtInitial_0p783_1p131 = ibooker.book1D("mSumCaloVsPtInitial_0p783_1p131","Sum CaloVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumCaloVsPtInitial_1p131_1p479 = ibooker.book1D("mSumCaloVsPtInitial_1p131_1p479","Sum CaloVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumCaloVsPtInitial_1p479_1p740 = ibooker.book1D("mSumCaloVsPtInitial_1p479_1p740","Sum CaloVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumCaloVsPtInitial_1p740_2p043 = ibooker.book1D("mSumCaloVsPtInitial_1p740_2p043","Sum CaloVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumCaloVsPtInitial_2p043_2p650 = ibooker.book1D("mSumCaloVsPtInitial_2p043_2p650","Sum CaloVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumCaloVsPtInitial_2p650_5p191 = ibooker.book1D("mSumCaloVsPtInitial_2p650_5p191","Sum CaloVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-
-      mSumCaloVsPt_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPt_n5p191_n2p650","Sum CaloVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumCaloVsPt_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPt_n2p650_n2p043","Sum CaloVsPt  variable in the eta range -2.650 to -2.043",1000,-5000,5000);
-      mSumCaloVsPt_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPt_n2p043_n1p740","Sum CaloVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumCaloVsPt_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPt_n1p740_n1p479","Sum CaloVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumCaloVsPt_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPt_n1p479_n1p131","Sum CaloVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumCaloVsPt_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPt_n1p131_n0p783","Sum CaloVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumCaloVsPt_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPt_n0p783_n0p522","Sum CaloVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumCaloVsPt_n0p522_0p522 = ibooker.book1D("mSumCaloVsPt_n0p522_0p522","Sum CaloVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumCaloVsPt_0p522_0p783 = ibooker.book1D("mSumCaloVsPt_0p522_0p783","Sum CaloVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumCaloVsPt_0p783_1p131 = ibooker.book1D("mSumCaloVsPt_0p783_1p131","Sum CaloVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumCaloVsPt_1p131_1p479 = ibooker.book1D("mSumCaloVsPt_1p131_1p479","Sum CaloVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumCaloVsPt_1p479_1p740 = ibooker.book1D("mSumCaloVsPt_1p479_1p740","Sum CaloVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumCaloVsPt_1p740_2p043 = ibooker.book1D("mSumCaloVsPt_1p740_2p043","Sum CaloVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumCaloVsPt_2p043_2p650 = ibooker.book1D("mSumCaloVsPt_2p043_2p650","Sum CaloVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumCaloVsPt_2p650_5p191 = ibooker.book1D("mSumCaloVsPt_2p650_5p191","Sum CaloVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-
-      mSumCaloPt_n5p191_n2p650 = ibooker.book1D("mSumCaloPt_n5p191_n2p650","Sum Calo tower pT variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumCaloPt_n2p650_n2p043 = ibooker.book1D("mSumCaloPt_n2p650_n2p043","Sum Calo tower pT variable in the eta range -2.650 to -2.043",1000,-5000,5000);
-      mSumCaloPt_n2p043_n1p740 = ibooker.book1D("mSumCaloPt_n2p043_n1p740","Sum Calo tower pT variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumCaloPt_n1p740_n1p479 = ibooker.book1D("mSumCaloPt_n1p740_n1p479","Sum Calo tower pT variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumCaloPt_n1p479_n1p131 = ibooker.book1D("mSumCaloPt_n1p479_n1p131","Sum Calo tower pT variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumCaloPt_n1p131_n0p783 = ibooker.book1D("mSumCaloPt_n1p131_n0p783","Sum Calo tower pT variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumCaloPt_n0p783_n0p522 = ibooker.book1D("mSumCaloPt_n0p783_n0p522","Sum Calo tower pT variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumCaloPt_n0p522_0p522 = ibooker.book1D("mSumCaloPt_n0p522_0p522","Sum Calo tower pT variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumCaloPt_0p522_0p783 = ibooker.book1D("mSumCaloPt_0p522_0p783","Sum Calo tower pT variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumCaloPt_0p783_1p131 = ibooker.book1D("mSumCaloPt_0p783_1p131","Sum Calo tower pT variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumCaloPt_1p131_1p479 = ibooker.book1D("mSumCaloPt_1p131_1p479","Sum Calo tower pT variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumCaloPt_1p479_1p740 = ibooker.book1D("mSumCaloPt_1p479_1p740","Sum Calo tower pT variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumCaloPt_1p740_2p043 = ibooker.book1D("mSumCaloPt_1p740_2p043","Sum Calo tower pT variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumCaloPt_2p043_2p650 = ibooker.book1D("mSumCaloPt_2p043_2p650","Sum Calo tower pT variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumCaloPt_2p650_5p191 = ibooker.book1D("mSumCaloPt_2p650_5p191","Sum Calo tower pT variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-      
-      
-    }
-
-    // particle flow variables histograms 
-    mSumpt           = ibooker.book1D("SumpT","Sum p_{T} of all the PF candidates per event",1000,0,10000);
-    
-    // Event variables
-    mNvtx            = ibooker.book1D("Nvtx",           "number of vertices", 60, 0, 60);
-    mHF              = ibooker.book1D("HF", "HF energy distribution",1000,0,10000);
-
-    // Jet parameters
-    mEta             = ibooker.book1D("Eta",          "Eta",          120,   -6,    6); 
-    mPhi             = ibooker.book1D("Phi",          "Phi",           70, -3.5,  3.5); 
-    mPt              = ibooker.book1D("Pt",           "Pt",           100,    0,  1000); 
-    mP               = ibooker.book1D("P",            "P",            100,    0,  1000); 
-    mEnergy          = ibooker.book1D("Energy",       "Energy",       100,    0,  1000); 
-    mMass            = ibooker.book1D("Mass",         "Mass",         100,    0,  200); 
-    mConstituents    = ibooker.book1D("Constituents", "Constituents", 100,    0,  100); 
-    mJetArea         = ibooker.book1D("JetArea",      "JetArea",       100,   0, 4);
-    mjetpileup       = ibooker.book1D("jetPileUp","jetPileUp",100,0,150);
-    mNJets_40        = ibooker.book1D("NJets_pt_greater_40", "NJets pT > 40 GeV",  50,    0,   100);
-    mNJets        = ibooker.book1D("NJets", "NJets",  50,    0,   100);
-    
-    if (mOutputFile.empty ()) 
-      LogInfo("OutputInfo") << " Histograms will NOT be saved";
-    else 
-      LogInfo("OutputInfo") << " Histograms will be saved to file:" << mOutputFile;
-
-    delete h2D_etabins_vs_pt2;
-    delete h2D_etabins_vs_pt;
-    
+    mPFCandpT_Forward_Unknown = ibooker.book1D("mPFCandpT_Forward_Unknown",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 0
+    mPFCandpT_Forward_ChargedHadron = ibooker.book1D("mPFCandpT_Forward_ChargedHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 1 
+    mPFCandpT_Forward_electron = ibooker.book1D("mPFCandpT_Forward_electron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 2
+    mPFCandpT_Forward_muon = ibooker.book1D("mPFCandpT_Forward_muon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 3
+    mPFCandpT_Forward_photon = ibooker.book1D("mPFCandpT_Forward_photon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 4
+    mPFCandpT_Forward_NeutralHadron = ibooker.book1D("mPFCandpT_Forward_NeutralHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 5
+    mPFCandpT_Forward_HadE_inHF = ibooker.book1D("mPFCandpT_Forward_HadE_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 6
+    mPFCandpT_Forward_EME_inHF = ibooker.book1D("mPFCandpT_Forward_EME_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 7
+        
   }
+
+  if(isCaloJet){
+
+    mNCalopart         = ibooker.book1D("NCalopart","No of particle flow candidates",1000,0,10000);
+    mCaloPt            = ibooker.book1D("CaloPt","Calo candidate p_{T}",1000,-5000,5000);
+    mCaloEta           = ibooker.book1D("CaloEta","Calo candidate #eta",120,-6,6);
+    mCaloPhi           = ibooker.book1D("CaloPhi","Calo candidate #phi",70,-3.5,3.5);
+    mCaloVsPt          = ibooker.book1D("CaloVsPt","Vs Calo candidate p_{T}",1000,-5000,5000);
+    mCaloVsPtInitial   = ibooker.book1D("CaloVsPtInitial","Vs background subtracted Calo candidate p_{T}",1000,-500,500);
+    mCaloArea          = ibooker.book1D("CaloArea","VS Calo candidate area",100,0,4);
+
+    mSumCaloVsPt       = ibooker.book1D("SumCaloVsPt","Sum of final Calo VS p_{T} ",1000,-10000,10000);
+    mSumCaloVsPtInitial= ibooker.book1D("SumCaloVsPtInitial","Sum Calo VS p_{T} after subtraction",1000,-10000,10000);
+    mSumCaloPt         = ibooker.book1D("SumCaloPt","Sum Calo p_{T}",1000,-10000,10000);
+    mSumCaloVsPt_eta   = ibooker.book2D("SumCaloVsPt_etaBins",h2D_etabins_vs_pt);
+    mSumCaloVsPtInitial_eta   = ibooker.book2D("SumCaloVsPtInitial_etaBins",h2D_etabins_vs_pt);
+    mSumCaloPt_eta     = ibooker.book2D("SumCaloPt_etaBins",h2D_etabins_vs_pt);
+
+    mSumSquaredCaloVsPt       = ibooker.book1D("SumSquaredCaloVsPt","Sum of final Calo VS p_{T} squared",10000,0,10000);
+    mSumSquaredCaloVsPtInitial= ibooker.book1D("SumSquaredCaloVsPtInitial","Sum of subtracted Calo VS p_{T} squared",10000,0,10000);
+    mSumSquaredCaloPt         = ibooker.book1D("SumSquaredCaloPt","Sum of initial Calo tower p_{T} squared",10000,0,10000);
+    mSumSquaredCaloVsPt_eta   = ibooker.book2D("SumSquaredCaloVsPt_etaBins",h2D_etabins_vs_pt2);
+    mSumSquaredCaloVsPtInitial_eta   = ibooker.book2D("SumSquaredCaloVsPtInitial_etaBins",h2D_etabins_vs_pt2);
+    mSumSquaredCaloPt_eta     = ibooker.book2D("SumSquaredCaloPt_etaBins",h2D_etabins_vs_pt2);
+
+    mSumCaloVsPtInitial_HF    = ibooker.book2D("SumCaloVsPtInitial_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumCaloVsPt_HF    = ibooker.book2D("SumCaloVsPt_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumCaloPt_HF    = ibooker.book2D("SumCaloPt_HF","HF Energy (y axis) vs Sum Calo tower p_{T}",1000,-1000,1000,1000,0,10000);
+
+    mSumCaloVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPtInitial_n5p191_n2p650","Sum CaloVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumCaloVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPtInitial_n2p650_n2p043","Sum CaloVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumCaloVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPtInitial_n2p043_n1p740","Sum CaloVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumCaloVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPtInitial_n1p740_n1p479","Sum CaloVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumCaloVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPtInitial_n1p479_n1p131","Sum CaloVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumCaloVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPtInitial_n1p131_n0p783","Sum CaloVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumCaloVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p783_n0p522","Sum CaloVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumCaloVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p522_0p522","Sum CaloVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumCaloVsPtInitial_0p522_0p783 = ibooker.book1D("mSumCaloVsPtInitial_0p522_0p783","Sum CaloVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumCaloVsPtInitial_0p783_1p131 = ibooker.book1D("mSumCaloVsPtInitial_0p783_1p131","Sum CaloVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumCaloVsPtInitial_1p131_1p479 = ibooker.book1D("mSumCaloVsPtInitial_1p131_1p479","Sum CaloVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumCaloVsPtInitial_1p479_1p740 = ibooker.book1D("mSumCaloVsPtInitial_1p479_1p740","Sum CaloVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumCaloVsPtInitial_1p740_2p043 = ibooker.book1D("mSumCaloVsPtInitial_1p740_2p043","Sum CaloVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumCaloVsPtInitial_2p043_2p650 = ibooker.book1D("mSumCaloVsPtInitial_2p043_2p650","Sum CaloVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumCaloVsPtInitial_2p650_5p191 = ibooker.book1D("mSumCaloVsPtInitial_2p650_5p191","Sum CaloVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mSumCaloVsPt_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPt_n5p191_n2p650","Sum CaloVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumCaloVsPt_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPt_n2p650_n2p043","Sum CaloVsPt  variable in the eta range -2.650 to -2.043",1000,-5000,5000);
+    mSumCaloVsPt_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPt_n2p043_n1p740","Sum CaloVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumCaloVsPt_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPt_n1p740_n1p479","Sum CaloVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumCaloVsPt_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPt_n1p479_n1p131","Sum CaloVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumCaloVsPt_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPt_n1p131_n0p783","Sum CaloVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumCaloVsPt_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPt_n0p783_n0p522","Sum CaloVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumCaloVsPt_n0p522_0p522 = ibooker.book1D("mSumCaloVsPt_n0p522_0p522","Sum CaloVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumCaloVsPt_0p522_0p783 = ibooker.book1D("mSumCaloVsPt_0p522_0p783","Sum CaloVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumCaloVsPt_0p783_1p131 = ibooker.book1D("mSumCaloVsPt_0p783_1p131","Sum CaloVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumCaloVsPt_1p131_1p479 = ibooker.book1D("mSumCaloVsPt_1p131_1p479","Sum CaloVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumCaloVsPt_1p479_1p740 = ibooker.book1D("mSumCaloVsPt_1p479_1p740","Sum CaloVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumCaloVsPt_1p740_2p043 = ibooker.book1D("mSumCaloVsPt_1p740_2p043","Sum CaloVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumCaloVsPt_2p043_2p650 = ibooker.book1D("mSumCaloVsPt_2p043_2p650","Sum CaloVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumCaloVsPt_2p650_5p191 = ibooker.book1D("mSumCaloVsPt_2p650_5p191","Sum CaloVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mSumCaloPt_n5p191_n2p650 = ibooker.book1D("mSumCaloPt_n5p191_n2p650","Sum Calo tower pT variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumCaloPt_n2p650_n2p043 = ibooker.book1D("mSumCaloPt_n2p650_n2p043","Sum Calo tower pT variable in the eta range -2.650 to -2.043",1000,-5000,5000);
+    mSumCaloPt_n2p043_n1p740 = ibooker.book1D("mSumCaloPt_n2p043_n1p740","Sum Calo tower pT variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumCaloPt_n1p740_n1p479 = ibooker.book1D("mSumCaloPt_n1p740_n1p479","Sum Calo tower pT variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumCaloPt_n1p479_n1p131 = ibooker.book1D("mSumCaloPt_n1p479_n1p131","Sum Calo tower pT variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumCaloPt_n1p131_n0p783 = ibooker.book1D("mSumCaloPt_n1p131_n0p783","Sum Calo tower pT variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumCaloPt_n0p783_n0p522 = ibooker.book1D("mSumCaloPt_n0p783_n0p522","Sum Calo tower pT variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumCaloPt_n0p522_0p522 = ibooker.book1D("mSumCaloPt_n0p522_0p522","Sum Calo tower pT variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumCaloPt_0p522_0p783 = ibooker.book1D("mSumCaloPt_0p522_0p783","Sum Calo tower pT variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumCaloPt_0p783_1p131 = ibooker.book1D("mSumCaloPt_0p783_1p131","Sum Calo tower pT variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumCaloPt_1p131_1p479 = ibooker.book1D("mSumCaloPt_1p131_1p479","Sum Calo tower pT variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumCaloPt_1p479_1p740 = ibooker.book1D("mSumCaloPt_1p479_1p740","Sum Calo tower pT variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumCaloPt_1p740_2p043 = ibooker.book1D("mSumCaloPt_1p740_2p043","Sum Calo tower pT variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumCaloPt_2p043_2p650 = ibooker.book1D("mSumCaloPt_2p043_2p650","Sum Calo tower pT variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumCaloPt_2p650_5p191 = ibooker.book1D("mSumCaloPt_2p650_5p191","Sum Calo tower pT variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+
+  }
+
+  // particle flow variables histograms 
+  mSumpt           = ibooker.book1D("SumpT","Sum p_{T} of all the PF candidates per event",1000,0,10000);
+
+  // Event variables
+  mNvtx            = ibooker.book1D("Nvtx",           "number of vertices", 60, 0, 60);
+  mHF              = ibooker.book1D("HF", "HF energy distribution",1000,0,10000);
+
+  // Jet parameters
+  mEta             = ibooker.book1D("Eta",          "Eta",          120,   -6,    6); 
+  mPhi             = ibooker.book1D("Phi",          "Phi",           70, -3.5,  3.5); 
+  mPt              = ibooker.book1D("Pt",           "Pt",           100,    0,  1000); 
+  mP               = ibooker.book1D("P",            "P",            100,    0,  1000); 
+  mEnergy          = ibooker.book1D("Energy",       "Energy",       100,    0,  1000); 
+  mMass            = ibooker.book1D("Mass",         "Mass",         100,    0,  200); 
+  mConstituents    = ibooker.book1D("Constituents", "Constituents", 100,    0,  100); 
+  mJetArea         = ibooker.book1D("JetArea",      "JetArea",       100,   0, 4);
+  mjetpileup       = ibooker.book1D("jetPileUp","jetPileUp",100,0,150);
+  mNJets_40        = ibooker.book1D("NJets_pt_greater_40", "NJets pT > 40 GeV",  100,    0,   100);
+  mNJets           = ibooker.book1D("NJets", "NJets",  100,    0,   50);
+
+  if (mOutputFile.empty ()) 
+    LogInfo("OutputInfo") << " Histograms will NOT be saved";
+  else 
+    LogInfo("OutputInfo") << " Histograms will be saved to file:" << mOutputFile;
+
+  delete h2D_etabins_vs_pt2;
+  delete h2D_etabins_vs_pt;
+  delete h2D_pfcand_etabins_vs_pt;
+  
+}
 
 
 
@@ -437,7 +688,7 @@ JetAnalyzer_HeavyIons::~JetAnalyzer_HeavyIons() {}
 // beginJob
 //------------------------------------------------------------------------------
 //void JetAnalyzer_HeavyIons::beginJob() {
-//  std::cout<<"inside the begin job function"<<endl;
+//  std:://cout<<"inside the begin job function"<<endl;
 //}
 
 
@@ -458,8 +709,12 @@ JetAnalyzer_HeavyIons::~JetAnalyzer_HeavyIons() {}
 //------------------------------------------------------------------------------
 void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
 {
+
+  // switch(mEvent.id().event() == 15296770)
+  // case 1:
+  //   break;
+
   // Get the primary vertices
-  //----------------------------------------------------------------------------
   edm::Handle<vector<reco::Vertex> > pvHandle;
   mEvent.getByToken(pvToken_, pvHandle);
   reco::Vertex::Point vtx(0,0,0);
@@ -494,28 +749,25 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
 
   mNvtx->Fill(nGoodVertices);
 
-
   // Get the Jet collection
   //----------------------------------------------------------------------------
-  
+
   std::vector<Jet> recoJets;
   recoJets.clear();
-  
+
   edm::Handle<CaloJetCollection>  caloJets;
   edm::Handle<JPTJetCollection>   jptJets;
   edm::Handle<PFJetCollection>    pfJets;
   edm::Handle<BasicJetCollection> basicJets;
-  
+
   // Get the Particle flow candidates and the Voronoi variables 
   edm::Handle<reco::PFCandidateCollection> pfCandidates; 
   edm::Handle<CaloTowerCollection> caloCandidates; 
   edm::Handle<reco::CandidateView> pfcandidates_;
   edm::Handle<reco::CandidateView> calocandidates_;
-  
+
   edm::Handle<edm::ValueMap<VoronoiBackground>> VsBackgrounds;
   edm::Handle<std::vector<float>> vn_;
-
-  edm::Handle<reco::Centrality> cent;
 
   if (isCaloJet) mEvent.getByToken(caloJetsToken_, caloJets);
   if (isJPTJet)  mEvent.getByToken(jptJetsToken_, jptJets);
@@ -523,10 +775,10 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     if(std::string("Pu")==UEAlgo) mEvent.getByToken(basicJetsToken_, basicJets);
     if(std::string("Vs")==UEAlgo) mEvent.getByToken(pfJetsToken_, pfJets);
   }
-  
+
   mEvent.getByToken(pfCandToken_, pfCandidates);
   mEvent.getByToken(pfCandViewToken_, pfcandidates_);
-  
+
   mEvent.getByToken(caloTowersToken_, caloCandidates);
   mEvent.getByToken(caloCandViewToken_, calocandidates_);
 
@@ -534,28 +786,45 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
   mEvent.getByToken(backgrounds_value_, vn_);
 
   // get the centrality 
-  mEvent.getByToken(centralityToken_, cent);
+  edm::Handle<reco::Centrality> cent;
+  mEvent.getByToken(centralityToken, cent);  //_centralitytag comes from the cfg
 
   mHF->Fill(cent->EtHFtowerSum());
   Float_t HF_energy = cent->EtHFtowerSum();
-
-  const reco::PFCandidateCollection *pfCandidateColl = pfCandidates.product();
   
+  edm::Handle<int> cbin;
+  mEvent.getByToken(centralityBinToken, cbin);
+  
+  if (!cent.isValid()) return;
+  int hibin = -999;
+  if(cent.isValid())
+    hibin = *cbin;
+  
+  
+  const reco::PFCandidateCollection *pfCandidateColl = pfCandidates.product();
+
   Float_t vsPt=0;
   Float_t vsPtInitial = 0;
   Float_t vsArea = 0;
-  Int_t NPFpart = 0;
-  Int_t NCaloTower = 0;
+  Int_t   NPFpart = 0;
+  Int_t   NCaloTower = 0;
   Float_t pfPt = 0;
   Float_t pfEta = 0;
   Float_t pfPhi = 0;
+  Int_t   pfID = 0;
+  Float_t pfDeltaR = 0; 
   Float_t caloPt = 0;
   Float_t caloEta = 0;
   Float_t caloPhi = 0;
   Float_t SumPt_value = 0;
 
   double edge_pseudorapidity[etaBins_ +1] = {-5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522, 0.522, 0.783, 1.131, 1.479, 1.740, 2.043, 2.650, 5.191 };
-  
+
+
+  vector < vector <float> > numbers;
+  vector <float> tempVector;
+  numbers.clear();
+  tempVector.clear();
 
   if(isCaloJet){
 
@@ -570,20 +839,21 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     // Need to set up histograms to get the RMS values for each pT bin 
     TH1F *hSumCaloVsPtInitial[nedge_pseudorapidity-1], *hSumCaloVsPt[nedge_pseudorapidity-1], *hSumCaloPt[nedge_pseudorapidity-1];
 
-    for(int i = 0;i<etaBins_;++i){
+    for(int i = 0;i<etaBins_;++i)
+      {
 
-      SumCaloVsPtInitial[i] = 0;
-      SumCaloVsPt[i] = 0;
-      SumCaloPt[i] = 0;
-      SumSquaredCaloVsPtInitial[i] = 0;
-      SumSquaredCaloVsPt[i] = 0;
-      SumSquaredCaloPt[i] = 0;
+        SumCaloVsPtInitial[i] = 0;
+        SumCaloVsPt[i] = 0;
+        SumCaloPt[i] = 0;
+        SumSquaredCaloVsPtInitial[i] = 0;
+        SumSquaredCaloVsPt[i] = 0;
+        SumSquaredCaloPt[i] = 0;
 
-      hSumCaloVsPtInitial[i] = new TH1F(Form("hSumCaloVsPtInitial_%d",i),"",10000,-10000,10000);
-      hSumCaloVsPt[i] = new TH1F(Form("hSumCaloVsPt_%d",i),"",10000,-10000,10000);
-      hSumCaloPt[i] = new TH1F(Form("hSumCaloPt_%d",i),"",10000,-10000,10000);
-      
-    }
+        hSumCaloVsPtInitial[i] = new TH1F(Form("hSumCaloVsPtInitial_%d",i),"",10000,-10000,10000);
+        hSumCaloVsPt[i] = new TH1F(Form("hSumCaloVsPt_%d",i),"",10000,-10000,10000);
+        hSumCaloPt[i] = new TH1F(Form("hSumCaloPt_%d",i),"",10000,-10000,10000);
+
+      }
 
     for(unsigned icand = 0;icand<caloCandidates->size(); icand++){
 
@@ -620,26 +890,26 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
 	  SumSquaredCaloPt[k] = SumSquaredCaloPt[k] + caloPt*caloPt;
 	  break;
 	}// eta selection statement 
-      
+
       }// eta bin loop
-    
+
       SumPt_value = SumPt_value + caloPt;
-    
+
       mCaloPt->Fill(caloPt);
       mCaloEta->Fill(caloEta);
       mCaloPhi->Fill(caloPhi);
       mCaloVsPt->Fill(vsPt);
       mCaloVsPtInitial->Fill(vsPtInitial);
       mCaloArea->Fill(vsArea);
-      
+
     }// calo tower candidate  loop
 
     for(int k = 0;k<nedge_pseudorapidity-1;k++){
-      
+
       hSumCaloVsPtInitial[k]->Fill(SumCaloVsPtInitial[k]);
       hSumCaloVsPt[k]->Fill(SumCaloVsPt[k]);
       hSumCaloPt[k]->Fill(SumCaloPt[k]);
-      
+
     }// eta bin loop  
 
     Float_t Evt_SumCaloVsPt = 0;
@@ -649,7 +919,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     Float_t Evt_SumSquaredCaloVsPt = 0;
     Float_t Evt_SumSquaredCaloVsPtInitial = 0;
     Float_t Evt_SumSquaredCaloPt = 0;
-    
+
 
     mSumCaloVsPtInitial_n5p191_n2p650->Fill(SumCaloVsPtInitial[0]);
     mSumCaloVsPtInitial_n2p650_n2p043->Fill(SumCaloVsPtInitial[1]);
@@ -701,7 +971,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
 
 
     for(size_t  k = 0;k<nedge_pseudorapidity-1;k++){
-    
+
       Evt_SumCaloVsPtInitial = Evt_SumCaloVsPtInitial + SumCaloVsPtInitial[k];
       Evt_SumCaloVsPt = Evt_SumCaloVsPt + SumCaloVsPt[k];
       Evt_SumCaloPt = Evt_SumCaloPt + SumCaloPt[k];
@@ -709,7 +979,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
       mSumCaloVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumCaloVsPtInitial[k]);
       mSumCaloVsPt_eta->Fill(edge_pseudorapidity[k],SumCaloVsPt[k]);
       mSumCaloPt_eta->Fill(edge_pseudorapidity[k],SumCaloPt[k]);
-            
+
       Evt_SumSquaredCaloVsPtInitial = Evt_SumSquaredCaloVsPtInitial + SumSquaredCaloVsPtInitial[k];
       Evt_SumSquaredCaloVsPt = Evt_SumSquaredCaloVsPt + SumSquaredCaloVsPt[k];
       Evt_SumSquaredCaloPt = Evt_SumSquaredCaloPt + SumSquaredCaloPt[k];
@@ -717,11 +987,11 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
       mSumSquaredCaloVsPtInitial_eta->Fill(edge_pseudorapidity[k],hSumCaloVsPtInitial[k]->GetRMS(1));
       mSumSquaredCaloVsPt_eta->Fill(edge_pseudorapidity[k],hSumCaloVsPt[k]->GetRMS(1));
       mSumSquaredCaloPt_eta->Fill(edge_pseudorapidity[k],hSumCaloPt[k]->GetRMS(1));
-    
+
       delete hSumCaloVsPtInitial[k];
       delete hSumCaloVsPt[k];
       delete hSumCaloPt[k];
-    
+
     }// eta bin loop  
 
     mSumCaloVsPtInitial->Fill(Evt_SumCaloVsPtInitial);
@@ -730,18 +1000,18 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     mSumCaloVsPtInitial_HF->Fill(Evt_SumCaloVsPtInitial,HF_energy);
     mSumCaloVsPt_HF->Fill(Evt_SumCaloVsPt,HF_energy);
     mSumCaloPt_HF->Fill(Evt_SumCaloPt,HF_energy);
-      
+
     mSumSquaredCaloVsPtInitial->Fill(Evt_SumSquaredCaloVsPtInitial);
     mSumSquaredCaloVsPt->Fill(Evt_SumSquaredCaloVsPt);
     mSumSquaredCaloPt->Fill(Evt_SumSquaredCaloPt);
-    
+
     mNCalopart->Fill(NCaloTower);
     mSumpt->Fill(SumPt_value);
 
   }// is calo jet 
 
   if(isPFJet){
-    
+
     Float_t SumPFVsPtInitial[etaBins_];
     Float_t SumPFVsPt[etaBins_];
     Float_t SumPFPt[etaBins_];
@@ -761,66 +1031,336 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
       SumSquaredPFVsPtInitial[i] = 0;
       SumSquaredPFVsPt[i] = 0;
       SumSquaredPFPt[i] = 0;
-      
+
       hSumPFVsPtInitial[i] = new TH1F(Form("hSumPFVsPtInitial_%d",i),"",10000,-10000,10000);
       hSumPFVsPt[i] = new TH1F(Form("hSumPFVsPt_%d",i),"",10000,-10000,10000);
       hSumPFPt[i] = new TH1F(Form("hSumPFPt_%d",i),"",10000,-10000,10000);
-     
+
     }
-    
-    for(unsigned icand=0;icand<pfCandidateColl->size(); icand++){
-    
-      const reco::PFCandidate pfCandidate = pfCandidateColl->at(icand);
-      reco::CandidateViewRef ref(pfcandidates_,icand);
 
-      if(pfCandidate.pt() < 5) continue;
-      
-      if(std::string("Vs")==UEAlgo) {
-      
-	const reco::VoronoiBackground& voronoi = (*VsBackgrounds)[ref];
-	vsPt = voronoi.pt();
-	vsPtInitial = voronoi.pt_subtracted();
-	vsArea = voronoi.area();
-      
-      }
-    
-      NPFpart++;
-      pfPt = pfCandidate.pt();
-      pfEta = pfCandidate.eta();
-      pfPhi = pfCandidate.phi();
+    vector<vector <float> > PF_Space(1,vector<float>(3)); 
+
+    for(unsigned icand=0;icand<pfCandidateColl->size(); icand++)
+      {
+        const reco::PFCandidate pfCandidate = pfCandidateColl->at(icand);
+        reco::CandidateViewRef ref(pfcandidates_,icand);
+        if(pfCandidate.pt() < 5) continue;
+
+        if(std::string("Vs")==UEAlgo) 
+	  {
+
+	    const reco::VoronoiBackground& voronoi = (*VsBackgrounds)[ref];
+	    vsPt = voronoi.pt();
+	    vsPtInitial = voronoi.pt_subtracted();
+	    vsArea = voronoi.area();
+
+	  }
+
+        NPFpart++;
+        pfPt = pfCandidate.pt();
+        pfEta = pfCandidate.eta();
+        pfPhi = pfCandidate.phi();
+	pfID = pfCandidate.particleId();
+
+	bool isBarrel = false; 
+	bool isEndcap = false; 
+	bool isForward = false; 
+
+	if(fabs(pfEta)<BarrelEta) isBarrel = true;
+	if(fabs(pfEta)>=BarrelEta && fabs(pfEta)<EndcapEta) isEndcap = true;
+	if(fabs(pfEta)>=EndcapEta && fabs(pfEta)<ForwardEta) isForward = true;
+	
+	switch(pfID){
+	case 0 :
+	  mPFCandpT_vs_eta_Unknown->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_Unknown->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_Unknown->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_Unknown->Fill(pfPt);
+	case 1 :
+	  mPFCandpT_vs_eta_ChargedHadron->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_ChargedHadron->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_ChargedHadron->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_ChargedHadron->Fill(pfPt);
+	case 2 :
+	  mPFCandpT_vs_eta_electron->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_electron->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_electron->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_electron->Fill(pfPt);
+	case 3 :
+	  mPFCandpT_vs_eta_muon->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_muon->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_muon->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_muon->Fill(pfPt);
+	case 4 :
+	  mPFCandpT_vs_eta_photon->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_photon->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_photon->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_photon->Fill(pfPt);
+	case 5 :
+	  mPFCandpT_vs_eta_NeutralHadron->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_NeutralHadron->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_NeutralHadron->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_NeutralHadron->Fill(pfPt);
+	case 6 :
+	  mPFCandpT_vs_eta_HadE_inHF->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_HadE_inHF->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_HadE_inHF->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_HadE_inHF->Fill(pfPt);
+	case 7 :
+	  mPFCandpT_vs_eta_EME_inHF->Fill(pfPt, pfEta);
+	  if(isBarrel) mPFCandpT_Barrel_EME_inHF->Fill(pfPt);
+	  if(isEndcap) mPFCandpT_Endcap_EME_inHF->Fill(pfPt);
+	  if(isForward) mPFCandpT_Forward_EME_inHF->Fill(pfPt);
+	}
+	
+	
+        //Fill 2d vector matrix
+        tempVector.push_back(pfPt);
+        tempVector.push_back(pfEta);
+        tempVector.push_back(pfPhi);
+        tempVector.push_back(vsPtInitial);
+        tempVector.push_back(vsPt);
 
 
-      for(size_t k = 0;k<nedge_pseudorapidity-1; k++){
-	if(pfEta >= edge_pseudorapidity[k] && pfEta < edge_pseudorapidity[k+1]){
-	  SumPFVsPtInitial[k] = SumPFVsPtInitial[k] + vsPtInitial;
-	  SumPFVsPt[k] = SumPFVsPt[k] + vsPt;
-	  SumPFPt[k] = SumPFPt[k] + pfPt;
+        numbers.push_back(tempVector);
+        tempVector.clear();
 
-	  SumSquaredPFVsPtInitial[k] = SumSquaredPFVsPtInitial[k] + vsPtInitial*vsPtInitial;
-	  SumSquaredPFVsPt[k] = SumSquaredPFVsPt[k] + vsPt*vsPt;
-	  SumSquaredPFPt[k] = SumSquaredPFPt[k] + pfPt*pfPt;
-	  break;
-	}// eta selection statement 
-      
-      }// eta bin loop
+        for(size_t k = 0;k<nedge_pseudorapidity-1; k++)
+	  {
+	    if(pfEta >= edge_pseudorapidity[k] && pfEta < edge_pseudorapidity[k+1]){
+	      SumPFVsPtInitial[k] = SumPFVsPtInitial[k] + vsPtInitial;
+	      SumPFVsPt[k] = SumPFVsPt[k] + vsPt;
+	      SumPFPt[k] = SumPFPt[k] + pfPt;
+
+	      SumSquaredPFVsPtInitial[k] = SumSquaredPFVsPtInitial[k] + vsPtInitial*vsPtInitial;
+	      SumSquaredPFVsPt[k] = SumSquaredPFVsPt[k] + vsPt*vsPt;
+	      SumSquaredPFPt[k] = SumSquaredPFPt[k] + pfPt*pfPt;
+	      break;
+	    }// eta selection statement 
+
+	  }// eta bin loop
+
+        SumPt_value = SumPt_value + pfPt;
+
+        mPFPt->Fill(pfPt);
+        mPFEta->Fill(pfEta);
+        mPFPhi->Fill(pfPhi);
+        mPFVsPt->Fill(vsPt);
+        mPFVsPtInitial->Fill(vsPtInitial); //filled with zeros (need a fix)
+        mPFVsPtInitial_HF->Fill(cent->EtHFtowerSum(), vsPtInitial,1); //filled with zeros (need a fix)
+
+        if(isBarrel)
+	  {
+	    if(hibin >= 190 && hibin < 200)
+	      mPFVsPtInitial_Barrel_Centrality_100_95->Fill(vsPtInitial);
+
+	    if(hibin >= 180 && hibin < 190)
+	      mPFVsPtInitial_Barrel_Centrality_95_90->Fill(vsPtInitial);
+
+	    if(hibin >= 170 && hibin < 180)
+	      mPFVsPtInitial_Barrel_Centrality_90_85->Fill(vsPtInitial);
+
+	    if(hibin >= 160 && hibin < 170)
+	      mPFVsPtInitial_Barrel_Centrality_85_80->Fill(vsPtInitial);
+
+	    if(hibin >= 150 && hibin < 160)
+	      mPFVsPtInitial_Barrel_Centrality_80_75->Fill(vsPtInitial);
+
+	    if(hibin >= 140 && hibin < 150)
+	      mPFVsPtInitial_Barrel_Centrality_75_70->Fill(vsPtInitial);
+
+	    if(hibin >= 130 && hibin < 140)
+	      mPFVsPtInitial_Barrel_Centrality_70_65->Fill(vsPtInitial);
+
+	    if(hibin >= 120 && hibin < 130)
+	      mPFVsPtInitial_Barrel_Centrality_65_60->Fill(vsPtInitial);
+
+	    if(hibin >= 110 && hibin < 120) 
+	      mPFVsPtInitial_Barrel_Centrality_60_55->Fill(vsPtInitial);
+
+	    if(hibin >= 100 && hibin < 110)
+	      mPFVsPtInitial_Barrel_Centrality_55_50->Fill(vsPtInitial);
+
+	    if(hibin >= 90 && hibin < 100)
+	      mPFVsPtInitial_Barrel_Centrality_50_45->Fill(vsPtInitial);
+
+	    if(hibin >= 80 && hibin < 90)
+	      mPFVsPtInitial_Barrel_Centrality_45_40->Fill(vsPtInitial);
+
+	    if(hibin >= 70 && hibin < 80)
+	      mPFVsPtInitial_Barrel_Centrality_40_35->Fill(vsPtInitial);
+
+	    if(hibin >= 60 && hibin < 70)
+	      mPFVsPtInitial_Barrel_Centrality_35_30->Fill(vsPtInitial);
+
+	    if(hibin >= 50 && hibin < 60)
+	      mPFVsPtInitial_Barrel_Centrality_30_25->Fill(vsPtInitial);
+
+	    if(hibin >= 40 && hibin < 50)
+	      mPFVsPtInitial_Barrel_Centrality_25_20->Fill(vsPtInitial);
+
+	    if(hibin >= 30 && hibin < 40)
+	      mPFVsPtInitial_Barrel_Centrality_20_15->Fill(vsPtInitial);
+
+	    if(hibin >= 20 && hibin < 30)
+	      mPFVsPtInitial_Barrel_Centrality_15_10->Fill(vsPtInitial);
+
+	    if(hibin >= 10 && hibin < 20)
+	      mPFVsPtInitial_Barrel_Centrality_10_5->Fill(vsPtInitial);
+
+	    if(hibin >= 0 && hibin < 10)
+	      mPFVsPtInitial_Barrel_Centrality_5_0->Fill(vsPtInitial);
+	  }
+
+
+        if(isEndcap)
+	  {
+
+	    if(hibin >= 190 && hibin < 200)
+	      mPFVsPtInitial_EndCap_Centrality_100_95->Fill(vsPtInitial);
+
+	    if(hibin >= 180 && hibin < 190)
+	      mPFVsPtInitial_EndCap_Centrality_95_90->Fill(vsPtInitial);
+
+	    if(hibin >= 170 && hibin < 180)
+	      mPFVsPtInitial_EndCap_Centrality_90_85->Fill(vsPtInitial);
+
+	    if(hibin >= 160 && hibin < 170)
+	      mPFVsPtInitial_EndCap_Centrality_85_80->Fill(vsPtInitial);
+
+	    if(hibin >= 150 && hibin < 160)
+	      mPFVsPtInitial_EndCap_Centrality_80_75->Fill(vsPtInitial);
+
+	    if(hibin >= 140 && hibin < 150)
+	      mPFVsPtInitial_EndCap_Centrality_75_70->Fill(vsPtInitial);
+
+	    if(hibin >= 130 && hibin < 140)
+	      mPFVsPtInitial_EndCap_Centrality_70_65->Fill(vsPtInitial);
+
+	    if(hibin >= 120 && hibin < 130)
+	      mPFVsPtInitial_EndCap_Centrality_65_60->Fill(vsPtInitial);
+
+	    if(hibin >= 110 && hibin < 120) 
+	      mPFVsPtInitial_EndCap_Centrality_60_55->Fill(vsPtInitial);
+
+	    if(hibin >= 100 && hibin < 110)
+	      mPFVsPtInitial_EndCap_Centrality_55_50->Fill(vsPtInitial);
+
+	    if(hibin >= 90 && hibin < 100)
+	      mPFVsPtInitial_EndCap_Centrality_50_45->Fill(vsPtInitial);
+
+	    if(hibin >= 80 && hibin < 90)
+	      mPFVsPtInitial_EndCap_Centrality_45_40->Fill(vsPtInitial);
+
+	    if(hibin >= 70 && hibin < 80)
+	      mPFVsPtInitial_EndCap_Centrality_40_35->Fill(vsPtInitial);
+
+	    if(hibin >= 60 && hibin < 70)
+	      mPFVsPtInitial_EndCap_Centrality_35_30->Fill(vsPtInitial);
+
+	    if(hibin >= 50 && hibin < 60)
+	      mPFVsPtInitial_EndCap_Centrality_30_25->Fill(vsPtInitial);
+
+	    if(hibin >= 40 && hibin < 50)
+	      mPFVsPtInitial_EndCap_Centrality_25_20->Fill(vsPtInitial);
+
+	    if(hibin >= 30 && hibin < 40)
+	      mPFVsPtInitial_EndCap_Centrality_20_15->Fill(vsPtInitial);
+
+	    if(hibin >= 20 && hibin < 30)
+	      mPFVsPtInitial_EndCap_Centrality_15_10->Fill(vsPtInitial);
+
+	    if(hibin >= 10 && hibin < 20)
+	      mPFVsPtInitial_EndCap_Centrality_10_5->Fill(vsPtInitial);
+
+	    if(hibin >= 0 && hibin < 10)
+	      mPFVsPtInitial_EndCap_Centrality_5_0->Fill(vsPtInitial);
+	    
+	  }
     
-      SumPt_value = SumPt_value + pfPt;
-    
-      mPFPt->Fill(pfPt);
-      mPFEta->Fill(pfEta);
-      mPFPhi->Fill(pfPhi);
-      mPFVsPt->Fill(vsPt);
-      mPFVsPtInitial->Fill(vsPtInitial);
-      mPFArea->Fill(vsArea);
-    
-    }// pf candidate loop 
+     
+        if(isForward)
+	  {
+
+
+	    if(hibin >= 190 && hibin < 200)
+	      mPFVsPtInitial_HF_Centrality_100_95->Fill(vsPtInitial);
+
+	    if(hibin >= 180 && hibin < 190)
+	      mPFVsPtInitial_HF_Centrality_95_90->Fill(vsPtInitial);
+
+	    if(hibin >= 170 && hibin < 180)
+	      mPFVsPtInitial_HF_Centrality_90_85->Fill(vsPtInitial);
+
+	    if(hibin >= 160 && hibin < 170)
+	      mPFVsPtInitial_HF_Centrality_85_80->Fill(vsPtInitial);
+
+	    if(hibin >= 150 && hibin < 160)
+	      mPFVsPtInitial_HF_Centrality_80_75->Fill(vsPtInitial);
+
+	    if(hibin >= 140 && hibin < 150)
+	      mPFVsPtInitial_HF_Centrality_75_70->Fill(vsPtInitial);
+
+	    if(hibin >= 130 && hibin < 140)
+	      mPFVsPtInitial_HF_Centrality_70_65->Fill(vsPtInitial);
+
+	    if(hibin >= 120 && hibin < 130)
+	      mPFVsPtInitial_HF_Centrality_65_60->Fill(vsPtInitial);
+
+	    if(hibin >= 110 && hibin < 120) 
+	      mPFVsPtInitial_HF_Centrality_60_55->Fill(vsPtInitial);
+
+	    if(hibin >= 100 && hibin < 110)
+	      mPFVsPtInitial_HF_Centrality_55_50->Fill(vsPtInitial);
+
+	    if(hibin >= 90 && hibin < 100)
+	      mPFVsPtInitial_HF_Centrality_50_45->Fill(vsPtInitial);
+
+	    if(hibin >= 80 && hibin < 90)
+	      mPFVsPtInitial_HF_Centrality_45_40->Fill(vsPtInitial);
+
+	    if(hibin >= 70 && hibin < 80)
+	      mPFVsPtInitial_HF_Centrality_40_35->Fill(vsPtInitial);
+
+	    if(hibin >= 60 && hibin < 70)
+	      mPFVsPtInitial_HF_Centrality_35_30->Fill(vsPtInitial);
+
+	    if(hibin >= 50 && hibin < 60)
+	      mPFVsPtInitial_HF_Centrality_30_25->Fill(vsPtInitial);
+
+	    if(hibin >= 40 && hibin < 50)
+	      mPFVsPtInitial_HF_Centrality_25_20->Fill(vsPtInitial);
+
+	    if(hibin >= 30 && hibin < 40)
+	      mPFVsPtInitial_HF_Centrality_20_15->Fill(vsPtInitial);
+
+	    if(hibin >= 20 && hibin < 30)
+	      mPFVsPtInitial_HF_Centrality_15_10->Fill(vsPtInitial);
+
+	    if(hibin >= 10 && hibin < 20)
+	      mPFVsPtInitial_HF_Centrality_10_5->Fill(vsPtInitial);
+
+	    if(hibin >= 0 && hibin < 10)
+	      mPFVsPtInitial_HF_Centrality_5_0->Fill(vsPtInitial);
+
+	    
+	  }
+
+
+
+
+	mPFArea->Fill(vsArea);
+
+
+
+      }// pf candidate loop 
 
     for(int k = 0;k<nedge_pseudorapidity-1;k++){
-      
+
       hSumPFVsPtInitial[k]->Fill(SumPFVsPtInitial[k]);
       hSumPFVsPt[k]->Fill(SumPFVsPt[k]);
       hSumPFPt[k]->Fill(SumPFPt[k]);
-      
+
     }// eta bin loop  
 
     Float_t Evt_SumPFVsPt = 0;
@@ -829,7 +1369,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     Float_t Evt_SumSquaredPFVsPt = 0;
     Float_t Evt_SumSquaredPFVsPtInitial = 0;
     Float_t Evt_SumSquaredPFPt = 0;
-    
+
     mSumPFVsPtInitial_n5p191_n2p650->Fill(SumPFVsPtInitial[0]);
     mSumPFVsPtInitial_n2p650_n2p043->Fill(SumPFVsPtInitial[1]);
     mSumPFVsPtInitial_n2p043_n1p740->Fill(SumPFVsPtInitial[2]);
@@ -879,7 +1419,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     mSumPFPt_2p650_5p191->Fill(SumPFPt[14]);
 
     for(size_t  k = 0;k<nedge_pseudorapidity-1;k++){
-    
+
       Evt_SumPFVsPtInitial = Evt_SumPFVsPtInitial + SumPFVsPtInitial[k];
       Evt_SumPFVsPt = Evt_SumPFVsPt + SumPFVsPt[k];
       Evt_SumPFPt = Evt_SumPFPt + SumPFPt[k];
@@ -908,60 +1448,72 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
     mSumPFVsPtInitial_HF->Fill(Evt_SumPFVsPtInitial,HF_energy);
     mSumPFVsPt_HF->Fill(Evt_SumPFVsPt,HF_energy);
     mSumPFPt_HF->Fill(Evt_SumPFPt,HF_energy);
-      
+
     mSumSquaredPFVsPtInitial->Fill(Evt_SumSquaredPFVsPtInitial);
     mSumSquaredPFVsPt->Fill(Evt_SumSquaredPFVsPt);
     mSumSquaredPFPt->Fill(Evt_SumSquaredPFPt);
-    
+
     mNPFpart->Fill(NPFpart);
     mSumpt->Fill(SumPt_value);
 
   }
-  
-  
+
   if (isCaloJet)
     {
-      for (unsigned ijet=0; ijet<caloJets->size(); ijet++) recoJets.push_back((*caloJets)[ijet]);
+      for (unsigned ijet=0; ijet<caloJets->size(); ijet++) 
+	{
+	  recoJets.push_back((*caloJets)[ijet]);
+	} 
     }
-  
+
   if (isJPTJet)
     {
-      for (unsigned ijet=0; ijet<jptJets->size(); ijet++) recoJets.push_back((*jptJets)[ijet]);
+      for (unsigned ijet=0; ijet<jptJets->size(); ijet++) 
+        recoJets.push_back((*jptJets)[ijet]);
     }
-  
-  if (isPFJet) {
-    if(std::string("Pu")==UEAlgo){
-      for (unsigned ijet=0; ijet<basicJets->size();ijet++) recoJets.push_back((*basicJets)[ijet]);
+
+  if (isPFJet) 
+    {
+      if(std::string("Pu")==UEAlgo)
+	{
+	  for (unsigned ijet=0; ijet<basicJets->size();ijet++) 
+	    {
+	      recoJets.push_back((*basicJets)[ijet]);
+	    }
+	}
+      if(std::string("Vs")==UEAlgo){
+        for (unsigned ijet=0; ijet<pfJets->size(); ijet++) 
+	  {
+	    recoJets.push_back((*pfJets)[ijet]);
+	  }
+      }
     }
-    if(std::string("Vs")==UEAlgo){
-      for (unsigned ijet=0; ijet<pfJets->size(); ijet++) recoJets.push_back((*pfJets)[ijet]);
+
+
+  if (isCaloJet && !caloJets.isValid()) 
+    {
+      return;
     }
-  }
-  
-  
-  
-  if (isCaloJet && !caloJets.isValid()) return;
-  if (isJPTJet  && !jptJets.isValid())  return;
+  if (isJPTJet  && !jptJets.isValid()) 
+    {
+      return;
+    }
   if (isPFJet){
     if(std::string("Pu")==UEAlgo){if(!basicJets.isValid())   return;}
     if(std::string("Vs")==UEAlgo){if(!pfJets.isValid())   return;}
   }
-  
+
 
   int nJet_40 = 0;
 
   mNJets->Fill(recoJets.size());
-  
-  for (unsigned ijet=0; ijet<recoJets.size(); ijet++) {
 
-    
+  for (unsigned ijet=0; ijet<recoJets.size(); ijet++) {
     if (recoJets[ijet].pt() > mRecoJetPtThreshold) {
       //counting forward and barrel jets
-      
       // get an idea of no of jets with pT>40 GeV 
       if(recoJets[ijet].pt() > 40)
 	nJet_40++;
-      
       if (mEta) mEta->Fill(recoJets[ijet].eta());
       if (mjetpileup) mjetpileup->Fill(recoJets[ijet].pileup());
       if (mJetArea)      mJetArea     ->Fill(recoJets[ijet].jetArea());
@@ -971,11 +1523,79 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSe
       if (mPt)           mPt          ->Fill(recoJets[ijet].pt());
       if (mMass)         mMass        ->Fill(recoJets[ijet].mass());
       if (mConstituents) mConstituents->Fill(recoJets[ijet].nConstituents());
-      
-    }
-  }
-  
-  if (mNJets_40) mNJets_40->Fill(nJet_40); 
-  
-}
 
+      for(size_t iii = 0 ; iii < numbers.size() ; iii++)
+        {
+          pfDeltaR = sqrt((numbers[iii][2]-recoJets[ijet].phi())*(numbers[iii][2]-recoJets[ijet].phi()) + (numbers[iii][1]-recoJets[ijet].eta())*(numbers[iii][1]-recoJets[ijet].eta())); //MZ
+
+          mPFVsPtInitialDeltaR_pTCorrected->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+
+
+          mPFVsPtDeltaR_pTCorrected->Fill(pfDeltaR,numbers[iii][4]/recoJets[ijet].pt()); //MZ
+
+          //if(pfDeltaR < 1.0)         
+          // mPFDeltaR ->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+          mPFDeltaR ->Fill(pfDeltaR); //MZ
+          mPFDeltaR_Scaled_R->Fill(pfDeltaR,1. / pow(pfDeltaR,2)); //MZ
+          //mPFDeltaR_pTCorrected->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+          mPFDeltaR_pTCorrected->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+
+          //mPFVsPtInitialDeltaR_pTCorrected->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+
+          if(recoJets[ijet].pt() > 20 && recoJets[ijet].pt() < 30)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_20To30->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_20To30->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+          if(recoJets[ijet].pt() > 30 && recoJets[ijet].pt() < 50)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_30To50->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_30To50->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+          if(recoJets[ijet].pt() > 50 && recoJets[ijet].pt() < 80)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_50To80->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_50To80->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+
+          if(recoJets[ijet].pt() > 80 && recoJets[ijet].pt() < 120)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_80To120->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_80To120->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+
+          if(recoJets[ijet].pt() > 120 && recoJets[ijet].pt() < 180)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_120To180->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_120To180->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+
+          if(recoJets[ijet].pt() > 180 && recoJets[ijet].pt() < 300)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_180To300->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_180To300->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+          if(recoJets[ijet].pt() > 300)
+	    {
+	      mPFDeltaR_pTCorrected_PFpT_300ToInf->Fill(pfDeltaR,numbers[iii][0]/recoJets[ijet].pt()); //MZ
+	      mPFDeltaR_pTCorrected_PFVsInitialpT_300ToInf->Fill(pfDeltaR,numbers[iii][3]/recoJets[ijet].pt()); //MZ
+	    }
+
+        }
+
+    }
+    //cout << "End RecoJets loop" << endl; 
+    if (mNJets_40) 
+      mNJets_40->Fill(nJet_40); 
+
+  } // end recojet loop 222
+
+  numbers.clear();
+
+}

--- a/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons_matching.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons_matching.cc
@@ -29,7 +29,7 @@ JetAnalyzer_HeavyIons_matching::JetAnalyzer_HeavyIons_matching(const edm::Parame
   std::string inputCollectionLabelJet2(mInputJet2Collection.label());
   
   //consumes
-
+  
   if(std::string("VsCalo") == JetType1) caloJet1Token_ = consumes<reco::CaloJetCollection>(mInputJet1Collection);
   if(std::string("VsPF") == JetType1) pfJetsToken_ = consumes<reco::PFJetCollection>(mInputJet1Collection);
   if(std::string("PuCalo") == JetType1) caloJet2Token_ = consumes<reco::CaloJetCollection>(mInputJet1Collection);
@@ -64,6 +64,11 @@ JetAnalyzer_HeavyIons_matching::JetAnalyzer_HeavyIons_matching(const edm::Parame
     mChargedEmEnergy_Jet1_unmatched = 0;
     mNeutralEmEnergy_Jet1_unmatched = 0;
     mChargedMuEnergy_Jet1_unmatched = 0;
+    mChargedHadEnergyFraction_Jet1_unmatched = 0;
+    mNeutralHadEnergyFraction_Jet1_unmatched = 0;
+    mPhotonEnergyFraction_Jet1_unmatched = 0;
+    mElectronEnergyFraction_Jet1_unmatched = 0;
+    mMuonEnergyFraction_Jet1_unmatched = 0;
   }
   
   if(std::string("VsPF") == JetType2){
@@ -72,6 +77,11 @@ JetAnalyzer_HeavyIons_matching::JetAnalyzer_HeavyIons_matching(const edm::Parame
     mChargedEmEnergy_Jet2_unmatched = 0;
     mNeutralEmEnergy_Jet2_unmatched = 0;
     mChargedMuEnergy_Jet2_unmatched = 0;
+    mChargedHadEnergyFraction_Jet2_unmatched = 0;
+    mNeutralHadEnergyFraction_Jet2_unmatched = 0;
+    mPhotonEnergyFraction_Jet2_unmatched = 0;
+    mElectronEnergyFraction_Jet2_unmatched = 0;
+    mMuonEnergyFraction_Jet2_unmatched = 0;
   }
   
   
@@ -80,38 +90,52 @@ JetAnalyzer_HeavyIons_matching::JetAnalyzer_HeavyIons_matching(const edm::Parame
 void JetAnalyzer_HeavyIons_matching::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & iRun,edm::EventSetup const &) 
   {
 
-    ibooker.setCurrentFolder("JetMET/HIJetValidation/"+mInputJet1Collection.label()+mInputJet2Collection.label());
+    ibooker.setCurrentFolder("JetMET/HIJetValidation/"+mInputJet1Collection.label()+"_DeltaRMatched_"+mInputJet2Collection.label());
     
-    mpT_ratio_Jet1Jet2 = ibooker.book1D("Ratio_Jet1pT_vs_Jet2pT","",100, 0, 10);
-    mpT_Jet1_matched = ibooker.book1D("Jet1_matched_jet_Spectra","",100, 0, 1000);
-    mpT_Jet2_matched = ibooker.book1D("Jet2_matched_jet_Spectra","",100, 0, 1000);
-    mpT_Jet1_unmatched = ibooker.book1D("Jet1_unmatched_jet_Spectra","",100, 0, 1000);
-    mpT_Jet2_unmatched = ibooker.book1D("Jet2_unmatched_jet_Spectra","",100, 0, 1000);
+    mpT_ratio_Jet1Jet2 = ibooker.book1D("Ratio_Jet1pT_vs_Jet2pT",Form(";Matched %s Jet pT / %s Jet pT;Counts", "JetType1", "JetType2"),100, 0, 10);
+    mpT_Jet1_matched = ibooker.book1D("Jet1_matched_jet_Spectra",Form(";Matched %s Spectra; counts", "JetType1"),100, 0, 1000);
+    mpT_Jet2_matched = ibooker.book1D("Jet2_matched_jet_Spectra",Form(";Matched %s Spectra; counts", "JetType2"),100, 0, 1000);
+    mpT_Jet1_unmatched = ibooker.book1D("Jet1_unmatched_jet_Spectra",Form(";Unmatched %s spectra;counts","JetType1"),100, 0, 1000);
+    mpT_Jet2_unmatched = ibooker.book1D("Jet2_unmatched_jet_Spectra",Form(";Unmatched %s spectra;counts","JetType2"),100, 0, 1000);
     
     if(std::string("VsCalo") == JetType1 || std::string("PuCalo") == JetType1){
-      mHadEnergy_Jet1_unmatched = ibooker.book1D("HadEnergy_Jet1_unmatched", "HadEnergy_Jet1_unmatched", 50, 0, 200);
-      mEmEnergy_Jet1_unmatched = ibooker.book1D("EmEnergy_Jet1_unmatched", "EmEnergy_Jet1_unmatched", 50, 0, 200);
+      mHadEnergy_Jet1_unmatched = ibooker.book1D("HadEnergy_Jet1_unmatched", Form("HadEnergy_Jet1_unmatched;HadEnergy unmatched %s;counts", "JetType1"), 50, 0, 200);
+      mEmEnergy_Jet1_unmatched = ibooker.book1D("EmEnergy_Jet1_unmatched", Form("EmEnergy_Jet1_unmatched;EMEnergy unmatched %s;counts", "JetType1"), 50, 0, 200);
     }
     
     if(std::string("VsCalo") == JetType2 || std::string("PuCalo") == JetType2){
-      mHadEnergy_Jet2_unmatched = ibooker.book1D("HadEnergy_Jet2_unmatched", "HadEnergy_Jet2_unmatched", 50, 0, 200);
-      mEmEnergy_Jet2_unmatched = ibooker.book1D("EmEnergy_Jet2_unmatched", "EmEnergy_Jet2_unmatched", 50, 0, 200);
+      mHadEnergy_Jet2_unmatched = ibooker.book1D("HadEnergy_Jet2_unmatched", Form("HadEnergy_Jet2_unmatched;HadEnergy unmatched %s;counts", "JetType2"), 50, 0, 200);
+      mEmEnergy_Jet2_unmatched = ibooker.book1D("EmEnergy_Jet2_unmatched", Form("EmEnergy_Jet2_unmatched;EMEnergy unmatched %s;counts", "JetType2"), 50, 0, 200);
     }
 
     if(std::string("VsPF") == JetType1){
-      mChargedHadronEnergy_Jet1_unmatched = ibooker.book1D("ChargedHadronEnergy_Jet1_unmatched", "charged HAD energy unmatched Jet1",    50, 0, 100);
-      mNeutralHadronEnergy_Jet1_unmatched = ibooker.book1D("ChargedHadronEnergy_Jet1_unmatched", "charged HAD energy unmatched Jet1",    50, 0, 100);
-      mChargedEmEnergy_Jet1_unmatched = ibooker.book1D("ChargedEmEnergy_Jet1_unmatched", "charged EM energy unmatched Jet1",    50, 0, 100);
-      mNeutralEmEnergy_Jet1_unmatched = ibooker.book1D("ChargedEmEnergy_Jet1_unmatched", "charged EM energy unmatched Jet1",    50, 0, 100);
-      mChargedMuEnergy_Jet1_unmatched = ibooker.book1D("ChargedMuEnergy_Jet1_unmatched", "charged Mu energy unmatched Jet1",    50, 0, 100);
+      mChargedHadronEnergy_Jet1_unmatched = ibooker.book1D("ChargedHadronEnergy_Jet1_unmatched", Form(";charged HAD energy unmatched %s;counts","JetType1"),    100, 0, 300);
+      mNeutralHadronEnergy_Jet1_unmatched = ibooker.book1D("neutralHadronEnergy_Jet1_unmatched", Form(";neutral HAD energy unmatched %s;counts", "JetType1"),    100, 0, 300);
+      mChargedEmEnergy_Jet1_unmatched = ibooker.book1D("ChargedEmEnergy_Jet1_unmatched", Form(";charged EM energy unmatched %s;counts", "JetType1"),    100, 0, 300);
+      mNeutralEmEnergy_Jet1_unmatched = ibooker.book1D("neutralEmEnergy_Jet1_unmatched", Form(";neutral EM energy unmatched %s;counts", "JetType1"),    100, 0, 300);
+      mChargedMuEnergy_Jet1_unmatched = ibooker.book1D("ChargedMuEnergy_Jet1_unmatched", Form(";charged Mu energy unmatched %s;counts", "JetType1"),    100, 0, 300);
+
+      mChargedHadEnergyFraction_Jet1_unmatched = ibooker.book1D("ChargedHadEnergyFraction_Jet1_unmatched",Form(";h^{+/-} Energy Fraction %s;counts", "JetType1"),50, 0, 1);
+      mNeutralHadEnergyFraction_Jet1_unmatched = ibooker.book1D("NeutralHadEnergyFraction_Jet1_unmatched",Form(";h^{0} Energy Fraction %s;counts", "JetType1"),50, 0, 1);
+      mPhotonEnergyFraction_Jet1_unmatched = ibooker.book1D("PhotonEnergyFraction_Jet1_unmatched",Form(";#gamma Energy Fraction %s;counts", "JetType1"),50, 0, 1);
+      mElectronEnergyFraction_Jet1_unmatched = ibooker.book1D("ElectronEnergyFraction_Jet1_unmatched",Form(";e Energy Fraction %s;counts", "JetType1"),50, 0, 1);
+      mMuonEnergyFraction_Jet1_unmatched = ibooker.book1D("MuonoEnergyFraction_Jet1_unmatched",Form(";#mu Energy Fraction %s;counts", "JetType1"),50, 0, 1);
+      
     }
 
     if(std::string("VsPF") == JetType2){
-      mChargedHadronEnergy_Jet2_unmatched = ibooker.book1D("ChargedHadronEnergy_Jet2_unmatched", "charged HAD energy unmatched Jet2",    50, 0, 100);
-      mNeutralHadronEnergy_Jet2_unmatched = ibooker.book1D("ChargedHadronEnergy_Jet2_unmatched", "charged HAD energy unmatched Jet2",    50, 0, 100);
-      mChargedEmEnergy_Jet2_unmatched = ibooker.book1D("ChargedEmEnergy_Jet2_unmatched", "charged EM energy unmatched Jet2",    50, 0, 100);
-      mNeutralEmEnergy_Jet2_unmatched = ibooker.book1D("ChargedEmEnergy_Jet2_unmatched", "charged EM energy unmatched Jet2",    50, 0, 100);
-      mChargedMuEnergy_Jet2_unmatched = ibooker.book1D("ChargedMuEnergy_Jet2_unmatched", "charged Mu energy unmatched Jet2",    50, 0, 100);
+      mChargedHadronEnergy_Jet2_unmatched = ibooker.book1D("ChargedHadronEnergy_Jet2_unmatched", Form(";charged HAD energy unmatched %s;counts","JetType2"),    100, 0, 300);
+      mNeutralHadronEnergy_Jet2_unmatched = ibooker.book1D("neutralHadronEnergy_Jet2_unmatched", Form(";neutral HAD energy unmatched %s;counts", "JetType2"),    100, 0, 300);
+      mChargedEmEnergy_Jet2_unmatched = ibooker.book1D("ChargedEmEnergy_Jet2_unmatched", Form(";charged EM energy unmatched %s;counts", "JetType2"),    100, 0, 300);
+      mNeutralEmEnergy_Jet2_unmatched = ibooker.book1D("neutralEmEnergy_Jet2_unmatched", Form(";neutral EM energy unmatched %s;counts", "JetType2"),    100, 0, 300);
+      mChargedMuEnergy_Jet2_unmatched = ibooker.book1D("ChargedMuEnergy_Jet2_unmatched", Form(";charged Mu energy unmatched %s;counts", "JetType2"),    100, 0, 300);
+
+      mChargedHadEnergyFraction_Jet2_unmatched = ibooker.book1D("ChargedHadEnergyFraction_Jet2_unmatched",Form(";h^{+/-} Energy Fraction %s;counts", "JetType2"),50, 0, 1);
+      mNeutralHadEnergyFraction_Jet2_unmatched = ibooker.book1D("NeutralHadEnergyFraction_Jet2_unmatched",Form(";h^{0} Energy Fraction %s;counts", "JetType2"),50, 0, 1);
+      mPhotonEnergyFraction_Jet2_unmatched = ibooker.book1D("PhotonEnergyFraction_Jet2_unmatched",Form(";#gamma Energy Fraction %s;counts", "JetType2"),50, 0, 1);
+      mElectronEnergyFraction_Jet2_unmatched = ibooker.book1D("ElectronEnergyFraction_Jet2_unmatched",Form(";e Energy Fraction %s;counts", "JetType2"),50, 0, 1);
+      mMuonEnergyFraction_Jet2_unmatched = ibooker.book1D("MuonoEnergyFraction_Jet2_unmatched",Form(";#mu Energy Fraction %s;counts", "JetType2"),50, 0, 1);
+
     }
     
     if (mOutputFile.empty ()) 
@@ -240,9 +264,9 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
     if(fabs(recoJet2[ijet2].eta()) < mRecoJetEtaCut) continue;
 
     MyJet JET2;
-    JET2.eta = recoJet1[ijet2].eta();
-    JET2.phi = recoJet1[ijet2].phi();
-    JET2.pt  = recoJet1[ijet2].pt();
+    JET2.eta = recoJet2[ijet2].eta();
+    JET2.phi = recoJet2[ijet2].phi();
+    JET2.pt  = recoJet2[ijet2].pt();
     JET2.id  = ijet2; 
 
     vJet2.push_back(JET2);
@@ -289,6 +313,7 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
       }
     }
 
+    
     ABItr itr;
     // matched Jets matching Jet 1 to Jet 2 
     for(itr = mABMatchedJets.begin(); itr != mABMatchedJets.end(); ++itr){
@@ -348,6 +373,12 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 	  mChargedEmEnergy_Jet1_unmatched->Fill((*pfJets)[Aj.id].chargedEmEnergy());
 	  mNeutralEmEnergy_Jet1_unmatched->Fill((*pfJets)[Aj.id].neutralEmEnergy());
 	  mChargedMuEnergy_Jet1_unmatched->Fill((*pfJets)[Aj.id].chargedMuEnergy());
+
+	  mChargedHadEnergyFraction_Jet1_unmatched->Fill((*pfJets)[Aj.id].chargedHadronEnergyFraction());
+	  mNeutralHadEnergyFraction_Jet1_unmatched->Fill((*pfJets)[Aj.id].neutralHadronEnergyFraction());
+	  mPhotonEnergyFraction_Jet1_unmatched->Fill((*pfJets)[Aj.id].photonEnergyFraction());
+	  mElectronEnergyFraction_Jet1_unmatched->Fill((*pfJets)[Aj.id].electronEnergyFraction());
+	  mMuonEnergyFraction_Jet1_unmatched->Fill((*pfJets)[Aj.id].muonEnergyFraction());
 	}
 	
       }
@@ -368,14 +399,20 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 					 + (*caloJet2)[Bj.id].emEnergyInHF()
 					 );
 	}
-		
-
+	
+	
 	if(std::string("VsPF") == JetType2){
 	  mChargedHadronEnergy_Jet2_unmatched->Fill((*pfJets)[Bj.id].chargedHadronEnergy());
 	  mNeutralHadronEnergy_Jet2_unmatched->Fill((*pfJets)[Bj.id].neutralHadronEnergy());
 	  mChargedEmEnergy_Jet2_unmatched->Fill((*pfJets)[Bj.id].chargedEmEnergy());
 	  mNeutralEmEnergy_Jet2_unmatched->Fill((*pfJets)[Bj.id].neutralEmEnergy());
 	  mChargedMuEnergy_Jet2_unmatched->Fill((*pfJets)[Bj.id].chargedMuEnergy());
+	  
+	  mChargedHadEnergyFraction_Jet2_unmatched->Fill((*pfJets)[Bj.id].chargedHadronEnergyFraction());
+	  mNeutralHadEnergyFraction_Jet2_unmatched->Fill((*pfJets)[Bj.id].neutralHadronEnergyFraction());
+	  mPhotonEnergyFraction_Jet2_unmatched->Fill((*pfJets)[Bj.id].photonEnergyFraction());
+	  mElectronEnergyFraction_Jet2_unmatched->Fill((*pfJets)[Bj.id].electronEnergyFraction());
+	  mMuonEnergyFraction_Jet2_unmatched->Fill((*pfJets)[Bj.id].muonEnergyFraction());
 	}
        
       }

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -25,6 +25,7 @@ from RecoHI.Configuration.Reconstruction_hiPF_cff import *
 
 # Heavy Ion Event Characterization
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import *
+from RecoHI.HiCentralityAlgos.CentralityBin_cfi import *
 from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import *
 from RecoHI.HiEvtPlaneAlgos.HiEvtPlane_cfi import *
 
@@ -42,6 +43,7 @@ globalRecoPbPb = cms.Sequence(hiTracking_wSplitting
                               * hiEgammaSequence
                               * hiParticleFlowReco
                               * hiCentrality
+                              * centralityBin
                               * hiClusterCompatibility
                               * hiEvtPlane
                               * hcalnoise
@@ -57,6 +59,7 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               * hiEgammaSequence
                                               * hiParticleFlowReco
                                               * hiCentrality
+                                              * centralityBin
                                               * hiClusterCompatibility
                                               * hiEvtPlane
                                               * hcalnoise
@@ -70,4 +73,3 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
 # Modify zero-suppression sequence here
 from RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi import *
 siStripZeroSuppression.storeCM = cms.bool(True)
-

--- a/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
+++ b/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
@@ -2,15 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 RecoHiCentralityFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
-
 RecoHiCentralityRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
-
 RecoHiCentralityAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep *_centralityBin_*_*',
                                            'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )

--- a/Validation/RecoJets/plugins/JetTester_HeavyIons.cc
+++ b/Validation/RecoJets/plugins/JetTester_HeavyIons.cc
@@ -14,7 +14,6 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
   mInputPFCandCollection         (iConfig.getParameter<edm::InputTag>       ("PFcands")),
   // mInputCandCollection           (iConfig.getParameter<edm::InputTag>       ("Cands")),
   // rhoTag                         (iConfig.getParameter<edm::InputTag>       ("srcRho")),
-  centrality                     (iConfig.getParameter<edm::InputTag>       ("centrality")),
   mOutputFile                    (iConfig.getUntrackedParameter<std::string>("OutputFile","")),
   JetType                        (iConfig.getUntrackedParameter<std::string>("JetType")),
   UEAlgo                         (iConfig.getUntrackedParameter<std::string>("UEAlgo")),
@@ -47,13 +46,18 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
   }
 
   genJetsToken_ = consumes<reco::GenJetCollection>(edm::InputTag(mInputGenCollection));
-  evtToken_ = consumes<edm::HepMCProduct>(edm::InputTag("generator"));
+  //evtToken_ = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"));
+  evtToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator"));
   pfCandToken_ = consumes<reco::PFCandidateCollection>(mInputPFCandCollection);
   pfCandViewToken_ = consumes<reco::CandidateView>(mInputPFCandCollection);
   caloCandViewToken_ = consumes<reco::CandidateView>(edm::InputTag("towerMaker"));
   backgrounds_ = consumes<edm::ValueMap<reco::VoronoiBackground> >(Background);
   backgrounds_value_ = consumes<std::vector<float> >(Background);
-  centralityToken_ = consumes<reco::Centrality>(centrality);
+  centralityTag_ = iConfig.getParameter<InputTag>("centralitycollection");
+  centralityToken = consumes<reco::Centrality>(centralityTag_);
+
+  centralityBinTag_ = (iConfig.getParameter<edm::InputTag> ("centralitybincollection"));
+  centralityBinToken = consumes<int>(centralityBinTag_);
   hiVertexToken_ = consumes<std::vector<reco::Vertex> >(edm::InputTag("hiSelectedVertex"));
   
   // need to initialize the PF cand histograms : which are also event variables 
@@ -68,21 +72,21 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumPFVsPt = 0;
     mSumPFVsPtInitial = 0;
     mSumPFPt = 0;
-    mSumPFVsPtInitial_eta = 0;
-    mSumPFVsPt_eta = 0;
-    mSumPFPt_eta = 0;
+    // mSumPFVsPtInitial_eta = 0;
+    // mSumPFVsPt_eta = 0;
+    // mSumPFPt_eta = 0;
     mSumSquaredPFVsPt = 0;
     mSumSquaredPFVsPtInitial = 0;
     mSumSquaredPFPt = 0;
-    mSumSquaredPFVsPtInitial_eta = 0;
-    mSumSquaredPFVsPt_eta = 0;
-    mSumSquaredPFPt_eta = 0;
+    // mSumSquaredPFVsPtInitial_eta = 0;
+    // mSumSquaredPFVsPt_eta = 0;
+    // mSumSquaredPFPt_eta = 0;
     mSumPFVsPtInitial_HF = 0;
     mSumPFVsPt_HF = 0;
     mSumPFPt_HF = 0;
-    mPFVsPtInitial_eta_phi = 0;
-    mPFVsPt_eta_phi = 0;
-    mPFPt_eta_phi = 0;
+    // mPFVsPtInitial_eta_phi = 0;
+    // mPFVsPt_eta_phi = 0;
+    // mPFPt_eta_phi = 0;
 
     mSumPFVsPtInitial_n5p191_n2p650 = 0;
     mSumPFVsPtInitial_n2p650_n2p043 = 0;
@@ -131,7 +135,43 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumPFPt_1p740_2p043 = 0;
     mSumPFPt_2p043_2p650 = 0;
     mSumPFPt_2p650_5p191 = 0;
-  
+
+    mPFCandpT_vs_eta_Unknown = 0; // pf id 0
+    mPFCandpT_vs_eta_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_vs_eta_electron = 0; // pf id - 2
+    mPFCandpT_vs_eta_muon = 0; // pf id - 3
+    mPFCandpT_vs_eta_photon = 0; // pf id - 4
+    mPFCandpT_vs_eta_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_vs_eta_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_vs_eta_EME_inHF = 0; // pf id - 7
+     
+    mPFCandpT_Barrel_Unknown = 0; // pf id 0
+    mPFCandpT_Barrel_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_Barrel_electron = 0; // pf id - 2
+    mPFCandpT_Barrel_muon = 0; // pf id - 3
+    mPFCandpT_Barrel_photon = 0; // pf id - 4
+    mPFCandpT_Barrel_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_Barrel_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_Barrel_EME_inHF = 0; // pf id - 7
+
+    mPFCandpT_Endcap_Unknown = 0; // pf id 0
+    mPFCandpT_Endcap_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_Endcap_electron = 0; // pf id - 2
+    mPFCandpT_Endcap_muon = 0; // pf id - 3
+    mPFCandpT_Endcap_photon = 0; // pf id - 4
+    mPFCandpT_Endcap_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_Endcap_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_Endcap_EME_inHF = 0; // pf id - 7
+
+    mPFCandpT_Forward_Unknown = 0; // pf id 0
+    mPFCandpT_Forward_ChargedHadron = 0; // pf id - 1 
+    mPFCandpT_Forward_electron = 0; // pf id - 2
+    mPFCandpT_Forward_muon = 0; // pf id - 3
+    mPFCandpT_Forward_photon = 0; // pf id - 4
+    mPFCandpT_Forward_NeutralHadron = 0; // pf id - 5
+    mPFCandpT_Forward_HadE_inHF = 0; // pf id - 6
+    mPFCandpT_Forward_EME_inHF = 0; // pf id - 7
+    
   }
   if(isCaloJet){
     mNCalopart = 0;
@@ -145,21 +185,21 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
     mSumCaloVsPt = 0;
     mSumCaloVsPtInitial = 0;
     mSumCaloPt = 0;
-    mSumCaloVsPtInitial_eta = 0;
-    mSumCaloVsPt_eta = 0;
-    mSumCaloPt_eta = 0;
+    // mSumCaloVsPtInitial_eta = 0;
+    // mSumCaloVsPt_eta = 0;
+    // mSumCaloPt_eta = 0;
     mSumSquaredCaloVsPt = 0;
     mSumSquaredCaloVsPtInitial = 0;
     mSumSquaredCaloPt = 0;
-    mSumSquaredCaloVsPtInitial_eta = 0;
-    mSumSquaredCaloVsPt_eta = 0;
-    mSumSquaredCaloPt_eta = 0;
+    // mSumSquaredCaloVsPtInitial_eta = 0;
+    // mSumSquaredCaloVsPt_eta = 0;
+    // mSumSquaredCaloPt_eta = 0;
     mSumCaloVsPtInitial_HF = 0;
     mSumCaloVsPt_HF = 0;
     mSumCaloPt_HF = 0;
-    mCaloVsPtInitial_eta_phi = 0;
-    mCaloVsPt_eta_phi = 0;
-    mCaloPt_eta_phi = 0;
+    // mCaloVsPtInitial_eta_phi = 0;
+    // mCaloVsPt_eta_phi = 0;
+    // mCaloPt_eta_phi = 0;
 
     mSumCaloVsPtInitial_n5p191_n2p650 = 0;
     mSumCaloVsPtInitial_n2p650_n2p043 = 0;
@@ -224,9 +264,9 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
 
   mDeltapT = 0;
   //mDeltapT_HF = 0;
-  mDeltapT_eta = 0;
-  //mDeltapT_phiMinusPsi2 = 0;
-  mDeltapT_eta_phi = 0;
+  // mDeltapT_eta = 0;
+  // //mDeltapT_phiMinusPsi2 = 0;
+  // mDeltapT_eta_phi = 0;
   
   // Jet parameters
   mEta          = 0;
@@ -241,287 +281,600 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet& iConfig) :
   mNJets_40     = 0;
   mNJets        = 0;
 
-  mVs_0_x = 0;
-  mVs_0_y = 0;
-  mVs_1_x = 0;
-  mVs_1_y = 0;
-  mVs_2_x = 0;
-  mVs_2_y = 0;
-  mVs_0_x_versus_HF = 0;
-  mVs_0_y_versus_HF = 0;
-  mVs_1_x_versus_HF = 0;
-  mVs_1_y_versus_HF = 0;
-  mVs_2_x_versus_HF = 0;
-  mVs_2_y_versus_HF = 0;
+  // mVs_0_x = 0;
+  // mVs_0_y = 0;
+  // mVs_1_x = 0;
+  // mVs_1_y = 0;
+  // mVs_2_x = 0;
+  // mVs_2_y = 0;
+  // mVs_0_x_versus_HF = 0;
+  // mVs_0_y_versus_HF = 0;
+  // mVs_1_x_versus_HF = 0;
+  // mVs_1_y_versus_HF = 0;
+  // mVs_2_x_versus_HF = 0;
+  // mVs_2_y_versus_HF = 0;
 
+  mGenEta      = 0;
+  mGenPhi      = 0;
+  mGenPt       = 0;
+  mPtHat       = 0;
+
+  mPtRecoOverGen_B_20_30_Cent_0_10 = 0;
+  mPtRecoOverGen_E_20_30_Cent_0_10 = 0;
+  mPtRecoOverGen_F_20_30_Cent_0_10 = 0;
+  mPtRecoOverGen_B_30_50_Cent_0_10 = 0;
+  mPtRecoOverGen_E_30_50_Cent_0_10 = 0;
+  mPtRecoOverGen_F_30_50_Cent_0_10 = 0;
+  mPtRecoOverGen_B_50_80_Cent_0_10 = 0;
+  mPtRecoOverGen_E_50_80_Cent_0_10 = 0;
+  mPtRecoOverGen_F_50_80_Cent_0_10 = 0;
+  mPtRecoOverGen_B_80_120_Cent_0_10 = 0;
+  mPtRecoOverGen_E_80_120_Cent_0_10 = 0;
+  mPtRecoOverGen_F_80_120_Cent_0_10 = 0;
+  mPtRecoOverGen_B_120_180_Cent_0_10 = 0;
+  mPtRecoOverGen_E_120_180_Cent_0_10 = 0;
+  mPtRecoOverGen_F_120_180_Cent_0_10 = 0;
+  mPtRecoOverGen_B_180_300_Cent_0_10 = 0;
+  mPtRecoOverGen_E_180_300_Cent_0_10 = 0;
+  mPtRecoOverGen_F_180_300_Cent_0_10 = 0;
+  mPtRecoOverGen_B_300_Inf_Cent_0_10 = 0;
+  mPtRecoOverGen_E_300_Inf_Cent_0_10 = 0;
+  mPtRecoOverGen_F_300_Inf_Cent_0_10 = 0;
+
+  mPtRecoOverGen_B_20_30_Cent_10_30 = 0;
+  mPtRecoOverGen_E_20_30_Cent_10_30 = 0;
+  mPtRecoOverGen_F_20_30_Cent_10_30 = 0;
+  mPtRecoOverGen_B_30_50_Cent_10_30 = 0;
+  mPtRecoOverGen_E_30_50_Cent_10_30 = 0;
+  mPtRecoOverGen_F_30_50_Cent_10_30 = 0;
+  mPtRecoOverGen_B_50_80_Cent_10_30 = 0;
+  mPtRecoOverGen_E_50_80_Cent_10_30 = 0;
+  mPtRecoOverGen_F_50_80_Cent_10_30 = 0;
+  mPtRecoOverGen_B_80_120_Cent_10_30 = 0;
+  mPtRecoOverGen_E_80_120_Cent_10_30 = 0;
+  mPtRecoOverGen_F_80_120_Cent_10_30 = 0;
+  mPtRecoOverGen_B_120_180_Cent_10_30 = 0;
+  mPtRecoOverGen_E_120_180_Cent_10_30 = 0;
+  mPtRecoOverGen_F_120_180_Cent_10_30 = 0;
+  mPtRecoOverGen_B_180_300_Cent_10_30 = 0;
+  mPtRecoOverGen_E_180_300_Cent_10_30 = 0;
+  mPtRecoOverGen_F_180_300_Cent_10_30 = 0;
+  mPtRecoOverGen_B_300_Inf_Cent_10_30 = 0;
+  mPtRecoOverGen_E_300_Inf_Cent_10_30 = 0;
+  mPtRecoOverGen_F_300_Inf_Cent_10_30 = 0;
+
+  mPtRecoOverGen_B_20_30_Cent_30_50 = 0;
+  mPtRecoOverGen_E_20_30_Cent_30_50 = 0;
+  mPtRecoOverGen_F_20_30_Cent_30_50 = 0;
+  mPtRecoOverGen_B_30_50_Cent_30_50 = 0;
+  mPtRecoOverGen_E_30_50_Cent_30_50 = 0;
+  mPtRecoOverGen_F_30_50_Cent_30_50 = 0;
+  mPtRecoOverGen_B_50_80_Cent_30_50 = 0;
+  mPtRecoOverGen_E_50_80_Cent_30_50 = 0;
+  mPtRecoOverGen_F_50_80_Cent_30_50 = 0;
+  mPtRecoOverGen_B_80_120_Cent_30_50 = 0;
+  mPtRecoOverGen_E_80_120_Cent_30_50 = 0;
+  mPtRecoOverGen_F_80_120_Cent_30_50 = 0;
+  mPtRecoOverGen_B_120_180_Cent_30_50 = 0;
+  mPtRecoOverGen_E_120_180_Cent_30_50 = 0;
+  mPtRecoOverGen_F_120_180_Cent_30_50 = 0;
+  mPtRecoOverGen_B_180_300_Cent_30_50 = 0;
+  mPtRecoOverGen_E_180_300_Cent_30_50 = 0;
+  mPtRecoOverGen_F_180_300_Cent_30_50 = 0;
+  mPtRecoOverGen_B_300_Inf_Cent_30_50 = 0;
+  mPtRecoOverGen_E_300_Inf_Cent_30_50 = 0;
+  mPtRecoOverGen_F_300_Inf_Cent_30_50 = 0;
+
+  mPtRecoOverGen_B_20_30_Cent_50_80 = 0;
+  mPtRecoOverGen_E_20_30_Cent_50_80 = 0;
+  mPtRecoOverGen_F_20_30_Cent_50_80 = 0;
+  mPtRecoOverGen_B_30_50_Cent_50_80 = 0;
+  mPtRecoOverGen_E_30_50_Cent_50_80 = 0;
+  mPtRecoOverGen_F_30_50_Cent_50_80 = 0;
+  mPtRecoOverGen_B_50_80_Cent_50_80 = 0;
+  mPtRecoOverGen_E_50_80_Cent_50_80 = 0;
+  mPtRecoOverGen_F_50_80_Cent_50_80 = 0;
+  mPtRecoOverGen_B_80_120_Cent_50_80 = 0;
+  mPtRecoOverGen_E_80_120_Cent_50_80 = 0;
+  mPtRecoOverGen_F_80_120_Cent_50_80 = 0;
+  mPtRecoOverGen_B_120_180_Cent_50_80 = 0;
+  mPtRecoOverGen_E_120_180_Cent_50_80 = 0;
+  mPtRecoOverGen_F_120_180_Cent_50_80 = 0;
+  mPtRecoOverGen_B_180_300_Cent_50_80 = 0;
+  mPtRecoOverGen_E_180_300_Cent_50_80 = 0;
+  mPtRecoOverGen_F_180_300_Cent_50_80 = 0;
+  mPtRecoOverGen_B_300_Inf_Cent_50_80 = 0;
+  mPtRecoOverGen_E_300_Inf_Cent_50_80 = 0;
+  mPtRecoOverGen_F_300_Inf_Cent_50_80 = 0;
+  
+  mPtRecoOverGen_GenPt_B_Cent_0_10 = 0;
+  mPtRecoOverGen_GenPt_E_Cent_0_10 = 0;
+  mPtRecoOverGen_GenPt_F_Cent_0_10 = 0;
+  mPtRecoOverGen_GenPt_B_Cent_10_30 = 0;
+  mPtRecoOverGen_GenPt_E_Cent_10_30 = 0;
+  mPtRecoOverGen_GenPt_F_Cent_10_30 = 0;
+  mPtRecoOverGen_GenPt_B_Cent_30_50 = 0;
+  mPtRecoOverGen_GenPt_E_Cent_30_50 = 0;
+  mPtRecoOverGen_GenPt_F_Cent_30_50 = 0;
+  mPtRecoOverGen_GenPt_B_Cent_50_80 = 0;
+  mPtRecoOverGen_GenPt_E_Cent_50_80 = 0;
+  mPtRecoOverGen_GenPt_F_Cent_50_80 = 0;
+
+  mPtRecoOverGen_GenEta_20_30_Cent_0_10 = 0;
+  mPtRecoOverGen_GenEta_30_50_Cent_0_10 = 0;
+  mPtRecoOverGen_GenEta_50_80_Cent_0_10 = 0;
+  mPtRecoOverGen_GenEta_80_120_Cent_0_10 = 0;
+  mPtRecoOverGen_GenEta_120_180_Cent_0_10 = 0;
+  mPtRecoOverGen_GenEta_180_300_Cent_0_10 = 0;
+  mPtRecoOverGen_GenEta_300_Inf_Cent_0_10 = 0;
+
+  mPtRecoOverGen_GenEta_20_30_Cent_10_30 = 0;
+  mPtRecoOverGen_GenEta_30_50_Cent_10_30 = 0;
+  mPtRecoOverGen_GenEta_50_80_Cent_10_30 = 0;
+  mPtRecoOverGen_GenEta_80_120_Cent_10_30 = 0;
+  mPtRecoOverGen_GenEta_120_180_Cent_10_30 = 0;
+  mPtRecoOverGen_GenEta_180_300_Cent_10_30 = 0;
+  mPtRecoOverGen_GenEta_300_Inf_Cent_10_30 = 0;
+
+  mPtRecoOverGen_GenEta_20_30_Cent_30_50 = 0;
+  mPtRecoOverGen_GenEta_30_50_Cent_30_50 = 0;
+  mPtRecoOverGen_GenEta_50_80_Cent_30_50 = 0;
+  mPtRecoOverGen_GenEta_80_120_Cent_30_50 = 0;
+  mPtRecoOverGen_GenEta_120_180_Cent_30_50 = 0;
+  mPtRecoOverGen_GenEta_180_300_Cent_30_50 = 0;
+  mPtRecoOverGen_GenEta_300_Inf_Cent_30_50 = 0;
+  
+  mPtRecoOverGen_GenEta_20_30_Cent_50_80 = 0;
+  mPtRecoOverGen_GenEta_30_50_Cent_50_80 = 0;
+  mPtRecoOverGen_GenEta_50_80_Cent_50_80 = 0;
+  mPtRecoOverGen_GenEta_80_120_Cent_50_80 = 0;
+  mPtRecoOverGen_GenEta_120_180_Cent_50_80 = 0;
+  mPtRecoOverGen_GenEta_180_300_Cent_50_80 = 0;
+  mPtRecoOverGen_GenEta_300_Inf_Cent_50_80 = 0;
+  
+      
 }
-  //DQMStore* dbe = &*edm::Service<DQMStore>();
+//DQMStore* dbe = &*edm::Service<DQMStore>();
    
 void JetTester_HeavyIons::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & iRun,edm::EventSetup const &) 
-  {
+{
 
-    //if (dbe) {
-    //dbe->setCurrentFolder("JetMET/JetValidation/"+mInputCollection.label());
+  //if (dbe) {
+  //dbe->setCurrentFolder("JetMET/JetValidation/"+mInputCollection.label());
 
-    ibooker.setCurrentFolder("JetMET/JetValidation/"+mInputCollection.label());
+  ibooker.setCurrentFolder("JetMET/JetValidation/"+mInputCollection.label());
 
-    // double log10PtMin  = 0.50;
-    // double log10PtMax  = 3.75;
-    // int    log10PtBins = 26; 
+  double log10PtMin  = 0.50;
+  double log10PtMax  = 3.75;
+  int    log10PtBins = 26; 
+  
+  static const size_t ncms_hcal_edge_pseudorapidity = 82 + 1;
+  static const double cms_hcal_edge_pseudorapidity[ncms_hcal_edge_pseudorapidity] = {
+    -5.191, -4.889, -4.716, -4.538, -4.363, -4.191, -4.013,
+    -3.839, -3.664, -3.489, -3.314, -3.139, -2.964, -2.853,
+    -2.650, -2.500, -2.322, -2.172, -2.043, -1.930, -1.830,
+    -1.740, -1.653, -1.566, -1.479, -1.392, -1.305, -1.218,
+    -1.131, -1.044, -0.957, -0.879, -0.783, -0.696, -0.609,
+    -0.522, -0.435, -0.348, -0.261, -0.174, -0.087,
+    0.000,
+    0.087, 0.174, 0.261, 0.348, 0.435, 0.522, 0.609,
+    0.696, 0.783, 0.879, 0.957, 1.044, 1.131, 1.218,
+    1.305, 1.392, 1.479, 1.566, 1.653, 1.740, 1.830,
+    1.930, 2.043, 2.172, 2.322, 2.500, 2.650, 2.853,
+    2.964, 3.139, 3.314, 3.489, 3.664, 3.839, 4.013,
+    4.191, 4.363, 4.538, 4.716, 4.889, 5.191
+  };
 
-    // double etaRange[91] = {
-    //     -6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2,
-    // 		     -4.0, -3.8, -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6,
-    // 		     -2.5, -2.4, -2.3, -2.2, -2.1, -2.0, -1.9, -1.8, -1.7, -1.6,
-    // 		     -1.5, -1.4, -1.3, -1.2, -1.1, -1.0, -0.9, -0.8, -0.7, -0.6,
-    // 		     -0.5, -0.4, -0.3, -0.2, -0.1,
-    // 		     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-    // 		     1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
-    // 		     2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,
-    // 		     3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8,
-    // 		     5.0, 5.2, 5.4, 5.6, 5.8, 6.0
-    //    };
-
+  double etaRange[91] = {-6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2,
+			 -4.0, -3.8, -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6,
+			 -2.5, -2.4, -2.3, -2.2, -2.1, -2.0, -1.9, -1.8, -1.7, -1.6,
+			 -1.5, -1.4, -1.3, -1.2, -1.1, -1.0, -0.9, -0.8, -0.7, -0.6,
+			 -0.5, -0.4, -0.3, -0.2, -0.1,
+			 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+			 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
+			 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,
+			 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8,
+			 5.0, 5.2, 5.4, 5.6, 5.8, 6.0};
     
-    static const size_t ncms_hcal_edge_pseudorapidity = 82 + 1;
-    static const double cms_hcal_edge_pseudorapidity[ncms_hcal_edge_pseudorapidity] = {
-      -5.191, -4.889, -4.716, -4.538, -4.363, -4.191, -4.013,
-      -3.839, -3.664, -3.489, -3.314, -3.139, -2.964, -2.853,
-      -2.650, -2.500, -2.322, -2.172, -2.043, -1.930, -1.830,
-      -1.740, -1.653, -1.566, -1.479, -1.392, -1.305, -1.218,
-      -1.131, -1.044, -0.957, -0.879, -0.783, -0.696, -0.609,
-      -0.522, -0.435, -0.348, -0.261, -0.174, -0.087,
-      0.000,
-      0.087, 0.174, 0.261, 0.348, 0.435, 0.522, 0.609,
-      0.696, 0.783, 0.879, 0.957, 1.044, 1.131, 1.218,
-      1.305, 1.392, 1.479, 1.566, 1.653, 1.740, 1.830,
-      1.930, 2.043, 2.172, 2.322, 2.500, 2.650, 2.853,
-      2.964, 3.139, 3.314, 3.489, 3.664, 3.839, 4.013,
-      4.191, 4.363, 4.538, 4.716, 4.889, 5.191
-    };
-    
-    //cout<<"inside the book histograms function"<<endl;
+  //cout<<"inside the book histograms function"<<endl;
 
-    double edge_pseudorapidity[etaBins_ +1] = {-5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522, 0.522, 0.783, 1.131, 1.479, 1.740, 2.043, 2.650, 5.191 };
+  double edge_pseudorapidity[etaBins_ +1] = {-5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522, 0.522, 0.783, 1.131, 1.479, 1.740, 2.043, 2.650, 5.191 };
 
-    TH2F *h2D_etabins_vs_pt2 = new TH2F("h2D_etabins_vs_pt2","etaBins (x axis), sum pt^{2} (y axis)",etaBins_,edge_pseudorapidity,10000,0,10000);
-    TH2F *h2D_etabins_vs_pt = new TH2F("h2D_etabins_vs_pt","etaBins (x axis), sum pt (y axis)",etaBins_,edge_pseudorapidity,10000,-1000,1000);
-    TH2F *h2D_etabins_vs_phi = new TH2F("h2D_etabins_vs_phi","candidate map, eta(x axis), phi (y axis), pt (z axis)",ncms_hcal_edge_pseudorapidity-1,cms_hcal_edge_pseudorapidity,36,-TMath::Pi(),TMath::Pi());
+  TH2F *h2D_etabins_vs_pt2 = new TH2F("h2D_etabins_vs_pt2","etaBins (x axis), sum pt^{2} (y axis)",etaBins_,edge_pseudorapidity,10000,0,10000);
+  TH2F *h2D_etabins_vs_pt = new TH2F("h2D_etabins_vs_pt","etaBins (x axis), sum pt (y axis)",etaBins_,edge_pseudorapidity,10000,-1000,1000);
+  TH2F *h2D_etabins_vs_phi = new TH2F("h2D_etabins_vs_phi","candidate map, eta(x axis), phi (y axis), pt (z axis)",ncms_hcal_edge_pseudorapidity-1,cms_hcal_edge_pseudorapidity,36,-TMath::Pi(),TMath::Pi());
+  TH2F *h2D_pfcand_etabins_vs_pt = new TH2F("h2D_etabins_vs_pt",";#eta;sum p_{T}",etaBins_,edge_pseudorapidity,300, 0, 300);
 
-    if(isPFJet){
+  if(isPFJet){
 
-      mNPFpart         = ibooker.book1D("NPFpart","No of particle flow candidates",1000,0,10000);
-      mPFPt            = ibooker.book1D("PFPt","PF candidate p_{T}",1000,-5000,5000);
-      mPFEta           = ibooker.book1D("PFEta","PF candidate #eta",120,-6,6);
-      mPFPhi           = ibooker.book1D("PFPhi","PF candidate #phi",70,-3.5,3.5);
-      mPFVsPt          = ibooker.book1D("PFVsPt","Vs PF candidate p_{T}",1000,-5000,5000);
-      mPFVsPtInitial   = ibooker.book1D("PFVsPtInitial","Vs background subtracted PF candidate p_{T}",1000,-5000,5000);
-      mPFArea          = ibooker.book1D("PFArea","VS PF candidate area",100,0,4);
+    mNPFpart         = ibooker.book1D("NPFpart","No of particle flow candidates",1000,0,10000);
+    mPFPt            = ibooker.book1D("PFPt","PF candidate p_{T}",1000,-5000,5000);
+    mPFEta           = ibooker.book1D("PFEta","PF candidate #eta",120,-6,6);
+    mPFPhi           = ibooker.book1D("PFPhi","PF candidate #phi",70,-3.5,3.5);
+    mPFVsPt          = ibooker.book1D("PFVsPt","Vs PF candidate p_{T}",1000,-5000,5000);
+    mPFVsPtInitial   = ibooker.book1D("PFVsPtInitial","Vs background subtracted PF candidate p_{T}",1000,-5000,5000);
+    mPFArea          = ibooker.book1D("PFArea","VS PF candidate area",100,0,4);
       
-      mSumPFVsPt       = ibooker.book1D("SumPFVsPt","Sum of final PF VS p_{T}",1000,-10000,10000);
-      mSumPFVsPtInitial= ibooker.book1D("SumPFVsPtInitial","Sum PF VS p_{T} after subtraction",1000,-10000,10000);
-      mSumPFPt         = ibooker.book1D("SumPFPt","Sum of initial PF p_{T}",1000,-10000,10000);
-      mSumPFVsPt_eta   = ibooker.book2D("SumPFVsPt_etaBins",h2D_etabins_vs_pt);
-      mSumPFVsPtInitial_eta   = ibooker.book2D("SumPFVsPtInitial_etaBins",h2D_etabins_vs_pt);
-      mSumPFPt_eta     = ibooker.book2D("SumPFPt_etaBins",h2D_etabins_vs_pt);
+    mSumPFVsPt       = ibooker.book1D("SumPFVsPt","Sum of final PF VS p_{T}",1000,-10000,10000);
+    mSumPFVsPtInitial= ibooker.book1D("SumPFVsPtInitial","Sum PF VS p_{T} after subtraction",1000,-10000,10000);
+    mSumPFPt         = ibooker.book1D("SumPFPt","Sum of initial PF p_{T}",1000,-10000,10000);
+    // mSumPFVsPt_eta   = ibooker.book2D("SumPFVsPt_etaBins",h2D_etabins_vs_pt);
+    // mSumPFVsPtInitial_eta   = ibooker.book2D("SumPFVsPtInitial_etaBins",h2D_etabins_vs_pt);
+    // mSumPFPt_eta     = ibooker.book2D("SumPFPt_etaBins",h2D_etabins_vs_pt);
 
-      mSumSquaredPFVsPt       = ibooker.book1D("SumSquaredPFVsPt","Sum PF Vs p_{T} square",10000,0,10000);
-      mSumSquaredPFVsPtInitial= ibooker.book1D("SumSquaredPFVsPtInitial","Sum PF Vs p_{T} square after subtraction ",10000,0,10000);
-      mSumSquaredPFPt         = ibooker.book1D("SumSquaredPFPt","Sum of initial PF p_{T} squared",10000,0,10000);
-      mSumSquaredPFVsPt_eta   = ibooker.book2D("SumSquaredPFVsPt_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredPFVsPtInitial_eta   = ibooker.book2D("SumSquaredPFVsPtInitial_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredPFPt_eta     = ibooker.book2D("SumSquaredPFPt_etaBins",h2D_etabins_vs_pt2);
+    mSumSquaredPFVsPt       = ibooker.book1D("SumSquaredPFVsPt","Sum PF Vs p_{T} square",10000,0,10000);
+    mSumSquaredPFVsPtInitial= ibooker.book1D("SumSquaredPFVsPtInitial","Sum PF Vs p_{T} square after subtraction ",10000,0,10000);
+    mSumSquaredPFPt         = ibooker.book1D("SumSquaredPFPt","Sum of initial PF p_{T} squared",10000,0,10000);
+    // mSumSquaredPFVsPt_eta   = ibooker.book2D("SumSquaredPFVsPt_etaBins",h2D_etabins_vs_pt2);
+    // mSumSquaredPFVsPtInitial_eta   = ibooker.book2D("SumSquaredPFVsPtInitial_etaBins",h2D_etabins_vs_pt2);
+    // mSumSquaredPFPt_eta     = ibooker.book2D("SumSquaredPFPt_etaBins",h2D_etabins_vs_pt2);
 
-      mSumPFVsPtInitial_HF    = ibooker.book2D("SumPFVsPtInitial_HF","HF Energy (y axis) vs Sum PF Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumPFVsPt_HF    = ibooker.book2D("SumPFVsPt_HF","HF energy (y axis) vs Sum PF Vs p_{T} final (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumPFPt_HF    = ibooker.book2D("SumPFPt_HF","HF energy (y axis) vs Sum initial PF p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
-      mPFVsPtInitial_eta_phi    = ibooker.book2D("PFVsPtInitial_eta_phi",h2D_etabins_vs_phi);
-      mPFVsPt_eta_phi    = ibooker.book2D("PFVsPt_eta_phi",h2D_etabins_vs_phi);
-      mPFPt_eta_phi    = ibooker.book2D("PFPt_eta_phi",h2D_etabins_vs_phi);
+    mSumPFVsPtInitial_HF    = ibooker.book2D("SumPFVsPtInitial_HF","HF Energy (y axis) vs Sum PF Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumPFVsPt_HF    = ibooker.book2D("SumPFVsPt_HF","HF energy (y axis) vs Sum PF Vs p_{T} final (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumPFPt_HF    = ibooker.book2D("SumPFPt_HF","HF energy (y axis) vs Sum initial PF p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
+    // mPFVsPtInitial_eta_phi    = ibooker.book2D("PFVsPtInitial_eta_phi",h2D_etabins_vs_phi);
+    // mPFVsPt_eta_phi    = ibooker.book2D("PFVsPt_eta_phi",h2D_etabins_vs_phi);
+    // mPFPt_eta_phi    = ibooker.book2D("PFPt_eta_phi",h2D_etabins_vs_phi);
 
-      mSumPFVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumPFVsPtInitial_n5p191_n2p650","Sum PFVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumPFVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumPFVsPtInitial_n2p650_n2p043","Sum PFVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumPFVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumPFVsPtInitial_n2p043_n1p740","Sum PFVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumPFVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumPFVsPtInitial_n1p740_n1p479","Sum PFVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumPFVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumPFVsPtInitial_n1p479_n1p131","Sum PFVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumPFVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumPFVsPtInitial_n1p131_n0p783","Sum PFVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumPFVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p783_n0p522","Sum PFVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumPFVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p522_0p522","Sum PFVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumPFVsPtInitial_0p522_0p783 = ibooker.book1D("mSumPFVsPtInitial_0p522_0p783","Sum PFVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumPFVsPtInitial_0p783_1p131 = ibooker.book1D("mSumPFVsPtInitial_0p783_1p131","Sum PFVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumPFVsPtInitial_1p131_1p479 = ibooker.book1D("mSumPFVsPtInitial_1p131_1p479","Sum PFVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumPFVsPtInitial_1p479_1p740 = ibooker.book1D("mSumPFVsPtInitial_1p479_1p740","Sum PFVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumPFVsPtInitial_1p740_2p043 = ibooker.book1D("mSumPFVsPtInitial_1p740_2p043","Sum PFVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumPFVsPtInitial_2p043_2p650 = ibooker.book1D("mSumPFVsPtInitial_2p043_2p650","Sum PFVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumPFVsPtInitial_2p650_5p191 = ibooker.book1D("mSumPFVsPtInitial_2p650_5p191","Sum PFVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+    mSumPFVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumPFVsPtInitial_n5p191_n2p650","Sum PFVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumPFVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumPFVsPtInitial_n2p650_n2p043","Sum PFVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumPFVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumPFVsPtInitial_n2p043_n1p740","Sum PFVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumPFVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumPFVsPtInitial_n1p740_n1p479","Sum PFVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumPFVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumPFVsPtInitial_n1p479_n1p131","Sum PFVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumPFVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumPFVsPtInitial_n1p131_n0p783","Sum PFVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumPFVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p783_n0p522","Sum PFVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumPFVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumPFVsPtInitial_n0p522_0p522","Sum PFVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumPFVsPtInitial_0p522_0p783 = ibooker.book1D("mSumPFVsPtInitial_0p522_0p783","Sum PFVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumPFVsPtInitial_0p783_1p131 = ibooker.book1D("mSumPFVsPtInitial_0p783_1p131","Sum PFVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumPFVsPtInitial_1p131_1p479 = ibooker.book1D("mSumPFVsPtInitial_1p131_1p479","Sum PFVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumPFVsPtInitial_1p479_1p740 = ibooker.book1D("mSumPFVsPtInitial_1p479_1p740","Sum PFVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumPFVsPtInitial_1p740_2p043 = ibooker.book1D("mSumPFVsPtInitial_1p740_2p043","Sum PFVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumPFVsPtInitial_2p043_2p650 = ibooker.book1D("mSumPFVsPtInitial_2p043_2p650","Sum PFVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumPFVsPtInitial_2p650_5p191 = ibooker.book1D("mSumPFVsPtInitial_2p650_5p191","Sum PFVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
 
-      mSumPFVsPt_n5p191_n2p650 = ibooker.book1D("mSumPFVsPt_n5p191_n2p650","Sum PFVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumPFVsPt_n2p650_n2p043 = ibooker.book1D("mSumPFVsPt_n2p650_n2p043","Sum PFVsPt  variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumPFVsPt_n2p043_n1p740 = ibooker.book1D("mSumPFVsPt_n2p043_n1p740","Sum PFVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumPFVsPt_n1p740_n1p479 = ibooker.book1D("mSumPFVsPt_n1p740_n1p479","Sum PFVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumPFVsPt_n1p479_n1p131 = ibooker.book1D("mSumPFVsPt_n1p479_n1p131","Sum PFVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumPFVsPt_n1p131_n0p783 = ibooker.book1D("mSumPFVsPt_n1p131_n0p783","Sum PFVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumPFVsPt_n0p783_n0p522 = ibooker.book1D("mSumPFVsPt_n0p783_n0p522","Sum PFVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumPFVsPt_n0p522_0p522 = ibooker.book1D("mSumPFVsPt_n0p522_0p522","Sum PFVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumPFVsPt_0p522_0p783 = ibooker.book1D("mSumPFVsPt_0p522_0p783","Sum PFVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumPFVsPt_0p783_1p131 = ibooker.book1D("mSumPFVsPt_0p783_1p131","Sum PFVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumPFVsPt_1p131_1p479 = ibooker.book1D("mSumPFVsPt_1p131_1p479","Sum PFVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumPFVsPt_1p479_1p740 = ibooker.book1D("mSumPFVsPt_1p479_1p740","Sum PFVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumPFVsPt_1p740_2p043 = ibooker.book1D("mSumPFVsPt_1p740_2p043","Sum PFVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumPFVsPt_2p043_2p650 = ibooker.book1D("mSumPFVsPt_2p043_2p650","Sum PFVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumPFVsPt_2p650_5p191 = ibooker.book1D("mSumPFVsPt_2p650_5p191","Sum PFVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+    mSumPFVsPt_n5p191_n2p650 = ibooker.book1D("mSumPFVsPt_n5p191_n2p650","Sum PFVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumPFVsPt_n2p650_n2p043 = ibooker.book1D("mSumPFVsPt_n2p650_n2p043","Sum PFVsPt  variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumPFVsPt_n2p043_n1p740 = ibooker.book1D("mSumPFVsPt_n2p043_n1p740","Sum PFVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumPFVsPt_n1p740_n1p479 = ibooker.book1D("mSumPFVsPt_n1p740_n1p479","Sum PFVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumPFVsPt_n1p479_n1p131 = ibooker.book1D("mSumPFVsPt_n1p479_n1p131","Sum PFVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumPFVsPt_n1p131_n0p783 = ibooker.book1D("mSumPFVsPt_n1p131_n0p783","Sum PFVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumPFVsPt_n0p783_n0p522 = ibooker.book1D("mSumPFVsPt_n0p783_n0p522","Sum PFVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumPFVsPt_n0p522_0p522 = ibooker.book1D("mSumPFVsPt_n0p522_0p522","Sum PFVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumPFVsPt_0p522_0p783 = ibooker.book1D("mSumPFVsPt_0p522_0p783","Sum PFVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumPFVsPt_0p783_1p131 = ibooker.book1D("mSumPFVsPt_0p783_1p131","Sum PFVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumPFVsPt_1p131_1p479 = ibooker.book1D("mSumPFVsPt_1p131_1p479","Sum PFVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumPFVsPt_1p479_1p740 = ibooker.book1D("mSumPFVsPt_1p479_1p740","Sum PFVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumPFVsPt_1p740_2p043 = ibooker.book1D("mSumPFVsPt_1p740_2p043","Sum PFVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumPFVsPt_2p043_2p650 = ibooker.book1D("mSumPFVsPt_2p043_2p650","Sum PFVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumPFVsPt_2p650_5p191 = ibooker.book1D("mSumPFVsPt_2p650_5p191","Sum PFVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
 
-      mSumPFPt_n5p191_n2p650 = ibooker.book1D("mSumPFPt_n5p191_n2p650","Sum PFPt  in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumPFPt_n2p650_n2p043 = ibooker.book1D("mSumPFPt_n2p650_n2p043","Sum PFPt  in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumPFPt_n2p043_n1p740 = ibooker.book1D("mSumPFPt_n2p043_n1p740","Sum PFPt  in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumPFPt_n1p740_n1p479 = ibooker.book1D("mSumPFPt_n1p740_n1p479","Sum PFPt  in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumPFPt_n1p479_n1p131 = ibooker.book1D("mSumPFPt_n1p479_n1p131","Sum PFPt  in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumPFPt_n1p131_n0p783 = ibooker.book1D("mSumPFPt_n1p131_n0p783","Sum PFPt  in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumPFPt_n0p783_n0p522 = ibooker.book1D("mSumPFPt_n0p783_n0p522","Sum PFPt  in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumPFPt_n0p522_0p522 = ibooker.book1D("mSumPFPt_n0p522_0p522","Sum PFPt  in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumPFPt_0p522_0p783 = ibooker.book1D("mSumPFPt_0p522_0p783","Sum PFPt  in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumPFPt_0p783_1p131 = ibooker.book1D("mSumPFPt_0p783_1p131","Sum PFPt  in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumPFPt_1p131_1p479 = ibooker.book1D("mSumPFPt_1p131_1p479","Sum PFPt  in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumPFPt_1p479_1p740 = ibooker.book1D("mSumPFPt_1p479_1p740","Sum PFPt  in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumPFPt_1p740_2p043 = ibooker.book1D("mSumPFPt_1p740_2p043","Sum PFPt  in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumPFPt_2p043_2p650 = ibooker.book1D("mSumPFPt_2p043_2p650","Sum PFPt  in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumPFPt_2p650_5p191 = ibooker.book1D("mSumPFPt_2p650_5p191","Sum PFPt  in the eta range 2.650 to 5.191",1000,-5000,5000);
-      
-    }
+    mSumPFPt_n5p191_n2p650 = ibooker.book1D("mSumPFPt_n5p191_n2p650","Sum PFPt  in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumPFPt_n2p650_n2p043 = ibooker.book1D("mSumPFPt_n2p650_n2p043","Sum PFPt  in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumPFPt_n2p043_n1p740 = ibooker.book1D("mSumPFPt_n2p043_n1p740","Sum PFPt  in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumPFPt_n1p740_n1p479 = ibooker.book1D("mSumPFPt_n1p740_n1p479","Sum PFPt  in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumPFPt_n1p479_n1p131 = ibooker.book1D("mSumPFPt_n1p479_n1p131","Sum PFPt  in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumPFPt_n1p131_n0p783 = ibooker.book1D("mSumPFPt_n1p131_n0p783","Sum PFPt  in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumPFPt_n0p783_n0p522 = ibooker.book1D("mSumPFPt_n0p783_n0p522","Sum PFPt  in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumPFPt_n0p522_0p522 = ibooker.book1D("mSumPFPt_n0p522_0p522","Sum PFPt  in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumPFPt_0p522_0p783 = ibooker.book1D("mSumPFPt_0p522_0p783","Sum PFPt  in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumPFPt_0p783_1p131 = ibooker.book1D("mSumPFPt_0p783_1p131","Sum PFPt  in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumPFPt_1p131_1p479 = ibooker.book1D("mSumPFPt_1p131_1p479","Sum PFPt  in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumPFPt_1p479_1p740 = ibooker.book1D("mSumPFPt_1p479_1p740","Sum PFPt  in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumPFPt_1p740_2p043 = ibooker.book1D("mSumPFPt_1p740_2p043","Sum PFPt  in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumPFPt_2p043_2p650 = ibooker.book1D("mSumPFPt_2p043_2p650","Sum PFPt  in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumPFPt_2p650_5p191 = ibooker.book1D("mSumPFPt_2p650_5p191","Sum PFPt  in the eta range 2.650 to 5.191",1000,-5000,5000);
 
-    if(isCaloJet){
+    mPFCandpT_vs_eta_Unknown = ibooker.book2D("PF_cand_X_unknown",h2D_pfcand_etabins_vs_pt); // pf id 0
+    mPFCandpT_vs_eta_ChargedHadron = ibooker.book2D("PF_cand_chargedHad",h2D_pfcand_etabins_vs_pt); // pf id - 1 
+    mPFCandpT_vs_eta_electron = ibooker.book2D("PF_cand_electron",h2D_pfcand_etabins_vs_pt); // pf id - 2
+    mPFCandpT_vs_eta_muon = ibooker.book2D("PF_cand_muon",h2D_pfcand_etabins_vs_pt); // pf id - 3
+    mPFCandpT_vs_eta_photon = ibooker.book2D("PF_cand_photon",h2D_pfcand_etabins_vs_pt); // pf id - 4
+    mPFCandpT_vs_eta_NeutralHadron = ibooker.book2D("PF_cand_neutralHad",h2D_pfcand_etabins_vs_pt); // pf id - 5
+    mPFCandpT_vs_eta_HadE_inHF = ibooker.book2D("PF_cand_HadEner_inHF",h2D_pfcand_etabins_vs_pt); // pf id - 6
+    mPFCandpT_vs_eta_EME_inHF = ibooker.book2D("PF_cand_EMEner_inHF",h2D_pfcand_etabins_vs_pt); // pf id - 7
 
-      mNCalopart         = ibooker.book1D("NCalopart","No of particle flow candidates",1000,0,10000);
-      mCaloPt            = ibooker.book1D("CaloPt","Calo candidate p_{T}",1000,-5000,5000);
-      mCaloEta           = ibooker.book1D("CaloEta","Calo candidate #eta",120,-6,6);
-      mCaloPhi           = ibooker.book1D("CaloPhi","Calo candidate #phi",70,-3.5,3.5);
-      mCaloVsPt          = ibooker.book1D("CaloVsPt","Vs Calo candidate p_{T}",1000,-5000,5000);
-      mCaloVsPtInitial   = ibooker.book1D("CaloVsPtInitial","Vs background subtracted Calo candidate p_{T}",1000,-5000,5000);
-      mCaloArea          = ibooker.book1D("CaloArea","VS Calo candidate area",100,0,4);
-      
-      mSumCaloVsPt       = ibooker.book1D("SumCaloVsPt","Sum of final Calo VS p_{T} ",1000,-10000,10000);
-      mSumCaloVsPtInitial= ibooker.book1D("SumCaloVsPtInitial","Sum Calo VS p_{T} after subtraction",1000,-10000,10000);
-      mSumCaloPt         = ibooker.book1D("SumCaloPt","Sum Calo p_{T}",1000,-10000,10000);
-      mSumCaloVsPt_eta   = ibooker.book2D("SumCaloVsPt_etaBins",h2D_etabins_vs_pt);
-      mSumCaloVsPtInitial_eta   = ibooker.book2D("SumCaloVsPtInitial_etaBins",h2D_etabins_vs_pt);
-      mSumCaloPt_eta     = ibooker.book2D("SumCaloPt_etaBins",h2D_etabins_vs_pt);
-
-      mSumSquaredCaloVsPt       = ibooker.book1D("SumSquaredCaloVsPt","Sum of final Calo VS p_{T} squared",10000,0,10000);
-      mSumSquaredCaloVsPtInitial= ibooker.book1D("SumSquaredCaloVsPtInitial","Sum of subtracted Calo VS p_{T} squared",10000,0,10000);
-      mSumSquaredCaloPt         = ibooker.book1D("SumSquaredCaloPt","Sum of initial Calo tower p_{T} squared",10000,0,10000);
-      mSumSquaredCaloVsPt_eta   = ibooker.book2D("SumSquaredCaloVsPt_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredCaloVsPtInitial_eta   = ibooker.book2D("SumSquaredCaloVsPtInitial_etaBins",h2D_etabins_vs_pt2);
-      mSumSquaredCaloPt_eta     = ibooker.book2D("SumSquaredCaloPt_etaBins",h2D_etabins_vs_pt2);
-
-      mSumCaloVsPtInitial_HF    = ibooker.book2D("SumCaloVsPtInitial_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumCaloVsPt_HF    = ibooker.book2D("SumCaloVsPt_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
-      mSumCaloPt_HF    = ibooker.book2D("SumCaloPt_HF","HF Energy (y axis) vs Sum Calo tower p_{T}",1000,-1000,1000,1000,0,10000);
-      mCaloVsPtInitial_eta_phi    = ibooker.book2D("CaloVsPtInitial_eta_phi",h2D_etabins_vs_phi);
-      mCaloVsPt_eta_phi    = ibooker.book2D("CaloVsPt_eta_phi",h2D_etabins_vs_phi);
-      mCaloPt_eta_phi    = ibooker.book2D("CaloPt_eta_phi",h2D_etabins_vs_phi);
-
-      mSumCaloVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPtInitial_n5p191_n2p650","Sum CaloVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumCaloVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPtInitial_n2p650_n2p043","Sum CaloVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
-      mSumCaloVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPtInitial_n2p043_n1p740","Sum CaloVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumCaloVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPtInitial_n1p740_n1p479","Sum CaloVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumCaloVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPtInitial_n1p479_n1p131","Sum CaloVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumCaloVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPtInitial_n1p131_n0p783","Sum CaloVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumCaloVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p783_n0p522","Sum CaloVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumCaloVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p522_0p522","Sum CaloVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumCaloVsPtInitial_0p522_0p783 = ibooker.book1D("mSumCaloVsPtInitial_0p522_0p783","Sum CaloVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumCaloVsPtInitial_0p783_1p131 = ibooker.book1D("mSumCaloVsPtInitial_0p783_1p131","Sum CaloVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumCaloVsPtInitial_1p131_1p479 = ibooker.book1D("mSumCaloVsPtInitial_1p131_1p479","Sum CaloVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumCaloVsPtInitial_1p479_1p740 = ibooker.book1D("mSumCaloVsPtInitial_1p479_1p740","Sum CaloVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumCaloVsPtInitial_1p740_2p043 = ibooker.book1D("mSumCaloVsPtInitial_1p740_2p043","Sum CaloVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumCaloVsPtInitial_2p043_2p650 = ibooker.book1D("mSumCaloVsPtInitial_2p043_2p650","Sum CaloVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumCaloVsPtInitial_2p650_5p191 = ibooker.book1D("mSumCaloVsPtInitial_2p650_5p191","Sum CaloVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-
-      mSumCaloVsPt_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPt_n5p191_n2p650","Sum CaloVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumCaloVsPt_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPt_n2p650_n2p043","Sum CaloVsPt  variable in the eta range -2.650 to -2.043",1000,-5000,5000);
-      mSumCaloVsPt_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPt_n2p043_n1p740","Sum CaloVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumCaloVsPt_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPt_n1p740_n1p479","Sum CaloVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumCaloVsPt_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPt_n1p479_n1p131","Sum CaloVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumCaloVsPt_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPt_n1p131_n0p783","Sum CaloVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumCaloVsPt_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPt_n0p783_n0p522","Sum CaloVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumCaloVsPt_n0p522_0p522 = ibooker.book1D("mSumCaloVsPt_n0p522_0p522","Sum CaloVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumCaloVsPt_0p522_0p783 = ibooker.book1D("mSumCaloVsPt_0p522_0p783","Sum CaloVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumCaloVsPt_0p783_1p131 = ibooker.book1D("mSumCaloVsPt_0p783_1p131","Sum CaloVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumCaloVsPt_1p131_1p479 = ibooker.book1D("mSumCaloVsPt_1p131_1p479","Sum CaloVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumCaloVsPt_1p479_1p740 = ibooker.book1D("mSumCaloVsPt_1p479_1p740","Sum CaloVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumCaloVsPt_1p740_2p043 = ibooker.book1D("mSumCaloVsPt_1p740_2p043","Sum CaloVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumCaloVsPt_2p043_2p650 = ibooker.book1D("mSumCaloVsPt_2p043_2p650","Sum CaloVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumCaloVsPt_2p650_5p191 = ibooker.book1D("mSumCaloVsPt_2p650_5p191","Sum CaloVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-
-      mSumCaloPt_n5p191_n2p650 = ibooker.book1D("mSumCaloPt_n5p191_n2p650","Sum Calo tower pT variable in the eta range -5.191 to -2.650",1000,-5000,5000);
-      mSumCaloPt_n2p650_n2p043 = ibooker.book1D("mSumCaloPt_n2p650_n2p043","Sum Calo tower pT variable in the eta range -2.650 to -2.043",1000,-5000,5000);
-      mSumCaloPt_n2p043_n1p740 = ibooker.book1D("mSumCaloPt_n2p043_n1p740","Sum Calo tower pT variable in the eta range -2.043 to -1.740",1000,-1000,1000);
-      mSumCaloPt_n1p740_n1p479 = ibooker.book1D("mSumCaloPt_n1p740_n1p479","Sum Calo tower pT variable in the eta range -1.740 to -1.479",1000,-1000,1000);
-      mSumCaloPt_n1p479_n1p131 = ibooker.book1D("mSumCaloPt_n1p479_n1p131","Sum Calo tower pT variable in the eta range -1.479 to -1.131",1000,-1000,1000);
-      mSumCaloPt_n1p131_n0p783 = ibooker.book1D("mSumCaloPt_n1p131_n0p783","Sum Calo tower pT variable in the eta range -1.131 to -0.783",1000,-1000,1000);
-      mSumCaloPt_n0p783_n0p522 = ibooker.book1D("mSumCaloPt_n0p783_n0p522","Sum Calo tower pT variable in the eta range -0.783 to -0.522",1000,-1000,1000);
-      mSumCaloPt_n0p522_0p522 = ibooker.book1D("mSumCaloPt_n0p522_0p522","Sum Calo tower pT variable in the eta range -0.522 to 0.522",1000,-1000,1000);
-      mSumCaloPt_0p522_0p783 = ibooker.book1D("mSumCaloPt_0p522_0p783","Sum Calo tower pT variable in the eta range 0.522 to 0.783",1000,-1000,1000);
-      mSumCaloPt_0p783_1p131 = ibooker.book1D("mSumCaloPt_0p783_1p131","Sum Calo tower pT variable in the eta range 0.783 to 1.131",1000,-1000,1000);
-      mSumCaloPt_1p131_1p479 = ibooker.book1D("mSumCaloPt_1p131_1p479","Sum Calo tower pT variable in the eta range 1.131 to 1.479",1000,-1000,1000);
-      mSumCaloPt_1p479_1p740 = ibooker.book1D("mSumCaloPt_1p479_1p740","Sum Calo tower pT variable in the eta range 1.479 to 1.740",1000,-1000,1000);
-      mSumCaloPt_1p740_2p043 = ibooker.book1D("mSumCaloPt_1p740_2p043","Sum Calo tower pT variable in the eta range 1.740 to 2.043",1000,-1000,1000);
-      mSumCaloPt_2p043_2p650 = ibooker.book1D("mSumCaloPt_2p043_2p650","Sum Calo tower pT variable in the eta range 2.043 to 2.650",1000,-5000,5000);
-      mSumCaloPt_2p650_5p191 = ibooker.book1D("mSumCaloPt_2p650_5p191","Sum Calo tower pT variable in the eta range 2.650 to 5.191",1000,-5000,5000);
-      
-    }
-
-    // particle flow variables histograms 
-    mSumpt           = ibooker.book1D("SumpT","Sum p_{T} of all the PF candidates per event",1000,0,10000);
-    mvn              = ibooker.book1D("vn","vn",100,0,10);
-    mpsin            = ibooker.book1D("mpsin","psin",100,0,10);
-
-    // Event variables
-    mNvtx            = ibooker.book1D("Nvtx",           "number of vertices", 60, 0, 60);
-    mHF              = ibooker.book1D("HF", "HF energy distribution",1000,0,10000);
-
-    // added Jan 12th 2015
-    mDeltapT  = ibooker.book1D("DeltapT","amount subtracted from candidate",400,-200,200);
-    //mDeltapT_HF  = ibooker.book2D("DeltapT_HF","",400,-200,200,1000,0,10000);
-    mDeltapT_eta = ibooker.book2D("DeltapT_eta","",60,-6,+6,400,-200,200);
-    //mDeltapT_phiMinusPsi2 = ibooker.book2D("DeltapT_phiMinusPsi2","",400,-200,200,35,-1.75,1.75);
-    mDeltapT_eta_phi = ibooker.book2D("DeltapT_eta_phi",h2D_etabins_vs_phi);
+    mPFCandpT_Barrel_Unknown = ibooker.book1D("mPFCandpT_Barrel_Unknown",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id  - 0
+    mPFCandpT_Barrel_ChargedHadron = ibooker.book1D("mPFCandpT_Barrel_ChargedHadron",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 1 
+    mPFCandpT_Barrel_electron = ibooker.book1D("mPFCandpT_Barrel_electron",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 2
+    mPFCandpT_Barrel_muon = ibooker.book1D("mPFCandpT_Barrel_muon",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 3
+    mPFCandpT_Barrel_photon = ibooker.book1D("mPFCandpT_Barrel_photon",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 4
+    mPFCandpT_Barrel_NeutralHadron = ibooker.book1D("mPFCandpT_Barrel_NeutralHadron",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 5
+    mPFCandpT_Barrel_HadE_inHF = ibooker.book1D("mPFCandpT_Barrel_HadE_inHF",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 6
+    mPFCandpT_Barrel_EME_inHF = ibooker.book1D("mPFCandpT_Barrel_EME_inHF",Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),300, 0, 300); // pf id - 7
     
-    // Jet parameters
-    mEta             = ibooker.book1D("Eta",          "Eta",          120,   -6,    6); 
-    mPhi             = ibooker.book1D("Phi",          "Phi",           70, -3.5,  3.5); 
-    mPt              = ibooker.book1D("Pt",           "Pt",           100,    0,  1000); 
-    mP               = ibooker.book1D("P",            "P",            100,    0,  1000); 
-    mEnergy          = ibooker.book1D("Energy",       "Energy",       100,    0,  1000); 
-    mMass            = ibooker.book1D("Mass",         "Mass",         100,    0,  200); 
-    mConstituents    = ibooker.book1D("Constituents", "Constituents", 100,    0,  100); 
-    mJetArea         = ibooker.book1D("JetArea",      "JetArea",       100,   0, 4);
-    mjetpileup       = ibooker.book1D("jetPileUp","jetPileUp",100,0,150);
-    mNJets_40        = ibooker.book1D("NJets_pt_greater_40", "NJets pT > 40 GeV",  50,    0,   100);
-    mNJets        = ibooker.book1D("NJets", "NJets",  50,    0,   100);
+    mPFCandpT_Endcap_Unknown = ibooker.book1D("mPFCandpT_Endcap_Unknown",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 0
+    mPFCandpT_Endcap_ChargedHadron = ibooker.book1D("mPFCandpT_Endcap_ChargedHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 1 
+    mPFCandpT_Endcap_electron = ibooker.book1D("mPFCandpT_Endcap_electron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 2
+    mPFCandpT_Endcap_muon = ibooker.book1D("mPFCandpT_Endcap_muon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 3
+    mPFCandpT_Endcap_photon = ibooker.book1D("mPFCandpT_Endcap_photon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 4
+    mPFCandpT_Endcap_NeutralHadron = ibooker.book1D("mPFCandpT_Endcap_NeutralHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 5
+    mPFCandpT_Endcap_HadE_inHF = ibooker.book1D("mPFCandpT_Endcap_HadE_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 6
+    mPFCandpT_Endcap_EME_inHF = ibooker.book1D("mPFCandpT_Endcap_EME_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),300, 0, 300); // pf id - 7
 
-    mVs_0_x  = ibooker.book1D("Vs_0_x","flow modulated sumpT from both HF (+ and -) with cos, vn = 0",1000,-10000,10000);
-    mVs_0_y  = ibooker.book1D("Vs_0_y","flow modulated sumpT from both HF (+ and -) with sin, vn = 0",1000,-10000,10000);
-    mVs_1_x  = ibooker.book1D("Vs_1_x","flow modulated sumpT from both HF (+ and -) with cos, vn = 1",1000,-10000,10000);
-    mVs_1_y  = ibooker.book1D("Vs_1_y","flow modulated sumpT from both HF (+ and -) with sin, vn = 1",1000,-10000,10000);
-    mVs_2_x  = ibooker.book1D("Vs_2_x","flow modulated sumpT from both HF (+ and -) with cos, vn = 2",1000,-10000,10000);
-    mVs_2_y  = ibooker.book1D("Vs_2_y","flow modulated sumpT from both HF (+ and -) with sin, vn = 2",1000,-10000,10000);
-    
-    mVs_0_x_versus_HF = ibooker.book2D("Vs_0_x_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with cos, vn = 0 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
-    mVs_0_y_versus_HF = ibooker.book2D("Vs_0_y_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with sin, vn = 0 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
-    mVs_1_x_versus_HF = ibooker.book2D("Vs_1_x_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with cos, vn = 1 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
-    mVs_1_y_versus_HF = ibooker.book2D("Vs_1_y_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with sin, vn = 1 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
-    mVs_2_x_versus_HF = ibooker.book2D("Vs_2_x_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with cos, vn = 2 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
-    mVs_2_y_versus_HF = ibooker.book2D("Vs_2_y_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with sin, vn = 2 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
-    
-    if (mOutputFile.empty ()) 
-      LogInfo("OutputInfo") << " Histograms will NOT be saved";
-    else 
-      LogInfo("OutputInfo") << " Histograms will be saved to file:" << mOutputFile;
-
-    delete h2D_etabins_vs_pt2;
-    delete h2D_etabins_vs_pt;
-    delete h2D_etabins_vs_phi;
+    mPFCandpT_Forward_Unknown = ibooker.book1D("mPFCandpT_Forward_Unknown",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 0
+    mPFCandpT_Forward_ChargedHadron = ibooker.book1D("mPFCandpT_Forward_ChargedHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 1 
+    mPFCandpT_Forward_electron = ibooker.book1D("mPFCandpT_Forward_electron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 2
+    mPFCandpT_Forward_muon = ibooker.book1D("mPFCandpT_Forward_muon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 3
+    mPFCandpT_Forward_photon = ibooker.book1D("mPFCandpT_Forward_photon",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 4
+    mPFCandpT_Forward_NeutralHadron = ibooker.book1D("mPFCandpT_Forward_NeutralHadron",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 5
+    mPFCandpT_Forward_HadE_inHF = ibooker.book1D("mPFCandpT_Forward_HadE_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 6
+    mPFCandpT_Forward_EME_inHF = ibooker.book1D("mPFCandpT_Forward_EME_inHF",Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),300, 0, 300); // pf id - 7
+        
+      
   }
+
+  if(isCaloJet){
+
+    mNCalopart         = ibooker.book1D("NCalopart","No of particle flow candidates",1000,0,10000);
+    mCaloPt            = ibooker.book1D("CaloPt","Calo candidate p_{T}",1000,-5000,5000);
+    mCaloEta           = ibooker.book1D("CaloEta","Calo candidate #eta",120,-6,6);
+    mCaloPhi           = ibooker.book1D("CaloPhi","Calo candidate #phi",70,-3.5,3.5);
+    mCaloVsPt          = ibooker.book1D("CaloVsPt","Vs Calo candidate p_{T}",1000,-5000,5000);
+    mCaloVsPtInitial   = ibooker.book1D("CaloVsPtInitial","Vs background subtracted Calo candidate p_{T}",1000,-5000,5000);
+    mCaloArea          = ibooker.book1D("CaloArea","VS Calo candidate area",100,0,4);
+      
+    mSumCaloVsPt       = ibooker.book1D("SumCaloVsPt","Sum of final Calo VS p_{T} ",1000,-10000,10000);
+    mSumCaloVsPtInitial= ibooker.book1D("SumCaloVsPtInitial","Sum Calo VS p_{T} after subtraction",1000,-10000,10000);
+    mSumCaloPt         = ibooker.book1D("SumCaloPt","Sum Calo p_{T}",1000,-10000,10000);
+    // mSumCaloVsPt_eta   = ibooker.book2D("SumCaloVsPt_etaBins",h2D_etabins_vs_pt);
+    // mSumCaloVsPtInitial_eta   = ibooker.book2D("SumCaloVsPtInitial_etaBins",h2D_etabins_vs_pt);
+    // mSumCaloPt_eta     = ibooker.book2D("SumCaloPt_etaBins",h2D_etabins_vs_pt);
+
+    mSumSquaredCaloVsPt       = ibooker.book1D("SumSquaredCaloVsPt","Sum of final Calo VS p_{T} squared",10000,0,10000);
+    mSumSquaredCaloVsPtInitial= ibooker.book1D("SumSquaredCaloVsPtInitial","Sum of subtracted Calo VS p_{T} squared",10000,0,10000);
+    mSumSquaredCaloPt         = ibooker.book1D("SumSquaredCaloPt","Sum of initial Calo tower p_{T} squared",10000,0,10000);
+    // mSumSquaredCaloVsPt_eta   = ibooker.book2D("SumSquaredCaloVsPt_etaBins",h2D_etabins_vs_pt2);
+    // mSumSquaredCaloVsPtInitial_eta   = ibooker.book2D("SumSquaredCaloVsPtInitial_etaBins",h2D_etabins_vs_pt2);
+    // mSumSquaredCaloPt_eta     = ibooker.book2D("SumSquaredCaloPt_etaBins",h2D_etabins_vs_pt2);
+
+    mSumCaloVsPtInitial_HF    = ibooker.book2D("SumCaloVsPtInitial_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} before subtraction (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumCaloVsPt_HF    = ibooker.book2D("SumCaloVsPt_HF","HF Energy (y axis) vs Sum Calo Vs p_{T} (x axis)",1000,-1000,1000,1000,0,10000);
+    mSumCaloPt_HF    = ibooker.book2D("SumCaloPt_HF","HF Energy (y axis) vs Sum Calo tower p_{T}",1000,-1000,1000,1000,0,10000);
+    // mCaloVsPtInitial_eta_phi    = ibooker.book2D("CaloVsPtInitial_eta_phi",h2D_etabins_vs_phi);
+    // mCaloVsPt_eta_phi    = ibooker.book2D("CaloVsPt_eta_phi",h2D_etabins_vs_phi);
+    // mCaloPt_eta_phi    = ibooker.book2D("CaloPt_eta_phi",h2D_etabins_vs_phi);
+
+    mSumCaloVsPtInitial_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPtInitial_n5p191_n2p650","Sum CaloVsPt Initial variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumCaloVsPtInitial_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPtInitial_n2p650_n2p043","Sum CaloVsPt Initial variable in the eta range -2.650 to -2.043 ",1000,-5000,5000);
+    mSumCaloVsPtInitial_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPtInitial_n2p043_n1p740","Sum CaloVsPt Initial variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumCaloVsPtInitial_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPtInitial_n1p740_n1p479","Sum CaloVsPt Initial variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumCaloVsPtInitial_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPtInitial_n1p479_n1p131","Sum CaloVsPt Initial variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumCaloVsPtInitial_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPtInitial_n1p131_n0p783","Sum CaloVsPt Initial variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumCaloVsPtInitial_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p783_n0p522","Sum CaloVsPt Initial variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumCaloVsPtInitial_n0p522_0p522 = ibooker.book1D("mSumCaloVsPtInitial_n0p522_0p522","Sum CaloVsPt Initial variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumCaloVsPtInitial_0p522_0p783 = ibooker.book1D("mSumCaloVsPtInitial_0p522_0p783","Sum CaloVsPt Initial variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumCaloVsPtInitial_0p783_1p131 = ibooker.book1D("mSumCaloVsPtInitial_0p783_1p131","Sum CaloVsPt Initial variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumCaloVsPtInitial_1p131_1p479 = ibooker.book1D("mSumCaloVsPtInitial_1p131_1p479","Sum CaloVsPt Initial variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumCaloVsPtInitial_1p479_1p740 = ibooker.book1D("mSumCaloVsPtInitial_1p479_1p740","Sum CaloVsPt Initial variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumCaloVsPtInitial_1p740_2p043 = ibooker.book1D("mSumCaloVsPtInitial_1p740_2p043","Sum CaloVsPt Initial variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumCaloVsPtInitial_2p043_2p650 = ibooker.book1D("mSumCaloVsPtInitial_2p043_2p650","Sum CaloVsPt Initial variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumCaloVsPtInitial_2p650_5p191 = ibooker.book1D("mSumCaloVsPtInitial_2p650_5p191","Sum CaloVsPt Initial variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mSumCaloVsPt_n5p191_n2p650 = ibooker.book1D("mSumCaloVsPt_n5p191_n2p650","Sum CaloVsPt  variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumCaloVsPt_n2p650_n2p043 = ibooker.book1D("mSumCaloVsPt_n2p650_n2p043","Sum CaloVsPt  variable in the eta range -2.650 to -2.043",1000,-5000,5000);
+    mSumCaloVsPt_n2p043_n1p740 = ibooker.book1D("mSumCaloVsPt_n2p043_n1p740","Sum CaloVsPt  variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumCaloVsPt_n1p740_n1p479 = ibooker.book1D("mSumCaloVsPt_n1p740_n1p479","Sum CaloVsPt  variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumCaloVsPt_n1p479_n1p131 = ibooker.book1D("mSumCaloVsPt_n1p479_n1p131","Sum CaloVsPt  variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumCaloVsPt_n1p131_n0p783 = ibooker.book1D("mSumCaloVsPt_n1p131_n0p783","Sum CaloVsPt  variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumCaloVsPt_n0p783_n0p522 = ibooker.book1D("mSumCaloVsPt_n0p783_n0p522","Sum CaloVsPt  variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumCaloVsPt_n0p522_0p522 = ibooker.book1D("mSumCaloVsPt_n0p522_0p522","Sum CaloVsPt  variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumCaloVsPt_0p522_0p783 = ibooker.book1D("mSumCaloVsPt_0p522_0p783","Sum CaloVsPt  variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumCaloVsPt_0p783_1p131 = ibooker.book1D("mSumCaloVsPt_0p783_1p131","Sum CaloVsPt  variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumCaloVsPt_1p131_1p479 = ibooker.book1D("mSumCaloVsPt_1p131_1p479","Sum CaloVsPt  variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumCaloVsPt_1p479_1p740 = ibooker.book1D("mSumCaloVsPt_1p479_1p740","Sum CaloVsPt  variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumCaloVsPt_1p740_2p043 = ibooker.book1D("mSumCaloVsPt_1p740_2p043","Sum CaloVsPt  variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumCaloVsPt_2p043_2p650 = ibooker.book1D("mSumCaloVsPt_2p043_2p650","Sum CaloVsPt  variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumCaloVsPt_2p650_5p191 = ibooker.book1D("mSumCaloVsPt_2p650_5p191","Sum CaloVsPt  variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+
+    mSumCaloPt_n5p191_n2p650 = ibooker.book1D("mSumCaloPt_n5p191_n2p650","Sum Calo tower pT variable in the eta range -5.191 to -2.650",1000,-5000,5000);
+    mSumCaloPt_n2p650_n2p043 = ibooker.book1D("mSumCaloPt_n2p650_n2p043","Sum Calo tower pT variable in the eta range -2.650 to -2.043",1000,-5000,5000);
+    mSumCaloPt_n2p043_n1p740 = ibooker.book1D("mSumCaloPt_n2p043_n1p740","Sum Calo tower pT variable in the eta range -2.043 to -1.740",1000,-1000,1000);
+    mSumCaloPt_n1p740_n1p479 = ibooker.book1D("mSumCaloPt_n1p740_n1p479","Sum Calo tower pT variable in the eta range -1.740 to -1.479",1000,-1000,1000);
+    mSumCaloPt_n1p479_n1p131 = ibooker.book1D("mSumCaloPt_n1p479_n1p131","Sum Calo tower pT variable in the eta range -1.479 to -1.131",1000,-1000,1000);
+    mSumCaloPt_n1p131_n0p783 = ibooker.book1D("mSumCaloPt_n1p131_n0p783","Sum Calo tower pT variable in the eta range -1.131 to -0.783",1000,-1000,1000);
+    mSumCaloPt_n0p783_n0p522 = ibooker.book1D("mSumCaloPt_n0p783_n0p522","Sum Calo tower pT variable in the eta range -0.783 to -0.522",1000,-1000,1000);
+    mSumCaloPt_n0p522_0p522 = ibooker.book1D("mSumCaloPt_n0p522_0p522","Sum Calo tower pT variable in the eta range -0.522 to 0.522",1000,-1000,1000);
+    mSumCaloPt_0p522_0p783 = ibooker.book1D("mSumCaloPt_0p522_0p783","Sum Calo tower pT variable in the eta range 0.522 to 0.783",1000,-1000,1000);
+    mSumCaloPt_0p783_1p131 = ibooker.book1D("mSumCaloPt_0p783_1p131","Sum Calo tower pT variable in the eta range 0.783 to 1.131",1000,-1000,1000);
+    mSumCaloPt_1p131_1p479 = ibooker.book1D("mSumCaloPt_1p131_1p479","Sum Calo tower pT variable in the eta range 1.131 to 1.479",1000,-1000,1000);
+    mSumCaloPt_1p479_1p740 = ibooker.book1D("mSumCaloPt_1p479_1p740","Sum Calo tower pT variable in the eta range 1.479 to 1.740",1000,-1000,1000);
+    mSumCaloPt_1p740_2p043 = ibooker.book1D("mSumCaloPt_1p740_2p043","Sum Calo tower pT variable in the eta range 1.740 to 2.043",1000,-1000,1000);
+    mSumCaloPt_2p043_2p650 = ibooker.book1D("mSumCaloPt_2p043_2p650","Sum Calo tower pT variable in the eta range 2.043 to 2.650",1000,-5000,5000);
+    mSumCaloPt_2p650_5p191 = ibooker.book1D("mSumCaloPt_2p650_5p191","Sum Calo tower pT variable in the eta range 2.650 to 5.191",1000,-5000,5000);
+      
+  }
+
+  // particle flow variables histograms 
+  mSumpt           = ibooker.book1D("SumpT","Sum p_{T} of all the PF candidates per event",1000,0,10000);
+  mvn              = ibooker.book1D("vn","vn",100,0,10);
+  mpsin            = ibooker.book1D("mpsin","psin",100,0,10);
+
+  // Event variables
+  mNvtx            = ibooker.book1D("Nvtx",           "number of vertices", 60, 0, 60);
+  mHF              = ibooker.book1D("HF", "HF energy distribution",1000,0,10000);
+
+  // added Jan 12th 2015
+  mDeltapT  = ibooker.book1D("DeltapT","amount subtracted from candidate",400,-200,200);
+  //mDeltapT_HF  = ibooker.book2D("DeltapT_HF","",400,-200,200,1000,0,10000);
+  mDeltapT_eta = ibooker.book2D("DeltapT_eta","",60,-6,+6,400,-200,200);
+  // //mDeltapT_phiMinusPsi2 = ibooker.book2D("DeltapT_phiMinusPsi2","",400,-200,200,35,-1.75,1.75);
+  // mDeltapT_eta_phi = ibooker.book2D("DeltapT_eta_phi",h2D_etabins_vs_phi);
+    
+  // Jet parameters
+  mEta             = ibooker.book1D("Eta",          "Eta",          120,   -6,    6); 
+  mPhi             = ibooker.book1D("Phi",          "Phi",           70, -3.5,  3.5); 
+  mPt              = ibooker.book1D("Pt",           "Pt",           100,    0,  1000); 
+  mP               = ibooker.book1D("P",            "P",            100,    0,  1000); 
+  mEnergy          = ibooker.book1D("Energy",       "Energy",       100,    0,  1000); 
+  mMass            = ibooker.book1D("Mass",         "Mass",         100,    0,  200); 
+  mConstituents    = ibooker.book1D("Constituents", "Constituents", 100,    0,  100); 
+  mJetArea         = ibooker.book1D("JetArea",      "JetArea",       100,   0, 4);
+  mjetpileup       = ibooker.book1D("jetPileUp","jetPileUp",100,0,150);
+  mNJets_40        = ibooker.book1D("NJets_pt_greater_40", "NJets pT > 40 GeV",  50,    0,   100);
+  mNJets        = ibooker.book1D("NJets", "NJets",  50,    0,   100);
+
+  // mVs_0_x  = ibooker.book1D("Vs_0_x","flow modulated sumpT from both HF (+ and -) with cos, vn = 0",1000,-10000,10000);
+  // mVs_0_y  = ibooker.book1D("Vs_0_y","flow modulated sumpT from both HF (+ and -) with sin, vn = 0",1000,-10000,10000);
+  // mVs_1_x  = ibooker.book1D("Vs_1_x","flow modulated sumpT from both HF (+ and -) with cos, vn = 1",1000,-10000,10000);
+  // mVs_1_y  = ibooker.book1D("Vs_1_y","flow modulated sumpT from both HF (+ and -) with sin, vn = 1",1000,-10000,10000);
+  // mVs_2_x  = ibooker.book1D("Vs_2_x","flow modulated sumpT from both HF (+ and -) with cos, vn = 2",1000,-10000,10000);
+  // mVs_2_y  = ibooker.book1D("Vs_2_y","flow modulated sumpT from both HF (+ and -) with sin, vn = 2",1000,-10000,10000);
+    
+  // mVs_0_x_versus_HF = ibooker.book2D("Vs_0_x_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with cos, vn = 0 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
+  // mVs_0_y_versus_HF = ibooker.book2D("Vs_0_y_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with sin, vn = 0 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
+  // mVs_1_x_versus_HF = ibooker.book2D("Vs_1_x_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with cos, vn = 1 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
+  // mVs_1_y_versus_HF = ibooker.book2D("Vs_1_y_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with sin, vn = 1 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
+  // mVs_2_x_versus_HF = ibooker.book2D("Vs_2_x_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with cos, vn = 2 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
+  // mVs_2_y_versus_HF = ibooker.book2D("Vs_2_y_versus_HF","flow modulated sumpT (y axis) from both HF (+ and -) with sin, vn = 2 versus HF energy (x axis)",1000,0,10000,1000,-10000,10000);
+
+  mPtRecoOverGen_B_20_30_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_20_30_Cent_0_10",    "20<genpt<30; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_20_30_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_20_30_Cent_0_10",    "20<genpt<30; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_20_30_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_20_30_Cent_0_10",    "20<genpt<30; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_30_50_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_30_50_Cent_0_10",    "30<genpt<50; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_30_50_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_30_50_Cent_0_10",    "30<genpt<50; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_30_50_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_30_50_Cent_0_10",    "30<genpt<50; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_50_80_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_50_80_Cent_0_10",    "50<genpt<80; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_50_80_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_50_80_Cent_0_10",    "50<genpt<80; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_50_80_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_50_80_Cent_0_10",    "50<genpt<80; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_80_120_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_80_120_Cent_0_10",    "80<genpt<120; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_80_120_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_80_120_Cent_0_10",    "80<genpt<120; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_80_120_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_80_120_Cent_0_10",    "80<genpt<120; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_120_180_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_120_180_Cent_0_10",    "120<genpt<180; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_120_180_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_120_180_Cent_0_10",    "120<genpt<180; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_120_180_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_120_180_Cent_0_10",    "120<genpt<180; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_180_300_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_180_300_Cent_0_10",    "180<genpt<300; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_180_300_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_180_300_Cent_0_10",    "180<genpt<300; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_180_300_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_180_300_Cent_0_10",    "180<genpt<300; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_300_Inf_Cent_0_10    = ibooker.book1D("PtRecoOverGen_B_300_Inf_Cent_0_10",    "300<genpt<Inf; recopt/genpt (0-10%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_300_Inf_Cent_0_10    = ibooker.book1D("PtRecoOverGen_E_300_Inf_Cent_0_10",    "300<genpt<Inf; recopt/genpt (0-10%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_300_Inf_Cent_0_10    = ibooker.book1D("PtRecoOverGen_F_300_Inf_Cent_0_10",    "300<genpt<Inf; recopt/genpt (0-10%) (Forward);counts",    90, 0, 2);
+
+
+  mPtRecoOverGen_B_20_30_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_20_30_Cent_10_30",    "20<genpt<30; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_20_30_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_20_30_Cent_10_30",    "20<genpt<30; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_20_30_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_20_30_Cent_10_30",    "20<genpt<30; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_30_50_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_30_50_Cent_10_30",    "30<genpt<50; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_30_50_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_30_50_Cent_10_30",    "30<genpt<50; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_30_50_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_30_50_Cent_10_30",    "30<genpt<50; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_50_80_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_50_80_Cent_10_30",    "50<genpt<80; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_50_80_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_50_80_Cent_10_30",    "50<genpt<80; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_50_80_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_50_80_Cent_10_30",    "50<genpt<80; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_80_120_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_80_120_Cent_10_30",    "80<genpt<120; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_80_120_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_80_120_Cent_10_30",    "80<genpt<120; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_80_120_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_80_120_Cent_10_30",    "80<genpt<120; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_120_180_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_120_180_Cent_10_30",    "120<genpt<180; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_120_180_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_120_180_Cent_10_30",    "120<genpt<180; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_120_180_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_120_180_Cent_10_30",    "120<genpt<180; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_180_300_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_180_300_Cent_10_30",    "180<genpt<300; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_180_300_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_180_300_Cent_10_30",    "180<genpt<300; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_180_300_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_180_300_Cent_10_30",    "180<genpt<300; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_300_Inf_Cent_10_30    = ibooker.book1D("PtRecoOverGen_B_300_Inf_Cent_10_30",    "300<genpt<Inf; recopt/genpt (10-30%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_300_Inf_Cent_10_30    = ibooker.book1D("PtRecoOverGen_E_300_Inf_Cent_10_30",    "300<genpt<Inf; recopt/genpt (10-30%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_300_Inf_Cent_10_30    = ibooker.book1D("PtRecoOverGen_F_300_Inf_Cent_10_30",    "300<genpt<Inf; recopt/genpt (10-30%) (Forward);counts",    90, 0, 2);
+    
+    
+  mPtRecoOverGen_B_20_30_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_20_30_Cent_30_50",    "20<genpt<30; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_20_30_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_20_30_Cent_30_50",    "20<genpt<30; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_20_30_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_20_30_Cent_30_50",    "20<genpt<30; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_30_50_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_30_50_Cent_30_50",    "30<genpt<50; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_30_50_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_30_50_Cent_30_50",    "30<genpt<50; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_30_50_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_30_50_Cent_30_50",    "30<genpt<50; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_50_80_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_50_80_Cent_30_50",    "50<genpt<80; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_50_80_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_50_80_Cent_30_50",    "50<genpt<80; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_50_80_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_50_80_Cent_30_50",    "50<genpt<80; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_80_120_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_80_120_Cent_30_50",    "80<genpt<120; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_80_120_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_80_120_Cent_30_50",    "80<genpt<120; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_80_120_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_80_120_Cent_30_50",    "80<genpt<120; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_120_180_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_120_180_Cent_30_50",    "120<genpt<180; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_120_180_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_120_180_Cent_30_50",    "120<genpt<180; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_120_180_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_120_180_Cent_30_50",    "120<genpt<180; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_180_300_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_180_300_Cent_30_50",    "180<genpt<300; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_180_300_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_180_300_Cent_30_50",    "180<genpt<300; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_180_300_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_180_300_Cent_30_50",    "180<genpt<300; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_300_Inf_Cent_30_50    = ibooker.book1D("PtRecoOverGen_B_300_Inf_Cent_30_50",    "300<genpt<Inf; recopt/genpt (30-50%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_300_Inf_Cent_30_50    = ibooker.book1D("PtRecoOverGen_E_300_Inf_Cent_30_50",    "300<genpt<Inf; recopt/genpt (30-50%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_300_Inf_Cent_30_50    = ibooker.book1D("PtRecoOverGen_F_300_Inf_Cent_30_50",    "300<genpt<Inf; recopt/genpt (30-50%) (Forward);counts",    90, 0, 2);
+
+  mPtRecoOverGen_B_20_30_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_20_30_Cent_50_80",    "20<genpt<30; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_20_30_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_20_30_Cent_50_80",    "20<genpt<30; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_20_30_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_20_30_Cent_50_80",    "20<genpt<30; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_50_80_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_50_80_Cent_50_80",    "30<genpt<50; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_50_80_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_50_80_Cent_50_80",    "30<genpt<50; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_50_80_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_50_80_Cent_50_80",    "30<genpt<50; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_50_80_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_50_80_Cent_50_80",    "50<genpt<80; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_50_80_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_50_80_Cent_50_80",    "50<genpt<80; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_50_80_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_50_80_Cent_50_80",    "50<genpt<80; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_80_120_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_80_120_Cent_50_80",    "80<genpt<120; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_80_120_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_80_120_Cent_50_80",    "80<genpt<120; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_80_120_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_80_120_Cent_50_80",    "80<genpt<120; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_120_180_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_120_180_Cent_50_80",    "120<genpt<180; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_120_180_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_120_180_Cent_50_80",    "120<genpt<180; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_120_180_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_120_180_Cent_50_80",    "120<genpt<180; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_180_300_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_180_300_Cent_50_80",    "180<genpt<300; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_180_300_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_180_300_Cent_50_80",    "180<genpt<300; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_180_300_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_180_300_Cent_50_80",    "180<genpt<300; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+  mPtRecoOverGen_B_300_Inf_Cent_50_80    = ibooker.book1D("PtRecoOverGen_B_300_Inf_Cent_50_80",    "300<genpt<Inf; recopt/genpt (50-80%) (Barrel);counts",    90, 0, 2);
+  mPtRecoOverGen_E_300_Inf_Cent_50_80    = ibooker.book1D("PtRecoOverGen_E_300_Inf_Cent_50_80",    "300<genpt<Inf; recopt/genpt (50-80%) (EndCap);counts",    90, 0, 2);
+  mPtRecoOverGen_F_300_Inf_Cent_50_80    = ibooker.book1D("PtRecoOverGen_F_300_Inf_Cent_50_80",    "300<genpt<Inf; recopt/genpt (50-80%) (Forward);counts",    90, 0, 2);
+
+
+  mPtRecoOverGen_GenPt_B_Cent_0_10          = ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_0_10",          Form("|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", BarrelEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_E_Cent_0_10          = ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_0_10",          Form("%2.2f<|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", BarrelEta, EndcapEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_F_Cent_0_10          = ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_0_10",          Form("%2.2f<|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", EndcapEta, ForwardEta),       log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_B_Cent_10_30          = ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_10_30",          Form("|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", BarrelEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_E_Cent_10_30          = ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_10_30",          Form("%2.2f<|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", BarrelEta, EndcapEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_F_Cent_10_30          = ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_10_30",          Form("%2.2f<|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", EndcapEta, ForwardEta),       log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_B_Cent_30_50          = ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_30_50",          Form("|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", BarrelEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_E_Cent_30_50          = ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_30_50",          Form("%2.2f<|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", BarrelEta, EndcapEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_F_Cent_30_50          = ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_30_50",          Form("%2.2f<|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", EndcapEta, ForwardEta),       log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_B_Cent_50_80          = ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_50_80",          Form("|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", BarrelEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_E_Cent_50_80          = ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_50_80",          Form("%2.2f<|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", BarrelEta, EndcapEta),     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_F_Cent_50_80          = ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_50_80",          Form("%2.2f<|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", EndcapEta, ForwardEta),       log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+
+  mPtRecoOverGen_GenEta_20_30_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_20_30_Cent_0_10","20<genpt<30 (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_30_50_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_30_50_Cent_0_10","30<genpt<50 (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_50_80_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_50_80_Cent_0_10","50<genpt<80 (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_80_120_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_80_120_Cent_0_10","80<genpt<120 (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_120_180_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_120_180_Cent_0_10","120<genpt<180 (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_180_300_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_180_300_Cent_0_10","180<genpt<300 (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_300_Inf_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenEta_300_Inf_Cent_0_10","300<genpt<Inf (0-10%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+    
+
+  mPtRecoOverGen_GenEta_20_30_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_20_30_Cent_10_30","20<genpt<30 (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_30_50_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_30_50_Cent_10_30","30<genpt<50 (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_50_80_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_50_80_Cent_10_30","50<genpt<80 (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_80_120_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_80_120_Cent_10_30","80<genpt<120 (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_120_180_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_120_180_Cent_10_30","120<genpt<180 (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_180_300_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_180_300_Cent_10_30","180<genpt<300 (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_300_Inf_Cent_10_30 = ibooker.bookProfile("PtRecoOverGen_GenEta_300_Inf_Cent_10_30","300<genpt<Inf (10-30%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+
+  mPtRecoOverGen_GenEta_20_30_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_20_30_Cent_30_50","20<genpt<30 (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_30_50_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_30_50_Cent_30_50","30<genpt<50 (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_50_80_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_50_80_Cent_30_50","50<genpt<80 (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_80_120_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_80_120_Cent_30_50","80<genpt<120 (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_120_180_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_120_180_Cent_30_50","120<genpt<180 (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_180_300_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_180_300_Cent_30_50","180<genpt<300 (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_300_Inf_Cent_30_50 = ibooker.bookProfile("PtRecoOverGen_GenEta_300_Inf_Cent_30_50","300<genpt<Inf (30-50%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+
+  mPtRecoOverGen_GenEta_20_30_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_20_30_Cent_50_80","20<genpt<30 (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_50_80_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_50_80_Cent_50_80","30<genpt<50 (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_50_80_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_50_80_Cent_50_80","50<genpt<80 (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_80_120_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_80_120_Cent_50_80","80<genpt<120 (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_120_180_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_120_180_Cent_50_80","120<genpt<180 (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_180_300_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_180_300_Cent_50_80","180<genpt<300 (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_300_Inf_Cent_50_80 = ibooker.bookProfile("PtRecoOverGen_GenEta_300_Inf_Cent_50_80","300<genpt<Inf (50-80%);geneta;recopt/genpt",90, etaRange, 0, 2, " ");
+    
+    
+  if (mOutputFile.empty ()) 
+    LogInfo("OutputInfo") << " Histograms will NOT be saved";
+  else 
+    LogInfo("OutputInfo") << " Histograms will be saved to file:" << mOutputFile;
+
+  delete h2D_etabins_vs_pt2;
+  delete h2D_etabins_vs_pt;
+  delete h2D_etabins_vs_phi;
+  delete h2D_pfcand_etabins_vs_pt;
+}
 
 
 
@@ -615,7 +968,30 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
   edm::Handle<edm::ValueMap<VoronoiBackground> > VsBackgrounds;
   edm::Handle<std::vector<float> > vn_;
 
+  // get the centrality 
   edm::Handle<reco::Centrality> cent;
+  mEvent.getByToken(centralityToken, cent);  //_centralitytag comes from the cfg
+
+  mHF->Fill(cent->EtHFtowerSum());
+  Float_t HF_energy = cent->EtHFtowerSum();
+  
+  edm::Handle<int> cbin;
+  mEvent.getByToken(centralityBinToken, cbin);
+  if (!cent.isValid()) return;
+  int hibin = -999;
+  if(cent.isValid()){
+    hibin = *cbin;
+  }
+
+  bool isCentral = false;
+  bool ismidCentral = false;
+  bool ismidPeripheral = false;
+  bool isPeripheral = false;
+
+  if(hibin < 20) isCentral = true;
+  if(hibin >= 20 && hibin < 60) ismidCentral = true;
+  if(hibin >= 60 && hibin < 100) ismidPeripheral = true;
+  if(hibin >= 100 && hibin < 160) isPeripheral = true;
   
   // for example
   // edm::Handle<PFCandidate /*name of actual handle*/> pfcand;
@@ -637,12 +1013,6 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
   mEvent.getByToken(backgrounds_, VsBackgrounds);
   mEvent.getByToken(backgrounds_value_, vn_);
 
-  // get the centrality 
-  mEvent.getByToken(centralityToken_, cent);
-
-  mHF->Fill(cent->EtHFtowerSum());
-  Float_t HF_energy = cent->EtHFtowerSum();
-
   //std::cout<<"HF energy = "<<HF_energy<<std::endl;
   
   const reco::PFCandidateCollection *pfCandidateColl = pfCandidates.product();
@@ -655,58 +1025,59 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
   Int_t NCaloTower = 0;
   Float_t pfPt = 0;
   Float_t pfEta = 0;
+  Int_t   pfID = 0;
   Float_t pfPhi = 0;
   Float_t caloPt = 0;
   Float_t caloEta = 0;
   Float_t caloPhi = 0;
   Float_t SumPt_value = 0;
-  Float_t vn_value[200];
-  Float_t psin_value[200];
+  // Float_t vn_value[200];
+  // Float_t psin_value[200];
   
-  Float_t vn[fourierOrder_][etaBins_];
-  Float_t psin[fourierOrder_][etaBins_];
-  Float_t sumpT[etaBins_];
+  // Float_t vn[fourierOrder_][etaBins_];
+  // Float_t psin[fourierOrder_][etaBins_];
+  //Float_t sumpT[etaBins_];
   
   double edge_pseudorapidity[etaBins_ +1] = {-5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522, 0.522, 0.783, 1.131, 1.479, 1.740, 2.043, 2.650, 5.191 };
   
   UEParameters vnUE(vn_.product(),fourierOrder_,etaBins_);
   
-  for(int ieta = 0;ieta<etaBins_;++ieta){
-    sumpT[ieta] = vnUE.get_sum_pt(ieta);
-    for(int ifour = 0;ifour<fourierOrder_; ++ifour){
-      vn[ifour][ieta] = vnUE.get_vn(ifour,ieta);
-      vn_value[ifour * etaBins_ + ieta]= vnUE.get_vn(ifour,ieta);
-      mvn->Fill(vn_value[ifour * etaBins_ + ieta]);
+  // for(int ieta = 0;ieta<etaBins_;++ieta){
+  //   sumpT[ieta] = vnUE.get_sum_pt(ieta);
+    // for(int ifour = 0;ifour<fourierOrder_; ++ifour){
+    //   vn[ifour][ieta] = vnUE.get_vn(ifour,ieta);
+    //   vn_value[ifour * etaBins_ + ieta]= vnUE.get_vn(ifour,ieta);
+    //   mvn->Fill(vn_value[ifour * etaBins_ + ieta]);
       
-      psin[ifour][ieta] = vnUE.get_psin(ifour,ieta);
-      psin_value[ifour * etaBins_ + ieta] = vnUE.get_psin(ifour,ieta);
-      mpsin->Fill(psin_value[ifour * etaBins_ + ieta]);
+    //   psin[ifour][ieta] = vnUE.get_psin(ifour,ieta);
+    //   psin_value[ifour * etaBins_ + ieta] = vnUE.get_psin(ifour,ieta);
+    //   mpsin->Fill(psin_value[ifour * etaBins_ + ieta]);
       
-    }
-  }
+    // }
+  //  }
   
   
   //lets start making the necessary plots 
-  Float_t Vs_0_x_minus = sumpT[0]*vn[0][0]*TMath::Cos(0*psin[0][0]);
-  Float_t Vs_0_x_plus = sumpT[14]*vn[0][14]*TMath::Cos(0*psin[0][14]);
-  Float_t Vs_0_y_minus = sumpT[0]*vn[0][0]*TMath::Sin(0*psin[0][0]);
-  Float_t Vs_0_y_plus = sumpT[14]*vn[0][14]*TMath::Sin(0*psin[0][14]);
-  Float_t Vs_0_x = Vs_0_x_minus + Vs_0_x_plus;
-  Float_t Vs_0_y = Vs_0_y_minus + Vs_0_y_plus;
+  // Float_t Vs_0_x_minus = sumpT[0]*vn[0][0]*TMath::Cos(0*psin[0][0]);
+  // Float_t Vs_0_x_plus = sumpT[14]*vn[0][14]*TMath::Cos(0*psin[0][14]);
+  // Float_t Vs_0_y_minus = sumpT[0]*vn[0][0]*TMath::Sin(0*psin[0][0]);
+  // Float_t Vs_0_y_plus = sumpT[14]*vn[0][14]*TMath::Sin(0*psin[0][14]);
+  // Float_t Vs_0_x = Vs_0_x_minus + Vs_0_x_plus;
+  // Float_t Vs_0_y = Vs_0_y_minus + Vs_0_y_plus;
   
-  Float_t Vs_1_x_minus = sumpT[0]*vn[1][0]*TMath::Cos(1*psin[1][0]);
-  Float_t Vs_1_x_plus = sumpT[14]*vn[1][14]*TMath::Cos(1*psin[1][14]);
-  Float_t Vs_1_y_minus = sumpT[0]*vn[1][0]*TMath::Sin(1*psin[1][0]);
-  Float_t Vs_1_y_plus = sumpT[14]*vn[1][14]*TMath::Sin(1*psin[1][14]);
-  Float_t Vs_1_x = Vs_1_x_minus + Vs_1_x_plus;
-  Float_t Vs_1_y = Vs_1_y_minus + Vs_1_y_plus;
+  // Float_t Vs_1_x_minus = sumpT[0]*vn[1][0]*TMath::Cos(1*psin[1][0]);
+  // Float_t Vs_1_x_plus = sumpT[14]*vn[1][14]*TMath::Cos(1*psin[1][14]);
+  // Float_t Vs_1_y_minus = sumpT[0]*vn[1][0]*TMath::Sin(1*psin[1][0]);
+  // Float_t Vs_1_y_plus = sumpT[14]*vn[1][14]*TMath::Sin(1*psin[1][14]);
+  // Float_t Vs_1_x = Vs_1_x_minus + Vs_1_x_plus;
+  // Float_t Vs_1_y = Vs_1_y_minus + Vs_1_y_plus;
   
-  Float_t Vs_2_x_minus = sumpT[0]*vn[2][0]*TMath::Cos(2*psin[2][0]);
-  Float_t Vs_2_x_plus = sumpT[14]*vn[2][14]*TMath::Cos(2*psin[2][14]);
-  Float_t Vs_2_y_minus = sumpT[0]*vn[2][0]*TMath::Sin(2*psin[2][0]);
-  Float_t Vs_2_y_plus = sumpT[14]*vn[2][14]*TMath::Sin(2*psin[2][14]);
-  Float_t Vs_2_x = Vs_2_x_minus + Vs_2_x_plus;
-  Float_t Vs_2_y = Vs_2_y_minus + Vs_2_y_plus;
+  // Float_t Vs_2_x_minus = sumpT[0]*vn[2][0]*TMath::Cos(2*psin[2][0]);
+  // Float_t Vs_2_x_plus = sumpT[14]*vn[2][14]*TMath::Cos(2*psin[2][14]);
+  // Float_t Vs_2_y_minus = sumpT[0]*vn[2][0]*TMath::Sin(2*psin[2][0]);
+  // Float_t Vs_2_y_plus = sumpT[14]*vn[2][14]*TMath::Sin(2*psin[2][14]);
+  // Float_t Vs_2_x = Vs_2_x_minus + Vs_2_x_plus;
+  // Float_t Vs_2_y = Vs_2_y_minus + Vs_2_y_plus;
   
   // Float_t Vs_3_x_minus = sumpT[0]*vn[3][0]*TMath::Cos(3*psin[3][0]);
   // Float_t Vs_3_x_plus = sumpT[14]*vn[3][14]*TMath::Cos(3*psin[3][14]);
@@ -722,19 +1093,19 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
   // Float_t Vs_4_x = Vs_4_x_minus + Vs_4_x_plus;
   // Float_t Vs_4_y = Vs_4_y_minus + Vs_4_y_plus;
 
-  mVs_0_x->Fill(Vs_0_x);
-  mVs_0_y->Fill(Vs_0_y);
-  mVs_1_x->Fill(Vs_1_x);
-  mVs_1_y->Fill(Vs_1_y);
-  mVs_2_x->Fill(Vs_2_x);
-  mVs_2_y->Fill(Vs_2_y);
+  // mVs_0_x->Fill(Vs_0_x);
+  // mVs_0_y->Fill(Vs_0_y);
+  // mVs_1_x->Fill(Vs_1_x);
+  // mVs_1_y->Fill(Vs_1_y);
+  // mVs_2_x->Fill(Vs_2_x);
+  // mVs_2_y->Fill(Vs_2_y);
 
-  mVs_0_x_versus_HF->Fill(HF_energy,Vs_0_x);
-  mVs_0_y_versus_HF->Fill(HF_energy,Vs_0_y);
-  mVs_1_x_versus_HF->Fill(HF_energy,Vs_1_x);
-  mVs_1_y_versus_HF->Fill(HF_energy,Vs_1_y);
-  mVs_2_x_versus_HF->Fill(HF_energy,Vs_2_x);
-  mVs_2_y_versus_HF->Fill(HF_energy,Vs_2_y);
+  // mVs_0_x_versus_HF->Fill(HF_energy,Vs_0_x);
+  // mVs_0_y_versus_HF->Fill(HF_energy,Vs_0_y);
+  // mVs_1_x_versus_HF->Fill(HF_energy,Vs_1_x);
+  // mVs_1_y_versus_HF->Fill(HF_energy,Vs_1_y);
+  // mVs_2_x_versus_HF->Fill(HF_energy,Vs_2_x);
+  // mVs_2_y_versus_HF->Fill(HF_energy,Vs_2_y);
 
   Float_t DeltapT = 0;
 
@@ -759,7 +1130,7 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
     }
 
     for(unsigned icand = 0;icand<caloCandidates->size(); icand++){
-    //for(unsigned icand = 0;icand<10; icand++){
+      //for(unsigned icand = 0;icand<10; icand++){
 
       const CaloTower & tower  = (*caloCandidates)[icand];
       reco::CandidateViewRef ref(calocandidates_,icand);
@@ -794,16 +1165,16 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
       //std::cout<<"vsPt = "<<vsPt<<std::endl;
       //std::cout<<"tower eta = "<<caloEta<<std::endl;
 
-      mCaloVsPtInitial_eta_phi->Fill(caloEta,caloPhi,vsPtInitial);
-      mCaloVsPt_eta_phi->Fill(caloEta,caloPhi,vsPt);
-      mCaloPt_eta_phi->Fill(caloEta,caloPhi,caloPt);
+      // mCaloVsPtInitial_eta_phi->Fill(caloEta,caloPhi,vsPtInitial);
+      // mCaloVsPt_eta_phi->Fill(caloEta,caloPhi,vsPt);
+      // mCaloPt_eta_phi->Fill(caloEta,caloPhi,caloPt);
 
       DeltapT = caloPt - vsPtInitial;
       //std::cout<<"Delta pT = "<<DeltapT<<std::endl;
       
       mDeltapT->Fill(DeltapT);
       mDeltapT_eta->Fill(caloEta,DeltapT);
-      mDeltapT_eta_phi->Fill(caloEta,caloPhi,DeltapT);
+      // mDeltapT_eta_phi->Fill(caloEta,caloPhi,DeltapT);
 
       for(size_t k = 0;k<nedge_pseudorapidity-1; k++){
 	if(caloEta >= edge_pseudorapidity[k] && caloEta < edge_pseudorapidity[k+1]){
@@ -909,13 +1280,13 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
       //mSumSquaredCaloPt->Fill(SumSquaredCaloPt[k]);
       Evt_SumSquaredCaloPt = Evt_SumSquaredCaloPt + SumSquaredCaloPt[k];
       
-      mSumCaloVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumCaloVsPtInitial[k]);
-      mSumCaloVsPt_eta->Fill(edge_pseudorapidity[k],SumCaloVsPt[k]);
-      mSumCaloPt_eta->Fill(edge_pseudorapidity[k],SumCaloPt[k]);
+      // mSumCaloVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumCaloVsPtInitial[k]);
+      // mSumCaloVsPt_eta->Fill(edge_pseudorapidity[k],SumCaloVsPt[k]);
+      // mSumCaloPt_eta->Fill(edge_pseudorapidity[k],SumCaloPt[k]);
       
-      mSumSquaredCaloVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumSquaredCaloVsPtInitial[k]);
-      mSumSquaredCaloVsPt_eta->Fill(edge_pseudorapidity[k],SumSquaredCaloVsPt[k]);
-      mSumSquaredCaloPt_eta->Fill(edge_pseudorapidity[k],SumSquaredCaloPt[k]);
+      // mSumSquaredCaloVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumSquaredCaloVsPtInitial[k]);
+      // mSumSquaredCaloVsPt_eta->Fill(edge_pseudorapidity[k],SumSquaredCaloVsPt[k]);
+      // mSumSquaredCaloPt_eta->Fill(edge_pseudorapidity[k],SumSquaredCaloPt[k]);
 
       //std::cout<<"eta iteration = "<<edge_pseudorapidity[k]<<std::endl;
       //std::cout<<"event value of sum tower pT = "<<Evt_SumCaloPt<<std::endl;
@@ -982,15 +1353,69 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
       pfPt = pfCandidate.pt();
       pfEta = pfCandidate.eta();
       pfPhi = pfCandidate.phi();
+      pfID = pfCandidate.particleId();
+
+      bool inBarrel = false; 
+      bool inEndcap = false; 
+      bool inForward = false; 
       
-      mPFVsPtInitial_eta_phi->Fill(pfEta,pfPhi,vsPtInitial);
-      mPFVsPt_eta_phi->Fill(pfEta,pfPhi,vsPt);
-      mPFPt_eta_phi->Fill(pfEta,pfPhi,pfPt);
+      if(fabs(pfEta)<BarrelEta) inBarrel = true;
+      if(fabs(pfEta)>=BarrelEta && fabs(pfEta)<EndcapEta) inEndcap = true;
+      if(fabs(pfEta)>=EndcapEta && fabs(pfEta)<ForwardEta) inForward = true;
+      
+      switch(pfID){
+      case 0 :
+	mPFCandpT_vs_eta_Unknown->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_Unknown->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_Unknown->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_Unknown->Fill(pfPt);
+      case 1 :
+	mPFCandpT_vs_eta_ChargedHadron->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_ChargedHadron->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_ChargedHadron->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_ChargedHadron->Fill(pfPt);
+      case 2 :
+	mPFCandpT_vs_eta_electron->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_electron->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_electron->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_electron->Fill(pfPt);
+      case 3 :
+	mPFCandpT_vs_eta_muon->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_muon->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_muon->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_muon->Fill(pfPt);
+      case 4 :
+	mPFCandpT_vs_eta_photon->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_photon->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_photon->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_photon->Fill(pfPt);
+      case 5 :
+	mPFCandpT_vs_eta_NeutralHadron->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_NeutralHadron->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_NeutralHadron->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_NeutralHadron->Fill(pfPt);
+      case 6 :
+	mPFCandpT_vs_eta_HadE_inHF->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_HadE_inHF->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_HadE_inHF->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_HadE_inHF->Fill(pfPt);
+      case 7 :
+	mPFCandpT_vs_eta_EME_inHF->Fill(pfPt, pfEta);
+	if(inBarrel) mPFCandpT_Barrel_EME_inHF->Fill(pfPt);
+	if(inEndcap) mPFCandpT_Endcap_EME_inHF->Fill(pfPt);
+	if(inForward) mPFCandpT_Forward_EME_inHF->Fill(pfPt);
+      }
+	
+
+      
+      // mPFVsPtInitial_eta_phi->Fill(pfEta,pfPhi,vsPtInitial);
+      // mPFVsPt_eta_phi->Fill(pfEta,pfPhi,vsPt);
+      // mPFPt_eta_phi->Fill(pfEta,pfPhi,pfPt);
 
       DeltapT = pfPt - vsPtInitial;
       mDeltapT->Fill(DeltapT);
       mDeltapT_eta->Fill(pfEta,DeltapT);
-      mDeltapT_eta_phi->Fill(pfEta,pfPhi,DeltapT);
+      // mDeltapT_eta_phi->Fill(pfEta,pfPhi,DeltapT);
 
       for(size_t k = 0;k<nedge_pseudorapidity-1; k++){
 	if(pfEta >= edge_pseudorapidity[k] && pfEta < edge_pseudorapidity[k+1]){
@@ -1001,7 +1426,6 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
 	  SumSquaredPFVsPtInitial[k] = SumSquaredPFVsPtInitial[k] + vsPtInitial*vsPtInitial;
 	  SumSquaredPFVsPt[k] = SumSquaredPFVsPt[k] + vsPt*vsPt;
 	  SumSquaredPFPt[k] = SumSquaredPFPt[k] + pfPt*pfPt;
-	  break;
 	  
 	}// eta selection statement 
       
@@ -1084,9 +1508,9 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
       //mSumPFPt->Fill(SumPFPt[k]);
       Evt_SumPFPt = Evt_SumPFPt + SumPFPt[k];
 
-      mSumPFVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumPFVsPtInitial[k]);
-      mSumPFVsPt_eta->Fill(edge_pseudorapidity[k],SumPFVsPt[k]);
-      mSumPFPt_eta->Fill(edge_pseudorapidity[k],SumPFPt[k]);
+      // mSumPFVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumPFVsPtInitial[k]);
+      // mSumPFVsPt_eta->Fill(edge_pseudorapidity[k],SumPFVsPt[k]);
+      // mSumPFPt_eta->Fill(edge_pseudorapidity[k],SumPFPt[k]);
 
       //mSumSquaredPFVsPtInitial->Fill(SumSquaredPFVsPtInitial[k]);
       Evt_SumSquaredPFVsPtInitial = Evt_SumSquaredPFVsPtInitial + SumSquaredPFVsPtInitial[k];
@@ -1095,9 +1519,9 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
       //mSumSquaredPFPt->Fill(SumSquaredPFPt[k]);
       Evt_SumSquaredPFPt = Evt_SumSquaredPFPt + SumSquaredPFPt[k];
 
-      mSumSquaredPFVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumSquaredPFVsPtInitial[k]);
-      mSumSquaredPFVsPt_eta->Fill(edge_pseudorapidity[k],SumSquaredPFVsPt[k]);
-      mSumSquaredPFPt_eta->Fill(edge_pseudorapidity[k],SumSquaredPFPt[k]);
+      // mSumSquaredPFVsPtInitial_eta->Fill(edge_pseudorapidity[k],SumSquaredPFVsPtInitial[k]);
+      // mSumSquaredPFVsPt_eta->Fill(edge_pseudorapidity[k],SumSquaredPFVsPt[k]);
+      // mSumSquaredPFPt_eta->Fill(edge_pseudorapidity[k],SumSquaredPFPt[k]);
 
       
     }// eta bin loop  
@@ -1175,19 +1599,404 @@ void JetTester_HeavyIons::analyze(const edm::Event& mEvent, const edm::EventSetu
   }
   
   if (mNJets_40) mNJets_40->Fill(nJet_40); 
+
+
+  // Gen level information:
+  if (!mEvent.isRealData()){
+
+    // Get ptHat
+    //------------------------------------------------------------------------
+    edm::Handle<GenEventInfoProduct> myGenEvt;
+    mEvent.getByToken(evtToken_, myGenEvt);
+
+    if (myGenEvt.isValid()) {
+      if(myGenEvt->hasBinningValues()){
+	double ptHat = myGenEvt->binningValues()[0];
+	if (mPtHat) mPtHat->Fill(ptHat);
+      }
+    }
+    // Gen jets
+    //------------------------------------------------------------------------
+    edm::Handle<GenJetCollection> genJets;
+    mEvent.getByToken(genJetsToken_, genJets);
+
+    if (!genJets.isValid()) return;
+      
+    for (GenJetCollection::const_iterator gjet=genJets->begin();  gjet!=genJets->end(); gjet++)	{
+      if(gjet->pt() > mMatchGenPtThreshold){
+	if (mGenEta) mGenEta->Fill(gjet->eta());
+	if (mGenPhi) mGenPhi->Fill(gjet->phi());
+	if (mGenPt)  mGenPt ->Fill(gjet->pt());
+      }
+    }
+
+    if (!(mInputGenCollection.label().empty())) {
+      for (GenJetCollection::const_iterator gjet=genJets->begin(); gjet!=genJets->end(); gjet++) {
+        if (fabs(gjet->eta()) > 6.) continue;  // Out of the detector 
+        if (gjet->pt() < mMatchGenPtThreshold) continue;
+        if (recoJets.size() <= 0) continue;
+
+	bool inBarrel = false; 
+	bool inEndcap = false; 
+	bool inForward = false; 
+	
+	if(fabs(gjet->eta())<BarrelEta) inBarrel = true;
+	if(fabs(gjet->eta())>=BarrelEta && fabs(gjet->eta())<EndcapEta) inEndcap = true;
+	if(fabs(gjet->eta())>=EndcapEta && fabs(gjet->eta())<ForwardEta) inForward = true;
+	
+        // pt response
+        //------------------------------------------------------------
+	int iMatch    =   -1;
+	double deltaRBest = 999;
+	double JetPtBest  =   0;
+	for (unsigned ijet=0; ijet<recoJets.size(); ++ijet) {
+	  double recoPt = recoJets[ijet].pt();
+	  if (recoPt > 10) {
+	    double delR = deltaR(gjet->eta(), gjet->phi(), recoJets[ijet].eta(), recoJets[ijet].phi());
+	    if (delR < deltaRBest) {
+	      deltaRBest = delR;
+	      JetPtBest  = recoPt;
+	      iMatch = ijet;
+	    }
+	  }
+	}
+	if (iMatch<0) continue;
+
+	//fillMatchHists(gjet->eta(),  gjet->phi(),  gjet->pt(), recoJets[iMatch].eta(), recoJets[iMatch].phi(),  recoJets[iMatch].pt(), hibin);
+	if(deltaRBest < mRThreshold){
+	  double genpt = gjet->pt();
+	  double geneta = gjet->eta();
+	  double response = JetPtBest / genpt;
+	  // Fill all the response histograms here: for each pT bin, eta region, centrality bin
+
+	  if(inBarrel) {
+	    if(isCentral)
+	      mPtRecoOverGen_GenPt_B_Cent_0_10->Fill(log10(genpt), response);
+	    if(ismidCentral)
+	      mPtRecoOverGen_GenPt_B_Cent_10_30->Fill(log10(genpt), response);
+	    if(ismidPeripheral)
+	      mPtRecoOverGen_GenPt_B_Cent_30_50->Fill(log10(genpt), response);
+	    if(isPeripheral)
+	      mPtRecoOverGen_GenPt_B_Cent_50_80->Fill(log10(genpt), response);
+	  }
+	  if(inEndcap) {
+	    if(isCentral)
+	      mPtRecoOverGen_GenPt_E_Cent_0_10->Fill(log10(genpt), response);
+	    if(ismidCentral)
+	      mPtRecoOverGen_GenPt_E_Cent_10_30->Fill(log10(genpt), response);
+	    if(ismidPeripheral)
+	      mPtRecoOverGen_GenPt_E_Cent_30_50->Fill(log10(genpt), response);
+	    if(isPeripheral)
+	      mPtRecoOverGen_GenPt_E_Cent_50_80->Fill(log10(genpt), response);
+	  }
+	  if(inForward) {
+	    if(isCentral)
+	      mPtRecoOverGen_GenPt_F_Cent_0_10->Fill(log10(genpt), response);
+	    if(ismidCentral)
+	      mPtRecoOverGen_GenPt_F_Cent_10_30->Fill(log10(genpt), response);
+	    if(ismidPeripheral)
+	      mPtRecoOverGen_GenPt_F_Cent_30_50->Fill(log10(genpt), response);
+	    if(isPeripheral)
+	      mPtRecoOverGen_GenPt_F_Cent_50_80->Fill(log10(genpt), response);
+	  }
+
+	  if( gjet->pt() >= 20 && gjet->pt() < 30 ){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_20_30_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_20_30_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_20_30_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_20_30_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_20_30_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_20_30_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_20_30_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_20_30_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_20_30_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_20_30_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_20_30_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_20_30_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_20_30_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_20_30_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_20_30_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_20_30_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 20-30
+
+	  if( gjet->pt() >= 30 && gjet->pt() < 50 ){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_30_50_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_30_50_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_30_50_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_30_50_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_30_50_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_30_50_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_30_50_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_30_50_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_30_50_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_30_50_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_30_50_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_30_50_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_30_50_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_30_50_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_30_50_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_30_50_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 30-50
+
+	  if( gjet->pt() >= 50 && gjet->pt() < 80 ){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_50_80_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_50_80_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_50_80_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_50_80_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_50_80_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_50_80_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_50_80_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_50_80_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_50_80_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_50_80_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_50_80_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_50_80_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_50_80_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_50_80_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_50_80_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_50_80_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 50-80
+
+	  if( gjet->pt() >= 80 && gjet->pt() < 120 ){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_80_120_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_80_120_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_80_120_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_80_120_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_80_120_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_80_120_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_80_120_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_80_120_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_80_120_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_80_120_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_80_120_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_80_120_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_80_120_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_80_120_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_80_120_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_80_120_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 80-120
+
+	  if( gjet->pt() >= 120 && gjet->pt() < 180 ){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_120_180_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_120_180_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_120_180_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_120_180_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_120_180_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_120_180_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_120_180_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_120_180_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_120_180_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_120_180_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_120_180_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_120_180_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_120_180_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_120_180_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_120_180_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_120_180_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 120-180
+
+	  if( gjet->pt() >= 180 && gjet->pt() < 300 ){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_180_300_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_180_300_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_180_300_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_180_300_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_180_300_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_180_300_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_180_300_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_180_300_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_180_300_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_180_300_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_180_300_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_180_300_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_180_300_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_180_300_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_180_300_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_180_300_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 180-300
+
+	  if(gjet->pt() >= 300){
+	    if(isCentral){
+	      mPtRecoOverGen_GenEta_300_Inf_Cent_0_10->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_300_Inf_Cent_0_10->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_300_Inf_Cent_0_10->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_300_Inf_Cent_0_10->Fill(response);	      
+	    }// 
+	    if(ismidCentral){
+	      mPtRecoOverGen_GenEta_300_Inf_Cent_10_30->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_300_Inf_Cent_10_30->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_300_Inf_Cent_10_30->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_300_Inf_Cent_10_30->Fill(response);	      
+	    }// 
+	    if(ismidPeripheral){
+	      mPtRecoOverGen_GenEta_300_Inf_Cent_30_50->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_300_Inf_Cent_30_50->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_300_Inf_Cent_30_50->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_300_Inf_Cent_30_50->Fill(response);	      
+	    }// 
+	    if(isPeripheral){
+	      mPtRecoOverGen_GenEta_300_Inf_Cent_50_80->Fill(geneta, response);
+	      if(inBarrel) 
+		mPtRecoOverGen_B_300_Inf_Cent_50_80->Fill(response);	      
+	      if(inEndcap)
+		mPtRecoOverGen_E_300_Inf_Cent_50_80->Fill(response);
+	      if(inForward)
+		mPtRecoOverGen_F_300_Inf_Cent_50_80->Fill(response);	      
+	    }// 
+	  }// pt bin 300-Inf
+	  
+	}// delta R < mRthreshold
+
+      }// gen jet collection loop
+
   
+    }// not empty gen collection
+
+  }// is the event real
+
 }
 
 
 //------------------------------------------------------------------------------
 // fillMatchHists
 //------------------------------------------------------------------------------
-void JetTester_HeavyIons::fillMatchHists(const double GenEta,
-			       const double GenPhi,
-			       const double GenPt,
-			       const double RecoEta,
-			       const double RecoPhi,
-			       const double RecoPt) 
-{
-  //nothing for now. 
-}
+// void JetTester_HeavyIons::fillMatchHists(const double GenEta,
+// 					 const double GenPhi,
+// 					 const double GenPt,
+// 					 const double RecoEta,
+// 					 const double RecoPhi,
+// 					 const double RecoPt,
+// 					 const double bin) 
+// {
+
+//   // nothing for now. 
+
+// }

--- a/Validation/RecoJets/plugins/JetTester_HeavyIons.h
+++ b/Validation/RecoJets/plugins/JetTester_HeavyIons.h
@@ -60,8 +60,12 @@
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "RecoJets/JetProducers/interface/JetMatchingTools.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 const Int_t MAXPARTICLE = 10000;
+const Double_t BarrelEta = 2.0;
+const Double_t EndcapEta = 3.0;
+const Double_t ForwardEta = 5.0;
 
 class MonitorElement;
 
@@ -89,7 +93,13 @@ class JetTester_HeavyIons : public DQMEDAnalyzer {
   edm::InputTag   mInputPFCandCollection;
   // edm::InputTag   mInputCandCollection;
   // edm::InputTag   rhoTag;
-  edm::InputTag   centrality;
+  edm::InputTag centralityTag_;
+  edm::EDGetTokenT<reco::Centrality> centralityToken;
+  edm::Handle<reco::Centrality> centrality_;
+
+  edm::InputTag centralityBinTag_;
+  edm::EDGetTokenT<int> centralityBinToken;
+  edm::Handle<int>centralityBin_;
   
   std::string     mOutputFile;
   std::string     JetType;
@@ -110,14 +120,13 @@ class JetTester_HeavyIons : public DQMEDAnalyzer {
   edm::EDGetTokenT<reco::BasicJetCollection> basicJetsToken_;
   edm::EDGetTokenT<reco::JPTJetCollection> jptJetsToken_;
   edm::EDGetTokenT<reco::GenJetCollection> genJetsToken_;
-  edm::EDGetTokenT<edm::HepMCProduct> evtToken_;
+  edm::EDGetTokenT<GenEventInfoProduct> evtToken_;
   edm::EDGetTokenT<reco::PFCandidateCollection> pfCandToken_; 
   edm::EDGetTokenT<reco::CandidateView> pfCandViewToken_;
   edm::EDGetTokenT<reco::CandidateView> caloCandViewToken_;
   //edm::EDGetTokenT<reco::VoronoiMap> backgrounds_;
   edm::EDGetTokenT<edm::ValueMap<reco::VoronoiBackground>> backgrounds_;
   edm::EDGetTokenT<std::vector<float>> backgrounds_value_;
-  edm::EDGetTokenT<reco::Centrality> centralityToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex> > hiVertexToken_;
   
   //Include Particle flow variables 
@@ -144,33 +153,33 @@ class JetTester_HeavyIons : public DQMEDAnalyzer {
   MonitorElement *mSumPFVsPtInitial;
   MonitorElement *mSumPFPt;
 
-  MonitorElement *mSumPFVsPtInitial_eta;
-  MonitorElement *mSumPFVsPt_eta;
-  MonitorElement *mSumPFPt_eta;
+  /* MonitorElement *mSumPFVsPtInitial_eta; */
+  /* MonitorElement *mSumPFVsPt_eta; */
+  /* MonitorElement *mSumPFPt_eta; */
 
   MonitorElement *mSumCaloVsPt;
   MonitorElement *mSumCaloVsPtInitial;
   MonitorElement *mSumCaloPt;
 
-  MonitorElement *mSumCaloVsPtInitial_eta;
-  MonitorElement *mSumCaloVsPt_eta;
-  MonitorElement *mSumCaloPt_eta;
+  /* MonitorElement *mSumCaloVsPtInitial_eta; */
+  /* MonitorElement *mSumCaloVsPt_eta; */
+  /* MonitorElement *mSumCaloPt_eta; */
 
   MonitorElement *mSumSquaredPFVsPt;
   MonitorElement *mSumSquaredPFVsPtInitial;
   MonitorElement *mSumSquaredPFPt;
 
-  MonitorElement *mSumSquaredPFVsPtInitial_eta;
-  MonitorElement *mSumSquaredPFVsPt_eta;
-  MonitorElement *mSumSquaredPFPt_eta;
+  /* MonitorElement *mSumSquaredPFVsPtInitial_eta; */
+  /* MonitorElement *mSumSquaredPFVsPt_eta; */
+  /* MonitorElement *mSumSquaredPFPt_eta; */
 
   MonitorElement *mSumSquaredCaloVsPt;
   MonitorElement *mSumSquaredCaloVsPtInitial;
   MonitorElement *mSumSquaredCaloPt;
 
-  MonitorElement *mSumSquaredCaloVsPtInitial_eta;
-  MonitorElement *mSumSquaredCaloVsPt_eta;
-  MonitorElement *mSumSquaredCaloPt_eta;
+  /* MonitorElement *mSumSquaredCaloVsPtInitial_eta; */
+  /* MonitorElement *mSumSquaredCaloVsPt_eta; */
+  /* MonitorElement *mSumSquaredCaloPt_eta; */
 
   // Event variables (including centrality)
   MonitorElement* mNvtx;
@@ -180,34 +189,34 @@ class JetTester_HeavyIons : public DQMEDAnalyzer {
   MonitorElement *mSumPFVsPt_HF;
   MonitorElement *mSumPFVsPtInitial_HF;
   MonitorElement *mSumPFPt_HF;
-  MonitorElement *mPFVsPtInitial_eta_phi;
-  MonitorElement *mPFVsPt_eta_phi;
-  MonitorElement *mPFPt_eta_phi;
+  /* MonitorElement *mPFVsPtInitial_eta_phi; */
+  /* MonitorElement *mPFVsPt_eta_phi; */
+  /* MonitorElement *mPFPt_eta_phi; */
   //MonitorElement *mSumDeltapT_HF;
   MonitorElement *mDeltapT;
   MonitorElement *mDeltapT_eta;
-  //MonitorElement *mDeltapT_phiMinusPsi2;
-  MonitorElement *mDeltapT_eta_phi;
+  /* //MonitorElement *mDeltapT_phiMinusPsi2; */
+  /* MonitorElement *mDeltapT_eta_phi; */
 
   MonitorElement *mSumCaloVsPt_HF;
   MonitorElement *mSumCaloVsPtInitial_HF;
   MonitorElement *mSumCaloPt_HF;
-  MonitorElement *mCaloVsPtInitial_eta_phi;
-  MonitorElement *mCaloVsPt_eta_phi;
-  MonitorElement *mCaloPt_eta_phi;
+  /* MonitorElement *mCaloVsPtInitial_eta_phi; */
+  /* MonitorElement *mCaloVsPt_eta_phi; */
+  /* MonitorElement *mCaloPt_eta_phi; */
 
-  MonitorElement *mVs_0_x;
-  MonitorElement *mVs_0_y;
-  MonitorElement *mVs_1_x;
-  MonitorElement *mVs_1_y;
-  MonitorElement *mVs_2_x;
-  MonitorElement *mVs_2_y;
-  MonitorElement *mVs_0_x_versus_HF;
-  MonitorElement *mVs_0_y_versus_HF;
-  MonitorElement *mVs_1_x_versus_HF;
-  MonitorElement *mVs_1_y_versus_HF;
-  MonitorElement *mVs_2_x_versus_HF;
-  MonitorElement *mVs_2_y_versus_HF;
+  /* MonitorElement *mVs_0_x; */
+  /* MonitorElement *mVs_0_y; */
+  /* MonitorElement *mVs_1_x; */
+  /* MonitorElement *mVs_1_y; */
+  /* MonitorElement *mVs_2_x; */
+  /* MonitorElement *mVs_2_y; */
+  /* MonitorElement *mVs_0_x_versus_HF; */
+  /* MonitorElement *mVs_0_y_versus_HF; */
+  /* MonitorElement *mVs_1_x_versus_HF; */
+  /* MonitorElement *mVs_1_y_versus_HF; */
+  /* MonitorElement *mVs_2_x_versus_HF; */
+  /* MonitorElement *mVs_2_y_versus_HF; */
   
   MonitorElement *mSumPFVsPtInitial_n5p191_n2p650;
   MonitorElement *mSumPFVsPtInitial_n2p650_n2p043;
@@ -319,6 +328,183 @@ class JetTester_HeavyIons : public DQMEDAnalyzer {
   MonitorElement* mNJets;
   MonitorElement* mNJets_40;
 
+  // histograms added on Oct 27th to study the gen-reco
+  MonitorElement* mGenEta;
+  MonitorElement* mGenPhi;
+  MonitorElement* mGenPt;
+  MonitorElement* mPtHat;
+
+  MonitorElement* mPtRecoOverGen_B_20_30_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_20_30_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_20_30_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_B_30_50_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_30_50_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_30_50_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_B_50_80_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_50_80_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_50_80_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_B_80_120_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_80_120_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_80_120_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_B_120_180_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_120_180_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_120_180_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_B_180_300_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_180_300_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_180_300_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_B_300_Inf_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_E_300_Inf_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_F_300_Inf_Cent_0_10;
+  
+  MonitorElement* mPtRecoOverGen_B_20_30_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_20_30_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_20_30_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_B_30_50_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_30_50_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_30_50_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_B_50_80_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_50_80_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_50_80_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_B_80_120_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_80_120_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_80_120_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_B_120_180_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_120_180_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_120_180_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_B_180_300_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_180_300_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_180_300_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_B_300_Inf_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_E_300_Inf_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_F_300_Inf_Cent_10_30;
+
+  MonitorElement* mPtRecoOverGen_B_20_30_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_20_30_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_20_30_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_B_30_50_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_30_50_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_30_50_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_B_50_80_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_50_80_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_50_80_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_B_80_120_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_80_120_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_80_120_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_B_120_180_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_120_180_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_120_180_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_B_180_300_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_180_300_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_180_300_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_B_300_Inf_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_E_300_Inf_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_F_300_Inf_Cent_30_50;
+
+  MonitorElement* mPtRecoOverGen_B_20_30_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_20_30_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_20_30_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_B_30_50_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_30_50_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_30_50_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_B_50_80_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_50_80_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_50_80_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_B_80_120_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_80_120_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_80_120_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_B_120_180_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_120_180_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_120_180_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_B_180_300_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_180_300_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_180_300_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_B_300_Inf_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_E_300_Inf_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_F_300_Inf_Cent_50_80;
+
+  // generation profiles
+  MonitorElement* mPtRecoOverGen_GenPt_B_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenPt_E_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenPt_F_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenPt_B_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenPt_E_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenPt_F_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenPt_B_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenPt_E_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenPt_F_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenPt_B_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenPt_E_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenPt_F_Cent_50_80;
+
+  MonitorElement* mPtRecoOverGen_GenEta_20_30_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenEta_30_50_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenEta_50_80_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenEta_80_120_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenEta_120_180_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenEta_180_300_Cent_0_10;
+  MonitorElement* mPtRecoOverGen_GenEta_300_Inf_Cent_0_10;
+
+  MonitorElement* mPtRecoOverGen_GenEta_20_30_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenEta_30_50_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenEta_50_80_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenEta_80_120_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenEta_120_180_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenEta_180_300_Cent_10_30;
+  MonitorElement* mPtRecoOverGen_GenEta_300_Inf_Cent_10_30;
+
+  MonitorElement* mPtRecoOverGen_GenEta_20_30_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenEta_30_50_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenEta_50_80_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenEta_80_120_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenEta_120_180_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenEta_180_300_Cent_30_50;
+  MonitorElement* mPtRecoOverGen_GenEta_300_Inf_Cent_30_50;
+  
+  MonitorElement* mPtRecoOverGen_GenEta_20_30_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenEta_30_50_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenEta_50_80_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenEta_80_120_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenEta_120_180_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenEta_180_300_Cent_50_80;
+  MonitorElement* mPtRecoOverGen_GenEta_300_Inf_Cent_50_80;
+  
+  MonitorElement* mPFCandpT_vs_eta_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_vs_eta_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_vs_eta_electron; // pf id - 2
+  MonitorElement* mPFCandpT_vs_eta_muon; // pf id - 3
+  MonitorElement* mPFCandpT_vs_eta_photon; // pf id - 4
+  MonitorElement* mPFCandpT_vs_eta_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_vs_eta_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_vs_eta_EME_inHF; // pf id - 7
+  
+  MonitorElement* mPFCandpT_Barrel_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_Barrel_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_Barrel_electron; // pf id - 2
+  MonitorElement* mPFCandpT_Barrel_muon; // pf id - 3
+  MonitorElement* mPFCandpT_Barrel_photon; // pf id - 4
+  MonitorElement* mPFCandpT_Barrel_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_Barrel_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_Barrel_EME_inHF; // pf id - 7
+
+  MonitorElement* mPFCandpT_Endcap_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_Endcap_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_Endcap_electron; // pf id - 2
+  MonitorElement* mPFCandpT_Endcap_muon; // pf id - 3
+  MonitorElement* mPFCandpT_Endcap_photon; // pf id - 4
+  MonitorElement* mPFCandpT_Endcap_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_Endcap_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_Endcap_EME_inHF; // pf id - 7
+
+  MonitorElement* mPFCandpT_Forward_Unknown; // pf id 0
+  MonitorElement* mPFCandpT_Forward_ChargedHadron; // pf id - 1 
+  MonitorElement* mPFCandpT_Forward_electron; // pf id - 2
+  MonitorElement* mPFCandpT_Forward_muon; // pf id - 3
+  MonitorElement* mPFCandpT_Forward_photon; // pf id - 4
+  MonitorElement* mPFCandpT_Forward_NeutralHadron; // pf id - 5
+  MonitorElement* mPFCandpT_Forward_HadE_inHF; // pf id - 6
+  MonitorElement* mPFCandpT_Forward_EME_inHF; // pf id - 7
+  
+ 
   // Parameters
 
   bool            isCaloJet;
@@ -330,7 +516,7 @@ class JetTester_HeavyIons : public DQMEDAnalyzer {
 
   static const size_t nedge_pseudorapidity = etaBins_ + 1;
 
- 
+
 };
 
 #endif

--- a/Validation/RecoJets/python/JetValidationHeavyIons_cff.py
+++ b/Validation/RecoJets/python/JetValidationHeavyIons_cff.py
@@ -26,7 +26,8 @@ JetAnalyzerICPU5Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -61,7 +62,8 @@ JetAnalyzerAkPU3Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -80,7 +82,8 @@ JetAnalyzerAkPU4Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -99,7 +102,8 @@ JetAnalyzerAkPU5Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -118,7 +122,8 @@ JetAnalyzerAkPU3PF = cms.EDAnalyzer("JetTester_HeavyIons",
                                     PFcands = cms.InputTag("particleFlowTmp"),
                                     Background = cms.InputTag("voronoiBackgroundPF"),
                                     #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
+                                    centralitycollection = cms.InputTag("hiCentrality"),
+                                    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                     JetCorrections = cms.string(""),
                                     recoJetPtThreshold = cms.double(10),        
                                     genEnergyFractionThreshold = cms.double(0.05),
@@ -137,7 +142,8 @@ JetAnalyzerAkPU4PF = cms.EDAnalyzer("JetTester_HeavyIons",
                                     PFcands = cms.InputTag("particleFlowTmp"),
                                     Background = cms.InputTag("voronoiBackgroundPF"),
                                     #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
+                                    centralitycollection = cms.InputTag("hiCentrality"),
+                                    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                     JetCorrections = cms.string(""),
                                     recoJetPtThreshold = cms.double(10),        
                                     genEnergyFractionThreshold = cms.double(0.05),
@@ -156,7 +162,8 @@ JetAnalyzerAkPU5PF = cms.EDAnalyzer("JetTester_HeavyIons",
                                     PFcands = cms.InputTag("particleFlowTmp"),
                                     Background = cms.InputTag("voronoiBackgroundPF"),
                                     #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
+                                    centralitycollection = cms.InputTag("hiCentrality"),
+                                    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                     JetCorrections = cms.string(""),
                                     recoJetPtThreshold = cms.double(10),        
                                     genEnergyFractionThreshold = cms.double(0.05),
@@ -176,7 +183,8 @@ JetAnalyzerAkVs2Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       #Cands = cms.InputTag("caloTowers"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -195,7 +203,8 @@ JetAnalyzerAkVs3Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -214,7 +223,8 @@ JetAnalyzerAkVs4Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -233,7 +243,8 @@ JetAnalyzerAkVs5Calo = cms.EDAnalyzer("JetTester_HeavyIons",
                                       PFcands = cms.InputTag("particleFlowTmp"),
                                       Background = cms.InputTag("voronoiBackgroundCalo"),
                                       #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                      centrality = cms.InputTag("hiCentrality"),
+                                      centralitycollection = cms.InputTag("hiCentrality"),
+                                      centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                       JetCorrections = cms.string(""),
                                       recoJetPtThreshold = cms.double(10),        
                                       genEnergyFractionThreshold = cms.double(0.05),
@@ -310,7 +321,8 @@ JetAnalyzerAkVs3PF = cms.EDAnalyzer("JetTester_HeavyIons",
                                     PFcands = cms.InputTag("particleFlowTmp"),
                                     Background = cms.InputTag("voronoiBackgroundPF"),
                                     #srcRho = cms.InputTag("akVs3PFJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
+                                    centralitycollection = cms.InputTag("hiCentrality"),
+                                    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                     JetCorrections = cms.string(""),
                                     recoJetPtThreshold = cms.double(10),        
                                     genEnergyFractionThreshold = cms.double(0.05),
@@ -330,7 +342,8 @@ JetAnalyzerAkVs4PF = cms.EDAnalyzer("JetTester_HeavyIons",
                                     PFcands = cms.InputTag("particleFlowTmp"),
                                     Background = cms.InputTag("voronoiBackgroundPF"),
                                     #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
+                                    centralitycollection = cms.InputTag("hiCentrality"),
+                                    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                     JetCorrections = cms.string(""),
                                     recoJetPtThreshold = cms.double(10),        
                                     genEnergyFractionThreshold = cms.double(0.05),
@@ -348,8 +361,9 @@ JetAnalyzerAkVs5PF = cms.EDAnalyzer("JetTester_HeavyIons",
                                     srcGen = cms.InputTag("ak5HiCleanedGenJets"),
                                     PFcands = cms.InputTag("particleFlowTmp"),
                                     Background = cms.InputTag("voronoiBackgroundPF"),
-                                      #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
-                                    centrality = cms.InputTag("hiCentrality"),
+                                    #srcRho = cms.InputTag("iterativeConePu5CaloJets","rho"),
+                                    centralitycollection = cms.InputTag("hiCentrality"),
+                                    centralitybincollection = cms.InputTag("centralityBin","HFtowers"),
                                     JetCorrections = cms.string(""),
                                     recoJetPtThreshold = cms.double(10),        
                                     genEnergyFractionThreshold = cms.double(0.05),
@@ -483,8 +497,8 @@ JetAnalyzerAk5PF = cms.EDAnalyzer("JetTester",
 hiJetValidation = cms.Sequence(
     #ak2HiCleanedGenJets
     ak3HiCleanedGenJets
-    #* ak4HiCleanedGenJets 
-    #* ak5HiCleanedGenJets
+    * ak4HiCleanedGenJets 
+    * ak5HiCleanedGenJets
 
     #* iterativeCone7HiCleanedGenJets
     #* iterativeCone5HiCleanedGenJets
@@ -492,24 +506,24 @@ hiJetValidation = cms.Sequence(
     #* JetAnalyzerICPU5Calo
 
     * JetAnalyzerAkPU3Calo
-    #* JetAnalyzerAkPU4Calo
-    #* JetAnalyzerAkPU5Calo
+    * JetAnalyzerAkPU4Calo
+    * JetAnalyzerAkPU5Calo
 
     * JetAnalyzerAkPU3PF
-    #* JetAnalyzerAkPU4PF
-    #* JetAnalyzerAkPU5PF
+    * JetAnalyzerAkPU4PF
+    * JetAnalyzerAkPU5PF
     
-    #* JetAnalyzerAkVs2Calo
+    * JetAnalyzerAkVs2Calo
     * JetAnalyzerAkVs3Calo	   
-    #* JetAnalyzerAkVs4Calo	   
+    * JetAnalyzerAkVs4Calo	   
     #* JetAnalyzerAkVs5Calo	   
     #* JetAnalyzerAkVs6Calo
     #* JetAnalyzerAkVs7Calo
     
     #* JetAnalyzerAkVs2PF
     * JetAnalyzerAkVs3PF
-    #* JetAnalyzerAkVs4PF	   
-    #* JetAnalyzerAkVs5PF
+    * JetAnalyzerAkVs4PF	   
+    * JetAnalyzerAkVs5PF
     #* JetAnalyzerAkVs6PF	   
     #* JetAnalyzerAkVs7PF
 


### PR DESCRIPTION
Backporting to 75X for the HIN-Jet DQM #12194 module and the centrality bin information #12002 . When checking this, i ran the matrix after merging with the #12259 and the workflows completed without any errors. We would like this to be in the latest 75X release by the next week since we have to run several tests. thanks a lot! 

Cheers
Raghav
