### PR TITLE
AssoByHits with GEM hits porting 8XY

### DIFF
--- a/SimMuon/MCTruth/BuildFile.xml
+++ b/SimMuon/MCTruth/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="DataFormats/CSCRecHit"/>
 <use   name="DataFormats/DTRecHit"/>
 <use   name="DataFormats/RPCRecHit"/>
+<use   name="DataFormats/GEMRecHit"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/MuonReco"/>

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -1,0 +1,70 @@
+#ifndef MCTruth_GEMHitAssociator_h
+#define MCTruth_GEMHitAssociator_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include <vector>
+#include <map>
+#include <string>
+#include <set>
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+class GEMHitAssociator {
+
+ public:
+
+   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
+   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
+   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
+
+   // Constructor with configurable parameters
+   GEMHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && ic);
+   GEMHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf);
+    
+   void initEvent(const edm::Event&, const edm::EventSetup&);
+
+   // Destructor
+   ~GEMHitAssociator(){}
+
+   std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit & hit);
+
+ private:
+    
+   const DigiSimLinks * theDigiSimLinks;
+   edm::InputTag GEMdigisimlinkTag;
+ 
+   bool crossingframe;
+   bool useGEMs_;
+   edm::InputTag GEMsimhitsTag;
+   edm::InputTag GEMsimhitsXFTag;
+    
+   edm::EDGetTokenT<CrossingFrame<PSimHit> > GEMsimhitsXFToken_;
+   edm::EDGetTokenT<edm::PSimHitContainer> GEMsimhitsToken_;
+   edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > GEMdigisimlinkToken_;
+
+   std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
+
+ };
+
+#endif
+

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -46,7 +46,7 @@ class GEMHitAssociator {
    // Destructor
    ~GEMHitAssociator(){}
 
-   std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit & hit);
+   std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit & hit) const;
 
  private:
     

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
@@ -13,6 +13,7 @@
 #include "SimMuon/MCTruth/interface/DTHitAssociator.h"
 #include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
 #include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
+#include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
@@ -40,6 +41,7 @@ class MuonAssociatorByHitsHelper {
     CSCHitAssociator const* cscHitAssoc_;
     DTHitAssociator const* dtHitAssoc_;
     RPCHitAssociator const* rpcHitAssoc_;
+    GEMHitAssociator const* gemHitAssoc_;
     std::function<void(const TrackHitsCollection&, const TrackingParticleCollection&)> diagnostics_;
   };
   
@@ -65,12 +67,12 @@ class MuonAssociatorByHitsHelper {
   void getMatchedIds
     (MapOfMatchedIds & tracker_matchedIds_valid, MapOfMatchedIds & muon_matchedIds_valid,
      MapOfMatchedIds & tracker_matchedIds_INVALID, MapOfMatchedIds & muon_matchedIds_INVALID,
-     int& n_tracker_valid, int& n_dt_valid, int& n_csc_valid, int& n_rpc_valid,
-     int& n_tracker_matched_valid, int& n_dt_matched_valid, int& n_csc_matched_valid, int& n_rpc_matched_valid,
-     int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID,
-     int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID,
+     int& n_tracker_valid, int& n_dt_valid, int& n_csc_valid, int& n_rpc_valid, int& n_gem_valid,
+     int& n_tracker_matched_valid, int& n_dt_matched_valid, int& n_csc_matched_valid, int& n_rpc_matched_valid, int& n_gem_matched_valid,
+     int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID, int& n_gem_INVALID,
+     int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID, int& n_gem_matched_INVALID,
      trackingRecHit_iterator begin, trackingRecHit_iterator end,
-     const TrackerHitAssociator* trackertruth, const DTHitAssociator& dttruth, const CSCHitAssociator& csctruth, const RPCHitAssociator& rpctruth,
+     const TrackerHitAssociator* trackertruth, const DTHitAssociator& dttruth, const CSCHitAssociator& csctruth, const RPCHitAssociator& rpctruth, const GEMHitAssociator& gemtruth,
      bool printRts, const TrackerTopology *) const;
   
   int getShared(MapOfMatchedIds & matchedIds, TrackingParticleCollection::const_iterator trpart) const;

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -182,6 +182,7 @@ private:
   TrackerMuonHitExtractor hitExtractor_;
 
   std::unique_ptr<RPCHitAssociator> rpctruth_;
+  std::unique_ptr<GEMHitAssociator> gemtruth_;
   std::unique_ptr<DTHitAssociator> dttruth_;
   std::unique_ptr<CSCHitAssociator> csctruth_;
   std::unique_ptr<TrackerHitAssociator> trackertruth_;
@@ -211,6 +212,7 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
 
    //hack for consumes
    RPCHitAssociator rpctruth(iConfig,consumesCollector());
+   GEMHitAssociator gemtruth(iConfig,consumesCollector());
    DTHitAssociator dttruth(iConfig,consumesCollector());
    CSCHitAssociator cscruth(iConfig,consumesCollector());
 
@@ -261,8 +263,10 @@ MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event& iEvent, const ed
    dttruth_.reset(new DTHitAssociator(iEvent,iSetup,config_,printRtS));
    // RPC hit association
    rpctruth_.reset( new RPCHitAssociator(iEvent,iSetup,config_) );
+   // GEM hit association
+   gemtruth_.reset( new GEMHitAssociator(iEvent,iSetup,config_) );
    
-   MuonAssociatorByHitsHelper::Resources resources = {tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get()};
+   MuonAssociatorByHitsHelper::Resources resources = {tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get()};
 
    if(diagnostics_) {
      diagnostics_->read(iEvent);

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -60,6 +60,12 @@ muonAssociatorByHitsCommonParameters = cms.PSet(
     RPCsimhitsXFTag = cms.InputTag("mix","g4SimHitsMuonRPCHits"),
     RPCdigisimlinkTag = cms.InputTag("simMuonRPCDigis","RPCDigiSimLink"),
     #
+    # for GEM Hit associator
+    useGEMs = cms.bool(False),
+    GEMsimhitsTag = cms.InputTag("g4SimHits","MuonGEMHits"),
+    GEMsimhitsXFTag = cms.InputTag("mix","g4SimHitsMuonGEMHits"),
+    GEMdigisimlinkTag = cms.InputTag("simMuonGEMDigis","GEM"),
+    #
     # for Tracker Hit associator
     #
     associatePixel = cms.bool(True),

--- a/SimMuon/MCTruth/python/muonAssociatorByHitsNoSimHitsHelper_cfi.py
+++ b/SimMuon/MCTruth/python/muonAssociatorByHitsNoSimHitsHelper_cfi.py
@@ -10,6 +10,7 @@ muonAssociatorByHitsNoSimHitsHelper = cms.EDProducer("MuonToTrackingParticleAsso
 # don't read simhits, they're not there
 muonAssociatorByHitsNoSimHitsHelper.CSCsimHitsTag = ""
 muonAssociatorByHitsNoSimHitsHelper.RPCsimhitsTag = ""
+muonAssociatorByHitsNoSimHitsHelper.GEMsimhitsTag = ""
 muonAssociatorByHitsNoSimHitsHelper.DTsimhitsTag  = ""
 
 ### The following is useful when running only on RECO

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -1,0 +1,127 @@
+#include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
+
+using namespace std;
+
+// Constructor
+GEMHitAssociator::GEMHitAssociator( const edm::ParameterSet& conf,
+				    edm::ConsumesCollector && iC):
+  GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
+  // CrossingFrame used or not ?
+  crossingframe(conf.getParameter<bool>("crossingframe")),
+  GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
+  GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag"))
+{
+  if (crossingframe){
+    GEMsimhitsXFToken_=iC.consumes<CrossingFrame<PSimHit> >(GEMsimhitsXFTag);
+  } else if (!GEMsimhitsTag.label().empty()) {
+    GEMsimhitsToken_=iC.consumes<edm::PSimHitContainer>(GEMsimhitsTag);
+  }
+
+  GEMdigisimlinkToken_=iC.consumes< edm::DetSetVector<StripDigiSimLink> >(GEMdigisimlinkTag);
+}
+
+GEMHitAssociator::GEMHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf ):
+  GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
+  // CrossingFrame used or not ?
+  crossingframe(conf.getParameter<bool>("crossingframe")),
+  GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
+  GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag"))
+{
+  initEvent(e,eventSetup);
+}
+
+void GEMHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eventSetup)
+{
+
+  if(useGEMs_){
+
+	  if (crossingframe) {
+	    
+	    edm::Handle<CrossingFrame<PSimHit> > cf;
+	    LogTrace("GEMHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<GEMsimhitsXFTag;
+	    e.getByLabel(GEMsimhitsXFTag, cf);
+	    
+	    std::auto_ptr<MixCollection<PSimHit> > 
+	      GEMsimhits( new MixCollection<PSimHit>(cf.product()) );
+	    LogTrace("GEMHitAssociator") <<"... size = "<<GEMsimhits->size();
+
+	    //   MixCollection<PSimHit> & simHits = *hits;
+	    
+	    for(MixCollection<PSimHit>::MixItr hitItr = GEMsimhits->begin();
+		hitItr != GEMsimhits->end(); ++hitItr) 
+	      {
+		_SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+	      }
+	    
+	  } else if (!GEMsimhitsTag.label().empty()) {
+	    edm::Handle<edm::PSimHitContainer> GEMsimhits;
+	    LogTrace("GEMHitAssociator") <<"getting PSimHit collection - "<<GEMsimhitsTag;
+	    e.getByLabel(GEMsimhitsTag, GEMsimhits);    
+	    LogTrace("GEMHitAssociator") <<"... size = "<<GEMsimhits->size();
+	    
+	    // arrange the hits by detUnit
+	    for(edm::PSimHitContainer::const_iterator hitItr = GEMsimhits->begin();
+		hitItr != GEMsimhits->end(); ++hitItr)
+	      {
+		_SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+	      }
+	  }
+
+	  edm::Handle<DigiSimLinks> digiSimLinks;
+	  LogTrace("GEMHitAssociator") <<"getting GEM Strip DigiSimLink collection - "<<GEMdigisimlinkTag;
+	  e.getByLabel(GEMdigisimlinkTag, digiSimLinks);
+	  theDigiSimLinks = digiSimLinks.product();
+
+  }
+
+}
+// end of constructor
+
+std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(const TrackingRecHit & hit) {
+  
+  std::vector<SimHitIdpr> matched;
+
+  if(useGEMs_){
+	
+	  //std::cout<<"gemboo "<<useGEMs_<<std::endl;
+
+	  const TrackingRecHit * hitp = &hit;
+	  const GEMRecHit * gemrechit = dynamic_cast<const GEMRecHit *>(hitp);
+
+	  if (gemrechit) {
+	    
+	    GEMDetId gemDetId = gemrechit->gemId();
+	    int fstrip = gemrechit->firstClusterStrip();
+	    int cls = gemrechit->clusterSize();
+	    //int bx = gemrechit->BunchX();
+
+	    DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(gemDetId);
+
+	    if (layerLinks != theDigiSimLinks->end()) {
+	    
+		for(int i = fstrip; i < (fstrip+cls); ++i) {
+			      
+			for(LayerLinks::const_iterator itlink = layerLinks->begin(); itlink != layerLinks->end(); ++itlink) {
+
+		  		int ch = static_cast<int>(itlink->channel());
+				if(ch != i) continue;
+
+				SimHitIdpr currentId(itlink->SimTrackId(), itlink->eventId());
+				if(find(matched.begin(),matched.end(),currentId ) == matched.end())
+					matched.push_back(currentId);
+
+			}
+
+		}
+
+	    }else edm::LogWarning("GEMHitAssociator")
+	      <<"*** WARNING in GEMHitAssociator: GEM layer "<<gemDetId<<" has no DigiSimLinks !"<<std::endl;
+	    
+	  } else edm::LogWarning("GEMHitAssociator")<<"*** WARNING in GEMHitAssociator::associateRecHit, null dynamic_cast !";
+
+  }
+  
+  return  matched;
+
+}
+

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -77,7 +77,7 @@ void GEMHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eve
 }
 // end of constructor
 
-std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(const TrackingRecHit & hit) {
+std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(const TrackingRecHit & hit) const {
   
   std::vector<SimHitIdpr> matched;
 

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -8,6 +8,7 @@ GEMHitAssociator::GEMHitAssociator( const edm::ParameterSet& conf,
   GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
   // CrossingFrame used or not ?
   crossingframe(conf.getParameter<bool>("crossingframe")),
+  useGEMs_(conf.getParameter<bool>("useGEMs")),
   GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
   GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag"))
 {
@@ -21,9 +22,10 @@ GEMHitAssociator::GEMHitAssociator( const edm::ParameterSet& conf,
 }
 
 GEMHitAssociator::GEMHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf ):
-  GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
+  GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
   // CrossingFrame used or not ?
   crossingframe(conf.getParameter<bool>("crossingframe")),
+  useGEMs_(conf.getParameter<bool>("useGEMs")),
   GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
   GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag"))
 {

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -142,6 +142,7 @@ MuonAssociatorByHits::MuonAssociatorByHits (const edm::ParameterSet& conf, edm::
 {
   //hack for consumes
   RPCHitAssociator rpctruth(conf,std::move(iC));
+  GEMHitAssociator gemtruth(conf,std::move(iC));
   DTHitAssociator dttruth(conf,std::move(iC));
   CSCHitAssociator muonTruth(conf,std::move(iC));
   if( conf.getUntrackedParameter<bool>("dumpInputCollections") ) {
@@ -181,8 +182,10 @@ MuonAssociatorByHits::associateRecoToSim( const edm::RefToBaseVector<reco::Track
   DTHitAssociator dttruth(*e,*setup,conf_,printRtS);  
   // RPC hit association
   RPCHitAssociator rpctruth(*e,*setup,conf_);
+  // GEM hit association
+  GEMHitAssociator gemtruth(*e,*setup,conf_);
    
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth};
+  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
 
   if(diagnostics_) {
     resources.diagnostics_ = [this, e](const TrackHitsCollection& hC, const TrackingParticleCollection& pC) {
@@ -226,8 +229,10 @@ MuonAssociatorByHits::associateSimToReco( const edm::RefToBaseVector<reco::Track
   DTHitAssociator dttruth(*e,*setup,conf_,printRtS);  
   // RPC hit association
   RPCHitAssociator rpctruth(*e,*setup,conf_);
+  // GEM hit association
+  GEMHitAssociator gemtruth(*e,*setup,conf_);
    
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth};
+  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
   
   auto bareAssoc = helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -65,6 +65,7 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
   auto const & csctruth = *resources.cscHitAssoc_;
   auto const& dttruth = *resources.dtHitAssoc_;
   auto const& rpctruth = *resources.rpcHitAssoc_;
+  auto const& gemtruth = *resources.gemHitAssoc_;
 
   int tracker_nshared = 0;
   int muon_nshared = 0;
@@ -117,51 +118,56 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
     int n_tracker_all = 0;
     int n_dt_all      = 0;     
     int n_csc_all     = 0;    
-    int n_rpc_all     = 0;    
+    int n_rpc_all     = 0;
+    int n_gem_all     = 0;
 
     int n_valid         = 0;        
     int n_tracker_valid = 0;
     int n_muon_valid    = 0;   
     int n_dt_valid      = 0;     
     int n_csc_valid     = 0;    
-    int n_rpc_valid     = 0;    
+    int n_rpc_valid     = 0;
+    int n_gem_valid     = 0;
 
     int n_tracker_matched_valid = 0;
     int n_muon_matched_valid    = 0;   
     int n_dt_matched_valid      = 0;     
     int n_csc_matched_valid     = 0;    
-    int n_rpc_matched_valid     = 0;    
+    int n_rpc_matched_valid     = 0;
+    int n_gem_matched_valid     = 0;
 
     int n_INVALID         = 0;        
     int n_tracker_INVALID = 0;
     int n_muon_INVALID    = 0;   
     int n_dt_INVALID      = 0;     
     int n_csc_INVALID     = 0;    
-    int n_rpc_INVALID     = 0;    
+    int n_rpc_INVALID     = 0;
+    int n_gem_INVALID     = 0;
     
     int n_tracker_matched_INVALID = 0;
     int n_muon_matched_INVALID    = 0;     
     int n_dt_matched_INVALID      = 0;     
     int n_csc_matched_INVALID     = 0;    
-    int n_rpc_matched_INVALID     = 0;    
+    int n_rpc_matched_INVALID     = 0;
+    int n_gem_matched_INVALID     = 0;
     
     printRtS = true;
     getMatchedIds(tracker_matchedIds_valid, muon_matchedIds_valid,
 		  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,       
-		  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid,
-		  n_tracker_matched_valid, n_dt_matched_valid, n_csc_matched_valid, n_rpc_matched_valid,
-		  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID,
-		  n_tracker_matched_INVALID, n_dt_matched_INVALID, n_csc_matched_INVALID, n_rpc_matched_INVALID,
+		  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid, n_gem_valid,
+		  n_tracker_matched_valid, n_dt_matched_valid, n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
+		  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID, n_gem_INVALID,
+		  n_tracker_matched_INVALID, n_dt_matched_INVALID, n_csc_matched_INVALID, n_rpc_matched_INVALID, n_gem_matched_INVALID,
                   track->first, track->second,
-		  trackertruth, dttruth, csctruth, rpctruth,
+		  trackertruth, dttruth, csctruth, rpctruth, gemtruth,
 		  printRtS,tTopo);
     
     n_matching_simhits = tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() + 
                          tracker_matchedIds_INVALID.size() +muon_matchedIds_INVALID.size(); 
 
-    n_muon_valid   = n_dt_valid + n_csc_valid + n_rpc_valid;
+    n_muon_valid   = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
     n_valid        = n_tracker_valid + n_muon_valid;
-    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID;
+    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
     n_INVALID      = n_tracker_INVALID + n_muon_INVALID;
 
     // all used hits (valid+INVALID), defined by UseTracker, UseMuon
@@ -169,10 +175,11 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
     n_dt_all      = n_dt_valid  + n_dt_INVALID;
     n_csc_all     = n_csc_valid + n_csc_INVALID;
     n_rpc_all     = n_rpc_valid + n_rpc_INVALID;
+    n_gem_all     = n_gem_valid + n_gem_INVALID;
     n_all         = n_valid + n_INVALID;
 
-    n_muon_matched_valid   = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid;
-    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID;
+    n_muon_matched_valid   = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid + n_gem_matched_valid;
+    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID + n_gem_matched_INVALID;
 
     // selected hits are set initially to valid hits
     int n_tracker_selected_hits = n_tracker_valid;
@@ -180,6 +187,7 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
     int n_dt_selected_hits      = n_dt_valid;
     int n_csc_selected_hits     = n_csc_valid;
     int n_rpc_selected_hits     = n_rpc_valid;
+    int n_gem_selected_hits     = n_gem_valid;
 
     // matched hits are a subsample of the selected hits
     int n_tracker_matched = n_tracker_matched_valid;
@@ -187,6 +195,7 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
     int n_dt_matched      = n_dt_matched_valid;
     int n_csc_matched     = n_csc_matched_valid;
     int n_rpc_matched     = n_rpc_matched_valid;
+    int n_gem_matched     = n_gem_matched_valid;
 
     std::string InvMuonHits, ZeroHitMuon;
     
@@ -200,11 +209,13 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
       n_dt_selected_hits   = n_dt_INVALID;
       n_csc_selected_hits  = n_csc_INVALID;
       n_rpc_selected_hits  = n_rpc_INVALID;
+      n_gem_selected_hits  = n_gem_INVALID;
 
       n_muon_matched = n_muon_matched_INVALID;
       n_dt_matched   = n_dt_matched_INVALID;
       n_csc_matched  = n_csc_matched_INVALID;
-      n_rpc_matched  = n_rpc_matched_INVALID;      
+      n_rpc_matched  = n_rpc_matched_INVALID;
+      n_gem_matched  = n_gem_matched_INVALID;
     }
 
     int n_selected_hits = n_tracker_selected_hits + n_muon_selected_hits;
@@ -213,11 +224,11 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
       <<"\n"<<"# TrackingRecHits: "<<(track->second - track->first) 
       <<"\n"<< "# used RecHits     = " << n_all <<" ("<<n_tracker_all<<"/"
-      <<n_dt_all<<"/"<<n_csc_all<<"/"<<n_rpc_all<<" in Tracker/DT/CSC/RPC)"<<", obtained from " << n_matching_simhits << " SimHits"
+      <<n_dt_all<<"/"<<n_csc_all<<"/"<<n_rpc_all<<"/"<<n_gem_all<<" in Tracker/DT/CSC/RPC/GEM)"<<", obtained from " << n_matching_simhits << " SimHits"
       <<"\n"<< "# selected RecHits = " <<n_selected_hits <<" (" <<n_tracker_selected_hits<<"/"
-      <<n_dt_selected_hits<<"/"<<n_csc_selected_hits<<"/"<<n_rpc_selected_hits<<" in Tracker/DT/CSC/RPC)"<<InvMuonHits
+      <<n_dt_selected_hits<<"/"<<n_csc_selected_hits<<"/"<<n_rpc_selected_hits<<"/"<<n_gem_selected_hits<<" in Tracker/DT/CSC/RPC/GEM)"<<InvMuonHits
       <<"\n"<< "# matched RecHits  = " <<n_matched<<" ("<<n_tracker_matched<<"/"
-      <<n_dt_matched<<"/"<<n_csc_matched<<"/"<<n_rpc_matched<<" in Tracker/DT/CSC/RPC)";
+      <<n_dt_matched<<"/"<<n_csc_matched<<"/"<<n_rpc_matched<<"/"<<n_gem_matched<<" in Tracker/DT/CSC/RPC/GEM)";
 
     if (n_all>0 && n_matching_simhits == 0)
       edm::LogWarning("MuonAssociatorByHitsHelper")
@@ -335,6 +346,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
   auto const & csctruth = *resources.cscHitAssoc_;
   auto const& dttruth = *resources.dtHitAssoc_;
   auto const& rpctruth = *resources.rpcHitAssoc_;
+  auto const& gemtruth = *resources.gemHitAssoc_;
 
   int tracker_nshared = 0;
   int muon_nshared = 0;
@@ -391,51 +403,56 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
     int n_tracker_all = 0;
     int n_dt_all      = 0;     
     int n_csc_all     = 0;    
-    int n_rpc_all     = 0;    
+    int n_rpc_all     = 0;
+    int n_gem_all     = 0;
 
     int n_valid         = 0;        
     int n_tracker_valid = 0;
     int n_muon_valid    = 0;   
     int n_dt_valid      = 0;     
     int n_csc_valid     = 0;    
-    int n_rpc_valid     = 0;    
+    int n_rpc_valid     = 0;
+    int n_gem_valid     = 0;
 
     int n_tracker_matched_valid = 0;
     int n_muon_matched_valid    = 0;   
     int n_dt_matched_valid      = 0;     
     int n_csc_matched_valid     = 0;    
-    int n_rpc_matched_valid     = 0;    
+    int n_rpc_matched_valid     = 0;
+    int n_gem_matched_valid     = 0;
 
     int n_INVALID         = 0;        
     int n_tracker_INVALID = 0;
     int n_muon_INVALID    = 0;   
     int n_dt_INVALID      = 0;     
     int n_csc_INVALID     = 0;    
-    int n_rpc_INVALID     = 0;    
+    int n_rpc_INVALID     = 0;
+    int n_gem_INVALID     = 0;
     
     int n_tracker_matched_INVALID = 0;
     int n_muon_matched_INVALID    = 0;     
     int n_dt_matched_INVALID      = 0;     
     int n_csc_matched_INVALID     = 0;    
-    int n_rpc_matched_INVALID     = 0;    
+    int n_rpc_matched_INVALID     = 0;
+    int n_gem_matched_INVALID     = 0;
     
     printRtS = false;
     getMatchedIds(tracker_matchedIds_valid, muon_matchedIds_valid,
 		  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,       
-		  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid,
-		  n_tracker_matched_valid, n_dt_matched_valid, n_csc_matched_valid, n_rpc_matched_valid,
-		  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID,
-		  n_tracker_matched_INVALID, n_dt_matched_INVALID, n_csc_matched_INVALID, n_rpc_matched_INVALID,
+		  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid, n_gem_valid,
+		  n_tracker_matched_valid, n_dt_matched_valid, n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
+		  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID, n_gem_INVALID,
+		  n_tracker_matched_INVALID, n_dt_matched_INVALID, n_csc_matched_INVALID, n_rpc_matched_INVALID, n_gem_matched_INVALID,
                   track->first, track->second,
-		  trackertruth, dttruth, csctruth, rpctruth,
+		  trackertruth, dttruth, csctruth, rpctruth, gemtruth,
 		  printRtS,tTopo);
     
     n_matching_simhits = tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() + 
                          tracker_matchedIds_INVALID.size() +muon_matchedIds_INVALID.size(); 
 
-    n_muon_valid   = n_dt_valid + n_csc_valid + n_rpc_valid;
+    n_muon_valid   = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
     n_valid        = n_tracker_valid + n_muon_valid;
-    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID;
+    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
     n_INVALID      = n_tracker_INVALID + n_muon_INVALID;
 
     // all used hits (valid+INVALID), defined by UseTracker, UseMuon
@@ -443,10 +460,11 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
     n_dt_all      = n_dt_valid  + n_dt_INVALID;
     n_csc_all     = n_csc_valid + n_csc_INVALID;
     n_rpc_all     = n_rpc_valid + n_rpc_INVALID;
+    n_gem_all     = n_gem_valid + n_gem_INVALID;
     n_all         = n_valid + n_INVALID;
 
-    n_muon_matched_valid   = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid;
-    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID;
+    n_muon_matched_valid   = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid + n_gem_matched_valid;
+    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID + n_gem_matched_INVALID;
 
      // selected hits are set initially to valid hits
     int n_tracker_selected_hits = n_tracker_valid;
@@ -454,6 +472,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
     int n_dt_selected_hits      = n_dt_valid;
     int n_csc_selected_hits     = n_csc_valid;
     int n_rpc_selected_hits     = n_rpc_valid;
+    int n_gem_selected_hits     = n_gem_valid;
 
     // matched hits are a subsample of the selected hits
     int n_tracker_matched = n_tracker_matched_valid;
@@ -461,6 +480,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
     int n_dt_matched      = n_dt_matched_valid;
     int n_csc_matched     = n_csc_matched_valid;
     int n_rpc_matched     = n_rpc_matched_valid;
+    int n_gem_matched     = n_gem_matched_valid;
 
     std::string InvMuonHits, ZeroHitMuon;
 
@@ -474,11 +494,13 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
       n_dt_selected_hits   = n_dt_INVALID;
       n_csc_selected_hits  = n_csc_INVALID;
       n_rpc_selected_hits  = n_rpc_INVALID;
+      n_gem_selected_hits  = n_gem_INVALID;
 
       n_muon_matched = n_muon_matched_INVALID;
       n_dt_matched   = n_dt_matched_INVALID;
       n_csc_matched  = n_csc_matched_INVALID;
       n_rpc_matched  = n_rpc_matched_INVALID;
+      n_gem_matched  = n_gem_matched_INVALID;
     }
 
     int n_selected_hits = n_tracker_selected_hits + n_muon_selected_hits;
@@ -487,11 +509,11 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
     if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
       <<"\n"<<"# TrackingRecHits: "<<(track->second - track->first) 
       <<"\n"<< "# used RecHits     = " <<n_all    <<" ("<<n_tracker_all<<"/"
-      <<n_dt_all<<"/"<<n_csc_all<<"/"<<n_rpc_all<<" in Tracker/DT/CSC/RPC)"<<", obtained from " << n_matching_simhits << " SimHits"
+      <<n_dt_all<<"/"<<n_csc_all<<"/"<<n_rpc_all<<"/"<<n_gem_all<<" in Tracker/DT/CSC/RPC/GEM)"<<", obtained from " << n_matching_simhits << " SimHits"
       <<"\n"<< "# selected RecHits = " <<n_selected_hits  <<" (" <<n_tracker_selected_hits<<"/"
-      <<n_dt_selected_hits<<"/"<<n_csc_selected_hits<<"/"<<n_rpc_selected_hits<<" in Tracker/DT/CSC/RPC)"<<InvMuonHits
+      <<n_dt_selected_hits<<"/"<<n_csc_selected_hits<<"/"<<n_rpc_selected_hits<<"/"<<n_gem_selected_hits<<" in Tracker/DT/CSC/RPC/GEM)"<<InvMuonHits
       <<"\n"<< "# matched RecHits = " <<n_matched<<" ("<<n_tracker_matched<<"/"
-      <<n_dt_matched<<"/"<<n_csc_matched<<"/"<<n_rpc_matched<<" in Tracker/DT/CSC/RPC)";
+      <<n_dt_matched<<"/"<<n_csc_matched<<"/"<<n_rpc_matched<<"/"<<n_gem_matched<<" in Tracker/DT/CSC/RPC/GEM)";
     
     if (printRtS && n_all>0 && n_matching_simhits==0)
       edm::LogWarning("MuonAssociatorByHitsHelper")
@@ -743,13 +765,13 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
 void MuonAssociatorByHitsHelper::getMatchedIds
 (MapOfMatchedIds & tracker_matchedIds_valid, MapOfMatchedIds & muon_matchedIds_valid,
  MapOfMatchedIds & tracker_matchedIds_INVALID, MapOfMatchedIds & muon_matchedIds_INVALID,       
- int& n_tracker_valid, int& n_dt_valid, int& n_csc_valid, int& n_rpc_valid,
- int& n_tracker_matched_valid, int& n_dt_matched_valid, int& n_csc_matched_valid, int& n_rpc_matched_valid,
- int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID,
- int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID,
+ int& n_tracker_valid, int& n_dt_valid, int& n_csc_valid, int& n_rpc_valid, int& n_gem_valid,
+ int& n_tracker_matched_valid, int& n_dt_matched_valid, int& n_csc_matched_valid, int& n_rpc_matched_valid, int& n_gem_matched_valid,
+ int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID, int& n_gem_INVALID,
+ int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID, int& n_gem_matched_INVALID,
  trackingRecHit_iterator begin, trackingRecHit_iterator end,
  const TrackerHitAssociator* trackertruth, 
- const DTHitAssociator& dttruth, const CSCHitAssociator& csctruth, const RPCHitAssociator& rpctruth, bool printRtS,
+ const DTHitAssociator& dttruth, const CSCHitAssociator& csctruth, const RPCHitAssociator& rpctruth, const GEMHitAssociator& gemtruth, bool printRtS,
  const TrackerTopology *tTopo) const
 
 {
@@ -763,21 +785,25 @@ void MuonAssociatorByHitsHelper::getMatchedIds
   n_dt_valid  = 0;
   n_csc_valid = 0;
   n_rpc_valid = 0;
+  n_gem_valid = 0;
 
   n_tracker_matched_valid = 0;
   n_dt_matched_valid  = 0;
   n_csc_matched_valid = 0;
   n_rpc_matched_valid = 0;
+  n_gem_matched_valid = 0;
   
   n_tracker_INVALID = 0;
   n_dt_INVALID  = 0;
   n_csc_INVALID = 0;
   n_rpc_INVALID = 0;
+  n_gem_INVALID = 0;
   
   n_tracker_matched_INVALID = 0;
   n_dt_matched_INVALID  = 0;
   n_csc_matched_INVALID = 0;
   n_rpc_matched_INVALID = 0;
+  n_gem_matched_INVALID = 0;
   
   std::vector<SimHitIdpr> SimTrackIds;
 
@@ -1095,6 +1121,38 @@ void MuonAssociatorByHitsHelper::getMatchedIds
             muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
 	  }
 	}
+      }
+          
+      // GEM Hits
+      else if (subdet == MuonSubdetId::GEM) {
+	GEMDetId gemdetid = GEMDetId(detid);
+	stringstream gem_detector_id;
+	gem_detector_id << gemdetid;
+	if (valid_Hit) hitlog = hitlog+" -Muon GEM- detID = "+gem_detector_id.str();	  
+	else hitlog = hitlog+" *** INVALID ***"+" -Muon GEM- detID = "+gem_detector_id.str();	  
+	
+	iH++;
+	SimTrackIds = gemtruth.associateRecHit(*hitp);
+	
+	if (valid_Hit) {
+	  n_gem_valid++;
+
+	  if (!SimTrackIds.empty()) {
+	    n_gem_matched_valid++;
+	    //muon_matchedIds_valid[iH] = SimTrackIds;
+            muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
+            
+	  }
+	} else {
+	  n_gem_INVALID++;
+	  
+	  if (!SimTrackIds.empty()) {
+	    n_gem_matched_INVALID++;
+	    //muon_matchedIds_INVALID[iH] = SimTrackIds;
+            muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
+	  }
+	}
+          
 	
       } else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
 	<<"TrackingRecHit "<<iloop<<"  *** WARNING *** Unexpected Hit from Detector = "<<det;

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
@@ -25,6 +25,7 @@ MuonToSimAssociatorByHits::MuonToSimAssociatorByHits (const edm::ParameterSet& c
 
   //hack for consumes
   RPCHitAssociator rpctruth(conf,std::move(iC));
+  GEMHitAssociator gemtruth(conf,std::move(iC));
   DTHitAssociator dttruth(conf,std::move(iC));
   CSCHitAssociator muonTruth(conf,std::move(iC));
 }
@@ -136,8 +137,10 @@ void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, S
     DTHitAssociator dttruth(*event,*setup,conf_,printRtS);  
     // RPC hit association
     RPCHitAssociator rpctruth(*event,*setup,conf_);
+    // GEM hit association
+    GEMHitAssociator gemtruth(*event,*setup,conf_);
    
-    MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth};
+    MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
 
     auto recSimColl = helper_.associateRecoToSimIndices(muonHitRefs,tPC,resources);
     for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -140,10 +140,12 @@ void MuonTrackValidator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run con
       nDThits_vs_eta.push_back( ibooker.book2D("nDThits_vs_eta","# DT hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       nCSChits_vs_eta.push_back( ibooker.book2D("nCSChits_vs_eta","# CSC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       nRPChits_vs_eta.push_back( ibooker.book2D("nRPChits_vs_eta","# RPC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
+      nGEMhits_vs_eta.push_back( ibooker.book2D("nGEMhits_vs_eta","# GEM hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
 
       h_DThits_eta.push_back( ibooker.bookProfile("DThits_eta","mean # DT hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_CSChits_eta.push_back( ibooker.bookProfile("CSChits_eta","mean # CSC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_RPChits_eta.push_back( ibooker.bookProfile("RPChits_eta","mean # RPC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
+      h_GEMhits_eta.push_back( ibooker.bookProfile("GEMhits_eta","mean # GEM hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_hits_eta.push_back( ibooker.bookProfile("hits_eta","mean #hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       nhits_vs_phi.push_back( ibooker.book2D("nhits_vs_phi","#hits vs #phi",nintPhi,minPhi,maxPhi,nintHit,minHit,maxHit) );
       h_hits_phi.push_back( ibooker.bookProfile("hits_phi","mean #hits vs #phi",nintPhi,minPhi,maxPhi, nintHit,minHit,maxHit) );
@@ -824,6 +826,7 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	nDThits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonDTHits());
 	nCSChits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonCSCHits());
 	nRPChits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonRPCHits());
+    if(useGEMs_) nGEMhits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonGEMHits());
 	
 	nlosthits_vs_eta[w]->Fill(getEta(track->eta()),track->numberOfLostHits());
 	
@@ -899,6 +902,7 @@ void MuonTrackValidator::endRun(Run const&, EventSetup const&) {
       doProfileX(nDThits_vs_eta[w],h_DThits_eta[w]);
       doProfileX(nCSChits_vs_eta[w],h_CSChits_eta[w]);
       doProfileX(nRPChits_vs_eta[w],h_RPChits_eta[w]);
+      if (useGEMs_) doProfileX(nGEMhits_vs_eta[w],h_GEMhits_eta[w]);
       
       doProfileX(nlosthits_vs_eta[w],h_losthits_eta[w]);
       //vs phi

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -140,7 +140,7 @@ void MuonTrackValidator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run con
       nDThits_vs_eta.push_back( ibooker.book2D("nDThits_vs_eta","# DT hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       nCSChits_vs_eta.push_back( ibooker.book2D("nCSChits_vs_eta","# CSC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       nRPChits_vs_eta.push_back( ibooker.book2D("nRPChits_vs_eta","# RPC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
-      nGEMhits_vs_eta.push_back( ibooker.book2D("nGEMhits_vs_eta","# GEM hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
+      if(useGEMs_) nGEMhits_vs_eta.push_back( ibooker.book2D("nGEMhits_vs_eta","# GEM hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
 
       h_DThits_eta.push_back( ibooker.bookProfile("DThits_eta","mean # DT hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_CSChits_eta.push_back( ibooker.bookProfile("CSChits_eta","mean # CSC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
@@ -827,7 +827,6 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	nCSChits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonCSCHits());
 	nRPChits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonRPCHits());
     if(useGEMs_) nGEMhits_vs_eta[w]->Fill(getEta(track->eta()),track->hitPattern().numberOfValidMuonGEMHits());
-	
 	nlosthits_vs_eta[w]->Fill(getEta(track->eta()),track->numberOfLostHits());
 	
 	//resolution of track params: fill 2D histos

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -145,7 +145,7 @@ void MuonTrackValidator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run con
       h_DThits_eta.push_back( ibooker.bookProfile("DThits_eta","mean # DT hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_CSChits_eta.push_back( ibooker.bookProfile("CSChits_eta","mean # CSC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_RPChits_eta.push_back( ibooker.bookProfile("RPChits_eta","mean # RPC hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
-      h_GEMhits_eta.push_back( ibooker.bookProfile("GEMhits_eta","mean # GEM hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
+      if(useGEMs_) h_GEMhits_eta.push_back( ibooker.bookProfile("GEMhits_eta","mean # GEM hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       h_hits_eta.push_back( ibooker.bookProfile("hits_eta","mean #hits vs eta",nint,min,max,nintHit,minHit,maxHit) );
       nhits_vs_phi.push_back( ibooker.book2D("nhits_vs_phi","#hits vs #phi",nintPhi,minPhi,maxPhi,nintHit,minHit,maxHit) );
       h_hits_phi.push_back( ibooker.bookProfile("hits_phi","mean #hits vs #phi",nintPhi,minPhi,maxPhi, nintHit,minHit,maxHit) );

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.h
@@ -22,6 +22,7 @@ class MuonTrackValidator : public DQMEDAnalyzer, protected MuonTrackValidatorBas
     dirName_ = pset.getParameter<std::string>("dirName");
     associatormap = pset.getParameter< edm::InputTag >("associatormap");
     UseAssociators = pset.getParameter< bool >("UseAssociators");
+    useGEMs_ = pset.getParameter< bool >("useGEMs");
     tpSelector = TrackingParticleSelector(pset.getParameter<double>("ptMinTP"),
 					  pset.getParameter<double>("minRapidityTP"),
 					  pset.getParameter<double>("maxRapidityTP"),
@@ -161,6 +162,7 @@ private:
   edm::EDGetTokenT<SimHitTPAssociationProducer::SimHitTPAssociationList> _simHitTpMapTag;
 
   bool UseAssociators;
+  bool useGEMs_;
   double minPhi, maxPhi;
   int nintPhi;
   bool useGsf;

--- a/Validation/RecoMuon/plugins/MuonTrackValidatorBase.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidatorBase.h
@@ -416,10 +416,10 @@ h->setBinContent(j+1, 0);
 
   //#hit vs eta: to be used with doProfileX
   std::vector<MonitorElement*> nhits_vs_eta,
-    nDThits_vs_eta,nCSChits_vs_eta,nRPChits_vs_eta;
+    nDThits_vs_eta,nCSChits_vs_eta,nRPChits_vs_eta,nGEMhits_vs_eta;
 
   std::vector<MonitorElement*> h_hits_eta,
-    h_DThits_eta,h_CSChits_eta,h_RPChits_eta;
+    h_DThits_eta,h_CSChits_eta,h_RPChits_eta,h_GEMhits_eta;;
     
 
   std::vector< std::vector<double> > etaintervals;

--- a/Validation/RecoMuon/python/MuonTrackValidator_cfi.py
+++ b/Validation/RecoMuon/python/MuonTrackValidator_cfi.py
@@ -41,6 +41,7 @@ muonTrackValidator = cms.EDAnalyzer("MuonTrackValidator",
     #
     # if *not* uses associators, the TP-RecoTrack maps has to be specified 
     UseAssociators = cms.bool(False),
+    useGEMs = cms.bool(False),
     associators = cms.vstring('a_MuonAssociator'),
     associatormap = cms.InputTag("tpToMuonTrackAssociation"),
     #


### PR DESCRIPTION
This PR contains the new module needed to associate the GEM tracking recHits (GEMHitAssociator) and the all the changes needed in the AssociatorByHits to make it associate also GEM tracking recHits. The association of GEM hits is disabled by default to avoid problems when the GEM detectors are not present in the geometry scenario. Moreover a new plot representing the averange number of GEM tracking recHits vs eta hs been added in the MuonTrackValidator. It is not filled by default, it has to be switched on when GEM detectors are present in the simulation. I checked the code with the following runTheMatrix command and all tests ended successfully: runTheMatrix.py -l limited -i all (with the use of GEM disabled, but I tested it also with GEM hits present and GEM association enabled without problems).

Same content as https://github.com/cms-sw/cmssw/pull/11962 in 76X.
