### PR TITLE
PackedCandidates.. comment out parts of unit test that are not expected to work given that data are packed upon creation with precision loss (same as #12430)

### DIFF
--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -50,15 +50,16 @@ void testPackedCandidate::testCopyConstructor() {
   //invalid Refs use a special key
   pat::PackedCandidate pc(lv, v, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
 
-  CPPUNIT_ASSERT(pc.polarP4() == plv);
-  CPPUNIT_ASSERT(pc.p4() == lv);
-  CPPUNIT_ASSERT(pc.vertex() == v);
+  //these by design do not work
+  //  CPPUNIT_ASSERT(pc.polarP4() == plv);
+  //  CPPUNIT_ASSERT(pc.p4() == lv);
+  //  CPPUNIT_ASSERT(pc.vertex() == v);
 
   pat::PackedCandidate copy_pc(pc);
 
-  CPPUNIT_ASSERT(copy_pc.polarP4() == plv);
-  CPPUNIT_ASSERT(copy_pc.p4() == lv);
-  CPPUNIT_ASSERT(copy_pc.vertex() == v);
+  //CPPUNIT_ASSERT(copy_pc.polarP4() == plv);
+  //CPPUNIT_ASSERT(copy_pc.p4() == lv);
+  //CPPUNIT_ASSERT(copy_pc.vertex() == v);
 
   CPPUNIT_ASSERT(&copy_pc.polarP4() != &pc.polarP4());
   CPPUNIT_ASSERT(&copy_pc.p4() != &pc.p4());
@@ -80,11 +81,6 @@ testPackedCandidate::testPackUnpack() {
 
   //invalid Refs use a special key
   pat::PackedCandidate pc(lv, v, -3./4.*3.1416, 11, reco::VertexRefProd(), reco::VertexRef().key());
-
-  CPPUNIT_ASSERT(pc.polarP4() == plv);
-  CPPUNIT_ASSERT(pc.p4() == lv);
-  CPPUNIT_ASSERT(pc.vertex() == v);
-  CPPUNIT_ASSERT(pc.pseudoTrack().p() == lv.P());
 
   pc.pack(true);
   pc.packVtx(true);
@@ -112,10 +108,10 @@ void testPackedCandidate::testSimulateReadFromRoot() {
   //invalid Refs use a special key
   pat::PackedCandidate pc(lv, v, -3./4.*3.1416, 11, reco::VertexRefProd(), reco::VertexRef().key());
 
-  CPPUNIT_ASSERT(pc.polarP4() == plv);
-  CPPUNIT_ASSERT(pc.p4() == lv);
-  CPPUNIT_ASSERT(pc.vertex() == v);
-  CPPUNIT_ASSERT(pc.pseudoTrack().p() == lv.P());
+  //  CPPUNIT_ASSERT(pc.polarP4() == plv);
+  //  CPPUNIT_ASSERT(pc.p4() == lv);
+  //  CPPUNIT_ASSERT(pc.vertex() == v);
+  //  CPPUNIT_ASSERT(pc.pseudoTrack().p() == lv.P());
 
   //When reading back from ROOT, these were not stored and are nulled out
   delete pc.p4_.exchange(nullptr);


### PR DESCRIPTION
backport from 80X to 76X
