### PR TITLE
 use TrackCollection instead of a view of tracks in muon track isolation (same as #12594 ) 

### DIFF
--- a/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.cc
@@ -20,7 +20,7 @@ using namespace muonisolation;
 using reco::isodeposit::Direction;
 
 PixelTrackExtractor::PixelTrackExtractor( const ParameterSet& par, edm::ConsumesCollector && iC ) :
-  theTrackCollectionToken(iC.consumes<View<Track> >(par.getParameter<edm::InputTag>("inputTrackCollection"))),
+  theTrackCollectionToken(iC.consumes<TrackCollection >(par.getParameter<edm::InputTag>("inputTrackCollection"))),
   theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
   theDiff_r(par.getParameter<double>("Diff_r")),
   theDiff_z(par.getParameter<double>("Diff_z")),
@@ -86,7 +86,7 @@ IsoDeposit PixelTrackExtractor::deposit(const Event & event, const EventSetup & 
 
   deposit.addCandEnergy(muon.pt());
 
-  Handle<View<Track> > tracksH;
+  Handle<TrackCollection> tracksH;
   event.getByToken(theTrackCollectionToken, tracksH);
   //  const TrackCollection tracks = *(tracksH.product());
   LogTrace(metname)<<"***** TRACK COLLECTION SIZE: "<<tracksH->size();

--- a/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.h
@@ -39,7 +39,7 @@ private:
   reco::isodeposit::Direction directionAtPresetRadius(const reco::Track& tk, double bz) const;
 private:
   // Parameter set
-  edm::EDGetTokenT<edm::View<reco::Track> > theTrackCollectionToken; //! Track Collection Token
+  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken; //! Track Collection Token
   std::string theDepositLabel;         //! name for deposit
   double theDiff_r;                    //! transverse distance to vertex
   double theDiff_z;                    //! z distance to vertex

--- a/RecoMuon/MuonIsolation/plugins/TrackExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackExtractor.cc
@@ -13,7 +13,7 @@ using namespace muonisolation;
 using reco::isodeposit::Direction;
 
 TrackExtractor::TrackExtractor( const ParameterSet& par, edm::ConsumesCollector && iC ) :
-  theTrackCollectionToken(iC.consumes<View<Track> >(par.getParameter<edm::InputTag>("inputTrackCollection"))),
+  theTrackCollectionToken(iC.consumes<TrackCollection>(par.getParameter<edm::InputTag>("inputTrackCollection"))),
   theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
   theDiff_r(par.getParameter<double>("Diff_r")),
   theDiff_z(par.getParameter<double>("Diff_z")),
@@ -52,7 +52,7 @@ IsoDeposit TrackExtractor::deposit(const Event & event, const EventSetup & event
   deposit.setVeto( veto(muonDir) );
   deposit.addCandEnergy(muon.pt());
 
-  Handle<View<Track> > tracksH;
+  Handle<TrackCollection> tracksH;
   event.getByToken(theTrackCollectionToken, tracksH);
   //  const TrackCollection tracks = *(tracksH.product());
   LogTrace(metname)<<"***** TRACK COLLECTION SIZE: "<<tracksH->size();

--- a/RecoMuon/MuonIsolation/plugins/TrackExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/TrackExtractor.h
@@ -37,7 +37,7 @@ private:
   reco::IsoDeposit::Veto veto( const reco::IsoDeposit::Direction & dir) const;
 private:
   // Parameter set
-  edm::EDGetTokenT<edm::View<reco::Track> > theTrackCollectionToken; //! Track Collection Label
+  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken; //! Track Collection Label
   std::string theDepositLabel;         //! name for deposit
   double theDiff_r;                    //! transverse distance to vertex
   double theDiff_z;                    //! z distance to vertex

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
@@ -9,17 +9,17 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
 {
   static const std::string metname = "MuonIsolation|TrackSelector";
   result_type result;
-  for (input_type::const_iterator it = tracks.begin(); it != tracks.end(); it++) {
+  for (auto const& tk: tracks) {
 
-//     float tZ = it->vz();
-//     float tD0 = fabs(it->d0());
-//     float tD0Cor = fabs(it->dxy(thePars.beamPoint));
-//     float tEta = it->eta();
-//     float tPhi = it->phi();
-//     unsigned int tHits = it->numberOfValidHits();
-//     float tChi2Ndof = it->normalizedChi2();
-//     float tChi2Prob = ChiSquaredProbability(it->chi2(), it->ndof());
-//     float tPt = it->pt();
+//     float tZ = tk.vz();
+//     float tD0 = fabs(tk.d0());
+//     float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
+//     float tEta = tk.eta();
+//     float tPhi = tk.phi();
+//     unsigned int tHits = tk.numberOfValidHits();
+//     float tChi2Ndof = tk.normalizedChi2();
+//     float tChi2Prob = ChiSquaredProbability(tk.chi2(), tk.ndof());
+//     float tPt = tk.pt();
 
 //     LogTrace(metname)<<"Tk vz: "<<tZ
 // 		     <<",  d0: "<<tD0
@@ -35,13 +35,13 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
     //! someone will have some fun reading the log if Debug is on
     //! the biggest reason is the numberOfValidHits call (the rest are not as costly)
 
-    float tZ = it->vz(); 
-    float tPt = it->pt();
-    float tD0 = fabs(it->d0());  
-    float tD0Cor = fabs(it->dxy(thePars.beamPoint));
-    float tEta = it->eta();
-    float tPhi = it->phi();
-    float tChi2Ndof = it->normalizedChi2();
+    float tZ = tk.vz(); 
+    float tPt = tk.pt();
+    float tD0 = fabs(tk.d0());  
+    float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
+    float tEta = tk.eta();
+    float tPhi = tk.phi();
+    float tChi2Ndof = tk.normalizedChi2();
     LogTrace(metname)<<"Tk vz: "<<tZ
 		     <<",  pt: "<<tPt
 		     <<",  d0: "<<tD0
@@ -59,20 +59,20 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
 
     //! skip if min Hits == 0; assumes any track has at least one valid hit
     if (thePars.nHitsMin > 0 ){
-      unsigned int tHits = it->numberOfValidHits();
+      unsigned int tHits = tk.numberOfValidHits();
       LogTrace(metname)<<", nHits: "<<tHits;
       if ( tHits < thePars.nHitsMin ) continue;
     }
 
     //! similarly here
     if(thePars.chi2ProbMin > 0){
-      float tChi2Prob = ChiSquaredProbability(it->chi2(), it->ndof());
+      float tChi2Prob = ChiSquaredProbability(tk.chi2(), tk.ndof());
       LogTrace(metname)<<", chi2Prob: "<<tChi2Prob<<std::endl;
       if ( tChi2Prob < thePars.chi2ProbMin ) continue;
     }
 
     LogTrace(metname)<<" ..... accepted"<<std::endl;
-    result.push_back(&*it);
+    result.push_back(&tk);
   } 
   return result;
 }

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.h
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.h
@@ -15,7 +15,7 @@ namespace muonisolation {
 
     typedef muonisolation::Range<float> Range;
     typedef std::list<const reco::Track*> result_type;
-    typedef edm::View<reco::Track> input_type;
+    typedef reco::TrackCollection input_type;
     typedef reco::TrackBase::Point BeamPoint;
   
     //!config parameters


### PR DESCRIPTION
use TrackCollection instead of a view of tracks in muon track isolation
the view in the end was never really used

this workaround reduces memory consumption of the muon reco code in HI events.
