### PR TITLE
Fix temporaries in the header

### DIFF
--- a/Validation/MuonGEMHits/interface/GEMDetLabel.h
+++ b/Validation/MuonGEMHits/interface/GEMDetLabel.h
@@ -1,5 +1,5 @@
 namespace GEMDetLabel {
-  std::string l_suffix[4] = {"_l1","_l2","_l1or2","_l1and2"};
-  std::string s_suffix[3] = {"_st1","_st2s","_st2"};
-  std::string c_suffix[3] = {"_all","_odd","_even"};
+  static const std::string l_suffix[4] = {"_l1","_l2","_l1or2","_l1and2"};
+  static const std::string s_suffix[3] = {"_st1","_st2s","_st2"};
+  static const std::string c_suffix[3] = {"_all","_odd","_even"};
 }


### PR DESCRIPTION
We have to make this as `static` or `extern` in order to keep the
lifetime of these arrays until application terminates. `static` needs to
be picked if values will not be compared by reference between various
translation units otherwise we need `extern`.

Should resolve valgrind detected issues, e.g.:

```
==27582== Invalid read of size 4
==27582==    at 0x5BFEE2D: __gnu_cxx::__exchange_and_add(int volatile*, int) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x5BFEEC1: __gnu_cxx::__exchange_and_add_dispatch(int*, int) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x5C0330F: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x5BFF9E2: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x71AD3EF: __tcf_2 (GEMDetLabel.h:4)
==27582==    by 0x3A46635B21: exit (in /lib64/libc-2.12.so)
==27582==    by 0x3A4661ED63: (below main) (in /lib64/libc-2.12.so)
==27582==  Address 0x60579c0 is 16 bytes inside a block of size 30 free'd
==27582==    at 0x40290B3: operator delete(void*) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/valgrind/3.10.1/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27582==    by 0x5C03D3F: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x5C0337E: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x5C0332B: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x5BFF9E2: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /afs/cern.ch/cms/sw/ReleaseCandidates/volB/slc6_amd64_gcc493/external/gcc/4.9.3/lib64/libstdc++.so.6.0.20)
==27582==    by 0x713F6FE: __tcf_2 (GEMDetLabel.h:4)
==27582==    by 0x3A46635B21: exit (in /lib64/libc-2.12.so)
==27582==    by 0x3A4661ED63: (below main) (in /lib64/libc-2.12.so)
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
