### PR TITLE
add HI-related products for pp runs in event content keep statements

### DIFF
--- a/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
@@ -25,7 +25,10 @@ RecoEcalFEVT = cms.PSet(
         'keep *_particleFlowSuperClusterECAL_*_*',
 	# DROP statements
 	'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
-        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
+        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*',
+        # temporarily here for pp for HI
+        'keep recoCaloClusters_islandBasicClusters_*_*'
+        )
 )
 # RECO content
 RecoEcalRECO = cms.PSet(
@@ -53,7 +56,10 @@ RecoEcalRECO = cms.PSet(
         'drop recoClusterShapes_*_*_*', 
         'drop recoBasicClustersToOnerecoClusterShapesAssociation_*_*_*',
         'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
-        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
+        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*',
+        # temporarily here for pp for HI
+        'keep recoCaloClusters_islandBasicClusters_*_*'
+)
 )
 # AOD content
 RecoEcalAOD = cms.PSet(

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -42,7 +42,10 @@ RecoEgammaFEVT = cms.PSet(
         'keep *_hfRecoEcalCandidate_*_*',
         'keep *_hfEMClusters_*_*',
         'keep *_gedGsfElectronCores_*_*',
-        'keep *_gedGsfElectrons_*_*'
+        'keep *_gedGsfElectrons_*_*',
+        #temporarily here for pp running with HI stuff
+        'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+        'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
   )                                                                 
 )
 
@@ -97,7 +100,10 @@ RecoEgammaRECO = cms.PSet(
         'keep *_hfRecoEcalCandidate_*_*',
         'keep *_hfEMClusters_*_*',
         'keep *_gedGsfElectronCores_*_*',
-        'keep *_gedGsfElectrons_*_*'
+        'keep *_gedGsfElectrons_*_*',
+        #temporarily here for pp running with HI stuff
+        'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+        'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
   )                                                                 
 )
 
@@ -141,7 +147,10 @@ RecoEgammaAOD = cms.PSet(
         'keep *_hfRecoEcalCandidate_*_*',
         'keep *_hfEMClusters_*_*',
         'keep *_gedGsfElectronCores_*_*',
-        'keep *_gedGsfElectrons_*_*'
+        'keep *_gedGsfElectrons_*_*',
+        #temporarily here for pp running with HI stuff
+        'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+        'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
   )                                                                 
 )
 


### PR DESCRIPTION
customize function from #12185
 didn't work with event contents built in pure python from ConfigBuilder as used in event processing.
Making a kludge here for 75X.

cmsDriver.py worked, however. So, customs function can still be used  there
