### PR TITLE
Don't dereference null pointer

### DIFF
--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -129,8 +129,8 @@ namespace edm {
             branchIDsToReplace_[i].push_back(*it);
           }
         }
+        secondaryFileSequence_->initAssociationsFromSecondary(associationsFromSecondary);
       }
-      secondaryFileSequence_->initAssociationsFromSecondary(associationsFromSecondary);
     }
   }
 


### PR DESCRIPTION
This is a trivial fix for a segfault in PoolSource. If secondaryFileNames are specified but not used, the secondary file names are cleared, but then the resulting nullptr is dereferenced. The fix is trivial and obvious. The segfault was observed by Matti Kortelainen.
This fix can easily be backported to prior releases should it become needed.
