### PR TITLE
Fixes for HI MC (mainly L1)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,23 +10,25 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '75X_mcRun1_pA_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v10',
+    'run2_design'       :   '75X_mcRun2_design_v11',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '75X_mcRun2_startup_v9',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v10',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v7',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v9',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v9',
+    'run1_data'         :   '75X_dataRun1_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v9',
+    'run2_data'         :   '75X_dataRun2_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v4',
+    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v6',
+    # GlobalTag for Run2 HLT: it points to the online GT
+    'run2_hlt_hi'       :   '75X_dataRun2_HLTHI_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v5',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [75X_mcRun2_design_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_design_v11) as [75X_mcRun2_design_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_design_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_design_v11/75X_mcRun2_design_v10): 
  - new JEC for MC Summer15_25nsV6 including uncerntainties
- **RunII Asymptotic scenario** : [75X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_asymptotic_v11) as [75X_mcRun2_asymptotic_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_asymptotic_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_asymptotic_v11/75X_mcRun2_asymptotic_v10): 
  - new JEC for MC Summer15_25nsV6 including uncerntainties
  - adding label AK4Calo for pp reference run at 5TeV JEC
- **RunII Heavy Ions scenario** : [75X_mcRun2_HeavyIon_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_HeavyIon_v9) as [75X_mcRun2_HeavyIon_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_HeavyIon_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_HeavyIon_v9/75X_mcRun2_HeavyIon_v7): 
  - Castor Gains to v1.0
  - updating ES Channel status, pedestal, thresholds (align to same values as in asymptotic pp)
  - adding HeavyIon event plane correction record
  - adding label AK4Calo for pp reference run at 5TeV JEC
  - changing the L1 menu to L1Menu_CollisionsHeavyIons2015_v2_mc
  - changing the L1TCalo parameters for HI collisions
  - updating the Strip APV gains from particles and Bad channel as in 76X for pp simulation
  - updating L1RCT parameters and L1RPCConfig to align as in following release cycles
## RunI data
- **RunI Offline processing** : [75X_dataRun1_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_v10) as [75X_dataRun1_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun1_v10/75X_dataRun1_v9): 
  - adding Heavy Ion event plane calibration record
  - adding label AK4Calo for pp reference run at 5TeV JEC
## RunII data
- **RunII Offline processing** : [75X_dataRun2_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_v10) as [75X_dataRun2_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun2_v10/75X_dataRun2_v9): 
  - adding Heavy Ion event plane calibration record
  - adding label AK4Calo for pp reference run at 5TeV JEC
  - new JEC for 2015 data including L2L3 residuals and  uncerntainties
- **RunII HLT processing** : [75X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HLT_frozen_v6) as [75X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun2_HLT_frozen_v6/75X_dataRun2_HLT_frozen_v4): 
  - adding the GBRForest payloads for MVA selection of HI Tracking
  - reverted BTag Jet MVA to the 74X values 
  - reverted PF hadron calibration to the 74X values
- **RunII HI HLT processing** : [75X_dataRun2_HLTHI_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HIHLT_v2) as [75X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HLT_frozen_v6) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun2_HLT_frozen_v6/75X_dataRun2_HLT_frozen_v6): 
  - adding negative energy filter tag
  - changing the AK4CaloHLT Jet Energy corrections to pick tag for Heavy Ions
  - using full Strip pedestals for Tracker Zero Suppression at HLT
## Upgrade
- **PhaseI design scenario** : [75X_upgrade2017_design_v6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_upgrade2017_design_v6) as [75X_upgrade2017_design_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_upgrade2017_design_v5) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_upgrade2017_design_v6/75X_upgrade2017_design_v5): 
  - new Pixel SIM LA for Phase-I
  - new Pixel LA for Phase-I
  - new Pixel templates for Phase-I
  - new Pixel SIM gains for Phase-I
  - new Pixel GenErrors for Phase-I
  - new Pixel gains for Phase-I
  - new Pixel quality for Phase-I
