### PR TITLE
Update tracking MiniAOD validation

### DIFF
--- a/DQM/TrackingMonitor/python/tracksDQMMiniAOD_cff.py
+++ b/DQM/TrackingMonitor/python/tracksDQMMiniAOD_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitor.packedCandidateTrackValidator_cfi import *
 
 packedCandidateTrackValidatorLostTracks = packedCandidateTrackValidator.clone(
-    trackToPackedCandiadteAssociation = "lostTracks",
+    trackToPackedCandidateAssociation = "lostTracks",
     rootFolder = "Tracking/PackedCandidate/lostTracks"
 )
 

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -149,6 +149,16 @@ class PackedCandidateTrackValidator: public DQMEDAnalyzer{
 
   std::string rootFolder_;
 
+  enum {
+    sf_AllTracks = 0,
+    sf_AssociatedToPC = 1,
+    sf_PCIsCharged = 2,
+    sf_PCHasTrack = 3,
+    sf_PCIsNotElectron = 4,
+    sf_PCHasHits = 5,
+    sf_PCNdofNot0 = 6,
+    sf_NoMissingInnerHits = 7
+  };
   MonitorElement *h_selectionFlow;
 
   MonitorElement *h_diffPx;
@@ -212,13 +222,15 @@ void PackedCandidateTrackValidator::fillDescriptions(edm::ConfigurationDescripti
 void PackedCandidateTrackValidator::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&, edm::EventSetup const&) {
   iBooker.setCurrentFolder(rootFolder_);
 
-  h_selectionFlow = iBooker.book1D("selectionFlow", "Track selection flow", 6, 0, 6);
+  h_selectionFlow = iBooker.book1D("selectionFlow", "Track selection flow", 8, -0.5, 7.5);
   h_selectionFlow->setBinLabel(1, "All tracks");
   h_selectionFlow->setBinLabel(2, "Associated to PackedCandidate");
   h_selectionFlow->setBinLabel(3, "PC is charged"),
   h_selectionFlow->setBinLabel(4, "PC has track");
   h_selectionFlow->setBinLabel(5, "PC is not electron");
   h_selectionFlow->setBinLabel(6, "PC has hits");
+  h_selectionFlow->setBinLabel(7, "PC ndof != 0");
+  h_selectionFlow->setBinLabel(8, "Track: no missing inner hits");
 
   constexpr int diffBins = 50;
   constexpr float diff = 1e-4;
@@ -283,38 +295,38 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
   for(size_t i=0; i<tracks.size(); ++i) {
     auto trackPtr = tracks.ptrAt(i);
     const reco::Track& track = *trackPtr;
-    h_selectionFlow->Fill(0.5);
+    h_selectionFlow->Fill(sf_AllTracks);
 
     pat::PackedCandidateRef pcRef = trackToPackedCandidate[trackPtr];
     if(pcRef.isNull()) {
       continue;
     }
-    h_selectionFlow->Fill(1.5);
+    h_selectionFlow->Fill(sf_AssociatedToPC);
 
     // Filter out neutral PackedCandidates, some of them may have track associated, and for those the charge comparison fails
     if(pcRef->charge() == 0) {
       continue;
     }
-    h_selectionFlow->Fill(2.5);
+    h_selectionFlow->Fill(sf_PCIsCharged);
 
     const reco::Track *trackPcPtr = pcRef->bestTrack();
     if(!trackPcPtr) {
       continue;
     }
-    h_selectionFlow->Fill(3.5);
+    h_selectionFlow->Fill(sf_PCHasTrack);
 
     // Filter out electrons to avoid comparisons to PackedCandidates with GsfTrack
     if(std::abs(pcRef->pdgId()) == 11) {
       continue;
     }
-    h_selectionFlow->Fill(4.5);
+    h_selectionFlow->Fill(sf_PCIsNotElectron);
 
     // Filter out PackedCandidate-tracks with no hits, as they won't have their details filled
     const reco::Track& trackPc = *trackPcPtr;
     if(trackPc.hitPattern().numberOfValidHits() == 0) {
       continue;
     }
-    h_selectionFlow->Fill(5.5);
+    h_selectionFlow->Fill(sf_PCHasHits);
 
 
     fillNoFlow(h_diffPx, trackPc.px() - track.px());
@@ -332,6 +344,7 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     // PackedCandidates that have ndof != 0.
     double diffNormalizedChi2 = 0;
     if(trackPc.ndof() != 0) {
+      h_selectionFlow->Fill(sf_PCNdofNot0);
       diffNormalizedChi2 = trackPc.normalizedChi2() - track.normalizedChi2();
       fillNoFlow(h_diffNormalizedChi2, diffNormalizedChi2);
     }
@@ -388,6 +401,7 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     // hasValidHitInFirstPixelBarrel is set only if numberOfLostHits(MISSING_INNER_HITS) == 0
     int diffHitPatternHasValidHitInFirstPixelBarrel = 0;
     if(track.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) == 0) {
+      h_selectionFlow->Fill(sf_NoMissingInnerHits);
       diffHitPatternHasValidHitInFirstPixelBarrel = static_cast<int>(trackPc.hitPattern().hasValidHitInFirstPixelBarrel()) - static_cast<int>(track.hitPattern().hasValidHitInFirstPixelBarrel());
       fillNoFlow(h_diffHitPatternHasValidHitInFirstPixelBarrel, diffHitPatternHasValidHitInFirstPixelBarrel);
     }

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -331,7 +331,7 @@ namespace {
               int flow_nbins,double flow_min,double flow_max) {
       hInrange = iBooker.book1D(name, title, nbins, min, max);
       hUnderOverflowSign = iBooker.book1D(name+"UnderOverFlowSign", title+" with over- and underflow, and sign flip", flow_nbins, flow_min, flow_max);
-      hStatus = iBooker.book1D(name+"Status", title+" status", 8, -0.5, 7.5);
+      hStatus = iBooker.book1D(name+"Status", title+" status", 7, -0.5, 6.5);
       hStatus->setBinLabel(1, "In range");
       hStatus->setBinLabel(2, "In range, sign flip");
       hStatus->setBinLabel(3, "Denormal");

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -71,7 +71,7 @@ class PackedCandidateTrackValidator: public DQMEDAnalyzer{
 
 PackedCandidateTrackValidator::PackedCandidateTrackValidator(const edm::ParameterSet& iConfig):
   tracksToken_(consumes<edm::View<reco::Track>>(iConfig.getUntrackedParameter<edm::InputTag>("tracks"))),
-  trackToPackedCandidateToken_(consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getUntrackedParameter<edm::InputTag>("trackToPackedCandiadteAssociation"))),
+  trackToPackedCandidateToken_(consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getUntrackedParameter<edm::InputTag>("trackToPackedCandidateAssociation"))),
   rootFolder_(iConfig.getUntrackedParameter<std::string>("rootFolder"))
 {}
 
@@ -81,7 +81,7 @@ void PackedCandidateTrackValidator::fillDescriptions(edm::ConfigurationDescripti
   edm::ParameterSetDescription desc;
 
   desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
-  desc.addUntracked<edm::InputTag>("trackToPackedCandiadteAssociation", edm::InputTag("packedPFCandidates"));
+  desc.addUntracked<edm::InputTag>("trackToPackedCandidateAssociation", edm::InputTag("packedPFCandidates"));
   desc.addUntracked<std::string>("rootFolder", "Tracking/PackedCandidate");
 
   descriptions.add("packedCandidateTrackValidator", desc);

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -27,10 +27,6 @@
 #include <iomanip>
 
 namespace {
-  float packUnpack(float value) {
-    return MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(value));
-  }
-
   template<typename T> void fillNoFlow(MonitorElement* h, T val){
     h->Fill(std::min(std::max(val,((T) h->getTH1()->GetXaxis()->GetXmin())),((T) h->getTH1()->GetXaxis()->GetXmax())));
   }

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -827,70 +827,70 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
        || diffHitPatternHasValidHitInFirstPixelBarrel != 0
        ) {
 
-      edm::LogWarning("PackedCandidateTrackValidator") << "Track " << i << " pt " << track.pt() << " eta " << track.eta() << " phi " << track.phi() << " chi2 " << track.chi2() << " ndof " << track.ndof()
-                                                       << "\n"
-                                                       << "  ptError " << track.ptError() << " etaError " << track.etaError() << " phiError " << track.phiError() << " dxyError " << track.dxyError() << " dzError " << track.dzError()
-                                                       << "\n"
-                                                       << "  refpoint " << track.referencePoint() << " momentum " << track.momentum()
-                                                       << "\n"
-                                                       << "  dxy " << track.dxy() << " dz " << track.dz()
-                                                       << "\n"
-                                                       << "  " << TrackAlgoPrinter(track)
-                                                       << " lost inner hits " << trackLostInnerHits
-                                                       << " lost outer hits " << track.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS)
-                                                       << " hitpattern " << HitPatternPrinter(track)
-                                                       << " \n"
-                                                       << " PC " << pcRef.id() << ":" << pcRef.key() << " track pt " << trackPc.pt() << " eta " << trackPc.eta() << " phi " << trackPc.phi() << " (PC " << pcRef->phi() << ") chi2 " << trackPc.chi2() << " ndof " << trackPc.ndof() << " pdgId " << pcRef->pdgId() << " mass " << pcRef->mass()
-                                                       << "\n"
-                                                       << "  ptError " << trackPc.ptError() << " etaError " << trackPc.etaError() << " phiError " << trackPc.phiError()
-                                                       << "\n"
-                                                       << "  pc.vertex " << pcRef->vertex() << " momentum " << pcRef->momentum() << " track " << trackPc.momentum()
-                                                       << "\n"
-                                                       << "  dxy " << trackPc.dxy() << " dz " << trackPc.dz() << " pc.dz " << pcRef->dz()
-                                                       << " dxyError " << trackPc.dxyError() << " dzError " << trackPc.dzError()
-                                                       << "\n"
-                                                       << "  dxy(PV) " << trackPc.dxy(pv.position()) << " dz(PV) " << trackPc.dz(pv.position())
-                                                       << " dxy(assocPV) " << trackPc.dxy(pcVertex.position()) << " dz(assocPV) " << trackPc.dz(pcVertex.position())
-                                                       << "\n"
-                                                       << " (diff PackedCandidate track)"
-                                                       << " highPurity " << diffHP << " " << trackPc.quality(reco::TrackBase::highPurity) << " " << track.quality(reco::TrackBase::highPurity)
-                                                       << " charge " << diffCharge << " " << trackPc.charge() << " " << track.charge()
-                                                       << " normalizedChi2 " << diffNormalizedChi2 << " " << trackPc.normalizedChi2() << " " << track.normalizedChi2()
-                                                       << "\n "
-                                                       << " numberOfHits " << diffNumberOfHits << " " << pcNumberOfHits << " " << trackNumberOfHits
-                                                       << " numberOfPixelHits " << diffNumberOfPixelHits << " " << pcNumberOfPixelHits << " " << trackNumberOfPixelHits
-                                                       << " numberOfStripHits # " << pcNumberOfStripHits << " " << trackNumberOfStripHits
-                                                       << "\n "
-                                                       << " hitPattern.numberOfValidPixelHits " << diffHitPatternNumberOfValidPixelHits << " " << trackPc.hitPattern().numberOfValidPixelHits() << " " << track.hitPattern().numberOfValidPixelHits()
-                                                       << " hitPattern.numberOfValidHits " << diffHitPatternNumberOfValidHits << " " << trackPc.hitPattern().numberOfValidHits() << " " << track.hitPattern().numberOfValidHits()
-                                                       << " hitPattern.hasValidHitInFirstPixelBarrel " << diffHitPatternHasValidHitInFirstPixelBarrel << " " << trackPc.hitPattern().hasValidHitInFirstPixelBarrel() << " " << track.hitPattern().hasValidHitInFirstPixelBarrel()
-                                                       << "\n "
-                                                       << " lostInnerHits  " << diffLostInnerHits << " " << pcRef->lostInnerHits() << " #"
-                                                       << " phi (5e-4) " << diffPhi << " " << trackPc.phi() << " " << track.phi()
-                                                       << "\n "
-                                                       << " dxy(assocPV) " << diffDxyAssocPV
-                                                       << "\n "
-                                                       << " dz(assocPV) " << diffDzAssocPV
-                                                       << "\n "
-                                                       << " dxy(PV) (0.05) " << diffDxyPV << " " << pcRef->dxy(pv.position()) << " " << track.dxy(pv.position())
-                                                       << "\n "
-                                                       << " dz(PV) (0.05) " << diffDzPV << " " << pcRef->dz(pv.position()) << " " << track.dz(pv.position())
-                                                       << "\n "
-                                                       << " cov(qoverp, qoverp)  " << diffCovQoverpQoverp
-                                                       << "\n "
-                                                       << " cov(lambda, lambda) " << diffCovLambdaLambda
-                                                       << "\n "
-                                                       << " cov(lambda, dsz) " << diffCovLambdaDsz
-                                                       << "\n "
-                                                       << " cov(phi, phi) " << diffCovPhiPhi
-                                                       << "\n "
-                                                       << " cov(phi, dxy) " << diffCovPhiDxy
-                                                       << "\n "
-                                                       << " cov(dxy, dxy) " << diffCovDxyDxy
-                                                       << "\n "
-                                                       << " cov(dxy, dsz) " << diffCovDxyDsz
-                                                       << "\n "
-                                                       << " cov(dsz, dsz) " << diffCovDszDsz;
+      edm::LogInfo("PackedCandidateTrackValidator") << "Track " << i << " pt " << track.pt() << " eta " << track.eta() << " phi " << track.phi() << " chi2 " << track.chi2() << " ndof " << track.ndof()
+                                                    << "\n"
+                                                    << "  ptError " << track.ptError() << " etaError " << track.etaError() << " phiError " << track.phiError() << " dxyError " << track.dxyError() << " dzError " << track.dzError()
+                                                    << "\n"
+                                                    << "  refpoint " << track.referencePoint() << " momentum " << track.momentum()
+                                                    << "\n"
+                                                    << "  dxy " << track.dxy() << " dz " << track.dz()
+                                                    << "\n"
+                                                    << "  " << TrackAlgoPrinter(track)
+                                                    << " lost inner hits " << trackLostInnerHits
+                                                    << " lost outer hits " << track.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS)
+                                                    << " hitpattern " << HitPatternPrinter(track)
+                                                    << " \n"
+                                                    << " PC " << pcRef.id() << ":" << pcRef.key() << " track pt " << trackPc.pt() << " eta " << trackPc.eta() << " phi " << trackPc.phi() << " (PC " << pcRef->phi() << ") chi2 " << trackPc.chi2() << " ndof " << trackPc.ndof() << " pdgId " << pcRef->pdgId() << " mass " << pcRef->mass()
+                                                    << "\n"
+                                                    << "  ptError " << trackPc.ptError() << " etaError " << trackPc.etaError() << " phiError " << trackPc.phiError()
+                                                    << "\n"
+                                                    << "  pc.vertex " << pcRef->vertex() << " momentum " << pcRef->momentum() << " track " << trackPc.momentum()
+                                                    << "\n"
+                                                    << "  dxy " << trackPc.dxy() << " dz " << trackPc.dz() << " pc.dz " << pcRef->dz()
+                                                    << " dxyError " << trackPc.dxyError() << " dzError " << trackPc.dzError()
+                                                    << "\n"
+                                                    << "  dxy(PV) " << trackPc.dxy(pv.position()) << " dz(PV) " << trackPc.dz(pv.position())
+                                                    << " dxy(assocPV) " << trackPc.dxy(pcVertex.position()) << " dz(assocPV) " << trackPc.dz(pcVertex.position())
+                                                    << "\n"
+                                                    << " (diff PackedCandidate track)"
+                                                    << " highPurity " << diffHP << " " << trackPc.quality(reco::TrackBase::highPurity) << " " << track.quality(reco::TrackBase::highPurity)
+                                                    << " charge " << diffCharge << " " << trackPc.charge() << " " << track.charge()
+                                                    << " normalizedChi2 " << diffNormalizedChi2 << " " << trackPc.normalizedChi2() << " " << track.normalizedChi2()
+                                                    << "\n "
+                                                    << " numberOfHits " << diffNumberOfHits << " " << pcNumberOfHits << " " << trackNumberOfHits
+                                                    << " numberOfPixelHits " << diffNumberOfPixelHits << " " << pcNumberOfPixelHits << " " << trackNumberOfPixelHits
+                                                    << " numberOfStripHits # " << pcNumberOfStripHits << " " << trackNumberOfStripHits
+                                                    << "\n "
+                                                    << " hitPattern.numberOfValidPixelHits " << diffHitPatternNumberOfValidPixelHits << " " << trackPc.hitPattern().numberOfValidPixelHits() << " " << track.hitPattern().numberOfValidPixelHits()
+                                                    << " hitPattern.numberOfValidHits " << diffHitPatternNumberOfValidHits << " " << trackPc.hitPattern().numberOfValidHits() << " " << track.hitPattern().numberOfValidHits()
+                                                    << " hitPattern.hasValidHitInFirstPixelBarrel " << diffHitPatternHasValidHitInFirstPixelBarrel << " " << trackPc.hitPattern().hasValidHitInFirstPixelBarrel() << " " << track.hitPattern().hasValidHitInFirstPixelBarrel()
+                                                    << "\n "
+                                                    << " lostInnerHits  " << diffLostInnerHits << " " << pcRef->lostInnerHits() << " #"
+                                                    << " phi (5e-4) " << diffPhi << " " << trackPc.phi() << " " << track.phi()
+                                                    << "\n "
+                                                    << " dxy(assocPV) " << diffDxyAssocPV
+                                                    << "\n "
+                                                    << " dz(assocPV) " << diffDzAssocPV
+                                                    << "\n "
+                                                    << " dxy(PV) (0.05) " << diffDxyPV << " " << pcRef->dxy(pv.position()) << " " << track.dxy(pv.position())
+                                                    << "\n "
+                                                    << " dz(PV) (0.05) " << diffDzPV << " " << pcRef->dz(pv.position()) << " " << track.dz(pv.position())
+                                                    << "\n "
+                                                    << " cov(qoverp, qoverp)  " << diffCovQoverpQoverp
+                                                    << "\n "
+                                                    << " cov(lambda, lambda) " << diffCovLambdaLambda
+                                                    << "\n "
+                                                    << " cov(lambda, dsz) " << diffCovLambdaDsz
+                                                    << "\n "
+                                                    << " cov(phi, phi) " << diffCovPhiPhi
+                                                    << "\n "
+                                                    << " cov(phi, dxy) " << diffCovPhiDxy
+                                                    << "\n "
+                                                    << " cov(dxy, dxy) " << diffCovDxyDxy
+                                                    << "\n "
+                                                    << " cov(dxy, dsz) " << diffCovDxyDsz
+                                                    << "\n "
+                                                    << " cov(dsz, dsz) " << diffCovDszDsz;
     }
   }
 }

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -325,8 +325,16 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     fillNoFlow(h_diffVy, trackPc.vy() - track.vy());
     fillNoFlow(h_diffVz, trackPc.vz() - track.vz());
 
-    auto diffNormalizedChi2 = trackPc.normalizedChi2() - track.normalizedChi2();
-    fillNoFlow(h_diffNormalizedChi2, diffNormalizedChi2);
+    // PackedCandidate recalculates the ndof in unpacking as
+    // (nhits+npixelhits-5), but some strip hits may have dimension 2.
+    // If PackedCandidate has ndof=0, the resulting normalizedChi2
+    // will be 0 too. Hence, the comparison makes sense only for those
+    // PackedCandidates that have ndof != 0.
+    double diffNormalizedChi2 = 0;
+    if(trackPc.ndof() != 0) {
+      diffNormalizedChi2 = trackPc.normalizedChi2() - track.normalizedChi2();
+      fillNoFlow(h_diffNormalizedChi2, diffNormalizedChi2);
+    }
     fillNoFlow(h_diffNdof, trackPc.ndof() - track.ndof());
 
     auto diffCharge = trackPc.charge() - track.charge();

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -385,8 +385,12 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     fillNoFlow(h_diffHitPatternNumberOfValidHits, diffHitPatternNumberOfValidHits);
     fillNoFlow(h_diffHitPatternNumberOfLostInnerHits, trackPc.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) - track.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS));
 
-    int diffHitPatternHasValidHitInFirstPixelBarrel = static_cast<int>(trackPc.hitPattern().hasValidHitInFirstPixelBarrel()) - static_cast<int>(track.hitPattern().hasValidHitInFirstPixelBarrel());
-    fillNoFlow(h_diffHitPatternHasValidHitInFirstPixelBarrel, diffHitPatternHasValidHitInFirstPixelBarrel);
+    // hasValidHitInFirstPixelBarrel is set only if numberOfLostHits(MISSING_INNER_HITS) == 0
+    int diffHitPatternHasValidHitInFirstPixelBarrel = 0;
+    if(track.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) == 0) {
+      diffHitPatternHasValidHitInFirstPixelBarrel = static_cast<int>(trackPc.hitPattern().hasValidHitInFirstPixelBarrel()) - static_cast<int>(track.hitPattern().hasValidHitInFirstPixelBarrel());
+      fillNoFlow(h_diffHitPatternHasValidHitInFirstPixelBarrel, diffHitPatternHasValidHitInFirstPixelBarrel);
+    }
 
     // Print warning if there are differences outside the expected range
     if(diffNormalizedChi2 < -1 || diffNormalizedChi2 > 0 || diffCharge != 0 || diffHP != 0 ||


### PR DESCRIPTION
This PR gives a major update to the tracking MiniAOD validation code.
- Compare only charged PackedCandidates
- Check `normalizedChi2` only if PackedCandidate ndof != 0
  - it it is 0, its `normalizedChi2` is 0 by construction
- Check `hasValidHitInFirstPixelBarrel()` only if there are no lost inner hits
  - if there are, this information is not valid
- Record the number of tracks used in the two cases above in the selection flow histogram
- Monitor the overflow of pixel hits, strip hits, and total number of hits
- Add (LogInfo) printout for track-PackedCandidate pairs where differences are outside tolerances
  - Helps to track them down
- Detailed monitoring of the precision of packed floating point values
  - Try to catch and monitor under/overflows and sign changes
  - Limit monitoring mainly to the packed quantities (e.g. prefer covariance matrix elements over the corresponding "errors"), but provide monitoring of most interesting quantities where "equality within packing precision" is not expected (e.g. pT)

Tested in CMSSW_8_0_X_2015-11-11-2300, expecting changes in `Tracking/PackedCandidate` DQM folder.

@rovere @VinInn @arizzi @gpetruc 
