### PR TITLE
Fix FileInPath test in FWCore/PythonParameterSet

### DIFF
--- a/FWCore/ParameterSet/src/FileInPath.cc
+++ b/FWCore/ParameterSet/src/FileInPath.cc
@@ -387,6 +387,12 @@ namespace edm
 	localTop_.clear();
       }
     }
+    if (releaseTop_ == localTop_) {
+      // RELEASETOP is the same as LOCALTOP.  This means that the environment is set
+      // for the base release itself.  So LOCALTOP actually contains the
+      // location of the base release.
+        localTop_.clear();
+    }
     if (!envstring(DATATOP, dataTop_)) {
       dataTop_.clear();
     }

--- a/FWCore/PythonParameterSet/test/fip.txt
+++ b/FWCore/PythonParameterSet/test/fip.txt
@@ -1,0 +1,1 @@
+Dummy file for the FileInPath test.

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -95,7 +95,7 @@ void testmakepset::secsourceAux() {
   PythonProcessDesc builder(config);
   std::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
 
-  CPPUNIT_ASSERT(0 != ps.get());
+  CPPUNIT_ASSERT(nullptr != ps.get());
 
   // Make sure this ParameterSet object has the right contents
   edm::ParameterSet const& mixingModuleParams = ps->getParameterSet("mix");
@@ -149,7 +149,7 @@ void testmakepset::usingBlockAux() {
   PythonProcessDesc builder(config);
   std::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
 
-  CPPUNIT_ASSERT(0 != ps.get());
+  CPPUNIT_ASSERT(nullptr != ps.get());
 
   // Make sure this ParameterSet object has the right contents
   edm::ParameterSet const& m1Params = ps->getParameterSet("m1");
@@ -186,8 +186,8 @@ void testmakepset::fileinpathAux() {
   "process = cms.Process('PROD')\n"
   "process.main = cms.PSet(\n"
   "    topo = cms.FileInPath('Geometry/TrackerSimData/data/trackersens.xml'),\n"
-  "    fip = cms.FileInPath('FWCore/ParameterSet/python/Config.py'),\n"
-  "    ufip = cms.untracked.FileInPath('FWCore/ParameterSet/python/Types.py'),\n"
+  "    fip = cms.FileInPath('FWCore/PythonParameterSet/test/fip.txt'),\n"
+  "    ufip = cms.untracked.FileInPath('FWCore/PythonParameterSet/test/ufip.txt'),\n"
   "    extraneous = cms.int32(12)\n"
   ")\n"
   "process.source = cms.Source('EmptySource')\n";
@@ -197,7 +197,7 @@ void testmakepset::fileinpathAux() {
   // Create the ParameterSet object from this configuration string.
   PythonProcessDesc builder(config);
   std::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
-  CPPUNIT_ASSERT(0 != ps.get());
+  CPPUNIT_ASSERT(nullptr != ps.get());
 
   edm::ParameterSet const& innerps = ps->getParameterSet("main");
   edm::FileInPath fip  = innerps.getParameter<edm::FileInPath>("fip");
@@ -205,19 +205,20 @@ void testmakepset::fileinpathAux() {
   CPPUNIT_ASSERT(innerps.existsAs<int>("extraneous"));
   CPPUNIT_ASSERT(!innerps.existsAs<int>("absent"));
   char *releaseBase = getenv("CMSSW_RELEASE_BASE");
-  bool localArea = (releaseBase != 0 && strlen(releaseBase) != 0);
+  char *localBase = getenv("CMSSW_BASE");
+  bool localArea = (releaseBase != nullptr && strlen(releaseBase) != 0 && strcmp(releaseBase, localBase));
   if(localArea) {
     CPPUNIT_ASSERT(fip.location() == edm::FileInPath::Local);
   }
-  CPPUNIT_ASSERT(fip.relativePath()  == "FWCore/ParameterSet/python/Config.py");
-  CPPUNIT_ASSERT(ufip.relativePath() == "FWCore/ParameterSet/python/Types.py");
+  CPPUNIT_ASSERT(fip.relativePath()  == "FWCore/PythonParameterSet/test/fip.txt");
+  CPPUNIT_ASSERT(ufip.relativePath() == "FWCore/PythonParameterSet/test/ufip.txt");
   std::string fullpath = fip.fullPath();
   std::cerr << "fullPath is: " << fip.fullPath() << std::endl;
   std::cerr << "copy of fullPath is: " << fullpath << std::endl;
 
   CPPUNIT_ASSERT(!fullpath.empty());
 
-  std::string tmpout = fullpath.substr(0, fullpath.find("FWCore/ParameterSet/python/Config.py")) + "tmp.py";
+  std::string tmpout = fullpath.substr(0, fullpath.find("FWCore/PythonParameterSet/test/fip.txt")) + "tmp.py";
 
   edm::FileInPath topo = innerps.getParameter<edm::FileInPath>("topo");
   CPPUNIT_ASSERT(topo.location() != edm::FileInPath::Local);
@@ -256,7 +257,7 @@ void testmakepset::fileinpathAux() {
   unlink(tmpout.c_str());
   std::shared_ptr<edm::ParameterSet> ps2 = builder2.parameterSet();
 
-  CPPUNIT_ASSERT(0 != ps2.get());
+  CPPUNIT_ASSERT(nullptr != ps2.get());
 
   edm::ParameterSet const& innerps2 = ps2->getParameterSet("main");
   edm::FileInPath fip2 = innerps2.getParameter<edm::FileInPath>("fip2");

--- a/FWCore/PythonParameterSet/test/ufip.txt
+++ b/FWCore/PythonParameterSet/test/ufip.txt
@@ -1,0 +1,1 @@
+Dummy file for the FileInPath test.


### PR DESCRIPTION
This needs to be tested as I cannot be 100% sure that this fixes the test, as I can't be certain that I've reproduced the conditions under which the test is run in the IB. Nonetheless, it _should_ fix it.
There are two separate problems fixed by this PR. Problem 2) caused the test failure.
1) The two local files used for the locality test were in a different package than the test. This will cause the test to fail if the package with the files is not checked out in the local working area. So, two dummy files were added to the test package for use in the locality test.
2) The test actually did account for the possibility that it was being run from the base release. However, the test assumed that in the base release, CMSSW_RELEASE_BASE had been set to the empty string. This is, in fact, the case. However, if the test is run under scram, scram apparently sets CMSSW_RELEASE_BASE to the location of the base release. Because of this, the test does not recognize that it is being run from the base release, and tests fail. So this PR now also checks to see if CMSSW_RELEASE_BASE is equal to CMSSW_BASE, and also treats this as being run from the base release.
