### PR TITLE
Updated the Phase2 Tracker Clusterizer

### DIFF
--- a/SimTracker/SiPhase2Digitizer/interface/Phase2TrackerClusterizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/interface/Phase2TrackerClusterizerAlgorithm.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
@@ -16,12 +16,12 @@ class Phase2TrackerClusterizerAlgorithm {
 
         Phase2TrackerClusterizerAlgorithm(unsigned int, unsigned int);
         void setup(const PixelGeomDetUnit*);
-        void clusterizeDetUnit(const edm::DetSet< PixelDigi >&, edmNew::DetSetVector< Phase2TrackerCluster1D >::FastFiller&);
+        void clusterizeDetUnit(const edm::DetSet< Phase2TrackerDigi >&, edmNew::DetSetVector< Phase2TrackerCluster1D >::FastFiller&);
 
     private:
 
-        void fillMatrix(edm::DetSet< PixelDigi >::const_iterator, edm::DetSet< PixelDigi >::const_iterator);
-        void clearMatrix(edm::DetSet< PixelDigi >::const_iterator, edm::DetSet< PixelDigi >::const_iterator);
+        void fillMatrix(edm::DetSet< Phase2TrackerDigi >::const_iterator, edm::DetSet< Phase2TrackerDigi >::const_iterator);
+        void clearMatrix(edm::DetSet< Phase2TrackerDigi >::const_iterator, edm::DetSet< Phase2TrackerDigi >::const_iterator);
 
         Phase2TrackerClusterizerArray matrix_;
         unsigned int maxClusterSize_;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerClusterizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerClusterizer.cc
@@ -45,8 +45,8 @@ namespace cms {
 
         // Get the Digis
         edm::Handle< edm::DetSetVector< Phase2TrackerDigi > > digis;
-        //event.getByLabel(src_, digis);
-        event.getByLabel("mix", "Tracker", digis); 
+        event.getByLabel(src_, digis);
+        //event.getByLabel("mix", "Tracker", digis); 
         
         // Get the geometry
         edm::ESHandle< TrackerGeometry > geomHandle;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerClusterizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerClusterizer.cc
@@ -6,7 +6,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include <vector>
+#include <iostream>
 
 namespace cms {
 
@@ -43,26 +44,22 @@ namespace cms {
     void Phase2TrackerClusterizer::produce(edm::Event& event, const edm::EventSetup& eventSetup) {
 
         // Get the Digis
-        edm::Handle< edm::DetSetVector< PixelDigi > > digis;
-        event.getByLabel(src_, digis);
-
+        edm::Handle< edm::DetSetVector< Phase2TrackerDigi > > digis;
+        //event.getByLabel(src_, digis);
+        event.getByLabel("mix", "Tracker", digis); 
+        
         // Get the geometry
         edm::ESHandle< TrackerGeometry > geomHandle;
         eventSetup.get< TrackerDigiGeometryRecord >().get(geomHandle);
         const TrackerGeometry* tkGeom(&(*geomHandle)); 
 
-        edm::ESHandle< TrackerTopology > tTopoHandle;
-        eventSetup.get< IdealGeometryRecord >().get(tTopoHandle);
-        const TrackerTopology* tTopo(tTopoHandle.product());
-
         // Global container for the clusters of each modules
         std::auto_ptr< Phase2TrackerCluster1DCollectionNew > outputClusters(new Phase2TrackerCluster1DCollectionNew());
 
         // Go over all the modules
-        for (edm::DetSetVector< PixelDigi >::const_iterator DSViter = digis->begin(); DSViter != digis->end(); ++DSViter) {
+        for (edm::DetSetVector< Phase2TrackerDigi >::const_iterator DSViter = digis->begin(); DSViter != digis->end(); ++DSViter) {
 
             DetId detId(DSViter->detId());
-            if (!isOuterTracker(detId, tTopo)) continue;
 
             // Geometry
             const GeomDetUnit* geomDetUnit(tkGeom->idToDetUnit(detId));
@@ -84,15 +81,6 @@ namespace cms {
 
         // Add the data to the output
         event.put(outputClusters);
-    }
-
-    bool Phase2TrackerClusterizer::isOuterTracker(const DetId& detid, const TrackerTopology* topo) {
-        if (detid.det() == DetId::Tracker) {
-            if (detid.subdetId() == PixelSubdetector::PixelBarrel) return (topo->pxbLayer(detid) >= 5);
-            else if (detid.subdetId() == PixelSubdetector::PixelEndcap) return (topo->pxfDisk(detid) >= 11);
-            else return false;
-        }
-        return false;
     }
 }
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerClusterizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerClusterizer.h
@@ -17,15 +17,11 @@ namespace cms {
     class Phase2TrackerClusterizer : public edm::EDProducer {
 
         public:
-
             explicit Phase2TrackerClusterizer(const edm::ParameterSet& conf);
             virtual ~Phase2TrackerClusterizer();
             virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup);
 
         private:
-
-            bool isOuterTracker(const DetId& detid, const TrackerTopology* topo);
-            
             edm::ParameterSet conf_;
             Phase2TrackerClusterizerAlgorithm* clusterizer_;
             edm::InputTag src_;

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerClusterizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerClusterizer_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Clusterizer options
 siPhase2Clusters = cms.EDProducer('Phase2TrackerClusterizer',
-    src = cms.InputTag("simSiTrackerDigis"),
+    src = cms.InputTag("mix", "Tracker"),
     maxClusterSize = cms.uint32(8),
     maxNumberClusters = cms.uint32(0)
 )

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerClusterizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerClusterizer_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Clusterizer options
 siPhase2Clusters = cms.EDProducer('Phase2TrackerClusterizer',
-    src = cms.InputTag("simSiPixelDigis", "Pixel"),
+    src = cms.InputTag("simSiTrackerDigis"),
     maxClusterSize = cms.uint32(8),
     maxNumberClusters = cms.uint32(0)
 )

--- a/SimTracker/SiPhase2Digitizer/src/Phase2TrackerClusterizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/src/Phase2TrackerClusterizerAlgorithm.cc
@@ -23,7 +23,7 @@ void Phase2TrackerClusterizerAlgorithm::setup(const PixelGeomDetUnit* pixDet) {
  * Go over the Digis and create clusters
  */
 
-void Phase2TrackerClusterizerAlgorithm::clusterizeDetUnit(const edm::DetSet< PixelDigi >& digis, edmNew::DetSetVector< Phase2TrackerCluster1D >::FastFiller& clusters) {
+void Phase2TrackerClusterizerAlgorithm::clusterizeDetUnit(const edm::DetSet< Phase2TrackerDigi >& digis, edmNew::DetSetVector< Phase2TrackerCluster1D >::FastFiller& clusters) {
 
     // Fill the 2D matrix with the ADC values
     fillMatrix(digis.begin(), digis.end());
@@ -82,15 +82,15 @@ void Phase2TrackerClusterizerAlgorithm::clusterizeDetUnit(const edm::DetSet< Pix
  * Copy the value of the Digis' ADC to the 2D matrix. An ADC of 255 means the cell is hit (binary read-out)
  */
 
-void Phase2TrackerClusterizerAlgorithm::fillMatrix(edm::DetSet< PixelDigi >::const_iterator begin, edm::DetSet< PixelDigi >::const_iterator end) {
-    for (edm::DetSet< PixelDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), (di->adc() != 0));
+void Phase2TrackerClusterizerAlgorithm::fillMatrix(edm::DetSet< Phase2TrackerDigi >::const_iterator begin, edm::DetSet< Phase2TrackerDigi >::const_iterator end) {
+    for (edm::DetSet< Phase2TrackerDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), true);
 }
 
 /*
  * Clear the array of hits
  */
 
-void Phase2TrackerClusterizerAlgorithm::clearMatrix(edm::DetSet< PixelDigi >::const_iterator begin, edm::DetSet< PixelDigi >::const_iterator end) {
-    for (edm::DetSet< PixelDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), false);
+void Phase2TrackerClusterizerAlgorithm::clearMatrix(edm::DetSet< Phase2TrackerDigi >::const_iterator begin, edm::DetSet< Phase2TrackerDigi >::const_iterator end) {
+    for (edm::DetSet< Phase2TrackerDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), false);
 }
 

--- a/SimTracker/SiPhase2Digitizer/test/ClustersValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/ClustersValidation.cc
@@ -125,7 +125,9 @@ void Phase2TrackerClusterizerValidation::analyze(const edm::Event& event, const 
 
     // Get the PixelDigiSimLinks
     edm::Handle< edm::DetSetVector< PixelDigiSimLink > > pixelSimLinks;
-    event.getByLabel(links_, pixelSimLinks);
+    event.getByLabel("simSiPixelDigis", "Tracker", pixelSimLinks);
+    
+//event.getByLabel(links_, pixelSimLinks);
 
     // Get the SimHits
     edm::Handle< edm::PSimHitContainer > simHitsRaw;

--- a/SimTracker/SiPhase2Digitizer/test/ClustersValidationTest_cfg.py
+++ b/SimTracker/SiPhase2Digitizer/test/ClustersValidationTest_cfg.py
@@ -18,7 +18,6 @@ process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.Validation_cff')
 process.load('DQMOffline.Configuration.DQMOfflineMC_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load('Geometry.TrackerNumberingBuilder.trackerTopologyConstants_cfi')
 
 # Number of events (-1 = all)
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
Following PR #12476 by @delaere I updated the Phase2 Tracker Clusterizer to use the new Digis data format. The input of the module changes but not the output. The workflow remains unchanged, only the module's code has been affected.

Tested with the 10800 workflow.
