### PR TITLE
Updating JEC in data/mc and fixes for HI

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,17 +10,17 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v11',
+    'run2_design'       :   '76X_mcRun2_design_v12',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '76X_mcRun2_startup_v11',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v11',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v12',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v11',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v12',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v10',
+    'run1_data'         :   '76X_dataRun1_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v10',
+    'run2_data'         :   '76X_dataRun2_v11',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes in GT
## RunII simulation
- **RunII Ideal scenario** : [76X_mcRun2_design_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v11) as [76X_mcRun2_design_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v12) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_design_v11/76X_mcRun2_design_v12): 
  -  updated MC JEC to v6 with updated L2L3Residuals and uncertainties for 25ns.
- **RunII Asymptotic scenario** : [76X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v11) as [76X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v12) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_asymptotic_v11/76X_mcRun2_asymptotic_v12): 
  - updated MC JEC to v6 with updated L2L3Residuals and uncertainties for 25ns;
  - adding label JEC with AK4Calo label for pp reference run at 5TeV.
- **RunII Heavy Ions scenario** : [76X_mcRun2_HeavyIon_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v11) as [76X_mcRun2_HeavyIon_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v12) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_HeavyIon_v11/76X_mcRun2_HeavyIon_v12): 
  -  adding event plane calibrations for HI trough HeavyIonRPRcd;
  -  adding label JEC with AK4Calo label for pp reference run at 5TeV.
## RunI data
- **RunI Offline processing** : [76X_dataRun1_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v10) as [76X_dataRun1_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v11) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v10/76X_dataRun1_v11): 
  - adding event plane calibrations for HI trough HeavyIonRPRcd;
  - adding label JEC with AK4Calo label for pp reference run at 5TeV;
  - updating AlCaReco Trigger bits to cover 2010 HI runs for new Tracker Alignment AlCaReco producers.
## RunII data
- **RunII Offline processing** : [76X_dataRun2_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v10) as [76X_dataRun2_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_v11) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v10/76X_dataRun2_v11):
  - adding event plane calibrations for HI trough HeavyIonRPRcd;
  - adding label JEC with AK4Calo label for pp reference run at 5TeV;
  - updating AlCaReco Trigger bits to cover 2010 HI runs for new Tracker Alignment AlCaReco producers.
  - updated DATA JEC to v3 with updated L2L3Residuals and uncertainties for 25ns;
