### PR TITLE
HcalTrigTowerDetId and read/dump changes for 1x1 HF TP

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1392,17 +1392,30 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalElectronicsMap&
       DetId trigger = fObject.lookupTrigger (eid);
       if (trigger.rawId ()) {
 	HcalText2DetIdConverter converter (trigger);
-	// changes by Jared, 6.03.09/(included 25.03.09)
-	//	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
-	sprintf (buf, " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
-		 //		 i,
-		 converter.getId().rawId(),
-		 // changes by Jared, 6.03.09/(included 25.03.09)
-		 //		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
-		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.slbSiteNumber(), eid.slbChannelIndex(),
-		 converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
-		 );
-	fOutput << buf << std::endl;
+        if( eid.isVMEid() ){
+	  // changes by Jared, 6.03.09/(included 25.03.09)
+	  //	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
+	  sprintf (buf, " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
+		   //		 i,
+		   converter.getId().rawId(),
+		   // changes by Jared, 6.03.09/(included 25.03.09)
+		   //		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
+		   eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.slbSiteNumber(), eid.slbChannelIndex(),
+		   converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
+	  	   );
+	  fOutput << buf << std::endl;
+        }else if( eid.isUTCAid() ){
+           sprintf (buf, " %7X %3d %3d   u %4d %7d %10d %14d %7s %5s %5s %6s",
+                    converter.getId().rawId(),
+//                    eid.crateId(), eid.slot(), 0, eid.spigot(), eid.fiberIndex(), eid.fiberChanId(), 
+                    eid.crateId(), eid.slot(), 0, 0, eid.fiberIndex(), eid.fiberChanId(), 
+                    converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
+                   );
+           fOutput << buf << std::endl;
+        }else{
+           sprintf (buf, "NOT SUPPORTED!");
+           fOutput << buf << std::endl;
+        }
       }
     } else {
       DetId channel = fObject.lookup (eid);
@@ -1418,10 +1431,11 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalElectronicsMap&
 		   converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
 		   );
 	} else {
-	  sprintf (buf, " %7X %3d %3d u %4d %7d %10d %14d %7s %5s %5s %6s",
+	  sprintf (buf, " %7X %3d %3d   u %4d %7d %10d %14d %7s %5s %5s %6s",
 		   //		 i,
 		   converter.getId().rawId(),
-		   eid.crateId(), eid.slot(), 0, eid.slot(), eid.fiberIndex(), eid.fiberChanId(),
+//		   eid.crateId(), eid.slot(), 0, eid.slot(), eid.fiberIndex(), eid.fiberChanId(),
+		   eid.crateId(), eid.slot(), 0, 0, eid.fiberIndex(), eid.fiberChanId(),
 		   converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
 		   );
 	}

--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -94,6 +94,10 @@ bool HcalText2DetIdConverter::init (DetId fId) {
     }
     else {
       flavorName = "HT";
+      setField (1, triggerId.ieta());
+      setField (2, triggerId.iphi());
+      setField (3, triggerId.version()*10 + triggerId.depth());
+/*      
       if (triggerId.version() == 0) {
         setField (1, triggerId.ieta());
         setField (2, triggerId.iphi());
@@ -105,6 +109,7 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       } else {
         // Unknown version
       }
+*/
     }
   }
   else if (genId.isHcalZDCDetId ()) {
@@ -170,6 +175,8 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     // has a 0 in the 10s digit, whereas 1x1 has a 1. The ones digit is still
     // used to indicate depth, although in the 1x1 case this must be 0, so we
     // set it as such.
+    mId = HcalTrigTowerDetId (getField (1), getField (2), getField (3));
+/*
     const int depth_field = getField(3);
     const int ones = depth_field % 10;
     const int tens = (depth_field - ones) / 10;
@@ -184,6 +191,7 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     } else {
       // Undefined version!
     }
+*/
   }
   else if (flavorName.find ("ZDC_") == 0) {
     HcalZDCDetId::Section section = flavorName == "ZDC_EM" ? HcalZDCDetId::EM :

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -1,5 +1,6 @@
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 const HcalTrigTowerDetId HcalTrigTowerDetId::Undefined(0x4a000000u);
 
@@ -13,12 +14,25 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(uint32_t rawid) : DetId(rawid) {
 HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi) : DetId(Hcal,HcalTriggerTower) {
   id_|=((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
     (iphi&0x7F);
+// Default to depth = 0 & version = 0
 }
 
 HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth) : DetId(Hcal,HcalTriggerTower) {
-  id_|=((depth&0x7)<<14) |
+  const int ones = depth % 10;
+  const int tens = (depth - ones) / 10;
+  // version convension   0 : default for 3x2 TP; 1, 2, 3 : for future & currently version = 1 is for 1x1 TP
+  // Note that in this conversion, depth can take values from 0 to 9 for different purpose 
+  // -> so depth should be = ones!
+  id_|=((ones&0x7)<<14) |
     ((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
     (iphi&0x7F);
+
+  const int version = tens;
+  if( version > 9 ){ // do NOT envision to have versions over 9...  
+     edm::LogError("HcalTrigTowerDetId")<<"in its ctor using depth, version larger than 9 (too many of it!)?"<<std::endl;
+  }
+
+  id_|=((version&0x7)<<17);
 }
 
 HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth, int version) : DetId(Hcal,HcalTriggerTower) {


### PR DESCRIPTION
] HcalTrigTowerDetId change to decode depth to version + real depth (for input depth>=10)
] In the HcalDbASCIIIO and HcalText2DetIdConverter, make changes to have consistent read/dump results for uHTR TP
