### PR TITLE
Updating Data GT for 2015 Run2 EOY Re-Reco

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,23 +10,25 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v12',
+    'run2_design'       :   '76X_mcRun2_design_v13',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v11',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v12',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v12',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v13',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v12',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v11',
+    'run1_data'         :   '76X_dataRun1_v13',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v11',
+    'run2_data'         :   '76X_dataRun2_v13',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v10',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v9',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v10',
+    # GlobalTag for Run2 HLT: it points to the online GT
+    'run2_hlt_hi'       :   '76X_dataRun2_HLTHI_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v7',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [76X_mcRun2_design_v13](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v13) as [76X_mcRun2_design_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_design_v12) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_design_v12/76X_mcRun2_design_v13): 
  -  adding additional labels for Castor SIM geometry 
- **RunII Asymptotic scenario** : [76X_mcRun2_asymptotic_v13](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v13) as [76X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_asymptotic_v12) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_asymptotic_v12/76X_mcRun2_asymptotic_v13): 
  - adding additional labels for Castor SIM geometry 
- **RunII Startup scenario** : [76X_mcRun2_startup_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v12) as [76X_mcRun2_startup_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_startup_v11) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_startup_v11/76X_mcRun2_startup_v12): 
  -  adding additional labels for Castor SIM geometry 
- **RunII Heavy Ions scenario** : [76X_mcRun2_HeavyIon_v13](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v13) as [76X_mcRun2_HeavyIon_v12](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_mcRun2_HeavyIon_v12) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_mcRun2_HeavyIon_v12/76X_mcRun2_HeavyIon_v13): 
  - adding additional labels for Castor SIM geometry 
  - updated centrality table for HFtowers in 200 bins 
  - updated underlying event table with latest estimations from PbPb first collisions 
  - updated JEC with HI tracking 
  - updated L1T menu with the version used in PbPb collisions 
  - introducing L1T calo params configuration for HI 
## RunI data
- **RunI HLT processing** : [75X_dataRun1_HLT_frozen_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_HLT_frozen_v10) as [75X_dataRun1_HLT_frozen_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_HLT_frozen_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun1_HLT_frozen_v9/75X_dataRun1_HLT_frozen_v10): 
  - adding negative energy filter payload
- **RunI Offline processing** : [76X_dataRun1_v13](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v13) as [76X_dataRun1_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v11) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun1_v11/76X_dataRun1_v13): 
  - **with updates for 2015 data Run2 EOY re-reco**
  - updated lumi based beamspot 
  - updated Tracker alignment (including APE and surface deformations) 
  - updated DT,CSC and muon GPR alignment - updated DT vdrif an ttrig 
  - updated CSC electronics caibrations 
  - updated SiStrip bad channel and particle gain 
  - updated Hcal gains and response corrections 
  - updated Castor local reco calibration for 0T re-reco 
  - updated Ecal IC, AdcToGeV, time calibrations, alignment and preshower intercalibrations 
  - updated centrality table with HFtowers label
## RunII data
- **RunII HLT processing** : [75X_dataRun1_HLT_frozen_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_HLT_frozen_v10) as [75X_dataRun1_HLT_frozen_v9](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_HLT_frozen_v9) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun1_HLT_frozen_v9/75X_dataRun1_HLT_frozen_v10): 
  - adding negative energy filter payload
- **RunII HI HLT processing** : [76X_dataRun2_HLTHI_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_HIHLT_v1) as [76X_dataRun2_HLT_frozen_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_HLT_frozen_v10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_HLTHI_v1/76X_dataRun2_HLT_frozen_v10): 
  - adding Tracking MVA selection for HI
  - changing the AK4CaloHLT Jet Energy corrections to pick tag for Heavy Ions
  - using full Strip pedestals for Tracker Zero Suppression at HLT
- **RunII Offline processing** : [76X_dataRun2_v13](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v13) as [76X_dataRun2_v11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v11) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_dataRun2_v11/76X_dataRun2_v13): 
  - **with updates for 2015 data Run2 EOY re-reco (tags contain run history)**
  - updated lumi based beamspot 
  - updated Tracker alignment (including APE and surface deformations) 
  - updated DT,CSC and muon GPR alignment - updated DT vdrif an ttrig 
  - updated CSC electronics caibrations 
  - updated SiStrip bad channel and particle gain 
  - updated Hcal gains and response corrections 
  - updated Castor local reco calibration for 0T re-reco 
  - updated Ecal IC, AdcToGeV, time calibrations, alignment and preshower intercalibrations 
  - updated centrality table with HFtowers label
## Upgrade
- **PhaseI design scenario** : [76X_upgrade2017_design_v8](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v8) as [76X_upgrade2017_design_v7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_upgrade2017_design_v7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/76X_upgrade2017_design_v8/76X_upgrade2017_design_v7): 
  - New Pixel SIM LA for Phase-I
  - New Pixel LA for Phase-I 
  - New Pixel templates for Phase-I 
  - New Pixel SIM gains for Phase-I
  - New Pixel GenErrors for Phase-I
  - New Pixel gains for Phase-I
  - New Pixel quality for Phase-I
