### PR TITLE
Remove -1 from ClassVersionID field in selection rules

### DIFF
--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -52,8 +52,8 @@
    <version ClassVersion="11" checksum="3200292660"/>
    <version ClassVersion="12" checksum="114160170"/>
   </class>
-  <class name="reco::Photon::PflowIDVariables"  ClassVersion="-1">
-   <version ClassVersion="-1" checksum="2819734289"/>
+  <class name="reco::Photon::PflowIDVariables"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2819734289"/>
   </class>
   <class name="reco::Photon::EnergyCorrections"  ClassVersion="16">
    <version ClassVersion="16" checksum="1544393913"/>

--- a/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
+++ b/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
@@ -13,8 +13,8 @@
   <class name="std::vector<PileupMixingContent>"/>  
   <class name="edm::Wrapper<PileupMixingContent>"/>
   <class name="edm::Wrapper<std::vector<PileupMixingContent> >"/>
-  <class name="PileupVertexContent" ClassVersion="-1">
-   <version ClassVersion="-1" checksum="3263569137"/>
+  <class name="PileupVertexContent" ClassVersion="3">
+   <version ClassVersion="3" checksum="3263569137"/>
   </class>
   <class name="std::vector<PileupVertexContent>"/>  
   <class name="edm::Wrapper<PileupVertexContent>"/>


### PR DESCRIPTION
-1 means that the class is unversioned and is supposed to only be
used internally. It is 'illegal' for user to explicitly use this value.

Both classes were not modified since their were introduced in CMSSW. For
safety reasons I picked ClassVersionID as 3.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
