### PR TITLE
NavigationSchoolAnalyzer fixed

### DIFF
--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -226,6 +226,11 @@ NavigationSchoolAnalyzer::~NavigationSchoolAnalyzer() {}
 
 
 void NavigationSchoolAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  tTopo = tTopoHandle.product();
+
   std::ostringstream byNav;
   std::ostringstream byGeom;
   std::ostringstream oldStyle;
@@ -237,7 +242,7 @@ void NavigationSchoolAnalyzer::analyze(const edm::Event& iEvent, const edm::Even
   //get the navigation school
   edm::ESHandle<NavigationSchool> nav;
   iSetup.get<NavigationSchoolRecord>().get(theNavigationSchoolName, nav);
-  byNav <<nav.product();
+  print(byNav,nav.product());
   printUsingGeom(byGeom,*nav.product());
   printOldStyle(oldStyle,*nav.product());
 
@@ -259,9 +264,9 @@ void NavigationSchoolAnalyzer::analyze(const edm::Event& iEvent, const edm::Even
 }
 
 void NavigationSchoolAnalyzer::beginRun(edm::Run & run, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  tTopo = tTopoHandle.product();
+//  edm::ESHandle<TrackerTopology> tTopoHandle;
+//  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+//  tTopo = tTopoHandle.product();
 
   //get the navigation school
   edm::ESHandle<NavigationSchool> nav;

--- a/RecoTracker/TkNavigation/test/navigationSchoolCharter.pl
+++ b/RecoTracker/TkNavigation/test/navigationSchoolCharter.pl
@@ -8,7 +8,7 @@
 ##   - edit the NavigationSchoolAnalyzer cfg.py to select which navigation school to print
 ##   - run the cfg.py for the NavigationSchoolAnalyzer
 ##   - perl -w navigationSchoolCharter.pl detailedInfo.log > yourSchool.dot
-##   - graphviz -Tpng -o yourSchool.png < yourSchool.dot
+##   - dot -Tpng -o yourSchool.png yourSchool.dot
 ##
 ## Output:
 ##   - red lines are 'inside-out' only (red = hot = bang = proton-proton collisions = in-out)


### PR DESCRIPTION
Introducing Topology in the analyze method in order to print again correctly the info of each layer.

@rovere 
