### PR TITLE
Set default HI Stage1 parameters

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/caloStage1Params_HI_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage1Params_HI_cfi.py
@@ -1,63 +1,29 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.L1TCalorimeter.caloStage1RegionSF_cfi import *
-from L1Trigger.L1TCalorimeter.caloStage1JetSF_cfi import *
-
 from L1Trigger.L1TCalorimeter.caloParams_cfi import caloParamsSource
 import L1Trigger.L1TCalorimeter.caloParams_cfi
-#caloStage1ParamsSource = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParamsSource.clone()
 caloStage1Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone()
 
-caloStage1Params.regionPUSType    = cms.string("zeroWall")       #"None" for no PU subtraction, "PUM0", "HICaloRingSub"
-caloStage1Params.regionPUSParams  = regionSubtraction_PU40_MC13TeV
+caloStage1Params.ppRecord = cms.bool(False)
+### nominal settings 2015-11-10
+### PUS mask
+caloStage1Params.jetRegionMask = cms.int32(0b0000100000000000010000)
+### EG 'iso' (eta) mask
+caloStage1Params.egEtaCut = cms.int32(0b0000001111111111000000)
+### Single track eta mask
+caloStage1Params.tauRegionMask = cms.int32(0b1111111100000011111111)
+### Centrality eta mask
+caloStage1Params.centralityRegionMask = cms.int32(0b0000111111111111110000)
+### jet seed threshold for 3x3 step of jet finding
+caloStage1Params.jetSeedThreshold = cms.double(0)
+### HTT settings
+caloStage1Params.etSumEtThreshold = cms.vdouble(0., 7.) #ET, HT
+### Minimum Bias thresholds
+caloStage1Params.minimumBiasThresholds = cms.vint32(4,4,6,6)
+### Centrality LUT
+caloStage1Params.centralityLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/centrality_extended_LUT_preRun.txt")
 
-# EG
-caloStage1Params.egLsb                = cms.double(1.)
-caloStage1Params.egSeedThreshold      = cms.double(0.)
-
-caloStage1Params.egMinPtJetIsolation = cms.int32(25)
-caloStage1Params.egMaxPtJetIsolation = cms.int32(63)
-caloStage1Params.egMinPtHOverEIsolation = cms.int32(1)
-caloStage1Params.egMaxPtHOverEIsolation = cms.int32(40)
-
-caloStage1Params.egPUSType    = cms.string("None")
-caloStage1Params.egPUSParams  = cms.vdouble()
-
-## EG Isolation LUT
-## caloStage1Params.egIsoLUTFile   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egIsoLUT_stage1.txt")
-caloStage1Params.egIsoLUTFile      = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egIsoLUT_stage1_isolEB0.30_isolEE0.50_combined.txt")
-#caloStage1Params.egIsoLUTFileBarrel   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egIsoLUT_stage1_isol0.30.txt")
-#caloStage1Params.egIsoLUTFileEndcaps  = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egIsoLUT_stage1_isol0.50.txt")
-
-# Tau
-caloStage1Params.tauSeedThreshold = cms.double(7.)
-caloStage1Params.tauNeighbourThreshold = cms.double(0.)
-#Tau parameters below are only used for setting tau isolation flag
-caloStage1Params.tauMaxPtTauVeto = cms.double(64.)
-caloStage1Params.tauMinPtJetIsolationB = cms.double(192.)
-caloStage1Params.tauMaxJetIsolationB  = cms.double(100.)
-caloStage1Params.tauMaxJetIsolationA = cms.double(0.1)
-caloStage1Params.tauIsoLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauIsoLUT_stage1_isolA0.10_isolB100.00_ch_switchToIsoBPt192.00_j8t8.txt")
-## caloStage1Params.tauCalibrationLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauCalibrationLUT_stage1.txt")
-caloStage1Params.tauCalibrationLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauL1Calib_LUT.txt")
-caloStage1Params.tauEtToHFRingEtLUTFile= cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauHwEtToHFRingScale_LUT.txt")
-caloStage1Params.isoTauEtaMin          = cms.int32(5)
-caloStage1Params.isoTauEtaMax          = cms.int32(16)
-# jets
-caloStage1Params.jetLsb                = cms.double(0.5)
-caloStage1Params.jetSeedThreshold      = cms.double(0.)
-caloStage1Params.jetNeighbourThreshold = cms.double(0.)
-caloStage1Params.jetCalibrationType    = cms.string("Stage1JEC")
-caloStage1Params.jetCalibrationParams  = jetSF_8TeV_data
-## caloStage1Params.jetCalibrationLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/jetCalibrationLUT_stage1_prelim.txt")
-caloStage1Params.jetCalibrationLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/jetCalibrationLUT_symmetric_0is0.txt")
-
-# sums
-caloStage1Params.etSumLsb                = cms.double(0.5)
-caloStage1Params.etSumEtaMin             = cms.vint32(4, 4) #ET, HT
-caloStage1Params.etSumEtaMax             = cms.vint32(17, 17) #ET, HT
-caloStage1Params.etSumEtThreshold        = cms.vdouble(0., 7.) #ET, HT
-
-# HI
-caloStage1Params.centralityLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/centralityLUT_5020TeV_stage1.txt")
-caloStage1Params.q2LUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/q2LUT_stage1.txt")
+#### not used, but necessary to set something to stop ESProducer error
+caloStage1Params.egPUSParams = cms.vdouble()
+caloStage1Params.etSumEtaMin = cms.vint32(4, 4) #ET, HT
+caloStage1Params.etSumEtaMax = cms.vint32(17, 17) #ET, HT

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -9,7 +9,7 @@ from L1Trigger.Configuration.L1Trigger_custom import customiseL1Menu
 # customization of run L1 emulator for 2015 Stage 1 configuration
 def customiseSimL1EmulatorForStage1(process):
 
-    process.load("L1Trigger.L1TCommon.l1tDigiToRaw_cfi")    
+    process.load("L1Trigger.L1TCommon.l1tDigiToRaw_cfi")
     process.load("EventFilter.L1TRawToDigi.caloStage1Digis_cfi")
     process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
 
@@ -149,16 +149,7 @@ def customiseSimL1EmulatorForPostLS1_25ns(process):
 def customiseSimL1EmulatorForPostLS1_Additional_HI(process):
     # set the Stage 1 heavy ions-specific parameters
     # all of these should eventually end up in a GT
-    if hasattr(process,'RCTConfigProducers'):
-        process.RCTConfigProducers.eicIsolationThreshold = cms.uint32(7)
-        process.RCTConfigProducers.hOeCut = cms.double(999)
-        process.RCTConfigProducers.eMinForHoECut = cms.double(999)
-        process.RCTConfigProducers.eMaxForHoECut = cms.double(999)
-        process.RCTConfigProducers.hMinForHoECut = cms.double(999)
-        process.RCTConfigProducers.eMinForFGCut = cms.double(999)
-    if hasattr(process,'caloStage1Params'):     
-        process.caloStage1Params.jetSeedThreshold = cms.double(0.)
-        process.caloStage1Params.regionPUSType = cms.string("zeroWall")
+    process.load('L1Trigger.L1TCalorimeter.caloStage1Params_HI_cfi')
     if hasattr(process,'caloConfig'):
         process.caloConfig.fwVersionLayer2 = cms.uint32(1)
     return process


### PR DESCRIPTION
@mulhearn @mandrenguyen 
This PR sets the default Stage1 Level-1 trigger parameters that we expect to use during data taking. It is meant to be merged before we start the HI MC campaign, but is not critical for data taking.

However, since we expect to get a new GT with a proper payload soon, I will also make a PR which removes the override so that we will properly pull from the GT.

Personally, I think that we should merge both PRs at once and just make the new GT quickly, because the current customization settings are junk (before this PR) and then we will get the new conditions right when the new GT shows up without having to wait for yet another PR merge. Others can comment on whether this is a good idea or not.
