### PR TITLE
Adding LumiPixelsMinBias in the AlCaRecoStreamsHeavyIons

### DIFF
--- a/Configuration/StandardSequences/python/AlCaRecoStreamsHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreamsHeavyIons_cff.py
@@ -35,6 +35,12 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalMinBiasHI_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBiasHI_cff import *
 
 ###############################################################
+# LUMI Calibration
+###############################################################
+# AlCaReco for A stream (PD=MinBias)
+from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixelsMinBias_cff import *
+
+###############################################################
 # ECAL Calibration
 ###############################################################
 
@@ -113,6 +119,7 @@ pathALCARECOTkAlMinBiasHI = cms.Path(seqALCARECOTkAlMinBiasHI*ALCARECOTkAlMinBia
 pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
 pathALCARECOSiStripCalZeroBias = cms.Path(seqALCARECOSiStripCalZeroBias*ALCARECOSiStripCalZeroBiasDQM)
+pathALCARECOLumiPixelsMinBias = cms.Path(seqALCARECOLumiPixelsMinBias)
 
 pathALCARECOHcalCalDijets = cms.Path(seqALCARECOHcalCalDijets*ALCARECOHcalCalDiJetsDQM)
 pathALCARECOHcalCalGammaJet = cms.Path(seqALCARECOHcalCalGammaJet)
@@ -226,6 +233,15 @@ ALCARECOStreamSiStripCalZeroBias = cms.FilteredStream(
 	paths  = (pathALCARECOSiStripCalZeroBias),
 	content = OutALCARECOSiStripCalZeroBias.outputCommands,
 	selectEvents = OutALCARECOSiStripCalZeroBias.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+ALCARECOStreamLumiPixelsMinBias = cms.FilteredStream(
+	responsible = 'Chris Palmer',
+	name = 'LumiPixelsMinBias',
+	paths  = (pathALCARECOLumiPixelsMinBias),
+	content = OutALCARECOLumiPixelsMinBias.outputCommands,
+	selectEvents = OutALCARECOLumiPixelsMinBias.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 


### PR DESCRIPTION
To allow `LumiPixelMinBias` to run in the HeavyIon scenario.
