### PR TITLE
missing-, inactive-, valid-hits and clusterChargePerCm Tracker Maps

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -20,7 +20,7 @@ SiStripMonitorDigi.TProfDigiApvCycle.subdetswitchon = True
 # APV shots monitoring
 SiStripMonitorDigi.TkHistoMapNApvShots_On = True 
 SiStripMonitorDigi.TkHistoMapNStripApvShots_On= True
-SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= True
+SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= False
 
 SiStripMonitorDigi.TH1NApvShots.subdetswitchon = True
 SiStripMonitorDigi.TH1NApvShots.globalswitchon = True

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -20,7 +20,7 @@ SiStripMonitorDigi.TProfDigiApvCycle.subdetswitchon = True
 # APV shots monitoring
 SiStripMonitorDigi.TkHistoMapNApvShots_On = True 
 SiStripMonitorDigi.TkHistoMapNStripApvShots_On= True
-SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= True
+SiStripMonitorDigi.TkHistoMapMedianChargeApvShots_On= False
 SiStripMonitorDigi.TH1NApvShots.subdetswitchon = True
 SiStripMonitorDigi.TH1NApvShots.globalswitchon = True
 SiStripMonitorDigi.TH1ChargeMedianApvShots.subdetswitchon = True

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
@@ -115,7 +115,13 @@ process.siStripOfflineAnalyser = cms.EDAnalyzer("SiStripOfflineDQM",
     cms.PSet(mapName=cms.untracked.string('StoNCorrOnTrack')),
     cms.PSet(mapName=cms.untracked.string('NApvShots'),mapMax=cms.untracked.double(-1.),logScale=cms.untracked.bool(True)),
 #    cms.PSet(mapName=cms.untracked.string('NApvShots'),mapMax=cms.untracked.double(-1.),logScale=cms.untracked.bool(True),psuMap=cms.untracked.bool(True),loadLVCabling=cms.untracked.bool(True)),
-    cms.PSet(mapName=cms.untracked.string('MedianChargeApvShots'),mapMax=cms.untracked.double(-1.))
+#    cms.PSet(mapName=cms.untracked.string('MedianChargeApvShots'),mapMax=cms.untracked.double(-1.)),
+#    cms.PSet(mapName=cms.untracked.string('ClusterCharge'),mapMax=cms.untracked.double(-1.)),
+    cms.PSet(mapName=cms.untracked.string('NumberMissingHits')),
+    cms.PSet(mapName=cms.untracked.string('ChargePerCMfromTrack')),
+#    cms.PSet(mapName=cms.untracked.string('ChargePerCMfromOrigin')),
+    cms.PSet(mapName=cms.untracked.string('NumberValidHits')),
+    cms.PSet(mapName=cms.untracked.string('NumberInactiveHits'))
     )
 )
 

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -147,6 +147,7 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
 
   // TkHistoMap added
   TkHistoMap* tkmapcluster; 
+  TkHistoMap* tkmapclusterch;
 
   int runNb, eventNb;
   int firstEvent;
@@ -194,6 +195,7 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
   bool globalswitchcstripvscpix;
   bool globalswitchMultiRegions;
   bool clustertkhistomapon;
+  bool clusterchtkhistomapon;
   bool createTrendMEs;
   bool trendVsLs_;
   bool globalswitchnclusvscycletimeprof2don;

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
@@ -19,6 +19,8 @@ SiStripCalZeroBiasMonitorCluster.ClusterLabel = cms.string('')
 
 SiStripCalZeroBiasMonitorCluster.TkHistoMap_On = cms.bool(False)
 
+SiStripCalZeroBiasMonitorCluster.ClusterChTkHistoMap_On = cms.bool(False)
+
 SiStripCalZeroBiasMonitorCluster.TopFolderName = cms.string('AlcaReco/SiStrip')
 
 SiStripCalZeroBiasMonitorCluster.BPTXfilter     = cms.PSet()

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -15,6 +15,8 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
     ClusterLabel = cms.string(''),
 
     TkHistoMap_On = cms.bool(True),
+
+    ClusterChTkHistoMap_On = cms.bool(True),
                                      
     TopFolderName = cms.string('SiStrip'),
 

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -168,6 +168,7 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
   module_clusterWidth_vs_amplitude_on = ParametersClusWidthVsAmpTH2.getParameter<bool>("moduleswitchon");
 
   clustertkhistomapon = conf_.getParameter<bool>("TkHistoMap_On");
+  clusterchtkhistomapon = conf_.getParameter<bool>("ClusterChTkHistoMap_On");
   createTrendMEs = conf_.getParameter<bool>("CreateTrendMEs");
   trendVsLs_ = conf_.getParameter<bool>("TrendVsLS");
   Mod_On_ = conf_.getParameter<bool>("Mod_On");
@@ -256,6 +257,11 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
       if ( (topFolderName_ == "SiStrip") or (std::string::npos != topFolderName_.find("HLT")) )
 	tkmapcluster = new TkHistoMap(ibooker , topFolderName_,"TkHMap_NumberOfCluster",0.,true);
       else tkmapcluster = new TkHistoMap(ibooker , topFolderName_+"/TkHistoMap","TkHMap_NumberOfCluster",0.,false);
+    }
+    if (clusterchtkhistomapon) {
+     if ( (topFolderName_ == "SiStrip") or (std::string::npos != topFolderName_.find("HLT")) )
+       tkmapclusterch = new TkHistoMap(ibooker , topFolderName_,"TkHMap_ClusterCharge",0.,true);
+     else tkmapclusterch = new TkHistoMap(ibooker , topFolderName_+"/TkHistoMap","TkHMap_ClusterCharge",0.,false);
     }
 
     // loop over detectors and book MEs
@@ -604,6 +610,7 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 	  (mod_single.NumberOfClusters)->Fill(0.); // no clusters for this detector module,fill histogram with 0
 	}
 	if(clustertkhistomapon) tkmapcluster->fill(detid,0.);
+        if(clusterchtkhistomapon) tkmapclusterch->fill(detid,0.);
 	if (found_layer_me && layerswitchnumclusterprofon) layer_single.LayerNumberOfClusterProfile->Fill(iDet, 0.0);
 	continue; // no clusters for this detid => jump to next step of loop
       }
@@ -642,6 +649,8 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 	short cluster_width    = ampls.size();
 	// add nr of strips of this cluster to total nr. of clusterized strips
 	total_clusterized_strips = total_clusterized_strips + cluster_width;
+
+	if(clusterchtkhistomapon) tkmapclusterch->fill(detid,static_cast<float>(clusterIter->charge()));
 
 	// cluster signal and noise from the amplitudes
 	float cluster_signal = 0.0;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -126,8 +126,11 @@ private:
   std::string topFolderName_;
   
   //******* TkHistoMaps
-  TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack;  
+  TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack; 
+  TkHistoMap *tkhisto_ClChPerCMfromOrigin, *tkhisto_ClChPerCMfromTrack;
+  TkHistoMap *tkhisto_NumMissingHits, *tkhisto_NumberInactiveHits, *tkhisto_NumberValidHits; 
   //******** TkHistoMaps
+  int numTracks;
  
   struct ModMEs{  
     MonitorElement* ClusterStoNCorr;
@@ -211,6 +214,7 @@ private:
   bool HistoFlag_On_;
   bool ring_flag;
   bool TkHistoMap_On_;
+  bool clchCMoriginTkHmap_On_;
 
   std::string TrackProducer_;
   std::string TrackLabel_;

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -23,7 +23,8 @@ SiStripMonitorTrack = cms.EDAnalyzer(
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),
     TkHistoMap_On = cms.bool(True),   
-    
+    clchCMoriginTkHmap_On = cms.bool(False), 
+
     ClusterConditions = cms.PSet( On       = cms.bool(False),
                                   minStoN  = cms.double(0.0),
                                   maxStoN  = cms.double(2000.0),

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -154,7 +154,13 @@ void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopolo
     tkhisto_StoNCorrOnTrack = new TkHistoMap(ibooker , topFolderName_ ,"TkHMap_StoNCorrOnTrack",         0.0,true);
     tkhisto_NumOnTrack      = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberOfOnTrackCluster",  0.0,true);
     tkhisto_NumOffTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberOfOfffTrackCluster",0.0,true);
+    tkhisto_ClChPerCMfromTrack  = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ChargePerCMfromTrack",0.0,true);
+    tkhisto_NumMissingHits      = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberMissingHits",0.0,true);
+    tkhisto_NumberInactiveHits  = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberInactiveHits",0.0,true);
+    tkhisto_NumberValidHits     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberValidHits",0.0,true);
   }
+  if (clchCMoriginTkHmap_On_)
+    tkhisto_ClChPerCMfromOrigin = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ChargePerCMfromOrigin",0.0,true);
   //******** TkHistoMaps
 
   std::vector<uint32_t> vdetId_;
@@ -657,6 +663,18 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
     TrajectoryStateOnSurface  updatedtsos=traj_mes_iterator->updatedState();
     ConstRecHitPointer ttrh=traj_mes_iterator->recHit();
 
+    if (TkHistoMap_On_ && (numTracks > 0)) {
+      uint32_t thedetid=ttrh->rawId();
+      if ( thedetid > 369120277-1 ) {
+        if ( (ttrh->getType()==1) )
+          tkhisto_NumMissingHits->add(thedetid,static_cast<float>(1./numTracks));
+        if ( (ttrh->getType()==2) )
+          tkhisto_NumberInactiveHits->add(thedetid,static_cast<float>(1./numTracks));
+        if ( (ttrh->getType()==0) )
+          tkhisto_NumberValidHits->add(thedetid,static_cast<float>(1./numTracks));
+      }
+    }
+
     if (!ttrh->isValid()) continue;
 
     const ProjectedSiStripRecHit2D* projhit  = dynamic_cast<const ProjectedSiStripRecHit2D*>( ttrh->hit() );
@@ -821,7 +839,8 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
   //  edm::ESHandle<TransientTrackBuilder> builder;
   //  es.get<TransientTrackRecord>().get("TransientTrackBuilder",builder);
   //  const TransientTrackBuilder* transientTrackBuilder = builder.product();
-      
+  
+  numTracks = trackCollectionHandle->size();    
   reco::TrackCollection trackCollection = *trackCollectionHandle;
   for (reco::TrackCollection::const_iterator track = trackCollection.begin(), etrack = trackCollection.end(); 
        track!=etrack; ++track) {
@@ -831,6 +850,19 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
      
     for (trackingRecHit_iterator hit = track->recHitsBegin(), ehit = track->recHitsEnd();
 	 hit!=ehit; ++hit) {
+
+      if (TkHistoMap_On_ && (numTracks > 0)) {
+        uint32_t thedetid=(*hit)->rawId();
+        if ( thedetid > 369120277-1 ) {
+          if ( ((*hit)->getType()==1) )
+            tkhisto_NumMissingHits->add(thedetid,static_cast<float>(1./numTracks));
+          if ( ((*hit)->getType()==2) )
+            tkhisto_NumberInactiveHits->add(thedetid,static_cast<float>(1./numTracks));
+          if ( ((*hit)->getType()==0) )
+            tkhisto_NumberValidHits->add(thedetid,static_cast<float>(1./numTracks));
+        }
+      }
+
       if (!(*hit)->isValid()) continue;
       DetId detID = (*hit)->geographicalId();
       if (detID.det() != DetId::Tracker) continue;
@@ -883,6 +915,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<TrajTrackAssociationCollection> TItkAssociatorCollection, const edm::EventSetup& es) {
   //Perform track study
+  numTracks = TItkAssociatorCollection->size();
   int i=0;
   for(TrajTrackAssociationCollection::const_iterator it =  TItkAssociatorCollection->begin();it !=  TItkAssociatorCollection->end(); ++it){
     const edm::Ref<std::vector<Trajectory> > traj_iterator = it->key;
@@ -1048,6 +1081,15 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
   LocalPoint locVtx = DetUnit->toLocal(GlobalPoint(0.0, 0.0, 0.0));
   LocalVector locDir(locVtx.x(), locVtx.y(), locVtx.z());
   float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, *cluster, locDir);
+
+  if (TkHistoMap_On_ && (flag == OnTrack)) {
+      uint32_t adet=cluster->detId();
+      tkhisto_ClChPerCMfromTrack->fill(adet,dQdx_fromTrack);
+  }
+  if (clchCMoriginTkHmap_On_ && (flag == OffTrack)){
+    uint32_t adet=cluster->detId();
+    tkhisto_ClChPerCMfromOrigin->fill(adet,dQdx_fromOrigin);
+  }
 
   if(flag==OnTrack){
     if (MEs.iSubdet != nullptr) MEs.iSubdet->totNClustersOnTrack++;


### PR DESCRIPTION
valid, missing and inactive recHit TrackerHistoMaps added.
inclusiveClusterCharge, ClusterChargePerCMfromOrigin and ClusterChargePerCMfromTrack TkHistoMaps also added.
inclusiveClusterCharge and ClusterChargePerCMfromTrack configurable.
SiStripDQM_OfflineTkMap_Template_cfg_DB.py updated to create the corresponding new TkMaps
TkHistoMapMedianChargeApvShots deactivated
