### PR TITLE
Fix for the reconnect-each-run policy in CondDBESSource 80X

### DIFF
--- a/CondCore/CondDB/src/PayloadProxy.cc
+++ b/CondCore/CondDB/src/PayloadProxy.cc
@@ -31,7 +31,7 @@ namespace cond {
 
     void BasePayloadProxy::reload(){
       std::string tag = m_iovProxy.tag();
-      if( !tag.empty() ) m_iovProxy.reload();
+      if( !tag.empty() ) loadTag( tag );
     }
     
     ValidityInterval BasePayloadProxy::setIntervalFor(cond::Time_t time, bool load) {


### PR DESCRIPTION
The fix consists in reverting back the previous fix in `PayloadProxy::reload`, same as #12386 
