### PR TITLE
Remove obsolete dependency of framework on FEDRawData

### DIFF
--- a/IOPool/Streamer/plugins/BuildFile.xml
+++ b/IOPool/Streamer/plugins/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ServiceRegistry"/>
-<use   name="DataFormats/FEDRawData"/>
 <use   name="IOPool/Streamer"/>
 <library   file="Module.cc" name="IOPoolStreamerPlugins">
   <flags   EDM_PLUGIN="1"/>


### PR DESCRIPTION
There is an obsolete unnecessary declared link dependency of IOPool/Streamer/plugins on
DataFormats/FEDRawData. This trivial, technical PR removes this obsolete declared dependnecy.
This is important, because there is a proposal to make the CMS framework available in a separate repository. DataFormats/FEDRawData should not be a part of this framework.
