### PR TITLE
Fix PackedCandidate vertex to post-packed value

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -595,7 +595,7 @@ namespace pat {
     void packVtx(bool unpackAfterwards=true) ;
     void unpackVtx() const ;
     void maybeUnpackBoth() const { if (!p4c_) unpack(); if (!vertex_) unpackVtx(); }
-    void packBoth() { pack(false); packVtx(false); delete p4_.exchange(nullptr); delete p4c_.exchange(nullptr); unpack(); unpackVtx(); } // do it this way, so that we don't loose precision on the angles before computing dxy,dz
+    void packBoth() { pack(false); packVtx(false); delete p4_.exchange(nullptr); delete p4c_.exchange(nullptr); delete vertex_.exchange(nullptr); unpack(); unpackVtx(); } // do it this way, so that we don't loose precision on the angles before computing dxy,dz
     void unpackTrk() const ;
 
     int8_t packedPuppiweight_;


### PR DESCRIPTION
I suspect #12367 was not enough to fully restore the 760pre7 behaviour of PackedCandidate packing given my 800per2 validation report
https://hypernews.cern.ch/HyperNews/CMS/get/relval/4324/16.html
Deleting also `vertex_` in `packBoth()` seems to make a difference in the dxy/dz and track reference point histograms to the right direction.

Tested in 800pre2.

@davidlange6 @arizzi @gpetruc 
