### PR TITLE
HF 1x1 TP production along 2x3 TP

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -21,243 +21,84 @@ CaloTPGTranscoderULUT::CaloTPGTranscoderULUT(const std::string& compressionFile,
                                                   compressionFile_(compressionFile),
                                                   decompressionFile_(decompressionFile)
 {
-  for (int i = 0; i < NOUTLUTS; i++) outputLUT_[i] = 0;
+  outputLUT_.clear();
 }
 
 CaloTPGTranscoderULUT::~CaloTPGTranscoderULUT() {
-  for (int i = 0; i < NOUTLUTS; i++) {
-    if (outputLUT_[i] != 0) delete [] outputLUT_[i];
-  }
 }
 
 void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
                                              HcalTrigTowerGeometry const& theTrigTowerGeometry) {
-// Initialize analytical compression LUT's here
-   // TODO cms::Error log
-  if (OUTPUT_LUT_SIZE != (unsigned int) 0x400) std::cout << "Error: Analytic compression expects 10-bit LUT; found LUT with " << OUTPUT_LUT_SIZE << " entries instead" << std::endl;
+    // Initialize analytical compression LUT's here
+    // TODO cms::Error log
+    if (OUTPUT_LUT_SIZE != (unsigned int) 0x400) std::cout << "Error: Analytic compression expects 10-bit LUT; found LUT with " << OUTPUT_LUT_SIZE << " entries instead" << std::endl;
 
-  std::vector<unsigned int> analyticalLUT(OUTPUT_LUT_SIZE, 0);
-  std::vector<unsigned int> identityLUT(OUTPUT_LUT_SIZE, 0);
+    std::vector<unsigned int> analyticalLUT(OUTPUT_LUT_SIZE, 0);
+    std::vector<unsigned int> identityLUT(OUTPUT_LUT_SIZE, 0);
 
-  // Compute compression LUT
-  for (unsigned int i=0; i < OUTPUT_LUT_SIZE; i++) {
+    // Compute compression LUT
+    for (unsigned int i=0; i < OUTPUT_LUT_SIZE; i++) {
 	analyticalLUT[i] = (unsigned int)(sqrt(14.94*log(1.+i/14.94)*i) + 0.5);
 	identityLUT[i] = min(i,0xffu);
-  }
+    }
  
-  for (int ieta=-32; ieta <= 32; ieta++){
-     for (int iphi = 1; iphi <= 72; iphi++){
-        if (!HTvalid(ieta,iphi)) continue;
-        int lutId = getOutputLUTId(ieta,iphi);
-        // TODO cms::Error log
-        if (outputLUT_[lutId] != 0){
-           std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
-           continue;
+    std::vector<DetId> allChannels = lutMetadata.getAllChannels();
+
+    for(std::vector<DetId>::iterator i=allChannels.begin(); i!=allChannels.end(); ++i){
+
+	if(HcalDetId(*i).subdet()!=HcalTriggerTower) continue;
+	
+	HcalTrigTowerDetId id(*i); 
+	if(!theTopology->validHT(HcalTrigTowerDetId(id))) continue;
+
+
+	unsigned int index = getOutputLUTId(id); 
+
+	if(index >= outputLUT_.size()){
+	    outputLUT_.resize(index+1);
+	    hcaluncomp_.resize(index+1);
+	}
+
+	const HcalLutMetadatum *meta = lutMetadata.getValues(id);
+	unsigned int threshold	     = meta->getOutputLutThreshold();
+
+	int ieta=id.ieta();
+	bool isHBHE = (abs(ieta) < theTrigTowerGeometry.firstHFTower()); 
+
+	for (unsigned int i = 0; i < threshold; ++i) outputLUT_[index].push_back(0);
+	for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i){
+	    LUT value =  isHBHE ? analyticalLUT[i] : identityLUT[i];
+	    outputLUT_[index].push_back(value);
         }
 
-        outputLUT_[lutId] = new LUT[OUTPUT_LUT_SIZE];
+	//now uncompression LUTs
+	hcaluncomp_[index].resize(TPGMAX);
 
-        HcalTrigTowerDetId id(ieta, iphi);
-        const HcalLutMetadatum *meta = lutMetadata.getValues(id);
-        int threshold = meta->getOutputLutThreshold();
+	double eta_low = 0., eta_high = 0.;
+	theTrigTowerGeometry.towerEtaBounds(ieta,eta_low,eta_high); 
+	double cosh_ieta   = fabs(cosh((eta_low + eta_high)/2.));
+	double granularity =  meta->getLutGranularity(); 
 
-        for (int i = 0; i < threshold; ++i)
-           outputLUT_[lutId][i] = 0;
+	double factor = isHBHE ?  (nominal_gain_ / cosh_ieta * granularity) : rctlsb_factor_;
 
-        for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
-           outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry.firstHFTower()) ? analyticalLUT[i] : identityLUT[i];
-     } //for iphi
-  } //for ieta
-}
-
-void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename, HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry) {
-  int tool;
-  std::ifstream userfile;
-  std::vector< std::vector<LUT> > outputluts;
-
-  std::cout << "Initializing compression LUT's from " << (char *)filename.data() << std::endl;
-  for (int i = 0; i < NOUTLUTS; i++) outputLUT_[i] = 0;
-  int maxid = 0, minid = 0x7FFFFFFF, rawid = 0;
-  for (int ieta=-32; ieta <= 32; ieta++) {
-    for (int iphi = 1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta,iphi)) {
-          rawid = getOutputLUTId(ieta, iphi);
-          if (outputLUT_[rawid] != 0) std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
-          else outputLUT_[rawid] = new LUT[OUTPUT_LUT_SIZE];
-          if (rawid < minid) minid = rawid;
-          if (rawid > maxid) maxid = rawid;
-        }
-	}
-  }
-
-  userfile.open((char *)filename.data());
-
-  if( userfile ) {
-    int nluts = 0;
-	std::string s;
-    std::vector<int> loieta,hiieta;
-    std::vector<int> loiphi,hiiphi;
-    getline(userfile,s);
-
-    getline(userfile,s);
-
-	unsigned int index = 0;
-	while (index < s.length()) {
-	  while (isspace(s[index])) index++;
-	  if (index < s.length()) nluts++;
-	  while (!isspace(s[index])) index++;
-	}
-	for (unsigned int i=0; i<=s.length(); i++) userfile.unget(); //rewind last line
-    outputluts.resize(nluts);
-    for (int i=0; i<nluts; i++) outputluts[i].resize(OUTPUT_LUT_SIZE);
-    
-    
-    for (int i=0; i<nluts; i++) {
-      userfile >> tool;
-      loieta.push_back(tool);
-    }
-    
-    for (int i=0; i<nluts; i++) {
-      userfile >> tool;
-      hiieta.push_back(tool);    
-    }
-   
-    for (int i=0; i<nluts; i++) {
-      userfile >> tool;
-      loiphi.push_back(tool);
-	
-    }
-    
-    for (int i=0; i<nluts; i++) {
-      userfile >> tool;
-      hiiphi.push_back(tool);
-    
-    }
-   	
-    for (unsigned int j=0; j<OUTPUT_LUT_SIZE; j++) { 
-      for(int i=0; i <nluts; i++) {
-		userfile >> tool;
-		if (tool < 0) {
-			std::cout << "Error: LUT can't have negative numbers; 0 used instead: " << i << ", " << j << " : = " << tool << std::endl;
-			tool = 0;
-		} else if (tool > 0xff) {
-			std::cout << "Error: LUT can't have >8-bit numbers; 0xff used instead: " << i << ", " << j << " : = " << tool << std::endl;
-			tool = 0xff;
-		}
-		outputluts[i][j] = tool;
-		if (userfile.eof()) std::cout << "Error: LUT file is truncated or has a wrong format: " << i << "," << j << std::endl;
-	  }
-    }
-    userfile.close();
-	
-	HcalDetId cell;
-	int id, ntot = 0;
-	for (int i=0; i < nluts; i++) {
-		int nini = 0;
-     		for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {      
-       			for (int ieta=loieta[i]; ieta <= hiieta[i]; ieta++) {
-	 				if (HTvalid(ieta,iphi)) {  
-	   					id = getOutputLUTId(ieta,iphi);
-	   					if (outputLUT_[id] == 0) throw cms::Exception("PROBLEM: outputLUT_ has not been initialized for ieta, iphi, id = ") << ieta << ", " << iphi << ", " << id << std::endl;
-		    			for (int j = 0; j <= 0x3ff; j++) outputLUT_[id][j] = outputluts[i][j];
-						nini++;
-						ntot++;
-	 				}
-       			}
-       }
-	
-    }
-	
-  } else {
-    
-    loadHCALCompress(lutMetadata,theTrigTowerGeometry);
-  }
-}
-
-void CaloTPGTranscoderULUT::loadHCALUncompress(HcalLutMetadata const& lutMetadata,
-                                               HcalTrigTowerGeometry const& theTrigTowerGeometry) {
-   hcaluncomp_.clear();
-   for (int i = 0; i < NOUTLUTS; i++){
-      RCTdecompression decompressionTable(TPGMAX,0);
-      hcaluncomp_.push_back(decompressionTable);
-   }
-
-   for (int ieta = -32; ieta <= 32; ++ieta){
-
-      double eta_low = 0., eta_high = 0.;
-		theTrigTowerGeometry.towerEtaBounds(ieta,eta_low,eta_high); 
-      double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
-
-		for (int iphi = 1; iphi <= 72; iphi++) {
-         if (!HTvalid(ieta, iphi)) continue;
-
-			int lutId = getOutputLUTId(ieta,iphi);
-         HcalTrigTowerDetId id(ieta, iphi);
-
-         const HcalLutMetadatum *meta = lutMetadata.getValues(id);
-         double factor = 0.;
-
-         // HF
-         if (abs(ieta) >= theTrigTowerGeometry.firstHFTower())
-            factor = rctlsb_factor_;
-         // HBHE
-         else 
-            factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
-
-         // tpg - compressed value
-         unsigned int tpg = outputLUT_[lutId][0];
-         int low = 0;
-         for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
-            if (outputLUT_[lutId][i] != tpg){
-               unsigned int mid = (low + i)/2;
-               hcaluncomp_[lutId][tpg] = (tpg == 0 ? low : factor * mid);
+        LUT tpg = outputLUT_[index][0];
+        int low = 0;
+        for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
+	    if (outputLUT_[index][i] != tpg){
+               unsigned int mid = (low + i)/2; 
+               hcaluncomp_[index][tpg] = (tpg == 0 ? low : factor * mid);
                low = i;
-               tpg = outputLUT_[lutId][i];
+               tpg = outputLUT_[index][i];
             }
-         }
-         hcaluncomp_[lutId][tpg] = factor * low;
-		} // for phi
-	} // for ieta
-}
-
-void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename, HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry)  {
-  std::ifstream userfile;
-  userfile.open(filename.c_str());
-  
-  hcaluncomp_.resize(NOUTLUTS);
-  for (int i = 0; i < NOUTLUTS; i++) hcaluncomp_[i].resize(TPGMAX);
-  
-  static const int etabound = 32;
-  if( userfile ) {
-	 double et;
-     for (int i=0; i<TPGMAX; i++) { 
-      for(int j = 1; j <=etabound; j++) {
-	    userfile >> et;
-		for (int iphi = 1; iphi <= 72; iphi++) {
-		  int itower = getOutputLUTId(j,iphi);
-		  if (itower >= 0) hcaluncomp_[itower][i] = et;
-		  itower = getOutputLUTId(-j,iphi);
-		  if (itower >= 0) hcaluncomp_[itower][i] = et;		  
-		}
-	  }
-	 }
-	 userfile.close();
-  }
-  else {
-
-    loadHCALUncompress(lutMetadata,theTrigTowerGeometry);
-  }
+        }
+        hcaluncomp_[index][tpg] = factor * low;
+    }
 }
 
 HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const {
-  int ieta = id.ieta();
-  int iphi = id.iphi();
-//  if (abs(ieta) > 28) iphi = iphi/4 + 1; // Changing iphi index from 1, 5, ..., 69 to 1, 2, ..., 18
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = getOutputLUTId(id);
 
-  if (itower < 0) cms::Exception("Invalid Data") << "No trigger tower found for ieta, iphi = " << ieta << ", " << iphi;
   if (sample >= OUTPUT_LUT_SIZE) {
-
     throw cms::Exception("Out of Range") << "LUT has 1024 entries for " << itower << " but " << sample << " was requested.";
     sample=OUTPUT_LUT_SIZE - 1;
   }
@@ -296,13 +137,10 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) co
 }
 
 double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const {
-
-  int ieta = hid.ieta();			// No need to check the validity,
-  int iphi = hid.iphi();			// as the values are guaranteed
   int compET = hc.compressedEt();	// to be within the range by the class
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = getOutputLUTId(hid);
   double etvalue = hcaluncomp_[itower][compET];
-  return(etvalue);
+  return etvalue;
 }
 
 EcalTriggerPrimitiveSample CaloTPGTranscoderULUT::ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const {
@@ -333,6 +171,10 @@ bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
 	return true;
 }
 
+int CaloTPGTranscoderULUT::getOutputLUTId(const HcalTrigTowerDetId& id) const {
+    return theTopology->detId2denseIdHT(id);
+}
+
 int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
 	int iphi = iphiin;
 	if (HTvalid(ieta, iphi)) {
@@ -347,48 +189,25 @@ int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) cons
 	} else return -1;	
 }
 
-std::vector<unsigned char> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id) const {
-   std::vector<unsigned char> lut;
-   int itower = getOutputLUTId(id.ieta(),id.iphi());
-   if (itower >= 0) {
-         lut.resize(OUTPUT_LUT_SIZE);
-	 for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; i++) lut[i]=outputLUT_[itower][i];
-   } 
-   return lut;
+std::vector<unsigned int> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id) const {
+   int itower = getOutputLUTId(id);
+   return outputLUT_[itower];
 }
 
 void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry)
 {
-   nominal_gain_ = lutMetadata.getNominalGain();
-   float rctlsb =lutMetadata.getRctLsb();
-   if (rctlsb != 0.25 && rctlsb != 0.5)
-      throw cms::Exception("RCTLSB") << " value=" << rctlsb << " (should be 0.25 or 0.5)" << std::endl;
-   rctlsb_factor_ = rctlsb;
+    theTopology = lutMetadata.topo();
+    nominal_gain_ = lutMetadata.getNominalGain();
+    float rctlsb =lutMetadata.getRctLsb();
+    if (rctlsb != 0.25 && rctlsb != 0.5)
+	throw cms::Exception("RCTLSB") << " value=" << rctlsb << " (should be 0.25 or 0.5)" << std::endl;
+    rctlsb_factor_ = rctlsb;
 
-   if (compressionFile_.empty() && decompressionFile_.empty()) {
-     loadHCALCompress(lutMetadata,theTrigTowerGeometry);
+    if (compressionFile_.empty() && decompressionFile_.empty()) {
+	loadHCALCompress(lutMetadata,theTrigTowerGeometry);
+    }
+    else {
+	throw cms::Exception("Not Implemented") << "setup of CaloTPGTranscoderULUT from text files";
    }
-   else {
-      // TODO Message to discourage using txt.
-      std::cout << "From Text File:" << std::endl;
-      loadHCALCompress(compressionFile_, lutMetadata,theTrigTowerGeometry);
-   }
-   loadHCALUncompress(decompressionFile_, lutMetadata,theTrigTowerGeometry);
 }
 
-//int CaloTPGTranscoderULUT::getLutGranularity(const DetId& id) const{
-//   int ieta = id.ietaAbs();
-//   if (ieta < 18) return 1;
-//   else if (ieta < 27) return 2;
-//   else if (ieta < 29) return 5;
-//   return 0;
-//}
-//
-//int CaloTPGTranscoderULUT::getLutThreshold(const DetId& id) const{
-//   int ieta = id.ietaAbs();
-//   if (ieta < 18) return 4;
-//   else if (ieta < 27) return 2;
-//   else if (ieta < 29) return 1;
-//   return 0;
-//}
-//

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -49,7 +49,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	if(HcalDetId(*i).subdet()!=HcalTriggerTower) continue;
 	
 	HcalTrigTowerDetId id(*i); 
-	if(!theTopology->validHT(HcalTrigTowerDetId(id))) continue;
+	if(!theTopology->validHT(id)) continue;
 
 
 	unsigned int index = getOutputLUTId(id); 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -160,16 +160,8 @@ void CaloTPGTranscoderULUT::rctJetUncompress(const HcalTrigTowerDetId& hid, cons
 }
 
 bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
-	int iphi = iphiin;
-	if (iphi <= 0 || iphi > 72 || ieta == 0 || abs(ieta) > 32) return false;
-	if (abs(ieta) > 28) {
-	  if (newHFphi) {
-	    if ((iphi/4)*4 + 1 != iphi) return false;
-	    iphi = iphi/4 + 1;
-	  }
-	  if (iphi > 18) return false;
-	}
-	return true;
+	HcalTrigTowerDetId id(ieta, iphiin);
+	return theTopology->validHT(id);
 }
 
 int CaloTPGTranscoderULUT::getOutputLUTId(const HcalTrigTowerDetId& id) const {
@@ -177,17 +169,8 @@ int CaloTPGTranscoderULUT::getOutputLUTId(const HcalTrigTowerDetId& id) const {
 }
 
 int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
-	int iphi = iphiin;
-	if (HTvalid(ieta, iphi)) {
-		int offset = 0, ietaabs;
-		ietaabs = abs(ieta);
-		if (ieta < 0) offset = NOUTLUTS/2;
-		if (ietaabs < 29) return 72*(ietaabs - 1) + (iphi - 1) + offset;
-		else {
-		  if (newHFphi) iphi = iphi/4 + 1;
-		  return 18*(ietaabs - 29) + iphi + 2015 + offset;
-		}
-	} else return -1;	
+	HcalTrigTowerDetId id(ieta, iphiin);
+	return theTopology->detId2denseIdHT(id);
 }
 
 std::vector<unsigned int> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id) const {

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -63,7 +63,8 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	unsigned int threshold	     = meta->getOutputLutThreshold();
 
 	int ieta=id.ieta();
-	bool isHBHE = (abs(ieta) < theTrigTowerGeometry.firstHFTower()); 
+	int version=id.version();
+	bool isHBHE = (abs(ieta) < theTrigTowerGeometry.firstHFTower(version)); 
 
 	for (unsigned int i = 0; i < threshold; ++i) outputLUT_[index].push_back(0);
 	for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i){
@@ -75,7 +76,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	hcaluncomp_[index].resize(TPGMAX);
 
 	double eta_low = 0., eta_high = 0.;
-	theTrigTowerGeometry.towerEtaBounds(ieta,eta_low,eta_high); 
+	theTrigTowerGeometry.towerEtaBounds(ieta,version,eta_low,eta_high); 
 	double cosh_ieta   = fabs(cosh((eta_low + eta_high)/2.));
 	double granularity =  meta->getLutGranularity(); 
 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -4,8 +4,7 @@
 #include <memory>
 #include <vector>
 #include "CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h"
-
-// tmp
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CondFormats/HcalObjects/interface/HcalLutMetadata.h"
 
 
@@ -34,8 +33,9 @@ public:
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
   virtual bool HTvalid(const int ieta, const int iphi) const;
-  virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id) const;
+  virtual std::vector<unsigned int> getCompressionLUT(HcalTrigTowerDetId id) const;
   virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&);
+  virtual int getOutputLUTId(const HcalTrigTowerDetId& id) const;
   virtual int getOutputLUTId(const int ieta, const int iphi) const;
 
  private:
@@ -43,8 +43,8 @@ public:
   typedef unsigned int LUT;
   typedef std::vector<double> RCTdecompression;
 
+  const HcalTopology* theTopology;
   // Constant
-  // TODO prefix k
   static const int NOUTLUTS = 4176;
   static const unsigned int OUTPUT_LUT_SIZE = 1024;
   static const int TPGMAX = 256;
@@ -52,11 +52,6 @@ public:
 
   // Member functions
   void loadHCALCompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical compression tables
-  void loadHCALCompress(const std::string& filename, HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Compression tables from file
-  void loadHCALUncompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical decompression
-  void loadHCALUncompress(const std::string& filename, HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Decompression tables from file
-  //int getLutGranularity(const DetId& id) const;
-  //int getLutThreshold(const DetId& id) const;
 
   // Member Variables
   double nominal_gain_;
@@ -68,7 +63,7 @@ public:
   std::vector<int> ZS;
   std::vector<int> LUTfactor;
 
-  LUT *outputLUT_[NOUTLUTS];
+  std::vector<std::vector<LUT> > outputLUT_;
   std::vector<RCTdecompression> hcaluncomp_;
 };
 #endif

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -20,6 +20,7 @@
 #include "CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h"
 #include "CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h"
 #include "FWCore/Utilities/interface/md5.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibCalorimetry/HcalTPGAlgos/interface/HcalEmap.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
@@ -134,7 +135,7 @@ std::vector<unsigned int> * LutXml::getLutFast( uint32_t det_id ){
   }
   */
    if (lut_map.find(det_id) != lut_map.end()) return &(lut_map)[det_id];
-   std::cerr << "LUT not found, null pointer is returned" << std::endl;
+   edm::LogError("LutXml") << "LUT not found, null pointer is returned";
    return 0;
 }
 
@@ -238,7 +239,7 @@ void LutXml::addLut( LutXml::Config & _config, XMLDOMBlock * checksums_xml )
     addData( "1024", "hex", _config.lut );
   }
   else{
-    std::cout << "Unknown LUT type...produced XML will be incorrect" << std::endl;
+    edm::LogError("LutXml") << "Unknown LUT type...produced XML will be incorrect";
   }
 
   // if the pointer to the checksums XML was given,
@@ -358,7 +359,7 @@ std::string LutXml::get_checksum( std::vector<unsigned int> & lut )
     }
   }
   else{
-    std::cout << "ERROR: irregular LUT size, do not know how to compute checksum, exiting..." << std::endl;
+    edm::LogError("LutXml") << "Irregular LUT size, do not know how to compute checksum, exiting...";
     exit(-1);
   }
   md5_finish(&md5er,digest);
@@ -374,8 +375,7 @@ std::string LutXml::get_checksum( std::vector<unsigned int> & lut )
 
 int LutXml::test_access( std::string filename ){
   //create_lut_map();
-  //std::cout << "Created map size: " << lut_map->size() << std::endl;
-  std::cout << "Created map size: " << lut_map.size() << std::endl;
+  edm::LogInfo("LutXml") << "Created map size: " << lut_map.size();
 
   struct timeval _t;
   gettimeofday( &_t, NULL );
@@ -383,7 +383,7 @@ int LutXml::test_access( std::string filename ){
 
   HcalEmap _emap("./backup/official_emap_v6.04_080905.txt");
   std::vector<HcalEmap::HcalEmapRow> & _map = _emap.get_map();
-  std::cout << "HcalEmap contains " << _map . size() << " entries" << std::endl;
+  edm::LogInfo("LutXml") << "HcalEmap contains " << _map . size() << " entries";
 
   int _counter=0;
   for (std::vector<HcalEmap::HcalEmapRow>::const_iterator row=_map.begin(); row!=_map.end(); ++row){
@@ -413,7 +413,7 @@ int LutXml::test_access( std::string filename ){
     }
   }
   gettimeofday( &_t, NULL );
-  std::cout << "access to " << _counter << " HCAL channels took: " << (double)(_t . tv_sec) + (double)(_t . tv_usec)/1000000.0 - _time << "sec" << std::endl;
+  edm::LogInfo("LutXml") << "access to " << _counter << " HCAL channels took: " << (double)(_t . tv_sec) + (double)(_t . tv_usec)/1000000.0 - _time << "sec";
 
   //std::cout << std::endl;
   //for (std::vector<unsigned int>::const_iterator i=l->begin();i!=l->end();i++){
@@ -470,12 +470,12 @@ HcalSubdetector LutXml::subdet_from_crate(int crate_, int eta, int depth){
     else if (eta==16 && depth!=3) result=HcalBarrel;
     else if (eta==16 && depth==3) result=HcalEndcap;
     else{
-      std::cerr << "Impossible to determine HCAL subdetector!!!" << std::endl;
+      edm::LogError("LutXml") << "Impossible to determine HCAL subdetector!!!";
       exit(-1);
     }
   }
   else{
-    std::cerr << "Impossible to determine HCAL subdetector!!!" << std::endl;
+    edm::LogError("LutXml") << "Impossible to determine HCAL subdetector!!!";
     exit(-1);
   }
 
@@ -574,7 +574,7 @@ int LutXml::create_lut_map( void ){
     }
   }
   else{
-    std::cerr << "XML file with LUTs is not loaded, cannot create map!" << std::endl;
+    edm::LogError("LutXml") << "XML file with LUTs is not loaded, cannot create map!";
   }
 
 

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -455,11 +455,12 @@ int LutXml::test_xpath( std::string filename ){
 }
 */
 
-HcalSubdetector LutXml::subdet_from_crate(int crate, int eta, int depth){
+HcalSubdetector LutXml::subdet_from_crate(int crate_, int eta, int depth){
   HcalSubdetector result;
   // HBHE: 0,1,4,5,10,11,14,15,17
   // HF: 2,9,12
   // HO: 3,6,7,13
+  int crate=crate_<20? crate_ : crate_-20;
 
   if (crate==2 || crate==9 || crate==12) result=HcalForward;
   else if (crate==3 || crate==6 || crate==7 || crate==13) result=HcalOuter;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -16,6 +16,8 @@
 
 #include "OnlineDB/Oracle/interface/Oracle.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalLutManager.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ZdcLut.h"
 #include "CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h"
@@ -136,28 +138,30 @@ int HcalLutManager_test::getLutSetFromFile_test( std::string _filename )
 {
   HcalLutManager _manager;
   HcalLutSet _set = _manager . getLutSetFromFile( _filename );
-  std::cout << "===> Test of HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename )" << std::endl << std::endl;
-  std::cout << _set . label << std::endl;
-  for (unsigned int i = 0; i != _set.subdet.size(); i++) std::cout << _set.subdet[i] << "	";
-  std::cout << std::endl;
-  for (unsigned int i = 0; i != _set.eta_min.size(); i++) std::cout << _set.eta_min[i] << "	";
-  std::cout << std::endl;
-  for (unsigned int i = 0; i != _set.eta_max.size(); i++) std::cout << _set.eta_max[i] << "	";
-  std::cout << std::endl;
-  for (unsigned int i = 0; i != _set.phi_min.size(); i++) std::cout << _set.phi_min[i] << "	";
-  std::cout << std::endl;
-  for (unsigned int i = 0; i != _set.phi_max.size(); i++) std::cout << _set.phi_max[i] << "	";
-  std::cout << std::endl;
-  for (unsigned int i = 0; i != _set.depth_min.size(); i++) std::cout << _set.depth_min[i] << "	";
-  std::cout << std::endl;
-  for (unsigned int i = 0; i != _set.depth_max.size(); i++) std::cout << _set.depth_max[i] << "	";
-  std::cout << std::endl;
+  std::stringstream s;
+  s << "===> Test of HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename )" << std::endl << std::endl;
+  s << _set . label << std::endl;
+  for (unsigned int i = 0; i != _set.subdet.size(); i++) s << _set.subdet[i] << "	";
+  s << std::endl;
+  for (unsigned int i = 0; i != _set.eta_min.size(); i++) s << _set.eta_min[i] << "	";
+  s << std::endl;
+  for (unsigned int i = 0; i != _set.eta_max.size(); i++) s << _set.eta_max[i] << "	";
+  s << std::endl;
+  for (unsigned int i = 0; i != _set.phi_min.size(); i++) s << _set.phi_min[i] << "	";
+  s << std::endl;
+  for (unsigned int i = 0; i != _set.phi_max.size(); i++) s << _set.phi_max[i] << "	";
+  s << std::endl;
+  for (unsigned int i = 0; i != _set.depth_min.size(); i++) s << _set.depth_min[i] << "	";
+  s << std::endl;
+  for (unsigned int i = 0; i != _set.depth_max.size(); i++) s << _set.depth_max[i] << "	";
+  s << std::endl;
   for (unsigned int j = 0; j != _set.lut[0].size(); j++){
     for (unsigned int i = 0; i != _set.lut.size(); i++){
-      std::cout << _set.lut[i][j] << "	";
+      s << _set.lut[i][j] << "	";
     }
-    std::cout << "---> " << j << std::endl;
+    s << "---> " << j << std::endl;
   }
+  edm::LogInfo("HcalLutManager") << s.str();
   return 0;
 }
 
@@ -170,8 +174,8 @@ HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename, int _type )
   std::string buf;
 
   if ( infile . is_open() ){
-    std::cout << "File " << _filename << " is open..." << std::endl;
-    std::cout << "Reading LUTs and their eta/phi/depth/subdet ranges...";
+    edm::LogInfo("HcalLutManager") << "File " << _filename << " is open..." << std::endl
+      << "Reading LUTs and their eta/phi/depth/subdet ranges...";
 
     // get label
     getline( infile, _lutset . label );
@@ -241,7 +245,7 @@ HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename, int _type )
     }
   }
 
-  std::cout << "done." << std::endl;
+  edm::LogInfo("HcalLutManager") << "done.";
 
   return _lutset;
 }
@@ -250,14 +254,14 @@ HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename, int _type )
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLutXmlFromAsciiMaster( std::string _filename, std::string _tag, int _crate, bool split_by_crate )
 {
-  std::cout << "Generating linearization (input) LUTs from ascii master file..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating linearization (input) LUTs from ascii master file...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   LMap _lmap;
   _lmap . read( "./backup/HCALmapHBEF.txt", "HBEF" );
   _lmap . read( "./backup/HCALmapHO.txt", "HO" );
   std::map<int,LMapRow> & _map = _lmap.get_map();
-  std::cout << "LMap contains " << _map . size() << " channels" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LMap contains " << _map . size() << " channels";
 
   // read LUTs and their eta/phi/depth/subdet ranges
   HcalLutSet _set = getLutSetFromFile( _filename );
@@ -297,7 +301,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLutXmlFromAsciiMast
       _cfg.slot = row->second.htr;
       if (row->second.fpga . find("top") != std::string::npos) _cfg.topbottom = 1;
       else if (row->second.fpga . find("bot") != std::string::npos) _cfg.topbottom = 0;
-      else std::cout << "Warning! fpga out of range..." << std::endl;
+      else edm::LogWarning("HcalLutManager") << "fpga out of range...";
       // FIXME: probably fixed. fiber==htr_fi, not rm_fi in LMAP notation.
       //_cfg.fiber = row->second.rm_fi;
       _cfg.fiber = row->second.htr_fi;
@@ -326,8 +330,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLutXmlFromAsciiMast
       }
     }
   }
-  std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-  std::cout << "Generating linearization (input) LUTs from ascii master file...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+    << "Generating linearization (input) LUTs from ascii master file...DONE" << std::endl;
   return _xml;
 }
 
@@ -336,17 +340,17 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLutXmlFromAsciiMast
 //
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXmlFromAsciiMasterEmap( std::string _filename, std::string _tag, int _crate, bool split_by_crate )
 {
-  std::cout << "Generating linearization (input) LUTs from ascii master file..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating linearization (input) LUTs from ascii master file...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   EMap _emap(emap);
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
-  std::cout << "EMap contains " << _map . size() << " entries" << std::endl;
+  edm::LogInfo("HcalLutManager") << "EMap contains " << _map . size() << " entries";
 
   // read LUTs and their eta/phi/depth/subdet ranges
   HcalLutSet _set = getLutSetFromFile( _filename );
   int lut_set_size = _set.lut.size(); // number of different luts
-  std::cout << "  ==> " << lut_set_size << " sets of different LUTs read from the master file" << std::endl;
+  edm::LogInfo("HcalLutManager") << "  ==> " << lut_set_size << " sets of different LUTs read from the master file";
 
   // setup "zero" LUT for channel masking
   std::vector<unsigned int> zeroLut;
@@ -392,7 +396,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
 	_cfg.slot = row->slot;
 	if (row->topbottom . find("t") != std::string::npos) _cfg.topbottom = 1;
 	else if (row->topbottom . find("b") != std::string::npos) _cfg.topbottom = 0;
-	else std::cout << "Warning! fpga out of range..." << std::endl;
+	else edm::LogWarning("HcalLutManager") << "fpga out of range...";
 	_cfg.fiber = row->fiber;
 	_cfg.fiberchan = row->fiberchan;
 	_cfg.lut_type = 1;
@@ -428,21 +432,21 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
       }
     }
   }
-  std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-  std::cout << "Generating linearization (input) LUTs from ascii master file...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+    << "Generating linearization (input) LUTs from ascii master file...DONE" << std::endl;
   return _xml;
 }
 
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXmlFromAsciiMasterEmap_new( std::string _filename, std::string _tag, int _crate, bool split_by_crate )
 {
-  std::cout << "Generating linearization (input) LUTs from ascii master file..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating linearization (input) LUTs from ascii master file...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   // read LUTs and their eta/phi/depth/subdet ranges
   HcalLutSet _set = getLutSetFromFile( _filename );
   int lut_set_size = _set.lut.size(); // number of different luts
-  std::cout << "  ==> " << lut_set_size << " sets of different LUTs read from the master file" << std::endl;
+  edm::LogInfo("HcalLutManager") << "  ==> " << lut_set_size << " sets of different LUTs read from the master file";
 
   RooGKCounter _counter;
   //loop over all EMap channels
@@ -521,30 +525,30 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
       }
     }
   }
-  std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-  std::cout << "Generating linearization (input) LUTs from ascii master file...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+    << "Generating linearization (input) LUTs from ascii master file...DONE" << std::endl;
   return _xml;
 }
 
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFromAsciiMaster( std::string _filename, std::string _tag, int _crate, bool split_by_crate )
 {
-  std::cout << "Generating compression (output) LUTs from ascii master file..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating compression (output) LUTs from ascii master file...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
-  std::cout << "instantiating CaloTPGTranscoderULUT in order to check the validity of (ieta,iphi)..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "instantiating CaloTPGTranscoderULUT in order to check the validity of (ieta,iphi)...";
   CaloTPGTranscoderULUT _coder;
 
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v6.03_080817.txt");
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v6.04_080905.txt");
   EMap _emap(emap);
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
-  std::cout << "EMap contains " << _map . size() << " channels" << std::endl;
+  edm::LogInfo("HcalLutManager") << "EMap contains " << _map . size() << " channels";
 
   // read LUTs and their eta/phi/depth/subdet ranges
   HcalLutSet _set = getLutSetFromFile( _filename, 2 );
   int lut_set_size = _set.lut.size(); // number of different luts
-  std::cout << "  ==> " << lut_set_size << " sets of different LUTs read from the master file" << std::endl;
+  edm::LogInfo("HcalLutManager") << "  ==> " << lut_set_size << " sets of different LUTs read from the master file";
 
   //loop over all EMap channels
   RooGKCounter _counter;
@@ -579,7 +583,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
       _cfg.slot = row->slot;
       if (row->topbottom . find("t") != std::string::npos) _cfg.topbottom = 1;
       else if (row->topbottom . find("b") != std::string::npos) _cfg.topbottom = 0;
-      else std::cout << "Warning! fpga out of range..." << std::endl;
+      else edm::LogWarning("HcalLutManager") << "fpga out of range...";
       _cfg.fiber = row->fiber;
       _cfg.fiberchan = row->fiberchan;
       if (_set.lut[lut_index].size() == 128) _cfg.lut_type = 1;
@@ -605,15 +609,15 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
       }
     }
   }
-  std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-  std::cout << "Generating compression (output) LUTs from ascii master file...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+    << "Generating compression (output) LUTs from ascii master file...DONE" << std::endl;
   return _xml;
 }
 
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXmlFromCoder( const HcalTPGCoder & _coder, std::string _tag, bool split_by_crate )
 {
-  std::cout << "Generating linearization (input) LUTs from HcaluLUTTPGCoder..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating linearization (input) LUTs from HcaluLUTTPGCoder...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v6.03_080817.txt");
@@ -625,7 +629,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
   // HO is not part of trigger, so TPGCoder cannot generate LUTs for it
   //_lmap . read( "backup/HCALmapHO.txt", "HO" );
   std::map<int,LMapRow> & _map = _lmap.get_map();
-  std::cout << "LMap contains " << _map . size() << " channels" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LMap contains " << _map . size() << " channels";
 
   // read LUTs and their eta/phi/depth/subdet ranges
   //HcalLutSet _set = getLinearizationLutSetFromCoder();
@@ -649,7 +653,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
     _cfg.slot = row->second.htr;
     if (row->second.fpga . find("top") != std::string::npos) _cfg.topbottom = 1;
     else if (row->second.fpga . find("bot") != std::string::npos) _cfg.topbottom = 0;
-    else std::cout << "Warning! fpga out of range..." << std::endl;
+    else edm::LogWarning("HcalLutManager") << "fpga out of range...";
     // FIXME: probably fixed. fiber==htr_fi, not rm_fi in LMAP notation.
     //_cfg.fiber = row->second.rm_fi;
     _cfg.fiber = row->second.htr_fi;
@@ -688,8 +692,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
       _counter.count();
     }
   }
-  std::cout << "Generated LUTs: " << _counter.getCount() << std::endl;
-  std::cout << "Generating linearization (input) LUTs from HcaluLUTTPGCoder...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generated LUTs: " << _counter.getCount() << std::endl
+    << "Generating linearization (input) LUTs from HcaluLUTTPGCoder...DONE" << std::endl;
   return _xml;
 }
 
@@ -698,12 +702,12 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXmlFromCoderEmap( const HcalTPGCoder & _coder, std::string _tag, bool split_by_crate )
 {
-  std::cout << "Generating linearization (input) LUTs from HcaluLUTTPGCoder..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating linearization (input) LUTs from HcaluLUTTPGCoder...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   EMap _emap(emap);
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
-  std::cout << "EMap contains " << _map . size() << " entries" << std::endl;
+  edm::LogInfo("HcalLutManager") << "EMap contains " << _map . size() << " entries";
 
   std::vector<unsigned int> zeroLut;
   for (size_t adc = 0; adc < 128; adc++) zeroLut.push_back(0);
@@ -731,7 +735,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
       _cfg.slot = row->slot;
       if (row->topbottom . find("t") != std::string::npos) _cfg.topbottom = 1;
       else if (row->topbottom . find("b") != std::string::npos) _cfg.topbottom = 0;
-      else std::cout << "Warning! fpga out of range..." << std::endl;
+      else edm::LogWarning("HcalLutManager") << "fpga out of range...";
       _cfg.fiber = row->fiber;
       _cfg.fiberchan = row->fiberchan;
       _cfg.lut_type = 1;
@@ -776,8 +780,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
       }
     }
   }
-  std::cout << "Generated LUTs: " << _counter.getCount() << std::endl;
-  std::cout << "Generating linearization (input) LUTs from HcaluLUTTPGCoder...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generated LUTs: " << _counter.getCount() << std::endl
+    << "Generating linearization (input) LUTs from HcaluLUTTPGCoder...DONE" << std::endl;
   return _xml;
 }
 
@@ -785,14 +789,14 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getLinearizationLutXml
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFromCoder( const CaloTPGTranscoderULUT & _coder, std::string _tag, bool split_by_crate )
 {
-    std::cout << "Generating compression (output) LUTs from CaloTPGTranscoderULUT," << std::endl;
-    std::cout << "initialized from Event Setup" << std::endl;
+    edm::LogInfo("HcalLutManager") << "Generating compression (output) LUTs from CaloTPGTranscoderULUT," << std::endl
+        << "initialized from Event Setup" << std::endl;
     std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
     EMap _emap(emap);
 
     std::vector<EMap::EMapRow> & _map = _emap.get_map();
-    std::cout << "EMap contains " << _map . size() << " channels" << std::endl;
+    edm::LogInfo("HcalLutManager") << "EMap contains " << _map . size() << " channels";
 
     RooGKCounter _counter;
     for( std::vector<EMap::EMapRow>::const_iterator row=_map.begin(); row!=_map.end(); row++ ){
@@ -819,7 +823,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 	_cfg.slot = row->slot;
 	if (row->topbottom . find("t") != std::string::npos) _cfg.topbottom = 1;
 	else if (row->topbottom . find("b") != std::string::npos) _cfg.topbottom = 0;
-	else std::cout << "Warning! fpga out of range..." << std::endl;
+	else edm::LogWarning("HcalLutManager") << "fpga out of range...";
 	_cfg.fiber = row->fiber;
 	_cfg.fiberchan = row->fiberchan;
 	_cfg.lut_type = 2;
@@ -841,8 +845,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 	    _counter.count();
 	}
     }
-    std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-    std::cout << "Generating compression (output) LUTs from CaloTPGTranscoderULUT...DONE" << std::endl;
+    edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+      << "Generating compression (output) LUTs from CaloTPGTranscoderULUT...DONE" << std::endl;
     return _xml;
 }
 
@@ -850,7 +854,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFromCoder( std::string _tag, bool split_by_crate )
 {
-  std::cout << "Generating compression (output) LUTs from CaloTPGTranscoderULUT" << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating compression (output) LUTs from CaloTPGTranscoderULUT";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v5_080208.txt");
@@ -859,7 +863,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
   EMap _emap(emap);
 
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
-  std::cout << "EMap contains " << _map . size() << " channels" << std::endl;
+  edm::LogInfo("HcalLutManager") << "EMap contains " << _map . size() << " channels";
 
   // read LUTs and their eta/phi/depth/subdet ranges
   //HcalLutSet _set = getLutSetFromFile( _filename, 2 );
@@ -888,7 +892,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
       _cfg.slot = row->slot;
       if (row->topbottom . find("t") != std::string::npos) _cfg.topbottom = 1;
       else if (row->topbottom . find("b") != std::string::npos) _cfg.topbottom = 0;
-      else std::cout << "Warning! fpga out of range..." << std::endl;
+      else edm::LogWarning("HcalLutManager") << "fpga out of range...";
       _cfg.fiber = row->fiber;
       _cfg.fiberchan = row->fiberchan;
       _cfg.lut_type = 2;
@@ -919,8 +923,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
       }
     }
   }
-  std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-  std::cout << "Generating compression (output) LUTs from CaloTPGTranscoderULUT...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+    << "Generating compression (output) LUTs from CaloTPGTranscoderULUT...DONE" << std::endl;
   return _xml;
 }
 
@@ -1104,7 +1108,7 @@ int HcalLutManager::createAllLutXmlFilesLinAsciiCompCoder( std::string _tag, std
 void HcalLutManager::addLutMap(std::map<int, boost::shared_ptr<LutXml> > & result, const std::map<int, boost::shared_ptr<LutXml> > & other)
 {
   for ( std::map<int, boost::shared_ptr<LutXml> >::const_iterator lut=other.begin(); lut!=other.end(); lut++ ){
-    std::cout << "Added LUTs for crate " << lut->first << std::endl;
+    edm::LogInfo("HcalLutManager") << "Added LUTs for crate " << lut->first;
     if ( result.count(lut->first)==0 ){
       result . insert( *lut );
     }
@@ -1138,25 +1142,25 @@ int HcalLutManager::test_xml_access( std::string _tag, std::string _filename )
   EMap _emap(emap);
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
   int map_size = _map . size();
-  std::cout << "EMap contains " << map_size << " channels" << std::endl;
+  edm::LogInfo("HcalLutManager") << "EMap contains " << map_size << " channels";
 
   // make sure that all init is done
   std::vector<unsigned int> _lut;
   _lut = getLutFromXml( _tag, 1107313727, hcal::ConfigurationDatabase::LinearizerLUT );
 
 
-  std::cout << std::endl << "Testing direct parsing of the LUT XML" << std::endl;
+  edm::LogInfo("HcalLutManager") << "Testing direct parsing of the LUT XML";
   struct timeval _t;
   gettimeofday( &_t, NULL );
   double _time =(double)(_t . tv_sec) + (double)(_t . tv_usec)/1000000.0;
   test_direct_xml_parsing(_filename);
   gettimeofday( &_t, NULL );
-  std::cout << "parsing took that much time: " << (double)(_t . tv_sec) + (double)(_t . tv_usec)/1000000.0 - _time << std::endl;
+  edm::LogInfo("HcalLutManager") << "parsing took that much time: " << (double)(_t . tv_sec) + (double)(_t . tv_usec)/1000000.0 - _time;
 
 
   gettimeofday( &_t, NULL );
   _time =(double)(_t . tv_sec) + (double)(_t . tv_usec)/1000000.0;
-  std::cout << "before loop over random LUTs: " << _time << std::endl;
+  edm::LogInfo("HcalLutManager") << "before loop over random LUTs: " << _time;
   int _raw_id;
 
   // loop over random LUTs
@@ -1190,13 +1194,13 @@ int HcalLutManager::test_xml_access( std::string _tag, std::string _filename )
     gettimeofday( &_t, NULL );
   }
   double d_time = _t.tv_sec+_t.tv_usec/1000000.0 - _time;
-  std::cout << "after the loop over random LUTs: " << _time+d_time << std::endl;  
-  std::cout << "total time: " << d_time << std::endl;  
+  edm::LogInfo("HcalLutManager") << "after the loop over random LUTs: " << _time+d_time << std::endl
+    << "total time: " << d_time << std::endl;  
   
-  std::cout << "LUT length = " << _lut . size() << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUT length = " << _lut . size();
   for ( std::vector<unsigned int>::const_iterator i = _lut . end() - 1; i != _lut . begin()-1; i-- )
     {
-      std::cout << (i-_lut.begin()) << "     " << _lut[(i-_lut.begin())] << std::endl;
+      edm::LogInfo("HcalLutManager") << (i-_lut.begin()) << "     " << _lut[(i-_lut.begin())];
       break;
     }
   
@@ -1216,7 +1220,7 @@ int HcalLutManager::read_lmap( std::string lmap_hbef_file, std::string lmap_ho_f
   lmap = new LMap();
   lmap -> read( lmap_hbef_file, "HBEF" );
   lmap -> read( lmap_ho_file, "HO" );
-  std::cout << "LMap contains " << lmap -> get_map() . size() << " channels (compare to 9072 of all HCAL channels)" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LMap contains " << lmap -> get_map() . size() << " channels (compare to 9072 of all HCAL channels)";
   return 0;
 }
 
@@ -1246,7 +1250,7 @@ int HcalLutManager::local_connect( std::string lut_xml_file, std::string lmap_hb
 
 std::vector<unsigned int> HcalLutManager::getLutFromXml( std::string tag, uint32_t _rawid, hcal::ConfigurationDatabase::LUTType _lt )
 {
-  std::cout << "getLutFromXml (new version) is not implemented. Use getLutFromXml_old() for now" << std::endl;
+  edm::LogInfo("HcalLutManager") << "getLutFromXml (new version) is not implemented. Use getLutFromXml_old() for now";
 
   std::vector<unsigned int> result;
 
@@ -1260,11 +1264,11 @@ std::vector<unsigned int> HcalLutManager::getLutFromXml( std::string tag, uint32
 std::vector<unsigned int> HcalLutManager::getLutFromXml_old( std::string tag, uint32_t _rawid, hcal::ConfigurationDatabase::LUTType _lt )
 {
   if ( !lmap ){
-    std::cout << "HcalLutManager: cannot find LUT without LMAP, exiting..." << std::endl;
+    edm::LogError("HcalLutManager") << "Cannot find LUT without LMAP, exiting...";
     exit(-1);
   }
   if ( !db ){
-    std::cout << "HcalLutManager: cannot find LUT, no source (local XML file), exiting..." << std::endl;
+    edm::LogError("HcalLutManager") << "Cannot find LUT, no source (local XML file), exiting...";
     exit(-1);
   }
 
@@ -1290,7 +1294,7 @@ std::vector<unsigned int> HcalLutManager::getLutFromXml_old( std::string tag, ui
     if ( _fpga . find("top") != std::string::npos ) topbottom = 1;
     else if ( _fpga . find("bot") != std::string::npos ) topbottom = 0;
     else{
-      std::cout << "HcalLutManager: irregular LMAP fpga value... do not know what to do - exiting" << std::endl;
+      edm::LogError("HcalLutManager") << "Irregular LMAP fpga value... do not know what to do - exiting";
       exit(-1);
     }
     if ( _lt == hcal::ConfigurationDatabase::LinearizerLUT ) luttype = 1;
@@ -1331,7 +1335,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::get_brickSet_from_orac
   db -> connect( _accessor );
   oracle::occi::Connection * _connection = db -> getConnection();  
 
-  std::cout << "Preparing to request the LUT CLOBs from the database..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Preparing to request the LUT CLOBs from the database...";
 
   //int crate = 0;
   
@@ -1349,19 +1353,19 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::get_brickSet_from_orac
 
   try {
     //SELECT
-    std::cout << "Executing the query..." << std::endl;
+    edm::LogInfo("HcalLutManager") << "Executing the query...";
     Statement* stmt = _connection -> createStatement();
     ResultSet *rs = stmt->executeQuery(query.c_str());
-    std::cout << "Executing the query... done" << std::endl;
+    edm::LogInfo("HcalLutManager") << "Executing the query... done";
     
-    std::cout << "Processing the query results..." << std::endl;
+    edm::LogInfo("HcalLutManager") << "Processing the query results...";
     //RooGKCounter _lines;
     while (rs->next()) {
       //_lines.count();
       oracle::occi::Clob clob = rs->getClob (1);
       int crate = rs->getInt(2);
       if ( crate != -1 ){ // not a brick with checksums
-	cout << "Getting LUTs for crate #" << crate << " out of the database...";
+	edm::LogInfo("HcalLutManager") << "Getting LUTs for crate #" << crate << " out of the database...";
 	brick_set = db -> clobToString(clob);
 	/*
 	// FIXME: DEBUG lut xml files from simple strings
@@ -1376,7 +1380,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::get_brickSet_from_orac
 	MemBufInputSource * lut_clob = new MemBufInputSource( (const XMLByte *)bs, strlen( bs ), "lut_clob", false );
 	boost::shared_ptr<LutXml> lut_xml = boost::shared_ptr<LutXml>( new LutXml( *lut_clob ) );
 	lut_map[crate] = lut_xml;
-        std::cout << " done" << std::endl;
+	edm::LogInfo("HcalLutManager") << "done";
       }
     }
     //Always terminate statement
@@ -1396,7 +1400,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::get_brickSet_from_orac
 
 int HcalLutManager::create_lut_loader( std::string file_list, std::string _prefix, std::string tag_name, std::string comment, std::string version, int subversion )
 {
-  std::cout << "Generating XML loader for LUTs..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating XML loader for LUTs...";
   //std::cout << _prefix << "..." << tag_name << std::endl;
 
   XMLLUTLoader::loaderBaseConfig baseConf;
@@ -1461,7 +1465,7 @@ int HcalLutManager::create_lut_loader( std::string file_list, std::string _prefi
   //doc . write( _prefix + "_Loader.xml" );
   doc . write( tag_name + "_Loader.xml" );
 
-  std::cout << "Generating XML loader for LUTs... done." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating XML loader for LUTs... done.";
 
   return 0;
 }
@@ -1472,7 +1476,8 @@ void HcalLutManager::test_emap( void ){
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v6.04_080905.txt");
   EMap _emap(emap);
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
-  std::cout << "EMap contains " << _map . size() << " channels" << std::endl;
+  std::stringstream s;
+  s << "EMap contains " << _map . size() << " channels" << std::endl;
   
   //loop over all EMap channels
   //RooGKCounter _c;
@@ -1480,14 +1485,15 @@ void HcalLutManager::test_emap( void ){
     
     // only trigger tower channels
     if ( row->subdet . find("HT") != std::string::npos ){
-      std::cout << " -----> Subdet = " << row->subdet << std::endl;
+      s << " -----> Subdet = " << row->subdet << std::endl;
       
       if (abs(row->ieta)>28){
 	//if (row->iphi == 71){
-	cout << " ==> (ieta,iphi) = " << row->ieta << ",	" << row->iphi << std::endl;
+	s << " ==> (ieta,iphi) = " << row->ieta << ",	" << row->iphi << std::endl;
       }
     }
   }
+  edm::LogInfo("HcalLutManager") << s.str();
 }
 
 
@@ -1559,7 +1565,7 @@ int HcalLutManager::createLutXmlFiles_HBEFFromCoder_HOFromAscii_ZDC( std::string
 std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getZdcLutXml( std::string _tag,
 								 bool split_by_crate )
 {
-  std::cout << "Generating ZDC LUTs ...may the Force be with us..." << std::endl;
+  edm::LogInfo("HcalLutManager") << "Generating ZDC LUTs ...may the Force be with us...";
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   EMap _emap(emap);
@@ -1567,7 +1573,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getZdcLutXml( std::str
   ZdcLut zdc;
 
   std::vector<EMap::EMapRow> & _map = _emap.get_map();
-  std::cout << "EMap contains " << _map . size() << " channels" << std::endl;
+  edm::LogInfo("HcalLutManager") << "EMap contains " << _map . size() << " channels";
 
   //loop over all EMap channels
   RooGKCounter _counter;
@@ -1591,7 +1597,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getZdcLutXml( std::str
       _cfg.slot = row->slot;
       if (row->topbottom . find("t") != std::string::npos) _cfg.topbottom = 1;
       else if (row->topbottom . find("b") != std::string::npos) _cfg.topbottom = 0;
-      else std::cout << "Warning! fpga out of range..." << std::endl;
+      else edm::LogWarning("HcalLutManager") << "fpga out of range...";
       _cfg.fiber = row->fiber;
       _cfg.fiberchan = row->fiberchan;
       _cfg.lut_type = 1;
@@ -1606,7 +1612,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getZdcLutXml( std::str
       std::vector<int> coder_lut = zdc.get_lut(row->zdc_section,
 					       row->zdc_zside,
 					       row->zdc_channel);
-      std::cout << "***DEBUG: ZDC lut size: " << coder_lut.size() << std::endl;
+      edm::LogInfo("HcalLutManager") << "***DEBUG: ZDC lut size: " << coder_lut.size();
       if (coder_lut.size()!=0){
 	for (std::vector<int>::const_iterator _i=coder_lut.begin(); _i!=coder_lut.end();_i++){
 	  unsigned int _temp = (unsigned int)(*_i);
@@ -1627,8 +1633,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getZdcLutXml( std::str
       } //size of lut
     }
   }
-  std::cout << "LUTs generated: " << _counter.getCount() << std::endl;
-  std::cout << "Generating ZDC LUTs...DONE" << std::endl;
+  edm::LogInfo("HcalLutManager") << "LUTs generated: " << _counter.getCount() << std::endl
+    << "Generating ZDC LUTs...DONE" << std::endl;
 
   return _xml;
 }

--- a/CaloOnlineTools/HcalOnlineDb/src/LMap.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/LMap.cc
@@ -231,8 +231,8 @@ EMap::EMap( const HcalElectronicsMap * emap ){
       row.slot      = eId->htrSlot();
       row.dcc       = eId->dccid();
       row.spigot    = eId->spigot();
-      row.fiber     = eId->slbSiteNumber();
-      row.fiberchan = eId->slbChannelIndex();
+      row.fiber     = eId->isVMEid() ? eId->slbSiteNumber()   : eId->fiberIndex();
+      row.fiberchan = eId->isVMEid() ? eId->slbChannelIndex() : eId->fiberChanId();
       if (eId->htrTopBottom()==1) row.topbottom = "t";
       else row.topbottom = "b";
       //

--- a/CaloOnlineTools/HcalOnlineDb/src/LMap.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/LMap.cc
@@ -24,6 +24,7 @@
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalAssistant.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 
@@ -70,12 +71,12 @@ int LMap::impl::read( std::string map_file, std::string type )
   ifstream inFile( map_file . c_str(), std::ios::in );
   if (!inFile)
     {
-      std::cout << "Unable to open file with the logical map: " << map_file << std::endl;
+      edm::LogError("LMap") << "Unable to open file with the logical map: " << map_file;
     }
   else
     {
-      std::cout << "File with the logical map opened successfully: " << map_file << std::endl;
-      std::cout << "Type: " << type << std::endl;
+      edm::LogInfo("LMap") << "File with the logical map opened successfully: " << map_file << std::endl
+        << "Type: " << type;
     }
   while (getline( inFile, _row ))
     {
@@ -156,7 +157,7 @@ int LMap::impl::read( std::string map_file, std::string type )
 	}
     }
   inFile.close();
-  std::cout << "LMap: " << lines . getCount() << " lines read" << std::endl;
+  edm::LogInfo("LMap") << lines . getCount() << " lines read";
 
   return 0;
 }
@@ -249,7 +250,7 @@ EMap::EMap( const HcalElectronicsMap * emap ){
     }
   }
   else{
-    std::cerr << "Pointer to HcalElectronicsMap is 0!!!" << std::endl;
+    edm::LogError("EMap") << "Pointer to HcalElectronicsMap is 0!!!";
   }
 }
 
@@ -261,10 +262,10 @@ int EMap::read_map( std::string filename )
   std::string _row;
   ifstream inFile( filename . c_str(), std::ios::in );
   if (!inFile){
-    std::cout << "Unable to open file with the electronic map: " << filename << std::endl;
+    edm::LogError("EMap") << "Unable to open file with the electronic map: " << filename;
   }
   else{
-    std::cout << "File with the electronic map opened successfully: " << filename << std::endl;
+    edm::LogInfo("EMap") << "File with the electronic map opened successfully: " << filename;
   }
   while (getline( inFile, _row )) {
     EMapRow aRow;
@@ -293,7 +294,7 @@ int EMap::read_map( std::string filename )
     }  
   }
   inFile.close();
-  std::cout << "EMap: " << lines . getCount() << " lines read" << std::endl;
+  edm::LogInfo("EMap") << lines . getCount() << " lines read";
 
   return 0;
 }

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -32,6 +32,10 @@ public:
   // get the topology pointer
   const HcalTopology& topology() const { return *theTopology; }
 
+  // Get the useRCT and use1x1 values
+  bool useRCT() const { return useRCT_; }
+  bool use1x1() const { return use1x1_; }
+
  private:
 
   /// the number of phi bins in this eta ring

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -12,22 +12,25 @@ public:
 
   HcalTrigTowerGeometry( const HcalTopology* topology );
 
-  void setupHF(bool useShortFibers, bool useQuadRings);
-  
   /// the mapping to and from DetIds
   std::vector<HcalTrigTowerDetId> towerIds(const HcalDetId & cellId) const;
   std::vector<HcalDetId> detIds(const HcalTrigTowerDetId &) const;
 
-  /// an interface for CaloSubdetectorGeometry
-  //std::vector<DetId> getValidDetIds(DetId::Detector det, int subdet) const;
-
-  /// the number of phi bins in this eta ring
-  int nPhiBins(int ieta) const {
-    int nPhiBinsHF = ( useUpgradeConfigurationHFTowers_ ? 36 : 18 );   
-    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+  void setupHFTowers(bool enableRCT, bool enable1x1) {
+    useRCT_=enableRCT;
+    use1x1_=enable1x1;
   }
 
   int firstHFTower() const {return 29;} 
+
+ private:
+
+  /// the number of phi bins in this eta ring
+  int nPhiBins(int ieta) const {
+    int nPhiBinsHF = ( 18 );   
+    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+  }
+
   int nTowers() const {return 32;}
 
   /// the number of HF eta rings in this trigger tower
@@ -40,15 +43,11 @@ public:
   /// where this tower begins and ends in eta
   void towerEtaBounds(int ieta, double & eta1, double & eta2) const;
 
-  void setUpgradeConfigurationHFTowers(bool value) {
-    useUpgradeConfigurationHFTowers_ = value;
-  }
 
-private:
+ private:
   const HcalTopology* theTopology;
-  bool useShortFibers_;
-  bool useHFQuadPhiRings_;
-  bool useUpgradeConfigurationHFTowers_;
+  bool useRCT_;
+  bool use1x1_;
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -29,7 +29,8 @@ public:
   /// number of towers (version dependent)
   int nTowers(int version) const {return (version==0)?(32):(41);}
 
-
+  // get the topology pointer
+  const HcalTopology& topology() const { return *theTopology; }
 
  private:
 

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -21,17 +21,23 @@ public:
     use1x1_=enable1x1;
   }
 
-  int firstHFTower() const {return 29;} 
+  int firstHFTower(int version) const {return (version==0)?(29):(30);} 
+
+  /// where this tower begins and ends in eta
+  void towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const;
+
+  /// number of towers (version dependent)
+  int nTowers(int version) const {return (version==0)?(32):(41);}
+
+
 
  private:
 
   /// the number of phi bins in this eta ring
-  int nPhiBins(int ieta) const {
+  int nPhiBins(int ieta, int version) const {
     int nPhiBinsHF = ( 18 );   
-    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+    return (abs(ieta) < firstHFTower(version)) ? 72 : nPhiBinsHF;
   }
-
-  int nTowers() const {return 32;}
 
   /// the number of HF eta rings in this trigger tower
   /// ieta starts at firstHFTower()
@@ -39,10 +45,6 @@ public:
 
   /// since the towers are irregular in eta in HF
   int firstHFRingInTower(int ietaTower) const;
-
-  /// where this tower begins and ends in eta
-  void towerEtaBounds(int ieta, double & eta1, double & eta2) const;
-
 
  private:
   const HcalTopology* theTopology;

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -6,7 +6,8 @@
 
 HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
 {
-  useFullGranularityHF_=config.getParameter<bool>("useFullGranularityHF");
+  enable1x1HF_=config.getParameter<bool>("enableHF1x1");
+  enableRCTHF_=config.getParameter<bool>("enableHFRCT");
 
   setWhatProduced( this );
 }
@@ -22,14 +23,15 @@ HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 
     m_hcalTrigTowerGeom =
 	boost::shared_ptr<HcalTrigTowerGeometry>( new HcalTrigTowerGeometry( &*hcalTopology));
-    m_hcalTrigTowerGeom->setUpgradeConfigurationHFTowers(useFullGranularityHF_);
+    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF_,enable1x1HF_);
 
     return m_hcalTrigTowerGeom;
 }
 
 void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
    edm::ParameterSetDescription desc;
-   desc.add<bool>("useFullGranularityHF", false);
+   desc.add<bool>("enableHF1x1", true);
+   desc.add<bool>("enableHFRCT", true);
    descriptions.add("HcalTrigTowerGeometryESProducer", desc);
 }
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -6,9 +6,6 @@
 
 HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
 {
-  enable1x1HF_=config.getParameter<bool>("enableHF1x1");
-  enableRCTHF_=config.getParameter<bool>("enableHFRCT");
-
   setWhatProduced( this );
 }
 
@@ -23,15 +20,16 @@ HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 
     m_hcalTrigTowerGeom =
 	boost::shared_ptr<HcalTrigTowerGeometry>( new HcalTrigTowerGeometry( &*hcalTopology));
-    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF_,enable1x1HF_);
+    HcalTopologyMode::TriggerMode tmode=hcalTopology->triggerMode();
+    bool enableRCTHF=(tmode==HcalTopologyMode::tm_LHC_RCT || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
+    bool enable1x1HF=(tmode==HcalTopologyMode::tm_LHC_1x1 || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
+    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF,enable1x1HF);
 
     return m_hcalTrigTowerGeom;
 }
 
 void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
    edm::ParameterSetDescription desc;
-   desc.add<bool>("enableHF1x1", true);
-   desc.add<bool>("enableHFRCT", true);
    descriptions.add("HcalTrigTowerGeometryESProducer", desc);
 }
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -22,7 +22,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  bool useFullGranularityHF_;
+  bool enable1x1HF_,enableRCTHF_;
   boost::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
 };
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -22,7 +22,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  bool enable1x1HF_,enableRCTHF_;
   boost::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
 };
 

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -21,7 +21,7 @@ HcalTrigTowerGeometry::towerIds(const HcalDetId & cellId) const {
     if (useRCT_) { 
       // first do eta
       int hfRing = cellId.ietaAbs();
-      int ieta = firstHFTower(); 
+      int ieta = firstHFTower(0); 
       // find the tower that contains this ring
       while(hfRing >= firstHFRingInTower(ieta+1)) {
 	++ieta;
@@ -129,7 +129,7 @@ HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) con
 
     if (hcalTrigTowerDetId.version()==0) {
     
-      int HfTowerPhiSize =  72 / nPhiBins(tower_ieta);
+      int HfTowerPhiSize =  72 / nPhiBins(tower_ieta,0);
 
       int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
       int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
@@ -190,9 +190,9 @@ HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) con
 int HcalTrigTowerGeometry::hfTowerEtaSize(int ieta) const {
   
   int ietaAbs = abs(ieta); 
-  assert(ietaAbs >= firstHFTower() && ietaAbs <= nTowers());
+  assert(ietaAbs >= firstHFTower(0) && ietaAbs <= nTowers(0));
   // the first three come from rings 29-31, 32-34, 35-37. The last has 4 rings: 38-41
-  return (ietaAbs == nTowers()) ? 4 : 3;
+  return (ietaAbs == nTowers(0)) ? 4 : 3;
   
 }
 
@@ -201,7 +201,7 @@ int HcalTrigTowerGeometry::firstHFRingInTower(int ietaTower) const {
   // count up to the correct HF ring
   int inputTower = abs(ietaTower);
   int result = theTopology->firstHFRing();
-  for(int iTower = firstHFTower(); iTower != inputTower; ++iTower) {
+  for(int iTower = firstHFTower(0); iTower != inputTower; ++iTower) {
     result += hfTowerEtaSize(iTower);
   }
   
@@ -211,10 +211,10 @@ int HcalTrigTowerGeometry::firstHFRingInTower(int ietaTower) const {
 }
 
 
-void HcalTrigTowerGeometry::towerEtaBounds(int ieta, double & eta1, double & eta2) const {
+void HcalTrigTowerGeometry::towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const {
   int ietaAbs = abs(ieta);
   std::pair<double,double> etas = 
-    (ietaAbs < firstHFTower()) ? theTopology->etaRange(HcalBarrel,ietaAbs) : 
+    (ietaAbs < firstHFTower(version)) ? theTopology->etaRange(HcalBarrel,ietaAbs) : 
     theTopology->etaRange(HcalForward,ietaAbs);
   eta1 = etas.first;
   eta2 = etas.second;

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -7,14 +7,8 @@
 
 HcalTrigTowerGeometry::HcalTrigTowerGeometry( const HcalTopology* topology )
     : theTopology( topology ) {
-  useShortFibers_=true;
-  useHFQuadPhiRings_=true;
-  useUpgradeConfigurationHFTowers_=!true;
-}
-
-void HcalTrigTowerGeometry::setupHF(bool useShortFibers, bool useQuadRings) {
-  useShortFibers_=useShortFibers;
-  useHFQuadPhiRings_=useQuadRings;
+  useRCT_=true;
+  use1x1_=true;
 }
 
 std::vector<HcalTrigTowerDetId> 
@@ -22,43 +16,36 @@ HcalTrigTowerGeometry::towerIds(const HcalDetId & cellId) const {
 
   std::vector<HcalTrigTowerDetId> results;
 
-  int HfTowerPhiSize, shift;
-  if ( useUpgradeConfigurationHFTowers_ ) { 
-    HfTowerPhiSize = 1;
-    shift = 0;
-  } else {
-    HfTowerPhiSize = 4;
-    shift = 1;
-  }
-  
   if(cellId.subdet() == HcalForward) {
-    // short fibers don't count
-    if(cellId.depth() == 1 || useShortFibers_) {
+
+    if (useRCT_) { 
       // first do eta
       int hfRing = cellId.ietaAbs();
       int ieta = firstHFTower(); 
       // find the tower that contains this ring
       while(hfRing >= firstHFRingInTower(ieta+1)) {
-        ++ieta;
+	++ieta;
       }
       
-      if ( useUpgradeConfigurationHFTowers_ && ieta == 29) {
-	ieta = 30; 
-      }
-
       ieta *= cellId.zside();
-
+      
       // now for phi
       // HF towers are quad, 18 in phi.
       // go two cells per trigger tower.
+      
+      int iphi = (((cellId.iphi()+1)/4) * 4 + 1)%72; // 71+1 --> 1, 3+5 --> 5
+      results.push_back( HcalTrigTowerDetId(ieta, iphi) );
+    } 
+    if (use1x1_) {
+      int hfRing = cellId.ietaAbs();
+      if (hfRing==29) hfRing=30; // sum 29 into 30.
 
-      int iphi = (((cellId.iphi()+shift)/HfTowerPhiSize) * HfTowerPhiSize + shift)%72; // 71+1 --> 1, 3+5 --> 5
-      if (useHFQuadPhiRings_ || cellId.ietaAbs() < theTopology->firstHFQuadPhiRing()) {
-        HcalTrigTowerDetId id(ieta, iphi);
-        if (useUpgradeConfigurationHFTowers_)
-          id.setVersion(1);
-        results.push_back(id);
-      }
+      int ieta = hfRing*cellId.zside();      
+      int iphi = cellId.iphi();
+
+      HcalTrigTowerDetId id(ieta,iphi);
+      id.setVersion(1); // version 1 for 1x1 HF granularity
+      results.push_back(id);
     }
       
   } else {
@@ -140,58 +127,67 @@ HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) con
 
   if (abs(cell_ieta) >= theTopology->firstHFRing()){  
 
-    int HfTowerPhiSize;
-    if   ( useUpgradeConfigurationHFTowers_ ) HfTowerPhiSize = 1;
-    else                                      HfTowerPhiSize = 72 / nPhiBins(tower_ieta);
+    if (hcalTrigTowerDetId.version()==0) {
     
-    int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
-    int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
+      int HfTowerPhiSize =  72 / nPhiBins(tower_ieta);
 
-    for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
+      int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
+      int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
+
+      for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
             
-      cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
-      if ( !useUpgradeConfigurationHFTowers_ ) cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
-      cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
-      cell_iphi += 72;                       // Don't want to take the mod of a negative number
-      cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
-      if ( !useUpgradeConfigurationHFTowers_) cell_iphi += 1;// There is no cell at iphi = 0
+	cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
+	cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
+	cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
+	cell_iphi += 72;                       // Don't want to take the mod of a negative number
+	cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
+	cell_iphi += 1;// There is no cell at iphi = 0
       
-      if (cell_iphi%2 == 0) continue;        // These cells don't exist.
+	if (cell_iphi%2 == 0) continue;        // These cells don't exist.
 
-      for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
+	for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
 		
-	cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
+	  cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
 
-	if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
+	  if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
 
-	theTopology->depthBinInformation(HcalForward, cell_ieta, n_depths, min_depth);  
+	  theTopology->depthBinInformation(HcalForward, cell_ieta, n_depths, min_depth);  
+	  
+	  // Negative tower_ieta -> negative cell_ieta
+	  int zside = 1;
+	  if (tower_ieta < 0) zside = -1;
 
-	// Negative tower_ieta -> negative cell_ieta
-	int zside = 1;
-	if (tower_ieta < 0) zside = -1;
+	  cell_ieta *= zside;	       
 
-	cell_ieta *= zside;	       
-
-	for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-	  results.push_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
+	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	    results.push_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
 	
-	if ( zside * cell_ieta == 30 ) {
-	  theTopology->depthBinInformation(HcalForward, 29 * zside, n_depths, min_depth);  
-	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
-	    results.push_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
+	  if ( zside * cell_ieta == 30 ) {
+	    theTopology->depthBinInformation(HcalForward, 29 * zside, n_depths, min_depth);  
+	    for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
+	      results.push_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
+	  }
 	}
-	
-      }    
+      }  
+    } else if (hcalTrigTowerDetId.version()==1) {
+      theTopology->depthBinInformation(HcalForward, tower_ieta, n_depths, min_depth);  
+      for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	results.push_back(HcalDetId(HcalForward, tower_ieta, tower_iphi, cell_depth));      
+      if (abs(tower_ieta)==30) {
+	int i29 = 29;
+	  if (tower_ieta < 0) i29 = -29;
+	  theTopology->depthBinInformation(HcalForward, i29, n_depths, min_depth);  
+	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	    results.push_back(HcalDetId(HcalForward, i29, tower_iphi, cell_depth));      
+      }
     }
   }
-
+  
   return results;
 }
 
 
 int HcalTrigTowerGeometry::hfTowerEtaSize(int ieta) const {
-  
-  if ( useUpgradeConfigurationHFTowers_ ) return 1;
   
   int ietaAbs = abs(ieta); 
   assert(ietaAbs >= firstHFTower() && ietaAbs <= nTowers());

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -53,8 +53,12 @@ HcalTrigTowerGeometry::towerIds(const HcalDetId & cellId) const {
       // go two cells per trigger tower.
 
       int iphi = (((cellId.iphi()+shift)/HfTowerPhiSize) * HfTowerPhiSize + shift)%72; // 71+1 --> 1, 3+5 --> 5
-      if (useHFQuadPhiRings_ || cellId.ietaAbs() < theTopology->firstHFQuadPhiRing())
-        results.push_back( HcalTrigTowerDetId(ieta, iphi) );
+      if (useHFQuadPhiRings_ || cellId.ietaAbs() < theTopology->firstHFQuadPhiRing()) {
+        HcalTrigTowerDetId id(ieta, iphi);
+        if (useUpgradeConfigurationHFTowers_)
+          id.setVersion(1);
+        results.push_back(id);
+      }
     }
       
   } else {

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
@@ -149,7 +149,7 @@ void HcalGeometryTester::testTriggerGeometry(const HcalTopology& topology) {
   std::cout << "HCAL trigger tower eta bounds " << std::endl;
   for(int ieta = 1; ieta <= 32; ++ieta) {
     double eta1, eta2;
-    trigTowers.towerEtaBounds(ieta, eta1, eta2);
+    trigTowers.towerEtaBounds(ieta, 0, eta1, eta2);
     std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
   }
 

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
@@ -73,7 +73,7 @@ void HcalGeometryTester::analyze(const edm::Event& /*iEvent*/,
   testTriggerGeometry(topology);
 
   testClosestCells(geom, topology);
-  std::cout << "Test SLHC Hcal Flexi geometry" << std::endl;
+  edm::LogInfo("HcalGeometryTester") << "Test SLHC Hcal Flexi geometry";
   std::vector<int> dins;
 
   testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalBarrel, " BARREL ",  dins );
@@ -89,20 +89,22 @@ void HcalGeometryTester::testValidDetIds(CaloSubdetectorGeometry* caloGeom,
 					 DetId::Detector det, int subdet, 
 					 std::string label) {
 
-  std::cout << std::endl << label << " : " << std::endl;
+  std::stringstream s;
+  s << label << " : " << std::endl;
   const std::vector<DetId>& idshb = caloGeom->getValidDetIds(det, subdet);
  
   int counter = 0;
   for (std::vector<DetId>::const_iterator i=idshb.begin(); i!=idshb.end(); 
        i++, ++counter) {
     HcalDetId hid=(*i);
-    std::cout << counter << ": din " << topology.detId2denseId(*i) << ":" 
+    s << counter << ": din " << topology.detId2denseId(*i) << ":" 
 	      << hid;
     const CaloCellGeometry * cell = caloGeom->getGeometry(*i);
-    std::cout << *cell << std::endl;
+    s << *cell << std::endl;
   }
  
-  std::cout << "=== Total " << counter << " cells in " << label << std::endl;
+  s << "=== Total " << counter << " cells in " << label << std::endl;
+  edm::LogInfo("HcalGeometryTester") << s.str();
 }
 
 void HcalGeometryTester::testClosestCells(CaloSubdetectorGeometry* g,
@@ -133,24 +135,23 @@ void HcalGeometryTester::testClosestCell(const HcalDetId & detId,
 					 CaloSubdetectorGeometry *geom) {
 
   const CaloCellGeometry* cell = geom->getGeometry(detId);
-  std::cout << "i/p " << detId << " position " << cell->getPosition();
   HcalDetId closest = geom->getClosestCell(cell->getPosition());
-  std::cout << " closest " << closest << std::endl;
+  edm::LogInfo("HcalGeometryTester") << "i/p " << detId << " position " << cell->getPosition() << " closest " << closest;
 
   if(closest != detId) {
-    std::cout << "ERROR mismatch.  Original HCAL cell is "
-	      << detId << " while nearest is " << closest << std::endl;
+    edm::LogError("HcalGeometryTester") << "Mismatch.  Original HCAL cell is "
+	      << detId << " while nearest is " << closest;
   }
 }
 
 void HcalGeometryTester::testTriggerGeometry(const HcalTopology& topology) {
 
   HcalTrigTowerGeometry trigTowers( &topology );
-  std::cout << "HCAL trigger tower eta bounds " << std::endl;
+  edm::LogInfo("HcalGeometryTester") << "HCAL trigger tower eta bounds ";
   for(int ieta = 1; ieta <= 32; ++ieta) {
     double eta1, eta2;
     trigTowers.towerEtaBounds(ieta, 0, eta1, eta2);
-    std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
+    edm::LogInfo("HcalGeometryTester") << ieta << " "  << eta1 << " " << eta2;
   }
 
   // now test some cell mappings
@@ -163,34 +164,35 @@ void HcalGeometryTester::testTriggerGeometry(const HcalTopology& topology) {
   typedef std::vector<HcalTrigTowerDetId> TowerDets;
   if (topology.valid(barrelDet)) {
     TowerDets barrelTowers = trigTowers.towerIds(barrelDet);
-    std::cout << "Trigger Tower Size: Barrel " << barrelTowers.size() << "\n";
+    edm::LogInfo("HcalGeometryTester") << "Trigger Tower Size: Barrel " << barrelTowers.size();
     assert(barrelTowers.size() ==1);
-    std::cout << barrelTowers[0] << std::endl;
+    edm::LogInfo("HcalGeometryTester") << barrelTowers[0];
   } 
   if (topology.valid(endcapDet)) {
     TowerDets endcapTowers = trigTowers.towerIds(endcapDet);
-    std::cout << "Trigger Tower Size: Endcap " << endcapTowers.size() << "\n";
+    edm::LogInfo("HcalGeometryTester") << "Trigger Tower Size: Endcap " << endcapTowers.size();
     assert(endcapTowers.size() >=1);
-    std::cout << endcapTowers[0] << std::endl;
-    if (endcapTowers.size() > 1) std::cout << endcapTowers[1] << std::endl;
+    edm::LogInfo("HcalGeometryTester") << endcapTowers[0];
+    if (endcapTowers.size() > 1)
+      edm::LogInfo("HcalGeometryTester") << endcapTowers[1];
   }
   if (topology.valid(forwardDet1)) {
     TowerDets forwardTowers1 = trigTowers.towerIds(forwardDet1);
-    std::cout << "Trigger Tower Size: Forward1 " << forwardTowers1.size() << "\n";
+    edm::LogInfo("HcalGeometryTester") << "Trigger Tower Size: Forward1 " << forwardTowers1.size();
     assert(forwardTowers1.size() ==1);
-    std::cout << forwardTowers1[0] << std::endl;
+    edm::LogInfo("HcalGeometryTester") << forwardTowers1[0];
   }
   if (topology.valid(forwardDet1)) {
     TowerDets forwardTowers2 = trigTowers.towerIds(forwardDet2);
-    std::cout << "Trigger Tower Size: Forward2 " << forwardTowers2.size() << "\n";
+    edm::LogInfo("HcalGeometryTester") << "Trigger Tower Size: Forward2 " << forwardTowers2.size();
     assert(forwardTowers2.size() ==1);
-    std::cout << forwardTowers2[0] << std::endl;
+    edm::LogInfo("HcalGeometryTester") << forwardTowers2[0];
   }
   if (topology.valid(forwardDet1)) {
     TowerDets forwardTowers3 = trigTowers.towerIds(forwardDet3);
-    std::cout << "Trigger Tower Size: Forward3 " << forwardTowers3.size() << "\n";
+    edm::LogInfo("HcalGeometryTester") << "Trigger Tower Size: Forward3 " << forwardTowers3.size();
     assert(forwardTowers3.size() ==1);
-    std::cout << forwardTowers3[0] << std::endl;
+    edm::LogInfo("HcalGeometryTester") << forwardTowers3[0];
   }
 }
 
@@ -200,40 +202,43 @@ void HcalGeometryTester::testFlexiValidDetIds(CaloSubdetectorGeometry* caloGeom,
 					      std::string label, 
 					      std::vector<int> &dins) {
 
-  std::cout << std::endl << label << " : " << std::endl;
+  std::stringstream s;
+  s << label << " : " << std::endl;
   const std::vector<DetId>& idshb = caloGeom->getValidDetIds(det, subdet);
     
   int counter = 0;
   for (std::vector<DetId>::const_iterator i=idshb.begin(); i!=idshb.end(); 
        i++, ++counter) {
     HcalDetId hid=(*i);
-    std::cout << counter << ": din " << topology.detId2denseId(*i) << ":" << hid;
+    s << counter << ": din " << topology.detId2denseId(*i) << ":" << hid;
     dins.push_back( topology.detId2denseId(*i));
 	
     const CaloCellGeometry * cell = caloGeom->getGeometry(*i);
-    std::cout << *cell << std::endl;
+    s << *cell << std::endl;
   }
 
   std::sort( dins.begin(), dins.end());
-  std::cout << "=== Total " << counter << " cells in " << label << std::endl;
+  s << "=== Total " << counter << " cells in " << label << std::endl;
 
   counter = 0;
   for (std::vector<int>::const_iterator i=dins.begin(); i != dins.end(); 
        ++i, ++counter) {
     HcalDetId hid = (topology.denseId2detId(*i));
     HcalDetId ihid = (topology.denseId2detId(dins[counter]));
-    std::cout << counter << ": din " << (*i) << " :" << hid << " == " << ihid << std::endl;
+    s << counter << ": din " << (*i) << " :" << hid << " == " << ihid << std::endl;
   }
+  edm::LogInfo("HcalGeometryTester") << s.str();
 }
 
 void HcalGeometryTester::testFlexiGeomHF(CaloSubdetectorGeometry* caloGeom) {
 
-  std::cout << std::endl << "Test HF Geometry : " << std::endl;
+  std::stringstream s;
+  s << "Test HF Geometry : " << std::endl;
   for (int ieta = 29; ieta <=41; ++ieta) {
     HcalDetId cell3 (HcalForward, ieta, 3, 1);
     const CaloCellGeometry* cellGeometry3 = caloGeom->getGeometry (cell3);
     if (cellGeometry3) {
-      std::cout << "cell geometry iphi=3 -> ieta=" << ieta
+      s << "cell geometry iphi=3 -> ieta=" << ieta
 		<< " eta " << cellGeometry3->getPosition().eta () << "+-" 
 		<< std::abs(cellGeometry3->getCorners()[0].eta() -
 			    cellGeometry3->getCorners()[2].eta())/2
@@ -243,6 +248,7 @@ void HcalGeometryTester::testFlexiGeomHF(CaloSubdetectorGeometry* caloGeom) {
 		<< std::endl;
     }
   }
+  edm::LogInfo("HcalGeometryTester") << s.str();
 }
 
 DEFINE_FWK_MODULE(HcalGeometryTester);

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -101,7 +101,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
   
      using namespace edm::es;
  
-     std:: cout << "object Key " << objectKey <<std::endl <<std::flush;
+     edm::LogInfo("L1CaloHcalScaleConfigOnlineProd") << "object Key " << objectKey;
 
      if(objectKey == "NULL" || objectKey == "")  // return default blank ecal scale	 
        return boost::shared_ptr< L1CaloHcalScale >( hcalScale );
@@ -325,8 +325,10 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
        } // zside
      }// eta
 
-     std::cout << std::setprecision(10);
-     hcalScale->print(std::cout);
+     std::stringstream s;
+     s << std::setprecision(10);
+     hcalScale->print(s);
+     edm::LogInfo("L1CaloHcalScaleConfigOnlineProd") << s.str();
 // ------------ method called to produce the data  ------------
      return boost::shared_ptr< L1CaloHcalScale >( hcalScale );
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -261,13 +261,14 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	 uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi);
 
 	 double eta_low = 0., eta_high = 0.;
-	 theTrigTowerGeometry->towerEtaBounds(ieta,eta_low,eta_high); 
+	 const int version_of_hcal_TPs = 0;
+	 theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs, eta_low,eta_high); 
 	 double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 
 	 if (!caloTPG->HTvalid(ieta, iphi)) continue;
 	 double factor = 0.;
-	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower())
+	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
 	   factor = rctlsb;
 	 else 
 	   factor = nominal_gain / cosh_ieta * lutGranularity;
@@ -275,7 +276,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   outputLut[k] = 0;
 	 
          for (unsigned int k = threshold; k < 1024; ++k)
-	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower()) ? analyticalLUT[k] : identityLUT[k];
+	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs)) ? analyticalLUT[k] : identityLUT[k];
 	 
 
 	   // tpg - compressed value

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
@@ -1,0 +1,15 @@
+#ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included
+#define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included 1
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+class HcalFeatureBit {
+	public:
+		HcalFeatureBit(){}
+		virtual ~HcalFeatureBit(){} //the virutal function is responcible for applying a cut based on a linear relationship of the energy
+        //deposited in the short vers long fibers.
+		virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const {return false;}
+		
+};
+#endif
+

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -1,0 +1,18 @@
+#ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included
+#define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included 1
+
+
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+
+class HcalFeatureHFEMBit : public HcalFeatureBit {
+public:    
+    HcalFeatureHFEMBit(double ShortMinE, double LongMinE, double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions);
+    ~HcalFeatureHFEMBit();
+    virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const;//cuts based on energy 
+    //depoisted in the long and short fibers
+private:
+    double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;
+    const HcalDbService& conditions_;
+};
+#endif

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -6,11 +6,12 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
-//#include "CalibFormats/HcalObjects/interface/HcalTPGCoder.h"
+
 #include "CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h"
 #include "CalibFormats/CaloTPG/interface/HcalTPGCompressor.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"//cuts based on short and long energy deposited.
 
 #include <map>
 #include <vector>
@@ -33,7 +34,7 @@ public:
            const HFDigiCollection& hfDigis,
            HcalTrigPrimDigiCollection& result,
 	   const HcalTrigTowerGeometry* trigTowerGeometry,
-           float rctlsb);
+           float rctlsb, const HcalFeatureBit* LongvrsShortCut=0);
 
   void runZS(HcalTrigPrimDigiCollection& tp);
   void runFEFormatError(const FEDRawDataCollection* rawraw,
@@ -56,7 +57,8 @@ public:
   void analyzeHFV1(
           const IntegerCaloSamples& SAMPLES,
           HcalTriggerPrimitiveDigi& result,
-          const int HF_LUMI_SHIFT
+          const int HF_LUMI_SHIFT,
+          const HcalFeatureBit* HCALFEM
           );
 
    // Member initialized by constructor
@@ -93,6 +95,8 @@ public:
   struct HFDetails {
       IntegerCaloSamples long_fiber;
       IntegerCaloSamples short_fiber;
+      HFDataFrame ShortDigi;
+      HFDataFrame LongDigi;
   };
   typedef std::map<HcalTrigTowerDetId, HFDetails> HFDetailMap;
   HFDetailMap theHFDetailMap;
@@ -110,6 +114,7 @@ public:
   //  else VetoedSum = Sum; 
   // ==============================
   // Map from FG id to veto booleans
+  HcalFeatureBit* LongvrsShortCut;
   typedef std::map<uint32_t, std::vector<bool> > TowerMapVeto;
   TowerMapVeto HF_Veto;
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -51,9 +51,13 @@ public:
   /// adds the actual RecHits
   void analyze(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result);
   // Version 0: RCT
-  void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, float rctlsb);
+  void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, const int hf_lumi_shift);
   // Version 1: 1x1
-  void analyzeHFV1(const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
+  void analyzeHFV1(
+          const IntegerCaloSamples& SAMPLES,
+          HcalTriggerPrimitiveDigi& result,
+          const int HF_LUMI_SHIFT
+          );
 
    // Member initialized by constructor
   const HcaluLUTTPGCoder* incoder_;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -50,7 +50,10 @@ public:
 
   /// adds the actual RecHits
   void analyze(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result);
+  // Version 0: RCT
   void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, float rctlsb);
+  // Version 1: 1x1
+  void analyzeHFV1(const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
 
    // Member initialized by constructor
   const HcaluLUTTPGCoder* incoder_;
@@ -82,6 +85,13 @@ public:
 
   typedef std::map<HcalTrigTowerDetId, IntegerCaloSamples> SumMap;
   SumMap theSumMap;  
+
+  struct HFDetails {
+      IntegerCaloSamples long_fiber;
+      IntegerCaloSamples short_fiber;
+  };
+  typedef std::map<HcalTrigTowerDetId, HFDetails> HFDetailMap;
+  HFDetailMap theHFDetailMap;
   
   typedef std::vector<IntegerCaloSamples> SumFGContainer;
   typedef std::map< HcalTrigTowerDetId, SumFGContainer > TowerMapFGSum;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
@@ -1,0 +1,68 @@
+
+//HcalFeatureHFEMBit
+//version 2.0
+
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"
+#include "CondFormats/HcalObjects/interface/HcalQIECoder.h"
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+
+
+HcalFeatureHFEMBit::HcalFeatureHFEMBit(double ShortMinE, double LongMinE,
+        double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions) : conditions_(conditions)
+{
+    ShortMinE_ = ShortMinE; //minimum energy deposited
+    LongMinE_ = LongMinE;
+    ShortLongCutSlope_ = ShortLongCutSlope; // this is a the slope of the cut line related to energy deposited in short fibers vrs long fibers
+    ShortLongCutOffset_ = ShortLongCutOffset; // this is the offset of said line.
+
+
+
+}
+
+HcalFeatureHFEMBit::~HcalFeatureHFEMBit() { }
+
+bool HcalFeatureHFEMBit::fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const//pass det id
+{
+
+    float ShortE = 0; //holds deposited energy
+    float LongE = 0;
+
+
+    HcalQIESample sQIESample(ADCShort, CapIdS, 1, 1);
+    //makes a QIE sample for the short fiber.
+    HFDataFrame shortf(Sid);
+    shortf.setSize(1); //not planning on there being anything else here at this point in time so setting the size to 1 shouldn't matter
+    shortf.setSample(0, sQIESample); //inputs data into digi.
+    const HcalCalibrations& calibrations = conditions_.getHcalCalibrations(Sid);
+    const HcalQIECoder* channelCoderS = conditions_.getHcalCoder(Sid);
+    const HcalQIEShape* shapeS = conditions_.getHcalShape(channelCoderS);
+
+    HcalCoderDb coders(*channelCoderS, *shapeS);
+
+    CaloSamples tools;
+    coders.adc2fC(shortf, tools);
+    ShortE = (tools[0] - calibrations.pedestal(CapIdS)) * calibrations.respcorrgain(CapIdS);
+
+    HcalQIESample lQIESample(ADCLong, CapIdL, 1, 1);
+    HFDataFrame longf(Lid);
+    longf.setSize(1);
+    longf.setSample(0, lQIESample);
+    const HcalCalibrations& calibrationL = conditions_.getHcalCalibrations(Lid);
+
+    CaloSamples tool_l;
+
+    const HcalQIECoder* channelCoderL = conditions_.getHcalCoder(Lid);
+    const HcalQIEShape* shapeL = conditions_.getHcalShape(channelCoderL);
+
+    HcalCoderDb coderL(*channelCoderL, *shapeL);
+
+    coderL.adc2fC(longf, tool_l); // this fills tool_l[0] with linearized adc
+    LongE = (tool_l[0] - calibrationL.pedestal(CapIdL)) * calibrationL.respcorrgain(CapIdL);
+
+    
+    // this actually does the cut
+    if((ShortE < ((LongE)-(ShortLongCutOffset_)) * ShortLongCutSlope_) && LongE > LongMinE_ && ShortE > ShortMinE_) return true;
+    else return false;
+}
+
+

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -87,7 +87,7 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    for(SumMap::iterator mapItr = theSumMap.begin(); mapItr != theSumMap.end(); ++mapItr) {
       result.push_back(HcalTriggerPrimitiveDigi(mapItr->first));
       HcalTrigTowerDetId detId(mapItr->second.id());
-      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower()) { 
+      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower(detId.version())) { 
          if (detId.version() == 0) {
             analyzeHF(mapItr->second, result.back(), hf_lumi_shift);
          } else if (detId.version() == 1) {

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -116,7 +116,6 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HBHEDataFrame & frame) {
 
 
 void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
-
    if(frame.id().depth() == 1 || frame.id().depth() == 2) {
       std::vector<HcalTrigTowerDetId> ids = theTrigTowerGeometry->towerIds(frame.id());
       assert(ids.size() == 1);
@@ -135,17 +134,19 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
 
       if ( theTowerMapFGSum.find(ids[0]) == theTowerMapFGSum.end() ) {
          SumFGContainer sumFG;
-         theTowerMapFGSum.insert(std::pair<HcalTrigTowerDetId, SumFGContainer >(ids[0], sumFG));
+         theTowerMapFGSum.insert(std::pair<HcalTrigTowerDetId, SumFGContainer>(ids[0], sumFG));
       }
 
       SumFGContainer& sumFG = theTowerMapFGSum[ids[0]];
       SumFGContainer::iterator sumFGItr;
       for ( sumFGItr = sumFG.begin(); sumFGItr != sumFG.end(); ++sumFGItr) {
-         if (sumFGItr->id() == fgid) break;
+         if (sumFGItr->id() == fgid) { break; }
       }
       // If find
       if (sumFGItr != sumFG.end()) {
-         for (int i=0; i<samples.size(); ++i) (*sumFGItr)[i] += samples[i];
+         for (int i=0; i<samples.size(); ++i) {
+            (*sumFGItr)[i] += samples[i];
+         }
       }
       else {
          //Copy samples (change to fgid)
@@ -160,9 +161,11 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
          vector<bool> vetoBits(samples.size(), false);
          HF_Veto[fgid] = vetoBits;
       }
-      for (int i=0; i<samples.size(); ++i)
-         if (samples[i] < minSignalThreshold_)
+      for (int i=0; i<samples.size(); ++i) {
+         if (samples[i] < minSignalThreshold_) {
             HF_Veto[fgid][i] = true;
+         }
+      }
    }
 }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -87,7 +87,7 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    for(SumMap::iterator mapItr = theSumMap.begin(); mapItr != theSumMap.end(); ++mapItr) {
       result.push_back(HcalTriggerPrimitiveDigi(mapItr->first));
       HcalTrigTowerDetId detId(mapItr->second.id());
-      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower(detId.version())) { 
+      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower()) { 
          if (detId.version() == 0) {
             analyzeHF(mapItr->second, result.back(), hf_lumi_shift);
          } else if (detId.version() == 1) {
@@ -328,7 +328,6 @@ void HcalTriggerPrimitiveAlgo::analyze(IntegerCaloSamples & samples, HcalTrigger
 
 
 void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, const int hf_lumi_shift) {
-   std::vector<bool> finegrain(numberOfSamples_, false);
    HcalTrigTowerDetId detId(samples.id());
 
    // Align digis and TP

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -1,7 +1,7 @@
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <iostream>
+
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
@@ -9,7 +9,8 @@
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
-
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"//cuts based on short and long energy deposited.
+#include <iostream>
 using namespace std;
 
 HcalTriggerPrimitiveAlgo::HcalTriggerPrimitiveAlgo( bool pf, const std::vector<double>& w, int latency,
@@ -50,7 +51,7 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
                                    const HFDigiCollection& hfDigis,
                                    HcalTrigPrimDigiCollection& result,
 				   const HcalTrigTowerGeometry* trigTowerGeometry,
-                                   float rctlsb) {
+                                   float rctlsb, const HcalFeatureBit* LongvrsShortCut) {
    theTrigTowerGeometry = trigTowerGeometry;
     
    incoder_=dynamic_cast<const HcaluLUTTPGCoder*>(incoder);
@@ -90,7 +91,7 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
          if (detId.version() == 0) {
             analyzeHF(mapItr->second, result.back(), hf_lumi_shift);
          } else if (detId.version() == 1) {
-            analyzeHFV1(mapItr->second, result.back(), hf_lumi_shift);
+            analyzeHFV1(mapItr->second, result.back(), hf_lumi_shift, LongvrsShortCut);
          } else {
             // Things are going to go poorly
          }
@@ -213,8 +214,10 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
             // Check the frame type to determine long vs short
             if (frame.id().depth() == 1) { // Long
                dit->second.long_fiber = samples;
+               dit->second.LongDigi = frame;
             } else if (frame.id().depth() == 2) { // Short
                dit->second.short_fiber = samples;
+               dit->second.ShortDigi = frame;
             } else {
                 // Neither long nor short... So we have no idea what to do
                 return;
@@ -378,7 +381,8 @@ void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTrigg
 void HcalTriggerPrimitiveAlgo::analyzeHFV1(
         const IntegerCaloSamples& SAMPLES,
         HcalTriggerPrimitiveDigi& result,
-        const int HF_LUMI_SHIFT
+        const int HF_LUMI_SHIFT,
+        const HcalFeatureBit* HCALFEM
         ) {
     // Align digis and TP
     const int SHIFT = SAMPLES.presamples() - numberOfPresamples_;
@@ -414,9 +418,19 @@ void HcalTriggerPrimitiveAlgo::analyzeHFV1(
         if (output[ibin] > MAX_OUTPUT) {
             output[ibin] = MAX_OUTPUT;
         }
-        // TODO for Lesko: Do EM fine grain bit algo
+        // TODO: Do EM fine grain bit algo
+        int ADCLong = HF_DETAILS->LongDigi[ibin].adc();
+        int ADCShort = HF_DETAILS->ShortDigi[ibin].adc();
+
+
+
+        if(HCALFEM != 0)
+        {
+            finegrain[ibin] = HCALFEM->fineGrainbit(ADCShort, HF_DETAILS->ShortDigi.id(), HF_DETAILS->ShortDigi[ibin].capid(), ADCLong, HF_DETAILS->LongDigi.id(), HF_DETAILS->LongDigi[ibin].capid());
+        }
     }
     outcoder_->compress(output, finegrain, result);
+    
 }
 
 void HcalTriggerPrimitiveAlgo::runZS(HcalTrigPrimDigiCollection & result){

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 LSParameter =cms.untracked.PSet(
-HcalFeatureHFEMBit= cms.bool(True),
+HcalFeatureHFEMBit= cms.bool(False),
 Min_Long_Energy= cms.double(10),#makes a cut based on energy deposited in short vrs long
     Min_Short_Energy= cms.double(10),
     Long_vrs_Short_Slope= cms.double(100.2),

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+LSParameter =cms.untracked.PSet(
+HcalFeatureHFEMBit= cms.bool(True),
+Min_Long_Energy= cms.double(10),#makes a cut based on energy deposited in short vrs long
+    Min_Short_Energy= cms.double(10),
+    Long_vrs_Short_Slope= cms.double(100.2),
+    Long_Short_Offset= cms.double(10.1))
+
+
 simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     peakFilter = cms.bool(True),
     weights = cms.vdouble(1.0, 1.0), ##hardware algo        
@@ -12,6 +20,9 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     numberOfPresamplesHF = cms.int32(2),
     MinSignalThreshold = cms.uint32(0), # For HF PMT veto
     PMTNoiseThreshold = cms.uint32(0),  # For HF PMT veto
+    LSConfig=LSParameter,
+    
+    
 #
     #vdouble weights = { -1, -1, 1, 1} //low lumi algo
     # Input digi label (_must_ be without zero-suppression!)

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -22,6 +22,9 @@
 
 #include <algorithm>
 
+
+
+
 HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 : 
   theAlgo_(ps.getParameter<bool>("peakFilter"),
@@ -41,6 +44,16 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
   runZS_(ps.getParameter<bool>("RunZS")),
   runFrontEndFormatError_(ps.getParameter<bool>("FrontEndFormatError"))
 {
+    HFEMB_ = false;
+    if(ps.exists("LSConfig"))
+    {
+        LongShortCut_ = ps.getUntrackedParameter<edm::ParameterSet>("LSConfig");
+        HFEMB_ = LongShortCut_.getParameter<bool>("HcalFeatureHFEMBit");
+        MinLongEnergy_ = LongShortCut_.getParameter<double>("Min_Long_Energy"); //minimum long energy
+        MinShortEnergy_ = LongShortCut_.getParameter<double>("Min_Short_Energy"); //minimum short energy
+        LongShortSlope_ = LongShortCut_.getParameter<double>("Long_vrs_Short_Slope"); //slope of the line that cuts are based on
+        LongShortOffset_ = LongShortCut_.getParameter<double>("Long_Short_Offset"); //offset of line
+    }
   // register for data access
   if (runFrontEndFormatError_) {
     tok_raw_ = consumes<FEDRawDataCollection>(inputTagFEDRaw_);
@@ -108,15 +121,31 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
   }
 
 
+    edm::ESHandle < HcalDbService > pSetup;
+    eventSetup.get<HcalDbRecord> ().get(pSetup);
+
+    HcalFeatureBit* hfembit = 0;
+
+    if(HFEMB_)
+    {
+        hfembit = new HcalFeatureHFEMBit(MinShortEnergy_, MinLongEnergy_, LongShortSlope_, LongShortOffset_, *pSetup); //inputs values that cut will be based on
+        theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+                *hbheDigis, *hfDigis, *result, &(*pG), rctlsb, hfembit);
+
+    }// Step C: Invoke the algorithm, passing in inputs and getting back outputs.
+    else
+    {
+        theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+                *hbheDigis, *hfDigis, *result, &(*pG), rctlsb);
+    }
+
   // Step C: Invoke the algorithm, passing in inputs and getting back outputs.
-  theAlgo_.run(inputCoder.product(),outTranscoder->getHcalCompressor().get(),
-	       *hbheDigis,  *hfDigis, *result, &(*pG), rctlsb);
+ 
 
   // Step C.1: Run FE Format Error / ZS for real data.
   if (runFrontEndFormatError_) {
 
-        edm::ESHandle < HcalDbService > pSetup;
-        eventSetup.get<HcalDbRecord> ().get(pSetup);
+       
         const HcalElectronicsMap *emap = pSetup->getHcalMapping();
 
         edm::Handle < FEDRawDataCollection > fedHandle;

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
@@ -32,11 +32,14 @@ private:
   /// input tag for FEDRawDataCollection
   edm::InputTag inputTagFEDRaw_;
   edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
-
+  double MinLongEnergy_, MinShortEnergy_, LongShortSlope_, LongShortOffset_;
+  
   bool runZS_;
 
   bool runFrontEndFormatError_;
 
+  bool HFEMB_;
+  edm::ParameterSet LongShortCut_;
 };
 
 #endif


### PR DESCRIPTION
This is a port of Alex Gude's PR #6614, but only the modifications done to the TP algorithm and the `HcalTowerAlgo`. The only errors I see with `runTheMatrix.py` are marked as coming from DAS.

This will add the 1x1 HF TP in the same collection as 2x3 HF TP, but the RCT already has a check in place to use only 2x3. To actually produce 1x1 TP, new LUT metadata is needed, either by supplying them manually or through a new globaltag. 2x3 production should not be affected by this.
