### PR TITLE
Seed Extension

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/python/trajectoryFilterForConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/trajectoryFilterForConversions_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-TrajectoryFilterForConversions = cms.PSet(
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+TrajectoryFilterForConversions = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     chargeSignificance = cms.double(-1.0),
     minPt = cms.double(0.9),
     minHitsMinPt = cms.int32(-1),

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -8,7 +8,8 @@ ElectronChi2.MaxChi2 = 2000.
 ElectronChi2.nSigma = 3.
 
 # Trajectory Filter
-TrajectoryFilterForElectrons = cms.PSet(
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+TrajectoryFilterForElectrons = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     chargeSignificance = cms.double(-1.0),
     minPt = cms.double(2.0),
     minHitsMinPt = cms.int32(-1),

--- a/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
@@ -11,7 +11,7 @@
 #include "TrackingTools/TrajectoryFiltering/interface/MinPtTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/LostHitsFractionTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h"
-
+#include "TrackingTools/TrajectoryFiltering/interface/SeedExtentionTrajectoryFilter.h"
 
 class CkfBaseTrajectoryFilter : public TrajectoryFilter {
 public:
@@ -25,7 +25,8 @@ public:
     theLostHitsFractionTrajectoryFilter(new LostHitsFractionTrajectoryFilter(pset, iC)),
     theMinHitsTrajectoryFilter(new MinHitsTrajectoryFilter(pset, iC)),
     theMinPtTrajectoryFilter(new MinPtTrajectoryFilter(pset, iC)),
-    theLooperTrajectoryFilter(new LooperTrajectoryFilter(pset, iC))
+    theLooperTrajectoryFilter(new LooperTrajectoryFilter(pset, iC)),
+    theSeedExtentionTrajectoryFilter(new SeedExtentionTrajectoryFilter(pset, iC))
   {}
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override {
@@ -57,6 +58,7 @@ protected:
     return true;}
 
   template <class T> bool TBC(T& traj) const{
+    if (!theSeedExtentionTrajectoryFilter->toBeContinued(traj)) return false;
     if (!theMaxHitsTrajectoryFilter->toBeContinued(traj)) return false;     
     if (!theMaxLostHitsTrajectoryFilter->toBeContinued(traj)) return false;
     if (!theMaxConsecLostHitsTrajectoryFilter->toBeContinued(traj)) return false;
@@ -76,6 +78,7 @@ protected:
   std::unique_ptr<MinHitsTrajectoryFilter> theMinHitsTrajectoryFilter;
   std::unique_ptr<MinPtTrajectoryFilter> theMinPtTrajectoryFilter;
   std::unique_ptr<LooperTrajectoryFilter> theLooperTrajectoryFilter;
+  std::unique_ptr<SeedExtentionTrajectoryFilter> theSeedExtentionTrajectoryFilter;
 };
 
 #endif

--- a/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
@@ -11,7 +11,7 @@
 #include "TrackingTools/TrajectoryFiltering/interface/MinPtTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/LostHitsFractionTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h"
-#include "TrackingTools/TrajectoryFiltering/interface/SeedExtentionTrajectoryFilter.h"
+#include "TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h"
 
 class CkfBaseTrajectoryFilter : public TrajectoryFilter {
 public:
@@ -26,7 +26,7 @@ public:
     theMinHitsTrajectoryFilter(new MinHitsTrajectoryFilter(pset, iC)),
     theMinPtTrajectoryFilter(new MinPtTrajectoryFilter(pset, iC)),
     theLooperTrajectoryFilter(new LooperTrajectoryFilter(pset, iC)),
-    theSeedExtentionTrajectoryFilter(new SeedExtentionTrajectoryFilter(pset, iC))
+    theSeedExtensionTrajectoryFilter(new SeedExtensionTrajectoryFilter(pset, iC))
   {}
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override {
@@ -58,7 +58,7 @@ protected:
     return true;}
 
   template <class T> bool TBC(T& traj) const{
-    if (!theSeedExtentionTrajectoryFilter->toBeContinued(traj)) return false;
+    if (!theSeedExtensionTrajectoryFilter->toBeContinued(traj)) return false;
     if (!theMaxHitsTrajectoryFilter->toBeContinued(traj)) return false;     
     if (!theMaxLostHitsTrajectoryFilter->toBeContinued(traj)) return false;
     if (!theMaxConsecLostHitsTrajectoryFilter->toBeContinued(traj)) return false;
@@ -78,7 +78,7 @@ protected:
   std::unique_ptr<MinHitsTrajectoryFilter> theMinHitsTrajectoryFilter;
   std::unique_ptr<MinPtTrajectoryFilter> theMinPtTrajectoryFilter;
   std::unique_ptr<LooperTrajectoryFilter> theLooperTrajectoryFilter;
-  std::unique_ptr<SeedExtentionTrajectoryFilter> theSeedExtentionTrajectoryFilter;
+  std::unique_ptr<SeedExtensionTrajectoryFilter> theSeedExtensionTrajectoryFilter;
 };
 
 #endif

--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
@@ -1,15 +1,15 @@
-#ifndef SeedExtentionTrajectoryFilter_H
-#define SeedExtentionTrajectoryFilter_H
+#ifndef SeedExtensionTrajectoryFilter_H
+#define SeedExtensionTrajectoryFilter_H
 
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
-class SeedExtentionTrajectoryFilter final : public TrajectoryFilter {
+class SeedExtensionTrajectoryFilter final : public TrajectoryFilter {
 public:
 
-  explicit SeedExtentionTrajectoryFilter() {} 
+  explicit SeedExtensionTrajectoryFilter() {} 
   
-  explicit SeedExtentionTrajectoryFilter(edm::ParameterSet const & pset, edm::ConsumesCollector&) :
-     theStrict(pset.existsAs<bool>("strictSeedExtention") ? pset.getParameter<bool>("strictSeedExtention"):false),
+  explicit SeedExtensionTrajectoryFilter(edm::ParameterSet const & pset, edm::ConsumesCollector&) :
+     theStrict(pset.existsAs<bool>("strictSeedExtension") ? pset.getParameter<bool>("strictSeedExtension"):false),
      theExtention(pset.existsAs<int>("seedExtention") ? pset.getParameter<int>("seedExtention"):0) {}
 
   virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
@@ -35,13 +35,13 @@ private:
 
 };
 
-template<class T> bool SeedExtentionTrajectoryFilter::looseTBC(const T& traj) const {
+template<class T> bool SeedExtensionTrajectoryFilter::looseTBC(const T& traj) const {
     return (int(traj.measurements().size())>int(traj.seedNHits())+theExtention) | (0==traj.lostHits());
 }
 
 
 // strict case as a real seeding: do not allow even inactive
-template<class T> bool SeedExtentionTrajectoryFilter::strictTBC(const T& traj) const {
+template<class T> bool SeedExtensionTrajectoryFilter::strictTBC(const T& traj) const {
     return traj.foundHits()>=int(traj.seedNHits())+theExtention;
 }
 

--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
@@ -10,7 +10,7 @@ public:
   
   explicit SeedExtensionTrajectoryFilter(edm::ParameterSet const & pset, edm::ConsumesCollector&) :
      theStrict(pset.existsAs<bool>("strictSeedExtension") ? pset.getParameter<bool>("strictSeedExtension"):false),
-     theExtention(pset.existsAs<int>("seedExtention") ? pset.getParameter<int>("seedExtention"):0) {}
+     theExtension(pset.existsAs<int>("seedExtension") ? pset.getParameter<int>("seedExtension"):0) {}
 
   virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
   virtual bool qualityFilter( const TempTrajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
@@ -30,19 +30,19 @@ private:
 
 
    bool theStrict=false;
-   int theExtention = 0;
+   int theExtension = 0;
 
 
 };
 
 template<class T> bool SeedExtensionTrajectoryFilter::looseTBC(const T& traj) const {
-    return (int(traj.measurements().size())>int(traj.seedNHits())+theExtention) | (0==traj.lostHits());
+    return (int(traj.measurements().size())>int(traj.seedNHits())+theExtension) | (0==traj.lostHits());
 }
 
 
 // strict case as a real seeding: do not allow even inactive
 template<class T> bool SeedExtensionTrajectoryFilter::strictTBC(const T& traj) const {
-    return traj.foundHits()>=int(traj.seedNHits())+theExtention;
+    return traj.foundHits()>=int(traj.seedNHits())+theExtension;
 }
 
 

--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtentionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtentionTrajectoryFilter.h
@@ -1,0 +1,51 @@
+#ifndef SeedExtentionTrajectoryFilter_H
+#define SeedExtentionTrajectoryFilter_H
+
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
+
+class SeedExtentionTrajectoryFilter final : public TrajectoryFilter {
+public:
+
+  explicit SeedExtentionTrajectoryFilter() {} 
+  
+  explicit SeedExtentionTrajectoryFilter(edm::ParameterSet const & pset, edm::ConsumesCollector&) :
+     theStrict(pset.existsAs<bool>("strictSeedExtention") ? pset.getParameter<bool>("strictSeedExtention"):false),
+     theExtention(pset.existsAs<int>("seedExtention") ? pset.getParameter<int>("seedExtention"):0) {}
+
+  virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
+  virtual bool qualityFilter( const TempTrajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
+
+  virtual bool toBeContinued( TempTrajectory& traj) const { return TBC<TempTrajectory>(traj);}
+  virtual bool toBeContinued( Trajectory& traj) const{ return TBC<Trajectory>(traj);}
+
+  virtual std::string name() const{return "LostHitsFractionTrajectoryFilter";}
+
+private:
+
+  template<class T> bool TBC(const T& traj) const {
+     return theStrict? strictTBC(traj) : looseTBC(traj);
+  }
+  template<class T> bool looseTBC(const T& traj) const;
+  template<class T> bool strictTBC(const T& traj) const;
+
+
+   bool theStrict=false;
+   int theExtention = 0;
+
+
+};
+
+template<class T> bool SeedExtentionTrajectoryFilter::looseTBC(const T& traj) const {
+    return (int(traj.measurements().size())>int(traj.seedNHits())+theExtention) | (0==traj.lostHits());
+}
+
+
+// strict case as a real seeding: do not allow even inactive
+template<class T> bool SeedExtentionTrajectoryFilter::strictTBC(const T& traj) const {
+    return traj.foundHits()>=int(traj.seedNHits())+theExtention;
+}
+
+
+
+
+#endif

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -28,6 +28,10 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
     maxLostHitsFraction = cms.double(1./10),
     constantValueForLostHitsFractionFilter = cms.double(2.),
 
+# Cut on the length of the seed extention (no lost hits allowed)
+    seedExtention = cms.int32(0),
+    strictSeedExtention = cms.bool(False),
+
 # Cuts for looperTrajectoryFilter
     minNumberOfHits = cms.int32(13),
     minNumberOfHitsPerLoop = cms.int32(4),

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -29,7 +29,7 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
     constantValueForLostHitsFractionFilter = cms.double(2.),
 
 # Cut on the length of the seed extention (no lost hits allowed)
-    seedExtention = cms.int32(0),
+    seedExtension = cms.int32(0),
     strictSeedExtension = cms.bool(False),
 
 # Cuts for looperTrajectoryFilter

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -30,7 +30,7 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
 
 # Cut on the length of the seed extention (no lost hits allowed)
     seedExtention = cms.int32(0),
-    strictSeedExtention = cms.bool(False),
+    strictSeedExtension = cms.bool(False),
 
 # Cuts for looperTrajectoryFilter
     minNumberOfHits = cms.int32(13),


### PR DESCRIPTION
Implement a Seed Extension as a TrajectoryFilter that requires no missing (or even no Invalid) hits as long as the track have less then a given number of hits beyond the seed.
The main purpose is (yet another way) to implement "Quadruplet seeding" for PhaseI.
It can also be used to reduce fakes (and speedup processing) in many other situations,
notably HLT.
Its indiscriminate use at RunII (i.e. changing the default) speeds-up tracking of almost a factor 2 at high pileup with minor loss in efficiency.
