### PR TITLE
phase1Pixel era digi to/from raw additions

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -59,3 +59,6 @@ def _modifyDigiToRawForStage1L1Trigger( theProcess ) :
 
 # A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
 modifyConfigurationStandardSequencesDigiToRawForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _modifyDigiToRawForStage1L1Trigger )
+if eras.phase1Pixel.isChosen() :
+    DigiToRaw.remove(siPixelRawData)
+    DigiToRaw.remove(castorRawData)

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -124,3 +124,6 @@ def _modifyRawToDigiForStage1Trigger( theProcess ) :
 eras.run2_common.toModify( RawToDigi, func=_modifyRawToDigiForRun2 )
 # A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
 modifyConfigurationStandardSequencesRawToDigiForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _modifyRawToDigiForStage1Trigger )
+if eras.phase1Pixel.isChosen() :
+    RawToDigi.remove(siPixelDigis)
+    RawToDigi.remove(castorDigis)


### PR DESCRIPTION
Another tranche of the `phase1Pixel` era changes, adding on from #12275 and #12359 (I'm submitting them individually by package to try and ease integration).  This one is for DigiToRaw and RawToDigi changes, equivalent to the [customise_DigiToRaw and customise_RawToDigi](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py#L36) functions.

**There should be no change whatsoever unless the `Run2_2017` era is active** (the only top-level era that contains phase1Pixel).

@atricomi, @delaere

@boudoul do you still want to be pinged about tracker/pixel upgrade issues?
