### PR TITLE
Fixes to HGC-BH Digitization + Code cleanup.

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -85,7 +85,7 @@ private :
   //handle sim hits
   int maxSimHitsAccTime_;
   double bxTime_;
-  std::unique_ptr<HGCSimHitDataAccumulator> simHitAccumulator_;  
+  std::unique_ptr<hgc::HGCSimHitDataAccumulator> simHitAccumulator_;  
   void resetSimHitDataAccumulator();
 
   //digitizers

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -12,26 +12,22 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h"
+
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h"
 
-typedef float HGCSimData_t;
-
-//15 time samples: 9 pre-samples, 1 in-time, 5 post-samples
-typedef std::array<HGCSimData_t,15> HGCSimHitData;
-
-//1st array=energy, 2nd array=energy weighted time-of-flight
-typedef std::unordered_map<uint32_t, std::array<HGCSimHitData,2> > HGCSimHitDataAccumulator; 
+namespace hgc = hgc_digi;
 
 template <class DFr>
 class HGCDigitizerBase {
  public:
- 
+  
   typedef edm::SortedCollection<DFr> DColl;
-
+  
   /**
      @short CTOR
-   */
- HGCDigitizerBase(const edm::ParameterSet &ps)  {
+  */
+  HGCDigitizerBase(const edm::ParameterSet &ps)  {
     bxTime_        = ps.getParameter<double>("bxTime");
     myCfg_         = ps.getParameter<edm::ParameterSet>("digiCfg"); 
     doTimeSamples_ = myCfg_.getParameter< bool >("doTimeSamples");
@@ -43,14 +39,14 @@ class HGCDigitizerBase {
     myFEelectronics_        = std::unique_ptr<HGCFEElectronics<DFr> >( new HGCFEElectronics<DFr>(feCfg) );
   }
       
-  /**
-     @short steer digitization mode
-   */
-  void run(std::auto_ptr<DColl> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType,CLHEP::HepRandomEngine* engine);
-
+ /**
+    @short steer digitization mode
+ */
+  void run(std::auto_ptr<DColl> &digiColl, hgc::HGCSimHitDataAccumulator &simData, uint32_t digitizationType,CLHEP::HepRandomEngine* engine);
+  
   /**
      @short getters
-   */
+  */
   float keV2fC() const { return keV2fC_; }
   bool toaModeByEnergy() const { return (myFEelectronics_->toaMode()==HGCFEElectronics<DFr>::WEIGHTEDBYE); }
   float tdcOnset() const { return myFEelectronics_->getTDCOnset(); }
@@ -58,24 +54,24 @@ class HGCDigitizerBase {
   /**
      @short a trivial digitization: sum energies and digitize without noise
    */
-  void runSimple(std::auto_ptr<DColl> &coll,HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
-
+  void runSimple(std::auto_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
+  
   /**
      @short prepares the output according to the number of time samples to produce
-   */
-  void updateOutput(std::auto_ptr<DColl> &coll,const DFr& rawDataFrame);
-
+  */
+  void updateOutput(std::auto_ptr<DColl> &coll, const DFr& rawDataFrame);
+  
   /**
      @short to be specialized by top class
-   */
-  virtual void runDigitizer(std::auto_ptr<DColl> &coll,HGCSimHitDataAccumulator &simData,uint32_t digitizerType, CLHEP::HepRandomEngine* engine)
+  */
+  virtual void runDigitizer(std::auto_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizerType, CLHEP::HepRandomEngine* engine)
   {
     throw cms::Exception("HGCDigitizerBaseException") << " Failed to find specialization of runDigitizer";
   }
-
+  
   /**
      @short DTOR
-   */
+  */
   ~HGCDigitizerBase() 
     { };
   

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h
@@ -1,0 +1,20 @@
+#ifndef __SimCalorimetry_HGCCalSimProducers_HGCDigitizerTypes_h__
+#define __SimCalorimetry_HGCCalSimProducers_HGCDigitizerTypes_h__
+
+#include <unordered_map>
+#include <array>
+
+namespace hgc_digi {
+
+  //15 time samples: 9 pre-samples, 1 in-time, 5 post-samples
+  constexpr size_t nSamples = 15;
+  
+  typedef float HGCSimData_t;
+  
+  typedef std::array<HGCSimData_t,nSamples> HGCSimHitData;
+  
+  //1st array=energy, 2nd array=energy weighted time-of-flight
+  typedef std::unordered_map<uint32_t, std::array<HGCSimHitData,2> > HGCSimHitDataAccumulator; 
+
+}
+#endif

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
@@ -8,7 +8,7 @@ class HGCEEDigitizer : public HGCDigitizerBase<HGCEEDataFrame> {
 
 public:
   HGCEEDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::auto_ptr<HGCEEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::auto_ptr<HGCEEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
   ~HGCEEDigitizer();
 private:
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -7,16 +7,20 @@
 #include "CLHEP/Random/RandGauss.h"
 #include "CLHEP/Random/RandGaussQ.h"
 
+#include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h"
+
 /**
    @class HGCFEElectronics
    @short models the behavior of the front-end electronics
  */
 
+namespace hgc = hgc_digi;
+
 template <class DFr>
 class HGCFEElectronics
 {
  public:
-
+  
   enum HGCFEElectronicsFirmwareVersion { TRIVIAL, SIMPLE, WITHTOT };
   enum HGCFEElectronicsTOTMode { WEIGHTEDBYE, SIMPLETHRESHOLD };
 
@@ -28,7 +32,8 @@ class HGCFEElectronics
   /**
      @short switches according to the firmware version
    */
-  inline void runShaper(DFr &dataFrame,std::vector<float> &chargeColl,std::vector<float> &toa, CLHEP::HepRandomEngine* engine)
+  inline void runShaper(DFr &dataFrame, hgc::HGCSimHitData& chargeColl, 
+                        hgc::HGCSimHitData& toa, CLHEP::HepRandomEngine* engine)
   {    
     switch(fwVersion_)
       {
@@ -50,25 +55,24 @@ class HGCFEElectronics
   /**
      @short converts charge to digis without pulse shape
    */
-  void runTrivialShaper(DFr &dataFrame,std::vector<float> &chargeColl);
+  void runTrivialShaper(DFr &dataFrame, hgc::HGCSimHitData& chargeColl);
 
   /**
      @short applies a shape to each time sample and propagates the tails to the subsequent time samples
    */
-  void runSimpleShaper(DFr &dataFrame,std::vector<float> &chargeColl);
+  void runSimpleShaper(DFr &dataFrame, hgc::HGCSimHitData& chargeColl);
 
   /**
      @short implements pulse shape and switch to time over threshold including deadtime
    */
-  void runShaperWithToT(DFr &dataFrame,std::vector<float> &chargeColl,std::vector<float> &toa, CLHEP::HepRandomEngine* engine);
+  void runShaperWithToT(DFr &dataFrame, hgc::HGCSimHitData& chargeColl, 
+                        hgc::HGCSimHitData& toa, CLHEP::HepRandomEngine* engine);
 
   /**
      @short returns how ToT will be computed
    */
   uint32_t toaMode() const { return toaMode_; }
   
-  void resetCaches();
-
   /**
      @short DTOR
    */
@@ -83,8 +87,8 @@ class HGCFEElectronics
     adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_, tdcResolutionInNs_; 
   uint32_t toaMode_;
   //caches
-  std::vector<bool>  busyFlags, totFlags;
-  std::vector<float> newCharge, toaFromToT;
+  std::array<bool,hgc::nSamples>  busyFlags, totFlags;
+  hgc::HGCSimHitData newCharge, toaFromToT;
 };
 
 #endif

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
@@ -4,13 +4,12 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 
-
 class HGCHEbackDigitizer : public HGCDigitizerBase<HGCHEDataFrame>
 {
  public:
 
   HGCHEbackDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
   ~HGCHEbackDigitizer();
 
  private:
@@ -18,7 +17,7 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCHEDataFrame>
   //calice-like digitization parameters
   float keV2MIP_, noise_MIP_;
   float nPEperMIP_, nTotalPE_, xTalk_, sdPixels_;
-  void runCaliceLikeDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
+  void runCaliceLikeDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
 };
 
 #endif 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
@@ -8,7 +8,7 @@ class HGCHEfrontDigitizer : public HGCDigitizerBase<HGCHEDataFrame> {
 
 public:
   HGCHEfrontDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
   ~HGCHEfrontDigitizer();
 private:
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -120,7 +120,7 @@ hgchebackDigitizer = cms.PSet(
         noise_MIP         = cms.double(0.20),
         doTimeSamples = cms.bool(False),
         nPEperMIP = cms.double(11.0),
-        nTotalPE  = cms.double(11560), #1156 pixels => saturation ~600MIP
+        nTotalPE  = cms.double(1156), #1156 pixels => saturation ~600MIP
         xTalk     = cms.double(0.25),
         sdPixels  = cms.double(3.0),
         feCfg   = cms.PSet( 
@@ -129,7 +129,7 @@ hgchebackDigitizer = cms.PSet(
             # n bits for the ADC 
             adcNbits        = cms.uint32(12),
             # ADC saturation : in this case we use the same variable but fC=MIP
-            adcSaturation_fC = cms.double(2048),
+            adcSaturation_fC = cms.double(1024),
             # threshold for digi production : in this case we use the same variable but fC=MIP
             adcThreshold_fC = cms.double(1.0)
             )

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -1,5 +1,7 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h"
 
+using namespace hgc_digi;
+
 template<class DFr>
 void HGCDigitizerBase<DFr>::run( std::auto_ptr<HGCDigitizerBase::DColl> &digiColl,
                                   HGCSimHitDataAccumulator &simData,
@@ -13,12 +15,12 @@ template<class DFr>
 void HGCDigitizerBase<DFr>::runSimple(std::auto_ptr<HGCDigitizerBase::DColl> &coll,
                                        HGCSimHitDataAccumulator &simData, 
                                        CLHEP::HepRandomEngine* engine) {
-  std::vector<float> chargeColl,toa;
+  HGCSimHitData chargeColl,toa;
   for(HGCSimHitDataAccumulator::iterator it=simData.begin();
       it!=simData.end();
       it++) {
-    chargeColl.resize(it->second[0].size()); 
-    toa.resize(it->second[0].size());
+    chargeColl.fill(0.f); 
+    toa.fill(0.f);
     for(size_t i=0; i<it->second[0].size(); i++) {
       double rawCharge((it->second)[0][i]);
       
@@ -45,9 +47,7 @@ void HGCDigitizerBase<DFr>::runSimple(std::auto_ptr<HGCDigitizerBase::DColl> &co
     
     //update the output according to the final shape
     updateOutput(coll,rawDataFrame);
-  }
-
-  myFEelectronics_->resetCaches();
+  }  
 }
 
 template<class DFr>

--- a/SimCalorimetry/HGCalSimProducers/src/HGCEEDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCEEDigitizer.cc
@@ -1,5 +1,7 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h"
 
+using namespace hgc_digi;
+
 //
 HGCEEDigitizer::HGCEEDigitizer(const edm::ParameterSet& ps) : HGCDigitizerBase(ps) { }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -5,11 +5,14 @@
 
 #include "vdt/vdtMath.h"
 
+using namespace hgc_digi;
+
 //
 HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitizerBase(ps)
 {
   edm::ParameterSet cfg = ps.getParameter<edm::ParameterSet>("digiCfg");
   keV2MIP_   = cfg.getParameter<double>("keV2MIP");
+  keV2fC_    = 1.0; //keV2MIP_; // hack for HEB
   noise_MIP_ = cfg.getParameter<double>("noise_MIP");
   nPEperMIP_ = cfg.getParameter<double>("nPEperMIP");
   nTotalPE_  = cfg.getParameter<double>("nTotalPE");
@@ -26,48 +29,50 @@ void HGCHEbackDigitizer::runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiCo
 //
 void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine)
 {
- 
+
   //switch to true if you want to print some details
-  const bool debug(false);
+  constexpr bool debug(false);
   
-  std::vector<float> chargeColl;
+  HGCSimHitData chargeColl;
   for(HGCSimHitDataAccumulator::iterator it=simData.begin();
       it!=simData.end();
       it++)
     {
-      chargeColl.resize(it->second[0].size());
-      for(size_t i=0; i<it->second[0].size(); i++)
-	{
-	  //convert total energy GeV->keV->MIP
-	  float totalIniMIPs( (it->second)[0][i]*1e6*keV2MIP_ );
-	  	  
+      chargeColl.fill(0.f);      
+      for(size_t i=0; i<it->second[0].size(); ++i)
+	{          
+	  //convert total energy keV->MIP, since converted to keV in accumulator
+	  float totalIniMIPs( (it->second)[0][i]*keV2MIP_ );
+          //std::cout << "energy in MIP: " << std::scientific << totalIniMIPs << std::endl;
+
 	  //generate random number of photon electrons
-	  uint32_t npe = (uint32_t)CLHEP::RandPoissonQ::shoot(engine,totalIniMIPs*nPEperMIP_);
-	  
+	  uint32_t npe = std::floor(CLHEP::RandPoissonQ::shoot(engine,totalIniMIPs*nPEperMIP_));
+          
 	  //number of pixels	
-	  float x=exp(-(float)(npe)/(float)(nTotalPE_));
+	  float x = vdt::fast_expf( -((float)npe)/nTotalPE_ );
 	  uint32_t nPixel(0);
-	  if(xTalk_*x!=1) nPixel=(uint32_t) std::max( float(nTotalPE_*(1-x)/(1-xTalk_*x)), float(0.) );
-	  
+	  if(xTalk_*x!=1) nPixel=(uint32_t) std::max( nTotalPE_*(1.f-x)/(1.f-xTalk_*x), 0.f );
+	            
 	  //update signal
-	  nPixel=(uint32_t)std::max( float(CLHEP::RandGaussQ::shoot(engine,(float)nPixel,(float)sdPixels_)), float(0.) );
-	  
+	  nPixel = (uint32_t)std::max( CLHEP::RandGaussQ::shoot(engine,(double)nPixel,sdPixels_), 0. );
+	            
 	  //convert to MIP again and saturate
 	  float totalMIPs(totalIniMIPs);
-	  if(nTotalPE_!=nPixel && (nTotalPE_-xTalk_*nPixel)/(nTotalPE_-nPixel)>0 )
-	    totalMIPs = (nTotalPE_/nPEperMIP_)*vdt::fast_logf((nTotalPE_-xTalk_*nPixel)/(nTotalPE_-nPixel));
+          const float xtalk = (nTotalPE_-xTalk_*((float)nPixel))/(nTotalPE_-((float)nPixel));
+	  if( nTotalPE_ != nPixel && xtalk > 0. )
+	    totalMIPs = (nTotalPE_/nPEperMIP_)*vdt::fast_logf(xtalk);
 	  else
-	    totalMIPs = 0;
+	    totalMIPs = 0.f;
 	  
 	  //add noise (in MIPs)
-	  chargeColl[i]=totalMIPs+std::max(CLHEP::RandGaussQ::shoot(engine,0.,noise_MIP_),0.);
+	  chargeColl[i] = totalMIPs+std::max( CLHEP::RandGaussQ::shoot(engine,0.,noise_MIP_), 0. );
 	  if(debug && (it->second)[0][i]>0) 
-	    std::cout << "[runCaliceLikeDigitizer] En=" << (it->second)[0][i]*1e6 << " keV = " << totalIniMIPs << " MIPs -> " << chargeColl[i] << " MIPs" << std::endl;
+	    std::cout << "[runCaliceLikeDigitizer] xtalk=" << xtalk << " En=" << (it->second)[0][i] << " keV -> " << totalIniMIPs << " raw-MIPs -> " << chargeColl[i] << " digi-MIPs" << std::endl;          
 	}	
       
       //init a new data frame and run shaper
       HGCHEDataFrame newDataFrame( it->first );
-      myFEelectronics_->runTrivialShaper( newDataFrame ,chargeColl);
+      myFEelectronics_->runTrivialShaper( newDataFrame, chargeColl );
 
       //prepare the output
       updateOutput(digiColl,newDataFrame);

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEfrontDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEfrontDigitizer.cc
@@ -1,5 +1,7 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h"
 
+using namespace hgc_digi;
+
 //
 HGCHEfrontDigitizer::HGCHEfrontDigitizer(const edm::ParameterSet &ps) : HGCDigitizerBase(ps) {
 }


### PR DESCRIPTION
This PR fixes the digitization of the backing hadron calorimeter when using the newer version of the ToT digitization.

The main issue was a double conversion of GeV to keV, which resulted in overflows. Likewise there were some conversions of unsigned values to negative floats which had to be casted appropriately.

There was also a minor refactorization of the code, mainly to use std:array where ever possible, and sticking configuration data inside an "hgc_digi" namespace.

I'll post some plots later that demonstrate the now-functioning digitization.
