### PR TITLE
pass isRepacked flag to config builder if set in a scenario

### DIFF
--- a/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
@@ -33,6 +33,11 @@ class HeavyIonsRun2(Reco):
                 if a['dataTier'] == 'MINIAOD':
                     raise RuntimeError("MINIAOD is not supported in HeavyIonsRun2")
 
+
+    def _setRepackedFlag(self,args):
+        if not 'repacked' in args:
+            args['repacked']= True
+
     def promptReco(self, globalTag, **args):
         """
         _promptReco_
@@ -41,6 +46,7 @@ class HeavyIonsRun2(Reco):
 
         """
         self._checkMINIAOD(**args)
+        self._setRepackedFlag(args)
 
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
@@ -64,6 +70,7 @@ class HeavyIonsRun2(Reco):
 
         """
         self._checkMINIAOD(**args)
+        self._setRepackedFlag(**args)
 
         if not 'skims' in args:
             args['skims']=['@allForExpress']

--- a/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
@@ -70,7 +70,7 @@ class HeavyIonsRun2(Reco):
 
         """
         self._checkMINIAOD(**args)
-        self._setRepackedFlag(**args)
+        self._setRepackedFlag(args)
 
         if not 'skims' in args:
             args['skims']=['@allForExpress']

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -26,6 +26,16 @@ class Reco(Scenario):
 
     """
 
+
+    def _checkRepackedFlag(self, options, **args):
+        if 'repacked' in args:
+            if args['repacked'] == True:
+                options.isRepacked = True
+            else:
+                options.isRepacked = False
+        
+
+
     def promptReco(self, globalTag, **args):
         """
         _promptReco_
@@ -55,6 +65,7 @@ class Reco(Scenario):
         """
         options.runUnscheduled=True
                     
+        self._checkRepackedFlag(options, **args)
 
         if 'customs' in args:
             options.customisation_file=args['customs']
@@ -115,6 +126,8 @@ class Reco(Scenario):
 
         if 'customs' in args:
             options.customisation_file=args['customs']
+
+        self._checkRepackedFlag(options,**args)
 
         cb = ConfigBuilder(options, process = process, with_output = True, with_input = True)
 

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -29,6 +29,8 @@ class RunPromptReco:
         self.alcaRecos = None
         self.PhysicsSkims = None
         self.dqmSeq = None
+        self.setRepacked = False
+        self.isRepacked = False
 
     def __call__(self):
         if self.scenario == None:
@@ -93,6 +95,9 @@ class RunPromptReco:
                 if self.dqmSeq:
                     kwds['dqmSeq'] = self.dqmSeq
 
+                if self.setRepacked:
+                    kwds['repacked'] = self.isRepacked
+
             process = scenario.promptReco(self.globalTag, **kwds)
 
         except NotImplementedError, ex:
@@ -119,7 +124,7 @@ class RunPromptReco:
 
 if __name__ == '__main__':
     valid = ["scenario=", "reco", "aod", "miniaod","dqm", "dqmio", "no-output",
-             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=", "dqmSeq=" ]
+             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=", "dqmSeq=", "isRepacked", "isNotRepacked" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -131,6 +136,7 @@ Where options are:
  --miniaod (to enable MiniAOD output)
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
+ --isRepacked --isNotRepacked (to override default repacked flags)
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
@@ -182,5 +188,12 @@ python RunPromptReco.py --scenario=ppRun2 --reco --aod --dqmio --global-tag GLOB
             recoinator.PhysicsSkims = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--dqmSeq":
             recoinator.dqmSeq = [ x for x in arg.split('+') if len(x) > 0 ]
+        if opt == "--isRepacked":
+            recoinator.setRepacked = True
+            recoinator.isRepacked = True
+        if opt == "--isNotRepacked":
+            recoinator.setRepacked = True
+            recoinator.isRepacked = False
+
 
     recoinator()


### PR DESCRIPTION
- default isRepacked is not set, leaving it to the configBuilder defaults
- HeavyIonsRun2 has isRepacked=True (corresponds to a swap of rawDataCollector with rawDataRepacker, which is happening in HLT, different from regular pp/cosmics data taking)

The python config Configuration/DataProcessing/test/RunPromptReco.py, which is useful in local tests,
has options --isRepacked or --isNotRepacked to override the isRepacked parameter.

Passing arguments to the T0 setup is more complicated and the flexibility to choose repacked or non-repacked inputs is not available with this PR.
The easiest is to introduce a new scenario (e.g. HeavyIonsRun2frompp )
