### PR TITLE
add a specific duplicateMerge algorithm

### DIFF
--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -97,7 +97,8 @@ public:
 
     /// track algorithm
     enum TrackAlgorithm {
-        undefAlgorithm = 0, ctf = 1, rs = 2, cosmics = 3,
+        undefAlgorithm = 0, ctf = 1, 
+        duplicateMerge = 2, cosmics = 3,
         initialStep = 4,
         lowPtTripletStep = 5,
         pixelPairStep = 6,

--- a/DataFormats/TrackReco/interface/trackAlgoPriorityOrder.h
+++ b/DataFormats/TrackReco/interface/trackAlgoPriorityOrder.h
@@ -24,8 +24,8 @@ namespace impl {
   constexpr reco::TrackBase::TrackAlgorithm algoPriorityOrder[] ={
     reco::TrackBase::undefAlgorithm,
     reco::TrackBase::ctf,
-    reco::TrackBase::rs,
     reco::TrackBase::cosmics,
+    reco::TrackBase::duplicateMerge,
     reco::TrackBase::initialStep,
     reco::TrackBase::highPtTripletStep,
     reco::TrackBase::detachedQuadStep,

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -9,7 +9,7 @@ using namespace reco;
 std::string const TrackBase::algoNames[] = {
     "undefAlgorithm",
     "ctf",
-    "rs",
+    "duplicateMerge",
     "cosmics",
     "initialStep",
     "lowPtTripletStep",

--- a/DataFormats/TrackReco/test/testTrack.cc
+++ b/DataFormats/TrackReco/test/testTrack.cc
@@ -103,10 +103,10 @@ void testTrack::checkAll() {
     am.set(reco::TrackBase::ctf);
     CPPUNIT_ASSERT(t.algo() == reco::TrackBase::ctf);
     CPPUNIT_ASSERT(t.algoMask()==am);
-    am.set(reco::TrackBase::rs);
-    t.setOriginalAlgorithm(reco::TrackBase::rs);
+    am.set(reco::TrackBase::cosmics);
+    t.setOriginalAlgorithm(reco::TrackBase::cosmics);
     CPPUNIT_ASSERT(t.algo() == reco::TrackBase::ctf);
-    CPPUNIT_ASSERT(t.originalAlgo() == reco::TrackBase::rs);
+    CPPUNIT_ASSERT(t.originalAlgo() == reco::TrackBase::cosmics);
     CPPUNIT_ASSERT(t.algoMask()==am);
     
 }

--- a/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
@@ -316,6 +316,7 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
 	unsigned int iter = 0; 
 	switch (trackRef->algo()) {
 	case TrackBase::ctf:
+        case TrackBase::duplicateMerge:
 	case TrackBase::initialStep:
 	  iter = 0;
 	  break;

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -161,6 +161,7 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   unsigned int Algo = 0; 
   switch (trackref->algo()) {
   case reco::TrackBase::ctf:
+  case reco::TrackBase::duplicateMerge:
   case reco::TrackBase::initialStep:
   case reco::TrackBase::lowPtTripletStep:
   case reco::TrackBase::pixelPairStep:

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1936,6 +1936,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       double blowError = 1.;
       switch (trackRef->algo()) {
       case TrackBase::ctf:
+      case TrackBase::duplicateMerge:
       case TrackBase::initialStep:
       case TrackBase::lowPtTripletStep:
       case TrackBase::pixelPairStep:
@@ -2397,6 +2398,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
 	switch (trackref->algo()) {
 	case TrackBase::ctf:
+        case TrackBase::duplicateMerge:
 	case TrackBase::initialStep:
 	case TrackBase::lowPtTripletStep:
 	case TrackBase::pixelPairStep:

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -2509,6 +2509,7 @@ unsigned int PFEGammaAlgo::whichTrackAlgo(const reco::TrackRef& trackRef) {
   unsigned int Algo = 0; 
   switch (trackRef->algo()) {
   case TrackBase::ctf:
+  case TrackBase::duplicateMerge:
   case TrackBase::initialStep:
   case TrackBase::lowPtTripletStep:
   case TrackBase::pixelPairStep:

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -365,6 +365,7 @@ unsigned int PFEGammaFilters::whichTrackAlgo(const reco::TrackRef& trackRef) {
   unsigned int Algo = 0; 
   switch (trackRef->algo()) {
   case TrackBase::ctf:
+  case TrackBase::duplicateMerge:
   case TrackBase::initialStep:
   case TrackBase::lowPtTripletStep:
   case TrackBase::pixelPairStep:

--- a/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
@@ -283,7 +283,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      
 	      if((Algo == reco::TrackBase::undefAlgorithm ||
 	          Algo == reco::TrackBase::ctf ||
-	          Algo == reco::TrackBase::rs ||
+	          Algo == reco::TrackBase::duplicateMerge ||
 	          Algo == reco::TrackBase::cosmics ||
 	          Algo == reco::TrackBase::initialStep ||
 	          Algo == reco::TrackBase::lowPtTripletStep ||

--- a/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
@@ -2675,6 +2675,7 @@ unsigned int PFElectronAlgo::whichTrackAlgo(const reco::TrackRef& trackRef) {
   unsigned int Algo = 0; 
   switch (trackRef->algo()) {
   case TrackBase::ctf:
+  case TrackBase::duplicateMerge:
   case TrackBase::initialStep:
   case TrackBase::lowPtTripletStep:
   case TrackBase::pixelPairStep:

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -477,6 +477,7 @@ bool PFElecTkProducer::isFifthStep(reco::PFRecTrackRef pfKfTrack) {
   switch (kfref->algo()) {
   case TrackBase::undefAlgorithm:
   case TrackBase::ctf:
+  case TrackBase::duplicateMerge:
   case TrackBase::initialStep:
   case TrackBase::lowPtTripletStep:
   case TrackBase::pixelPairStep:

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -288,7 +288,6 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
     switch((*ie)->algo()) {
     case reco::TrackBase::undefAlgorithm:
     case reco::TrackBase::ctf:
-    case reco::TrackBase::rs:
     case reco::TrackBase::cosmics:
       nNotIterative++;
       break;
@@ -296,6 +295,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
     case reco::TrackBase::lowPtTripletStep:
     case reco::TrackBase::pixelPairStep:
     case reco::TrackBase::detachedTripletStep:
+    case reco::TrackBase::duplicateMerge:
       break;
     case reco::TrackBase::mixedTripletStep:
     case reco::TrackBase::pixelLessStep:

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -252,11 +252,12 @@ void DuplicateListMerger::produce(edm::StreamID, edm::Event& iEvent, const edm::
   assert(producer.selTracks_->size()==pquals->size());
   
   for (auto isel=0U;isel<nsel;++isel) {
+    algoMask[isel].set(reco::TrackBase::duplicateMerge);
     auto & otk = (*producer.selTracks_)[isel];
     otk.setQualityMask((*pquals)[isel]);
     otk.setAlgorithm(reco::TrackBase::duplicateMerge);
     otk.setOriginalAlgorithm(oriAlgo[isel]);
-    otk.setAlgoMask(algoMask[isel]|reco::TrackBase::duplicateMerge);
+    otk.setAlgoMask(algoMask[isel]);
   }
 
   

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -254,9 +254,9 @@ void DuplicateListMerger::produce(edm::StreamID, edm::Event& iEvent, const edm::
   for (auto isel=0U;isel<nsel;++isel) {
     auto & otk = (*producer.selTracks_)[isel];
     otk.setQualityMask((*pquals)[isel]);
-    otk.setAlgorithm(oriAlgo[isel]);
-    //    otk.setOriginalAlgorithm(oriAlgo[isel]);
-    otk.setAlgoMask(algoMask[isel]);
+    otk.setAlgorithm(reco::TrackBase::duplicateMerge);
+    otk.setOriginalAlgorithm(oriAlgo[isel]);
+    otk.setAlgoMask(algoMask[isel]|reco::TrackBase::duplicateMerge);
   }
 
   


### PR DESCRIPTION
duplicate-Merged tracks were inheriting the algorithm of the innermost piece.
This was causing confusion at many levels (besides the difficulties in validating and analyzing these tracks)

Here we assign them their own algo flag.

purely technical change.  Track migration form previous algo to the new one expected.
see https://innocent.web.cern.ch/innocent/RelVal/pu15_80_dma/
If physics change, there is a bug downstream, most probably in code other than tracker.
