### PR TITLE
pixel vs HF energy filter (76X version of #12487)

### DIFF
--- a/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
+++ b/HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h
@@ -1,0 +1,49 @@
+#ifndef _HLTPixelActivityHFSumEnergyFilter_H
+#define _HLTPixelActivityHFSumEnergyFilter_H
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+
+//
+// class declaration
+//
+
+class HLTPixelActivityHFSumEnergyFilter : public edm::stream::EDFilter<> {
+public:
+  explicit HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet&);
+  ~HLTPixelActivityHFSumEnergyFilter();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+private:
+  virtual bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+  edm::InputTag inputTag_;   // input tag identifying product containing pixel clusters
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
+  edm::EDGetTokenT<HFRecHitCollection> HFHitsToken_;
+  edm::InputTag HFHits_;
+  double eCut_HF_;
+  double eMin_HF_;
+  double offset_;
+  double slope_;
+};
+
+#endif

--- a/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
@@ -1,0 +1,75 @@
+#include "HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// constructors and destructor
+//
+
+HLTPixelActivityHFSumEnergyFilter::HLTPixelActivityHFSumEnergyFilter(const edm::ParameterSet& config) :
+  inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
+  HFHits_       (config.getParameter<edm::InputTag>("HFHitCollection")),  
+  eCut_HF_      (config.getParameter<double>("eCut_HF")),
+  eMin_HF_      (config.getParameter<double>("eMin_HF")),
+  offset_       (config.getParameter<double>("offset")),
+  slope_        (config.getParameter<double>("slope"))
+{
+  inputToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(inputTag_);
+  HFHitsToken_ = consumes<HFRecHitCollection>(HFHits_); 
+  
+  LogDebug("") << "Using the " << inputTag_ << " input collection";
+}
+
+HLTPixelActivityHFSumEnergyFilter::~HLTPixelActivityHFSumEnergyFilter()
+{
+}
+
+void
+HLTPixelActivityHFSumEnergyFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("inputTag",edm::InputTag("hltSiPixelClusters"));
+  desc.add<edm::InputTag>("HFHitCollection",edm::InputTag("hltHfreco"));
+  desc.add<double>("eCut_HF",0);
+  desc.add<double>("eMin_HF",10000.);
+  desc.add<double>("offset",-1000.);
+  desc.add<double>("slope",0.5);
+  descriptions.add("hltPixelActivityHFSumEnergyFilter",desc);
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+bool HLTPixelActivityHFSumEnergyFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  // get hold of products from Event
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > clusterColl;
+  iEvent.getByToken(inputToken_, clusterColl);
+
+  unsigned int clusterSize = clusterColl->dataSize();
+  LogDebug("") << "Number of clusters: " << clusterSize;
+
+  edm::Handle<HFRecHitCollection> HFRecHitsH;
+  iEvent.getByToken(HFHitsToken_,HFRecHitsH);
+
+  double sumE = 0.;
+
+  for (HFRecHitCollection::const_iterator it=HFRecHitsH->begin(); it!=HFRecHitsH->end(); it++) {
+    if (it->energy()>eCut_HF_) {
+      sumE += it->energy();
+    }
+  }
+
+  bool accept = false;
+
+  double thres = offset_ + slope_ * sumE;
+  double diff = clusterSize - thres;    //diff = clustersize - (correlation line + offset)
+  if(sumE>eMin_HF_ && diff < 0.) accept = true;
+  
+  // return with final filter decision
+  return accept;
+}

--- a/HLTrigger/special/src/SealModule.cc
+++ b/HLTrigger/special/src/SealModule.cc
@@ -29,6 +29,7 @@
 #include "HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h"
 
 #include "HLTrigger/special/interface/HLTPixelAsymmetryFilter.h"
+#include "HLTrigger/special/interface/HLTPixelActivityHFSumEnergyFilter.h"
 #include "HLTrigger/special/interface/HLTHFAsymmetryFilter.h"
 #include "HLTrigger/special/interface/HLTTrackerHaloFilter.h"
 
@@ -65,5 +66,6 @@ DEFINE_FWK_MODULE(HLTEcalResonanceFilter);
 DEFINE_FWK_MODULE(HLTRegionalEcalResonanceFilter);
 
 DEFINE_FWK_MODULE(HLTPixelAsymmetryFilter);
+DEFINE_FWK_MODULE(HLTPixelActivityHFSumEnergyFilter);
 DEFINE_FWK_MODULE(HLTHFAsymmetryFilter);
 DEFINE_FWK_MODULE(HLTTrackerHaloFilter);


### PR DESCRIPTION
This filter checks correlation between number of pixel clusters and HF energy sum. The idea is to have a filter firing when the expected correlation is broken. Adds HLTPixelActivityHFSumEnergyFilter module.

76X version of #12487
