### PR TITLE
Backport of #12523: Small bugfixes in alignment workflows

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -221,12 +221,12 @@ rfmkdir -p .oO[datadir]Oo./ExtendedOfflineValidation_Images
 
 if [[ $HOSTNAME = lxplus[0-9]*\.cern\.ch ]] # check for interactive mode
 then
-    image_files=$(ls --color=never | find .oO[workdir]Oo./ExtendedOfflineValidation_Images/ -name \*ps -o -name \*root)
+    image_files=$(ls --color=never | find .oO[workdir]Oo./ExtendedOfflineValidation_Images/ -name \*ps -o -name \*root -o -name \*png -o -name \*pdf)
     echo -e "\n\nProduced plot files:"
     #echo ${image_files}
     ls .oO[workdir]Oo./ExtendedOfflineValidation_Images
 else
-    image_files=$(ls --color=never | find ExtendedOfflineValidation_Images/ -name \*ps -o -name \*root)
+    image_files=$(ls --color=never | find ExtendedOfflineValidation_Images/ -name \*ps -o -name \*root -o -name \*png -o -name \*pdf)
     echo -e "\n\nProduced plot files:"
     #echo ${image_files}
     ls ExtendedOfflineValidation_Images

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -186,6 +186,10 @@ class ValidationJob:
                     "script": script,
                     "bsub": "/afs/cern.ch/cms/caf/scripts/cmsbsub"
                     }
+                for ext in ("stdout", "stderr", "stdout.gz", "stderr.gz"):
+                    oldlog = "%(logDir)s/%(jobName)s."%repMap + ext
+                    if os.path.exists(oldlog):
+                        os.remove(oldlog)
                 bsubOut=getCommandOutput2("%(bsub)s %(commands)s "
                                           "-J %(jobName)s "
                                           "-o %(logDir)s/%(jobName)s.stdout "
@@ -539,6 +543,11 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
                 "bsub": "/afs/cern.ch/cms/caf/scripts/cmsbsub",
                 "conditions": '"' + " && ".join(["ended(" + jobId + ")" for jobId in ValidationJob.batchJobIds]) + '"'
                 }
+            for ext in ("stdout", "stderr", "stdout.gz", "stderr.gz"):
+                oldlog = "%(logDir)s/%(jobName)s."%repMap + ext
+                if os.path.exists(oldlog):
+                    os.remove(oldlog)
+
             getCommandOutput2("%(bsub)s %(commands)s "
                               "-o %(logDir)s/%(jobName)s.stdout "
                               "-e %(logDir)s/%(jobName)s.stderr "

--- a/Alignment/OfflineValidation/scripts/visualizationTracker.C
+++ b/Alignment/OfflineValidation/scripts/visualizationTracker.C
@@ -318,10 +318,10 @@ string getGifMergeCommand(int start, int breakspot1, int breakspot2, int end) {
     return str;
 }
 
-//gets string that is a unix command that merges gifs using ImageMagick
+//gets string that is a unix command that merges gifs using GraphicsMagick
 string getConvertCommand(int start, int breakspot1, int breakspot2, int end) {
     string str = "";
-    str += "convert -loop 0 -delay 5 ";
+    str += "gm convert -loop 0 -delay 5 ";
     for (int i = start; i < breakspot1; i++) {
         str += "images/i"+to_string(i)+".gif ";
     }
@@ -448,7 +448,7 @@ void runVisualizer(TString input,
     //gSystem->Exec(TString(getGifMergeCommand(0, start1, start2, _i)));
     gSystem->Exec(TString(getConvertCommand(0, start1, start2, _i)));
     cout << "images merged." << endl;
-    gSystem->Exec(TString("convert "+_outputFileName+".gif -rotate 90 "+_outputFileName+"_rotated.gif"));
+    gSystem->Exec(TString("gm convert "+_outputFileName+".gif -rotate 90 "+_outputFileName+"_rotated.gif"));
     cout << "images rotated." << endl;
 }
 

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
@@ -12,12 +12,15 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
+#include "CondFormats/Alignment/interface/DetectorGlobalPosition.h"
+#include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackingGeometryAligner/interface/GeometryAligner.h"
 #include "CLHEP/Random/RandGauss.h"
@@ -117,7 +120,7 @@ void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm:
 	setup.get<TrackerTopologyRcd>().get(tTopoHandle);
 	const TrackerTopology* const tTopo = tTopoHandle.product();
 
-	edm::ESHandle<GeometricDet>  geom;
+	edm::ESHandle<GeometricDet> geom;
 	setup.get<IdealGeometryRecord>().get(geom);
 	edm::ESHandle<PTrackerParameters> ptp;
 	setup.get<PTrackerParametersRcd>().get( ptp );
@@ -132,9 +135,13 @@ void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm:
 		setup.get<TrackerAlignmentRcd>().get(alignments);
 		setup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
 
+		edm::ESHandle<Alignments> globalPositionRcd;
+		setup.get<TrackerDigiGeometryRecord>().getRecord<GlobalPositionRcd>().get(globalPositionRcd);
+
 		//apply the latest alignments
 		GeometryAligner aligner;
-		aligner.applyAlignments<TrackerGeometry>( &(*tracker), &(*alignments), &(*alignmentErrors), AlignTransform() );
+		aligner.applyAlignments<TrackerGeometry>( &(*tracker), &(*alignments), &(*alignmentErrors),
+							  align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Tracker)));
 
 	}
 


### PR DESCRIPTION
- fix the bug I mentioned in the alignment meeting yesterday in the systematic misalignment tool
  - new geometry comparison for applying "misalignment" with no shift, I think what's left is rounding errors:
    ![image](https://cloud.githubusercontent.com/assets/5262585/11310926/a0798c7a-8f9a-11e5-94f0-918488c6bd90.png)
- fix bug that Gregor mentioned last week, of not copying png and pdf files
- a couple of other minor bugs
