### PR TITLE
phase1Pixel era DQM additions part 1

### DIFF
--- a/DQM/SiPixelMonitorCluster/python/SiPixelMonitorCluster_cfi.py
+++ b/DQM/SiPixelMonitorCluster/python/SiPixelMonitorCluster_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 SiPixelClusterSource = cms.EDAnalyzer("SiPixelClusterSource",
     TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelClusters"),
@@ -20,3 +25,5 @@ SiPixelClusterSource = cms.EDAnalyzer("SiPixelClusterSource",
     bigEventSize = cms.untracked.int32(100)
 )
 
+# Modify for if the phase 1 pixel detector is active
+eras.phase1Pixel.toModify( SiPixelClusterSource, isUpgrade=cms.untracked.bool(True) )

--- a/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
+++ b/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 SiPixelDigiSource = cms.EDAnalyzer("SiPixelDigiSource",
     TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelDigis"),
@@ -26,4 +31,6 @@ SiPixelDigiSource = cms.EDAnalyzer("SiPixelDigiSource",
     bigEventSize = cms.untracked.int32(1000)
 )
 
+# Modify for if the phase 1 pixel detector is active
+eras.phase1Pixel.toModify( SiPixelDigiSource, isUpgrade=cms.untracked.bool(True) )
 

--- a/DQM/SiPixelMonitorRawData/python/SiPixelMonitorRawData_cfi.py
+++ b/DQM/SiPixelMonitorRawData/python/SiPixelMonitorRawData_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 SiPixelRawDataErrorSource = cms.EDAnalyzer("SiPixelRawDataErrorSource",
     TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelDigis"),
@@ -13,4 +18,5 @@ SiPixelRawDataErrorSource = cms.EDAnalyzer("SiPixelRawDataErrorSource",
     bladeOn = cms.untracked.bool(False)
 )
 
-
+# Modify for if the phase 1 pixel detector is active
+eras.phase1Pixel.toModify( SiPixelRawDataErrorSource, isUpgrade=cms.untracked.bool(True) )

--- a/DQM/SiPixelMonitorRecHit/python/SiPixelMonitorRecHit_cfi.py
+++ b/DQM/SiPixelMonitorRecHit/python/SiPixelMonitorRecHit_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 SiPixelRecHitSource = cms.EDAnalyzer("SiPixelRecHitSource",
     TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelRecHits"),
@@ -17,3 +22,6 @@ SiPixelRecHitSource = cms.EDAnalyzer("SiPixelRecHitSource",
     bladeOn = cms.untracked.bool(False),
     diskOn = cms.untracked.bool(False)
 )
+
+# Modify for if the phase 1 pixel detector is active
+eras.phase1Pixel.toModify( SiPixelRecHitSource, isUpgrade=cms.untracked.bool(True) )

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 SiPixelHitEfficiencySource = cms.EDAnalyzer("SiPixelHitEfficiencySource",
     src = cms.InputTag("siPixelHitEfficiency"),
     debug = cms.untracked.bool(False),                          
@@ -18,3 +23,6 @@ SiPixelHitEfficiencySource = cms.EDAnalyzer("SiPixelHitEfficiencySource",
     applyEdgeCut = cms.untracked.bool(False),
     nSigma_EdgeCut = cms.untracked.double(2.)             
 )
+
+# Modify for if the phase 1 pixel detector is active
+eras.phase1Pixel.toModify( SiPixelHitEfficiencySource, isUpgrade=cms.untracked.bool(True) )

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 SiPixelTrackResidualSource = cms.EDAnalyzer("SiPixelTrackResidualSource",
     TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelTrackResiduals"),
@@ -24,3 +29,6 @@ SiPixelTrackResidualSource = cms.EDAnalyzer("SiPixelTrackResidualSource",
 
     trajectoryInput = cms.InputTag('generalTracks')              
 )
+
+# Modify for if the phase 1 pixel detector is active
+eras.phase1Pixel.toModify( SiPixelTrackResidualSource, isUpgrade=cms.untracked.bool(True) )

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# This object is used to make changes for different running scenarios
+#
+from Configuration.StandardSequences.Eras import eras
+
 #Analyzer taken from online dqm
 from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
 from DQM.TrackingMonitor.MonitorTrackGLBMuons_cfi import *
@@ -27,6 +32,9 @@ muonMonitors = cms.Sequence(muonTrackAnalyzers*
                             muonIdDQM*
                             dqmInfoMuons*
                             muIsoDQM_seq)
+# Modify for if the phase 1 pixel detector is active
+if eras.phase1Pixel.isChosen() :
+    muonMonitors.remove(muonAnalyzer)
 
 muonMonitorsAndQualityTests = cms.Sequence(muonMonitors*muonQualityTests)
 


### PR DESCRIPTION
Another tranche of phase1Pixel era changes. This one is for DQM changes, equivalent to **part** of the [customise_DQM](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X_2015-11-15-2300/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py#L86) function.

Note that the commands in [line 99](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X_2015-11-15-2300/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py#L99) onwards will come in another PR, i.e.

``` python
    from DQM.TrackingMonitor.customizeTrackingMonitorSeedNumber import customise_trackMon_IterativeTracking_PHASE1PU140
    from DQM.TrackingMonitor.customizeTrackingMonitorSeedNumber import customise_trackMon_IterativeTracking_PHASE1PU70

    if pileup>100:
        process=customise_trackMon_IterativeTracking_PHASE1PU140(process)
    else:
        process=customise_trackMon_IterativeTracking_PHASE1PU70(process)
```

...are not implemented yet.  Those look to be quite involved changes that will probably be easier to integrate in smaller chunks.

**There should be no change whatsoever unless the Run2_2017 era is active** (the only top-level era that contains phase1Pixel).

@atricomi, @delaere, @boudoul, @makortel 
