### PR TITLE
Remove HLT-like customisations from RelVal step for HI Run2 MC

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -469,7 +469,7 @@ steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AM
 U2000by1={'--relval': '2000,1'}
 U80by1={'--relval': '80,1'}
 
-hiAlca = {'--conditions':'auto:run2_mc_HIon', '--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI'}
+hiAlca = {'--conditions':'auto:run2_mc_hi', '--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI'}
 hiAlca2011 = {'--conditions':'auto:run1_mc_hi'}
 
 hiDefaults2011=merge([hiAlca2011,{'--scenario':'HeavyIons','-n':2,'--beamspot':'RealisticHI2011Collision'}])
@@ -1289,7 +1289,7 @@ stepMiniAODMC = merge([{'--conditions'   : 'auto:run2_mc',
 #steps['MINIAODDATAs2']     =merge([{'--filein':'file:step2.root'},stepMiniAODData])
 steps['MINIAODMCUP15']     =merge([stepMiniAODMC])
 #steps['MINIAODMCUP1550']   =merge([{'--conditions':'auto:run2_mc_50ns','--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_50ns'},stepMiniAODMC])
-#steps['MINIAODMCUP15HI']   =merge([{'--conditions':'auto:run2_mc_HIon','--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI'},stepMiniAODMC])
+#steps['MINIAODMCUP15HI']   =merge([{'--conditions':'auto:run2_mc_hi','--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI'},stepMiniAODMC])
 steps['MINIAODMCUP15FS']   =merge([{'--filein':'file:step1.root','--fast':''},stepMiniAODMC])
 steps['MINIAODMCUP15FS50'] =merge([{'--conditions':'auto:run2_mc_50ns','--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_50ns'},steps['MINIAODMCUP15FS']])
 

--- a/RecoHI/HiCentralityAlgos/test/test_addBin_cfg.py
+++ b/RecoHI/HiCentralityAlgos/test/test_addBin_cfg.py
@@ -5,15 +5,7 @@ process = cms.Process("TEST")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #process.GlobalTag.globaltag = 'STARTHI53_LV1'
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc_HIon', '')
-
-process.GlobalTag.toGet.extend([
-	cms.PSet(record = cms.string("HeavyIonRcd"),
-		tag = cms.string("CentralityTable_HFtowers200_Glauber2010A_v5315x01_offline"),
-		connect = cms.untracked.string("frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS"),
-		label = cms.untracked.string("HFtowers")
-	),
-])
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc_hi', '')
 
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(100),

--- a/RecoHI/HiCentralityAlgos/test/test_filter_cfg.py
+++ b/RecoHI/HiCentralityAlgos/test/test_filter_cfg.py
@@ -5,15 +5,7 @@ process = cms.Process("TEST")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #process.GlobalTag.globaltag = 'STARTHI53_LV1'
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc_HIon', '')
-
-process.GlobalTag.toGet.extend([
-	cms.PSet(record = cms.string("HeavyIonRcd"),
-		tag = cms.string("CentralityTable_HFtowers200_Glauber2010A_v5315x01_offline"),
-		connect = cms.untracked.string("frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS"),
-		label = cms.untracked.string("HFtowers")
-	),
-])
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc_hi', '')
 
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(100),


### PR DESCRIPTION
The `run2_mc_HIon` key is added to the list of available GlobalTags for testing purposes, originally in `autoCond`, by `autoCondHLT`, so it is specific for TSG tests, like `addOn`.
This key is now removed in RelVal steps and local tests. It is in fact kept for HLT tests.
