### PR TITLE
Migration of modules used in PbPb HLT to do ZeroSuppression to stream modules in 75X

### DIFF
--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
@@ -7,12 +7,12 @@
  */
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h" 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class RawDataCollectorByLabel: public edm::EDProducer {
+class RawDataCollectorByLabel: public edm::stream::EDProducer<> {
 public:
     
     ///Constructor

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -3,7 +3,7 @@
 #define EventFilter_SiStripRawToDigi_SiStripDigiToRawModule_H
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
@@ -21,7 +21,7 @@ namespace sistrip {
      @brief A plug-in module that takes StripDigis as input from the
      Event and creates an EDProduct comprising a FEDRawDataCollection.
   */
-  class dso_hidden DigiToRawModule final : public edm::EDProducer {
+  class dso_hidden DigiToRawModule final : public edm::stream::EDProducer<> {
   
   public:
   


### PR DESCRIPTION
Dear all,

We have realized that two modules used in the PbPb HLT ZeroSuppression sequence are still legacy ones:  RawDataCollectorByLabel and SiStripDigiToRawModule. I don't know how important the migration of these modules to streamer ones is. For any case, I have migrated the modules and verified that HLT runs and gives the same rates before and after the migration. Similar PRs will be made for 76X and 80X.

I am cc'ing TSG experts for comments.

@mandrenguyen @fwyzard @Martin-Grunewald 

Cheers,
Krisztian
