### PR TITLE
Add BX correlation MEs

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -17,10 +17,13 @@ namespace ecaldqm {
     bool analyze(void const*, Collections) override;
 
     void runOnRecHits(EcalRecHitCollection const&, Collections);
+    void runOnUncalibRecHits(EcalUncalibratedRecHitCollection const&);
 
   private:
     void setParams(edm::ParameterSet const&) override;
 
+    float chi2ThresholdEB_;
+    float chi2ThresholdEE_;
     float energyThresholdEB_;
     float energyThresholdEE_;
   };
@@ -30,6 +33,11 @@ namespace ecaldqm {
     case kEBRecHit:
     case kEERecHit:
       if(_p) runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
+      return true;
+      break;
+    case kEBUncalibRecHit:
+    case kEEUncalibRecHit:
+      if(_p) runOnUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(_p));
       return true;
       break;
     default:

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -4,6 +4,8 @@ EaxisEdges = []
 for i in range(50) :
     EaxisEdges.append(pow(10., -0.5 + 2.5 / 50. * i))
 
+chi2ThresholdEE = 50.
+chi2ThresholdEB = 16.
 energyThresholdEE = 3.
 energyThresholdEB = 1.
 timeWindow = 12.5
@@ -11,6 +13,8 @@ summaryTimeWindow = 7.
 
 ecalTimingTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
+        chi2ThresholdEE = cms.untracked.double(chi2ThresholdEE),
+        chi2ThresholdEB = cms.untracked.double(chi2ThresholdEB),
         energyThresholdEE = cms.untracked.double(energyThresholdEE),
         energyThresholdEB = cms.untracked.double(energyThresholdEB)
     ),
@@ -85,6 +89,44 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing vs amplitude %(sm)s'),
             description = cms.untracked.string('Correlation between hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
+        ),
+        TimeAmpBXm = cms.untracked.PSet(
+            kind = cms.untracked.string('TH2F'),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(100.0),
+                nbins = cms.untracked.int32(100),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Amplitude BX-1 [ADC]')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1000.0),
+                nbins = cms.untracked.int32(250),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('In-time amplitude [ADC]')
+            ),
+            btype = cms.untracked.string('User'),
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT in-time vs BX-1 amplitude%(suffix)s'),
+            description = cms.untracked.string('Correlation between in-time amplitude and BX-1 out-of-time amplitude. Only events with kGood reconstruction flag set, energy > ( ' + ('EB:%f, EE:%f' % (energyThresholdEB*20., energyThresholdEE*5.)) + ' ) GeV, and chi2 < ( ' + ('EB:%f, EE:%f' % (chi2ThresholdEB, chi2ThresholdEE)) + ' ) are used.')
+        ),
+        TimeAmpBXp = cms.untracked.PSet(
+            kind = cms.untracked.string('TH2F'),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(100.0),
+                nbins = cms.untracked.int32(100),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Amplitude BX+1 [ADC]')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1000.0),
+                nbins = cms.untracked.int32(250),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('In-time amplitude [ADC]')
+            ),
+            btype = cms.untracked.string('User'),
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT in-time vs BX+1 amplitude%(suffix)s'),
+            description = cms.untracked.string('Correlation between in-time amplitude and BX+1 out-of-time amplitude. Only events with kGood reconstruction flag set, energy > ( ' + ('EB:%f, EE:%f' % (energyThresholdEB*20., energyThresholdEE*5.)) + ' ) GeV, and chi2 < ( ' + ('EB:%f, EE:%f' % (chi2ThresholdEB, chi2ThresholdEE)) + ' ) are used.')
         ),
         Time1D = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing 1D %(sm)s'),


### PR DESCRIPTION
Add new timing monitor elements for EB and EE+/-:
- in-time vs OOT BX-1
- in-time vs OOT BX+1

Modify chi2 thresholds to be read in from config parameters.
