### PR TITLE
add customization to switch to Global ECAL reco from multifit

### DIFF
--- a/RecoHI/Configuration/python/customise_ECALsequence.py
+++ b/RecoHI/Configuration/python/customise_ECALsequence.py
@@ -11,4 +11,10 @@ def changeHeavyIonsToUseECALGlobalFit(process) :
         process.ecalRecHit.EBuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEB")
         process.caloReco.replace(process.ecalUncalibRecHitSequence, process.ecalUncalibRecHitSequenceHI)
 
+    if hasattr (process, "ecalMonitorTask") :
+        process.ecalMonitorTask.collectionTags.EBUncalibRecHit = cms.untracked.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEB")
+        process.ecalMonitorTask.collectionTags.EEUncalibRecHit = cms.untracked.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEE")
+        process.ecalMonitorTask.collectionTags.EBLaserLedUncalibRecHit = cms.untracked.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEB")
+        process.ecalMonitorTask.collectionTags.EELaserLedUncalibRecHit = cms.untracked.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEE")
+
     return process

--- a/RecoHI/Configuration/python/customise_ECALsequence.py
+++ b/RecoHI/Configuration/python/customise_ECALsequence.py
@@ -1,14 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 def changeHeavyIonsToUseECALGlobalFit(process) :
-    process.load('RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi')
-    process.ecalUncalibRecHitSequenceHI = cms.Sequence(process.ecalGlobalUncalibRecHit*
-                                                       process.ecalDetIdToBeRecovered)
-    process.ecalLocalRecoSequenceHI     = cms.Sequence(process.ecalUncalibRecHitSequenceHI*
-                                                       process.ecalRecHitSequence)
-    process.ecalRecHit.EEuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEE")
-    process.ecalRecHit.EBuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEB")
-
-    process.caloReco.replace(process.ecalUncalibRecHitSequence, process.ecalUncalibRecHitSequenceHI)
+    if hasattr (process, "caloReco") :
+        process.load('RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi')
+        process.ecalUncalibRecHitSequenceHI = cms.Sequence(process.ecalGlobalUncalibRecHit*
+                                                           process.ecalDetIdToBeRecovered)
+        process.ecalLocalRecoSequenceHI     = cms.Sequence(process.ecalUncalibRecHitSequenceHI*
+                                                           process.ecalRecHitSequence)
+        process.ecalRecHit.EEuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEE")
+        process.ecalRecHit.EBuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEB")
+        process.caloReco.replace(process.ecalUncalibRecHitSequence, process.ecalUncalibRecHitSequenceHI)
 
     return process

--- a/RecoHI/Configuration/python/customise_ECALsequence.py
+++ b/RecoHI/Configuration/python/customise_ECALsequence.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+def changeHeavyIonsToUseECALGlobalFit(process) :
+    process.load('RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi')
+    process.ecalUncalibRecHitSequenceHI = cms.Sequence(process.ecalGlobalUncalibRecHit*
+                                                       process.ecalDetIdToBeRecovered)
+    process.ecalLocalRecoSequenceHI     = cms.Sequence(process.ecalUncalibRecHitSequenceHI*
+                                                       process.ecalRecHitSequence)
+    process.ecalRecHit.EEuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEE")
+    process.ecalRecHit.EBuncalibRecHitCollection = cms.InputTag("ecalGlobalUncalibRecHit","EcalUncalibRecHitsEB")
+
+    process.caloReco.replace(process.ecalUncalibRecHitSequence, process.ecalUncalibRecHitSequenceHI)
+
+    return process


### PR DESCRIPTION
@slava77 @yetkinyilmaz @ttrk
As discussed in the RECO meeting earlier today, this is a customization that changes the ecal reconstruction method from default multifit to global. 

It is not enabled in any workflows, but local testing confirmed that the Global reco was run when the customization was added.

Please advise if this should be forward ported to 76X and 80X.
