### PR TITLE
Updating Data GT for 2015 Run2 EOY Re-Reco, RunII Simulation with new SIM geometries, and Upgrade GT with Pixel conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,23 +10,25 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v12',
+    'run2_design'       :   '76X_mcRun2_design_v13',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v11',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v12',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v12',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v13',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v12',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v11',
+    'run1_data'         :   '76X_dataRun1_v15',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v11',
+    'run2_data'         :   '76X_dataRun2_v15',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v9',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v10',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v9',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v10',
+    # GlobalTag for Run2 HLT for HI: it points to the online GT
+    'run2_hlt_hi'       :   '76X_dataRun2_HLTHI_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v7',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of Global Tag Changes
## RunII Simulation
- **Ideal scenario**: [76X_mcRun2_design_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_design_v13): As [76X_mcRun2_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_design_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun2_design_v13/76X_mcRun2_design_v12):
  - added further labels for Castor SIM geometry
- **Asymptotic scenario**: [76X_mcRun2_asymptotic_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_asymptotic_v13): As [76X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_asymptotic_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/):
  - added further labels for Castor SIM geometry
- **Startup scenario**: [76X_mcRun2_startup_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_startup_v12): As [76X_mcRun2_startup_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_startup_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun2_startup_v12/76X_mcRun2_startup_v11):
  - added further labels for Castor SIM geometry
## RunI Data
- **HLT processing**: [76X_dataRun1_HLT_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_HLT_frozen_v10): As [76X_dataRun1_HLT_frozen_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_HLT_frozen_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun1_HLT_frozen_v10/76X_dataRun1_HLT_frozen_v9):
  - added Record for HCAL negative energy filter
- **Offline processing**: [76X_dataRun1_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_v15): As [76X_dataRun1_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun1_v15/76X_dataRun1_v11):
  - explicit tag differences:
    - updated Tracker alignment, surface deformations and APE for the full range of 2015 data taking
    - updated Lumi Section based beamspot for 2015B,C,D taking into account new Tracker alignment
    - updated DT,CSC and muon GPR alignment due to updated Tracker alignment
    - updated DT vdrift and tTrig constants
    - updated CSC timing constants
    - updated SiStrip bad channel and particle APV gain corrections
    - updated Hcal gains and response correction (taking into account HE radiation damage and HO calibration)
    - updated Castor local reco calibrations (Channel quality,Electronic map, Gains, GainWidths, Pedestals, PedestalWidths, QIEData, RecoParams, Saturation corrections)
    - updated Ecal channel status, IC, AdcToGeV, time calibrations
    - updated Ecal Barrel and Endcap alignment due to updated Tracker alignment
    - updated ES IC
    - updated centrality table with HFtowers label
    - updated JEC with AK4Calo label for pp reference run at 5TeV
  - differences introduced by append IOVs:
    - new IOVs for L1T O2O
    - new IOVs for ECAL O2O
    - new IOVs for HCAL LUT (alternating tables for 0T and 3.8T)
    - new IOVs for SiStrip O2O pointing to prompt tags
    - new IOVs for RunInfo (up to run 263284)
    - new IOVs for CSC Crosstalk, Gains, Noise and Pedestals
    - new IOVs for Ecal bad channels, laser corrections, pedestals, and pulse shapes
    - new IOVs for Preshower alignment (alternating 0T and 3.8T geometries)
    - new IOVs for HCal channel quality
    - new IOVs for Pixel templates at 0T.
## RunII Data
- **HLT processing**: [76X_dataRun2_HLT_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLT_frozen_v10): As [76X_dataRun2_HLT_frozen_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLT_frozen_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun2_HLT_frozen_v10/76X_dataRun2_HLT_frozen_v9):
  - added Record for HCAL negative energy filter
- **HLT HI processing**: [76X_dataRun2_HLTHI_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLTHI_v1): As [76X_dataRun2_HLT_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLT_frozen_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun2_HLTHI_v1/76X_dataRun2_HLT_frozen_v10):
  - added Tracking MVA selection for HI
  - updated SiStrip pedestals with full fledged values for SiStrip Zero Suppression at HLT
  - updated AK4Calo JEC for HLT with values for HI
- **Offline processing**: [76X_dataRun2_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_v15): As [76X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun2_v15/76X_dataRun2_v11):
  - explicit tag differences:
    - updated Tracker alignment, surface deformations and APE for the full range of 2015 data taking
    - updated Lumi Section based beamspot for 2015B,C,D taking into account new Tracker alignment
    - updated DT,CSC and muon GPR alignment due to updated Tracker alignment
    - updated DT vdrift and tTrig constants
    - updated CSC timing constants
    - updated SiStrip bad channel and particle APV gain corrections
    - updated Hcal gains and response correction (taking into account HE radiation damage and HO calibration)
    - updated Castor local reco calibrations (Channel quality,Electronic map, Gains, GainWidths, Pedestals, PedestalWidths, QIEData, RecoParams, Saturation corrections)
    - updated Ecal channel status, IC, AdcToGeV, time calibrations
    - updated Ecal Barrel and Endcap alignment due to updated Tracker alignment
    - updated ES IC
    - updated centrality table with HFtowers label
    - updated JEC with AK4Calo label for pp reference run at 5TeV
  - differences introduced by append IOVs:
    - new IOVs for L1T O2O
    - new IOVs for ECAL O2O
    - new IOVs for HCAL LUT (alternating tables for 0T and 3.8T)
    - new IOVs for SiStrip O2O pointing to prompt tags
    - new IOVs for RunInfo (up to run 263284)
    - new IOVs for CSC Crosstalk, Gains, Noise and Pedestals
    - new IOVs for Ecal bad channels, laser corrections, pedestals, and pulse shapes
    - new IOVs for Preshower alignment (alternating 0T and 3.8T geometries)
    - new IOVs for HCal channel quality
    - new IOVs for Pixel templates at 0T.
## Upgrade simulation
- **2017 ideal scenario**: [76X_upgrade2017_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/): As [76X_upgrade2017_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_upgrade2017_design_v8/76X_upgrade2017_design_v7):
  - New Pixel SIM LA for Phase-I
  - New Pixel LA for Phase-I
  - New Pixel templates for Phase-I
  - New Pixel SIM gains for Phase-I
  - New Pixel GenErrors for Phase-I
  - New Pixel gains for Phase-I
  - New Pixel quality for Phase-I.
