### PR TITLE
SiStrip unpacker corrupted buffer fix

### DIFF
--- a/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
@@ -132,7 +132,6 @@ namespace sistrip {
                         FED_VIRGIN_RAW = 2, 
                         FED_PROC_RAW = 6, 
                         FED_ZERO_SUPPR = 10,
-                        //FED_ZERO_SUPPR_CMO = 4,
                         FED_ZERO_SUPPR_LITE = 3,
                         FED_ZERO_SUPPR_LITE_CMO = 4,
                         FED_ZERO_SUPPR_LITE8_TT = 12,

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -79,7 +79,7 @@ namespace sistrip {
       uint16_t payloadLength_;
       uint8_t validChannels_;
       bool fePresent_[FEUNITS_PER_FED];
-      bool legacyUnpacker_;
+      bool legacyUnpacker_=false;
     };
 
   //class for unpacking data from ZS FED channels

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -150,7 +150,6 @@ namespace sistrip {
   //convert name of an element of enum to enum value (useful for getting values from config)
   FEDBufferFormat fedBufferFormatFromString(const std::string& bufferFormatString);
   FEDHeaderType fedHeaderTypeFromString(const std::string& headerTypeString);
-  //FEDLegacyReadoutMode fedLegacyReadoutModeFromString(const std::string& readoutModeString); //FIXME to be introduced
   FEDReadoutMode fedReadoutModeFromString(const std::string& readoutModeString);
   FEDDAQEventType fedDAQEventTypeFromString(const std::string& daqEventTypeString);
 
@@ -1486,20 +1485,18 @@ namespace sistrip {
         case READOUT_MODE_PROC_RAW:
           return PACKET_CODE_PROC_RAW;
         case READOUT_MODE_ZERO_SUPPRESSED:
-        //case READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE:
           return PACKET_CODE_ZERO_SUPPRESSED;
         case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
         case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
           return PACKET_CODE_ZERO_SUPPRESSED_LITE10;
-        case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
-        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
-          return PACKET_CODE_ZERO_SUPPRESSED_LITE8;
         case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
         case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
           return PACKET_CODE_ZERO_SUPPRESSED_LITE8_BOTBOT;
         case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
         case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
           return PACKET_CODE_ZERO_SUPPRESSED_LITE8_TOPBOT;
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+        case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
         case READOUT_MODE_PREMIX_RAW:
         case READOUT_MODE_SPY:
         case READOUT_MODE_INVALID:

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -36,7 +36,6 @@ namespace sistrip {
     switch(mode_) {
     case READOUT_MODE_ZERO_SUPPRESSED:                         rawdigi_ = false; break;
     case READOUT_MODE_ZERO_SUPPRESSED_FAKE:                    rawdigi_ = false; break;
-  //case READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE:              rawdigi_ = false; break;
     case READOUT_MODE_ZERO_SUPPRESSED_LITE10:                  rawdigi_ = false; break;
     case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:       rawdigi_ = false; break;
     case READOUT_MODE_ZERO_SUPPRESSED_LITE8:                   rawdigi_ = false; break;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -274,8 +274,7 @@ namespace sistrip {
 	uint16_t ipair = ( useFedKey_ || (!legacy_ && mode == sistrip::READOUT_MODE_SCOPE) || (legacy_ && lmode == sistrip::READOUT_MODE_LEGACY_SCOPE) ) ? 0 : iconn->apvPairNumber();
 
 	if ((!legacy_ && (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED || mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_FAKE))
-         || (legacy_ && (lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL || lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE))
-       /*|| mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE*/) { 
+         || (legacy_ && (lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL || lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE)) ) {
 	
 	  Registry regItem(key, 0, zs_work_digis_.size(), 0);
 	

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -74,14 +74,12 @@ namespace sistrip {
     uint16_t minLength;
     switch (readoutMode()) {
     case READOUT_MODE_ZERO_SUPPRESSED:
+    case READOUT_MODE_ZERO_SUPPRESSED_FAKE:
       minLength = 7;
       break;
     case READOUT_MODE_PREMIX_RAW:
       minLength = 2;
       break;
-    /*case READOUT_MODE_ZERO_SUPPRESSED_CMOVERRIDE:
-      minLength = 7;
-      break;*/
     case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
     case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
     case READOUT_MODE_ZERO_SUPPRESSED_LITE8:

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -359,8 +359,6 @@ try {
 
       try {
         // create unpacker
-        //sistrip::FEDZSChannelUnpacker unpacker = static_cast<sistrip::FEDZSChannelUnpacker>(
-        //  sistrip::FEDBSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(fedCh), 8));
         sistrip::FEDZSChannelUnpacker unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(fedCh));
 
         // unpack


### PR DESCRIPTION
The FEDBuffer object modified in #12157 to introduce the new FED readout modes was feeding corrupted data due to an improperly set variable (the switch between the legacy unpacker and its updated version). 
Also, the packet code returned in the case of a ZS lite format was improperly set.

This commit has been tested against 4.53 and 140.53, and the baseline behaviour on the list of corrupted FED (<7_5_5) has been restored (4.53):

![fedvsapvid](https://cloud.githubusercontent.com/assets/330969/11102394/9192305c-88bc-11e5-8c87-d96b6b29dd27.png)
![corruptedfeds](https://cloud.githubusercontent.com/assets/330969/11102398/9b8d1040-88bc-11e5-8c0e-1b3558d33eea.png)
