### PR TITLE
Fix problem in edmStreamStallGrapher

### DIFF
--- a/FWCore/Concurrency/bin/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/bin/edmStreamStallGrapher.py
@@ -189,6 +189,8 @@ def createPDFImage(processingSteps, numStreams, stalledModuleInfo):
   streamColors = [[] for x in xrange(numStreams+1)]
   
   for n,trans,s,time,delayed in processingSteps:
+    if n == "FINISH INIT":
+      continue
     if trans == kStarted:
       streamStartDepth[s] +=1
       streamTime[s] = time


### PR DESCRIPTION
When making the pdf graph the beginning of time was truncated by accident.
