### PR TITLE
Fix for on Track Cluster plots in Offline Pixel DQM for HI runs

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -97,15 +97,18 @@ SiPixelHitEfficiencySource.diskOn = False
 SiPixelHitEfficiencySource.ringOn = False
 
 #HI track modules
-hiTracks = "hiGlobalPrimTracks"
+hiTracks = "hiGeneralTracks"
 
 SiPixelTrackResidualSource_HeavyIons = SiPixelTrackResidualSource.clone(
-    TrackCandidateProducer = 'hiPrimTrackCandidates',
-    trajectoryInput = hiTracks
+    TrackCandidateProducer = hiTracks,
+    trajectoryInput = hiTracks,
+    tracksrc=hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
-    trajectoryInput = hiTracks
+    trajectoryInput = hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 

--- a/DQM/SiPixelCommon/python/SiPixelP5DQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelP5DQM_source_cff.py
@@ -107,11 +107,13 @@ hiTracks = "hiGlobalPrimTracks"
 
 SiPixelTrackResidualSource_HeavyIons = SiPixelTrackResidualSource.clone(
     TrackCandidateProducer = 'hiPrimTrackCandidates',
-    trajectoryInput = hiTracks
+    trajectoryInput = hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
-    trajectoryInput = hiTracks
+    trajectoryInput = hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 #DQM service

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -74,7 +74,8 @@ class SiPixelHitEfficiencySource : public DQMEDAnalyzer {
     bool firstRun;
     
     std::map<uint32_t, SiPixelHitEfficiencyModule*> theSiPixelStructure;
-    
+
+    std::string vtxsrc_;    
     int nmissing,nvalid; 
     
     int nvtx_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -71,7 +71,7 @@ class SiPixelTrackResidualSource : public DQMEDAnalyzer {
     edm::EDGetTokenT<std::vector<reco::Track> > trackToken_;
     edm::EDGetTokenT<TrajTrackAssociationCollection> trackAssociationToken_;
     edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clustersrcToken_;
-
+    std::string vtxsrc_;
 
     bool debug_; 
     bool modOn; 

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
@@ -13,8 +13,9 @@ SiPixelHitEfficiencySource = cms.EDAnalyzer("SiPixelHitEfficiencySource",
     bladeOn = cms.untracked.bool(True),
     diskOn = cms.untracked.bool(False),
     updateEfficiencies = cms.untracked.bool(False), 
+    vtxsrc = cms.untracked.string('offlinePrimaryVertices'),
 
-    trajectoryInput = cms.InputTag('rsWithMaterialTracksP5'),  
+    trajectoryInput = cms.InputTag('generalTracks'),  
     applyEdgeCut = cms.untracked.bool(False),
     nSigma_EdgeCut = cms.untracked.double(2.)             
 )

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
@@ -21,6 +21,7 @@ SiPixelTrackResidualSource = cms.EDAnalyzer("SiPixelTrackResidualSource",
     bladeOn = cms.untracked.bool(True),
     diskOn = cms.untracked.bool(True),
     PtMinRes = cms.untracked.double(4.0),
+    vtxsrc= cms.untracked.string("offlinePrimaryVertices"),
 
     trajectoryInput = cms.InputTag('generalTracks')              
 )

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -86,7 +86,8 @@ SiPixelHitEfficiencySource::SiPixelHitEfficiencySource(const edm::ParameterSet& 
    debug_ = pSet_.getUntrackedParameter<bool>("debug", false); 
    applyEdgeCut_ = pSet_.getUntrackedParameter<bool>("applyEdgeCut");
    nSigma_EdgeCut_ = pSet_.getUntrackedParameter<double>("nSigma_EdgeCut");
-   vertexCollectionToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+   vtxsrc_= pSet_.getUntrackedParameter<std::string>("vtxsrc","offlinePrimaryVertices");
+   vertexCollectionToken_ = consumes<reco::VertexCollection>(vtxsrc_);
    tracksrc_ = consumes<TrajTrackAssociationCollection>(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
    clusterCollectionToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(std::string("siPixelClusters"));
 

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -84,7 +84,8 @@ SiPixelTrackResidualSource::SiPixelTrackResidualSource(const edm::ParameterSet& 
    ttrhbuilder_ = pSet_.getParameter<std::string>("TTRHBuilder");
    ptminres_= pSet.getUntrackedParameter<double>("PtMinRes",4.0) ;
    beamSpotToken_ = consumes<reco::BeamSpot>(std::string("offlineBeamSpot"));
-   offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+   vtxsrc_=pSet_.getUntrackedParameter<std::string>("vtxsrc",  "offlinePrimaryVertices");
+   offlinePrimaryVerticesToken_ =  consumes<reco::VertexCollection>(vtxsrc_);// consumes<reco::VertexCollection>(std::string("hiSelectedVertex"));     //"offlinePrimaryVertices"));
    generalTracksToken_ = consumes<reco::TrackCollection>(pSet_.getParameter<edm::InputTag>("tracksrc"));
    tracksrcToken_ = consumes<std::vector<Trajectory> >(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
    trackToken_ = consumes<std::vector<reco::Track> >(pSet_.getParameter<edm::InputTag>("trajectoryInput"));


### PR DESCRIPTION
Important fixies for Pixel DQM in HI runs, it brings back OnTrack Clusters plots and Hit efficiency plots in Pixel Offline DQM. The primary vertex label and tracks label in previous version were wrong for HI running
