### PR TITLE
Reorganize sequences for the harvesting modules of PV and V0 validation

### DIFF
--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -14,8 +14,7 @@ from Validation.RecoParticleFlow.PFValidationClient_cff import *
 from Validation.RPCRecHits.postValidation_cfi import *
 from Validation.RecoTau.DQMMCValidation_cfi import *
 from Validation.RecoEgamma.photonFastSimPostProcessor_cff import *
-from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_Client_cfi import *
-from Validation.RecoVertex.PostProcessorV0_cfi import *
+from Validation.RecoVertex.PostProcessorVertex_cff import *
 from Validation.RecoMET.METPostProcessor_cff import *
 from DQMOffline.RecoB.dqmCollector_cff import *
 
@@ -23,8 +22,7 @@ from DQMOffline.RecoB.dqmCollector_cff import *
 postValidation = cms.Sequence(
       recoMuonPostProcessors
     + postProcessorTrackSequence
-    + postProcessorVertex
-    + postProcessorV0
+    + postProcessorVertexSequence
     + MuIsoValPostProcessor
     + calotowersPostProcessor
     + hcalSimHitsPostProcessor

--- a/Validation/RecoVertex/python/PostProcessorVertex_cff.py
+++ b/Validation/RecoVertex/python/PostProcessorVertex_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoVertex.PostProcessorV0_cfi import *
+from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_Client_cfi import *
+
+
+postProcessorVertexSequence = cms.Sequence(
+    postProcessorVertex +
+    postProcessorV0
+)
+
+postProcessorVertexStandAlone = cms.Sequence(postProcessorVertexSequence)

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
@@ -61,5 +61,3 @@ postProcessorVertex = cms.EDAnalyzer("DQMGenericClient",
                                      outputFileName = cms.untracked.string(""),
                                      verbose = cms.untracked.uint32(5)
 )
-
-postProcessorVertexStandAlone = cms.Sequence(postProcessorVertex)


### PR DESCRIPTION
This PR creates a common sequence to contain the harvesting modules of primary vertex and V0 validation, and that sequence is then added to postValidation sequence. The main motivation for this reorganization is to include postProcessorV0 in postProcessorVertexStandAlone (since the V0 validation is part of vertexValidationStandalone).

Tested in 800pre2, no changes expected.

@rovere @VinInn 
