### PR TITLE
Fix 108xx (Extended2023Muondev) workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -119,7 +119,7 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'BE5D' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5D',
                  'BE5DPixel10D' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10D',
                  '2017dev' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2017dev',
-                 'Extended2023Muondev' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muondev',
+                 'Extended2023Muondev' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muondev,SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_removeTTI',
                  'BE5DPixel10DLHCCCooling' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DLHCCCooling',
                  'Extended2023' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023HGCalMuon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon',

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -742,6 +742,12 @@ def cust_2023TTI_forHLT(process):
     process=l1EventContent_TTI_forHLT(process)
     return process
 
+def cust_removeTTI(process):
+    """ Removes L1TrackTrigger_step from the schedule for geometries that
+    don't yet work with it. """
+    if hasattr(process,'L1TrackTrigger_step'):
+        process.schedule.remove( process.L1TrackTrigger_step )
+    return process
 
 def noCrossing(process):
     process=customise_NoCrossing(process)


### PR DESCRIPTION
Adds some customisations to allow the 108xx workflows to run:
1. Take out L1TrackTrigger_step since it doesn't work with stacks yet.
2. Change some of the inputs from ("simSiPixelDigis") to ("simSiPixelDigis","Pixel").
3. Remove modules that crash or create exceptions from the DQM and Validation sequences.

Tested with 10800 (four muons).  If/when this goes in I'll ask for some 108xx workflows to be added to the default tests.

For (1) I added another customisation to the default workflow description.  I figured track trigger people will be working on it and will want to re-enable it easily.  Burying it somewhere in the current customisation would make that difficult.

@atricomi, @delaere - The biggest thing for (3) is that `TrackerHitAssociator` has the name of the digiSimLink collection hardcoded (see [TrackerHitAssociator.cc#L75](https://github.com/cms-sw/cmssw/blob/CMSSW_6_2_SLHCDEV_X_2015-11-15-1100/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc#L75)).  Fixing this would allow most modules to go back in.  The whole of the recoMuonValidation had to come out for this reason.  Not sure if it's worth fixing the code here or just changing for 8_0_X.

@ebrondol, @boudoul 
