### PR TITLE
Change of DigiToRaw code to keep SiStrip Error information during data repacking

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -8,7 +8,9 @@ import EventFilter.SiStripRawToDigi.SiStripDigiToRaw_cfi
 SiStripDigiToZSRaw = EventFilter.SiStripRawToDigi.SiStripDigiToRaw_cfi.SiStripDigiToRaw.clone(
     InputModuleLabel = 'siStripZeroSuppression',
     InputDigiLabel = cms.string('VirginRaw'),
-    FedReadoutMode = cms.string('ZERO_SUPPRESSED')
+    FedReadoutMode = cms.string('ZERO_SUPPRESSED'),
+    CopyBufferHeader = cms.bool(True),
+    RawDataTag = cms.InputTag('rawDataCollector')
     )
 
 SiStripRawDigiToVirginRaw = SiStripDigiToZSRaw.clone(

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -429,6 +429,9 @@ namespace sistrip {
       virtual void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status) = 0;
       virtual void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address) = 0;
       virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister) = 0;
+      virtual void setDAQRegister(const uint32_t daqRegister) = 0;
+      virtual void setDAQRegister2(const uint32_t daqRegister2) = 0;
+      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister) = 0;
       virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length) = 0;
       void setChannelStatus(const uint8_t internalFEUnitNum, const uint8_t internalFEUnitChannelNum, const FEDChannelStatus status);
     };
@@ -453,6 +456,9 @@ namespace sistrip {
       virtual void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status);
       virtual void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address);
       virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister);
+      virtual void setDAQRegister(const uint32_t daqRegister);
+      virtual void setDAQRegister2(const uint32_t daqRegister2);
+      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister);
       virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length);
     private:
       static const size_t APV_ERROR_HEADER_SIZE_IN_64BIT_WORDS = 3;
@@ -503,7 +509,11 @@ namespace sistrip {
       virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister);
       virtual void setDAQRegister(const uint32_t daqRegister);
       virtual void setDAQRegister2(const uint32_t daqRegister2);
+      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister);
       virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length);
+      static uint32_t get32BitWordFrom(const uint8_t* startOfWord);
+      const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
+      uint8_t* feWord(const uint8_t internalFEUnitNum);
       FEDFullDebugHeader(const std::vector<uint16_t>& feUnitLengths = std::vector<uint16_t>(FEUNITS_PER_FED,0),
                          const std::vector<uint8_t>& feMajorityAddresses = std::vector<uint8_t>(FEUNITS_PER_FED,0),
                          const std::vector<FEDChannelStatus>& channelStatus = std::vector<FEDChannelStatus>(FEDCH_PER_FED,CHANNEL_STATUS_NO_PROBLEMS),
@@ -511,10 +521,7 @@ namespace sistrip {
                          const uint32_t daqRegister = 0, const uint32_t daqRegister2 = 0);
     private:
       bool getBit(const uint8_t internalFEDChannelNum, const uint8_t bit) const;
-      static uint32_t get32BitWordFrom(const uint8_t* startOfWord);
       static void set32BitWordAt(uint8_t* startOfWord, const uint32_t value);
-      const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
-      uint8_t* feWord(const uint8_t internalFEUnitNum);
       void setBit(const uint8_t internalFEDChannelNum, const uint8_t bit, const bool value);
       
       //These methods return true if there was an error of the appropriate type (ie if the error bit is 0).

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -243,11 +243,7 @@ namespace sistrip {
 	//zeroSuppressed here means converted to 8 bit...
 	if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
 	FEDStripData fedData(zeroSuppressed);
-	/*if ( edm::isDebugEnabled() ) {
-	  edm::LogWarning("DigiToRaw")
-	    << "[sistrip::DigiToRaw::createFedBuffers_]"
-	    << "Fed " << *ifed ;
-	    }*/
+	
 	
 	for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
 	  
@@ -265,11 +261,7 @@ namespace sistrip {
 	  
 	  FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
 
-	  /*if ( edm::isDebugEnabled() ) {
-	    edm::LogWarning("DigiToRaw") 
-	      << "[DigiToRaw::createFedBuffers] " 
-	      << " detid = " << key << " apvpair = " << ipair;
-	      }*/
+	
 	  
 	 
 	  // Find digis for DetID in collection
@@ -285,11 +277,6 @@ namespace sistrip {
 	  if (digis == collection->end()) { continue; } 
 	  
 
-	  /*if ( edm::isDebugEnabled() ) {
-	    edm::LogWarning("DigiToRaw") 
-	      << "[DigiToRaw::createFedBuffers] " 
-	      << " digi found ";
-	      }*/
 	  
 
 	  typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
@@ -327,12 +314,6 @@ namespace sistrip {
 	    
 	    // Add digi to buffer
 	    chanData[strip] = (*idigi).adc();
-	    /*if ( edm::isDebugEnabled() ) {
-	      edm::LogWarning("DigiToRaw") 
-		<< "[DigiToRaw::createFedBuffers] " 
-		<< " adc value = " << chanData[strip];
-		}*/
-	    
 	  }
 	}
 	// if ((*idigi).strip() >= (ipair+1)*256) break;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -140,7 +140,7 @@ namespace sistrip {
 	    fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(),rawfedData.size(),true));
 	    //bufferBase.reset(new sistrip::FEDBufferBase(rawfedData.data(),rawfedData.size()));
 	  } catch (const cms::Exception& e) {
-	    std::cerr << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
 		      << " Invalid raw data, cannot get buffer..."
 		      << std::endl;
 	  }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -153,10 +153,12 @@ namespace sistrip {
 	      << " Original header type: " << fedbuffer->headerType();
 	  }
 
-	  //bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_APV_ERROR);//fedbuffer->headerType());
-	  //bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
-	  //bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
-	  //bufferGenerator_.trackerSpecialHeader() = TrackerSpecialHeader((fedbuffer->trackerSpecialHeader()).data());
+
+	  bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_FULL_DEBUG);
+	  //fedbuffer->headerType());
+	  bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
+	  bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
+	  
 	  if(ifed==fed_ids.begin()){  fedbuffer->dump(std::cout); std::cout << std::endl;}
 	  bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
 	  bufferGenerator_.setReadoutMode(mode_);

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -189,7 +189,6 @@ namespace sistrip {
 	      << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
 	      << debugStream.str();
 	  }
-          
           //status registers
           (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
           (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
@@ -197,12 +196,17 @@ namespace sistrip {
           for(uint8_t iFE=1; iFE<6; iFE++) {
             (bufferGenerator_.feHeader()).set32BitReservedRegister(iFE,fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE)+10));
           }
+
+          std::vector<bool> feEnabledVec;
+	  feEnabledVec.resize(FEUNITS_PER_FED,true);
 	  for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
+            feEnabledVec[iFE]=fedbuffer->trackerSpecialHeader().feEnabled(iFE);  
             (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE,fedFeHeader->feUnitMajorityAddress(iFE));
 	    for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
 	      (bufferGenerator_.feHeader()).setChannelStatus(iFE,iFEUnitChannel,fedFeHeader->getChannelStatus(iFE,iFEUnitChannel));
 	    }//loop on channels
 	  }//loop on fe units
+          bufferGenerator_.setFEUnitEnables(feEnabledVec);
 
 	  if ( edm::isDebugEnabled() ) {
 	    std::ostringstream debugStream;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -9,7 +9,9 @@
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "FWCore/Utilities/interface/CRC16.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <vector>
 
@@ -63,10 +65,44 @@ namespace sistrip {
 				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
     createFedBuffers_(event, cabling, collection, buffers, false);
   }
+
+  //with copy of headers from initial raw data collection (raw->digi->raw)
+  void DigiToRaw::createFedBuffers( edm::Event& event,
+				    edm::ESHandle<SiStripFedCabling>& cabling,
+				    edm::Handle<FEDRawDataCollection> & rawbuffers,
+				    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
+				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+    createFedBuffers_(event, cabling, rawbuffers, collection, buffers, true);
+  }
   
+  void DigiToRaw::createFedBuffers( edm::Event& event,
+				    edm::ESHandle<SiStripFedCabling>& cabling,
+				    edm::Handle<FEDRawDataCollection> & rawbuffers,
+				    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
+				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+    createFedBuffers_(event, cabling, rawbuffers, collection, buffers, false);
+  }
+
+
+
+
   template<class Digi_t>
   void DigiToRaw::createFedBuffers_( edm::Event& event,
 				     edm::ESHandle<SiStripFedCabling>& cabling,
+				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
+				     std::auto_ptr<FEDRawDataCollection>& buffers,
+				     bool zeroSuppressed) {
+
+    edm::Handle<FEDRawDataCollection> rawbuffers;
+    //CAMM initialise to some dummy empty buffers??? Or OK like this ?
+    createFedBuffers_(event,cabling,rawbuffers,collection,buffers,zeroSuppressed);
+
+  }
+
+  template<class Digi_t>
+  void DigiToRaw::createFedBuffers_( edm::Event& event,
+				     edm::ESHandle<SiStripFedCabling>& cabling,
+				     edm::Handle<FEDRawDataCollection> & rawbuffers,
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
 				     std::auto_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
@@ -74,36 +110,187 @@ namespace sistrip {
       
       //set the L1ID to use in the buffers
       bufferGenerator_.setL1ID(0xFFFFFF & event.id().event());
-      
       auto fed_ids = cabling->fedIds();
+
+      std::cout << " Are you valid or not ??" << std::endl;
+      //copy header if valid rawbuffers handle
+      if (rawbuffers.isValid()){
+	std::cout << " yes..." << std::endl;
+	if ( edm::isDebugEnabled() ) {
+	  edm::LogWarning("DigiToRaw")
+	    << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    << " Valid raw buffers, getting headers from them..."
+	    << " Number of feds: " << fed_ids.size() << " between "
+	    << *(fed_ids.begin()) << " and " << *(fed_ids.end());
+	}
+	
+	const FEDRawDataCollection& rawDataCollection = *rawbuffers;
+
+	for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
+	  const FEDRawData& rawfedData = rawDataCollection.FEDData(*ifed);
+
+	  if ( edm::isDebugEnabled() ) {
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << "Fed " << *ifed << " : size of buffer = " << rawfedData.size();
+	  }
+	  
+	  //need to construct full object to copy full header
+	  std::auto_ptr<const sistrip::FEDBuffer> fedbuffer;
+	  //std::auto_ptr<const sistrip::FEDBufferBase> bufferBase;
+	  try {
+	    fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(),rawfedData.size(),true));
+	    //bufferBase.reset(new sistrip::FEDBufferBase(rawfedData.data(),rawfedData.size()));
+	  } catch (const cms::Exception& e) {
+	    std::cerr << "[sistrip::DigiToRaw::createFedBuffers_]"
+		      << " Invalid raw data, cannot get buffer..."
+		      << std::endl;
+	  }
+	  
+	  if ( edm::isDebugEnabled() ) {
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " Original header type: " << fedbuffer->headerType();
+	  }
+
+	  //bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_APV_ERROR);//fedbuffer->headerType());
+	  //bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
+	  //bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
+	  //bufferGenerator_.trackerSpecialHeader() = TrackerSpecialHeader((fedbuffer->trackerSpecialHeader()).data());
+	  if(ifed==fed_ids.begin()){  fedbuffer->dump(std::cout); std::cout << std::endl;}
+	  bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
+	  bufferGenerator_.setReadoutMode(mode_);
+
+	  if ( edm::isDebugEnabled() ) {
+	    std::ostringstream debugStream;
+	    if(ifed==fed_ids.begin()){  bufferGenerator_.trackerSpecialHeader().print(std::cout); std::cout << std::endl;}
+	    bufferGenerator_.trackerSpecialHeader().print(debugStream);
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " Tracker special header apveAddress: " << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apveAddress())
+	      << " - event type = " << bufferGenerator_.getDAQEventType()
+	      << " - buffer format = " << bufferGenerator_.getBufferFormat() << "\n"
+	      << " - SpecialHeader bufferformat " << bufferGenerator_.trackerSpecialHeader().bufferFormat()
+	      << " - headertype " << bufferGenerator_.trackerSpecialHeader().headerType()
+	      << " - readoutmode " << bufferGenerator_.trackerSpecialHeader().readoutMode()
+	      << " - apvaddrregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apvAddressErrorRegister())
+	      << " - feenabledregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feEnableRegister())
+	      << " - feoverflowregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feOverflowRegister())
+	      << " - statusregister " << bufferGenerator_.trackerSpecialHeader().fedStatusRegister() << "\n"
+	      << " SpecialHeader: " << debugStream.str();
+	  }
+
+	  //bufferGenerator_.feHeader() = ;
+	  std::auto_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
+	  FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
+	  if ( edm::isDebugEnabled() ) {
+	    std::ostringstream debugStream;
+	    if(ifed==fed_ids.begin()){  std::cout << "FEHeader before transfer: " << std::endl;fedFeHeader->print(std::cout);std::cout  <<std::endl;}
+	    fedFeHeader->print(debugStream);
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
+	      << debugStream.str();
+	  }
+          
+          //status registers
+          (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
+          (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
+          (bufferGenerator_.feHeader()).setDAQRegister(fedFeHeader->daqRegister());
+          for(uint8_t iFE=1; iFE<6; iFE++) {
+            (bufferGenerator_.feHeader()).set32BitReservedRegister(iFE,fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE)+10));
+          }
+	  for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
+            //added these 2
+            (bufferGenerator_.feHeader()).setFEUnitLength(iFE,fedFeHeader->feUnitLength(iFE));
+            (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE,fedFeHeader->feUnitMajorityAddress(iFE));
+	    for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
+	      (bufferGenerator_.feHeader()).setChannelStatus(iFE,iFEUnitChannel,fedFeHeader->getChannelStatus(iFE,iFEUnitChannel));
+	    }//loop on channels
+	  }//loop on fe units
+
+	  if ( edm::isDebugEnabled() ) {
+	    std::ostringstream debugStream;
+	    if(ifed==fed_ids.begin()){  std::cout << "\nFEHeader after transfer: " << std::endl;bufferGenerator_.feHeader().print(std::cout); std::cout << std::endl;}
+	    bufferGenerator_.feHeader().print(debugStream);
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+	      << debugStream.str();
+	  }
+	}//loop on fedids
+	if ( edm::isDebugEnabled() ) {
+	  edm::LogWarning("DigiToRaw")
+	    << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    << "end of first loop on feds";
+	}
+
+      }
+      
+      if ( edm::isDebugEnabled() ) {
+	edm::LogWarning("DigiToRaw")
+	  << "[sistrip::DigiToRaw::createFedBuffers_]"
+	  << "Now getting the digis..."
+	  << " Number of feds: " << fed_ids.size() << " between "
+	  << *(fed_ids.begin()) << " and " << *(fed_ids.end());
+      }
+
       for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
         
-        auto conns = cabling->fedConnections(*ifed);
-        
+	auto conns = cabling->fedConnections(*ifed);
+	
 	//for special mode premix raw, data is zero-suppressed but not converted to 8 bit
 	//zeroSuppressed here means converted to 8 bit...
 	if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
-        FEDStripData fedData(zeroSuppressed);
-        
+	FEDStripData fedData(zeroSuppressed);
+	/*if ( edm::isDebugEnabled() ) {
+	  edm::LogWarning("DigiToRaw")
+	    << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    << "Fed " << *ifed ;
+	    }*/
+	
 	for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
-          
+	  
 	  // Determine FED key from cabling
 	  uint32_t fed_key = ( ( iconn->fedId() & sistrip::invalid_ ) << 16 ) | ( iconn->fedCh() & sistrip::invalid_ );
-	
+	  
 	  // Determine whether DetId or FED key should be used to index digi containers
 	  uint32_t key = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? fed_key : iconn->detId();
-          
-          // Check key is non-zero and valid
+	  
+	  // Check key is non-zero and valid
 	  if ( !key || ( key == sistrip::invalid32_ ) ) { continue; }
-
+	  
 	  // Determine APV pair number (needed only when using DetId)
 	  uint16_t ipair = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? 0 : iconn->apvPairNumber();
-          
-          FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
+	  
+	  FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
 
+	  /*if ( edm::isDebugEnabled() ) {
+	    edm::LogWarning("DigiToRaw") 
+	      << "[DigiToRaw::createFedBuffers] " 
+	      << " detid = " << key << " apvpair = " << ipair;
+	      }*/
+	  
+	 
 	  // Find digis for DetID in collection
+	  if (!collection.isValid()){
+	    if ( edm::isDebugEnabled() ) {
+	      edm::LogWarning("DigiToRaw") 
+		<< "[DigiToRaw::createFedBuffers] " 
+		<< "digis collection is not valid...";
+	    }
+	    break;
+	  }
 	  typename std::vector< edm::DetSet<Digi_t> >::const_iterator digis = collection->find( key );
 	  if (digis == collection->end()) { continue; } 
+	  
+
+	  /*if ( edm::isDebugEnabled() ) {
+	    edm::LogWarning("DigiToRaw") 
+	      << "[DigiToRaw::createFedBuffers] " 
+	      << " digi found ";
+	      }*/
+	  
 
 	  typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
 	  for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
@@ -111,7 +298,7 @@ namespace sistrip {
 	    if ( STRIP(idigi, digis_begin) < ipair*256 ||
 		 STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
 	    const unsigned short strip = STRIP(idigi, digis_begin) % 256;
-
+	    
 	    if ( strip >= STRIPS_PER_FEDCH ) {
 	      if ( edm::isDebugEnabled() ) {
 		std::stringstream ss;
@@ -121,10 +308,10 @@ namespace sistrip {
 	      }
 	      continue;
 	    }
-	  
+	    
 	    // check if value already exists
 	    if ( edm::isDebugEnabled() ) {
-              const uint16_t value = 0;//chanData[strip];
+	      const uint16_t value = 0;//chanData[strip];
 	      if ( value && value != (*idigi).adc() ) {
 		std::stringstream ss; 
 		ss << "[sistrip::DigiToRaw::createFedBuffers]" 
@@ -137,20 +324,40 @@ namespace sistrip {
 		edm::LogWarning("DigiToRaw") << ss.str();
 	      }
 	    }
-
+	    
 	    // Add digi to buffer
 	    chanData[strip] = (*idigi).adc();
-
+	    /*if ( edm::isDebugEnabled() ) {
+	      edm::LogWarning("DigiToRaw") 
+		<< "[DigiToRaw::createFedBuffers] " 
+		<< " adc value = " << chanData[strip];
+		}*/
+	    
 	  }
-	  // if ((*idigi).strip() >= (ipair+1)*256) break;
+	}
+	// if ((*idigi).strip() >= (ipair+1)*256) break;
+	
+	if ( edm::isDebugEnabled() ) {
+	  edm::LogWarning("DigiToRaw") 
+	    << "DigiToRaw::createFedBuffers] " 
+	    << "Almost at the end...";
+	}
+	//create the buffer
+	FEDRawData& fedrawdata = buffers->FEDData( *ifed );
+	bufferGenerator_.generateBuffer(&fedrawdata,fedData,*ifed);
+
+	if ( edm::isDebugEnabled() ) {
+	  std::ostringstream debugStream;
+	  bufferGenerator_.feHeader().print(debugStream);
+	  edm::LogWarning("DigiToRaw")
+	    << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+	    << debugStream.str();
 	}
 
-        //create the buffer
-        FEDRawData& fedrawdata = buffers->FEDData( *ifed );
-        bufferGenerator_.generateBuffer(&fedrawdata,fedData,*ifed);
         
-       }
-    }
+      }//loop on feds
+    }//try
     catch (const std::exception& e) {
       if ( edm::isDebugEnabled() ) {
 	edm::LogWarning("DigiToRaw") 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -112,10 +112,8 @@ namespace sistrip {
       bufferGenerator_.setL1ID(0xFFFFFF & event.id().event());
       auto fed_ids = cabling->fedIds();
 
-      std::cout << " Are you valid or not ??" << std::endl;
       //copy header if valid rawbuffers handle
       if (rawbuffers.isValid()){
-	std::cout << " yes..." << std::endl;
 	if ( edm::isDebugEnabled() ) {
 	  edm::LogWarning("DigiToRaw")
 	    << "[sistrip::DigiToRaw::createFedBuffers_]"

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -157,7 +157,6 @@ namespace sistrip {
 	  bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
 	  bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
 	  
-	  if(ifed==fed_ids.begin()){  fedbuffer->dump(std::cout); std::cout << std::endl;}
 	  bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
 	  bufferGenerator_.setReadoutMode(mode_);
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
@@ -32,12 +32,25 @@ namespace sistrip {
     DigiToRaw( FEDReadoutMode, bool use_fed_key );
     ~DigiToRaw();
     
+    //digi to raw with default headers
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
 			   edm::Handle< edm::DetSetVector<SiStripDigi> >& digis,
 			   std::auto_ptr<FEDRawDataCollection>& buffers );
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
+			   edm::Handle< edm::DetSetVector<SiStripRawDigi> >& digis,
+			   std::auto_ptr<FEDRawDataCollection>& buffers);
+
+    //with input raw data for copying header   
+    void createFedBuffers( edm::Event&, 
+			   edm::ESHandle<SiStripFedCabling>& cabling,
+			   edm::Handle<FEDRawDataCollection> & rawbuffers,
+			   edm::Handle< edm::DetSetVector<SiStripDigi> >& digis,
+			   std::auto_ptr<FEDRawDataCollection>& buffers );
+    void createFedBuffers( edm::Event&, 
+			   edm::ESHandle<SiStripFedCabling>& cabling,
+			   edm::Handle<FEDRawDataCollection> & rawbuffers,
 			   edm::Handle< edm::DetSetVector<SiStripRawDigi> >& digis,
 			   std::auto_ptr<FEDRawDataCollection>& buffers);
     
@@ -51,6 +64,17 @@ namespace sistrip {
 			    edm::Handle< edm::DetSetVector<Digi_t> >& digis,
 			    std::auto_ptr<FEDRawDataCollection>& buffers,
 			    bool zeroSuppressed);
+
+    template<class Digi_t>
+    void createFedBuffers_( edm::Event&, 
+			    edm::ESHandle<SiStripFedCabling>& cabling,
+			    edm::Handle<FEDRawDataCollection> & rawbuffers,
+			    edm::Handle< edm::DetSetVector<Digi_t> >& digis,
+			    std::auto_ptr<FEDRawDataCollection>& buffers,
+			    bool zeroSuppressed);
+
+
+
     uint16_t STRIP(const edm::DetSet<SiStripDigi>::const_iterator& it, const edm::DetSet<SiStripDigi>::const_iterator& begin) const;
     uint16_t STRIP(const edm::DetSet<SiStripRawDigi>::const_iterator& it, const edm::DetSet<SiStripRawDigi>::const_iterator& begin) const;
     

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -1,4 +1,3 @@
-
 #include "SiStripDigiToRawModule.h"
 #include "SiStripDigiToRaw.h"
 
@@ -23,12 +22,12 @@ namespace sistrip {
   DigiToRawModule::DigiToRawModule( const edm::ParameterSet& pset ) :
     inputModuleLabel_( pset.getParameter<std::string>( "InputModuleLabel" ) ),
     inputDigiLabel_( pset.getParameter<std::string>( "InputDigiLabel" ) ),
-    copyBufferHeader_(pset.getUntrackedParameter<bool>("CopyBufferHeader",false)),
+    copyBufferHeader_(pset.getParameter<bool>("CopyBufferHeader")),
     mode_( fedReadoutModeFromString(pset.getParameter<std::string>( "FedReadoutMode" ))),
     rawdigi_( false ),
     digiToRaw_(0),
     eventCounter_(0),
-    rawDataTag_(pset.getUntrackedParameter<edm::InputTag>("RawDataTag",edm::InputTag("rawDataCollector","")))
+    rawDataTag_(pset.getParameter<edm::InputTag>("RawDataTag"))
   {
     if ( edm::isDebugEnabled() ) {
       LogDebug("DigiToRawModule") 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -160,13 +160,13 @@ namespace sistrip {
     if( rawdigi_ ) {
       edm::Handle< edm::DetSetVector<SiStripRawDigi> > rawdigis;
       iEvent.getByToken( tokenRawDigi, rawdigis );
-      digiToRaw_->createFedBuffers( iEvent, cabling, rawdigis, buffers );
       if (copyBufferHeader_) digiToRaw_->createFedBuffers( iEvent, cabling, rawbuffers, rawdigis, buffers );
+      else digiToRaw_->createFedBuffers( iEvent, cabling, rawdigis, buffers );
     } else {
       edm::Handle< edm::DetSetVector<SiStripDigi> > digis;
       iEvent.getByToken( tokenDigi, digis );
-      digiToRaw_->createFedBuffers( iEvent, cabling, digis, buffers );
       if (copyBufferHeader_) digiToRaw_->createFedBuffers( iEvent, cabling, rawbuffers, digis, buffers );
+      else digiToRaw_->createFedBuffers( iEvent, cabling, digis, buffers );
     }
 
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -28,7 +28,7 @@ namespace sistrip {
     rawdigi_( false ),
     digiToRaw_(0),
     eventCounter_(0),
-    rawDataTag_(pset.getUntrackedParameter<edm::InputTag>("RawDataTag",edm::InputTag("source","")))
+    rawDataTag_(pset.getUntrackedParameter<edm::InputTag>("RawDataTag",edm::InputTag("rawDataCollector","")))
   {
     if ( edm::isDebugEnabled() ) {
       LogDebug("DigiToRawModule") 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -7,6 +7,8 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
@@ -21,10 +23,12 @@ namespace sistrip {
   DigiToRawModule::DigiToRawModule( const edm::ParameterSet& pset ) :
     inputModuleLabel_( pset.getParameter<std::string>( "InputModuleLabel" ) ),
     inputDigiLabel_( pset.getParameter<std::string>( "InputDigiLabel" ) ),
+    copyBufferHeader_(pset.getUntrackedParameter<bool>("CopyBufferHeader",false)),
     mode_( fedReadoutModeFromString(pset.getParameter<std::string>( "FedReadoutMode" ))),
     rawdigi_( false ),
     digiToRaw_(0),
-    eventCounter_(0)
+    eventCounter_(0),
+    rawDataTag_(pset.getUntrackedParameter<edm::InputTag>("RawDataTag",edm::InputTag("source","")))
   {
     if ( edm::isDebugEnabled() ) {
       LogDebug("DigiToRawModule") 
@@ -77,7 +81,15 @@ namespace sistrip {
       tokenRawDigi = consumes< edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, inputDigiLabel_));
     } else {
       tokenDigi = consumes< edm::DetSetVector<SiStripDigi> >(edm::InputTag(inputModuleLabel_, inputDigiLabel_));
-
+    }
+    if (copyBufferHeader_){
+      //CAMM input raw module label or same as digi ????
+      if( edm::isDebugEnabled()) {
+	edm::LogWarning("DigiToRawModule") 
+	  << "[sistrip::DigiToRawModule::DigiToRawModule]"
+	  << "Copying buffer header from collection " << rawDataTag_;
+      }
+      tokenRawBuffer = consumes<FEDRawDataCollection>(rawDataTag_);
     }
 
     produces<FEDRawDataCollection>();
@@ -112,15 +124,37 @@ namespace sistrip {
     edm::ESHandle<SiStripFedCabling> cabling;
     iSetup.get<SiStripFedCablingRcd>().get( cabling );
 
+    //get buffer header from original rawdata
+    edm::Handle<FEDRawDataCollection> rawbuffers;
+    if (copyBufferHeader_){
+      if( edm::isDebugEnabled()) {
+	edm::LogWarning("DigiToRawModule") 
+	  << "[sistrip::DigiToRawModule::DigiToRawModule]"
+	  << "Getting raw buffer: ";
+      }
+      try {
+	iEvent.getByToken( tokenRawBuffer, rawbuffers );
+      } catch (const cms::Exception& e){
+	if( edm::isDebugEnabled()) {
+	  edm::LogWarning("DigiToRawModule") 
+	    << "[sistrip::DigiToRawModule::DigiToRawModule]"
+	    << " Failed to get collection " << rawDataTag_;
+	}
+      }
+    }
+
     if( rawdigi_ ) {
       edm::Handle< edm::DetSetVector<SiStripRawDigi> > rawdigis;
       iEvent.getByToken( tokenRawDigi, rawdigis );
       digiToRaw_->createFedBuffers( iEvent, cabling, rawdigis, buffers );
+      if (copyBufferHeader_) digiToRaw_->createFedBuffers( iEvent, cabling, rawbuffers, rawdigis, buffers );
     } else {
       edm::Handle< edm::DetSetVector<SiStripDigi> > digis;
       iEvent.getByToken( tokenDigi, digis );
       digiToRaw_->createFedBuffers( iEvent, cabling, digis, buffers );
+      if (copyBufferHeader_) digiToRaw_->createFedBuffers( iEvent, cabling, rawbuffers, digis, buffers );
     }
+
 
     iEvent.put( buffers );
   

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -11,9 +11,24 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include <cstdlib>
 
 namespace sistrip {
+	
+  //fill Descriptions needed to define default parameters	
+  void DigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("InputModuleLabel", "simSiStripDigis");
+    desc.add<std::string>("InputDigiLabel", "ZeroSuppressed");
+    desc.add<std::string>("FedReadoutMode", "ZERO_SUPPRESSED");
+    desc.add<bool>("UseFedKey", false);
+    desc.add<bool>("UseWrongDigiType", false);
+    desc.add<bool>("CopyBufferHeader", false);
+    desc.add<edm::InputTag>("RawDataTag", edm::InputTag("rawDataCollector"));
+    descriptions.add("SiStripDigiToRawModule",desc);
+  }
 
   // -----------------------------------------------------------------------------
   /** 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -10,6 +10,9 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "boost/cstdint.hpp"
 #include <string>
+namespace edm {
+  class ConfigurationDescriptions;
+}
 
 namespace sistrip {
 
@@ -33,6 +36,7 @@ namespace sistrip {
     virtual void endJob() {}
   
     virtual void produce( edm::Event&, const edm::EventSetup& );
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
   private:
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "boost/cstdint.hpp"
 #include <string>
 
@@ -37,12 +38,16 @@ namespace sistrip {
 
     std::string inputModuleLabel_;
     std::string inputDigiLabel_;
+    //CAMM can we do without this bool based on the mode ?
+    bool copyBufferHeader_;
     FEDReadoutMode mode_;
     bool rawdigi_;
     DigiToRaw* digiToRaw_;
     uint32_t eventCounter_;
     edm::EDGetTokenT< edm::DetSetVector<SiStripRawDigi> > tokenRawDigi;
     edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > tokenDigi;
+    edm::InputTag rawDataTag_;
+    edm::EDGetTokenT<FEDRawDataCollection> tokenRawBuffer;
 
   };
 

--- a/EventFilter/SiStripRawToDigi/python/SiStripDigiToRaw_cfi.py
+++ b/EventFilter/SiStripRawToDigi/python/SiStripDigiToRaw_cfi.py
@@ -6,6 +6,8 @@ SiStripDigiToRaw = cms.EDProducer(
     InputDigiLabel = cms.string('ZeroSuppressed'),
     FedReadoutMode = cms.string('ZERO_SUPPRESSED'),
     UseFedKey = cms.bool(False),
-    UseWrongDigiType = cms.bool(False)
+    UseWrongDigiType = cms.bool(False),
+    CopyBufferHeader = cms.bool(False),
+    RawDataTag = cms.InputTag('rawDataCollector')
     )
 

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1096,6 +1096,18 @@ namespace sistrip {
   {
     return;
   }
+  void FEDAPVErrorHeader::setDAQRegister(const uint32_t daqRegister)
+  {
+    return;
+  }
+  void FEDAPVErrorHeader::setDAQRegister2(const uint32_t daqRegister2)
+  {
+    return;
+  }
+  void FEDAPVErrorHeader::set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister)
+  {
+    return;
+  }
   void FEDAPVErrorHeader::setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length)
   {
     return;
@@ -1230,6 +1242,12 @@ namespace sistrip {
   void FEDFullDebugHeader::setDAQRegister2(const uint32_t daqRegister2)
   {
     set32BitWordAt(feWord(6)+10,daqRegister2);
+  }
+
+  //used by DigiToRaw to copy reserved registers in internalFEUnit buffers 1 through 5
+  void FEDFullDebugHeader::set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister)
+  {
+    set32BitWordAt(feWord(internalFEUnitNum)+10,reservedRegister);
   }
   
   void FEDFullDebugHeader::setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length)


### PR DESCRIPTION
This PR fixes the bug which caused empty histograms for SiStrip FED Errors in the DQM. This is prepared for the HIN data taking period after we saw the aforementioned issues. 
thanks! 
@abaty @icali 
