### PR TITLE
Fix of OnTrack Clusters plots in Pixel Offline DQM for HI runs

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -97,15 +97,18 @@ SiPixelHitEfficiencySource.diskOn = False
 SiPixelHitEfficiencySource.ringOn = False
 
 #HI track modules
-hiTracks = "hiGlobalPrimTracks"
+hiTracks = "hiGeneralTracks"
 
 SiPixelTrackResidualSource_HeavyIons = SiPixelTrackResidualSource.clone(
-    TrackCandidateProducer = 'hiPrimTrackCandidates',
-    trajectoryInput = hiTracks
+    TrackCandidateProducer = hiTracks,
+    trajectoryInput = hiTracks,
+    tracksrc=hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
-    trajectoryInput = hiTracks
+    trajectoryInput = hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 

--- a/DQM/SiPixelCommon/python/SiPixelP5DQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelP5DQM_source_cff.py
@@ -107,11 +107,13 @@ hiTracks = "hiGlobalPrimTracks"
 
 SiPixelTrackResidualSource_HeavyIons = SiPixelTrackResidualSource.clone(
     TrackCandidateProducer = 'hiPrimTrackCandidates',
-    trajectoryInput = hiTracks
+    trajectoryInput = hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
-    trajectoryInput = hiTracks
+    trajectoryInput = hiTracks,
+    vtxsrc='hiSelectedVertex'
     )
 
 #DQM service

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -74,7 +74,8 @@ class SiPixelHitEfficiencySource : public DQMEDAnalyzer {
     bool firstRun;
     
     std::map<uint32_t, SiPixelHitEfficiencyModule*> theSiPixelStructure;
-    
+
+    std::string vtxsrc_;    
     int nmissing,nvalid; 
     
     int nvtx_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -71,7 +71,7 @@ class SiPixelTrackResidualSource : public DQMEDAnalyzer {
     edm::EDGetTokenT<std::vector<reco::Track> > trackToken_;
     edm::EDGetTokenT<TrajTrackAssociationCollection> trackAssociationToken_;
     edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clustersrcToken_;
-
+    std::string vtxsrc_;
 
     bool debug_; 
     bool modOn; 
@@ -163,6 +163,7 @@ class SiPixelTrackResidualSource : public DQMEDAnalyzer {
     //
 
     std::vector<MonitorElement*> meClPosLayersOnTrack;
+    std::vector<MonitorElement*> meClPosLayersLadVsModOnTrack;
     std::vector<MonitorElement*> meClPosLayersNotOnTrack;
     std::vector<MonitorElement*> meClPosDiskspzOnTrack;
     std::vector<MonitorElement*> meClPosDisksmzOnTrack;

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
@@ -13,8 +13,9 @@ SiPixelHitEfficiencySource = cms.EDAnalyzer("SiPixelHitEfficiencySource",
     bladeOn = cms.untracked.bool(True),
     diskOn = cms.untracked.bool(False),
     updateEfficiencies = cms.untracked.bool(False), 
+    vtxsrc = cms.untracked.string('offlinePrimaryVertices'),
 
-    trajectoryInput = cms.InputTag('rsWithMaterialTracksP5'),  
+    trajectoryInput = cms.InputTag('generalTracks'),  
     applyEdgeCut = cms.untracked.bool(False),
     nSigma_EdgeCut = cms.untracked.double(2.)             
 )

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
@@ -21,6 +21,7 @@ SiPixelTrackResidualSource = cms.EDAnalyzer("SiPixelTrackResidualSource",
     bladeOn = cms.untracked.bool(True),
     diskOn = cms.untracked.bool(True),
     PtMinRes = cms.untracked.double(4.0),
+    vtxsrc= cms.untracked.string("offlinePrimaryVertices"),
 
     trajectoryInput = cms.InputTag('generalTracks')              
 )

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -86,7 +86,8 @@ SiPixelHitEfficiencySource::SiPixelHitEfficiencySource(const edm::ParameterSet& 
    debug_ = pSet_.getUntrackedParameter<bool>("debug", false); 
    applyEdgeCut_ = pSet_.getUntrackedParameter<bool>("applyEdgeCut");
    nSigma_EdgeCut_ = pSet_.getUntrackedParameter<double>("nSigma_EdgeCut");
-   vertexCollectionToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+   vtxsrc_= pSet_.getUntrackedParameter<std::string>("vtxsrc","offlinePrimaryVertices");
+   vertexCollectionToken_ = consumes<reco::VertexCollection>(vtxsrc_);
    tracksrc_ = consumes<TrajTrackAssociationCollection>(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
    clusterCollectionToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(std::string("siPixelClusters"));
 

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -84,7 +84,8 @@ SiPixelTrackResidualSource::SiPixelTrackResidualSource(const edm::ParameterSet& 
    ttrhbuilder_ = pSet_.getParameter<std::string>("TTRHBuilder");
    ptminres_= pSet.getUntrackedParameter<double>("PtMinRes",4.0) ;
    beamSpotToken_ = consumes<reco::BeamSpot>(std::string("offlineBeamSpot"));
-   offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+   vtxsrc_=pSet_.getUntrackedParameter<std::string>("vtxsrc",  "offlinePrimaryVertices");
+   offlinePrimaryVerticesToken_ =  consumes<reco::VertexCollection>(vtxsrc_);// consumes<reco::VertexCollection>(std::string("hiSelectedVertex"));     //"offlinePrimaryVertices"));
    generalTracksToken_ = consumes<reco::TrackCollection>(pSet_.getParameter<edm::InputTag>("tracksrc"));
    tracksrcToken_ = consumes<std::vector<Trajectory> >(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
    trackToken_ = consumes<std::vector<reco::Track> >(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
@@ -480,6 +481,17 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
     meClPosLayersOnTrack.push_back(iBooker.book2D(ss1.str(),ss2.str(),200,-30.,30.,128,-3.2,3.2));
     meClPosLayersOnTrack.at(i-1)->setAxisTitle("Global Z (cm)",1);
     meClPosLayersOnTrack.at(i-1)->setAxisTitle("Global #phi",2);
+
+    int ybins = -1; float ymin = 0.; float ymax = 0.;
+    if (i==1) { ybins = 23; ymin = -11.5; ymax = 11.5; }
+    if (i==2) { ybins = 33; ymin = -17.5; ymax = 17.5; }
+    if (i==3) { ybins = 45; ymin = -24.5; ymax = 24.5; }
+    ss1.str(std::string()); ss1 << "position_" + clustersrc_.label() + "_LadvsMod_Layer_" << i;
+    ss2.str(std::string()); ss2 << "Clusters Layer" << i << "_LadvsMod (on track)";
+    meClPosLayersLadVsModOnTrack.push_back(iBooker.book2D(ss1.str(),ss2.str(),11,-5.5,5.5,ybins,ymin,ymax));
+    meClPosLayersLadVsModOnTrack.at(i-1)->setAxisTitle("z-module",1);
+    meClPosLayersLadVsModOnTrack.at(i-1)->setAxisTitle("Ladder",2);
+
   }
   //fpix
   for (int i = 1; i <= noOfDisks; i++)
@@ -1035,10 +1047,26 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		DBlayer = PixelBarrelName(DetId((*hit).geographicalId()), tTopo, isUpgrade).layerName();
 		float phi = clustgp.phi(); 
 		float z = clustgp.z();
+
+                PixelBarrelName pbn(DetId((*hit).geographicalId()), tTopo, isUpgrade);
+                int ladder = pbn.ladderName();
+                int module = pbn.moduleName();
+
+		PixelBarrelName::Shell sh = pbn.shell(); //enum
+                int ladderSigned=ladder;
+                int moduleSigned=module;
+                // Shell { mO = 1, mI = 2 , pO =3 , pI =4 };
+                int shell = int(sh);
+                // change the module sign for z<0
+                if(shell==1 || shell==2) { moduleSigned = -module; }
+                // change ladeer sign for Outer )x<0)
+                if(shell==1 || shell==3) { ladderSigned = -ladder; }
+
 		for (int i = 0; i < noOfLayers; i++)
 		  {
           if (DBlayer == i + 1) {
              meClPosLayersOnTrack.at(i)->Fill(z,phi);
+	     meClPosLayersLadVsModOnTrack.at(i)->Fill(moduleSigned,ladderSigned);
              meClChargeOnTrack_layers.at(i)->Fill(corrCharge);
              meClSizeOnTrack_layers.at(i)->Fill((*clust).size());
              meClSizeXOnTrack_layers.at(i)->Fill((*clust).sizeX());


### PR DESCRIPTION
Use of correct primary vertex label and track collection labels for HI running and add cluster occupancy plots per module 
