### PR TITLE
Removed thread_local from RandomNumberGeneratorService

### DIFF
--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -56,10 +56,6 @@ namespace edm {
     const std::uint32_t RandomNumberGeneratorService::maxSeedHepJames =  900000000U;
     const std::uint32_t RandomNumberGeneratorService::maxSeedTRandom3 = 4294967295U;
 
-    // This supports the mySeed function
-    // DELETE THIS WHEN/IF that functions is deleted.
-    thread_local std::string RandomNumberGeneratorService::moduleLabel_;
-
     RandomNumberGeneratorService::RandomNumberGeneratorService(ParameterSet const& pset,
                                                                ActivityRegistry& activityRegistry):
       nStreams_(0),
@@ -202,13 +198,6 @@ namespace edm {
         activityRegistry.watchPostModuleStreamEndLumi(this, &RandomNumberGeneratorService::postModuleStreamEndLumi);
       }
 
-      // The next 5 lines support the mySeed function
-      // DELETE THEM when/if that function is deleted.
-      activityRegistry.watchPostModuleConstruction(this, &RandomNumberGeneratorService::postModuleConstruction);
-      activityRegistry.watchPreModuleBeginJob(this, &RandomNumberGeneratorService::preModuleBeginJob);
-      activityRegistry.watchPostModuleBeginJob(this, &RandomNumberGeneratorService::postModuleBeginJob);
-      activityRegistry.watchPreModuleEndJob(this, &RandomNumberGeneratorService::preModuleEndJob);
-      activityRegistry.watchPostModuleEndJob(this, &RandomNumberGeneratorService::postModuleEndJob);
     }
 
     RandomNumberGeneratorService::~RandomNumberGeneratorService() {
@@ -299,15 +288,10 @@ namespace edm {
       std::string label;
       ModuleCallingContext const* mcc = CurrentModuleOnThread::getCurrentModuleOnThread();
       if(mcc == nullptr) {
-        if(!moduleLabel_.empty()) {
-          label = moduleLabel_;
-        }
-        else {
-          throw Exception(errors::LogicError)
-            << "RandomNumberGeneratorService::getEngine()\n"
-               "Requested a random number engine from the RandomNumberGeneratorService\n"
-               "when no module was active. ModuleCallingContext is null\n";
-        }
+        throw Exception(errors::LogicError)
+          << "RandomNumberGeneratorService::getEngine()\n"
+          "Requested a random number engine from the RandomNumberGeneratorService\n"
+          "from an unallowed transition. ModuleCallingContext is null\n";
       } else {
         label = mcc->moduleDescription()->moduleLabel();
       }
@@ -366,36 +350,6 @@ namespace edm {
       if(iter != seedsAndNameMap_.end()) {
         iter->second.setModuleID(description.id());
       }
-      // The next line supports the mySeed function
-      // DELETE IT when/if that function is deleted.
-      moduleLabel_ = description.moduleLabel();
-    }
-
-    // The next 5 functions support the mySeed function
-    // DELETE THEM when/if that function is deleted.
-    void
-    RandomNumberGeneratorService::postModuleConstruction(ModuleDescription const& description) {
-      moduleLabel_.clear();
-    }
-
-    void
-    RandomNumberGeneratorService::preModuleBeginJob(ModuleDescription const& description) {
-      moduleLabel_ = description.moduleLabel();
-    }
-
-    void
-    RandomNumberGeneratorService::postModuleBeginJob(ModuleDescription const& description) {
-      moduleLabel_.clear();
-    }
-
-    void
-    RandomNumberGeneratorService::preModuleEndJob(ModuleDescription const& description) {
-      moduleLabel_ = description.moduleLabel();
-    }
-
-    void
-    RandomNumberGeneratorService::postModuleEndJob(ModuleDescription const& description) {
-      moduleLabel_.clear();
     }
 
     void

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -105,14 +105,6 @@ namespace edm {
       void preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc);
       void postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc);
 
-      // The next 5 functions support the mySeed function
-      // DELETE THEM when/if that function is deleted.
-      void postModuleConstruction(ModuleDescription const& description);
-      void preModuleBeginJob(ModuleDescription const& description);
-      void postModuleBeginJob(ModuleDescription const& description);
-      void preModuleEndJob(ModuleDescription const& description);
-      void postModuleEndJob(ModuleDescription const& description);
-
       /// These two are used by the RandomEngineStateProducer
       virtual std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const override;
       virtual std::vector<RandomEngineState> const& getEventCache(StreamID const&) const override;
@@ -275,10 +267,6 @@ namespace edm {
       std::uint32_t eventSeedOffset_;
 
       bool verbose_;
-
-      // The next data member supports the mySeed function
-      // DELETE IT when/if that function is deleted.
-      static thread_local std::string moduleLabel_;
 
       static const std::vector<std::uint32_t>::size_type maxSeeds;
       static const std::vector<std::uint32_t>::size_type maxStates;

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -166,7 +166,15 @@ TestRandomNumberServiceGlobal::TestRandomNumberServiceGlobal(edm::ParameterSet c
 
   if(dump_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    std::cout << "*** TestRandomNumberServiceGlobal constructor " << rng->mySeed() << "\n";
+    bool exceptionThrown = true;
+    try {
+       std::cout << "*** TestRandomNumberServiceGlobal constructor " << rng->mySeed() << "\n";
+       exceptionThrown = false;
+    } catch( cms::Exception const&) {
+    }
+    if(not exceptionThrown) {
+       throw cms::Exception("FailedToThrow")<<"RandomNunberGenerator::mySeed did not throw";
+    }
   }
 }
 
@@ -284,15 +292,29 @@ TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID, edm::Event const&
 
 void TestRandomNumberServiceGlobal::beginJob() {
   if(dump_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    std::cout << "*** TestRandomNumberServiceGlobal beginJob " << rng->mySeed() << "\n";
+    bool exceptionThrown = true;
+    try {
+       edm::Service<edm::RandomNumberGenerator> rng;
+       std::cout << "*** TestRandomNumberServiceGlobal beginJob " << rng->mySeed() << "\n";
+    } catch( cms::Exception const&) {
+    }
+    if(not exceptionThrown) {
+       throw cms::Exception("FailedToThrow")<<"RandomNunberGenerator::mySeed did not throw";
+    }
   }
 }
 
 void TestRandomNumberServiceGlobal::endJob() {
   if(dump_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    std::cout << "*** TestRandomNumberServiceGlobal endJob " << rng->mySeed() << "\n";
+    bool exceptionThrown = true;
+    try {
+       edm::Service<edm::RandomNumberGenerator> rng;
+       std::cout << "*** TestRandomNumberServiceGlobal endJob " << rng->mySeed() << "\n";
+    } catch( cms::Exception const&) {
+    }
+    if(not exceptionThrown) {
+       throw cms::Exception("FailedToThrow")<<"RandomNunberGenerator::mySeed did not throw";
+    }
   }
 }
 

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -1,4 +1,3 @@
-*** TestRandomNumberServiceGlobal constructor 83
 
 
 RandomNumberGeneratorService dump
@@ -33,7 +32,6 @@ RandomNumberGeneratorService dump
         t2 2 2 RanecuEngine  engine does not know seeds
         t3 84 TRandom3  engine does not know seeds
         t4 85 HepJamesRandom  85
-*** TestRandomNumberServiceGlobal beginJob 83
 *** TestRandomNumberServiceGlobal beginLuminosityBlock 83
 TRandom3
 *** TestRandomNumberServiceGlobal analyze 83
@@ -48,4 +46,3 @@ TRandom3
 TRandom3
 *** TestRandomNumberServiceGlobal analyze 83
 TRandom3
-*** TestRandomNumberServiceGlobal endJob 83


### PR DESCRIPTION
The thread_local in RandomNumberGeneratorService was being used to
support a backwards compatible interface. The old interface is also
supported for certain transitions via another thread_local from
the framework. It appears that the old interface is no longer being
called by non-framework supported transitions.
