### PR TITLE
Updating MC GT for HeavyIon production, Data GT for 2015 Run2 EOY Re-Reco, HLT GT for HeavyIon data taking.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,17 +16,17 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '75X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v9',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v10',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v10',
+    'run1_data'         :   '75X_dataRun1_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v10',
+    'run2_data'         :   '75X_dataRun2_v11',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v4',
+    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v5',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v6',
+    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v7',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt_hi'       :   '75X_dataRun2_HLTHI_v2',
+    'run2_hlt_hi'       :   '75X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  '75X_upgrade2017_design_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of Global Tag changes
## RunII Simulation
- Heavy Ion scenario: 75X_mcRun2_HeavyIon_v10: As 75X_mcRun2_HeavyIon_v9 with the following changes:
  - updated centrality table for HFtowers in 200 bins
  - updated underlying event table with latest estimations from PbPb first collisions
  - updated JEC with HI tracking
  - updated L1T menu with the version used in PbPb collisions
  - updated strip bad channels with the payload with TOB L3 FED 434 and 439 IN, computed using 25 ns Run 254790.
## RunI Data
- HLT processing: 75X_dataRun1_HLT_frozen_v5: As 75X_dataRun1_HLT_frozen_v4 (snapshot time set to 2015-12-02 11:30:00 UTC) with the following changes:
  - added HCAL negative energy filter record
  - revert BTag MVA to the values of 74X in order to keep HLT performance on data
  - revert PF hadron calibration to the values of 74X in order to keep HLT performance on data.
- Offline processing: 75X_dataRun1_v11: As 75X_dataRun1_v10 with the following changes:
  - updates for 2015 EOY data re-reco (backported from 76X)
    - lumi based beamspot
    - Tracker alignment, APE and surface deformations
    - DT, CSC, and muon GPR alignment
    - DT Vdrift and Ttrig
    - CSC electronics calibrations
    - SiStrip bad channel and particle gain
    - Hcal gains and response corrections
    - Castor local reco calibration for 0T re-reco
    - Ecal IC, AdcToGeV, time calibrations, alignment
    - ES intercalibration
  - merge Run1 and Run2 tags for Centrality tables in HF Towers.
## RunII Data
- HLT processing: 75X_dataRun2_HLT_frozen_v7: As 75X_dataRun2_HLT_frozen_v5 (snapshot time set to 2015-11-20 17:40:00 UTC) with the following changes:
  - added HCAL negative energy filter record.
- HLT HeavyIon processing: 75X_dataRun2_HLTHI_frozen_v4: As 75X_dataRun2_HLTHI_v2 (snapshot time set 2015-11-19 22:15:00 UTC) to with the following changes:
  - updated tag for AK4Calo HLT JEC for pp reference run at 5 TeV and HI run. The first IOV contains the payload computed with ECAL multifit on top of RECO.
- Offline processing: 75X_dataRun2_v11: As 75X_dataRun2_v10 with the following changes:
  - updates for 2015 EOY data re-reco (backported from 76X)
    - lumi based beamspot
    - Tracker alignment, APE and surface deformations
    - DT, CSC, and muon GPR alignment
    - DT Vdrift and Ttrig
    - CSC electronics calibrations
    - SiStrip bad channel and particle gain
    - Hcal gains and response corrections
    - Castor local reco calibration for 0T re-reco
    - Ecal IC, AdcToGeV, time calibrations, alignment
    - ES intercalibration
  - merge Run1 and Run2 tags for Centrality tables in HF Towers.
