### PR TITLE
use offline BS in HeavyIonsRun2 prompt

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -214,7 +214,6 @@ def customiseRun2ExpressHI(process):
 ##############################################################################
 def customiseRun2PromptHI(process):
     process = customiseRun2CommonHI(process)
-    process = _swapOfflineBSwithOnline(process)
 
     process = _addLumiProducer(process)
 


### PR DESCRIPTION
use offline beamspot for HI prompt

tested in CMSSW_7_5_5_patch3
- expanded configs made for HeavyIonsRun2 prompt now point to the offline beam spot producer
- tested in 261626 (no useful data to plot here)
- tested in DoubleEG-Run2015B-251721 with HeavyIonsRun2 prompt: small differences show up consistent with beam spot change
