### PR TITLE
DQM input source update to catch exception when corrupted data comes

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -143,8 +143,16 @@ bool DQMStreamerReader::openNextFile_() {
   std::string p = fiterator_.make_path(currentLumi.datafn);
 
   if (boost::filesystem::exists(p)) {
-    openFile_(currentLumi);
-    return true;
+    try {
+      openFile_(currentLumi);
+      return true;
+    } catch (const cms::Exception& e) {
+      fiterator_.logFileAction(std::string("Can't deserialize registry data (in open file): ") + e.what(), p);
+      fiterator_.logLumiState(currentLumi, "error: data file corrupted");
+
+      closeFile_("data file corrupted");
+      return false;
+    }
   } else {
     /* dat file missing */
     fiterator_.logFileAction("Data file (specified in json) is missing:", p);
@@ -288,12 +296,27 @@ bool DQMStreamerReader::checkNextEvent() {
   if (file_.streamFile_->newHeader()) {
     // A new file has been opened and we must compare Headers here !!
     // Get header/init from reader
-    InitMsgView const* header = getHeaderMsg();
-    deserializeAndMergeWithRegistry(*header, true);
+
+    try {
+      InitMsgView const* header = getHeaderMsg();
+      deserializeAndMergeWithRegistry(*header, true);
+    } catch (const cms::Exception& e) {
+      fiterator_.logFileAction(std::string("Can't deserialize registry data: ") + e.what());
+      closeFile_("data file corrupted");
+      return checkNextEvent();
+    }
+  }
+
+  // try to recover from corrupted files/events
+  try {
+    deserializeEvent(*eview);
+  } catch (const cms::Exception& e) {
+    fiterator_.logFileAction(std::string("Can't deserialize event data: ") + e.what());
+    closeFile_("error");
+    return checkNextEvent();
   }
 
   processedEventPerLs_ += 1;
-  deserializeEvent(*eview);
 
   return true;
 }

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -144,7 +144,11 @@ namespace edm {
       std::cerr << "Error from StreamerInputSource: checksum of Init registry blob failed "
                 << " chksum from registry data = " << adler32_chksum << " from header = "
                 << initView.adler32_chksum() << " host name = " << initView.hostName() << std::endl;
+
       // skip event (based on option?) or throw exception?
+      throw cms::Exception("StreamDeserialization", "Checksum error")
+                << " chksum from registry data = " << adler32_chksum << " from header = "
+                << initView.adler32_chksum() << " host name = " << initView.hostName() << std::endl;
     }
 
     TClass* desc = getTClass(typeid(SendJobHeader));
@@ -214,7 +218,12 @@ namespace edm {
       std::cerr << "Error from StreamerInputSource: checksum of event data blob failed "
                 << " chksum from event = " << adler32_chksum << " from header = "
                 << eventView.adler32_chksum() << " host name = " << eventView.hostName() << std::endl;
+
       // skip event (based on option?) or throw exception?
+      throw cms::Exception("StreamDeserialization", "Checksum error")
+        << " chksum from event = " << adler32_chksum << " from header = "
+        << eventView.adler32_chksum() << " host name = " << eventView.hostName() << std::endl;
+
     }
     if(origsize != 78 && origsize != 0) {
       // compressed


### PR DESCRIPTION
(cherry picked from commit d3cede7f60a6177be0da1eb37e2ea706e398a56b)

the changes mainly affect the DQM input source used at the online while the base class is ~untouched. basically the code now throws an exception when corrupted data is processed. the jobs would have crashed anyway.

@dmitrijus 
