### PR TITLE
phase1Pixel era harvesting additions

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 #Client:
 sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
     EventOffsetForInit = cms.untracked.int32(10),
@@ -13,6 +18,11 @@ sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
     DoHitEfficiency = cms.untracked.bool(True),
     isUpgrade = cms.untracked.bool(False)	
 )
+# Modify for running with the Phase 1 pixel detector.
+# Note that with this change the sipixelPhase1Client block below is not
+# necessary, but I'll leave it for pixel upgrade experts to decide whether
+# to take it out or not.
+eras.phase1Pixel.toModify( sipixelEDAClient, isUpgrade=True )
 
 sipixelPhase1Client = cms.EDAnalyzer("SiPixelEDAClient",
     EventOffsetForInit = cms.untracked.int32(10),

--- a/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
@@ -27,3 +27,10 @@ crt_dqmoffline = cms.Sequence( siStripCertificationInfo *
                                egammaDataCertificationTask *
                                dqmOfflineTriggerCert )
 
+#
+# Make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+if eras.phase1Pixel.isChosen():
+    crt_dqmoffline.remove(dataCertificationJetMET)
+    crt_dqmoffline.remove(sipixelCertification)


### PR DESCRIPTION
Another tranche of `phase1Pixel` era changes. This one is for Harvesting changes, equivalent to the [customise_harvesting](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X_2015-11-15-2300/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py#L139) function.

**There should be no change whatsoever unless the Run2_2017 era is active** (the only top-level era that contains phase1Pixel).

@atricomi, @delaere - In [DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X_2015-11-15-2300/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py#L17) there is also a `sipixelPhase1Client` analyzer, which is now redundant (and corresponding `PixelOfflinePhase1DQMClient` sequence).  I didn't take them out though because I don't know what else relies on them, and you also might prefer to do your configuration using those.

@boudoul
