### PR TITLE
Update for keeping gen-level nuclear info in AOD

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1464,7 +1464,7 @@ class ConfigBuilder(object):
         if sequence == 'pdigi_valid' or sequence == 'pdigi_valid_nogen' or sequence == 'pdigi_hi':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
 
-	if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and not self.process.source.type_()=='EmptySource':
+	if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and sequence != 'pdigi_hi' and not self.process.source.type_()=='EmptySource':
 		if self._options.inputEventContent=='':
 			self._options.inputEventContent='REGEN'
 		else:

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1461,7 +1461,7 @@ class ConfigBuilder(object):
         if self._options.gflash==True:
                 self.loadAndRemember("Configuration/StandardSequences/GFlashDIGI_cff")
 
-        if sequence == 'pdigi_valid' or sequence == 'pdigi_valid_nogen' :
+        if sequence == 'pdigi_valid' or sequence == 'pdigi_valid_nogen' or sequence == 'pdigi_hi':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
 
 	if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and not self.process.source.type_()=='EmptySource':

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -761,9 +761,9 @@ steps['RESIM']=merge([{'-s':'reGEN,reSIM','-n':10},steps['DIGI']])
 #steps['RESIMDIGI']=merge([{'-s':'reGEN,reSIM,DIGI,L1,DIGI2RAW,HLT:@fake,RAW2DIGI,L1Reco','-n':10,'--restoreRNDSeeds':'','--process':'HLT'},steps['DIGI']])
 
     
-steps['DIGIHI']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:HIon,RAW2DIGI,L1Reco'}, hiDefaults, step2Upg2015Defaults])
-steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake,RAW2DIGI,L1Reco'}, hiDefaults2011, step2Defaults])
-steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_valid_nogen,L1,DIGI2RAW,HLT:HIon,RAW2DIGI,L1Reco', '-n':2}, hiDefaults, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
+steps['DIGIHI']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon,RAW2DIGI,L1Reco'}, hiDefaults, step2Upg2015Defaults])
+steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake,RAW2DIGI,L1Reco'}, hiDefaults2011, step2Defaults])
+steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon,RAW2DIGI,L1Reco', '-n':2}, hiDefaults, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
 
 
 # PRE-MIXING : https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation#Pre_Mixing_Instructions

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -33,3 +33,8 @@ pdigi = cms.Sequence(fixGenInfo*cms.SequencePlaceholder("randomEngineStateProduc
 pdigi_valid = cms.Sequence(pdigi)
 pdigi_nogen=cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*cms.SequencePlaceholder("mix")*doAllDigi*addPileupInfo)
 pdigi_valid_nogen=cms.Sequence(pdigi_nogen)
+
+
+# 75X update for Heavy Ions
+from GeneratorInterface.HiGenCommon.HeavyIon_cff import *
+pdigi_hi=cms.Sequence(heavyIon+pdigi_nogen)

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -37,4 +37,4 @@ pdigi_valid_nogen=cms.Sequence(pdigi_nogen)
 
 # 75X update for Heavy Ions
 from GeneratorInterface.HiGenCommon.HeavyIon_cff import *
-pdigi_hi=cms.Sequence(heavyIon+pdigi_nogen)
+pdigi_hi=cms.Sequence(pdigi_valid_nogen+heavyIon)

--- a/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
@@ -35,6 +35,7 @@ Implementation:
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/HiGenData/interface/GenHIEvent.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 #include "HepMC/HeavyIon.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -52,11 +53,11 @@ class GenHIEventProducer : public edm::EDProducer {
 
     private:
         virtual void produce(edm::Event&, const edm::EventSetup&) override;
-        std::vector<std::string> hepmcSrc_;
+        edm::InputTag hepmcSrc_;
         edm::ESHandle < ParticleDataTable > pdt;
 
-  double ptCut_;
-  bool doParticleInfo_;
+        double ptCut_;
+        bool doParticleInfo_;
 };
 
 //
@@ -74,10 +75,10 @@ class GenHIEventProducer : public edm::EDProducer {
 GenHIEventProducer::GenHIEventProducer(const edm::ParameterSet& iConfig)
 {
     produces<edm::GenHIEvent>();
-    hepmcSrc_ = iConfig.getParameter<std::vector<std::string> >("generators");
+    hepmcSrc_ = iConfig.getParameter<edm::InputTag>("src");
     doParticleInfo_ = iConfig.getUntrackedParameter<bool>("doParticleInfo",false);
     if(doParticleInfo_){
-      ptCut_ = iConfig.getUntrackedParameter<double> ("ptCut",1.);
+      ptCut_ = iConfig.getParameter<double> ("ptCut");
     }
 }
 
@@ -120,11 +121,20 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     double EtMR = 0; // Normalized of total energy bym
     double TotEnergy = 0; // Total energy bym
 
-    for(size_t ihep = 0; ihep < hepmcSrc_.size(); ++ihep){
-        Handle<edm::HepMCProduct> hepmc;
-        iEvent.getByLabel(hepmcSrc_[ihep],hepmc);
+    Handle<CrossingFrame<edm::HepMCProduct> > hepmc;
 
-        const HepMC::GenEvent* evt = hepmc->GetEvent();
+    iEvent.getByLabel(hepmcSrc_,hepmc);
+    MixCollection<HepMCProduct> mix(hepmc.product());
+
+	if(mix.size() < 1){
+	   throw cms::Exception("MatchVtx")
+	      <<"Mixing has "<<mix.size()<<" sub-events, should have been at least 1"
+	      <<endl;
+	}
+
+	// use the last event, bkg for embedding, signal in non-embedded
+	const HepMCProduct& hievt = mix.getObject(mix.size()-1);
+        const HepMC::GenEvent* evt = hievt.GetEvent();
 	if(doParticleInfo_){
 	  HepMC::GenEvent::particle_const_iterator begin = evt->particles_begin();
 	  HepMC::GenEvent::particle_const_iterator end = evt->particles_end();
@@ -171,7 +181,7 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		ecc = hi->eccentricity();
             }
         }
-    }
+
     // Get the normalized total energy bym
     if(TotEnergy != 0){
         EtMR = TotEnergy/2;

--- a/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
@@ -53,7 +53,8 @@ class GenHIEventProducer : public edm::EDProducer {
 
     private:
         virtual void produce(edm::Event&, const edm::EventSetup&) override;
-        edm::InputTag hepmcSrc_;
+
+        edm::EDGetTokenT<CrossingFrame<edm::HepMCProduct> > hepmcSrc_;
         edm::ESHandle < ParticleDataTable > pdt;
 
         double ptCut_;
@@ -75,7 +76,9 @@ class GenHIEventProducer : public edm::EDProducer {
 GenHIEventProducer::GenHIEventProducer(const edm::ParameterSet& iConfig)
 {
     produces<edm::GenHIEvent>();
-    hepmcSrc_ = iConfig.getParameter<edm::InputTag>("src");
+
+    hepmcSrc_ = consumes<CrossingFrame<edm::HepMCProduct> >(iConfig.getParameter<edm::InputTag>("src"));
+
     doParticleInfo_ = iConfig.getUntrackedParameter<bool>("doParticleInfo",false);
     if(doParticleInfo_){
       ptCut_ = iConfig.getParameter<double> ("ptCut");
@@ -123,7 +126,7 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     Handle<CrossingFrame<edm::HepMCProduct> > hepmc;
 
-    iEvent.getByLabel(hepmcSrc_,hepmc);
+    iEvent.getByToken(hepmcSrc_,hepmc);
     MixCollection<HepMCProduct> mix(hepmc.product());
 
 	if(mix.size() < 1){

--- a/GeneratorInterface/HiGenCommon/python/HeavyIon_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/HeavyIon_cff.py
@@ -2,10 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from SimGeneral.HepPDTESSource.pythiapdt_cfi import *
 heavyIon = cms.EDProducer("GenHIEventProducer",
-                            doReco     = cms.bool(True),
-                            doMC       = cms.bool(True),
-                            generators = cms.vstring("generator"),
-                            ptCut      = cms.double(0),
+                          src = cms.InputTag("mix","generator"),
                           )
 
 

--- a/SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 HiMixRAW = cms.PSet(
     outputCommands = cms.untracked.vstring(
+        'keep *_heavyIon_*_*'
 #        'keep *_mix_MergedTrackTruth_*',
 #        'drop CrossingFramePlaybackInfoExtended_mix_*_*',
 #        'keep *_mix_*_SIM',
@@ -10,6 +11,7 @@ HiMixRAW = cms.PSet(
 
 HiMixRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
+        'keep *_heavyIon_*_*'
 #        'keep *_mix_MergedTrackTruth_*',
 #        'drop CrossingFramePlaybackInfoExtended_mix_*_*',
 #        'keep *_mix_*_SIM',
@@ -18,6 +20,7 @@ HiMixRECO = cms.PSet(
 
 HiMixAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
+        'keep *_heavyIon_*_*'
     )
 )
 

--- a/SimGeneral/MixingModule/python/HiMix_cff.py
+++ b/SimGeneral/MixingModule/python/HiMix_cff.py
@@ -35,5 +35,7 @@ mix = cms.EDProducer("MixingModule",
     mixObjects = cms.PSet(theMixObjects)
 )
 
+mix.mixObjects.mixHepMC.makeCrossingFrame = True
+
 
 


### PR DESCRIPTION
This pull-request contains a fix in order to keep all nuclear information (npart, ncoll, reaction plane) when the HepMCProduct is dropped.

This should be considered as a bug-fix in 75X, the production of the "heavyIon" object has to be in the digi step in order to be usable for some large GEN-SIM samples already produced.

The implementation for CMSSW_8_0_X will be different, it will be added to the gen step, in a more elegant way.
