### PR TITLE
Fixes to PackedCandidate (76X)

### DIFF
--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -13,9 +13,9 @@ namespace logintpack
         int8_t pack8logCeil(double x,double lmin, double lmax, uint8_t base=128)
         {
                 if(base>128) base=128;
-                float l =log(fabs(x));
-                float centered = (l-lmin)/(lmax-lmin)*base;
-                int8_t  r=ceil(centered);
+                const double l = std::log(std::abs(x));
+                const double centered = (l-lmin)/(lmax-lmin)*base;
+                int8_t  r=std::ceil(centered);
                 if(centered >= base-1) r=base-1;
                 if(centered < 0) r=0;
                 if(x<0) r = r==0 ? -1 : -r;
@@ -25,8 +25,8 @@ namespace logintpack
 	int8_t pack8log(double x,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
-		float l =log(fabs(x));
-		float centered = (l-lmin)/(lmax-lmin)*base;
+		const double l = std::log(std::abs(x));
+		const double centered = (l-lmin)/(lmax-lmin)*base;
 		int8_t  r=centered;
 		if(centered >= base-1) r=base-1;
 		if(centered < 0) r=0;
@@ -39,8 +39,8 @@ namespace logintpack
 	int8_t pack8logClosed(double x,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
-		float l =log(fabs(x));
-		float centered = (l-lmin)/(lmax-lmin)*(base-1);
+		const double l = std::log(std::abs(x));
+		const double centered = (l-lmin)/(lmax-lmin)*(base-1);
 		int8_t  r=round(centered);
 		if(centered >= base-1) r=base-1;
 		if(centered < 0) r=0;
@@ -52,9 +52,9 @@ namespace logintpack
 	double unpack8log(int8_t i,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
-	        float basef=base;
-		float l=lmin+abs(i)/basef*(lmax-lmin);
-		float val=exp(l);
+	        const double basef=base;
+		const double l=lmin+std::abs(i)/basef*(lmax-lmin);
+		const double val=std::exp(l);
 		if(i<0) return -val; else return val;
 	}
 
@@ -62,10 +62,10 @@ namespace logintpack
 	double unpack8logClosed(int8_t i,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
-	        float basef=base-1;
-		float l=lmin+abs(i)/basef*(lmax-lmin);
-                if (abs(i) == base-1) l = lmax;
-		float val=exp(l);
+	        const double basef=base-1;
+		double l=lmin+std::abs(i)/basef*(lmax-lmin);
+		if (std::abs(i) == base-1) l = lmax;
+		const double val=std::exp(l);
 		if(i<0) return -val; else return val;
 	}
 

--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -5,6 +5,11 @@
 
 namespace logintpack
 {
+        constexpr int8_t smallestPositive = 0;
+        // note that abs(unpack(smallestNegative)) == unpack(1), i.e. there
+        // is no "x" such that "unpack(x) == -unpack(0)"
+        constexpr int8_t smallestNegative = -1;
+
         int8_t pack8logCeil(double x,double lmin, double lmax, uint8_t base=128)
         {
                 if(base>128) base=128;
@@ -13,7 +18,7 @@ namespace logintpack
                 int8_t  r=ceil(centered);
                 if(centered >= base-1) r=base-1;
                 if(centered < 0) r=0;
-                if(x<0) r=-r;
+                if(x<0) r = r==0 ? -1 : -r;
                 return r;
         }
 
@@ -25,7 +30,7 @@ namespace logintpack
 		int8_t  r=centered;
 		if(centered >= base-1) r=base-1;
 		if(centered < 0) r=0;
-		if(x<0) r=-r;
+		if(x<0) r = r==0 ? -1 : -r;
 		return r;
 	}
 
@@ -39,7 +44,7 @@ namespace logintpack
 		int8_t  r=round(centered);
 		if(centered >= base-1) r=base-1;
 		if(centered < 0) r=0;
-		if(x<0) r=-r;
+		if(x<0) r = r==0 ? -1 : -r;
 		return r;
 	}
 

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -144,11 +144,13 @@ pat::PackedCandidate::~PackedCandidate() {
 
 float pat::PackedCandidate::dxy(const Point &p) const {
 	maybeUnpackBoth();
-	return -(vertex_.load()->X()-p.X()) * std::sin(float(p4_.load()->Phi())) + (vertex_.load()->Y()-p.Y()) * std::cos(float(p4_.load()->Phi()));
+	const float phi = float(p4_.load()->Phi())+dphi_;
+	return -(vertex_.load()->X()-p.X()) * std::sin(phi) + (vertex_.load()->Y()-p.Y()) * std::cos(phi);
 }
 float pat::PackedCandidate::dz(const Point &p) const {
     maybeUnpackBoth();
-    return (vertex_.load()->Z()-p.Z())  - ((vertex_.load()->X()-p.X()) * std::cos(float(p4_.load()->Phi())) + (vertex_.load()->Y()-p.Y()) * std::sin(float(p4_.load()->Phi()))) * p4_.load()->Pz()/p4_.load()->Pt();
+    const float phi = float(p4_.load()->Phi())+dphi_;
+    return (vertex_.load()->Z()-p.Z())  - ((vertex_.load()->X()-p.X()) * std::cos(phi) + (vertex_.load()->Y()-p.Y()) * std::sin(phi)) * p4_.load()->Pz()/p4_.load()->Pt();
 }
 
 void pat::PackedCandidate::unpackTrk() const {

--- a/DataFormats/PatCandidates/test/BuildFile.xml
+++ b/DataFormats/PatCandidates/test/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/PatCandidates"/>
-<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testPackedGenParticle.cc,testRunner.cpp"/>
+<bin name="testDataFormatsPatCandidates" file="testPackedCandidate.cc,testPackedGenParticle.cc,testlogintpack.cpp,testRunner.cpp"/>
 <bin   name="testKinResolutions" file="testKinParametrizations.cc,testKinResolutions.cc,testRunner.cpp">
   <flags   NO_TESTRUN="1"/>
 </bin>

--- a/DataFormats/PatCandidates/test/testlogintpack.cpp
+++ b/DataFormats/PatCandidates/test/testlogintpack.cpp
@@ -1,6 +1,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <iostream>
 #include <iomanip>
+#include <limits>
 
 #include "DataFormats/PatCandidates/interface/liblogintpack.h"
 
@@ -20,11 +21,11 @@ private:
 };
 
 namespace {
-  double pack(double x)         { return logintpack::pack8log        (x, -15, 0); }
-  double packceil(double x)     { return logintpack::pack8logCeil    (x, -15, 0); }
-  double packclosed(double x)   { return logintpack::pack8log        (x, -15, 0); }
-  double unpack(int8_t x)       { return logintpack::unpack8log      (x, -15, 0); }
-  double unpackclosed(int8_t x) { return logintpack::unpack8logClosed(x, -15, 0); }
+  int8_t pack(double x)          { return logintpack::pack8log        (x, -15, 0); }
+  int8_t packceil(double x)      { return logintpack::pack8logCeil    (x, -15, 0); }
+  int8_t packclosed(double x)    { return logintpack::pack8log        (x, -15, 0); }
+  double unpack(int8_t x)        { return logintpack::unpack8log      (x, -15, 0); }
+  double unpackclosed(int8_t x)  { return logintpack::unpack8logClosed(x, -15, 0); }
 }
 
 void testlogintpack::test() {
@@ -33,9 +34,9 @@ void testlogintpack::test() {
   constexpr int8_t largestPositive = 127;
   constexpr int8_t largestNegative = -127;
 
-  const float smallestValuePos = std::exp(-15.f);
-  const float smallestValueNeg = -std::exp(-15.f+1.f/128.f*15.f);
-  const float smallestValueNegForClosed = -std::exp(-15.f+1.f/127.f*15.f);
+  const double smallestValuePos = std::exp(-15.);
+  const double smallestValueNeg = -std::exp(-15.+1./128.*15.);
+  const double smallestValueNegForClosed = -std::exp(-15.+1./127.*15.);
   CPPUNIT_ASSERT(pack(smallestValuePos) == smallestPositive);
   CPPUNIT_ASSERT(packceil(smallestValuePos) == smallestPositive);
   CPPUNIT_ASSERT(packclosed(smallestValuePos) == smallestPositive);
@@ -49,9 +50,8 @@ void testlogintpack::test() {
   CPPUNIT_ASSERT(unpack(packceil(smallestValueNeg)) == smallestValueNeg);
   CPPUNIT_ASSERT(unpackclosed(packclosed(smallestValueNegForClosed)) == smallestValueNegForClosed);
 
-  const float largestValuePos = std::exp(-15.f+127.f/128.f*15.f);
-  const float largestValueNeg = -largestValuePos;
-  CPPUNIT_ASSERT(pack(std::exp(0.f)) == largestPositive); // this one actually overflows
+  const double largestValuePos = std::exp(-15.+127./128.*15.);
+  const double largestValueNeg = -largestValuePos;
   CPPUNIT_ASSERT(pack(largestValuePos) == largestPositive);
   CPPUNIT_ASSERT(packceil(largestValuePos) == largestPositive);
   CPPUNIT_ASSERT(unpack(largestPositive) == largestValuePos);
@@ -60,12 +60,32 @@ void testlogintpack::test() {
   CPPUNIT_ASSERT(packceil(largestValueNeg) == largestNegative);
   CPPUNIT_ASSERT(unpack(largestNegative) == largestValueNeg);
 
-  const float largestValueClosedPos = std::exp(0.f);
-  const float largestValueClosedNeg = -largestValueClosedPos;
+  const double largestValueClosedPos = std::exp(0.);
+  const double largestValueClosedNeg = -largestValueClosedPos;
   CPPUNIT_ASSERT(packclosed(largestValueClosedPos) == largestPositive);
   CPPUNIT_ASSERT(unpackclosed(largestPositive) == largestValueClosedPos);
   CPPUNIT_ASSERT(packclosed(largestValueClosedNeg) == largestNegative);
   CPPUNIT_ASSERT(unpackclosed(largestNegative) == largestValueClosedNeg);
+
+  const double someValue = std::exp(-15. + 1/128.*15.);
+  const float someValueFloat = std::exp(-15.f + 1/128.f*15.f);
+  CPPUNIT_ASSERT(unpack(packceil(someValue)) == someValue);
+  CPPUNIT_ASSERT(static_cast<float>(unpack(packceil(someValue))) == someValueFloat);
+  {
+    union { float flt; uint32_t i32; } conv;
+    conv.flt = someValueFloat;
+    conv.i32 += 1;
+    const float someValuePlus1Ulp32 = conv.flt;
+    CPPUNIT_ASSERT(static_cast<float>(unpack(packceil(someValuePlus1Ulp32))) >= someValuePlus1Ulp32);
+  }
+  {
+    union { double flt; uint64_t i64; } conv;
+    conv.flt = someValue;
+    conv.i64 += 1;
+    const float someValuePlus1Ulp64 = conv.flt;
+    CPPUNIT_ASSERT(unpack(packceil(someValuePlus1Ulp64)) >= someValuePlus1Ulp64);
+  }
+
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testlogintpack);

--- a/DataFormats/PatCandidates/test/testlogintpack.cpp
+++ b/DataFormats/PatCandidates/test/testlogintpack.cpp
@@ -1,0 +1,72 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <iostream>
+#include <iomanip>
+
+#include "DataFormats/PatCandidates/interface/liblogintpack.h"
+
+class testlogintpack : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testlogintpack);
+
+  CPPUNIT_TEST(test);
+
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void test();
+
+private:
+};
+
+namespace {
+  double pack(double x)         { return logintpack::pack8log        (x, -15, 0); }
+  double packceil(double x)     { return logintpack::pack8logCeil    (x, -15, 0); }
+  double packclosed(double x)   { return logintpack::pack8log        (x, -15, 0); }
+  double unpack(int8_t x)       { return logintpack::unpack8log      (x, -15, 0); }
+  double unpackclosed(int8_t x) { return logintpack::unpack8logClosed(x, -15, 0); }
+}
+
+void testlogintpack::test() {
+  using logintpack::smallestPositive;
+  using logintpack::smallestNegative;
+  constexpr int8_t largestPositive = 127;
+  constexpr int8_t largestNegative = -127;
+
+  const float smallestValuePos = std::exp(-15.f);
+  const float smallestValueNeg = -std::exp(-15.f+1.f/128.f*15.f);
+  const float smallestValueNegForClosed = -std::exp(-15.f+1.f/127.f*15.f);
+  CPPUNIT_ASSERT(pack(smallestValuePos) == smallestPositive);
+  CPPUNIT_ASSERT(packceil(smallestValuePos) == smallestPositive);
+  CPPUNIT_ASSERT(packclosed(smallestValuePos) == smallestPositive);
+  CPPUNIT_ASSERT(unpack(smallestPositive) == smallestValuePos);
+  CPPUNIT_ASSERT(unpackclosed(smallestPositive) == smallestValuePos);
+
+  CPPUNIT_ASSERT(pack(smallestValueNeg) == smallestNegative);
+  CPPUNIT_ASSERT(packceil(smallestValueNeg) == smallestNegative);
+  CPPUNIT_ASSERT(unpack(smallestNegative) == smallestValueNeg);
+  CPPUNIT_ASSERT(unpack(pack(smallestValueNeg)) == smallestValueNeg);
+  CPPUNIT_ASSERT(unpack(packceil(smallestValueNeg)) == smallestValueNeg);
+  CPPUNIT_ASSERT(unpackclosed(packclosed(smallestValueNegForClosed)) == smallestValueNegForClosed);
+
+  const float largestValuePos = std::exp(-15.f+127.f/128.f*15.f);
+  const float largestValueNeg = -largestValuePos;
+  CPPUNIT_ASSERT(pack(std::exp(0.f)) == largestPositive); // this one actually overflows
+  CPPUNIT_ASSERT(pack(largestValuePos) == largestPositive);
+  CPPUNIT_ASSERT(packceil(largestValuePos) == largestPositive);
+  CPPUNIT_ASSERT(unpack(largestPositive) == largestValuePos);
+
+  CPPUNIT_ASSERT(pack(largestValueNeg) == largestNegative);
+  CPPUNIT_ASSERT(packceil(largestValueNeg) == largestNegative);
+  CPPUNIT_ASSERT(unpack(largestNegative) == largestValueNeg);
+
+  const float largestValueClosedPos = std::exp(0.f);
+  const float largestValueClosedNeg = -largestValueClosedPos;
+  CPPUNIT_ASSERT(packclosed(largestValueClosedPos) == largestPositive);
+  CPPUNIT_ASSERT(unpackclosed(largestPositive) == largestValueClosedPos);
+  CPPUNIT_ASSERT(packclosed(largestValueClosedNeg) == largestNegative);
+  CPPUNIT_ASSERT(unpackclosed(largestNegative) == largestValueClosedNeg);
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testlogintpack);
+


### PR DESCRIPTION
Backport of #12581. Copied description:
- Add missing `+dphi_` to `dxy(Point)` and `dz(Point)`
  - Otherwise they give different results than `dxy()` and `dzAssociatedPV()` for the point of associated PV
  - Note that this does not affect packing, only unpacking
- Fix smallest negative being packed as smallest positive
  - Currently negative numbers whose `abs(pack(x)) < 1` (e.g. (`-exp(lmin)`) get packed as `0`, which is unpacked as the smallest positive numbers (`exp(lmin)`)
  - Here the issue is fixed by packing such negative numbers as `-1`
  - It follows that for negative numbers the smallest unpacked value (by abs) is `-exp(lmin + 1/base*(lmax-lmin))`, while for positive numbers the smallest value is `exp(lmin)`
- Use doubles in intermediate steps in liblogintpack
  - With floats current `pack8logCeil()` rounds towards zero for certain input values

The PR also adds some unit tests for liblogintpack.

Tested in 7_6_1 that short matrix runs, for results relied the tests done in 80X for #12581.

@arizzi @gpetruc 
