### PR TITLE
Slhc26 me0 segment time pr v2

### DIFF
--- a/DataFormats/GEMDigi/interface/ME0DigiPreReco.h
+++ b/DataFormats/GEMDigi/interface/ME0DigiPreReco.h
@@ -16,7 +16,7 @@ class ME0DigiPreReco{
 
 public:
 //  explicit ME0DigiPreReco (float x, float y, float ex, float ey, float corr, float tof);
-  explicit ME0DigiPreReco (float x, float y, float ex, float ey, float corr, float tof, int pdgid);
+  explicit ME0DigiPreReco (float x, float y, float ex, float ey, float corr, float tof, int pdgid, bool prompt);
   ME0DigiPreReco ();
 
   bool operator==(const ME0DigiPreReco& digi) const;
@@ -29,8 +29,9 @@ public:
   float ey() const { return ey_; }
   float corr() const { return corr_; }
   float tof() const { return tof_;}
-//cesare changes
+  // coding mc-truth
   int pdgid() const { return pdgid_;}
+  bool prompt() const { return prompt_;}
   void print() const;
 
 private:
@@ -40,8 +41,9 @@ private:
   float ey_;
   float corr_;
   float tof_;
-//cesare changes
+  // coding mc-truth
   int pdgid_;
+  bool prompt_;
 };
 
 std::ostream & operator<<(std::ostream & o, const ME0DigiPreReco& digi);

--- a/DataFormats/GEMDigi/src/ME0DigiPreReco.cc
+++ b/DataFormats/GEMDigi/src/ME0DigiPreReco.cc
@@ -11,14 +11,15 @@
 #include <iostream>
 
 //ME0DigiPreReco::ME0DigiPreReco (float x, float y, float ex, float ey, float corr, float tof) :
-ME0DigiPreReco::ME0DigiPreReco (float x, float y, float ex, float ey, float corr, float tof, int pdgid) :
+ME0DigiPreReco::ME0DigiPreReco (float x, float y, float ex, float ey, float corr, float tof, int pdgid, bool prompt) :
   x_(x),
   y_(y),
   ex_(ex),
   ey_(ey),
   corr_(corr),
   tof_(tof),
-  pdgid_(pdgid)
+  pdgid_(pdgid),
+  prompt_(prompt)
 {}
 
 ME0DigiPreReco::ME0DigiPreReco ():
@@ -28,7 +29,8 @@ ME0DigiPreReco::ME0DigiPreReco ():
   ey_(0.),
   corr_(0.),
   tof_(-1.),
-  pdgid_(0)
+  pdgid_(0),
+  prompt_(0)
 {}
 
 
@@ -63,12 +65,12 @@ bool ME0DigiPreReco::operator<(const ME0DigiPreReco& digi) const
 std::ostream & operator<<(std::ostream & o, const ME0DigiPreReco& digi)
 {
 //  return o << "local x=" << digi.x() << " cm y=" << digi.y()<<" cm ex=" << digi.ex() << " cm ey=" << digi.ey()<< " cm tof="<<digi.tof()<<" ns";
-  return o << "local x=" << digi.x() << " cm y=" << digi.y()<<" cm ex=" << digi.ex() << " cm ey=" << digi.ey()<< " cm tof="<<digi.tof()<<" ns"<<" pdgID "<<digi.pdgid();
+  return o << "local x=" << digi.x() << " cm y=" << digi.y()<<" cm ex=" << digi.ex() << " cm ey=" << digi.ey()<< " cm tof="<<digi.tof()<<" ns"<<" pdgID "<<digi.pdgid()<<" prompt? "<<digi.prompt();
 }
 
 void ME0DigiPreReco::print() const
 {
 //  std::cout << "local x=" << this->x() << " cm y=" << this->y() <<" cm tof="<<this->tof()<<" ns"<<std::endl;
-  std::cout << "local x=" << this->x() << " cm y=" << this->y() <<" cm tof="<<this->tof()<<" ns"<<" pdgID "<<this->pdgid()<<std::endl;
+  std::cout << "local x=" << this->x() << " cm y=" << this->y() <<" cm tof="<<this->tof()<<" ns"<<" pdgID "<<this->pdgid()<<" prompt? "<<this->prompt()<<std::endl;
 }
 

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -24,9 +24,10 @@
 <class name="MuonDigiCollection<GEMDetId,GEMCSCCoPadDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCSCCoPadDigi> >" splitLevel="0"/> 
 
-<class name="ME0DigiPreReco" ClassVersion="11">
+<class name="ME0DigiPreReco" ClassVersion="12">
  <version ClassVersion="10" checksum="79088950"/>
  <version ClassVersion="11" checksum="1930707888"/>
+ <version ClassVersion="12" checksum="2284466085"/>
 </class>
 <class name="std::vector<ME0DigiPreReco>"/>
 <class name="std::map<ME0DetId,std::vector<ME0DigiPreReco> >"/>

--- a/DataFormats/GEMRecHit/interface/ME0Segment.h
+++ b/DataFormats/GEMRecHit/interface/ME0Segment.h
@@ -26,7 +26,7 @@ public:
 	
     /// Constructor
     ME0Segment(const std::vector<const ME0RecHit*>& proto_segment, LocalPoint origin, 
-        	LocalVector direction, AlgebraicSymMatrix errors, double chi2);
+	       LocalVector direction, AlgebraicSymMatrix errors, double chi2, double averageTime, double timeUncrt);
   
     /// Destructor
     virtual ~ME0Segment();
@@ -67,17 +67,20 @@ public:
 
     ME0DetId me0DetId() const { return  geographicalId(); }
 
-    float time() const;
+    float time() const    { return theTimeValue; }
+    float timeErr() const { return theTimeUncrt; }
     
     void print() const;		
     
  private:
     
     std::vector<ME0RecHit> theME0RecHits;
-    LocalPoint theOrigin;   // in chamber frame - the GeomDet local coordinate system
-    LocalVector theLocalDirection; // in chamber frame - the GeomDet local coordinate system
+    LocalPoint theOrigin;            // in chamber frame - the GeomDet local coordinate system
+    LocalVector theLocalDirection;   // in chamber frame - the GeomDet local coordinate system
     AlgebraicSymMatrix theCovMatrix; // the covariance matrix
     double theChi2;
+    double theTimeValue;             // the best time estimate of the segment
+    double theTimeUncrt;             // the uncertainty on the time estimation
 };
 
 std::ostream& operator<<(std::ostream& os, const ME0Segment& seg);

--- a/DataFormats/GEMRecHit/src/ME0Segment.cc
+++ b/DataFormats/GEMRecHit/src/ME0Segment.cc
@@ -17,10 +17,10 @@ namespace {
 }
 
 ME0Segment::ME0Segment(const std::vector<const ME0RecHit*>& proto_segment, LocalPoint origin, 
-	LocalVector direction, AlgebraicSymMatrix errors, double chi2) : 
+		       LocalVector direction, AlgebraicSymMatrix errors, double chi2, double averageTime, double timeUncrt) : 
   RecSegment(buildDetId(proto_segment.front()->me0Id())),
   theOrigin(origin), 
-  theLocalDirection(direction), theCovMatrix(errors), theChi2(chi2){
+  theLocalDirection(direction), theCovMatrix(errors), theChi2(chi2), theTimeValue(averageTime), theTimeUncrt(timeUncrt) {
 
   for(unsigned int i=0; i<proto_segment.size(); ++i)
     theME0RecHits.push_back(*proto_segment[i]);
@@ -82,17 +82,6 @@ AlgebraicMatrix ME0Segment::projectionMatrix() const {
   return theProjectionMatrix;
 }
 
-float ME0Segment::time() const {
-  float averageTime=0;
-  for (std::vector<ME0RecHit>::const_iterator itRH = theME0RecHits.begin();
-       itRH != theME0RecHits.end(); ++itRH) {
-    const  ME0RecHit *recHit = &(*itRH);
-    averageTime+=recHit->tof();
-  }
-  averageTime=averageTime/(theME0RecHits.size());
-  return averageTime;
-}
-
 //
 void ME0Segment::print() const {
   std::cout << *this << std::endl;
@@ -106,7 +95,8 @@ std::ostream& operator<<(std::ostream& os, const ME0Segment& seg) {
     " dirErr = (" << sqrt(seg.localDirectionError().xx())<<","<<sqrt(seg.localDirectionError().yy())<<
     "0,)\n"<<
     "            chi2/ndf = " << seg.chi2()/double(seg.degreesOfFreedom()) << 
-    " #rechits = " << seg.specificRecHits().size();
+    " #rechits = " << seg.specificRecHits().size() <<
+    " time = "<< seg.time() << " +/- " << seg.timeErr() << " ns ";
   return os;  
 }
 

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -22,7 +22,8 @@
   <class name="edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> > >" splitLevel="0"/>
 
-  <class name="ME0Segment" splitLevel="0" ClassVersion="10">
+  <class name="ME0Segment" splitLevel="0" ClassVersion="11">
+   <version ClassVersion="11" checksum="140443132"/>
    <version ClassVersion="10" checksum="2562385753"/>
   </class>
   <class name="std::vector<ME0Segment*>" splitLevel="0"/>

--- a/RecoLocalMuon/GEMRecHit/interface/ME0RecHitBaseAlgo.h
+++ b/RecoLocalMuon/GEMRecHit/interface/ME0RecHitBaseAlgo.h
@@ -57,5 +57,8 @@ class ME0RecHitBaseAlgo {
                        const GlobalPoint& globPos, 
                        LocalPoint& Point,
                        LocalError& error) const = 0;
+
+  bool recOnlyMuons;
+  bool recOnlyPrompt;
 };
 #endif

--- a/RecoLocalMuon/GEMRecHit/python/me0RecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/me0RecHits_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 me0RecHits = cms.EDProducer("ME0RecHitProducer",
     recAlgoConfig = cms.PSet(
-
+        recOnlyMuons = cms.bool(False),
+        recOnlyPrompt = cms.bool(False),
     ),
     recAlgo = cms.string('ME0RecHitStandardAlgo'),
     me0DigiLabel = cms.InputTag("simMuonME0Digis"),

--- a/RecoLocalMuon/GEMRecHit/python/me0Segments_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/me0Segments_cfi.py
@@ -12,6 +12,7 @@ me0Segments = cms.EDProducer("ME0SegmentProducer",
         preClusteringUseChaining = cms.bool(True),
         dPhiChainBoxMax = cms.double(.02),
         dEtaChainBoxMax = cms.double(.05),
+        dTimeChainBoxMax = cms.double(1.50), # 1ns, +/- time to fly through 30cm thick ME0
         maxRecHitsInCluster = cms.int32(6)
     )
 )

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitBaseAlgo.cc
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitBaseAlgo.cc
@@ -13,8 +13,8 @@
 #include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 ME0RecHitBaseAlgo::ME0RecHitBaseAlgo(const edm::ParameterSet& config) {
+  recOnlyMuons = config.getParameter<bool>("recOnlyMuons");
 }
 
 ME0RecHitBaseAlgo::~ME0RecHitBaseAlgo(){}
@@ -33,11 +33,10 @@ const ME0DigiPreRecoCollection::Range& digiRange){
     // Call the compute method
     bool OK = this->compute(*digi, point, tmpErr);
     if (!OK) continue;
-
-    if (std::abs(digi->pdgid()) == 13) {
-      ME0RecHit* recHit = new ME0RecHit(me0Id,digi->tof(),point,tmpErr);
-      result.push_back(recHit);
-    }
+    if (recOnlyMuons && std::abs(digi->pdgid()) != 13)  continue;
+    if (recOnlyPrompt && !digi->prompt()) continue;
+    ME0RecHit* recHit = new ME0RecHit(me0Id,digi->tof(),point,tmpErr);
+    result.push_back(recHit);
   }
   return result;
 }

--- a/RecoLocalMuon/GEMRecHit/src/ME0SegAlgoMM.h
+++ b/RecoLocalMuon/GEMRecHit/src/ME0SegAlgoMM.h
@@ -76,6 +76,7 @@ private:
   bool    preClustering_useChaining;
   double  dPhiChainBoxMax;
   double  dEtaChainBoxMax;
+  double  dTimeChainBoxMax;
   int     maxRecHitsInCluster;
   
  private:

--- a/RecoLocalMuon/GEMRecHit/src/ME0SegmentBuilder.cc
+++ b/RecoLocalMuon/GEMRecHit/src/ME0SegmentBuilder.cc
@@ -57,7 +57,7 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
     }    
     ME0SegmentAlgorithm::ME0Ensamble ensamble(std::pair<const ME0EtaPartition*, std::map<uint32_t,const ME0EtaPartition *> >(firstlayer,ens));
     
-    LogDebug("ME0Segment|ME0") << "found " << me0RecHits.size() << " rechits in chamber " << *enIt;
+    LogDebug("ME0Segment|ME0") << "found " << me0RecHits.size() << " rechits in chamber " /*<< *enIt*/;
     
     // given the chamber select the appropriate algo... and run it
     std::vector<ME0Segment> segv = algo->run(ensamble, me0RecHits);

--- a/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
@@ -32,34 +32,20 @@ private:
   bool corr;
   bool etaproj;
   bool digitizeOnlyMuons_;
+  double gaussianSmearing_;
   double averageEfficiency_;
-  bool doBkgNoise_;
-// bool simulateIntrinsicNoise_;
+  // bool simulateIntrinsicNoise_; // not implemented
+  // double averageNoiseRate_;     // not implemented
   bool simulateElectronBkg_;
-  double averageNoiseRate_;
-  int bxwidth_;
+  bool simulateNeutralBkg_;
   int minBunch_;
   int maxBunch_;
   CLHEP::RandGaussQ* gauss_;
   CLHEP::RandFlat* flat1_;
   CLHEP::RandFlat* flat2_;
   CLHEP::RandFlat* poisson_;
-//params for the simple pol6 model of neutral bkg for ME0:
-  double ME0ModNeuBkgParam0;
-  double ME0ModNeuBkgParam1;
-  double ME0ModNeuBkgParam2;
-  double ME0ModNeuBkgParam3;
-  double ME0ModNeuBkgParam4;
-  double ME0ModNeuBkgParam5;
-  double ME0ModNeuBkgParam6;
-  double ME0ModElecBkgParam0;
-  double ME0ModElecBkgParam1;
-  double ME0ModElecBkgParam2;
-  double ME0ModElecBkgParam3;
-  double ME0ModElecBkgParam4;
-  double ME0ModElecBkgParam5;
-  double ME0ModElecBkgParam6;
-  double ME0ModElecBkgParam7;
+  // params for the simple pol6 model of neutral bkg for ME0:
+  std::vector<double> neuBkg, eleBkg;
 };
 #endif
 

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -5,17 +5,17 @@ simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
     inputCollection = cms.string('g4SimHitsMuonME0Hits'),
     digiPreRecoModelString = cms.string('PreRecoGaussian'),
     timeResolution = cms.double(0.001), # in ns
-    phiResolution = cms.double(0.05), # in cm average resoltion along local x in case of no correlation
-    etaResolution = cms.double(1.),# in cm average resoltion along local y in case of no correlation
+    phiResolution = cms.double(0.05),   # in cm average resolution along local x in case of no correlation
+    etaResolution = cms.double(1.),     # in cm average resolution along local y in case of no correlation
     useCorrelation = cms.bool(False),
     useEtaProjectiveGEO = cms.bool(False),
     averageEfficiency = cms.double(0.98),
-    doBkgNoise = cms.bool(True), #False == No background simulation
     digitizeOnlyMuons = cms.bool(False),
-# simulateIntrinsicNoise = cms.bool(False),
-    simulateElectronBkg = cms.bool(True), #True - will simulate electron background
-    averageNoiseRate = cms.double(0.001), #intrinsic noise
-    bxwidth = cms.int32(25),
-    minBunch = cms.int32(-5), ## in terms of 25 ns
-    maxBunch = cms.int32(3)
+    gaussianSmearing = cms.bool(True),
+    # simulateIntrinsicNoise = cms.bool(False), # intrinsic noise --> not implemented
+    # averageNoiseRate = cms.double(0.001),     # intrinsic noise --> not implemented
+    simulateElectronBkg = cms.bool(True),       # True - will simulate electron background
+    simulateNeutralBkg  = cms.bool(True),       # True - will simulate neutral (n+g)  background
+    minBunch = cms.int32(-5),                   # [x 25 ns], forms the readout window together with maxBunch,
+    maxBunch = cms.int32(3),                    # we should think of shrinking this window ...
 )

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -69,7 +69,7 @@ void ME0PreRecoGaussianModel::simulateSignal(const ME0EtaPartition* roll, const 
     double x=0.0, y=0.0;
     if(gaussianSmearing_) { // Gaussian Smearing
       x=gauss_->fire(entry.x(), sigma_u);
-      y=gauss_->fire(entry.x(), sigma_u);
+      y=gauss_->fire(entry.y(), sigma_v);
     }
     else { // Uniform Smearing ... use the sigmas as boundaries
       x=entry.x()+(flat1_->fire(0., 1.)-0.5)*sigma_u;

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -4,6 +4,7 @@
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 #include "DataFormats/GEMDigi/interface/ME0DigiPreReco.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CLHEP/Random/RandomEngine.h"
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGaussQ.h"

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -82,6 +82,14 @@ void ME0PreRecoGaussianModel::simulateSignal(const ME0EtaPartition* roll, const 
     int pdgid = hit.particleType();
     ME0DigiPreReco digi(x, y, ex, ey, corr, tof, pdgid, 1);
     digi_.insert(digi);
+
+    edm::LogVerbatim("ME0PreRecoGaussianModel") << "[ME0PreRecoDigi :: simulateSignal] :: simhit in "<<roll->id()<<" at loc x = "<<std::setw(8)<<entry.x()<<" [cm]"
+                                                << " loc y = "<<std::setw(8)<<entry.y()<<" [cm] time = "<<std::setw(8)<<hit.timeOfFlight()<<" [ns] pdgid = "<<std::showpos<<std::setw(4)<<pdgid;
+    edm::LogVerbatim("ME0PreRecoGaussianModel") << "[ME0PreRecoDigi :: simulateSignal] :: digi   in "<<roll->id()<<" at loc x = "<<std::setw(8)<<x<<" [cm] loc y = "<<std::setw(8)<<y<<" [cm]"
+                                                <<" time = "<<std::setw(8)<<tof<<" [ns]";
+    edm::LogVerbatim("ME0PreRecoGaussianModel") << "[ME0PreRecoDigi :: simulateSignal] :: digi   in "<<roll->id()<<" with DX = "<<std::setw(8)<<(entry.x()-x)<<" [cm]"
+                                                <<" DY = "<<std::setw(8)<<(entry.y()-y)<<" [cm] DT = "<<std::setw(8)<<(hit.timeOfFlight()-tof)<<" [ns]";
+
   }
 }
 void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
@@ -100,6 +108,10 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
   double myTanPhi    = (topLength - bottomLength) / (height * 2);
   double rollRadius = top_->radius();
   trArea = height * (topLength + bottomLength) / 2.0;
+
+  edm::LogVerbatim("ME0PreRecoGaussianModelNoise") << "[ME0PreRecoDigi :: simulateNoise] :: extracting parameters from the TrapezoidalStripTopology";
+  edm::LogVerbatim("ME0PreRecoGaussianModelNoise") << "[ME0PreRecoDigi :: simulateNoise] :: bottom = "<<bottomLength<<" [cm] top  = "<<topLength<<" [cm] height = "<<height
+						   <<" [cm] radius = "<<rollRadius<<" [cm]" ;
 
   // simulate intrinsic noise and background hits in all BX that are being read out
   for(int bx=minBunch_; bx<maxBunch_+1; ++bx) {
@@ -131,6 +143,10 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
       const double averageElecRate(averageElectronRatePerRoll * (bxwidth*1.0e-9) * trArea); 
       int n_elechits(poisson_->fire(averageElecRate));
 
+      edm::LogVerbatim("ME0PreRecoGaussianModelNoise") << "[ME0PreRecoDigi :: simulateNoise :: ele bkg] :: myRandY = "<<std::setw(12)<<myRandY<<" => local y = "<<std::setw(12)<<yy_rand<<" [cm]"
+                                                       <<" => global y (global R) = "<<std::setw(12)<<yy_glob<<" [cm] || Probability = "<<std::setw(12)<<averageElecRate
+                                                       <<" => efficient? "<<n_elechits<<std::endl;
+
       // max length in x for given y coordinate (cfr trapezoidal eta partition)
       double xMax = topLength/2.0 - (height/2.0 - yy_rand) * myTanPhi;
 
@@ -152,6 +168,10 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
 	else 	            pdgid = 11;  // positron
 	ME0DigiPreReco digi(xx_rand, yy_rand, ex, ey, corr, time, pdgid, 0);
 	digi_.insert(digi);
+
+	edm::LogVerbatim("ME0PreRecoGaussianModelNoise") << "[ME0PreRecoDigi :: simulateNoise :: ele bkg] :: electron hit in "<<roll->id()<<" pdgid = "<<pdgid<<" bx = "<<bx
+                                                         <<" ==> digitized at loc x = "<<xx_rand<<" loc y = "<<yy_rand<<" time = "<<time<<" [ns]";
+
       }
     }
 
@@ -172,6 +192,10 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
       // Rate [Hz/cm^2] * 25*10^-9 [s] * Area [cm] = # hits in this roll
       const double averageNeutrRate(averageNeutralRatePerRoll * (bxwidth*1.0e-9) * trArea);
       int n_hits(poisson_->fire(averageNeutrRate));
+
+      edm::LogVerbatim("ME0PreRecoGaussianModelNoise") << "[ME0PreRecoDigi :: simulateNoise :: neu bkg] :: myRandY = "<<std::setw(12)<<myRandY<<" => local y = "<<std::setw(12)<<yy_rand<<" [cm]"
+                                                       <<" => global y (global R) = "<<std::setw(12)<<yy_glob<<" [cm] || Probability "<<std::setw(12)<<averageNeutrRate
+                                                       <<" => efficient? "<<n_hits<<std::endl;
 
       // max length in x for given y coordinate (cfr trapezoidal eta partition)
       double xMax = topLength/2.0 - (height/2.0 - yy_rand) * myTanPhi;
@@ -194,6 +218,10 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
         else                 pdgid = 22;   // photons:  GEM sensitivity for photons:  1.04% ==> neutron fraction = (0.08 / 1.04) = 0.077 = 0.08
         ME0DigiPreReco digi(xx_rand, yy_rand, ex, ey, corr, time, pdgid, 0);
         digi_.insert(digi);
+
+	edm::LogVerbatim("ME0PreRecoGaussianModelNoise") << "[ME0PreRecoDigi :: simulateNoise :: neu bkg] :: neutral hit in "<<roll->id()<<" pdgid = "<<pdgid<<" bx = "<<bx
+                                                         <<" ==> digitized at loc x = "<<xx_rand<<" loc y = "<<yy_rand<<" time = "<<time<<" [ns]";
+
       }
     }
 

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -11,43 +11,40 @@
 #include <cmath>
 #include <utility>
 #include <map>
+
+
+const double cspeed = 29.9792458; // [cm/ns]
+const int bxwidth   = 25;         // [ns]
+
 ME0PreRecoGaussianModel::ME0PreRecoGaussianModel(const edm::ParameterSet& config) :
-    ME0DigiPreRecoModel(config), sigma_t(config.getParameter<double>("timeResolution")), sigma_u(
-        config.getParameter<double>("phiResolution")), sigma_v(config.getParameter<double>("etaResolution")), corr(
-        config.getParameter<bool>("useCorrelation")), etaproj(config.getParameter<bool>("useEtaProjectiveGEO")), digitizeOnlyMuons_(
-        config.getParameter<bool>("digitizeOnlyMuons")), averageEfficiency_(
-        config.getParameter<double>("averageEfficiency")), doBkgNoise_(config.getParameter<bool>("doBkgNoise"))
-//, simulateIntrinsicNoise_(config.getParameter<bool>("simulateIntrinsicNoise"))
-        , simulateElectronBkg_(config.getParameter<bool>("simulateElectronBkg")), averageNoiseRate_(
-        config.getParameter<double>("averageNoiseRate")), bxwidth_(config.getParameter<int>("bxwidth")), minBunch_(
-        config.getParameter<int>("minBunch")), maxBunch_(config.getParameter<int>("maxBunch"))
+    ME0DigiPreRecoModel(config), 
+    sigma_t(config.getParameter<double>("timeResolution")), 
+    sigma_u(config.getParameter<double>("phiResolution")), 
+    sigma_v(config.getParameter<double>("etaResolution")), 
+    corr(config.getParameter<bool>("useCorrelation")), 
+    etaproj(config.getParameter<bool>("useEtaProjectiveGEO")), 
+    digitizeOnlyMuons_(config.getParameter<bool>("digitizeOnlyMuons")), 
+    gaussianSmearing_(config.getParameter<bool>("gaussianSmearing")),
+    averageEfficiency_(config.getParameter<double>("averageEfficiency")), 
+    // simulateIntrinsicNoise_(config.getParameter<bool>("simulateIntrinsicNoise")),
+    // averageNoiseRate_(config.getParameter<double>("averageNoiseRate")), 
+    simulateElectronBkg_(config.getParameter<bool>("simulateElectronBkg")), 
+    simulateNeutralBkg_(config.getParameter<bool>("simulateNeutralBkg")), 
+    minBunch_(config.getParameter<int>("minBunch")), 
+    maxBunch_(config.getParameter<int>("maxBunch"))
 {
-//params for the simple pol6 model of neutral and electron bkg for ME0:
-  ME0ModNeuBkgParam0 = 899644;
-  ME0ModNeuBkgParam1 = -30841;
-  ME0ModNeuBkgParam2 = 441.28;
-  ME0ModNeuBkgParam3 = -3.3405;
-  ME0ModNeuBkgParam4 = 0.0140588;
-  ME0ModNeuBkgParam5 = -3.11473e-05;
-  ME0ModNeuBkgParam6 = 2.83736e-08;
-  ME0ModElecBkgParam0 = 4.68590e+05;
-  ME0ModElecBkgParam1 = -1.63834e+04;
-  ME0ModElecBkgParam2 = 2.35700e+02;
-  ME0ModElecBkgParam3 = -1.77706e+00;
-  ME0ModElecBkgParam4 = 7.39960e-03;
-  ME0ModElecBkgParam5 = -1.61448e-05;
-  ME0ModElecBkgParam6 = 1.44368e-08;
+  // polynomial parametrisation of neutral (n+g) and electron background
+  neuBkg.push_back(899644.0);     neuBkg.push_back(-30841.0);     neuBkg.push_back(441.28); 
+  neuBkg.push_back(-3.3405);      neuBkg.push_back(0.0140588);    neuBkg.push_back(-3.11473e-05); neuBkg.push_back(2.83736e-08);
+  eleBkg.push_back(4.68590e+05);  eleBkg.push_back(-1.63834e+04); eleBkg.push_back(2.35700e+02);
+  eleBkg.push_back(-1.77706e+00); eleBkg.push_back(7.39960e-03);  eleBkg.push_back(-1.61448e-05); eleBkg.push_back(1.44368e-08);
 }
 ME0PreRecoGaussianModel::~ME0PreRecoGaussianModel()
 {
-  if (flat1_)
-    delete flat1_;
-  if (flat2_)
-    delete flat2_;
-  if (gauss_)
-    delete gauss_;
-  if (poisson_)
-    delete poisson_;
+  if (flat1_)   delete flat1_;
+  if (flat2_)   delete flat2_;
+  if (gauss_)   delete gauss_;
+  if (poisson_) delete poisson_;
 }
 void ME0PreRecoGaussianModel::setRandomEngine(CLHEP::HepRandomEngine& eng)
 {
@@ -60,119 +57,146 @@ void ME0PreRecoGaussianModel::simulateSignal(const ME0EtaPartition* roll, const 
 {
   for (const auto & hit : simHits)
   {
-    if (std::abs(hit.particleType()) != 13 && digitizeOnlyMuons_)
-      continue;
-// GEM efficiency
-    if (flat1_->fire(1) > averageEfficiency_)
-      continue;
+    // Digitize only Muons?
+    if (std::abs(hit.particleType()) != 13 && digitizeOnlyMuons_) continue;
+    // Digitize only in [minBunch,maxBunch] window
+    // window is: [(2n-1)*bxw/2, (2n+1)*bxw/2], n = [minBunch, maxBunch]
+    if(hit.timeOfFlight() < (2*minBunch_-1)*bxwidth*1.0/2 || hit.timeOfFlight() > (2*maxBunch_+1)*bxwidth*1.0/2) continue;
+    // is GEM efficient?
+    if (flat1_->fire(1) > averageEfficiency_) continue;
+    // create digi
     auto entry = hit.entryPoint();
-    float x = gauss_->fire(entry.x(), sigma_u);
-    float y = gauss_->fire(entry.y(), sigma_v);
-    float ex = sigma_u;
-    float ey = sigma_v;
-    float corr = 0.;
-    float tof = gauss_->fire(hit.timeOfFlight(), sigma_t);
+    double x=0.0, y=0.0;
+    if(gaussianSmearing_) { // Gaussian Smearing
+      x=gauss_->fire(entry.x(), sigma_u);
+      y=gauss_->fire(entry.x(), sigma_u);
+    }
+    else { // Uniform Smearing ... use the sigmas as boundaries
+      x=entry.x()+(flat1_->fire(0., 1.)-0.5)*sigma_u;
+      y=entry.y()+(flat1_->fire(0., 1.)-0.5)*sigma_v;
+    }
+    double ex = sigma_u;
+    double ey = sigma_v;
+    double corr = 0.;
+    double tof = gauss_->fire(hit.timeOfFlight(), sigma_t);
     int pdgid = hit.particleType();
-// please keep hit time always 0 for this model
-    ME0DigiPreReco digi(x, y, ex, ey, corr, tof, pdgid);
+    ME0DigiPreReco digi(x, y, ex, ey, corr, tof, pdgid, 1);
     digi_.insert(digi);
   }
 }
 void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll)
 {
-  const double cspeed = 299792458;
   double trArea(0.0);
-  const ME0DetId me0Id(roll->id());
-  if (me0Id.region() == 0)
-  {
-    throw cms::Exception("Geometry")
-        << "GEMSynchronizer::simulateNoise() - this GEM id is from barrel, which cannot happen.";
-  }
+
+  // Extract detailed information from the Strip Topology:
+  // base_bottom, base_top, height, strips, pads 
+  // note that (0,0) is in the middle of the roll ==> all param are at all half length
   const TrapezoidalStripTopology* top_(dynamic_cast<const TrapezoidalStripTopology*>(&(roll->topology())));
-// base_bottom, base_top, height, strips, pads (all half length)
+
   auto& parameters(roll->specs()->parameters());
-  float semiBottomEdge(parameters[0]);
-  float semiTopEdge(parameters[1]);
-  float semiHeight(parameters[2]);
-  float myTanPhi = (semiTopEdge - semiBottomEdge) / (semiHeight * 2);
+  double bottomLength(parameters[0]); bottomLength = 2*bottomLength; // bottom is largest length, so furtest away from beamline
+  double topLength(parameters[1]);    topLength    = 2*topLength;    // top is shortest length, so closest to beamline
+  double height(parameters[2]);       height       = 2*height;
+  double myTanPhi    = (topLength - bottomLength) / (height * 2);
   double rollRadius = top_->radius();
-  const int nBxing(maxBunch_ - minBunch_ + 1);
-  trArea = 2 * semiHeight * (semiTopEdge + semiBottomEdge);
-// if (simulateIntrinsicNoise_)
-// {
-// }
-//simulate bkg contribution
-  if (!doBkgNoise_)
-    return;
-  double aveNeutrRateBotRoll = 0.;
-  double averageNoiseElectronRatePerRoll = 0.;
-  int pdgid = 0;
-  float myRand = flat2_->fire(0., 1.);
-  float yy_rand = 2 * semiHeight * (myRand - 0.5);
-  double radius_rand = rollRadius + yy_rand;
-  if (simulateElectronBkg_)
-    averageNoiseElectronRatePerRoll = ME0ModElecBkgParam0 + ME0ModElecBkgParam1 * radius_rand
-        + ME0ModElecBkgParam2 * radius_rand * radius_rand
-        + ME0ModElecBkgParam3 * radius_rand * radius_rand * radius_rand
-        + ME0ModElecBkgParam4 * radius_rand * radius_rand * radius_rand * radius_rand
-        + ME0ModElecBkgParam5 * radius_rand * radius_rand * radius_rand * radius_rand * radius_rand
-        + ME0ModElecBkgParam6 * radius_rand * radius_rand * radius_rand * radius_rand * radius_rand * radius_rand;
-  const double averageNoiseElec(averageNoiseElectronRatePerRoll * nBxing * bxwidth_ * trArea * 1.0e-9);
-  int n_elechits(poisson_->fire(averageNoiseElec));
-  double xMax = semiTopEdge - (semiHeight - yy_rand) * myTanPhi;
-  for (int i = 0; i < n_elechits; ++i)
-  {
-//calculate xx_rand at a given yy_rand
-    float myRandX = flat1_->fire(0., 1.);
-    float xx_rand = 2 * xMax * (myRandX - 0.5);
-    float ex = sigma_u;
-    float ey = sigma_v;
-    float corr = 0.;
-    GlobalPoint pointDigiHit = roll->toGlobal(LocalPoint(xx_rand, yy_rand));
-//calc tof to the random estimated point
-    double stripRadius = sqrt(
-        pointDigiHit.x() * pointDigiHit.x() + pointDigiHit.y() * pointDigiHit.y()
-            + pointDigiHit.z() * pointDigiHit.z());
-    double timeCalibrationOffset_ = (stripRadius * 1e+9) / (cspeed * 1e+2); //[ns]
-    float tof = gauss_->fire(timeCalibrationOffset_, sigma_t);
-    float myrand = flat1_->fire(0., 1.);
-    if (myrand <= 0.5)
-      pdgid = -11;
-    else
-      pdgid = 11;
-    ME0DigiPreReco digi(xx_rand, yy_rand, ex, ey, corr, tof, pdgid);
-    digi_.insert(digi);
-  }
-  aveNeutrRateBotRoll = ME0ModNeuBkgParam0 + ME0ModNeuBkgParam1 * radius_rand
-      + ME0ModNeuBkgParam2 * radius_rand * radius_rand + ME0ModNeuBkgParam3 * radius_rand * radius_rand * radius_rand
-      + ME0ModNeuBkgParam4 * radius_rand * radius_rand * radius_rand * radius_rand
-      + ME0ModNeuBkgParam5 * radius_rand * radius_rand * radius_rand * radius_rand * radius_rand
-      + ME0ModNeuBkgParam6 * radius_rand * radius_rand * radius_rand * radius_rand * radius_rand * radius_rand;
-  const double averageNoiseNeutrall(aveNeutrRateBotRoll * nBxing * bxwidth_ * trArea * 1.0e-9);
-  int n_hits(poisson_->fire(averageNoiseNeutrall));
-  for (int i = 0; i < n_hits; ++i)
-  {
-//calculate xx_rand at a given yy_rand
-    float myRandX = flat1_->fire(0., 1.);
-    float xx_rand = 2 * xMax * (myRandX - 0.5);
-    float ex = sigma_u;
-    float ey = sigma_v;
-    float corr = 0.;
-    GlobalPoint pointDigiHit = roll->toGlobal(LocalPoint(xx_rand, yy_rand));
-//calc tof to the random estimated point
-    double stripRadius = sqrt(
-        pointDigiHit.x() * pointDigiHit.x() + pointDigiHit.y() * pointDigiHit.y()
-            + pointDigiHit.z() * pointDigiHit.z());
-    double timeCalibrationOffset_ = (stripRadius * 1e+9) / (cspeed * 1e+2); //[ns]
-    float tof = gauss_->fire(timeCalibrationOffset_, sigma_t);
-//distribute bkg between neutrons and gammas
-    float myrand = flat1_->fire(0., 1.);
-    if (myrand <= 0.1)
-      pdgid = 2112; // neutrons
-    else
-      pdgid = 22;
-    ME0DigiPreReco digi(xx_rand, yy_rand, ex, ey, corr, tof, pdgid);
-    digi_.insert(digi);
-  }
+  trArea = height * (topLength + bottomLength) / 2.0;
+
+  // simulate intrinsic noise and background hits in all BX that are being read out
+  for(int bx=minBunch_; bx<maxBunch_+1; ++bx) {
+
+    // 1) Intrinsic Noise ... Not implemented right now
+    // ------------------------------------------------
+    // if (simulateIntrinsicNoise_)
+    // {
+    // }
+
+    // 2) Background Noise 
+    // ----------------------------
+ 
+    // 2a) electron background
+    // -----------------------
+    if (simulateElectronBkg_) {
+
+      double myRandY = flat2_->fire(0., 1.);
+      double yy_rand = height * (myRandY - 0.5); // random Y coord in Local Coords
+      double yy_glob = rollRadius + yy_rand;     // random Y coord in Global Coords
+
+      // Extract / Calculate the Average Electron Rate 
+      // for the given global Y coord from Parametrization
+      double averageElectronRatePerRoll = 0.0;
+      double yy_helper = 1.0;
+      for(int j=0; j<7; ++j) { averageElectronRatePerRoll += eleBkg[j]*yy_helper; yy_helper *= yy_glob; }
+
+      // Rate [Hz/cm^2] * 25*10^-9 [s] * Area [cm] = # hits in this roll 
+      const double averageElecRate(averageElectronRatePerRoll * (bxwidth*1.0e-9) * trArea); 
+      int n_elechits(poisson_->fire(averageElecRate));
+
+      // max length in x for given y coordinate (cfr trapezoidal eta partition)
+      double xMax = topLength/2.0 - (height/2.0 - yy_rand) * myTanPhi;
+
+      // loop over amount of electron hits in this roll
+      for (int i = 0; i < n_elechits; ++i) {
+	//calculate xx_rand at a given yy_rand
+	double myRandX = flat1_->fire(0., 1.);
+	double xx_rand = 2 * xMax * (myRandX - 0.5);
+	double ex = sigma_u;
+	double ey = sigma_v;
+	double corr = 0.;
+	// extract random time in this BX
+	double myrandT = flat1_->fire(0., 1.);
+	double minBXtime = (bx-0.5)*bxwidth;      // double maxBXtime = (bx+0.5)*bxwidth;
+	double time = myrandT*bxwidth+minBXtime;
+	double myrandP = flat1_->fire(0., 1.);
+	int pdgid = 0;
+	if (myrandP <= 0.5) pdgid = -11; // electron
+	else 	            pdgid = 11;  // positron
+	ME0DigiPreReco digi(xx_rand, yy_rand, ex, ey, corr, time, pdgid, 0);
+	digi_.insert(digi);
+      }
+    }
+
+    // 2b) neutral (n+g) background
+    // ----------------------------
+    if (simulateNeutralBkg_) {
+
+      double myRandY = flat2_->fire(0., 1.);
+      double yy_rand = height * (myRandY - 0.5); // random Y coord in Local Coords
+      double yy_glob = rollRadius + yy_rand;    // random Y coord in Global Coords
+
+      // Extract / Calculate the Average Electron Rate 
+      // for the given global Y coord from Parametrization
+      double averageNeutralRatePerRoll = 0.0;
+      double yy_helper = 1.0;
+      for(int j=0; j<7; ++j) { averageNeutralRatePerRoll += neuBkg[j]*yy_helper; yy_helper *= yy_glob; }
+
+      // Rate [Hz/cm^2] * 25*10^-9 [s] * Area [cm] = # hits in this roll
+      const double averageNeutrRate(averageNeutralRatePerRoll * (bxwidth*1.0e-9) * trArea);
+      int n_hits(poisson_->fire(averageNeutrRate));
+
+      // max length in x for given y coordinate (cfr trapezoidal eta partition)
+      double xMax = topLength/2.0 - (height/2.0 - yy_rand) * myTanPhi;
+
+      // loop over amount of neutral hits in this roll
+      for (int i = 0; i < n_hits; ++i) {
+	//calculate xx_rand at a given yy_rand
+	double myRandX = flat1_->fire(0., 1.);
+	double xx_rand = 2 * xMax * (myRandX - 0.5);
+	double ex = sigma_u;
+	double ey = sigma_v;
+	double corr = 0.;
+	// extract random time in this BX
+        double myrandT = flat1_->fire(0., 1.);
+        double minBXtime = (bx-0.5)*bxwidth;
+	double time = myrandT*bxwidth+minBXtime;
+	int pdgid = 0;
+        double myrandP = flat1_->fire(0., 1.);
+        if (myrandP <= 0.08) pdgid = 2112; // neutrons: GEM sensitivity for neutrons: 0.08%
+        else                 pdgid = 22;   // photons:  GEM sensitivity for photons:  1.04% ==> neutron fraction = (0.08 / 1.04) = 0.077 = 0.08
+        ME0DigiPreReco digi(xx_rand, yy_rand, ex, ey, corr, time, pdgid, 0);
+        digi_.insert(digi);
+      }
+    }
+
+  } // end loop over bx
 }
 

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoNoSmearModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoNoSmearModel.cc
@@ -32,7 +32,7 @@ ME0PreRecoNoSmearModel::simulateSignal(const ME0EtaPartition* roll,
     float t = hit.timeOfFlight();
     int pdgid=hit.particleType();
      // please keep hit time always 0 for this model
-    ME0DigiPreReco digi(x,y,ex,ey,corr,t,pdgid);
+    ME0DigiPreReco digi(x,y,ex,ey,corr,t,pdgid,1);
     digi_.insert(digi);
   }
 }


### PR DESCRIPTION
Cleaned up version of closed PR #12370. It includes:
- time in ME0Segment DataFormat
- time clustering in ME0Segment Algorithm
- rewritten version of Neutron Background simulation in ME0PreReco Digitizer
- bool to distinguish Neutron Background from Prompt Background in ME0PreReco DataFormat
- handles to reconstruct only muons, muons+prompt, muons+prompt+neutron  in ME0 RecHit
