### PR TITLE
Disable deprecation warning when running Phase 1 pixel workflows

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -13,13 +13,13 @@ from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads import fix
 import SLHCUpgradeSimulations.Configuration.aging as aging
 
 def cust_2017(process):
-    process=customisePostLS1(process)
+    process=customisePostLS1(process,displayDeprecationWarning=False)
     process=customisePhase1Tk(process)
     #process=customise_HcalPhase0(process)
     return process
 
 def cust_2019(process):
-    process=customisePostLS1(process)
+    process=customisePostLS1(process,displayDeprecationWarning=False)
     process=customisePhase1Tk(process)
     process=customise_HcalPhase1(process)
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -43,25 +43,26 @@ def customisePostLS1_Common(process):
     return process
 
 
-def customisePostLS1(process):
-    print """
-    #
-    # -- Warning! You are using a deprecated customisation function. --
-    #
-    # It will probably run fine, but the customisations you are getting may be out of date.
-    # You should update your configuration file by
-    #   If using cmsDriver:
-    #       1) remove the "--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1" option
-    #       2) add the option "--era Run2_25ns"
-    #   If using a pre-made configuration file:
-    #       1) remove or comment out the "process = customisePostLS1(process)" line.
-    #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
-    #          the process declaration).
-    #       3) add "eras.Run2_25ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_25ns)"
-    #
-    # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
-    #
-    """
+def customisePostLS1(process,displayDeprecationWarning=True):
+    if displayDeprecationWarning :
+        print """
+        #
+        # -- Warning! You are using a deprecated customisation function. --
+        #
+        # It will probably run fine, but the customisations you are getting may be out of date.
+        # You should update your configuration file by
+        #   If using cmsDriver:
+        #       1) remove the "--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1" option
+        #       2) add the option "--era Run2_25ns" 
+        #   If using a pre-made configuration file:
+        #       1) remove or comment out the "process = customisePostLS1(process)" line.
+        #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+        #          the process declaration).
+        #       3) add "eras.Run2_25ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_25ns)" 
+        #
+        # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
+        #
+        """
     # common customisation
     process = customisePostLS1_Common(process)
 
@@ -86,25 +87,26 @@ def customisePostLS1_lowPU(process):
     return process
 
 
-def customisePostLS1_50ns(process):
-    print """
-    #
-    # -- Warning! You are using a deprecated customisation function. --
-    #
-    # It will probably run fine, but the customisations you are getting may be out of date.
-    # You should update your configuration file by
-    #   If using cmsDriver:
-    #       1) remove the "--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_50ns" option
-    #       2) add the option "--era Run2_50ns"
-    #   If using a pre-made configuration file:
-    #       1) remove or comment out the "process = customisePostLS1_50ns(process)" line.
-    #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
-    #          the process declaration).
-    #       3) add "eras.Run2_50ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_50ns)"
-    #
-    # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
-    #
-    """
+def customisePostLS1_50ns(process,displayDeprecationWarning=True):
+    if displayDeprecationWarning :
+        print """
+        #
+        # -- Warning! You are using a deprecated customisation function. --
+        #
+        # It will probably run fine, but the customisations you are getting may be out of date.
+        # You should update your configuration file by
+        #   If using cmsDriver:
+        #       1) remove the "--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_50ns" option
+        #       2) add the option "--era Run2_50ns"
+        #   If using a pre-made configuration file:
+        #       1) remove or comment out the "process = customisePostLS1_50ns(process)" line.
+        #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+        #          the process declaration).
+        #       3) add "eras.Run2_50ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_50ns)"
+        #
+        # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
+        #
+        """
 
     # common customisations
     process = customisePostLS1_Common(process)
@@ -116,25 +118,26 @@ def customisePostLS1_50ns(process):
     return process
 
 
-def customisePostLS1_HI(process):
-    print """
-    #
-    # -- Warning! You are using a deprecated customisation function. --
-    #
-    # It will probably run fine, but the customisations you are getting may be out of date.
-    # You should update your configuration file by
-    #   If using cmsDriver:
-    #       1) remove the "--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI" option
-    #       2) add the option "--era Run2_HI"
-    #   If using a pre-made configuration file:
-    #       1) remove or comment out the "process = customisePostLS1_HI(process)" line.
-    #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
-    #          the process declaration).
-    #       3) add "eras.Run2_HI" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_HI)"
-    #
-    # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
-    #
-    """
+def customisePostLS1_HI(process,displayDeprecationWarning=True):
+    if displayDeprecationWarning :
+        print """
+        #
+        # -- Warning! You are using a deprecated customisation function. --
+        #
+        # It will probably run fine, but the customisations you are getting may be out of date.
+        # You should update your configuration file by
+        #   If using cmsDriver:
+        #       1) remove the "--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI" option
+        #       2) add the option "--era Run2_HI"
+        #   If using a pre-made configuration file:
+        #       1) remove or comment out the "process = customisePostLS1_HI(process)" line.
+        #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+        #          the process declaration).
+        #       3) add "eras.Run2_HI" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_HI)"
+        #
+        # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
+        #
+        """
 
     # common customisation
     process = customisePostLS1_Common(process)


### PR DESCRIPTION
Because the phase 1 customisation function calls the postLS1 one, it prints out the "please use Run2 era" deprecation warning.  This confuses users since they didn't ask to run the Run 2 customisation.
This disables that warning when running the cust_2017 and cust_2019 customisation functions.

The plan was to get the phase 1 era working instead but that's taking longer than expected.

@atricomi, @delaere, @boudoul, @makortel 
