### PR TITLE
Update track-PV and track-jet associations in tracking validation, add more collections to standalone mode

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -81,23 +81,18 @@ trackingParticleRecoTrackAsssociationSignal = trackingParticleRecoTrackAsssociat
 )
 
 # select tracks from the PV
-# first convert to RecoChargedRefCandidates
-trackRefsForValidation = cms.EDProducer("ChargedRefCandidateProducer",
-    particleType = cms.string('pi+'),
-    src = cms.InputTag("generalTracks")
-)
-# then use the "PV sorting" module to select the candidates associated to PV
-trackRefsFromPV = _sortedPrimaryVertices.clone(
-    particles = "trackRefsForValidation",
-    produceAssociationToOriginalVertices = True,
-    produceNoPileUpCollection = True,
-    produceSortedVertices = False,
-    jets = "ak4CaloJets",
-    vertices = "offlinePrimaryVertices"
-)
-# and finally extract tracks from there
-generalTracksFromPV = _recoChargedRefCandidateToTrackRefProducer.clone(
-    src = cms.InputTag("trackRefsFromPV", "originalNoPileUp")
+from CommonTools.RecoAlgos.TrackWithVertexRefSelector_cfi import trackWithVertexRefSelector as _trackWithVertexRefSelector
+generalTracksFromPV = _trackWithVertexRefSelector.clone(
+    src = "generalTracks",
+    ptMin = 0,
+    ptMax = 1e10,
+    ptErrorCut = 1e10,
+    quality = "loose",
+    vertexTag = "offlinePrimaryVertices",
+    nVertices = 1,
+    vtxFallback = False,
+    zetaVtx = 0.1, # 1 mm
+    rhoVtx = 1e10, # intentionally no dxy cut
 )
 # and then the selectors
 cutsRecoTracksFromPVInitialStep         = cutsRecoTracksInitialStep.clone(src="generalTracksFromPV")
@@ -266,8 +261,6 @@ tracksValidationSelectors = cms.Sequence(
     cutsRecoTracksAK4PFJets
 )
 tracksValidationSelectorsFromPV = cms.Sequence(
-    trackRefsForValidation*
-    trackRefsFromPV*
     generalTracksFromPV*
     cutsRecoTracksFromPVHp
 )

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -47,13 +47,13 @@ cutsRecoTracksBtvLike = btvTracks_cfi.btvTrackRefs.clone()
 
 # Select tracks associated to AK4 jets
 import RecoJets.JetAssociationProducers.ak4JTA_cff as ak4JTA_cff
-ak4JetTracksAssociatorAtVertexPFAll = ak4JTA_cff.ak4JetTracksAssociatorAtVertexPF.clone(
+ak4JetTracksAssociatorExplicitAll = ak4JTA_cff.ak4JetTracksAssociatorExplicit.clone(
     jets = "ak4PFJets"
 )
 from JetMETCorrections.Configuration.JetCorrectors_cff import *
 import CommonTools.RecoAlgos.jetTracksAssociationToTrackRefs_cfi as jetTracksAssociationToTrackRefs_cfi
 cutsRecoTracksAK4PFJets = jetTracksAssociationToTrackRefs_cfi.jetTracksAssociationToTrackRefs.clone(
-    association = "ak4JetTracksAssociatorAtVertexPFAll",
+    association = "ak4JetTracksAssociatorExplicitAll",
     jets = "ak4PFJets",
     correctedPtMin = 10,
 )
@@ -257,7 +257,7 @@ tracksValidationSelectors = cms.Sequence(
     cutsRecoTracksMuonSeededStepOutIn*
     cutsRecoTracksMuonSeededStepOutInHp*
     cutsRecoTracksBtvLike*
-    ak4JetTracksAssociatorAtVertexPFAll*
+    ak4JetTracksAssociatorExplicitAll*
     cutsRecoTracksAK4PFJets
 )
 tracksValidationSelectorsFromPV = cms.Sequence(
@@ -334,7 +334,7 @@ tracksValidationStandalone = cms.Sequence(
 )
 
 # 'slim' sequences that only depend on track and tracking particle collections
-tracksValidationSelectorsSlim = tracksValidationSelectors.copyAndExclude([cutsRecoTracksBtvLike,ak4JetTracksAssociatorAtVertexPFAll,cutsRecoTracksAK4PFJets])
+tracksValidationSelectorsSlim = tracksValidationSelectors.copyAndExclude([cutsRecoTracksBtvLike,ak4JetTracksAssociatorExplicitAll,cutsRecoTracksAK4PFJets])
 
 tracksPreValidationSlim = cms.Sequence(
     tracksValidationSelectorsSlim +

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -16,30 +16,67 @@ from CommonTools.RecoAlgos.sortedPrimaryVertices_cfi import sortedPrimaryVertice
 from CommonTools.RecoAlgos.recoChargedRefCandidateToTrackRefProducer_cfi import recoChargedRefCandidateToTrackRefProducer as _recoChargedRefCandidateToTrackRefProducer
 
 ## Track selectors
+_algos = [
+    "generalTracks",
+    "initialStep",
+    "lowPtTripletStep",
+    "pixelPairStep",
+    "detachedTripletStep",
+    "mixedTripletStep",
+    "pixelLessStep",
+    "tobTecStep",
+    "jetCoreRegionalStep",
+    "muonSeededStepInOut",
+    "muonSeededStepOutIn",
+]
+def _algoToSelector(algo):
+    sel = ""
+    if algo != "generalTracks":
+        sel = algo[0].upper()+algo[1:]
+    return "cutsRecoTracks"+sel
+
+def _addSelectorsByAlgo():
+    names = []
+    seq = cms.Sequence()
+    for algo in _algos:
+        if algo == "generalTracks":
+            continue
+        modName = _algoToSelector(algo)
+        mod = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=[algo])
+        globals()[modName] = mod
+        names.append(modName)
+        seq += mod
+    return (names, seq)
+def _addSelectorsByHp():
+    seq = cms.Sequence()
+    names = []
+    for algo in _algos:
+        modName = _algoToSelector(algo)
+        modNameHp = modName+"Hp"
+        if algo == "generalTracks":
+            mod = cutsRecoTracks_cfi.cutsRecoTracks.clone(quality=["highPurity"])
+        else:
+            mod = globals()[modName].clone(quality=["highPurity"])
+        globals()[modNameHp] = mod
+        names.append(modNameHp)
+        seq += mod
+    return (names, seq)
+def _addSelectorsBySrc(modules, midfix, src):
+    seq = cms.Sequence()
+    names = []
+    for modName in modules:
+        modNameNew = modName.replace("cutsRecoTracks", "cutsRecoTracks"+midfix)
+        mod = globals()[modName].clone(src=src)
+        globals()[modNameNew] = mod
+        names.append(modNameNew)
+        seq += mod
+    return (names, seq)
+
 # Validation iterative steps
-cutsRecoTracksInitialStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["initialStep"])
-cutsRecoTracksLowPtTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["lowPtTripletStep"])
-cutsRecoTracksPixelPairStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["pixelPairStep"])
-cutsRecoTracksDetachedTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["detachedTripletStep"])
-cutsRecoTracksMixedTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["mixedTripletStep"])
-cutsRecoTracksPixelLessStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["pixelLessStep"])
-cutsRecoTracksTobTecStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["tobTecStep"])
-cutsRecoTracksJetCoreRegionalStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["jetCoreRegionalStep"])
-cutsRecoTracksMuonSeededStepInOut = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["muonSeededStepInOut"])
-cutsRecoTracksMuonSeededStepOutIn = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["muonSeededStepOutIn"])
+(_selectorsByAlgo, tracksValidationSelectorsByAlgo) = _addSelectorsByAlgo()
 
 # high purity
-cutsRecoTracksHp = cutsRecoTracks_cfi.cutsRecoTracks.clone(quality=["highPurity"])
-cutsRecoTracksInitialStepHp = cutsRecoTracksInitialStep.clone(quality=["highPurity"])
-cutsRecoTracksLowPtTripletStepHp = cutsRecoTracksLowPtTripletStep.clone(quality=["highPurity"])
-cutsRecoTracksPixelPairStepHp = cutsRecoTracksPixelPairStep.clone(quality=["highPurity"])
-cutsRecoTracksDetachedTripletStepHp = cutsRecoTracksDetachedTripletStep.clone(quality=["highPurity"])
-cutsRecoTracksMixedTripletStepHp = cutsRecoTracksMixedTripletStep.clone(quality=["highPurity"])
-cutsRecoTracksPixelLessStepHp = cutsRecoTracksPixelLessStep.clone(quality=["highPurity"])
-cutsRecoTracksTobTecStepHp = cutsRecoTracksTobTecStep.clone(quality=["highPurity"])
-cutsRecoTracksJetCoreRegionalStepHp = cutsRecoTracksJetCoreRegionalStep.clone(quality=["highPurity"])
-cutsRecoTracksMuonSeededStepInOutHp = cutsRecoTracksMuonSeededStepInOut.clone(quality=["highPurity"])
-cutsRecoTracksMuonSeededStepOutInHp = cutsRecoTracksMuonSeededStepOutIn.clone(quality=["highPurity"])
+(_selectorsByAlgoHp, tracksValidationSelectorsByAlgoHp) = _addSelectorsByHp()
 
 # BTV-like selection
 import PhysicsTools.RecoAlgos.btvTracks_cfi as btvTracks_cfi
@@ -95,58 +132,22 @@ generalTracksFromPV = _trackWithVertexRefSelector.clone(
     rhoVtx = 1e10, # intentionally no dxy cut
 )
 # and then the selectors
-cutsRecoTracksFromPVInitialStep         = cutsRecoTracksInitialStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVLowPtTripletStep    = cutsRecoTracksLowPtTripletStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVPixelPairStep       = cutsRecoTracksPixelPairStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVDetachedTripletStep = cutsRecoTracksDetachedTripletStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVMixedTripletStep    = cutsRecoTracksMixedTripletStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVPixelLessStep       = cutsRecoTracksPixelLessStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVTobTecStep          = cutsRecoTracksTobTecStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVJetCoreRegionalStep = cutsRecoTracksJetCoreRegionalStep.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVMuonSeededStepInOut = cutsRecoTracksMuonSeededStepInOut.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVMuonSeededStepOutIn = cutsRecoTracksMuonSeededStepOutIn.clone(src="generalTracksFromPV")
-# high purity
-cutsRecoTracksFromPVHp                    = cutsRecoTracksHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVInitialStepHp         = cutsRecoTracksInitialStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVLowPtTripletStepHp    = cutsRecoTracksLowPtTripletStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVPixelPairStepHp       = cutsRecoTracksPixelPairStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVDetachedTripletStepHp = cutsRecoTracksDetachedTripletStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVMixedTripletStepHp    = cutsRecoTracksMixedTripletStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVPixelLessStepHp       = cutsRecoTracksPixelLessStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVTobTecStepHp          = cutsRecoTracksTobTecStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVJetCoreRegionalStepHp = cutsRecoTracksJetCoreRegionalStepHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVMuonSeededStepInOutHp = cutsRecoTracksMuonSeededStepInOutHp.clone(src="generalTracksFromPV")
-cutsRecoTracksFromPVMuonSeededStepOutInHp = cutsRecoTracksMuonSeededStepOutInHp.clone(src="generalTracksFromPV")
+(_selectorsFromPV, tracksValidationSelectorsFromPV) = _addSelectorsBySrc([_selectorsByAlgoHp[0]], "FromPV", "generalTracksFromPV")
+(_selectorsFromPVStandalone, tracksValidationSelectorsFromPVStandalone) = _addSelectorsBySrc(_selectorsByAlgo+_selectorsByAlgoHp[1:], "FromPV", "generalTracksFromPV")
+tracksValidationSelectorsFromPV.insert(0, generalTracksFromPV)
 
 
 ## MTV instances
 trackValidator= Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidator.clone()
 
-trackValidator.label=cms.VInputTag(cms.InputTag("generalTracks"),
-                                   cms.InputTag("cutsRecoTracksHp"),
-                                   cms.InputTag("cutsRecoTracksInitialStep"),
-                                   cms.InputTag("cutsRecoTracksInitialStepHp"),
-                                   cms.InputTag("cutsRecoTracksLowPtTripletStep"),
-                                   cms.InputTag("cutsRecoTracksLowPtTripletStepHp"),
-                                   cms.InputTag("cutsRecoTracksPixelPairStep"),
-                                   cms.InputTag("cutsRecoTracksPixelPairStepHp"),
-                                   cms.InputTag("cutsRecoTracksDetachedTripletStep"),
-                                   cms.InputTag("cutsRecoTracksDetachedTripletStepHp"),
-                                   cms.InputTag("cutsRecoTracksMixedTripletStep"),
-                                   cms.InputTag("cutsRecoTracksMixedTripletStepHp"),
-                                   cms.InputTag("cutsRecoTracksPixelLessStep"),
-                                   cms.InputTag("cutsRecoTracksPixelLessStepHp"),
-                                   cms.InputTag("cutsRecoTracksTobTecStep"),
-                                   cms.InputTag("cutsRecoTracksTobTecStepHp"),
-                                   cms.InputTag("cutsRecoTracksJetCoreRegionalStep"),
-                                   cms.InputTag("cutsRecoTracksJetCoreRegionalStepHp"),
-                                   cms.InputTag("cutsRecoTracksMuonSeededStepInOut"),
-                                   cms.InputTag("cutsRecoTracksMuonSeededStepInOutHp"),
-                                   cms.InputTag("cutsRecoTracksMuonSeededStepOutIn"),
-                                   cms.InputTag("cutsRecoTracksMuonSeededStepOutInHp"),
-                                   cms.InputTag("cutsRecoTracksBtvLike"),
-                                   cms.InputTag("cutsRecoTracksAK4PFJets"),
-                                   )
+trackValidator.label=cms.VInputTag(
+    ["generalTracks"] +
+    _selectorsByAlgo +
+    _selectorsByAlgoHp +
+    [
+        "cutsRecoTracksBtvLike",
+        "cutsRecoTracksAK4PFJets",
+    ])
 trackValidator.useLogPt=cms.untracked.bool(True)
 trackValidator.dodEdxPlots = True
 trackValidator.doPVAssociationPlots = True
@@ -162,10 +163,7 @@ if eras.fastSim.isChosen():
 # signal tracks vs. signal TPs
 trackValidatorFromPV = trackValidator.clone(
     dirName = "Tracking/TrackFromPV/",
-    label = [
-        "generalTracksFromPV",
-        "cutsRecoTracksFromPVHp",
-    ],
+    label = ["generalTracksFromPV"]+_selectorsFromPV,
     label_tp_effic = "trackingParticlesSignal",
     label_tp_fake = "trackingParticlesSignal",
     associators = ["trackingParticleRecoTrackAsssociationSignal"],
@@ -174,28 +172,7 @@ trackValidatorFromPV = trackValidator.clone(
     doPVAssociationPlots = False,
 )
 trackValidatorFromPVStandalone = trackValidatorFromPV.clone()
-trackValidatorFromPVStandalone.label.extend([
-    "cutsRecoTracksFromPVInitialStep",
-    "cutsRecoTracksFromPVInitialStepHp",
-    "cutsRecoTracksFromPVLowPtTripletStep",
-    "cutsRecoTracksFromPVLowPtTripletStepHp",
-    "cutsRecoTracksFromPVPixelPairStep",
-    "cutsRecoTracksFromPVPixelPairStepHp",
-    "cutsRecoTracksFromPVDetachedTripletStep",
-    "cutsRecoTracksFromPVDetachedTripletStepHp",
-    "cutsRecoTracksFromPVMixedTripletStep",
-    "cutsRecoTracksFromPVMixedTripletStepHp",
-    "cutsRecoTracksFromPVPixelLessStep",
-    "cutsRecoTracksFromPVPixelLessStepHp",
-    "cutsRecoTracksFromPVTobTecStep",
-    "cutsRecoTracksFromPVTobTecStepHp",
-    "cutsRecoTracksFromPVJetCoreRegionalStep",
-    "cutsRecoTracksFromPVJetCoreRegionalStepHp",
-    "cutsRecoTracksFromPVMuonSeededStepInOut",
-    "cutsRecoTracksFromPVMuonSeededStepInOutHp",
-    "cutsRecoTracksFromPVMuonSeededStepOutIn",
-    "cutsRecoTracksFromPVMuonSeededStepOutInHp",
-])
+trackValidatorFromPVStandalone.label.extend(_selectorsFromPVStandalone)
 
 # For fake rate of signal tracks vs. all TPs, and pileup rate of
 # signal tracks vs. non-signal TPs
@@ -216,7 +193,7 @@ trackValidatorAllTPEffic = trackValidator.clone(
     dirName = "Tracking/TrackAllTPEffic/",
     label = [
         "generalTracks",
-        "cutsRecoTracksHp",
+        _selectorsByAlgoHp[0],
     ],
     doSimPlots = False,
     doRecoTrackPlots = False, # Fake rate of all tracks vs. all TPs is already included in trackValidator
@@ -235,56 +212,11 @@ trackValidatorAllTPEfficStandalone = trackValidatorAllTPEffic.clone(
 
 # the track selectors
 tracksValidationSelectors = cms.Sequence(
-    cutsRecoTracksHp*
-    cutsRecoTracksInitialStep*
-    cutsRecoTracksInitialStepHp*
-    cutsRecoTracksLowPtTripletStep*
-    cutsRecoTracksLowPtTripletStepHp*
-    cutsRecoTracksPixelPairStep*
-    cutsRecoTracksPixelPairStepHp*
-    cutsRecoTracksDetachedTripletStep*
-    cutsRecoTracksDetachedTripletStepHp*
-    cutsRecoTracksMixedTripletStep*
-    cutsRecoTracksMixedTripletStepHp*
-    cutsRecoTracksPixelLessStep*
-    cutsRecoTracksPixelLessStepHp*
-    cutsRecoTracksTobTecStep*
-    cutsRecoTracksTobTecStepHp*
-    cutsRecoTracksJetCoreRegionalStep*
-    cutsRecoTracksJetCoreRegionalStepHp*
-    cutsRecoTracksMuonSeededStepInOut*
-    cutsRecoTracksMuonSeededStepInOutHp*
-    cutsRecoTracksMuonSeededStepOutIn*
-    cutsRecoTracksMuonSeededStepOutInHp*
-    cutsRecoTracksBtvLike*
-    ak4JetTracksAssociatorExplicitAll*
+    tracksValidationSelectorsByAlgo +
+    tracksValidationSelectorsByAlgoHp +
+    cutsRecoTracksBtvLike +
+    ak4JetTracksAssociatorExplicitAll +
     cutsRecoTracksAK4PFJets
-)
-tracksValidationSelectorsFromPV = cms.Sequence(
-    generalTracksFromPV*
-    cutsRecoTracksFromPVHp
-)
-tracksValidationSelectorsFromPVStandalone = cms.Sequence(
-    cutsRecoTracksFromPVInitialStep*
-    cutsRecoTracksFromPVInitialStepHp*
-    cutsRecoTracksFromPVLowPtTripletStep*
-    cutsRecoTracksFromPVLowPtTripletStepHp*
-    cutsRecoTracksFromPVPixelPairStep*
-    cutsRecoTracksFromPVPixelPairStepHp*
-    cutsRecoTracksFromPVDetachedTripletStep*
-    cutsRecoTracksFromPVDetachedTripletStepHp*
-    cutsRecoTracksFromPVMixedTripletStep*
-    cutsRecoTracksFromPVMixedTripletStepHp*
-    cutsRecoTracksFromPVPixelLessStep*
-    cutsRecoTracksFromPVPixelLessStepHp*
-    cutsRecoTracksFromPVTobTecStep*
-    cutsRecoTracksFromPVTobTecStepHp*
-    cutsRecoTracksFromPVJetCoreRegionalStep*
-    cutsRecoTracksFromPVJetCoreRegionalStepHp*
-    cutsRecoTracksFromPVMuonSeededStepInOut*
-    cutsRecoTracksFromPVMuonSeededStepInOutHp*
-    cutsRecoTracksFromPVMuonSeededStepOutIn*
-    cutsRecoTracksFromPVMuonSeededStepOutInHp
 )
 tracksValidationTruth = cms.Sequence(
     tpClusterProducer +
@@ -345,7 +277,7 @@ trackValidatorSlim = trackValidator.clone(
     doPVAssociationPlots = cms.untracked.bool(False),
     dodEdxPlots = False
 )
-for _label in [cms.InputTag("cutsRecoTracksBtvLike"),cms.InputTag("cutsRecoTracksAK4PFJets")]:
+for _label in ["cutsRecoTracksBtvLike", "cutsRecoTracksAK4PFJets"]:
     trackValidatorSlim.label.remove(_label)
 
 tracksValidationSlim = cms.Sequence(

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -227,6 +227,8 @@ trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.si
 trackValidatorAllTPEfficStandalone = trackValidatorAllTPEffic.clone(
     label = trackValidator.label.value()
 )
+for _label in ["cutsRecoTracksBtvLike", "cutsRecoTracksAK4PFJets"]:
+    trackValidatorAllTPEfficStandalone.label.remove(_label)
 
 
 # the track selectors


### PR DESCRIPTION
This PR contains the following updates to tracking validation
- Associate tracks to PV by simple dz(PV) cut instead of the PV sorter (in "fromPV" variants of MultiTrackValidator)
  - Main motivation is to be able to do the same association with tracking-only information, and whether running (tracking-only) RECO on the fly or using RECO+DIGI as an input
- Monitor the tracks from AK4 PFJet constituents instead of those in cone of DeltaR < 0.4
  - It is more interesting to us to monitor what exactly gets clustered
- For standalone mode (not used in RelVals), add iteration selections using originalAlgo and algoMask
- Generalize the configuration of monitored iterations such that it will be straightforward to customize the iterations for e.g. Phase1 tracking with eras

Tested in CMSSW_8_0_X_2015-11-12-1100, expecting changes in `Tracking/TrackFromPV`, `Tracking/TrackFromPVAllTP`, and `Tracking/Track/cutsRecoAK4PFJets_trackingParticleRecoAsssociation` DQM folders.

@rovere @VinInn 
