### PR TITLE
Changed an HLT path name

### DIFF
--- a/Configuration/Skimming/python/PP_HighPtJetSkim_cff.py
+++ b/Configuration/Skimming/python/PP_HighPtJetSkim_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # HLT jet trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltJet150 = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltJet150.HLTPaths = ["HLT_AK4CaloJet150_Eta2p1_v*"]
+hltJet150.HLTPaths = ["HLT_AK4CaloJet150_v*"]
 hltJet150.throw = False
 hltJet150.andOr = True
 


### PR DESCRIPTION
A path in the HLT menu that's used in the central skim.
@fwyzard prefers to deploy a new patch release rather than update the menu.
The patch including this fix, has to be deployed in 24 hours to be in time for datataking
