### PR TITLE
adds HLTPixelActivityHFSumEnergyFilter module (superseeds #12483)

### DIFF
--- a/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
+++ b/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
@@ -1,0 +1,52 @@
+#ifndef _HLTPixelActivityHFSumEnergyFilter_H
+#define _HLTPixelActivityHFSumEnergyFilter_H
+
+// system include files
+#include <memory>
+
+// user include files
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+
+//
+// class declaration
+//
+
+class HLTPixelActivityHFSumEnergyFilter : public HLTFilter {
+public:
+  explicit HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet&);
+  ~HLTPixelActivityHFSumEnergyFilter();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+private:
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+
+  edm::InputTag inputTag_;          // input tag identifying product containing pixel digis
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
+  edm::EDGetTokenT<HFRecHitCollection> HFHitsToken_;
+  edm::InputTag HFHits_;
+  double eCut_HF_;
+  double eMin_HF_;
+  double offset_;
+  double slope_;
+  double maxDiff_;
+};
+
+#endif

--- a/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
+++ b/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
@@ -44,7 +44,6 @@ private:
   double eMin_HF_;
   double offset_;
   double slope_;
-  double maxDiff_;
 };
 
 #endif

--- a/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
+++ b/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
@@ -5,23 +5,21 @@
 #include <memory>
 
 // user include files
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
-#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
@@ -29,16 +27,16 @@
 // class declaration
 //
 
-class HLTPixelActivityHFSumEnergyFilter : public HLTFilter {
+class HLTPixelActivityHFSumEnergyFilter : public edm::stream::EDFilter<> {
 public:
   explicit HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet&);
   ~HLTPixelActivityHFSumEnergyFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  edm::InputTag inputTag_;          // input tag identifying product containing pixel digis
+  edm::InputTag inputTag_;   // input tag identifying product containing pixel clusters
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
   edm::EDGetTokenT<HFRecHitCollection> HFHitsToken_;
   edm::InputTag HFHits_;

--- a/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
@@ -14,8 +14,7 @@ HLTPixelActivityHFSumEnergyFilter::HLTPixelActivityHFSumEnergyFilter(const edm::
   eCut_HF_      (config.getParameter<double>("eCut_HF")),
   eMin_HF_      (config.getParameter<double>("eMin_HF")),
   offset_       (config.getParameter<double>("offset")),
-  slope_        (config.getParameter<double>("slope")),
-  maxDiff_      (config.getParameter<double>("maxDiff"))
+  slope_        (config.getParameter<double>("slope"))
 {
   inputToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(inputTag_);
   HFHitsToken_ = consumes<HFRecHitCollection>(HFHits_); 
@@ -33,10 +32,9 @@ HLTPixelActivityHFSumEnergyFilter::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>("inputTag",edm::InputTag("hltSiPixelClusters"));
   desc.add<edm::InputTag>("HFHitCollection",edm::InputTag("hltHfreco"));
   desc.add<double>("eCut_HF",0);
-  desc.add<double>("eMin_HF",0);
-  desc.add<double>("offset",0);
-  desc.add<double>("slope",0);
-  desc.add<double>("maxDiff",1e-5);
+  desc.add<double>("eMin_HF",10000.);
+  desc.add<double>("offset",-1000.);
+  desc.add<double>("slope",0.5);
   descriptions.add("hltPixelActivityHFSumEnergyFilter",desc);
 }
 
@@ -66,11 +64,11 @@ bool HLTPixelActivityHFSumEnergyFilter::filter(edm::Event& iEvent, const edm::Ev
     }
   }
 
-  bool accept = kFALSE;
+  bool accept = false;
 
   double thres = offset_ + slope_ * sumE;
-  double diff = clusterSize - thres;
-  if(sumE>eMin_HF_ && diff < maxDiff_) accept = kTRUE;
+  double diff = clusterSize - thres;    //diff = clustersize - (correlation line + offset)
+  if(sumE>eMin_HF_ && diff < 0.) accept = true;
   
   // return with final filter decision
   return accept;

--- a/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
@@ -1,0 +1,89 @@
+#include "HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+//
+// constructors and destructor
+//
+
+HLTPixelActivityHFSumEnergyFilter::HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet& config) : HLTFilter(config),                                                                            inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
+  HFHits_       (config.getParameter<edm::InputTag>("HFHitCollection")),  
+  eCut_HF_      (config.getParameter<double>("eCut_HF")),
+  eMin_HF_      (config.getParameter<double>("eMin_HF")),
+  offset_       (config.getParameter<double>("offset")),
+  slope_        (config.getParameter<double>("slope")),
+  maxDiff_      (config.getParameter<double>("maxDiff"))
+{
+  inputToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(inputTag_);
+  HFHitsToken_ = consumes<HFRecHitCollection>(HFHits_); 
+  
+  LogDebug("") << "Using the " << inputTag_ << " input collection";
+}
+
+HLTPixelActivityHFSumEnergyFilter::~HLTPixelActivityHFSumEnergyFilter()
+{
+}
+
+void
+HLTPixelActivityHFSumEnergyFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("inputTag",edm::InputTag("hltSiPixelClusters"));
+  desc.add<edm::InputTag>("HFHitCollection",edm::InputTag("hltHfreco"));
+  desc.add<double>("eCut_HF",0);
+  desc.add<double>("eMin_HF",0);
+  desc.add<double>("offset",0);
+  desc.add<double>("slope",0);
+  desc.add<double>("maxDiff",1e-5);
+  descriptions.add("hltPixelActivityHFSumEnergyFilter",desc);
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+bool HLTPixelActivityHFSumEnergyFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+{
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) filterproduct.addCollectionTag(inputTag_);
+
+  // get hold of products from Event
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > clusterColl;
+  event.getByToken(inputToken_, clusterColl);
+
+  unsigned int clusterSize = clusterColl->dataSize();
+  LogDebug("") << "Number of clusters: " << clusterSize;
+
+  edm::Handle<HFRecHitCollection> HFRecHitsH;
+  event.getByToken(HFHitsToken_,HFRecHitsH);
+
+  double sumE = 0.;
+
+  for (HFRecHitCollection::const_iterator it=HFRecHitsH->begin(); it!=HFRecHitsH->end(); it++) {
+    if (it->energy()>eCut_HF_) {
+      sumE += it->energy();
+    }
+  }
+
+  bool accept = kFALSE;
+
+  double thres = offset_ + slope_ * sumE;
+  double diff = clusterSize - thres;
+  if(sumE>eMin_HF_ && diff < maxDiff_) accept = kTRUE;
+  
+  // return with final filter decision
+  return accept;
+}

--- a/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
@@ -58,7 +58,10 @@ bool HLTPixelActivityHFSumEnergyFilter::hltFilter(edm::Event& event, const edm::
   // this HLT filter, and place it in the Event.
 
   // The filter object
-  if (saveTags()) filterproduct.addCollectionTag(inputTag_);
+  if (saveTags()) {
+	filterproduct.addCollectionTag(inputTag_);
+        filterproduct.addCollectionTag(HFHits_);
+  }
 
   // get hold of products from Event
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > clusterColl;

--- a/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
@@ -3,18 +3,13 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "FWCore/Utilities/interface/StreamID.h"
 
 //
 // constructors and destructor
 //
 
-HLTPixelActivityHFSumEnergyFilter::HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet& config) : HLTFilter(config),                                                                            inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
+HLTPixelActivityHFSumEnergyFilter::HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet& config) :
+  inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
   HFHits_       (config.getParameter<edm::InputTag>("HFHitCollection")),  
   eCut_HF_      (config.getParameter<double>("eCut_HF")),
   eMin_HF_      (config.getParameter<double>("eMin_HF")),
@@ -35,7 +30,6 @@ HLTPixelActivityHFSumEnergyFilter::~HLTPixelActivityHFSumEnergyFilter()
 void
 HLTPixelActivityHFSumEnergyFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("inputTag",edm::InputTag("hltSiPixelClusters"));
   desc.add<edm::InputTag>("HFHitCollection",edm::InputTag("hltHfreco"));
   desc.add<double>("eCut_HF",0);
@@ -51,27 +45,18 @@ HLTPixelActivityHFSumEnergyFilter::fillDescriptions(edm::ConfigurationDescriptio
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelActivityHFSumEnergyFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixelActivityHFSumEnergyFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  // All HLT filters must create and fill an HLT filter object,
-  // recording any reconstructed physics objects satisfying (or not)
-  // this HLT filter, and place it in the Event.
-
-  // The filter object
-  if (saveTags()) {
-	filterproduct.addCollectionTag(inputTag_);
-        filterproduct.addCollectionTag(HFHits_);
-  }
 
   // get hold of products from Event
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > clusterColl;
-  event.getByToken(inputToken_, clusterColl);
+  iEvent.getByToken(inputToken_, clusterColl);
 
   unsigned int clusterSize = clusterColl->dataSize();
   LogDebug("") << "Number of clusters: " << clusterSize;
 
   edm::Handle<HFRecHitCollection> HFRecHitsH;
-  event.getByToken(HFHitsToken_,HFRecHitsH);
+  iEvent.getByToken(HFHitsToken_,HFRecHitsH);
 
   double sumE = 0.;
 

--- a/HLTrigger/special/src/SealModule.cc
+++ b/HLTrigger/special/src/SealModule.cc
@@ -29,6 +29,7 @@
 #include "HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h"
 
 #include "HLTrigger/special/interface/HLTPixelAsymmetryFilter.h"
+#include "HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h"
 #include "HLTrigger/special/interface/HLTHFAsymmetryFilter.h"
 #include "HLTrigger/special/interface/HLTTrackerHaloFilter.h"
 
@@ -65,5 +66,6 @@ DEFINE_FWK_MODULE(HLTEcalResonanceFilter);
 DEFINE_FWK_MODULE(HLTRegionalEcalResonanceFilter);
 
 DEFINE_FWK_MODULE(HLTPixelAsymmetryFilter);
+DEFINE_FWK_MODULE(HLTPixelActivityHFSumEnergyFilter);
 DEFINE_FWK_MODULE(HLTHFAsymmetryFilter);
 DEFINE_FWK_MODULE(HLTTrackerHaloFilter);


### PR DESCRIPTION
This PR superseeds #12483

Adds HLTPixelActivityHFSumEnergyFilter module. This filter checks correlation between number of pixel clusters and HF energy sum. The idea is to have a filter firing when the expected correlation is broken.

Remark 1 : This module is NOT for the pp reference run.
Remark 2 : This module is for PbPb run.

@kkrajczar 
@icali
@ttrk
