### PR TITLE
Protect against particle with no mother

### DIFF
--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -3871,7 +3871,7 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
   /////// separate loop to compare with miniAOD
   for ( reco::GenParticleCollection::const_iterator mcIter=genParticles->begin() ; mcIter!=genParticles->end() ; mcIter++ ) {
     if ( !(mcIter->pdgId() == 22 ) ) continue;
-    if ( !(mcIter->mother()->pdgId()==25) ) continue;
+    if ( mcIter->mother() != nullptr and  !(mcIter->mother()->pdgId()==25) ) continue;
     if ( fabs(mcIter->eta()) > 2.5 ) continue;
      
     float mcPhi= mcIter->phi();

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
@@ -202,7 +202,7 @@ PhotonValidatorMiniAOD::analyze( const edm::Event &iEvent, const edm::EventSetup
 
     for ( reco::GenParticleCollection::const_iterator mcIter=genParticles->begin() ; mcIter!=genParticles->end() ; mcIter++ ) {
         if ( !(mcIter->pdgId() == 22 ) ) continue;
-        if ( !(mcIter->mother()->pdgId()==25) ) continue;
+        if ( mcIter->mother() != nullptr && !(mcIter->mother()->pdgId()==25) ) continue;
         if ( fabs(mcIter->eta()) > 2.5 ) continue;
 	//       if ( mcIter->pt() < 5) continue;
         //        if ( fabs(mcIter->eta()) > 1.4442 && fabs(mcIter->eta()) < 1.566) continue;


### PR DESCRIPTION
Need to first check that GenParticle::mother() is not returning a
null pointer before attempting to dereference the pointer.
This solves a crash seen in the integration build release validation jobs.
