### PR TITLE
Use ExtVec on PPC64LE

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -20,7 +20,7 @@ typedef double VECTOR_EXT( 64 ) float64x8_t;
 // x86_64.
 // XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65486
 // XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65491
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__powerpc64__) || defined(__PPC64__) || defined(__powerpc__)
 typedef long double VECTOR_EXT( 32 ) float128x2_t;
 typedef long double VECTOR_EXT( 64 ) float128x4_t;
 typedef long double VECTOR_EXT( 128 ) float128x8_t;
@@ -57,7 +57,7 @@ struct ExtVecTraits<double, 4> {
 // x86_64.
 // XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65486
 // XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65491
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__powerpc64__) || defined(__PPC64__) || defined(__powerpc__)
 template<>
 struct ExtVecTraits<long double, 2> {
   typedef long double VECTOR_EXT( 2*sizeof(long double) ) type;

--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -1,7 +1,7 @@
 #ifndef DataFormat_Math_SSEVec_H
 #define DataFormat_Math_SSEVec_H
 
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__)
+#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) && !defined(__powerpc64__) && !defined(__PPC64__) && !defined(__powerpc__)
 #if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 4)
 #include <x86intrin.h>
 #define CMS_USE_SSE

--- a/DataFormats/Math/interface/sse_mathfun.h
+++ b/DataFormats/Math/interface/sse_mathfun.h
@@ -1,7 +1,7 @@
 #ifndef SSE_MATHFUN_H
 #define SSE_MATHFUN_H
 
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__)
+#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) && !defined(__powerpc64__) && !defined(__PPC64__) && !defined(__powerpc__)
 #if (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 4)) || defined(__clang__)
 #include <x86intrin.h>
 #define CMS_USE_SSE

--- a/DataFormats/Math/src/SSEVec.cc
+++ b/DataFormats/Math/src/SSEVec.cc
@@ -1,4 +1,4 @@
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__)
+#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) && !defined(__powerpc64__) && !defined(__PPC64__) && !defined(__powerpc__)
 #include "DataFormats/Math/interface/SSEVec.h"
 #include "DataFormats/Math/interface/SSERot.h"
 using namespace mathSSE;

--- a/DataFormats/Math/test/SSEVec_t.cpp
+++ b/DataFormats/Math/test/SSEVec_t.cpp
@@ -1,4 +1,4 @@
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__)
+#if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) && !defined(__powerpc64__) && !defined(__PPC64__) && !defined(__powerpc__)
 #include "DataFormats/Math/interface/SSEVec.h"
 
 #include<cmath>

--- a/DataFormats/Math/test/rdtscp.h
+++ b/DataFormats/Math/test/rdtscp.h
@@ -1,7 +1,7 @@
 #ifndef RDPSCP_H
 #define RDPSCP_H
 // performance test
-#if !defined(__arm__) && !defined(__aarch64__)
+#if !defined(__arm__) && !defined(__aarch64__) && !defined(__powerpc64__) && !defined(__PPC64__) && !defined(__powerpc__)
 #include <x86intrin.h>
 #include <cpuid.h>
 #ifdef __clang__


### PR DESCRIPTION
Treat PPC64LE in a same way as ARMv7/ARMv8/MIC architectures.
Tested on fc22_ppc64le_gcc493.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
