### PR TITLE
ZDC unpacker update (as #12544 but also keep old zdc digis in HI AOD)

### DIFF
--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -157,13 +157,6 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
 	  }
 	if (fed.size()!=0)
 	  {
-			//const HcalDCCHeader* dccHeader=(const HcalDCCHeader*)(fed.data());
-			//const HcalDTCHeader* dtcHeader=(const HcalDTCHeader*)(fed.data());
-			//int mode_ = 0;
-		  //bool is_VME_DCC=(dccHeader->getDCCDataFormatVersion()<0x10) || ((mode_&0x1)==0);
-		  //int dccid=(is_VME_DCC)?(dccHeader->getSourceId()-sourceIdOffset_):(dtcHeader->getSourceId()-sourceIdOffset_);
-		  //int dccid=dccHeader->getSourceId();
-		  //std::cout << __LINE__ << " fedid = " << *i << " dccid = " << dccid << std::endl;
 	    zdcunpacker_.unpack(fed,*readoutMap,colls,*report);
 	    report->addUnpacked(*i); 
 	  }

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -17,11 +17,14 @@ using namespace std;
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
+#include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
+#include "EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h"
+
 
 CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   dataTag_(conf.getParameter<edm::InputTag>("InputLabel")),
   unpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
-  zdcunpacker_(conf.getParameter<int>("ZDCFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
+  zdcunpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
   ctdcunpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
   filter_(conf.getParameter<bool>("FilterDataQuality"),conf.getParameter<bool>("FilterDataQuality"),false,0,0,-1),
   fedUnpackList_(conf.getUntrackedParameter<std::vector<int> >("FEDs",std::vector<int>())),
@@ -154,6 +157,13 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
 	  }
 	if (fed.size()!=0)
 	  {
+			//const HcalDCCHeader* dccHeader=(const HcalDCCHeader*)(fed.data());
+			//const HcalDTCHeader* dtcHeader=(const HcalDTCHeader*)(fed.data());
+			//int mode_ = 0;
+		  //bool is_VME_DCC=(dccHeader->getDCCDataFormatVersion()<0x10) || ((mode_&0x1)==0);
+		  //int dccid=(is_VME_DCC)?(dccHeader->getSourceId()-sourceIdOffset_):(dtcHeader->getSourceId()-sourceIdOffset_);
+		  //int dccid=dccHeader->getSourceId();
+		  //std::cout << __LINE__ << " fedid = " << *i << " dccid = " << dccid << std::endl;
 	    zdcunpacker_.unpack(fed,*readoutMap,colls,*report);
 	    report->addUnpacked(*i); 
 	  }

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -17,9 +17,6 @@ using namespace std;
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-#include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
-#include "EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h"
-
 
 CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   dataTag_(conf.getParameter<edm::InputTag>("InputLabel")),

--- a/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc
+++ b/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc
@@ -14,7 +14,7 @@
 #include <map>
 
 
-namespace HcalUnpacker_impl {
+namespace ZdcUnpacker_impl {
   template <class DigiClass>
   const unsigned short* unpack_compact(const unsigned short* startPoint, const unsigned short* limit, DigiClass& digi, 
 				       int presamples, const HcalElectronicsId& eid, int startSample, int endSample, 
@@ -274,7 +274,7 @@ void ZdcUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& emap
 			if (!did.null()) {
 				if (did.det()==DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId) {
 					colls.zdcCont->push_back(ZDCDataFrame(HcalZDCDetId(did)));
-					ptr_header=HcalUnpacker_impl::unpack_compact<ZDCDataFrame>(ptr_header, ptr_end, colls.zdcCont->back(), nps, eid, startSample_, endSample_, expectedOrbitMessageTime_, htr);
+					ptr_header=ZdcUnpacker_impl::unpack_compact<ZDCDataFrame>(ptr_header, ptr_end, colls.zdcCont->back(), nps, eid, startSample_, endSample_, expectedOrbitMessageTime_, htr);
 				}
 			} else {
 				report.countUnmappedDigi(eid);

--- a/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc
+++ b/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc
@@ -1,4 +1,5 @@
 #include "EventFilter/CastorRawToDigi/interface/ZdcUnpacker.h"
+#include "EventFilter/HcalRawToDigi/interface/HcalUnpacker.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalTTPUnpacker.h"
@@ -12,236 +13,278 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <map>
 
-namespace ZdcUnpacker_impl {
+
+namespace HcalUnpacker_impl {
   template <class DigiClass>
-  const HcalQIESample* unpack(const HcalQIESample* startPoint, const HcalQIESample* limit, DigiClass& digi, int presamples, const CastorElectronicsId& eid, int startSample, int endSample, int expectedTime, const HcalHTRData& hhd) {
+  const unsigned short* unpack_compact(const unsigned short* startPoint, const unsigned short* limit, DigiClass& digi, 
+				       int presamples, const HcalElectronicsId& eid, int startSample, int endSample, 
+				       int expectedTime, const HcalHTRData& hhd) {
     // set parameters
     digi.setPresamples(presamples);
-    int fiber=startPoint->fiber();
-    int fiberchan=startPoint->fiberChan();
+    digi.setReadoutIds(eid);
+    int flavor, error_flags, capid0, channelid;
+
+    HcalHTRData::unpack_per_channel_header(*startPoint,flavor,error_flags,capid0,channelid);
+    bool isCapRotating=!(error_flags&0x1);
+    bool fiberErr=(error_flags&0x2);
+    bool dataValid=!(error_flags&0x2);
+    int fiberchan=channelid&0x3;
+    int fiber=((channelid>>2)&0x7)+1;
+
     uint32_t zsmask=hhd.zsBunchMask()>>startSample;
     digi.setZSInfo(hhd.isUnsuppressed(),hhd.wasMarkAndPassZS(fiber,fiberchan),zsmask);
 
     if (expectedTime>=0 && !hhd.isUnsuppressed()) {
       digi.setFiberIdleOffset(hhd.getFibOrbMsgBCN(fiber)-expectedTime);
     }
-    int myFiberChan=startPoint->fiberAndChan();
+
+    // what is my sample number?
     int ncurr=0,ntaken=0;
-    const HcalQIESample* qie_work=startPoint;
-    while (qie_work!=limit && qie_work->fiberAndChan()==myFiberChan) {
-      if (ncurr>=startSample && ncurr<=endSample) {
-        digi.setSample(ntaken,*qie_work);
-        ++ntaken;
+    const unsigned short* qie_work=startPoint;
+    // we branch here between normal (flavor=5) and error mode (flavor=6)
+    if (flavor==5) {
+      for (qie_work++; qie_work!=limit && !HcalHTRData::is_channel_header(*qie_work); qie_work++) {
+	int capidn=(isCapRotating)?((capid0+ncurr)%4):(capid0);
+	int capidn1=(isCapRotating)?((capid0+ncurr+1)%4):(capid0);
+	// two samples in one...
+	HcalQIESample s0((*qie_work)&0x7F,capidn,fiber,fiberchan,dataValid,fiberErr);
+	HcalQIESample s1(((*qie_work)>>8)&0x7F,capidn1,fiber,fiberchan,dataValid,fiberErr);
+	
+	if (ncurr>=startSample && ncurr<=endSample) {
+	  digi.setSample(ntaken,s0);
+	  ++ntaken;
+	}
+	ncurr++;
+	if (ncurr>=startSample && ncurr<=endSample) {
+	  digi.setSample(ntaken,s1);
+	  ++ntaken;
+	}
+	ncurr++;
       }
-      ncurr++;
-      qie_work++;
+      digi.setSize(ntaken);
+    } else if (flavor==6) {
+      for (qie_work++; qie_work!=limit && !HcalHTRData::is_channel_header(*qie_work); qie_work++) {
+	if (ncurr>=startSample && ncurr<=endSample) {
+	  HcalQIESample sample((*qie_work)&0x7F,((*qie_work)>>8)&0x3,fiber,fiberchan,((*qie_work)>>10)&0x1,((*qie_work)>>11)&0x1);
+	  digi.setSample(ntaken,sample);
+	  ++ntaken;
+	}
+	ncurr++;
+      }
+      digi.setSize(ntaken);
+    } else {
+      edm::LogWarning("Bad Data") << "Invalid flavor " << flavor;
+      qie_work=limit;
     }
-    digi.setSize(ntaken);
     return qie_work;
   }
+  
 }
-
-namespace ZdcUnpacker_implOldData {
-  template <class DigiClass>
-  const HcalQIESample* unpackOld(const HcalQIESample* startPoint, const HcalQIESample* limit, DigiClass& digi, int presamples, const HcalElectronicsId& eid, int startSample, int endSample, int expectedTime, const HcalHTRData& hhd) {
-    // set parameters
-    digi.setPresamples(presamples);
-    int fiber=startPoint->fiber();
-    int fiberchan=startPoint->fiberChan();
-    uint32_t zsmask=hhd.zsBunchMask()>>startSample;
-    digi.setZSInfo(hhd.isUnsuppressed(),hhd.wasMarkAndPassZS(fiber,fiberchan),zsmask);
-
-    if (expectedTime>=0 && !hhd.isUnsuppressed()) {
-      digi.setFiberIdleOffset(hhd.getFibOrbMsgBCN(fiber)-expectedTime);
-    }
-    int myFiberChan=startPoint->fiberAndChan();
-    int ncurr=0,ntaken=0;
-    const HcalQIESample* qie_work=startPoint;
-    while (qie_work!=limit && qie_work->fiberAndChan()==myFiberChan) {
-      if (ncurr>=startSample && ncurr<=endSample) {
-        digi.setSample(ntaken,*qie_work);
-        ++ntaken;
-      }
-      ncurr++;
-      qie_work++;
-    }
-    digi.setSize(ntaken);
-    return qie_work;
-  }
-}
-
-namespace { inline bool isTPGSOI(const HcalTriggerPrimitiveSample& s) {
-  return (s.raw()&0x200)!=0;
-}
-}
-
 
 ZdcUnpacker::ZdcUnpacker(int sourceIdOffset, int beg, int end) : sourceIdOffset_(sourceIdOffset) , expectedOrbitMessageTime_(-1)
 {
-  if ( beg >= 0 && beg <= ZDCDataFrame::MAXSAMPLES -1 ) {
-    startSample_ = beg;
-  } else {
-    startSample_ = 0;
-  }
-  if ( end >= 0 && end <= ZDCDataFrame::MAXSAMPLES -1 && end >= beg ) {
-    endSample_ = end;
-  } else {
-    endSample_ = ZDCDataFrame::MAXSAMPLES -1;
-  }
+	if ( beg >= 0 && beg <= ZDCDataFrame::MAXSAMPLES -1 ) {
+		startSample_ = beg;
+	} else {
+		startSample_ = 0;
+	}
+	if ( end >= 0 && end <= ZDCDataFrame::MAXSAMPLES -1 && end >= beg ) {
+		endSample_ = end;
+	} else {
+		endSample_ = ZDCDataFrame::MAXSAMPLES -1;
+	}
 }
 
 void ZdcUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& emap,
-                         CastorRawCollections& colls, HcalUnpackerReport& report, bool silent) {
+		CastorRawCollections& colls, HcalUnpackerReport& report, bool silent) {
 
-  if (raw.size()<16) {
-    if (!silent) edm::LogWarning("Invalid Data") << "Empty/invalid DCC data, size = " << raw.size();
-    return;
-  }
+	if (raw.size()<16) {
+		if (!silent) edm::LogWarning("Invalid Data") << "Empty/invalid DCC data, size = " << raw.size();
+		return;
+	}
 
-  // get the DCC header
-  const HcalDCCHeader* dccHeader=(const HcalDCCHeader*)(raw.data());
-  int dccid=dccHeader->getSourceId();//-sourceIdOffset_;
+	// get the DCC header
+	const HcalDCCHeader* dccHeader=(const HcalDCCHeader*)(raw.data());
+	int dccid=dccHeader->getSourceId()-sourceIdOffset_;
 
-  // walk through the HTR data...
-  HcalHTRData htr;
-  const unsigned short* daq_first, *daq_last, *tp_first, *tp_last;
-  const HcalQIESample* qie_begin, *qie_end, *qie_work;
-  std::map<CastorElectronicsId,uint32_t> myEMap;
-  std::map<HcalElectronicsId,uint32_t> myEMapOldData;
+	// walk through the HTR data...
+	HcalHTRData htr;
+	const unsigned short* daq_first, *daq_last, *tp_first, *tp_last;
+	std::map<HcalElectronicsId,DetId> myEMap;
 
 
-//////ZDC MAP for NEW data (2015 PbPb are newer)
-  //PZDC
-  myEMap[CastorElectronicsId(0,1,0,3,18,8,1)]=0x54000051;//PZDC EM1
-  myEMap[CastorElectronicsId(1,1,0,3,18,8,1)]=0x54000052;//PZDC EM2
-  myEMap[CastorElectronicsId(2,1,0,3,18,8,1)]=0x54000053;//PZDC EM3
-  myEMap[CastorElectronicsId(0,2,0,3,18,8,1)]=0x54000054;//PZDC EM4
-  myEMap[CastorElectronicsId(1,2,0,3,18,8,1)]=0x54000055;//PZDC EM5
-  myEMap[CastorElectronicsId(2,2,0,3,18,8,1)]=0x54000061;//PZDC HAD1
-  myEMap[CastorElectronicsId(0,3,0,3,18,8,1)]=0x54000062;//PZDC HAD2
-  myEMap[CastorElectronicsId(1,3,0,3,18,8,1)]=0x54000063;//PZDC HAD3
-  myEMap[CastorElectronicsId(2,3,0,3,18,8,1)]=0x54000064;//PZDC HAD4
+	//////ZDC MAP for NEW data (2015 PbPb are newer)
+	//PZDC
+	HcalElectronicsId eid = HcalElectronicsId(0, 1, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000051);//PZDC EM1
 
-  //NZDC
-  myEMap[CastorElectronicsId(0,1,1,3,18,8,0)]=0x54000011;//NZDC EM1
-  myEMap[CastorElectronicsId(1,1,1,3,18,8,0)]=0x54000012;//NZDC EM2
-  myEMap[CastorElectronicsId(2,1,1,3,18,8,0)]=0x54000013;//NZDC EM3
-  myEMap[CastorElectronicsId(0,2,1,3,18,8,0)]=0x54000014;//NZDC EM4
-  myEMap[CastorElectronicsId(1,2,1,3,18,8,0)]=0x54000015;//NZDC EM5
-  myEMap[CastorElectronicsId(2,2,1,3,18,8,0)]=0x54000021;//NZDC HAD1
-  myEMap[CastorElectronicsId(0,3,1,3,18,8,0)]=0x54000022;//NZDC HAD2
-  myEMap[CastorElectronicsId(1,3,1,3,18,8,0)]=0x54000023;//NZDC HAD3
-  myEMap[CastorElectronicsId(2,3,1,3,18,8,0)]=0x54000024;//NZDC HAD4
+	eid = HcalElectronicsId(1, 1, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000052);//PZDC EM2
 
-/////ZDC MAP for OLD data (2013 pPb run and earlier)
-  //PZDC
-  myEMapOldData[HcalElectronicsId(0,1,12,22,12,8,1)]=0x54000051;//PZDC EM1
-  myEMapOldData[HcalElectronicsId(1,1,12,22,12,8,1)]=0x54000052;//PZDC EM2
-  myEMapOldData[HcalElectronicsId(2,1,12,22,12,8,1)]=0x54000053;//PZDC EM3
-  myEMapOldData[HcalElectronicsId(0,2,12,22,12,8,1)]=0x54000054;//PZDC EM4
-  myEMapOldData[HcalElectronicsId(1,2,12,22,12,8,1)]=0x54000055;//PZDC EM5
-  myEMapOldData[HcalElectronicsId(2,2,12,22,12,8,1)]=0x54000061;//PZDC HAD1
-  myEMapOldData[HcalElectronicsId(0,3,12,22,12,8,1)]=0x54000062;//PZDC HAD2
-  myEMapOldData[HcalElectronicsId(1,3,12,22,12,8,1)]=0x54000063;//PZDC HAD3
-  myEMapOldData[HcalElectronicsId(2,3,12,22,12,8,1)]=0x54000064;//PZDC HAD4
+	eid = HcalElectronicsId(2, 1, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000053);//PZDC EM3
 
-  //NZDC
-  myEMapOldData[HcalElectronicsId(0,1,13,22,12,8,0)]=0x54000011;//NZDC EM1
-  myEMapOldData[HcalElectronicsId(1,1,13,22,12,8,0)]=0x54000012;//NZDC EM2
-  myEMapOldData[HcalElectronicsId(2,1,13,22,12,8,0)]=0x54000013;//NZDC EM3
-  myEMapOldData[HcalElectronicsId(0,2,13,22,12,8,0)]=0x54000014;//NZDC EM4
-  myEMapOldData[HcalElectronicsId(1,2,13,22,12,8,0)]=0x54000015;//NZDC EM5
-  myEMapOldData[HcalElectronicsId(2,2,13,22,12,8,0)]=0x54000021;//NZDC HAD1
-  myEMapOldData[HcalElectronicsId(0,3,13,22,12,8,0)]=0x54000022;//NZDC HAD2
-  myEMapOldData[HcalElectronicsId(1,3,13,22,12,8,0)]=0x54000023;//NZDC HAD3
-  myEMapOldData[HcalElectronicsId(2,3,13,22,12,8,0)]=0x54000024;//NZDC HAD4
-  //slot is 17
+	eid = HcalElectronicsId(0, 2, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000061);//PZDC HAD1
 
-  for (int spigot=0; spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++) {
-    if (!dccHeader->getSpigotPresent(spigot)) continue;
+	eid = HcalElectronicsId(1, 2, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000054);//PZDC EM4
 
-    int retval=dccHeader->getSpigotData(spigot,htr,raw.size());
-    if (retval!=0) {
-      if (retval==-1) {
-        if (!silent) edm::LogWarning("Invalid Data") << "Invalid HTR data (data beyond payload size) observed on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
-        report.countSpigotFormatError();
-      }
-      continue;
-    }
-    // check
-    if (dccHeader->getSpigotCRCError(spigot)) {
-      if (!silent)
-        edm::LogWarning("Invalid Data") << "CRC Error on HTR data observed on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
-      report.countSpigotFormatError();
-      continue;
-    }
-    if (!htr.check()) {
-      if (!silent)
-        edm::LogWarning("Invalid Data") << "Invalid HTR data observed on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
-      report.countSpigotFormatError();
-      continue;
-    }
-    if (htr.isHistogramEvent()) {
-      if (!silent)
-        edm::LogWarning("Invalid Data") << "Histogram data passed to non-histogram unpacker on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
-      continue;
+	eid = HcalElectronicsId(2, 2, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000055);//PZDC EM5
 
-    }
-    if ((htr.getFirmwareFlavor()&0xE0)==0x80) { // some kind of TTP data
-      if (colls.ttp!=0) {
-        HcalTTPUnpacker ttpUnpack;
-        colls.ttp->push_back(HcalTTPDigi());
-        ttpUnpack.unpack(htr,colls.ttp->back());
-      } else {
-        LogDebug("ZdcUnpackerHcalTechTrigProcessor") << "Skipping data on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId() << " which is from the TechTrigProcessor (use separate unpacker!)";
-      }
-      continue;
-    }
-    if (htr.getFirmwareFlavor()>=0x80) {
-      if (!silent) edm::LogWarning("ZdcUnpacker") << "Skipping data on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId() << " which is of unknown flavor " << htr.getFirmwareFlavor();
-      continue;
-    }
-    // calculate "real" number of presamples
-    //int nps=htr.getNPS()-startSample_;
+	eid = HcalElectronicsId(0, 3, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000062);//PZDC HAD2
 
-    // get pointers
-    htr.dataPointers(&daq_first,&daq_last,&tp_first,&tp_last);
-    unsigned int smid=htr.getSubmodule();
-    int htr_tb=smid&0x1;
-    int htr_slot=(smid>>1)&0x1F;
-    int htr_cr=(smid>>6)&0x1F;
+	eid = HcalElectronicsId(1, 3, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000063);//PZDC HAD3
 
-    //////////////////////////////////////////////
-    qie_begin=(const HcalQIESample*)daq_first;
-    qie_end=(const HcalQIESample*)(daq_last+1); // one beyond last..
+	eid = HcalElectronicsId(2, 3, 0, 3);
+	eid.setHTR(18, 8, 1);
+	myEMap[eid]=DetId(0x54000064);//PZDC HAD4
 
-    for (qie_work=qie_begin; qie_work!=qie_end;) {    
-      if (qie_work->raw()==0xFFFF) {
-        qie_work++;
-        continue; // filler word
-      }
-      // lookup the right channel
-      HcalElectronicsId eidOld(qie_work->fiberChan(),qie_work->fiber(),spigot,dccid);
-      CastorElectronicsId eid(qie_work->fiberChan(),qie_work->fiber(),spigot,dccid);
-      eid.setHTR(htr_cr,htr_slot,htr_tb);
-	  if(myEMap.find(CastorElectronicsId(qie_work->fiberChan(),qie_work->fiber(),spigot,3,htr_cr,htr_slot,htr_tb))->second!=0x0)
-	  {
-	  colls.zdcCont->push_back(ZDCDataFrame(HcalZDCDetId(myEMap.find(CastorElectronicsId(qie_work->fiberChan(),qie_work->fiber(),spigot,3,htr_cr,htr_slot,htr_tb))->second)));
-	  qie_work=ZdcUnpacker_impl::unpack<ZDCDataFrame>(qie_work,qie_end,colls.zdcCont->back(),0,CastorElectronicsId(qie_work->fiberChan(),qie_work->fiber(),spigot,3,htr_cr,htr_slot,htr_tb),startSample_,endSample_,expectedOrbitMessageTime_,htr);
-	  }
-	  else if (myEMapOldData.find(HcalElectronicsId(qie_work->fiberChan(),qie_work->fiber(),spigot,22,htr_cr,htr_slot,htr_tb))->second!=0x0)
-	  {
-	  colls.zdcCont->push_back(ZDCDataFrame(HcalZDCDetId(myEMapOldData.find(HcalElectronicsId(qie_work->fiberChan(),qie_work->fiber(),spigot,22,htr_cr,htr_slot,htr_tb))->second)));
-	  qie_work=ZdcUnpacker_implOldData::unpackOld<ZDCDataFrame>(qie_work,qie_end,colls.zdcCont->back(),0,HcalElectronicsId(qie_work->fiberChan(),qie_work->fiber(),spigot,22,htr_cr,htr_slot,htr_tb),startSample_,endSample_,expectedOrbitMessageTime_,htr);
-	  }
-	  else for (int fiberC=qie_work->fiberAndChan();
-	  qie_work!=qie_end && qie_work->fiberAndChan()==fiberC;
-	  qie_work++);
+	//NZDC
+	eid = HcalElectronicsId(0,1,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000011);//NZDC EM1
+
+	eid = HcalElectronicsId(1,1,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000012);//NZDC EM2
+
+	eid = HcalElectronicsId(2,1,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000013);//NZDC EM3
+
+	eid = HcalElectronicsId(0,2,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000015);//NZDC EM5
+
+	eid = HcalElectronicsId(1,2,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000021);//NZDC HAD1
+
+	eid = HcalElectronicsId(2,2,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000014);//NZDC EM4
+
+	eid = HcalElectronicsId(0,3,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000022);//NZDC HAD2
+
+	eid = HcalElectronicsId(1,3,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000023);//NZDC HAD3
+
+	eid = HcalElectronicsId(2,3,1,3);
+	eid.setHTR(18, 8, 0);
+	myEMap[eid]=DetId(0x54000024);//NZDC HAD4
+
+	for (int spigot=0; spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++)
+	{
+		if (!dccHeader->getSpigotPresent(spigot)) continue;
+		int retval=dccHeader->getSpigotData(spigot,htr,raw.size());
+		if (retval!=0) {
+			if (retval==-1) {
+				if (!silent) edm::LogWarning("Invalid Data") << "Invalid HTR data (data beyond payload size) observed on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
+				report.countSpigotFormatError();
+			}
+			continue;
+		}
+		// check
+		if (dccHeader->getSpigotCRCError(spigot)) {
+			if (!silent)
+				edm::LogWarning("Invalid Data") << "CRC Error on HTR data observed on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
+			report.countSpigotFormatError();
+			continue;
+		}
+		if (!htr.check()) {
+			if (!silent)
+				edm::LogWarning("Invalid Data") << "Invalid HTR data observed on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
+			report.countSpigotFormatError();
+			continue;
+		}
+		if (htr.isHistogramEvent()) {
+			if (!silent)
+				edm::LogWarning("Invalid Data") << "Histogram data passed to non-histogram unpacker on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId();
+			continue;
+
+		}
+		if ((htr.getFirmwareFlavor()&0xE0)==0x80) { // some kind of TTP data
+			if (colls.ttp!=0) {
+				HcalTTPUnpacker ttpUnpack;
+				colls.ttp->push_back(HcalTTPDigi());
+				ttpUnpack.unpack(htr,colls.ttp->back());
+			} else {
+				LogDebug("ZdcUnpackerHcalTechTrigProcessor") << "Skipping data on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId() << " which is from the TechTrigProcessor (use separate unpacker!)";
+			}
+			continue;
+		}
+		if (htr.getFirmwareFlavor()>=0x80) {
+			if (!silent) edm::LogWarning("ZdcUnpacker") << "Skipping data on spigot " << spigot << " of DCC with source id " << dccHeader->getSourceId() << " which is of unknown flavor " << htr.getFirmwareFlavor();
+			continue;
+		}
+		// calculate "real" number of presamples
+		int nps=htr.getNPS()-startSample_;
+
+		// get pointers
+		htr.dataPointers(&daq_first,&daq_last,&tp_first,&tp_last);
+		unsigned int smid=htr.getSubmodule();
+		int htr_tb=smid&0x1;
+		int htr_slot=(smid>>1)&0x1F;
+		int htr_cr=(smid>>6)&0x1F;
 
 
-    }//end of loop over qies
-  }//end of loop over spigots
+		const unsigned short* ptr_header=daq_first;
+		const unsigned short* ptr_end=daq_last+1;
+		int flavor, error_flags, capid0, channelid;
+
+		while (ptr_header!=ptr_end) {
+			if (*ptr_header==0xFFFF) { // impossible filler word
+				ptr_header++;
+				continue;
+			}
+			// unpack the header word
+			bool isheader=HcalHTRData::unpack_per_channel_header(*ptr_header,flavor,error_flags,capid0,channelid);
+			if (!isheader) {
+				ptr_header++;
+				continue;
+			}
+			int fiberchan=channelid&0x3;
+			int fiber=((channelid>>2)&0x7)+1;
+
+			// lookup the right channel
+			HcalElectronicsId eid(fiberchan,fiber,spigot,dccid);
+			eid.setHTR(htr_cr,htr_slot,htr_tb);
+			auto it = myEMap.find(eid);
+			DetId did;
+			if (it != myEMap.end())
+			{
+				did = it->second;
+			}
+
+			if (!did.null()) {
+				if (did.det()==DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId) {
+					colls.zdcCont->push_back(ZDCDataFrame(HcalZDCDetId(did)));
+					ptr_header=HcalUnpacker_impl::unpack_compact<ZDCDataFrame>(ptr_header, ptr_end, colls.zdcCont->back(), nps, eid, startSample_, endSample_, expectedOrbitMessageTime_, htr);
+				}
+			} else {
+				report.countUnmappedDigi(eid);
+				for (ptr_header++;
+					ptr_header!=ptr_end && !HcalHTRData::is_channel_header(*ptr_header);
+					ptr_header++);
+			}
+
+		}
+	}//end of loop over spigots
 }
 
 
-//  LocalWords:  htr

--- a/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
@@ -10,6 +10,7 @@ RecoHiEvtPlaneRECO = cms.PSet(
 
 RecoHiEvtPlaneAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoEvtPlanes_hiEvtPlane_*_*',
+                                           'keep ZDCRecHitsSorted_zdcreco_*_*',
                                            'keep ZDCDataFramesSorted_castorDigis_*_*',
                                            'keep HFRecHitsSorted_hfreco_*_*'
                                           )

--- a/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
@@ -10,8 +10,7 @@ RecoHiEvtPlaneRECO = cms.PSet(
 
 RecoHiEvtPlaneAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoEvtPlanes_hiEvtPlane_*_*',
-                                           'keep ZDCRecHitsSorted_zdcreco_*_*',
-                                           'keep ZDCDataFramesSorted_hcalDigis_*_*',
+                                           'keep ZDCDataFramesSorted_castorDigis_*_*',
                                            'keep HFRecHitsSorted_hfreco_*_*'
                                           )
     )

--- a/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
@@ -11,6 +11,9 @@ RecoHiEvtPlaneRECO = cms.PSet(
 RecoHiEvtPlaneAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoEvtPlanes_hiEvtPlane_*_*',
                                            'keep ZDCRecHitsSorted_zdcreco_*_*',
+                                           #for backward compatibility
+                                           'keep ZDCDataFramesSorted_hcalDigis_*_*',
+                                           #new place for ZDC
                                            'keep ZDCDataFramesSorted_castorDigis_*_*',
                                            'keep HFRecHitsSorted_hfreco_*_*'
                                           )


### PR DESCRIPTION
copy from #12544:
- [+] update working on compact FEDs readout
-  slides at https://www.dropbox.com/s/jpb9tlf2sqta5ju/11-23-15_ZDCunpacker.pdf?dl=0
- also added the old ZDCDataFramesSorted_hcalDigis (for MC and old data if it ever comes up as AOD) as well as to reduce number of changes in the event content (one add, instead of "add and remove")

I made this PR in the interest of time, otherwise would have waited for @BetterWang to update.
