### PR TITLE
Updating Pixel Local Reco calibrations for 2017 Upgrade simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v7',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in GT
## Upgrade
- **PhaseI design scenario** : [76X_upgrade2017_design_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v8) as [76X_upgrade2017_design_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_upgrade2017_design_v8/76X_upgrade2017_design_v7): 
  - New Pixel SIM LA for Phase-I
  - New Pixel LA for Phase-I 
  - New Pixel templates for Phase-I 
  - New Pixel SIM gains for Phase-I
  - New Pixel GenErrors for Phase-I
  - New Pixel gains for Phase-I
  - New Pixel quality for Phase-I
