### PR TITLE
Message should include file name

### DIFF
--- a/FWCore/Utilities/python/FileUtils.py
+++ b/FWCore/Utilities/python/FileUtils.py
@@ -8,7 +8,7 @@ def loadListFromFile (filename):
     retval = []
     filename = os.path.expanduser (filename)
     if not os.path.exists (filename):
-        print "Error: '%s' file does not exist."
+        print "Error: file '%s' does not exist."%(filename)
         raise RuntimeError("Bad filename")
     source = open (filename, 'r')        
     for line in source.readlines():


### PR DESCRIPTION
An error message due to a missing file was printed out containing literally '%s' instead of the file name. This trivial PR fixes this. Problem reported by Andreas Kuensken.
