### PR TITLE
move edm plugin FedRawDataInputSource definition in the plugin directory

### DIFF
--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
-<use   name="DQMServices/Components"/>
 <use   name="DQMServices/Core"/>
+<use   name="DQMServices/Components"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="FWCore/Framework"/>
 <use   name="DataFormats/BeamSpot"/>

--- a/EventFilter/Utilities/plugins/SealModule.cc
+++ b/EventFilter/Utilities/plugins/SealModule.cc
@@ -11,6 +11,8 @@
 #include "EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h"
 #include "EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h"
 #include "EventFilter/Utilities/plugins/DaqFakeReader.h"
+#include "FWCore/Framework/interface/InputSourceMacros.h"
+#include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
 
 using namespace edm::serviceregistry;
 using namespace evf;
@@ -36,3 +38,4 @@ DEFINE_FWK_MODULE(RawStreamFileWriterForBU);
 DEFINE_FWK_MODULE(EvFOutputModule);
 DEFINE_FWK_MODULE(ShmStreamConsumer);
 DEFINE_FWK_MODULE(DaqFakeReader);
+DEFINE_FWK_INPUT_SOURCE(FedRawDataInputSource);

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -1281,7 +1281,3 @@ std::pair<bool,unsigned int> FedRawDataInputSource::getEventReport(unsigned int 
   else 
     return std::pair<bool,unsigned int>(false,0);
 }
-
-
-// define this class as an input source
-DEFINE_FWK_INPUT_SOURCE( FedRawDataInputSource);


### PR DESCRIPTION
EDM plugin FedRawDataInputSource was defined in the shared library and so any edm plugin which links against EventFilterUtilities sees it and adds duplicate definitions. 

this should fix the error we have see in the latest 80X IBs
https://cms-sw.github.io/relvalLogDetail.html#slc6_amd64_gcc493;CMSSW_8_0_X_2015-11-18-1100
