### PR TITLE
Restore CSCHaloData to AOD, which was inadvertently deleted by PR 11068

### DIFF
--- a/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
+++ b/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
@@ -71,6 +71,7 @@ RecoMETAOD = cms.PSet(
                                            'keep HcalNoiseSummary_hcalnoise_*_*',
                                            #'keep *GlobalHaloData_*_*_*',
                                            'keep recoGlobalHaloData_GlobalHaloData_*_*',
+                                           'keep recoCSCHaloData_CSCHaloData_*_*',
                                            'keep recoBeamHaloSummary_BeamHaloSummary_*_*'
                                            )
     )


### PR DESCRIPTION
#11068 was intended as a simple clean-up to replace certain wildcards in `keep` statements with explicit strings, but in the process a `keep` statement for recoCSCHaloData was accidentally deleted in RecoMET_EventContent_cff.py. This PR restores this missing CSC halo data to AOD.
