### PR TITLE
Remove duplicate data from PoolSource

### DIFF
--- a/IOPool/Input/src/EmbeddedRootSource.cc
+++ b/IOPool/Input/src/EmbeddedRootSource.cc
@@ -15,9 +15,24 @@ namespace edm {
   EmbeddedRootSource::EmbeddedRootSource(ParameterSet const& pset, VectorInputSourceDescription const& desc) :
     VectorInputSource(pset, desc),
     rootServiceChecker_(),
+    nStreams_(desc.allocations_->numberOfStreams()),
+    // The default value provided as the second argument to the getUntrackedParameter function call
+    // is not used when the ParameterSet has been validated and the parameters are not optional
+    // in the description.  This is currently true when PoolSource is the primary input source.
+    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
+    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
+    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
+    // and should be deleted from the code.
+    //
+    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
+    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
+    productSelectorRules_(pset, "inputCommands", "InputSource"),
     catalog_(pset.getUntrackedParameter<std::vector<std::string> >("fileNames"),
       pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
-    fileSequence_(new RootEmbeddedFileSequence(pset, *this, catalog_, desc.allocations_->numberOfStreams())) {
+    // Note: fileSequence_ needs to be initialized last, because it uses data members 
+    // initialized previously in its own initialization.
+    fileSequence_(new RootEmbeddedFileSequence(pset, *this, catalog_)) {
   }
 
   EmbeddedRootSource::~EmbeddedRootSource() {}
@@ -48,7 +63,15 @@ namespace edm {
 
   void
   EmbeddedRootSource::dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) {
-    fileSequence_->dropUnwantedBranches_(wantedBranches);
+    std::vector<std::string> rules;
+    rules.reserve(wantedBranches.size() + 1);
+    rules.emplace_back("drop *");
+    for(std::string const& branch : wantedBranches) {
+      rules.push_back("keep " + branch + "_*");
+    }
+    ParameterSet pset;
+    pset.addUntrackedParameter("inputCommands", rules);
+    productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
   }
 
   void
@@ -61,6 +84,16 @@ namespace edm {
     desc.addUntracked<std::vector<std::string> >("fileNames")
         ->setComment("Names of files to be processed.");
     desc.addUntracked<std::string>("overrideCatalog", std::string());
+    desc.addUntracked<bool>("skipBadFiles", false)
+        ->setComment("True:  Ignore any missing or unopenable input file.\n"
+                     "False: Throw exception if missing or unopenable input file.");
+    desc.addUntracked<bool>("bypassVersionCheck", false)
+        ->setComment("True:  Bypass release version check.\n"
+                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
+    desc.addUntracked<int>("treeMaxVirtualSize", -1)
+        ->setComment("Size of ROOT TTree TBasket cache.  Affects performance.");
+
+    ProductSelectorRules::fillDescription(desc, "inputCommands");
     RootEmbeddedFileSequence::fillDescription(desc);
 
     descriptions.add("source", desc);

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -9,6 +9,7 @@ EmbeddedRootSource: This is an InputSource
 
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
@@ -35,17 +36,31 @@ namespace edm {
     using VectorInputSource::processHistoryRegistryForUpdate;
     using VectorInputSource::productRegistryUpdate;
 
+    // const accessors
+    bool skipBadFiles() const {return skipBadFiles_;}
+    bool bypassVersionCheck() const {return bypassVersionCheck_;}
+    unsigned int nStreams() const {return nStreams_;}
+    int treeMaxVirtualSize() const {return treeMaxVirtualSize_;}
+    ProductSelectorRules const& productSelectorRules() const {return productSelectorRules_;}
+
     static void fillDescriptions(ConfigurationDescriptions & descriptions);
 
   private:
     virtual void closeFile_();
-    virtual void beginJob();
-    virtual void endJob();
+    virtual void beginJob() override;
+    virtual void endJob() override;
     virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) override;
     virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
     virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     
     RootServiceChecker rootServiceChecker_;
+
+    unsigned int nStreams_;
+    bool skipBadFiles_;
+    bool bypassVersionCheck_;
+    int const treeMaxVirtualSize_;
+    ProductSelectorRules productSelectorRules_;
+
     InputFileCatalog catalog_;
     std::unique_ptr<RootEmbeddedFileSequence> fileSequence_;
     

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -68,22 +68,31 @@ namespace edm {
       pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
     secondaryCatalog_(pset.getUntrackedParameter<std::vector<std::string> >("secondaryFileNames", std::vector<std::string>()),
       pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
-    primaryFileSequence_(new RootPrimaryFileSequence(pset, *this, catalog_, desc.allocations_->numberOfStreams())),
-    secondaryFileSequence_(secondaryCatalog_.empty() ? nullptr :
-                           new RootSecondaryFileSequence(pset, *this, secondaryCatalog_, desc.allocations_->numberOfStreams())),
     secondaryRunPrincipal_(),
     secondaryLumiPrincipal_(),
     secondaryEventPrincipals_(),
     branchIDsToReplace_(),
-    resourceSharedWithDelayedReaderPtr_(new SharedResourcesAcquirer{SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()})
+    nStreams_(desc.allocations_->numberOfStreams()),
+    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles")),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck")),
+    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize")),
+    setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber")),
+    productSelectorRules_(pset, "inputCommands", "InputSource"),
+    dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches")),
+    labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC")),
+    resourceSharedWithDelayedReaderPtr_(new SharedResourcesAcquirer{SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()}),
+    // Note: primaryFileSequence_ and secondaryFileSequence_ need to be initialized last, because they use data members 
+    // initialized previously in their own initialization.
+    primaryFileSequence_(new RootPrimaryFileSequence(pset, *this, catalog_)),
+    secondaryFileSequence_(secondaryCatalog_.empty() ? nullptr :
+                           new RootSecondaryFileSequence(pset, *this, secondaryCatalog_))
   {
     if (secondaryCatalog_.empty() && pset.getUntrackedParameter<bool>("needSecondaryFileNames", false)) {
       throw Exception(errors::Configuration, "PoolSource") << "'secondaryFileNames' must be specified\n";
     }
     if(secondaryFileSequence_) {
-      unsigned int nStreams = desc.allocations_->numberOfStreams();
-      secondaryEventPrincipals_.reserve(nStreams);
-      for(unsigned int index = 0; index < nStreams; ++index) {
+      secondaryEventPrincipals_.reserve(nStreams_);
+      for(unsigned int index = 0; index < nStreams_; ++index) {
         secondaryEventPrincipals_.emplace_back(new EventPrincipal(secondaryFileSequence_->fileProductRegistry(),
                                                                   secondaryFileSequence_->fileBranchIDListHelper(),
                                                                   std::make_shared<ThinnedAssociationsHelper const>(),
@@ -95,28 +104,26 @@ namespace edm {
       ProductRegistry::ProductList const& secondary = secondaryFileSequence_->fileProductRegistry()->productList();
       ProductRegistry::ProductList const& primary = primaryFileSequence_->fileProductRegistry()->productList();
       std::set<BranchID> associationsFromSecondary;
-      typedef ProductRegistry::ProductList::const_iterator const_iterator;
-      typedef ProductRegistry::ProductList::iterator iterator;
       //this is the registry used by the 'outside' world and only has the primary file information in it at present
       ProductRegistry::ProductList& fullList = productRegistryUpdate().productListUpdator();
-      for(const_iterator it = secondary.begin(), itEnd = secondary.end(); it != itEnd; ++it) {
-        if(it->second.present()) {
-          idsToReplace[it->second.branchType()].insert(it->second.branchID());
-          if(it->second.branchType() == InEvent &&
-             it->second.unwrappedType() == typeid(ThinnedAssociation)) {
-            associationsFromSecondary.insert(it->second.branchID());
+      for(auto const& item : secondary) {
+        if(item.second.present()) {
+          idsToReplace[item.second.branchType()].insert(item.second.branchID());
+          if(item.second.branchType() == InEvent &&
+             item.second.unwrappedType() == typeid(ThinnedAssociation)) {
+            associationsFromSecondary.insert(item.second.branchID());
           }
           //now make sure this is marked as not dropped else the product will not be 'get'table from the Event
-          iterator itFound = fullList.find(it->first);
+          auto itFound = fullList.find(item.first);
           if(itFound != fullList.end()) {
             itFound->second.setDropped(false);
           }
         }
       }
-      for(const_iterator it = primary.begin(), itEnd = primary.end(); it != itEnd; ++it) {
-        if(it->second.present()) {
-          idsToReplace[it->second.branchType()].erase(it->second.branchID());
-          associationsFromSecondary.erase(it->second.branchID());
+      for(auto const& item : primary) {
+        if(item.second.present()) {
+          idsToReplace[item.second.branchType()].erase(item.second.branchID());
+          associationsFromSecondary.erase(item.second.branchID());
         }
       }
       if(idsToReplace[InEvent].empty() && idsToReplace[InLumi].empty() && idsToReplace[InRun].empty()) {
@@ -124,9 +131,8 @@ namespace edm {
       } else {
         for(int i = InEvent; i < NumBranchTypes; ++i) {
           branchIDsToReplace_[i].reserve(idsToReplace[i].size());
-          for(std::set<BranchID>::const_iterator it = idsToReplace[i].begin(), itEnd = idsToReplace[i].end();
-               it != itEnd; ++it) {
-            branchIDsToReplace_[i].push_back(*it);
+          for(auto const& id : idsToReplace[i]) {   
+            branchIDsToReplace_[i].push_back(id);
           }
         }
         secondaryFileSequence_->initAssociationsFromSecondary(associationsFromSecondary);
@@ -303,6 +309,21 @@ namespace edm {
     desc.addUntracked<bool>("needSecondaryFileNames", false)
         ->setComment("If True, 'secondaryFileNames' must be specified and be non-empty.");
     desc.addUntracked<std::string>("overrideCatalog", std::string());
+    desc.addUntracked<bool>("skipBadFiles", false)
+        ->setComment("True:  Ignore any missing or unopenable input file.\n"
+                     "False: Throw exception if missing or unopenable input file.");
+    desc.addUntracked<bool>("bypassVersionCheck", false)
+        ->setComment("True:  Bypass release version check.\n"
+                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
+    desc.addUntracked<int>("treeMaxVirtualSize", -1)
+        ->setComment("Size of ROOT TTree TBasket cache. Affects performance.");
+    desc.addUntracked<unsigned int>("setRunNumber", 0U)
+        ->setComment("If non-zero, change number of first run to this number. Apply same offset to all runs. Allowed only for simulation.");
+    desc.addUntracked<bool>("dropDescendantsOfDroppedBranches", true)
+        ->setComment("If True, also drop on input any descendent of any branch dropped on input.");
+    desc.addUntracked<bool>("labelRawDataLikeMC", true)
+        ->setComment("If True: replace module label for raw data to match MC. Also use 'LHC' as process.");
+    ProductSelectorRules::fillDescription(desc, "inputCommands");
     InputSource::fillDescription(desc);
     RootPrimaryFileSequence::fillDescription(desc);
 

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -11,6 +11,7 @@ PoolSource: This is an InputSource
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
+#include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/InputSource.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
@@ -33,40 +34,59 @@ namespace edm {
     using InputSource::processHistoryRegistryForUpdate;
     using InputSource::productRegistryUpdate;
 
+    // const accessors
+    bool skipBadFiles() const {return skipBadFiles_;}
+    bool dropDescendants() const {return dropDescendants_;}
+    bool bypassVersionCheck() const {return bypassVersionCheck_;}
+    bool labelRawDataLikeMC() const {return labelRawDataLikeMC_;}
+    unsigned int nStreams() const {return nStreams_;}
+    int treeMaxVirtualSize() const {return treeMaxVirtualSize_;}
+    RunNumber_t setRun() const {return setRun_;}
+    ProductSelectorRules const& productSelectorRules() const {return productSelectorRules_;}
+
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void readEvent_(EventPrincipal& eventPrincipal);
-    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
-    virtual void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
-    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
-    virtual void readRun_(RunPrincipal& runPrincipal);
-    virtual std::unique_ptr<FileBlock> readFile_();
-    virtual void closeFile_();
-    virtual void endJob();
-    virtual ItemType getNextItemType();
+    virtual void readEvent_(EventPrincipal& eventPrincipal) override;
+    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    virtual void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
+    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
+    virtual void readRun_(RunPrincipal& runPrincipal) override;
+    virtual std::unique_ptr<FileBlock> readFile_() override;
+    virtual void closeFile_() override;
+    virtual void endJob() override;
+    virtual ItemType getNextItemType() override;
     virtual bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) override;
-    virtual void skip(int offset);
-    virtual bool goToEvent_(EventID const& eventID);
-    virtual void rewind_();
-    virtual void preForkReleaseResources();
-    virtual bool randomAccess_() const;
-    virtual ProcessingController::ForwardState forwardState_() const;
-    virtual ProcessingController::ReverseState reverseState_() const;
+    virtual void skip(int offset) override;
+    virtual bool goToEvent_(EventID const& eventID) override;
+    virtual void rewind_() override;
+    virtual void preForkReleaseResources() override;
+    virtual bool randomAccess_() const override;
+    virtual ProcessingController::ForwardState forwardState_() const override;
+    virtual ProcessingController::ReverseState reverseState_() const override;
 
     SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const override;
     
     RootServiceChecker rootServiceChecker_;
     InputFileCatalog catalog_;
     InputFileCatalog secondaryCatalog_;
-    std::unique_ptr<RootPrimaryFileSequence> primaryFileSequence_;
-    std::unique_ptr<RootSecondaryFileSequence> secondaryFileSequence_;
     std::shared_ptr<RunPrincipal> secondaryRunPrincipal_;
     std::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
     std::vector<std::unique_ptr<EventPrincipal>> secondaryEventPrincipals_;
     std::array<std::vector<BranchID>, NumBranchTypes>  branchIDsToReplace_;
+
+    unsigned int nStreams_;
+    bool skipBadFiles_;
+    bool bypassVersionCheck_;
+    int const treeMaxVirtualSize_;
+    RunNumber_t setRun_;
+    ProductSelectorRules productSelectorRules_;
+    bool dropDescendants_;
+    bool labelRawDataLikeMC_;
     
     std::unique_ptr<SharedResourcesAcquirer> resourceSharedWithDelayedReaderPtr_;
+    std::unique_ptr<RootPrimaryFileSequence> primaryFileSequence_;
+    std::unique_ptr<RootSecondaryFileSequence> secondaryFileSequence_;
   }; // class PoolSource
 }
 #endif

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -26,12 +26,10 @@ namespace edm {
   RootEmbeddedFileSequence::RootEmbeddedFileSequence(
                 ParameterSet const& pset,
                 EmbeddedRootSource& input,
-                InputFileCatalog const& catalog,
-                unsigned int nStreams) :
+                InputFileCatalog const& catalog) :
     RootInputFileSequence(pset, catalog),
     input_(input),
     orderedProcessHistoryIDs_(),
-    nStreams_(nStreams),
     sequential_(pset.getUntrackedParameter<bool>("sequential", false)),
     sameLumiBlock_(pset.getUntrackedParameter<bool>("sameLumiBlock", false)),
     fptr_(nullptr),
@@ -44,10 +42,6 @@ namespace edm {
     // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
     // and should be deleted from the code.
     initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0U)),
-    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
-    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
-    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
-    productSelectorRules_(pset, "inputCommands", "InputSource"),
     enablePrefetching_(false) {
 
     if(noFiles()) {
@@ -100,7 +94,7 @@ namespace edm {
         --count;
         int offset = distribution(dre);
         setAtFileSequenceNumber(offset);
-        initFile(skipBadFiles_);
+        initFile(input_.skipBadFiles());
       }
     }
     if(rootFile()) {
@@ -139,13 +133,13 @@ namespace edm {
           false,   // initialNumberOfEventsToSkip_ != 0 (not used)
           -1,      // remainingEvents() 
           -1,      // remainingLuminosityBlocks()
-	  nStreams_,
+	  input_.nStreams(),
           0U,      // treeCacheSize_
-          treeMaxVirtualSize_,
+          input_.treeMaxVirtualSize(),
           InputSource::RunsLumisAndEvents,
           0U,      // setRun_
           false,   // noEventSort_
-          productSelectorRules_,
+          input_.productSelectorRules(),
           InputType::SecondarySource,
           std::make_shared<BranchIDListHelper>(),
           std::make_shared<ThinnedAssociationsHelper>(),
@@ -156,23 +150,10 @@ namespace edm {
           indexesIntoFiles(),
           currentIndexIntoFile,
           orderedProcessHistoryIDs_,
-          bypassVersionCheck_,
+          input_.bypassVersionCheck(),
           false,   // labelRawDataLikeMC_
           false,   // usingGoToEvent_
           enablePrefetching_);
-  }
-
-  void
-  RootEmbeddedFileSequence::dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) {
-    std::vector<std::string> rules;
-    rules.reserve(wantedBranches.size() + 1);
-    rules.emplace_back("drop *");
-    for(std::string const& branch : wantedBranches) {
-      rules.push_back("keep " + branch + "_*");
-    }
-    ParameterSet pset;
-    pset.addUntrackedParameter("inputCommands", rules);
-    productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
   }
 
   void
@@ -193,7 +174,6 @@ namespace edm {
 
   bool
   RootEmbeddedFileSequence::readOneSequential(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*) {
-    skipBadFiles_ = false;
     assert(rootFile());
     rootFile()->nextEventEntry();
     bool found = rootFile()->readCurrentEvent(cache);
@@ -215,7 +195,6 @@ namespace edm {
   RootEmbeddedFileSequence::readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* idp) {
     assert(idp);
     EventID const& id = *idp;
-    skipBadFiles_ = false;
     int offset = initialNumberOfEventsToSkip_;
     initialNumberOfEventsToSkip_ = 0;
     if(offset > 0) {
@@ -255,7 +234,6 @@ namespace edm {
 
   void
   RootEmbeddedFileSequence::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& idx) {
-    skipBadFiles_ = false;
     EventID const& id = idx.eventID();
     bool found = skipToItem(id.run(), id.luminosityBlock(), id.event(), idx.fileNameHash());
     if(!found) {
@@ -276,7 +254,6 @@ namespace edm {
   RootEmbeddedFileSequence::readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const*) {
     assert(rootFile());
     assert(engine);
-    skipBadFiles_ = false;
     unsigned int currentSeqNumber = sequenceNumberOfFile();
     while(eventsRemainingInFile_ == 0) {
 
@@ -311,7 +288,6 @@ namespace edm {
     assert(engine);
     assert(idp);
     EventID const& id = *idp;
-    skipBadFiles_ = false;
     if(noMoreFiles() || !rootFile() ||
         rootFile()->indexIntoFileIter().run() != id.run() ||
         rootFile()->indexIntoFileIter().lumi() != id.luminosityBlock()) {
@@ -363,15 +339,5 @@ namespace edm {
                      "False: loopEvents() reads events regardless of lumi.");
     desc.addUntracked<unsigned int>("skipEvents", 0U)
         ->setComment("Skip the first 'skipEvents' events. Used only if 'sequential' is True and 'sameLumiBlock' is False");
-    desc.addUntracked<bool>("skipBadFiles", false)
-        ->setComment("True:  Ignore any missing or unopenable input file.\n"
-                     "False: Throw exception if missing or unopenable input file.");
-    desc.addUntracked<bool>("bypassVersionCheck", false)
-        ->setComment("True:  Bypass release version check.\n"
-                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
-    desc.addUntracked<int>("treeMaxVirtualSize", -1)
-        ->setComment("Size of ROOT TTree TBasket cache.  Affects performance.");
-
-    ProductSelectorRules::fillDescription(desc, "inputCommands");
   }
 }

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -9,7 +9,6 @@ RootEmbeddedFileSequence: This is an InputSource
 
 #include "RootInputFileSequence.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
@@ -34,14 +33,12 @@ namespace edm {
   public:
     explicit RootEmbeddedFileSequence(ParameterSet const& pset,
                                    EmbeddedRootSource& input,
-                                   InputFileCatalog const& catalog,
-                                   unsigned int nStreams);
+                                   InputFileCatalog const& catalog);
     virtual ~RootEmbeddedFileSequence();
 
     RootEmbeddedFileSequence(RootEmbeddedFileSequence const&) = delete; // Disallow copying and moving
     RootEmbeddedFileSequence& operator=(RootEmbeddedFileSequence const&) = delete; // Disallow copying and moving
 
-    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
     virtual void closeFile_() override;
     void endJob();
     void skipEntries(unsigned int offset);
@@ -52,7 +49,6 @@ namespace edm {
     bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
     void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
 
-    void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     static void fillDescription(ParameterSetDescription & desc);
   private:
     virtual void initFile_(bool skipBadFiles) override;
@@ -62,16 +58,11 @@ namespace edm {
 
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
-    unsigned int nStreams_; 
     bool sequential_;
     bool sameLumiBlock_;
     bool (RootEmbeddedFileSequence::* fptr_)(EventPrincipal&, size_t&, CLHEP::HepRandomEngine*, EventID const*);
     int eventsRemainingInFile_;
     int initialNumberOfEventsToSkip_;
-    bool skipBadFiles_;
-    bool bypassVersionCheck_;
-    int const treeMaxVirtualSize_;
-    ProductSelectorRules productSelectorRules_;
     bool enablePrefetching_;
   }; // class RootEmbeddedFileSequence
 }

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -302,8 +302,10 @@ namespace edm {
       LogWarning("") << "Input file: " << fileName() << " was not found or could not be opened, and will be skipped.\n";
     }
   }
+
   void
   RootInputFileSequence::setIndexIntoFile(size_t index) {
    indexesIntoFiles_[index] = rootFile()->indexIntoFileSharedPtr();
   }
+
 }

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -21,33 +21,17 @@ namespace edm {
   RootPrimaryFileSequence::RootPrimaryFileSequence(
                 ParameterSet const& pset,
                 PoolSource& input,
-                InputFileCatalog const& catalog,
-                unsigned int nStreams) :
+                InputFileCatalog const& catalog) :
     RootInputFileSequence(pset, catalog),
     input_(input),
     firstFile_(true),
     branchesMustMatch_(BranchDescription::Permissive),
     orderedProcessHistoryIDs_(),
-    nStreams_(nStreams),
     eventSkipperByID_(EventSkipperByID::create(pset).release()),
-    // The default value provided as the second argument to the getUntrackedParameter function call
-    // is not used when the ParameterSet has been validated and the parameters are not optional
-    // in the description.  This is currently true when PoolSource is the primary input source.
-    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
-    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
-    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
-    // and should be deleted from the code.
-    initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0U)),
-    noEventSort_(pset.getUntrackedParameter<bool>("noEventSort", true)),
-    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
-    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
-    treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize) : 0U),
-    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
-    setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
-    productSelectorRules_(pset, "inputCommands", "InputSource"),
+    initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents")),
+    noEventSort_(pset.getUntrackedParameter<bool>("noEventSort")),
+    treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize") : 0U),
     duplicateChecker_(new DuplicateChecker(pset)),
-    dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches", true)),
-    labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC", true)),
     usingGoToEvent_(false),
     enablePrefetching_(false) {
 
@@ -69,7 +53,7 @@ namespace edm {
     }
     // Open the first file.
     for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
-      initFile(skipBadFiles_);
+      initFile(input_.skipBadFiles());
       if(rootFile()) break;
     }
     if(rootFile()) {
@@ -94,7 +78,7 @@ namespace edm {
       // The first input file has already been opened.
       firstFile_ = false;
       if(!rootFile()) {
-        initFile(skipBadFiles_);
+        initFile(input_.skipBadFiles());
       }
     } else {
       if(!nextFile()) {
@@ -140,25 +124,25 @@ namespace edm {
           initialNumberOfEventsToSkip_ != 0,
           remainingEvents(),
           remainingLuminosityBlocks(),
-	  nStreams_,
+	  input_.nStreams(),
           treeCacheSize_,
-          treeMaxVirtualSize_,
+          input_.treeMaxVirtualSize(),
           input_.processingMode(),
-          setRun_,
+          input_.setRun(),
           noEventSort_,
-          productSelectorRules_,
+          input_.productSelectorRules(),
           InputType::Primary,
           input_.branchIDListHelper(),
           input_.thinnedAssociationsHelper(),
           std::vector<BranchID>(), // associationsFromSecondary_
           duplicateChecker_,
-          dropDescendants_,
+          input_.dropDescendants(),
           input_.processHistoryRegistryForUpdate(),
           indexesIntoFiles(),
           currentIndexIntoFile,
           orderedProcessHistoryIDs_,
-          bypassVersionCheck_,
-          labelRawDataLikeMC_,
+          input_.bypassVersionCheck(),
+          input_.labelRawDataLikeMC(),
           usingGoToEvent_,
           enablePrefetching_);
   }
@@ -169,7 +153,7 @@ namespace edm {
       return false;
     }
 
-    initFile(skipBadFiles_);
+    initFile(input_.skipBadFiles());
 
     if(rootFile()) {
       // make sure the new product registry is compatible with the main one
@@ -346,28 +330,13 @@ namespace edm {
                      "Note 1: Events within the same lumi will always be processed contiguously.\n"
                      "Note 2: Lumis within the same run will always be processed contiguously.\n"
                      "Note 3: Any sorting occurs independently in each input file (no sorting across input files).");
-    desc.addUntracked<bool>("skipBadFiles", false)
-        ->setComment("True:  Ignore any missing or unopenable input file.\n"
-                     "False: Throw exception if missing or unopenable input file.");
-    desc.addUntracked<bool>("bypassVersionCheck", false)
-        ->setComment("True:  Bypass release version check.\n"
-                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
     desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
         ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
-    desc.addUntracked<int>("treeMaxVirtualSize", -1)
-        ->setComment("Size of ROOT TTree TBasket cache.  Affects performance.");
-    desc.addUntracked<unsigned int>("setRunNumber", 0U)
-        ->setComment("If non-zero, change number of first run to this number. Apply same offset to all runs.  Allowed only for simulation.");
-    desc.addUntracked<bool>("dropDescendantsOfDroppedBranches", true)
-        ->setComment("If True, also drop on input any descendent of any branch dropped on input.");
     std::string defaultString("permissive");
     desc.addUntracked<std::string>("branchesMustMatch", defaultString)
         ->setComment("'strict':     Branches in each input file must match those in the first file.\n"
                      "'permissive': Branches in each input file may be any subset of those in the first file.");
-    desc.addUntracked<bool>("labelRawDataLikeMC", true)
-        ->setComment("If True: replace module label for raw data to match MC. Also use 'LHC' as process.");
 
-    ProductSelectorRules::fillDescription(desc, "inputCommands");
     EventSkipperByID::fillDescription(desc);
     DuplicateChecker::fillDescription(desc);
   }

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -34,14 +34,12 @@ namespace edm {
   public:
     explicit RootPrimaryFileSequence(ParameterSet const& pset,
                                    PoolSource& input,
-                                   InputFileCatalog const& catalog,
-                                   unsigned int nStreams);
+                                   InputFileCatalog const& catalog);
     virtual ~RootPrimaryFileSequence();
 
     RootPrimaryFileSequence(RootPrimaryFileSequence const&) = delete; // Disallow copying and moving
     RootPrimaryFileSequence& operator=(RootPrimaryFileSequence const&) = delete; // Disallow copying and moving
 
-    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
     std::unique_ptr<FileBlock> readFile_();
     virtual void closeFile_() override;
     void endJob();
@@ -67,19 +65,11 @@ namespace edm {
     BranchDescription::MatchMode branchesMustMatch_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
-    unsigned int nStreams_; 
     std::shared_ptr<EventSkipperByID> eventSkipperByID_;
     int initialNumberOfEventsToSkip_;
     bool noEventSort_;
-    bool skipBadFiles_;
-    bool bypassVersionCheck_;
     unsigned int treeCacheSize_;
-    int const treeMaxVirtualSize_;
-    RunNumber_t setRun_;
-    ProductSelectorRules productSelectorRules_;
     std::shared_ptr<DuplicateChecker> duplicateChecker_;
-    bool dropDescendants_;
-    bool labelRawDataLikeMC_;
     bool usingGoToEvent_;
     bool enablePrefetching_;
   }; // class RootPrimaryFileSequence

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -21,27 +21,10 @@ namespace edm {
   RootSecondaryFileSequence::RootSecondaryFileSequence(
                 ParameterSet const& pset,
                 PoolSource& input,
-                InputFileCatalog const& catalog,
-                unsigned int nStreams) :
+                InputFileCatalog const& catalog) :
     RootInputFileSequence(pset, catalog),
     input_(input),
-    firstFile_(true),
     orderedProcessHistoryIDs_(),
-    nStreams_(nStreams),
-    // The default value provided as the second argument to the getUntrackedParameter function call
-    // is not used when the ParameterSet has been validated and the parameters are not optional
-    // in the description.  This is currently true when PoolSource is the primary input source.
-    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
-    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
-    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
-    // and should be deleted from the code.
-    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
-    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
-    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
-    setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
-    productSelectorRules_(pset, "inputCommands", "InputSource"),
-    dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches", true)),
-    labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC", true)),
     enablePrefetching_(false) {
 
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
@@ -59,7 +42,7 @@ namespace edm {
 
     // Open the first file.
     for(setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
-      initFile(skipBadFiles_);
+      initFile(input_.skipBadFiles());
       if(rootFile()) break;
     }
     if(rootFile()) {
@@ -100,25 +83,25 @@ namespace edm {
           false,   // initialNumberOfEventsToSkip_ != 0
           -1,      // remainingEvents() 
           -1,      // remainingLuminosityBlocks()
-	  nStreams_,
+	  input_.nStreams(),
           0U,      // treeCacheSize_
-          treeMaxVirtualSize_,
+          input_.treeMaxVirtualSize(),
           input_.processingMode(),
-          setRun_,
+          input_.setRun(),
           false,   // noEventSort_
-          productSelectorRules_,
+          input_.productSelectorRules(),
           InputType::SecondaryFile,
           input_.branchIDListHelper(),
           input_.thinnedAssociationsHelper(),
           associationsFromSecondary_,
           nullptr, //duplicateChecker_
-          dropDescendants_,
+          input_.dropDescendants(),
           input_.processHistoryRegistryForUpdate(),
           indexesIntoFiles(),
           currentIndexIntoFile,
           orderedProcessHistoryIDs_,
-          bypassVersionCheck_,
-          labelRawDataLikeMC_,
+          input_.bypassVersionCheck(),
+          input_.labelRawDataLikeMC(),
           false,   // usingGoToEvent_
           enablePrefetching_);
   }

--- a/IOPool/Input/src/RootSecondaryFileSequence.h
+++ b/IOPool/Input/src/RootSecondaryFileSequence.h
@@ -22,7 +22,6 @@ namespace edm {
   class BranchID;
   class FileCatalogItem;
   class InputFileCatalog;
-  class ParameterSetDescription;
   class PoolSource;
   class RootFile;
 
@@ -30,35 +29,22 @@ namespace edm {
   public:
     explicit RootSecondaryFileSequence(ParameterSet const& pset,
                                    PoolSource& input,
-                                   InputFileCatalog const& catalog,
-                                   unsigned int nStreams);
+                                   InputFileCatalog const& catalog);
     virtual ~RootSecondaryFileSequence();
 
     RootSecondaryFileSequence(RootSecondaryFileSequence const&) = delete; // Disallow copying and moving
     RootSecondaryFileSequence& operator=(RootSecondaryFileSequence const&) = delete; // Disallow copying and moving
 
-    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
     virtual void closeFile_() override;
     void endJob();
-    static void fillDescription(ParameterSetDescription & desc);
     void initAssociationsFromSecondary(std::set<BranchID> const&);
   private:
     virtual void initFile_(bool skipBadFiles) override;
     virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
 
     PoolSource& input_;
-    bool firstFile_;
     std::vector<BranchID> associationsFromSecondary_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
-
-    unsigned int nStreams_; 
-    bool skipBadFiles_;
-    bool bypassVersionCheck_;
-    int const treeMaxVirtualSize_;
-    RunNumber_t setRun_;
-    ProductSelectorRules productSelectorRules_;
-    bool dropDescendants_;
-    bool labelRawDataLikeMC_;
     bool enablePrefetching_;
   }; // class RootSecondaryFileSequence
 }


### PR DESCRIPTION
PoolSource contains two data members that contain copies of the same parameters or data. This PR removes the duplication by moving these parameters up to PoolSource itself. In the secondary input source (EmbeddedRootSource), there is no such duplication, but the same data is also moved up to the source for consistency with PoolSource. This PR also does some C++11 modernization by adding missing override keywords and changing a few iterator loops to range based for loops.
