### PR TITLE
fixed bug in the corrected MET in the JetID cleaned module

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -203,7 +203,12 @@ def customiseFor12062(process):
         module.recordLabel = cms.string('HLT')
     return process
 
+def customiseFor12318(process);
 
+    if hasattr(process, 'hltMetCleanUsingJetID'):
+        delattr(process.hltMetCleanUsingJetID, 'usePt')
+    return process
+    
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
@@ -217,6 +222,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor11497(process)
         process = customiseFor12044(process)
         process = customiseFor12062(process)
+        process = customiseFor12318(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -1,5 +1,3 @@
-import FWCore.ParameterSet.Config as cms
-
 # reusable functions
 def producers_by_type(process, *types):
     return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
@@ -209,12 +207,31 @@ def customiseFor12318(process);
        if hasattr(process.hltMetCleanUsingJetID, 'usePt'):
           delattr(process.hltMetCleanUsingJetID, 'usePt')
     return process
-    
+
+
+import FWCore.ParameterSet.Config as cms
+
+# Remove hcalTopologyConstants
+def customiseFor11920(process):
+    if hasattr(process,'HcalGeometryFromDBEP'):
+        if hasattr(process.HcalGeometryFromDBEP,'hcalTopologyConstants'):
+            delattr(process.HcalGeometryFromDBEP,'hcalTopologyConstants')
+    if hasattr(process,'HcalTopologyIdealEP'):
+        if hasattr(process.HcalTopologyIdealEP,'hcalTopologyConstants'):
+            delattr(process.HcalTopologyIdealEP,'hcalTopologyConstants')
+    if hasattr(process,'CaloTowerGeometryFromDBEP'):
+        if hasattr(process.CaloTowerGeometryFromDBEP,'hcalTopologyConstants'):
+            delattr(process.CaloTowerGeometryFromDBEP,'hcalTopologyConstants')
+    return process
+
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
     cmsswVersion = os.environ['CMSSW_VERSION']
 
+    if cmsswVersion >= "CMSSW_8_0":
+        process = customiseFor11920(process)
+        process = customiseFor12318(process)
     if cmsswVersion >= "CMSSW_7_6":
         process = customiseFor10418(process)
         process = customiseFor10353(process)
@@ -223,7 +240,6 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor11497(process)
         process = customiseFor12044(process)
         process = customiseFor12062(process)
-        process = customiseFor12318(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -207,7 +207,7 @@ def customiseFor12318(process):
 
     if hasattr(process, 'hltMetCleanUsingJetID'):
        if hasattr(process.hltMetCleanUsingJetID, 'usePt'):
-          delattr(process.hltMetCleanUsingJetID, 'usePt')
+           delattr(process.hltMetCleanUsingJetID, 'usePt')
     return process
 
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -206,7 +206,8 @@ def customiseFor12062(process):
 def customiseFor12318(process);
 
     if hasattr(process, 'hltMetCleanUsingJetID'):
-        delattr(process.hltMetCleanUsingJetID, 'usePt')
+       if hasattr(process.hltMetCleanUsingJetID, 'usePt'):
+          delattr(process.hltMetCleanUsingJetID, 'usePt')
     return process
     
 # CMSSW version specific customizations

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -201,7 +201,7 @@ def customiseFor12062(process):
         module.recordLabel = cms.string('HLT')
     return process
 
-def customiseFor12318(process);
+def customiseFor12318(process):
 
     if hasattr(process, 'hltMetCleanUsingJetID'):
        if hasattr(process.hltMetCleanUsingJetID, 'usePt'):

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -1,3 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
 # reusable functions
 def producers_by_type(process, *types):
     return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
@@ -209,7 +211,6 @@ def customiseFor12318(process):
     return process
 
 
-import FWCore.ParameterSet.Config as cms
 
 # Remove hcalTopologyConstants
 def customiseFor11920(process):

--- a/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
+++ b/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
@@ -12,8 +12,7 @@
 
 // Constructor
 HLTMETCleanerUsingJetID::HLTMETCleanerUsingJetID(const edm::ParameterSet& iConfig)
-      : usePt_         (iConfig.getParameter<bool>("usePt")),
-        minPt_         (iConfig.getParameter<double>("minPt")),
+      :  minPt_         (iConfig.getParameter<double>("minPt")),
         maxEta_        (iConfig.getParameter<double>("maxEta")),
         metLabel_      (iConfig.getParameter<edm::InputTag>("metLabel")),
         jetsLabel_     (iConfig.getParameter<edm::InputTag>("jetsLabel")),
@@ -32,7 +31,6 @@ HLTMETCleanerUsingJetID::~HLTMETCleanerUsingJetID() {}
 // Fill descriptions
 void HLTMETCleanerUsingJetID::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<bool>("usePt", false);
     desc.add<double>("minPt", 20.);
     desc.add<double>("maxEta", 5.);
     desc.add<edm::InputTag>("metLabel", edm::InputTag("hltMet"));
@@ -60,11 +58,10 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
     double sumet_jets = 0.;
     if (jets->size() > 0 ) {
         for(reco::CaloJetCollection::const_iterator j = jets->begin(); j != jets->end(); ++j) {
-            double pt = usePt_ ? j->pt() : j->et();
+            double pt =  j->et();
             double eta = j->eta();
-            double phi = j->phi();
-            double px = usePt_ ? j->px() : j->et() * cos(phi);
-            double py = usePt_ ? j->py() : j->et() * sin(phi);
+            double px =  j->px();
+            double py =  j->py();
 
             if (pt > minPt_ && std::abs(eta) < maxEta_) {
                 mex_jets -= px;
@@ -79,11 +76,10 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
     double sumet_goodJets = 0.;
     if (goodJets->size() > 0) {
         for(reco::CaloJetCollection::const_iterator j = goodJets->begin(); j != goodJets->end(); ++j) {
-            double pt = usePt_ ? j->pt() : j->et();
+            double pt =  j->pt();
             double eta = j->eta();
-            double phi = j->phi();
-            double px = usePt_ ? j->px() : j->pt() * cos(phi);
-            double py = usePt_ ? j->py() : j->pt() * sin(phi);
+            double px = j->px() ;
+            double py =  j->py() ;
 
             if (pt > minPt_ && std::abs(eta) < maxEta_) {
                 mex_goodJets -= px;
@@ -93,15 +89,19 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
         }
     }
 
+
+
+
     if (met->size() > 0) {
+
         double mex_diff = mex_goodJets - mex_jets;
         double mey_diff = mey_goodJets - mey_jets;
-        //double sumet_diff = sumet_goodJets - sumet_jets;  // cannot set sumet...
-        reco::Candidate::LorentzVector p4_diff(mex_diff, mey_diff, 0, sqrt(mex_diff*mex_diff + mey_diff*mey_diff));
 
-        reco::CaloMET cleanmet = met->front();
-        cleanmet.setP4(cleanmet.p4() + p4_diff);
+        reco::Candidate::LorentzVector p4_diff(met->front().px()+mex_diff, mey_diff+met->front().py(), 0, sqrt((met->front().px()+mex_diff)*(met->front().px() +mex_diff)+(met->front().py()+mey_diff)*(met->front().py() +mey_diff)));
+         reco::CaloMET cleanmet ;
+        cleanmet.setP4(p4_diff);
         result->push_back(cleanmet);
+
     }
 
     iEvent.put( result );


### PR DESCRIPTION
Fix the bug in the HLTMETCleanerUsingJetID.cc.

Remove usePt option "which was wrongly set to false"
to use met.pt() n coherent with standard met definition. 
Modified Cleaned MET collection be massless after correcting for JetID.
