### PR TITLE
Remove obsolete conditional compilations in Framework only

### DIFF
--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -97,20 +97,17 @@ namespace edm {
     /// default constructor
     AssociationMap() { }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     // You will see better performance if you use other constructors.
     // Use this when the arguments the other constructors require are
     // not easily available.
     explicit
     AssociationMap(EDProductGetter const* getter) :
       ref_(getter) { }
-#endif
 
     // It is rare for this to be useful
     explicit
     AssociationMap(const ref_type & ref) : ref_(ref) { }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     // In most cases this is the best constructor to use.
     // This constructor should be passed 2 arguments, except in the
     // case where the template parameter is OneToValue where it should
@@ -143,7 +140,6 @@ namespace edm {
 
     template<typename... Args>
     AssociationMap(Args... args) : ref_(std::forward<Args>(args)...) {}
-#endif
 
     /// clear map
     void clear() { map_.clear(); transientMap_.clear(); }

--- a/DataFormats/Common/interface/AssociationMapHelpers.h
+++ b/DataFormats/Common/interface/AssociationMapHelpers.h
@@ -23,12 +23,10 @@ namespace edm {
       typedef V value_type;
       KeyVal() : key(), val() { }
       KeyVal(const K & k, const V & v) : key(k), val(v) { }
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
       template<typename K_, typename V_>
       KeyVal(K_&& k, V_&& v) : key(std::forward<K_>(k)),val(std::forward<V_>(v)){}
 
       KeyVal(EDProductGetter const* getter) : key(ProductID(), getter), val(ProductID(), getter) { }
-#endif
 
       K key;
       V val;
@@ -39,12 +37,10 @@ namespace edm {
       typedef K key_type;
       Key() { }
       Key(const K & k) : key(k) { }
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
       template<typename K_>
       Key(K_&& k) : key(std::forward<K_>(k)) { }
 
       Key(EDProductGetter const* getter) : key(ProductID(), getter) { }
-#endif
 
       K key;
     };

--- a/DataFormats/Common/interface/AssociationVector.h
+++ b/DataFormats/Common/interface/AssociationVector.h
@@ -22,10 +22,8 @@
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #include <type_traits>
-#endif
 #include <memory>
 
 namespace edm {
@@ -113,23 +111,17 @@ namespace edm {
     enum CacheState { kUnset, kFilling, kSet };
     CVal data_;
     KeyRefProd ref_;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     mutable std::atomic<transient_vector_type*> transientVector_;
-#else
-    mutable transient_vector_type* transientVector_;
-#endif
 
     transient_vector_type const& transientVector() const;
     void fixup() const;
   };
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline typename AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::transient_vector_type const&
   AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::transientVector() const {
     fixup();
     return *(transientVector_.load(std::memory_order_acquire)); }
-#endif
   
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::AssociationVector() :
@@ -141,7 +133,6 @@ namespace edm {
     data_(coll == 0 ? ref->size() : coll->size()), ref_(ref),
     transientVector_( new transient_vector_type(coll == 0 ? ref->size() : coll->size())) { }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::
     AssociationVector(AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper> const& o) :
@@ -151,14 +142,11 @@ namespace edm {
         transientVector_.store( new transient_vector_type(*t), std::memory_order_release);
       }
     }
-#endif
   
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::~AssociationVector() {
     delete transientVector_.load(std::memory_order_acquire);
   }
-#endif
 
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline typename AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::const_reference
@@ -178,9 +166,7 @@ namespace edm {
   template< typename K>
   inline typename CVal::const_reference
   AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::operator[](edm::Ptr<K> const& k) const {
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     static_assert(std::is_base_of<K,key_type>::value, "edm::Ptr's key type is not a base class of AssociationVector's item type");
-#endif
     checkForWrongProduct(k.id(), ref_.id());
     return data_[ k.key() ];
   }
@@ -189,15 +175,11 @@ namespace edm {
   template< typename K>
   typename CVal::const_reference
   AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::operator[](edm::RefToBase<K> const& k) const {
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     static_assert(std::is_base_of<K,key_type>::value,"edm::RefToBase's key type is not a base class of AssociationVector's item type");
-#endif
     checkForWrongProduct(k.id(), ref_.id());
     return data_[ k.key() ];
   }
 
-
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline typename CVal::reference
   AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::operator[](KeyRef const& k) {
@@ -207,9 +189,7 @@ namespace edm {
     checkForWrongProduct(keyRef.id(), ref_.id());
     return data_[ keyRef.key() ];
   }
-#endif
   
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>&
   AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::operator=(self const& o) {
@@ -231,7 +211,6 @@ namespace edm {
     (*t)[ i ].first = ref;
     (*t)[ i ].second = data_[ i ];
   }
-#endif
 
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline typename AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::size_type
@@ -244,7 +223,6 @@ namespace edm {
     return data_.empty();
   }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline void AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::clear() {
     data_.clear();
@@ -273,7 +251,6 @@ namespace edm {
       }
     }
   }
-#endif
 
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   void AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::fillView(ProductID const& id,

--- a/DataFormats/Common/interface/AtomicPtrCache.h
+++ b/DataFormats/Common/interface/AtomicPtrCache.h
@@ -27,10 +27,8 @@
 //
 
 // system include files
- #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #include <memory>
-#endif
 // user include files
 
 // forward declarations
@@ -58,11 +56,9 @@ namespace edm {
     T const* load() const;
 
     bool isSet() const;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     ///returns true if actually was set.
     /// Will delete value held by iNewValue if not the first time set
     bool set(std::unique_ptr<T> iNewValue) const;
-#endif
     // ---------- static member functions --------------------
     
     // ---------- member functions ---------------------------
@@ -79,13 +75,8 @@ namespace edm {
   private:
     
     // ---------- member data --------------------------------
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     mutable std::atomic<T*> m_data;
-#else
-    mutable T* m_data;
-#endif
   };
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename T>
   inline AtomicPtrCache<T>::AtomicPtrCache():m_data{nullptr} {}
   
@@ -150,6 +141,5 @@ namespace edm {
     T* tmp = m_data.exchange(nullptr);
     return tmp;
   }
-#endif
 }
 #endif

--- a/DataFormats/Common/interface/ConvertHandle.h
+++ b/DataFormats/Common/interface/ConvertHandle.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_Common_ConvertHandle_h
 #define DataFormats_Common_ConvertHandle_h
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include "DataFormats/Common/interface/BasicHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
@@ -37,15 +36,5 @@ namespace edm {
     h.swap(result);
   }
 }
-#else
-namespace edm {
-  class BasicHandle;
-  template<typename T> class Handle;
-  
-  template<typename T>
-  void convert_handle(BasicHandle & bh,
-                      Handle<T>& result);
-}
-#endif
 
 #endif

--- a/DataFormats/Common/interface/DetSetVector.h
+++ b/DataFormats/Common/interface/DetSetVector.h
@@ -41,10 +41,6 @@ behavior (usually a core dump).
 
 #include "boost/concept_check.hpp"
 #include "boost/mpl/if.hpp"
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-#else
-#include "boost/bind.hpp"
-#endif
 
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Common/interface/DetSet.h"
@@ -382,28 +378,20 @@ namespace edm {
   {
     std::transform(this->begin(), this->end(),
 		   std::back_inserter(result),
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 		   std::bind(&DetSet<T>::id,std::placeholders::_1));
-#else
-		   boost::bind(&DetSet<T>::id,_1));
-#endif
   }
 
   template <class T>
   inline
   void
   DetSetVector<T>::post_insert() {
-#ifndef CMS_NOCXX11
     _sets.shrink_to_fit();
-#endif
     if (_alreadySorted) return; 
     typename collection_type::iterator i = _sets.begin();
     typename collection_type::iterator e = _sets.end();
     // For each DetSet...
     for (; i != e; ++i) {
-#ifndef CMS_NOCXX11
       i->data.shrink_to_fit();
-#endif
       // sort the Detset pointed to by
       std::sort(i->data.begin(), i->data.end());
     }

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -12,8 +12,6 @@
 #include <boost/any.hpp>
 #include <memory>
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
-
 
 #include<vector>
 #include <cassert>
@@ -194,13 +192,11 @@ namespace edmNew {
 	v.m_data.push_back(d);
 	item.size++;
       }
-#ifndef CMS_NOCXX11
       void push_back(data_type && d) {
         checkCapacityExausted();
         v.m_data.push_back(std::move(d));
         item.size++;
       }
-#endif
 
       data_type & back() { return v.m_data.back();}
       
@@ -255,10 +251,8 @@ namespace edmNew {
     }
     
     void shrink_to_fit() {
-#ifndef CMS_NOCXX11
       m_ids.shrink_to_fit();
       m_data.shrink_to_fit();
-#endif
     }
 
     void resize(size_t isize, size_t dsize) {

--- a/DataFormats/Common/interface/FillView.h
+++ b/DataFormats/Common/interface/FillView.h
@@ -21,7 +21,6 @@ namespace edm {
   class ProductID;
 
   namespace detail {
-#ifndef __GCCXML__
 
     template <class COLLECTION>
     void
@@ -44,14 +43,6 @@ namespace edm {
         helpers.emplace_back(id,key);
       }
     }
-#else
-    template <class COLLECTION>
-    void
-    reallyFillView(COLLECTION const& coll,
-                   ProductID const& id,
-                   std::vector<void const*>& ptrs,
-                   FillViewHelperVector& helpers);
-#endif
   }
   template <class T, class A>
   void

--- a/DataFormats/Common/interface/Holder.h
+++ b/DataFormats/Common/interface/Holder.h
@@ -22,28 +22,28 @@ namespace edm {
       Holder& operator= (Holder const& rhs);
       void swap(Holder& other);
       virtual ~Holder();
-      virtual BaseHolder<T>* clone() const GCC11_OVERRIDE;
+      virtual BaseHolder<T>* clone() const override;
 
-      virtual T const* getPtr() const GCC11_OVERRIDE;
-      virtual ProductID id() const GCC11_OVERRIDE;
-      virtual size_t key() const GCC11_OVERRIDE;
-      virtual bool isEqualTo(BaseHolder<T> const& rhs) const GCC11_OVERRIDE;
+      virtual T const* getPtr() const override;
+      virtual ProductID id() const override;
+      virtual size_t key() const override;
+      virtual bool isEqualTo(BaseHolder<T> const& rhs) const override;
       REF const& getRef() const;
 
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
-					  std::string& msg) const GCC11_OVERRIDE;
+					  std::string& msg) const override;
 
-      virtual std::auto_ptr<RefHolderBase> holder() const GCC11_OVERRIDE {
+      virtual std::auto_ptr<RefHolderBase> holder() const override {
 	return std::auto_ptr<RefHolderBase>( new RefHolder<REF>( ref_ ) );
       }
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const GCC11_OVERRIDE;
-      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
+      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
+      virtual EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const GCC11_OVERRIDE { return ref_.isAvailable(); }
+      virtual bool isAvailable() const override { return ref_.isAvailable(); }
 
-      virtual bool isTransient() const GCC11_OVERRIDE { return ref_.isTransient(); }
+      virtual bool isTransient() const override { return ref_.isTransient(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -29,32 +29,30 @@ namespace edm {
       // sure if use of auto_ptr here causes any troubles elsewhere.
       IndirectHolder() : BaseHolder<T>(), helper_( 0 ) { }
       IndirectHolder(std::shared_ptr<RefHolderBase> p);
-#ifndef __GCCXML__
       template< typename U>
       IndirectHolder(std::unique_ptr<U> p): helper_(p.release()) {}
-#endif
       IndirectHolder(IndirectHolder const& other);
       IndirectHolder& operator= (IndirectHolder const& rhs);
       void swap(IndirectHolder& other);
       virtual ~IndirectHolder();
       
-      virtual BaseHolder<T>* clone() const GCC11_OVERRIDE;
-      virtual T const* getPtr() const GCC11_OVERRIDE;
-      virtual ProductID id() const GCC11_OVERRIDE;
-      virtual size_t key() const GCC11_OVERRIDE;
-      virtual bool isEqualTo(BaseHolder<T> const& rhs) const GCC11_OVERRIDE;
+      virtual BaseHolder<T>* clone() const override;
+      virtual T const* getPtr() const override;
+      virtual ProductID id() const override;
+      virtual size_t key() const override;
+      virtual bool isEqualTo(BaseHolder<T> const& rhs) const override;
 
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
-					  std::string& msg) const GCC11_OVERRIDE;
-      virtual std::auto_ptr<RefHolderBase> holder() const GCC11_OVERRIDE;
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const GCC11_OVERRIDE;
-      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
+					  std::string& msg) const override;
+      virtual std::auto_ptr<RefHolderBase> holder() const override;
+      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
+      virtual EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const GCC11_OVERRIDE { return helper_->isAvailable(); }
+      virtual bool isAvailable() const override { return helper_->isAvailable(); }
 
-      virtual bool isTransient() const GCC11_OVERRIDE { return helper_->isTransient(); }
+      virtual bool isTransient() const override { return helper_->isTransient(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -26,18 +26,18 @@ namespace edm {
       virtual ~IndirectVectorHolder();
       IndirectVectorHolder& operator= (IndirectVectorHolder const& rhs);
       void swap(IndirectVectorHolder& other);
-      virtual BaseVectorHolder<T>* clone() const GCC11_OVERRIDE;
-      virtual BaseVectorHolder<T>* cloneEmpty() const GCC11_OVERRIDE;
-      virtual ProductID id() const GCC11_OVERRIDE;
-      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
-      virtual bool empty() const GCC11_OVERRIDE;
-      virtual size_type size() const GCC11_OVERRIDE;
-      virtual void clear() GCC11_OVERRIDE;
-      virtual base_ref_type const at(size_type idx) const GCC11_OVERRIDE;
-      virtual std::auto_ptr<reftobase::RefVectorHolderBase> vectorHolder() const GCC11_OVERRIDE {
+      virtual BaseVectorHolder<T>* clone() const override;
+      virtual BaseVectorHolder<T>* cloneEmpty() const override;
+      virtual ProductID id() const override;
+      virtual EDProductGetter const* productGetter() const override;
+      virtual bool empty() const override;
+      virtual size_type size() const override;
+      virtual void clear() override;
+      virtual base_ref_type const at(size_type idx) const override;
+      virtual std::auto_ptr<reftobase::RefVectorHolderBase> vectorHolder() const override {
 	return std::auto_ptr<reftobase::RefVectorHolderBase>( helper_->clone() );
       }
-      virtual void push_back( const BaseHolder<T> * r ) GCC11_OVERRIDE {
+      virtual void push_back( const BaseHolder<T> * r ) override {
 	typedef IndirectHolder<T> holder_type;
 	const holder_type * h = dynamic_cast<const holder_type *>( r );
 	if( h == 0 )
@@ -48,7 +48,7 @@ namespace edm {
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const GCC11_OVERRIDE { return helper_->isAvailable(); }
+      virtual bool isAvailable() const override { return helper_->isAvailable(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)
@@ -91,10 +91,10 @@ namespace edm {
 	typename RefVectorHolderBase::const_iterator i;
       };
 
-      const_iterator begin() const GCC11_OVERRIDE {
+      const_iterator begin() const override {
 	return const_iterator( new const_iterator_imp_specific( helper_->begin() ) );
       }
-      const_iterator end() const GCC11_OVERRIDE {
+      const_iterator end() const override {
 	return const_iterator( new const_iterator_imp_specific( helper_->end() ) );
       }
     };

--- a/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
+++ b/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
@@ -3,11 +3,7 @@
 #include "DataFormats/Common/interface/AssociationMapHelpers.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <functional>
-#else
-#include "boost/bind.hpp"
-#endif
 #include <map>
 #include <vector>
 #include <algorithm>
@@ -100,22 +96,15 @@ namespace edm {
     static void sort(map_type & m) {
       //      using namespace boost::lambda;
       for(typename map_type::iterator i = m.begin(), iEnd = m.end(); i != iEnd; ++i) {
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
         using std::placeholders::_1;
         using std::placeholders::_2;
-#endif
 	map_assoc & v = i->second;
 	// Q std::pair<index, Q>::*quality = &std::pair<index, Q>::second;
 	// std::sort(v.begin(), v.end(),
 	// 	  bind(quality, boost::lambda::_2) < bind(quality, boost::lambda::_1));
            std::sort(v.begin(), v.end(), 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
                   std::bind(std::less<Q>(), 
                   std::bind(&std::pair<index, Q>::second,_2), std::bind( &std::pair<index, Q>::second,_1)
-#else
-                  boost::bind(std::less<Q>(), 
-                  boost::bind(&std::pair<index, Q>::second,_2), boost::bind( &std::pair<index, Q>::second,_1)
-#endif
                              )
            );
 

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -17,7 +17,6 @@
 #include <functional>
 #include <typeinfo>
 #include <vector>
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 namespace edm {
   class ProductID;
@@ -125,9 +124,7 @@ namespace edm {
 #endif
 
     void shrink_to_fit() {
-#ifndef CMS_NOCXX11
       data_.shrink_to_fit();
-#endif
     }
 
 

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -290,7 +290,6 @@ namespace edm {
 #include "DataFormats/Common/interface/HolderToVectorTrait_Ptr_specialization.h"
 #include <vector>
 
-#ifndef __GCCXML__
 namespace edm {
   template <typename T>
   inline
@@ -311,6 +310,5 @@ namespace edm {
     }
   }
 }
-#endif
 
 #endif

--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -37,12 +37,8 @@ namespace edm {
 
     explicit PtrVectorBase(ProductID const& productID, void const* prodPtr = 0,
                            EDProductGetter const* prodGetter = 0)
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     :
       core_(productID, prodPtr, prodGetter, false), indicies_(), cachedItems_(nullptr) {}
-#else
-    ;
-#endif
     
     PtrVectorBase( const PtrVectorBase&);
 
@@ -82,11 +78,7 @@ namespace edm {
 
     /// Clear the PtrVector
     void clear()
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     { core_ = RefCore(); indicies_.clear(); if(cachedItems_) { delete cachedItems_.load(); cachedItems_.store(nullptr); } }
-#else
-    ;
-#endif
   
     bool operator==(PtrVectorBase const& iRHS) const;
     // ---------- static member functions --------------------
@@ -174,11 +166,7 @@ namespace edm {
     // ---------- member data --------------------------------
     RefCore core_;
     std::vector<key_type> indicies_;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     mutable std::atomic<std::vector<void const*>*> cachedItems_; //! transient
-#else
-    mutable std::vector<void const*>* cachedItems_;               //!transient
-#endif
 
   };
 }

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -13,9 +13,7 @@ RefCore: The component of edm::Ref containing the product ID and product getter.
 
 #include <algorithm>
 #include <typeinfo>
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
-#endif
 
 namespace edm {
   class RefCoreWithIndex;
@@ -33,11 +31,9 @@ namespace edm {
     
     RefCore& operator=(RefCore const&);
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     RefCore( RefCore&& iOther) : cachePtr_(iOther.cachePtr_.load()), processIndex_(iOther.processIndex_),
     productIndex_(iOther.productIndex_) {}
     RefCore& operator=(RefCore&&) = default;
-#endif
     
     ProductID id() const {ID_IMPL;}
 
@@ -111,18 +107,12 @@ namespace edm {
     void setTransient() {SETTRANSIENT_IMPL;}
     void setCacheIsProductPtr(const void* iItem) const {SETCACHEISPRODUCTPTR_IMPL(iItem);}
     void setCacheIsProductGetter(EDProductGetter const * iGetter) const {SETCACHEISPRODUCTGETTER_IMPL(iGetter);}
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     bool cachePtrIsInvalid() const { return 0 == (reinterpret_cast<std::uintptr_t>(cachePtr_.load()) & refcoreimpl::kCacheIsProductPtrMask); }
-#endif
 
     //The low bit of the address is used to determine  if the cachePtr_
     // is storing the productPtr or the EDProductGetter. The bit is set if
     // the address refers to the EDProductGetter.
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     mutable std::atomic<void const*> cachePtr_; // transient
-#else
-    mutable void const* cachePtr_;               // transient
-#endif
     //The following is what is stored in a ProductID
     // the high bit of processIndex is used to store info on
     // if this is transient.
@@ -151,7 +141,6 @@ namespace edm {
     return lhs.isTransient() ? (rhs.isTransient() ? lhs.productPtr() < rhs.productPtr() : false) : (rhs.isTransient() ? true : lhs.id() < rhs.id());
   }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   inline 
   void
   RefCore::swap(RefCore & other) {
@@ -163,7 +152,6 @@ namespace edm {
   inline void swap(edm::RefCore & lhs, edm::RefCore & rhs) {
     lhs.swap(rhs);
   }
-#endif
 }
 
 #endif

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -18,9 +18,7 @@ RefCoreWithIndex: The component of edm::Ref containing the product ID and produc
 #include <algorithm>
 #include <typeinfo>
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
-#endif
 
 namespace edm {  
   class RefCoreWithIndex {
@@ -35,11 +33,9 @@ namespace edm {
     
     RefCoreWithIndex& operator=(RefCoreWithIndex const&);
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     RefCoreWithIndex( RefCoreWithIndex&& iOther): cachePtr_(iOther.cachePtr_.load()),processIndex_(iOther.processIndex_),
     productIndex_(iOther.productIndex_),elementIndex_(iOther.elementIndex_) {}
     RefCoreWithIndex& operator=(RefCoreWithIndex&&) = default;
-#endif
 
     ProductID id() const {ID_IMPL;}
 
@@ -138,11 +134,7 @@ namespace edm {
     //The low bit of the address is used to determine  if the cachePtr_
     // is storing the productPtr or the EDProductGetter. The bit is set if
     // the address refers to the EDProductGetter.
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     mutable std::atomic<void const*> cachePtr_; // transient
-#else
-    mutable void const* cachePtr_;               // transient
-#endif
     //The following is what is stored in a ProductID
     // the high bit of processIndex is used to store info on
     // if this is transient.
@@ -152,7 +144,6 @@ namespace edm {
 
   };
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   inline 
   void
   RefCoreWithIndex::swap(RefCoreWithIndex & other) {
@@ -161,7 +152,6 @@ namespace edm {
     other.cachePtr_.store(cachePtr_.exchange(other.cachePtr_.load()));
     std::swap(elementIndex_,other.elementIndex_);
   }
-#endif
 
   inline void swap(edm::RefCoreWithIndex & lhs, edm::RefCoreWithIndex & rhs) {
     lhs.swap(rhs);

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -24,28 +24,28 @@ namespace edm {
       explicit RefHolder(REF const& ref);
       void swap(RefHolder& other);
       virtual ~RefHolder();
-      virtual RefHolderBase* clone() const GCC11_OVERRIDE;
+      virtual RefHolderBase* clone() const override;
 
-      virtual ProductID id() const GCC11_OVERRIDE;
-      virtual size_t key() const GCC11_OVERRIDE;
-      virtual bool isEqualTo(RefHolderBase const& rhs) const GCC11_OVERRIDE;
+      virtual ProductID id() const override;
+      virtual size_t key() const override;
+      virtual bool isEqualTo(RefHolderBase const& rhs) const override;
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
-					  std::string& msg) const GCC11_OVERRIDE;
+					  std::string& msg) const override;
       REF const& getRef() const;
       void setRef(REF const& r);
-      virtual std::auto_ptr<RefVectorHolderBase> makeVectorHolder() const GCC11_OVERRIDE;
-      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
+      virtual std::auto_ptr<RefVectorHolderBase> makeVectorHolder() const override;
+      virtual EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const GCC11_OVERRIDE { return ref_.isAvailable(); }
+      virtual bool isAvailable() const override { return ref_.isAvailable(); }
 
-      virtual bool isTransient() const GCC11_OVERRIDE { return ref_.isTransient(); }
+      virtual bool isTransient() const override { return ref_.isTransient(); }
 
       //Needed for ROOT storage
       CMS_CLASS_VERSION(10)
     private:
-      virtual void const* pointerToType(std::type_info const& iToType) const GCC11_OVERRIDE;
+      virtual void const* pointerToType(std::type_info const& iToType) const override;
       REF ref_;
     };
 

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -44,9 +44,7 @@ reference type.
 #include "DataFormats/Common/interface/RefHolder.h"
 
 #include <memory>
-#ifndef __GCCXML__
 #include <type_traits>
-#endif
 
 namespace edm {
   //--------------------------------------------------------------------
@@ -77,11 +75,9 @@ namespace edm {
     explicit RefToBase(RefProd<C> const& r);
     RefToBase(RefToBaseProd<T> const& r, size_t i);
     RefToBase(Handle<View<T> > const& handle, size_t i);
-#ifndef __GCCXML__
     template <typename T1>
     explicit RefToBase(RefToBase<T1> const & r );
     RefToBase(std::unique_ptr<reftobase::BaseHolder<value_type>>);
-#endif
     RefToBase(std::shared_ptr<reftobase::RefHolderBase> p);
 
     ~RefToBase();
@@ -156,7 +152,6 @@ namespace edm {
     holder_(new reftobase::Holder<T,RefProd<C> >(iRef))
   { }
 
-#ifndef __GCCXML__
   template <class T>
   template <typename T1>
   inline
@@ -178,7 +173,6 @@ namespace edm {
   RefToBase<T>::RefToBase(std::unique_ptr<reftobase::BaseHolder<value_type>> p):
     holder_(p.release())
   {}
-#endif
 
   template <class T>
   inline
@@ -247,7 +241,6 @@ namespace edm {
     return  holder_->key();
   }
 
-#ifndef __GCCXML__
   namespace {
     // If the template parameters are classes or structs they should be
     // related by inheritance, otherwise they should be the same type.
@@ -312,7 +305,6 @@ namespace edm {
                          );
     return REF();
   }
-#endif
 
   /// Checks for null
   template <class T>

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -132,7 +132,6 @@ namespace edm {
     return * operator->();
   }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   /// Member dereference operator
   template<typename T>
   inline
@@ -160,7 +159,6 @@ namespace edm {
     }
     return viewPtr();
   }
-#endif
 
   template<typename T>
   inline
@@ -198,7 +196,6 @@ namespace edm {
 #include "DataFormats/Common/interface/FillView.h"
 
 namespace edm {
-#ifndef __GCCXML__
   template<typename T>
   template<typename C>
   inline
@@ -209,7 +206,6 @@ namespace edm {
     fillView(* ref.product(), ref.id(), pointers, helpers);
     product_.setProductPtr(new View<T>(pointers, helpers, ref.refCore().productGetter()));
   }
-#endif
 
   template<typename T>
   template<typename C>

--- a/DataFormats/Common/interface/RefVectorHolder.h
+++ b/DataFormats/Common/interface/RefVectorHolder.h
@@ -203,21 +203,13 @@ namespace edm {
     template <typename REFV>
     std::shared_ptr<RefHolderBase>
     RefVectorHolder<REFV>::refBase(size_t idx) const {
-#ifdef __GCCXML__
-      return std::shared_ptr<RefHolderBase>(new RefHolder<typename REFV::value_type>(refs_[idx]));
-#else
       return std::shared_ptr<RefHolderBase>(std::make_shared<RefHolder<typename REFV::value_type> >(refs_[idx]));
-#endif
     }
 
     template<typename REFV>
     std::shared_ptr<RefHolderBase>
     RefVectorHolder<REFV>::const_iterator_imp_specific::deref() const {
-#ifdef __GCCXML__
-      return std::shared_ptr<RefHolderBase>(new RefHolder<typename REFV::value_type>(*i));
-#else
       return std::shared_ptr<RefHolderBase>(std::make_shared<RefHolder<typename REFV::value_type> >(*i));
-#endif
     }
   }
 }

--- a/DataFormats/Common/interface/ValueMap.h
+++ b/DataFormats/Common/interface/ValueMap.h
@@ -159,10 +159,8 @@ namespace edm {
     bool empty() const { return values_.empty(); }
     void clear() { values_.clear(); ids_.clear(); }
     void shrink_to_fit() {
-#ifndef CMS_NOCXX11
       ids_.shrink_to_fit();  
       values_.shrink_to_fit();
-#endif
     }
 
 

--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -38,17 +38,13 @@ namespace edm {
   class ViewBase {
   public:
     virtual ~ViewBase();
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     std::unique_ptr<ViewBase> clone() const;
-#endif
 
   protected:
     ViewBase();
     ViewBase(ViewBase const&);
     ViewBase& operator=(ViewBase const&);
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     virtual std::unique_ptr<ViewBase> doClone() const = 0;
-#endif
     void swap(ViewBase&) {} // Nothing to swap
   };
 
@@ -140,9 +136,7 @@ namespace edm {
   private:
     seq_t items_;
     std::vector<Ptr<value_type> > vPtrs_;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     std::unique_ptr<ViewBase> doClone() const override;
-#endif
   };
 
   // Associated free functions (same as for std::vector)
@@ -164,7 +158,6 @@ namespace edm {
     vPtrs_() {
   }
 
-#ifndef __GCCXML__
   template<typename T>
   View<T>::View(std::vector<void const*> const& pointers,
                 FillViewHelperVector const& helpers,
@@ -193,7 +186,6 @@ namespace edm {
       }
     }
   }
-#endif
 
   template<typename T>
   View<T>::~View() {
@@ -278,7 +270,6 @@ namespace edm {
     return *items_[pos];
   }
 
-#ifndef __GCCXML__
   template<typename T>
   inline
   RefToBase<T>
@@ -295,7 +286,6 @@ namespace edm {
                           }
                         } );
   }
-#endif
   
   template<typename T>
   inline
@@ -336,13 +326,11 @@ namespace edm {
       output.items_[i] = first;
   }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename T>
   std::unique_ptr<ViewBase>
   View<T>::doClone() const {
     return std::unique_ptr<ViewBase>{new View(*this)};
   }
-#endif
   
   template<typename T>
   inline

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -27,9 +27,7 @@ namespace edm {
     typedef T value_type;
     typedef T wrapped_type; // used with the dictionary to identify Wrappers
     Wrapper() : WrapperBase(), present(false), obj() {}
-#ifndef __GCCXML__
     explicit Wrapper(std::unique_ptr<T> ptr);
-#endif
     virtual ~Wrapper() {}
     T const* product() const {return (present ? &obj : 0);}
     T const* operator->() const {return product();}
@@ -45,28 +43,26 @@ namespace edm {
     CMS_CLASS_VERSION(3)
 
 private:
-    virtual bool isPresent_() const GCC11_OVERRIDE {return present;}
-    virtual std::type_info const& dynamicTypeInfo_() const GCC11_OVERRIDE {return typeid(T);}
-    virtual std::type_info const& wrappedTypeInfo_() const GCC11_OVERRIDE {return typeid(Wrapper<T>);}
+    virtual bool isPresent_() const override {return present;}
+    virtual std::type_info const& dynamicTypeInfo_() const override {return typeid(T);}
+    virtual std::type_info const& wrappedTypeInfo_() const override {return typeid(Wrapper<T>);}
 
-    virtual std::type_info const& valueTypeInfo_() const GCC11_OVERRIDE;
-    virtual std::type_info const& memberTypeInfo_() const GCC11_OVERRIDE;
-#ifndef __GCCXML__
-    virtual bool isMergeable_() const GCC11_OVERRIDE;
-    virtual bool mergeProduct_(WrapperBase const* newProduct) GCC11_OVERRIDE;
-    virtual bool hasIsProductEqual_() const GCC11_OVERRIDE;
-    virtual bool isProductEqual_(WrapperBase const* newProduct) const GCC11_OVERRIDE;
-#endif
+    virtual std::type_info const& valueTypeInfo_() const override;
+    virtual std::type_info const& memberTypeInfo_() const override;
+    virtual bool isMergeable_() const override;
+    virtual bool mergeProduct_(WrapperBase const* newProduct) override;
+    virtual bool hasIsProductEqual_() const override;
+    virtual bool isProductEqual_(WrapperBase const* newProduct) const override;
 
     virtual void do_fillView(ProductID const& id,
                              std::vector<void const*>& pointers,
-                             FillViewHelperVector& helpers) const GCC11_OVERRIDE;
+                             FillViewHelperVector& helpers) const override;
     virtual void do_setPtr(std::type_info const& iToType,
                            unsigned long iIndex,
-                           void const*& oPtr) const GCC11_OVERRIDE;
+                           void const*& oPtr) const override;
     virtual void do_fillPtrVector(std::type_info const& iToType,
                                   std::vector<unsigned long> const& iIndices,
-                                  std::vector<void const*>& oPtr) const GCC11_OVERRIDE;
+                                  std::vector<void const*>& oPtr) const override;
 
   private:
     // We wish to disallow copy construction and assignment.
@@ -78,7 +74,6 @@ private:
     T obj;
   };
 
-#ifndef __GCCXML__
   template<typename T>
   inline
   void swap_or_assign(T& a, T& b) {
@@ -149,7 +144,6 @@ private:
     assert(wrappedNewProduct != nullptr);
     return detail::doIsProductEqual<T>()(obj, wrappedNewProduct->obj);
   }
-#endif
 }
 
 #include "DataFormats/Common/interface/WrapperView.icc"

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -43,12 +43,10 @@ namespace edm {
       return other.dynamicTypeInfo() == dynamicTypeInfo();
     }
 
-#ifndef __GCCXML__
     bool isMergeable() const {return isMergeable_();}
     bool mergeProduct(WrapperBase const* newProduct) {return mergeProduct_(newProduct);}
     bool hasIsProductEqual() const {return hasIsProductEqual_();}
     bool isProductEqual(WrapperBase const* newProduct) const {return isProductEqual_(newProduct);}
-#endif
 
   private:
     virtual std::type_info const& dynamicTypeInfo_() const = 0;
@@ -60,12 +58,10 @@ namespace edm {
     // declare it = 0.
     virtual bool isPresent_() const {return true;}
 
-#ifndef __GCCXML__
     virtual bool isMergeable_() const = 0;
     virtual bool mergeProduct_(WrapperBase const* newProduct ) = 0;
     virtual bool hasIsProductEqual_() const = 0;
     virtual bool isProductEqual_(WrapperBase const* newProduct) const = 0;
-#endif
 
     virtual void do_fillView(ProductID const& id,
                              std::vector<void const*>& pointers,

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -40,7 +40,6 @@ namespace edm {
       }
     };
 
-#ifndef __GCCXML__
     // valueTypeInfo_() will return typeid(T::value_type) if T::value_type is declared and typeid(void) otherwise.
     // Definitions for the following struct and function templates are not needed; we only require the declarations.
     template<typename T> static yes_tag& has_value_type(typename T::value_type*);
@@ -162,7 +161,6 @@ namespace edm {
         return true; // Should never be called
       }
     };
-#endif
   }
 }
 #endif

--- a/DataFormats/Common/interface/WrapperView.icc
+++ b/DataFormats/Common/interface/WrapperView.icc
@@ -100,12 +100,10 @@ namespace edm {
       };
   }
 
-#ifndef __GCCXML__
   template<typename T>
   void DoFillView<T>::operator()(T const& obj, ProductID const& id, std::vector<void const*>& pointers, FillViewHelperVector& helpers) const {
     helpers::ViewFiller<T>::fill(obj, id, pointers, helpers);
   }
-#endif
 
   template<typename T>
   void DoSetPtr<T>::operator()(T const& obj, std::type_info const& iToType, unsigned long iIndex, void const*& oPtr) const {

--- a/DataFormats/Common/interface/refcore_implementation.h
+++ b/DataFormats/Common/interface/refcore_implementation.h
@@ -21,11 +21,9 @@
 //
 
 // system include files
-#ifndef __GCCXML__
 #include <limits>
 #include <cstdint>
 #include <atomic>
-#endif
 
 // user include files
 
@@ -34,7 +32,6 @@ namespace edm {
   namespace refcoreimpl {
     const unsigned short kTransientBit = 0x8000;
     const unsigned short kProcessIndexMask = 0x3FFF;
-#ifndef __GCCXML__
     const std::uintptr_t kCacheIsProductPtrBit = 0x1;
     const std::uintptr_t kCacheIsProductPtrMask = std::numeric_limits<std::uintptr_t>::max() ^ kCacheIsProductPtrBit;
 
@@ -77,14 +74,6 @@ namespace edm {
       auto tmp = iCache.load(); 
       return (!refcoreimpl::cacheIsProductPtr(tmp))? reinterpret_cast<EDProductGetter const*>(reinterpret_cast<std::uintptr_t>(tmp)&refcoreimpl::kCacheIsProductPtrMask):static_cast<EDProductGetter const*>(nullptr);
     }
-#else
-    bool cacheIsProductPtr( void const* iPtr) ;
-    void setCacheIsItem(void const*&, void const*);
-    void setCacheIsProductGetter(void const*&, EDProductGetter const*);
-    void const* productPtr(void const*);
-    EDProductGetter const* productGetter(void const*);
-    bool tryToSetCacheItemForFirstTime(void const*& iCache, void const* iNewValue);
-#endif
 
   }
 }

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -17,7 +17,6 @@
 // Original Author:  Chris Jones
 //         Created:  Tue May  8 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <memory>
 #include <string>
@@ -147,5 +146,4 @@ namespace fwlite {
 };
 
 }
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -18,7 +18,6 @@
 //         Created:  Fri Jan 29 12:45:17 CST 2010
 //
 
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 // user include files
 #include "DataFormats/Common/interface/EDProductGetter.h"
@@ -117,7 +116,5 @@ namespace fwlite {
     };
 
 }
-
-#endif /*__CINT__ */
 
 #endif

--- a/DataFormats/FWLite/interface/EntryFinder.h
+++ b/DataFormats/FWLite/interface/EntryFinder.h
@@ -16,7 +16,6 @@
 //
 // Original Author:  Bill Tanenbaum
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 
 // user include files
@@ -43,5 +42,4 @@ namespace fwlite {
      edm::FileIndex fileIndex_;
    };
 }
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/ErrorThrower.h
+++ b/DataFormats/FWLite/interface/ErrorThrower.h
@@ -18,7 +18,6 @@
 //         Created:  Tue Sep 23 09:58:07 EDT 2008
 //
 
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <typeinfo>
 
@@ -53,5 +52,4 @@ namespace  fwlite {
    };
 
 }
-#endif
 #endif

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -21,7 +21,7 @@
     foos.getByLabel(ev, "myFoos");
  }
  \endcode
- The above example will work for both CINT and compiled code. However, it is possible to exactly
+ The above example will work for both ROOT and compiled code. However, it is possible to exactly
  match the full framework if you only intend to compile your code.  In that case the access
  would look like
 
@@ -41,7 +41,6 @@
 // Original Author:  Chris Jones
 //         Created:  Tue May  8 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <typeinfo>
 #include <map>
@@ -203,5 +202,4 @@ namespace fwlite {
    };
 
 }
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/EventBase.h
+++ b/DataFormats/FWLite/interface/EventBase.h
@@ -17,7 +17,6 @@
 // Original Author:  Charles Plager
 //         Created:  Tue May  8 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <string>
 #include <typeinfo>
@@ -74,5 +73,4 @@ namespace fwlite
    };
 } // fwlite namespace
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/EventHistoryGetter.h
+++ b/DataFormats/FWLite/interface/EventHistoryGetter.h
@@ -17,7 +17,6 @@
 // Original Author:
 //         Created:  Wed Feb 10 11:15:16 CST 2010
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/HistoryGetterBase.h"
@@ -42,5 +41,4 @@ namespace fwlite {
 
 }
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/Handle.h
+++ b/DataFormats/FWLite/interface/Handle.h
@@ -25,12 +25,9 @@ namespace edm {
   template<typename T> class Wrapper;
 }
 
-#if !defined(__CINT__) && !defined(__MAKECINT__)
-//CINT can't handle parsing these files
 #include "DataFormats/FWLite/interface/EventBase.h"
 #include "DataFormats/FWLite/interface/ErrorThrower.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#endif
 
 // forward declarations
 namespace fwlite {
@@ -271,34 +268,4 @@ class Handle
 
 }
 
-#if defined(__CINT__) || defined(__MAKECINT__)
-#include <RVersion.h>
-#if ROOT_VERSION_CODE >= 336384 // ROOT_VERSION(5,34,0), doesn't work
-
-// "magic" typedefs for CINT
-#define DECL_HANDLE_VECTOR(T) \
-typedef fwlite::Handle<vector<T> > Handle<vector<T,allocator<T> > >
-
-// derived from RootAutoLibraryLoader specials list
-namespace edm {
-  DECL_HANDLE_VECTOR(bool);
-
-  DECL_HANDLE_VECTOR(char);
-  DECL_HANDLE_VECTOR(unsigned char);
-  // vector<signed char> gives CINT conniptions
-  //  DECL_HANDLE_VECTOR(signed char);
-  DECL_HANDLE_VECTOR(short);
-  DECL_HANDLE_VECTOR(unsigned short);
-  DECL_HANDLE_VECTOR(int);
-  DECL_HANDLE_VECTOR(unsigned int);
-  DECL_HANDLE_VECTOR(long);
-  DECL_HANDLE_VECTOR(unsigned long);
-  DECL_HANDLE_VECTOR(long long);
-  DECL_HANDLE_VECTOR(unsigned long long);
-
-  DECL_HANDLE_VECTOR(float);
-  DECL_HANDLE_VECTOR(double);
-}
-#endif
-#endif
 #endif

--- a/DataFormats/FWLite/interface/HistoryGetterBase.h
+++ b/DataFormats/FWLite/interface/HistoryGetterBase.h
@@ -17,7 +17,6 @@
 // Original Author:
 //         Created:  Wed Feb 10 11:15:16 CST 2010
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
@@ -39,6 +38,5 @@ namespace fwlite {
     };
 }
 
-#endif /*__CINT__ */
 
 #endif

--- a/DataFormats/FWLite/interface/InternalDataKey.h
+++ b/DataFormats/FWLite/interface/InternalDataKey.h
@@ -18,7 +18,6 @@
 // Original Author:  Eric Vaandering
 //         Created:  Jan 29 09:01:20 CDT 2009
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -95,5 +94,4 @@ namespace fwlite {
 
 }
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/LumiHistoryGetter.h
+++ b/DataFormats/FWLite/interface/LumiHistoryGetter.h
@@ -17,7 +17,6 @@
 // Original Author:
 //         Created:  Wed Feb 10 11:15:16 CST 2010
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 #include "DataFormats/FWLite/interface/LuminosityBlock.h"
 #include "DataFormats/FWLite/interface/HistoryGetterBase.h"
@@ -42,5 +41,4 @@ namespace fwlite {
 
 }
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -17,7 +17,6 @@
 // Original Author:  Eric Vaandering
 //         Created:  Wed Jan 13 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <typeinfo>
 #include <map>
@@ -138,5 +137,4 @@ namespace fwlite {
    };
 
 }
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/LuminosityBlockBase.h
+++ b/DataFormats/FWLite/interface/LuminosityBlockBase.h
@@ -17,7 +17,6 @@
 // Original Author:  Eric Vaandering
 //         Created:  Wed Jan  13 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <string>
 #include <typeinfo>
@@ -60,5 +59,4 @@ namespace fwlite
    };
 } // fwlite namespace
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -17,7 +17,6 @@
 // Original Author:  Salvatore Rappoccio
 //         Created:  Thu Jul  9 22:05:56 CDT 2009
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <memory>
 #include <string>
@@ -172,5 +171,4 @@ class MultiChainEvent: public EventBase
 };
 
 }
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -17,7 +17,6 @@
 // Original Author:  Eric Vaandering
 //         Created:  Wed Jan 13 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
 #include <typeinfo>
 #include <map>
@@ -130,5 +129,4 @@ namespace fwlite {
    };
 
 }
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/RunBase.h
+++ b/DataFormats/FWLite/interface/RunBase.h
@@ -17,7 +17,7 @@
 // Original Author:  Eric Vaandering
 //         Created:  Wed Jan  13 15:01:20 EDT 2007
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
+
 // system include files
 #include <string>
 #include <typeinfo>
@@ -66,5 +66,4 @@ namespace fwlite
    };
 } // fwlite namespace
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/FWLite/interface/RunFactory.h
+++ b/DataFormats/FWLite/interface/RunFactory.h
@@ -18,8 +18,6 @@
 //         Created:  Wed Feb 10 11:15:16 CST 2010
 //
 
-#if !defined(__CINT__) && !defined(__MAKECINT__)
-
 #include <memory>
 
 #include "DataFormats/FWLite/interface/Run.h"
@@ -44,6 +42,5 @@ namespace fwlite {
     };
 }
 
-#endif /*__CINT__ */
 
 #endif

--- a/DataFormats/FWLite/interface/RunHistoryGetter.h
+++ b/DataFormats/FWLite/interface/RunHistoryGetter.h
@@ -17,7 +17,6 @@
 // Original Author:
 //         Created:  Wed Feb 10 11:15:16 CST 2010
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 #include "DataFormats/FWLite/interface/Run.h"
 #include "DataFormats/FWLite/interface/HistoryGetterBase.h"
@@ -42,5 +41,4 @@ namespace fwlite {
 
 }
 
-#endif /*__CINT__ */
 #endif

--- a/DataFormats/Provenance/interface/ModuleDescription.h
+++ b/DataFormats/Provenance/interface/ModuleDescription.h
@@ -70,13 +70,9 @@ namespace edm {
     static unsigned int getUniqueID();
 
     ///Returns a value identifying an invalid id (the max unsigned int value)
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     static constexpr unsigned int invalidID() {
         return std::numeric_limits<unsigned int>::max();
     }
-#else
-    static unsigned int invalidID();
-#endif
 
   private:
 

--- a/DataFormats/Provenance/interface/ProcessHistory.h
+++ b/DataFormats/Provenance/interface/ProcessHistory.h
@@ -30,10 +30,8 @@ namespace edm {
     explicit ProcessHistory(size_type n) : data_(n), transient_() {}
     explicit ProcessHistory(collection_type const& vec) : data_(vec), transient_() {}
 
-#ifndef __GCCXML__
     template<typename... Args>
     void emplace_back(Args&&... args) {data_.emplace_back(std::forward<Args>(args)...); phid() = ProcessHistoryID();}
-#endif
 
     void push_front(const_reference t) {data_.insert(data_.begin(), t); phid() = ProcessHistoryID();}
     void push_back(const_reference t) {data_.push_back(t); phid() = ProcessHistoryID();}

--- a/DataFormats/Provenance/interface/ProcessHistoryRegistry.h
+++ b/DataFormats/Provenance/interface/ProcessHistoryRegistry.h
@@ -22,10 +22,8 @@ namespace edm {
     typedef ProcessHistoryVector vector_type;
 
     ProcessHistoryRegistry();
-#ifndef __GCCXML__
     ProcessHistoryRegistry(ProcessHistoryRegistry const&) = delete; // Disallow copying and moving
     ProcessHistoryRegistry& operator=(ProcessHistoryRegistry const&) = delete; // Disallow copying and moving
-#endif
     bool registerProcessHistory(ProcessHistory const& processHistory);
     bool getMapped(ProcessHistoryID const& key, ProcessHistory& value) const;
     ProcessHistory const* getMapped(ProcessHistoryID const& key) const;

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -27,9 +27,7 @@ namespace edm {
   class ProductProvenanceRetriever : private boost::noncopyable {
   public:
     explicit ProductProvenanceRetriever(unsigned int iTransitionIndex);
-#ifndef __GCCXML__
     explicit ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader);
-#endif
 
     ~ProductProvenanceRetriever();
 

--- a/FWCore/Common/interface/EventBase.h
+++ b/FWCore/Common/interface/EventBase.h
@@ -19,7 +19,6 @@
 // Original Author:  Chris Jones
 //         Created:  Thu Aug 27 11:01:06 CDT 2009
 //
-#if !defined(__CINT__) && !defined(__MAKECINT__)
 
 // user include files
 #include "DataFormats/Common/interface/BasicHandle.h"
@@ -86,7 +85,6 @@ namespace edm {
 
    };
 
-#if !defined(__REFLEX__)
    template<typename T>
    bool
    EventBase::getByLabel(InputTag const& tag, Handle<T>& result) const {
@@ -110,9 +108,7 @@ namespace edm {
       }
       return true;
    }
-#endif
   
 }
-#endif /*!defined(__CINT__) && !defined(__MAKECINT__)*/
 
 #endif

--- a/FWCore/Common/interface/LuminosityBlockBase.h
+++ b/FWCore/Common/interface/LuminosityBlockBase.h
@@ -21,8 +21,6 @@
 //         Created:  Tue Jan 12 15:31:00 CDT 2010
 //
 
-#if !defined(__CINT__) && !defined(__MAKECINT__)
-
 #include "DataFormats/Common/interface/BasicHandle.h"
 #include "DataFormats/Common/interface/ConvertHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -70,7 +68,6 @@ namespace edm {
 
   };
 
-#if !defined(__REFLEX__)
    template<class T>
    bool
    LuminosityBlockBase::getByLabel(const InputTag& tag, Handle<T>& result) const {
@@ -82,8 +79,6 @@ namespace edm {
       }
       return true;
    }
-#endif
 
 }
-#endif /*!defined(__CINT__) && !defined(__MAKECINT__)*/
 #endif

--- a/FWCore/Common/interface/RunBase.h
+++ b/FWCore/Common/interface/RunBase.h
@@ -21,8 +21,6 @@
 //         Created:  Tue Jan 12 15:31:00 CDT 2010
 //
 
-#if !defined(__CINT__) && !defined(__MAKECINT__)
-
 #include "DataFormats/Common/interface/BasicHandle.h"
 #include "DataFormats/Common/interface/ConvertHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -57,7 +55,6 @@ namespace edm {
 
   };
 
-#if !defined(__REFLEX__)
    template<typename T>
    bool
    RunBase::getByLabel(InputTag const& tag, Handle<T>& result) const {
@@ -69,8 +66,6 @@ namespace edm {
       }
       return true;
    }
-#endif
 
 }
-#endif /*!defined(__CINT__) && !defined(__MAKECINT__)*/
 #endif

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -44,9 +44,7 @@ public:
     MessageSender &
     operator<< ( T const & t )
   {
-#ifndef __GCCXML__
     if (valid()) (*errorobj_p) << t;
-#endif
     return *this;
   }
 

--- a/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
@@ -4,19 +4,7 @@
 
 using namespace std;
 
-#if defined(__CINT__) && !defined(__MAKECINT__)
-class loadFWLite {
-   public:
-      loadFWLite() {
-         gSystem->Load("libFWCoreFWLite");
-         FWLiteEnabler::enable();
-      }
-};
-
-static loadFWLite lfw;
-#else
 #include "FWCore/FWLite/interface/FWLiteEnabler.h"
-#endif
 
 void proof_thing2_sel()
 {

--- a/FWCore/TFWLiteSelector/test/proof_thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing_sel.C
@@ -4,19 +4,7 @@
 
 using namespace std;
 
-#if defined(__CINT__) && !defined(__MAKECINT__)
-class loadFWLite {
-   public:
-      loadFWLite() {
-         gSystem->Load("libFWCoreFWLite");
-         FWLiteEnabler::enable();
-      }
-};
-
-static loadFWLite lfw;
-#else
 #include "FWCore/FWLite/interface/FWLiteEnabler.h"
-#endif
 
 void proof_thing_sel()
 {

--- a/FWCore/Utilities/interface/ConstRespectingPtr.h
+++ b/FWCore/Utilities/interface/ConstRespectingPtr.h
@@ -17,9 +17,7 @@ the classes_def.xml file if it is a member of a persistent class!
 // Original Author:  W. David Dagenhart
 //         Created:  20 March 2014
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <memory>
-#endif
 
 namespace edm {
 
@@ -42,9 +40,7 @@ namespace edm {
 
     bool isSet() const;
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     void set(std::unique_ptr<T> iNewValue);
-#endif
 
     T* release();
     void reset();
@@ -56,8 +52,6 @@ namespace edm {
 
     T* m_data;
   };
-
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 
   template<typename T>
   ConstRespectingPtr<T>::ConstRespectingPtr() : m_data(nullptr) {}
@@ -91,6 +85,5 @@ namespace edm {
     delete m_data;
     m_data = nullptr;
   }
-#endif
 }
 #endif

--- a/FWCore/Utilities/interface/InputTag.h
+++ b/FWCore/Utilities/interface/InputTag.h
@@ -1,10 +1,7 @@
 #ifndef FWCore_Utilities_InputTag_h
 #define FWCore_Utilities_InputTag_h
 
-#ifndef __GCCXML__
 #include <atomic>
-#endif
-
 #include <iosfwd>
 #include <string>
 
@@ -29,14 +26,10 @@ namespace edm {
 
     InputTag(InputTag const& other);
 
-#ifndef __GCCXML__
     InputTag(InputTag&& other);
-#endif
     InputTag& operator=(InputTag const& other);
 
-#ifndef __GCCXML__
     InputTag& operator=(InputTag&& other);
-#endif
 
     std::string encode() const;
 
@@ -67,11 +60,7 @@ namespace edm {
     CMS_THREAD_GUARD(index_) mutable TypeID typeID_;
     CMS_THREAD_GUARD(index_) mutable void const* productRegistry_;
 
-#ifndef __GCCXML__
     mutable std::atomic<unsigned int> index_;
-#else
-    unsigned int index_;
-#endif
 
     CMS_THREAD_GUARD(index_) mutable char branchType_;
 

--- a/FWCore/Utilities/interface/ProductHolderIndex.h
+++ b/FWCore/Utilities/interface/ProductHolderIndex.h
@@ -7,7 +7,6 @@ namespace edm {
 
   typedef unsigned int ProductHolderIndex;
 
-#ifndef __GCCXML__
   enum ProductHolderIndexValues {
 
     // All values of the ProductHolderIndex in this enumeration should
@@ -18,6 +17,5 @@ namespace edm {
     ProductHolderIndexInitializing = std::numeric_limits<unsigned int>::max() - 1,
     ProductHolderIndexAmbiguous = std::numeric_limits<unsigned int>::max() - 2
   };
-#endif
 }
 #endif

--- a/FWCore/Utilities/interface/TypeID.h
+++ b/FWCore/Utilities/interface/TypeID.h
@@ -40,9 +40,7 @@ namespace edm {
 
     std::string friendlyClassName() const;
 
-#ifndef __GCCXML__
     explicit operator bool() const;
-#endif
     
     using TypeIDBase::name;
 

--- a/FWCore/Utilities/interface/atomic_value_ptr.h
+++ b/FWCore/Utilities/interface/atomic_value_ptr.h
@@ -15,15 +15,9 @@
 // are *not* atomic, as an object of type T must be copied or moved.
 // ----------------------------------------------------------------------
 
-#ifndef __GCCXML__
 #include <atomic>
-#endif
 
 #include <memory>
-
-#ifdef __GCCXML__
-#define nullptr 0
-#endif
 
 namespace edm {
 
@@ -76,7 +70,6 @@ namespace edm {
       return *this;
     }
 
-#ifndef __GCCXML__
     atomic_value_ptr(atomic_value_ptr&& orig) :
       myP(orig.myP) { orig.myP.store(nullptr); }
 
@@ -85,7 +78,6 @@ namespace edm {
       exchangeWithLocal(local);
       return *this;
     }
-#endif
 
     // --------------------------------------------------
     // Access mechanisms:
@@ -124,7 +116,6 @@ namespace edm {
       return *this;
     }
 
-#ifndef __GCCXML__
     // --------------------------------------------------
     // move-like construct/assign from unique_ptr<>:
     // --------------------------------------------------
@@ -139,7 +130,6 @@ namespace edm {
       exchangeWithLocal(local);
       return *this;
     }
-#endif
 
   T* load() const {
     return myP.load();
@@ -194,11 +184,7 @@ namespace edm {
     // Member data:
     // --------------------------------------------------
 
-#ifndef __GCCXML__
     mutable std::atomic<T*> myP;
-#else
-    T* myP;
-#endif
 
   }; // atomic_value_ptr
 

--- a/FWCore/Utilities/interface/clone_ptr.h
+++ b/FWCore/Utilities/interface/clone_ptr.h
@@ -2,7 +2,6 @@
 #define FWCore_Utilities_clone_ptr_h
 
 #include<memory>
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 namespace extstd {
 

--- a/FWCore/Utilities/interface/value_ptr.h
+++ b/FWCore/Utilities/interface/value_ptr.h
@@ -35,10 +35,6 @@
 #include <algorithm> // for std::swap()
 #include <memory>
 
-#ifdef __GCCXML__
-#define nullptr 0
-#endif
-
 namespace edm {
 
   // --------------------------------------------------------------------
@@ -89,7 +85,6 @@ namespace edm {
       return *this;
     }
 
-#ifndef __GCCXML__
     // --------------------------------------------------
     // Move constructor/move assignment:
     // --------------------------------------------------
@@ -105,7 +100,6 @@ namespace edm {
       } 
       return *this;
     }
-#endif
 
     // --------------------------------------------------
     // Access mechanisms:
@@ -150,7 +144,6 @@ namespace edm {
       return *this;
     }
 
-#ifndef __GCCXML__
     // --------------------------------------------------
     // Move-like construct/assign from unique_ptr<>:
     // --------------------------------------------------
@@ -163,7 +156,6 @@ namespace edm {
       swap(temp);
       return *this;
     }
-#endif
 
   // The following typedef, function, and operator definition
   // support the following syntax:

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -39,11 +39,7 @@ namespace edm {
     catalog_(pset.getUntrackedParameter<std::string>("catalog")),
     maxFileSize_(pset.getUntrackedParameter<int>("maxSize")),
     compressionLevel_(pset.getUntrackedParameter<int>("compressionLevel")),
-#if ROOT_VERSION_CODE >= ROOT_VERSION(5,30,0)
     compressionAlgorithm_(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
-#else
-    compressionAlgorithm_("ZLIB"),
-#endif
     basketSize_(pset.getUntrackedParameter<int>("basketSize")),
     eventAutoFlushSize_(pset.getUntrackedParameter<int>("eventAutoFlushCompressedSize")),
     splitLevel_(std::min<int>(pset.getUntrackedParameter<int>("splitLevel") + 1, 99)),
@@ -386,10 +382,8 @@ namespace edm {
                      "If over maximum, new output file will be started at next input file transition.");
     desc.addUntracked<int>("compressionLevel", 7)
         ->setComment("ROOT compression level of output file.");
-#if ROOT_VERSION_CODE >= ROOT_VERSION(5,30,0)
     desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
         ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
-#endif
     desc.addUntracked<int>("basketSize", 16384)
         ->setComment("Default ROOT basket size in output file.");
     desc.addUntracked<int>("eventAutoFlushCompressedSize",-1)->setComment("Set ROOT auto flush stored data size (in bytes) for event TTree. The value sets how large the compressed buffer is allowed to get. The uncompressed buffer can be quite a bit larger than this depending on the average compression ratio. The value of -1 just uses ROOT's default value. The value of 0 turns off this feature.");

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -40,9 +40,7 @@
 #include "Rtypes.h"
 #include "RVersion.h"
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(5,30,0)
 #include "Compression.h"
-#endif
 
 #include <algorithm>
 #include <iomanip>
@@ -110,7 +108,6 @@ namespace edm {
       parentageIDs_(),
       branchesWithStoredHistory_(),
       wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
-#if ROOT_VERSION_CODE >= ROOT_VERSION(5,30,0)
     if (om_->compressionAlgorithm() == std::string("ZLIB")) {
       filePtr_->SetCompressionAlgorithm(ROOT::kZLIB);
     } else if (om_->compressionAlgorithm() == std::string("LZMA")) {
@@ -119,7 +116,6 @@ namespace edm {
       throw Exception(errors::Configuration) << "PoolOutputModule configured with unknown compression algorithm '" << om_->compressionAlgorithm() << "'\n"
 					     << "Allowed compression algorithms are ZLIB and LZMA\n";
     }
-#endif
     if (-1 != om->eventAutoFlushSize()) {
       eventTree_.setAutoFlush(-1*om->eventAutoFlushSize());
     }

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -61,12 +61,6 @@ namespace edm {
     TClass* getRootClass(std::string const& name) {
       TClass* tc = TClass::GetClass(name.c_str());    
       
-      // get ROOT TClass for this product
-      // CINT::Type* cint_type = CINT::Type::get(typ_ref);
-      // tc_ = cint_type->rootClass();
-      // TClass* tc = TClass::GetClass(typeid(se));
-      // tc_ = TClass::GetClass("edm::SendEvent");
-      
       if(tc == 0) {
 	throw edm::Exception(errors::Configuration,"getRootClass")
 	  << "could not find TClass for " << name


### PR DESCRIPTION
For some reason, double initial and final underscores appear in this comment as single underscores. They should be double.
This PR removes the use of obsolete conditional compilations from the framework, now that C++11 and ROOT6 are supported from now on.
In particular, _ _CINT__, _ _MAKECINT__, _ _GCCXML__, _ _REFLEX__, and CMS_NOCXX11 are no longer ever set, GCC11_OVERRIDE always evaluates to "override", and ROOT_VERSION_CODE is always larger that the ROOT releases to which it is being compared.
Note that _ _ROOTCLING__ is still used, so uses of _ _ROOTCLING__ are untouched by this PR.
This clean up is for Core Software only. Code outside core software is not touched.
This PR should not affect the compiled code at all.
Note also that all uses of std::atomic<T> in the framework are transient, so they do not need to be protected from ROOT. This is unchanged by this PR.
