### PR TITLE
phase1Pixel era validation additions

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -48,6 +48,11 @@ hltvalidation = cms.Sequence(
     +hltbtagValidationSequence
     )
 
+# The higgs validation is not compatible with the Phase 1 pixel, so
+# take it out if that is active.
+from Configuration.StandardSequences.Eras import eras
+if eras.phase1Pixel.isChosen():
+    hltvalidation.remove(HiggsValidationSequence)
 
 # additional producer sequence prior to hltvalidation_fastsim
 # to evacuate producers from the EndPath

--- a/Validation/RecoTrack/python/SiTrackingRecHitsValid_cff.py
+++ b/Validation/RecoTrack/python/SiTrackingRecHitsValid_cff.py
@@ -5,3 +5,7 @@ from Validation.RecoTrack.SiPixelTrackingRecHitsValid_cfi import *
 from Validation.RecoTrack.SiStripTrackingRecHitsValid_cfi import *
 trackingRecHitsValid = cms.Sequence(PixelTrackingRecHitsValid*StripTrackingRecHitsValid)
 
+# If the Phase 1 pixel detector is active, don't run this validation sequence
+from Configuration.StandardSequences.Eras import eras
+if eras.phase1Pixel.isChosen():
+    trackingRecHitsValid.remove(PixelTrackingRecHitsValid)


### PR DESCRIPTION
Second tranche of `phase1Pixel` era changes, adding on from #12275.  This one is validation customisations which should be equivalent to the [phase1TkCustoms.customise_Validation](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X_2015-11-10-1100/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py#L108) function.

**There should be no change whatsoever unless the Run2_2017 era is active** (the only top-level era that contains phase1Pixel).

I'm assuming HLTValidation_cff.py is not auto-generated (I never know which HLT stuff is or isn't).  If it is I'll have to find somewhere else to put the change.

@atricomi, @delaere:
Note the lines...

``` python
process.validation_step.remove(process.HLTSusyExoVal)
process.validation_step.remove(process.relvalMuonBits)
```

...have not been ported from the customisation to the era.  Neither appear to still be in use in 8_0_X.  `HLTSusyExoVal` never seems to be used by anything - there is a `HLTSusyExoValSeq` though, do you know if that should be taken out?  I'll leave it as is unless you say otherwise.
`relvalMuonBits` appears to be taken out for all sequences now, it's commented out in [HLTriggerOffline/Muon/python/HLTMuonVal_cff.py#L15](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X_2015-11-10-1100/HLTriggerOffline/Muon/python/HLTMuonVal_cff.py#L15)
