### PR TITLE
Re-enabling LogWarning in HadronAndPartonSelector

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -164,7 +164,7 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    if( !partonSelector_ )
    {
      if ( partonMode_=="Undefined" )
-       edm::LogInfo("UndefinedPartonMode") << "Could not automatically determine the hadronizer type and set the correct parton selection mode. Parton-based jet flavour will not be defined.";
+       edm::LogWarning("UndefinedPartonMode") << "Could not automatically determine the hadronizer type and set the correct parton selection mode. Parton-based jet flavour will not be defined.";
      else if ( partonMode_=="Pythia6" )
      {
        partonSelector_ = PartonSelectorPtr( new Pythia6PartonSelector() );


### PR DESCRIPTION
LogWarning in HadronAndPartonSelector was replaced with LogInfo in #11963 to quiet down the printout. After fixes in #12060 and #12080, this PR now re-enables LogWarning.
