### PR TITLE
Updated HLT paths for skims according to the final PbPb menu

### DIFF
--- a/Configuration/Skimming/python/HI_BJetSkim_cff.py
+++ b/Configuration/Skimming/python/HI_BJetSkim_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # HLT jet trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltJetHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltJetHI.HLTPaths = ["HLT_PuAK4CaloBJetCSV80_Eta2p1_v*"]
+hltJetHI.HLTPaths = ["HLT_HIPuAK4CaloBJetCSV80_Eta2p1_v*"]
 hltJetHI.throw = False
 hltJetHI.andOr = True
 

--- a/Configuration/Skimming/python/HI_D0MesonSkim_cff.py
+++ b/Configuration/Skimming/python/HI_D0MesonSkim_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltDmeson60 = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltDmeson60.HLTPaths = ["HLT_DmesonHITrackingGlobal_Dpt60_v*"]
+hltDmeson60.HLTPaths = ["HLT_HIDmesonHITrackingGlobal_Dpt60_v*"]
 hltDmeson60.throw = False
 hltDmeson60.andOr = True
 

--- a/Configuration/Skimming/python/HI_HighPtJetSkim_cff.py
+++ b/Configuration/Skimming/python/HI_HighPtJetSkim_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # HLT jet trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltHIJet150 = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltHIJet150.HLTPaths = ["HLT_PuAK4CaloJet150_Eta2p1_v*"]
+hltHIJet150.HLTPaths = ["HLT_HIPuAK4CaloJet150_Eta5p1_v*"]
 hltHIJet150.throw = False
 hltHIJet150.andOr = True
 

--- a/Configuration/Skimming/python/HI_MinBiasSkim_cff.py
+++ b/Configuration/Skimming/python/HI_MinBiasSkim_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # HLT dimuon trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltMinBiasHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltMinBiasHI.HLTPaths = ["HLT_L1MinimumBiasHF2AND_v*"]
+hltMinBiasHI.HLTPaths = ["HLT_HIL1MinimumBiasHF2AND_v*"]
 hltMinBiasHI.throw = False
 hltMinBiasHI.andOr = True
 


### PR DESCRIPTION
A few HLT paths have to be changed in the prompt skims to reflect the final PbPb menu.
This is needed for PbPb data-taking, not the pp reference run. 
Would be great if this could be in the release built later today.
I will communicate the primary dataset names corresponding to these skims to the T0 hn.
