### PR TITLE
Monitor duplicateMerge track algo in MultiTrackValidator

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -29,6 +29,7 @@ _algos = [
     "jetCoreRegionalStep",
     "muonSeededStepInOut",
     "muonSeededStepOutIn",
+    "duplicateMerge",
 ]
 def _algoToSelector(algo):
     sel = ""

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -64,6 +64,7 @@ _trackAlgoOrder = [
     'jetCoreRegionalStep',
     'muonSeededStepInOut',
     'muonSeededStepOutIn',
+    'duplicateMerge',
 ]
 
 _pageNameMap = {
@@ -307,7 +308,10 @@ class TrackingPageSet(PageSet):
         sectionName = quality
 
         # put all non-iterative stuff under OOTB
-        if "ootb" not in algo and "Step" not in algo:
+        #
+        # it is bit of a hack to access trackingPlots.TrackingPlotFolder this way,
+        # but it was simple and it works
+        if not plotterFolder._plotFolder.isAlgoIterative(algo):
             pageName = "ootb"
             sectionName = algo
 

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -258,7 +258,7 @@ _resolutionsPt = PlotGroup("resolutionsPt", [
 #
 ########################################
 
-_possibleTrackingColls = [
+_possibleTrackingIterations = [
     'initialStep',
     'lowPtTripletStep',
     'pixelPairStep',
@@ -269,6 +269,9 @@ _possibleTrackingColls = [
     'jetCoreRegionalStep',
     'muonSeededStepInOut',
     'muonSeededStepOutIn',
+    'duplicateMerge',
+]
+_possibleTrackingColls = _possibleTrackingIterations+[
     'ak4PFJets',
     'btvLike',
 ]
@@ -443,6 +446,10 @@ class TrackingPlotFolder(PlotFolder):
         """
         (algo, quality) = translatedDqmSubFolder
         return limitOnlyTo(algo, quality)
+
+    # track-specific hack
+    def isAlgoIterative(self, algo):
+        return algo in _possibleTrackingIterations
 
 def _trackingFolders(lastDirName="Track"):
     return [


### PR DESCRIPTION
This PR is a follow-up to #12577 by adding the monitoring of duplicateMerge to tracking validation.

Tested in CMSSW_8_0_X_2015-12-03-2300, expecting addition of "duplicateMerge" algorithm in MTV summary plots and corresponding subfolders for the plots.

@rovere @VinInn 
