### PR TITLE
Fix the Digi customization for phase2Tk to keep the new digis

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10Ddev.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10Ddev.py
@@ -32,7 +32,6 @@ def customise(process):
 
 def customise_Digi(process):
     process.digitisation_step.remove(process.mix.digitizers.pixel)
-    process.load('Geometry.TrackerGeometryBuilder.StackedTrackerGeometry_cfi')
     process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
     process.mix.digitizers.pixel=process.phase2TrackerDigitizer
     process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
@@ -48,6 +47,12 @@ def customise_Digi(process):
         process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
         process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
 
+    # keep new digis
+    alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
+    for a in alist:
+        b=a+'output'
+        if hasattr(process,b):
+            getattr(process,b).outputCommands.append('keep Phase2TrackerDigiedmDetSetVector_*_*_*')
     return process
 
 


### PR DESCRIPTION
Fixes two things in customise_Digi for phase2Tk:
1. Drop the now deprecated and unused StackedTrackerGeometry
2. Add the new digis to the output (should have been done long ago)

This will be followed by a PR by @thomaslenzi to take these new digis as input of the clusterizer (the present phase2 OT clusterizer reads an empty deprecated collection).

Tested with the 10800 workflow.
