### PR TITLE
Update rivetHarvesting_cfi.py

### DIFF
--- a/GeneratorInterface/RivetInterface/python/rivetHarvesting_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/rivetHarvesting_cfi.py
@@ -4,8 +4,8 @@ rivetHarvesting = cms.EDAnalyzer('RivetHarvesting',
   AnalysisNames = cms.vstring('CMS_2010_S8808686', 'MC_DIPHOTON', 'MC_JETS', 'MC_GENERIC'),
   CrossSection = cms.double(1000),
   HepMCCollection = cms.InputTag('generatorSmeared'),
-  OutputFile = cms.string('out.aida'),
-  FilesToHarvest = cms.vstring('file1.aida', 'file2.aida'),
+  OutputFile = cms.string('out.yoda'),
+  FilesToHarvest = cms.vstring('file1.yoda', 'file2.yoda'),
   VSumOfWeights = cms.vdouble(1.0, 1.0),
   VCrossSections = cms.vdouble(1.0, 1.0)
 )


### PR DESCRIPTION
Default name of output should be '.yoda' since Rivet 2.X
