### PR TITLE
Changes the energy threshold on the EcalDeadCellTriggerPrimitiveFilter

### DIFF
--- a/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
+++ b/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
@@ -12,7 +12,7 @@ EcalDeadCellTriggerPrimitiveFilter = cms.EDFilter(
     verbose = cms.int32( 1 ),
     
     tpDigiCollection = cms.InputTag("ecalTPSkimNA"),
-    etValToBeFlagged = cms.double(127.5),
+    etValToBeFlagged = cms.double(127.49),
     
     ebReducedRecHitCollection = cms.InputTag("reducedEcalRecHitsEB"),
     eeReducedRecHitCollection = cms.InputTag("reducedEcalRecHitsEE"),


### PR DESCRIPTION
There is a subtle rounding error in EcalDeadCellTriggerPrimitiveFilter.cc. Adjusting the threshold to 127.49 GeV gives the correct functionality.
