### PR TITLE
fix harvesting configuration for T0

### DIFF
--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -116,7 +116,6 @@ def harvestingMode(process, datasetName, args,rANDl=True):
     if rANDl and (not args.get('newDQMIO', False)):
         process.source.processingMode = cms.untracked.string('RunsAndLumis')
     process.dqmSaver.workflow = datasetName
-    process.dqmSaver.saveByLumiSection = 1
     if args.has_key('referenceFile') and args.get('referenceFile', ''):
         process.DQMStore.referenceFileName = cms.untracked.string(args['referenceFile'])
 


### PR DESCRIPTION
not sure why the saveByLumiSection option was activated for the T0 harvesting. this is wrong and cause a crash when combined to the recent development to the DQMFileSaver class.
