### PR TITLE
Speed up makeRef and sorting of trajectory

### DIFF
--- a/DataFormats/Common/interface/DetSetNew.h
+++ b/DataFormats/Common/interface/DetSetNew.h
@@ -75,6 +75,9 @@ namespace edmNew {
     inline
     const_iterator end() const { return data()+m_size;}
 
+   DataContainer const & container() const { return *m_data; }
+
+    int offset() const {return m_offset;}
 
     inline
     id_type id() const { return m_id;}

--- a/DataFormats/Common/interface/DetSetNew.h
+++ b/DataFormats/Common/interface/DetSetNew.h
@@ -1,7 +1,7 @@
 #ifndef DataFormats_Common_DetSetNew_h
 #define DataFormats_Common_DetSetNew_h
 
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include <vector>
 #include <cassert>
 
@@ -75,8 +75,6 @@ namespace edmNew {
     inline
     const_iterator end() const { return data()+m_size;}
 
-   DataContainer const & container() const { return *m_data; }
-
     int offset() const {return m_offset;}
 
     inline
@@ -90,8 +88,19 @@ namespace edmNew {
 
     inline
     bool empty() const { return m_size==0;}
+
+
+    template<typename HandleT>
+    edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>
+    makeRefTo(HandleT const & handle, const_iterator ci) const {
+      return edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>( handle.id(), ci, ci - &(container().front()) );
+    }
+
     
   private:
+
+     DataContainer const & container() const { return *m_data; }
+   
     data_type const * data() const {
       if(m_offset|m_size) assert(m_data);
       return m_data ? (&((*m_data)[m_offset])) : 0;

--- a/DataFormats/Common/interface/DetSetVector.h
+++ b/DataFormats/Common/interface/DetSetVector.h
@@ -468,6 +468,7 @@ namespace edm {
    //helper function to make it easier to create a edm::Ref
 
   template<class HandleT>
+  inline
   Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>
   makeRefTo(const HandleT& iHandle,
              det_id_type iDetID,
@@ -490,6 +491,7 @@ namespace edm {
   }
 
   template<class HandleT>
+  inline
   Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>
   makeRefToDetSetVector(const HandleT& iHandle,
              det_id_type iDetID,

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -694,16 +694,35 @@ namespace edm {
 namespace edmNew {
    //helper function to make it easier to create a edm::Ref to a new DSV
   template<class HandleT>
+  // inline
   edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>
   makeRefTo(const HandleT& iHandle,
              typename HandleT::element_type::value_type::const_iterator itIter) {
     BOOST_MPL_ASSERT((boost::is_same<typename HandleT::element_type, DetSetVector<typename HandleT::element_type::value_type::value_type> >));
-    typename HandleT::element_type::size_type index = (itIter - &*iHandle->data().begin()); 
+    auto index = itIter - &iHandle->data().front(); 
     return edm::Ref<typename HandleT::element_type,
 	       typename HandleT::element_type::value_type::value_type>
-	      (iHandle,index);
+	      (iHandle.id(), &(*itIter), index);
   }
 }
+
+
+namespace edmNew {
+   //helper function to make it easier to create a edm::Ref to a new DSV
+  template<class HandleT>
+  // inline
+  edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>
+  makeRefTo(const HandleT& iHandle,
+             typename HandleT::element_type::value_type::const_iterator itIter, int index) {
+    BOOST_MPL_ASSERT((boost::is_same<typename HandleT::element_type, DetSetVector<typename HandleT::element_type::value_type::value_type> >));
+    // auto index = itIter - &iHandle->data().front();
+    return edm::Ref<typename HandleT::element_type,
+               typename HandleT::element_type::value_type::value_type>
+              (iHandle.id(), &(*itIter), index);
+  }
+}
+
+
 
 #include "DataFormats/Common/interface/ContainerMaskTraits.h"
 

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -707,22 +707,6 @@ namespace edmNew {
 }
 
 
-namespace edmNew {
-   //helper function to make it easier to create a edm::Ref to a new DSV
-  template<class HandleT>
-  // inline
-  edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>
-  makeRefTo(const HandleT& iHandle,
-             typename HandleT::element_type::value_type::const_iterator itIter, int index) {
-    BOOST_MPL_ASSERT((boost::is_same<typename HandleT::element_type, DetSetVector<typename HandleT::element_type::value_type::value_type> >));
-    // auto index = itIter - &iHandle->data().front();
-    return edm::Ref<typename HandleT::element_type,
-               typename HandleT::element_type::value_type::value_type>
-              (iHandle.id(), &(*itIter), index);
-  }
-}
-
-
 
 #include "DataFormats/Common/interface/ContainerMaskTraits.h"
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -57,10 +57,8 @@ void SiStripRecHitConverterAlgorithm::
 run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& output, LocalVector trackdirection)
 {
 
-  edmNew::DetSetVector<SiStripCluster>::const_iterator dse = inputhandle->end();
-  for (edmNew::DetSetVector<SiStripCluster>::const_iterator 
-	 DS = inputhandle->begin(); DS != dse; ++DS ) {     
-    edmNew::det_id_type id = (*DS).id();
+  for (auto const & DS : *inputhandle) {     
+    auto id = DS.id();
     if(!useModule(id)) continue;
 
     Collector collector = StripSubdetector(id).stereo()  
@@ -70,14 +68,14 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& ou
     bool bad128StripBlocks[6]; fillBad128StripBlocks( id, bad128StripBlocks);
     
     GeomDetUnit const & du = *(tracker->idToDetUnit(id));
-    edmNew::DetSet<SiStripCluster>::const_iterator cle = (*DS).end();
-    for(edmNew::DetSet<SiStripCluster>::const_iterator 
-	  cluster = (*DS).begin();  cluster != cle; ++cluster ) {     
+    for(auto const & cluster : DS) {
 
-      if(isMasked(*cluster,bad128StripBlocks)) continue;
+      if(isMasked(cluster,bad128StripBlocks)) continue;
 
-      StripClusterParameterEstimator::LocalValues parameters = 	parameterestimator->localParameters(*cluster,du);
-      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, du, edmNew::makeRefTo(inputhandle,cluster) ));
+      StripClusterParameterEstimator::LocalValues parameters = 	parameterestimator->localParameters(cluster,du);
+      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, du, 
+                                           edmNew::makeRefTo(inputhandle, &cluster, &cluster - &(DS.container().front())) 
+                                          ));
     }
 
     if (collector.empty()) collector.abort();

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -74,7 +74,7 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& ou
 
       StripClusterParameterEstimator::LocalValues parameters = 	parameterestimator->localParameters(cluster,du);
       collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, du, 
-                                           edmNew::makeRefTo(inputhandle, &cluster, &cluster - &(DS.container().front())) 
+                                           DS.makeRefTo(inputhandle, &cluster) 
                                           ));
     }
 

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -361,7 +361,7 @@ GroupedCkfTrajectoryBuilder::groupedLimitedCandidates (const TrajectorySeed& see
       if ((int)newCand.size() > theMaxCand) {
 	//ShowCand()(newCand);
 
- 	sort( newCand.begin(), newCand.end(), GroupedTrajCandLess(theLostHitPenalty,theFoundHitBonus));
+ 	std::partial_sort( newCand.begin(), newCand.begin()+theMaxCand, newCand.end(), GroupedTrajCandLess(theLostHitPenalty,theFoundHitBonus));
  	newCand.erase( newCand.begin()+theMaxCand, newCand.end());
       }
       LogDebug("CkfPattern")<<"newCand(2): after removing extra candidates.\n"<<PrintoutHelper::dumpCandidates(newCand);

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -361,7 +361,7 @@ GroupedCkfTrajectoryBuilder::groupedLimitedCandidates (const TrajectorySeed& see
       if ((int)newCand.size() > theMaxCand) {
 	//ShowCand()(newCand);
 
- 	std::partial_sort( newCand.begin(), newCand.begin()+theMaxCand, newCand.end(), GroupedTrajCandLess(theLostHitPenalty,theFoundHitBonus));
+ 	std::nth_element( newCand.begin(), newCand.begin()+theMaxCand, newCand.end(), GroupedTrajCandLess(theLostHitPenalty,theFoundHitBonus));
  	newCand.erase( newCand.begin()+theMaxCand, newCand.end());
       }
       LogDebug("CkfPattern")<<"newCand(2): after removing extra candidates.\n"<<PrintoutHelper::dumpCandidates(newCand);

--- a/RecoTracker/CkfPattern/plugins/GroupedTrajCandLess.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedTrajCandLess.h
@@ -10,55 +10,30 @@
  *  a penalty for "lost" hits.
  */
 
-class dso_internal GroupedTrajCandLess : public std::binary_function< const Trajectory&,
-			    const Trajectory&, bool>
+class dso_internal GroupedTrajCandLess
 {
 public:
 
   GroupedTrajCandLess( float p=5, float b=0) : penalty(p), bonus(b) {}
 
-  bool operator()( const Trajectory& a, const Trajectory& b) const {
-    return score(a) < score(b);
-  }
-
-  bool operator()( const TempTrajectory& a, const TempTrajectory& b) const {
+  template<typename T>
+  bool operator()( const T& a, const T& b) const {
     return score(a) < score(b);
   }
 
 private:
-  float score (const Trajectory& t) const
-  {
-//     int ndf(-5);
-//     float chi2(0.);
-//     vector<TrajectoryMeasurement> measurements(t.measurements());
-//     for ( vector<TrajectoryMeasurement>::const_iterator im=measurements.begin();
-// 	  im!=measurements.end(); im++ ) {
-//       if ( im->recHit().isValid() ) {
-// 	ndf += im->recHit().dimension();
-// 	chi2 += im->estimate();
-//       }
-//     }
-
-//     float normChi2(0.);
-//     if ( ndf>0 ) {
-//       // normalise chi2 to number of (2d) hits
-//       normChi2 = chi2/ndf*2;
-//     }
-//     else {
-// //       // include bonus for found hits
-// //       normChi2 = chi2 - ndf/2*penalty;
-//     }
-//     normChi2 -= t.foundHits()*2*b;
-//     return normChi2+t.lostHits()*penalty;
-
-
-    return t.chiSquared()-t.foundHits()*bonus+t.lostHits()*penalty 
-      + 0.5*(1-cos(t.dPhiCacheForLoopersReconstruction()))*penalty;
+  template<typename T>
+  float looperPenalty(const T&t) const {
+    return (t.dPhiCacheForLoopersReconstruction()==0) ? 0.f : 
+     0.5f*(1.f-std::cos(t.dPhiCacheForLoopersReconstruction()))*penalty;
   }
-  float score (const TempTrajectory& t) const
+
+  template<typename T>
+  float score (const T & t) const
   {
+
     return t.chiSquared()-t.foundHits()*bonus+t.lostHits()*penalty 
-      + 0.5*(1-cos(t.dPhiCacheForLoopersReconstruction()))*penalty;
+      + looperPenalty(t);
   }
 
  private:

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -85,7 +85,7 @@ TkPixelMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Measur
        return result;
      }
      if(data.pixelClustersToSkip().empty() or (not data.pixelClustersToSkip()[index]) ) {
-       SiPixelClusterRef cluster = edmNew::makeRefTo( data.pixelData().handle(), ci );
+       SiPixelClusterRef cluster = detSet.makeRefTo( data.pixelData().handle(), ci );
        result.push_back( buildRecHit( cluster, ts.localParameters() ) );
      }else{   
        LogDebug("TkPixelMeasurementDet")<<"skipping this cluster from last iteration on "<<fastGeomDet().geographicalId().rawId()<<" key: "<<index;

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -29,7 +29,7 @@ bool TkStripMeasurementDet::empty(const MeasurementTrackerEvent & data) const {
     const detset & detSet = data.stripData().detSet(index()); 
     for ( auto ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
-      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
+      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci, ci - &(detSet.container().front())  ); 
       if (accept(cluster, data.stripClustersToSkip()))
 	return false;
     }
@@ -47,7 +47,7 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Measur
     for ( new_const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
       // for ( ClusterIterator ci=theClusterRange.first; ci != theClusterRange.second; ci++) {
-      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
+      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci, ci - &(detSet.container().front())  ); 
       if (accept(cluster, data.stripClustersToSkip()))
 	result.push_back( buildRecHit( cluster, ts));
       else LogDebug("TkStripMeasurementDet")<<"skipping this str from last iteration on"<<rawId()<<" key: "<<cluster.key();
@@ -75,14 +75,14 @@ bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,
     // there are hits on the left of the utraj
     auto leftCluster = rightCluster;
     while ( --leftCluster >=  detSet.begin()) {
-      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster ); 
+      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster, leftCluster - &(detSet.container().front()) ); 
       bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
       if(!isCompatible) break; // exit loop on first incompatible hit
       for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();								
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
-    SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster ); 
+    SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster, rightCluster - &(detSet.container().front())); 
     bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
     if(!isCompatible) break; // exit loop on first incompatible hit
     for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
@@ -110,13 +110,13 @@ bool TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& state
     // there are hits on the left of the utraj
     auto leftCluster = rightCluster;
     while ( --leftCluster >=  detSet.begin()) {
-      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster ); 
+      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster, leftCluster - &(detSet.container().front()) ); 
       bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result);
       if(!isCompatible) break; // exit loop on first incompatible hit
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
-    SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster ); 
+    SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster, rightCluster - &(detSet.container().front()) ); 
     bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result);
     if(!isCompatible) break; // exit loop on first incompatible hit
   }
@@ -143,13 +143,13 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, 
       // there are hits on the left of the utraj
       auto leftCluster = rightCluster;
       while ( --leftCluster >=  detSet.begin()) {
-	SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster ); 
+	SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster, leftCluster - &(detSet.container().front()) ); 
 	bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result, diffs);
 	if(!isCompatible) break; // exit loop on first incompatible hit
       }
     }
     for ( ; rightCluster != detSet.end(); rightCluster++) {
-      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster ); 
+      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster, rightCluster - &(detSet.container().front()) ); 
       bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result,diffs);
       if(!isCompatible) break; // exit loop on first incompatible hit
     }
@@ -209,10 +209,9 @@ TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& ts, const 
 
     const detset & detSet = data.stripData().detSet(index()); 
     result.reserve(detSet.size());
-    for ( new_const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
+    for (auto ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
-      // for ( ClusterIterator ci=theClusterRange.first; ci != theClusterRange.second; ci++) {
-      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
+      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci, ci - &(detSet.container().front()) ); 
       if (accept(cluster, data.stripClustersToSkip()))
 	buildSimpleRecHit( cluster, ts,result);
       else LogDebug("TkStripMeasurementDet")<<"skipping this str from last iteration on"<<rawId()<<" key: "<<cluster.key();

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -29,7 +29,7 @@ bool TkStripMeasurementDet::empty(const MeasurementTrackerEvent & data) const {
     const detset & detSet = data.stripData().detSet(index()); 
     for ( auto ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
-      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci, ci - &(detSet.container().front())  ); 
+      SiStripClusterRef  cluster = detSet.makeRefTo( data.stripData().handle(), ci); 
       if (accept(cluster, data.stripClustersToSkip()))
 	return false;
     }
@@ -47,7 +47,7 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Measur
     for ( new_const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
       // for ( ClusterIterator ci=theClusterRange.first; ci != theClusterRange.second; ci++) {
-      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci, ci - &(detSet.container().front())  ); 
+      SiStripClusterRef  cluster = detSet.makeRefTo( data.stripData().handle(), ci); 
       if (accept(cluster, data.stripClustersToSkip()))
 	result.push_back( buildRecHit( cluster, ts));
       else LogDebug("TkStripMeasurementDet")<<"skipping this str from last iteration on"<<rawId()<<" key: "<<cluster.key();
@@ -75,14 +75,14 @@ bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,
     // there are hits on the left of the utraj
     auto leftCluster = rightCluster;
     while ( --leftCluster >=  detSet.begin()) {
-      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster, leftCluster - &(detSet.container().front()) ); 
+      SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
       bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
       if(!isCompatible) break; // exit loop on first incompatible hit
       for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();								
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
-    SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster, rightCluster - &(detSet.container().front())); 
+    SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
     bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
     if(!isCompatible) break; // exit loop on first incompatible hit
     for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
@@ -110,13 +110,13 @@ bool TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& state
     // there are hits on the left of the utraj
     auto leftCluster = rightCluster;
     while ( --leftCluster >=  detSet.begin()) {
-      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster, leftCluster - &(detSet.container().front()) ); 
+      SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
       bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result);
       if(!isCompatible) break; // exit loop on first incompatible hit
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
-    SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster, rightCluster - &(detSet.container().front()) ); 
+    SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
     bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result);
     if(!isCompatible) break; // exit loop on first incompatible hit
   }
@@ -143,13 +143,13 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, 
       // there are hits on the left of the utraj
       auto leftCluster = rightCluster;
       while ( --leftCluster >=  detSet.begin()) {
-	SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), leftCluster, leftCluster - &(detSet.container().front()) ); 
+	SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
 	bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result, diffs);
 	if(!isCompatible) break; // exit loop on first incompatible hit
       }
     }
     for ( ; rightCluster != detSet.end(); rightCluster++) {
-      SiStripClusterRef clusterref = edmNew::makeRefTo( data.stripData().handle(), rightCluster, rightCluster - &(detSet.container().front()) ); 
+      SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
       bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result,diffs);
       if(!isCompatible) break; // exit loop on first incompatible hit
     }
@@ -211,7 +211,7 @@ TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& ts, const 
     result.reserve(detSet.size());
     for (auto ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
-      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci, ci - &(detSet.container().front()) ); 
+      SiStripClusterRef  cluster = detSet.makeRefTo( data.stripData().handle(), ci); 
       if (accept(cluster, data.stripClustersToSkip()))
 	buildSimpleRecHit( cluster, ts,result);
       else LogDebug("TkStripMeasurementDet")<<"skipping this str from last iteration on"<<rawId()<<" key: "<<cluster.key();


### PR DESCRIPTION
Two independent optimizations
makeRef avoiding multiple deferencing of Handle
use nth_element to "sort" Trajectory  (it may produce regression)
