### PR TITLE
Fix ownership problem in TMVAEvaluator

### DIFF
--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -17,7 +17,6 @@ class TMVAEvaluator {
 
   public:
     TMVAEvaluator();
-    ~TMVAEvaluator();
 
     void initialize(const std::string & options, const std::string & method, const std::string & weightFile,
                     const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useGBRForest=false, bool useAdaBoost=false);
@@ -33,13 +32,12 @@ class TMVAEvaluator {
     bool mIsInitialized;
     bool mUsingGBRForest;
     bool mUseAdaBoost;
-    bool mReleaseAtEnd;
 
     std::string mMethod;
     mutable std::mutex m_mutex;
     [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVA::Reader> mReader;
     std::unique_ptr<TMVA::IMethod> mIMethod;
-    std::unique_ptr<const GBRForest> mGBRForest;
+    std::shared_ptr<const GBRForest> mGBRForest;
 
     [[cms::thread_guard("m_mutex")]] mutable std::map<std::string,std::pair<size_t,float>> mVariables;
     [[cms::thread_guard("m_mutex")]] mutable std::map<std::string,std::pair<size_t,float>> mSpectators;

--- a/CommonTools/Utils/src/TMVAEvaluator.cc
+++ b/CommonTools/Utils/src/TMVAEvaluator.cc
@@ -8,15 +8,8 @@
 
 
 TMVAEvaluator::TMVAEvaluator() :
-  mIsInitialized(false), mUsingGBRForest(false), mUseAdaBoost(false), mReleaseAtEnd(false)
+  mIsInitialized(false), mUsingGBRForest(false), mUseAdaBoost(false)
 {
-}
-
-
-TMVAEvaluator::~TMVAEvaluator()
-{
-  if (mReleaseAtEnd)
-    mGBRForest.release();
 }
 
 
@@ -72,12 +65,12 @@ void TMVAEvaluator::initializeGBRForest(const GBRForest* gbrForest, const std::v
   for(std::vector<std::string>::const_iterator it = spectators.begin(); it!=spectators.end(); ++it)
     mSpectators.insert( std::make_pair( *it, std::make_pair( it - spectators.begin(), 0. ) ) );
 
-  mGBRForest.reset( gbrForest );
+  // do not take ownership if getting GBRForest from an external source
+  mGBRForest = std::shared_ptr<const GBRForest>(gbrForest, [](const GBRForest*) {} );
 
   mIsInitialized = true;
   mUsingGBRForest = true;
   mUseAdaBoost = useAdaBoost;
-  mReleaseAtEnd = true; // need to release ownership at the end if getting GBRForest from an external source
 }
 
 


### PR DESCRIPTION
The TMVAEvaluator was meant to own the GBRForest if the TMVAEvaluator
made the instance itself else it was not supposed to own it if it
was given a GBRForest externally. However, for both cases the code
used an std::unique_ptr and attempted to call 'release' in the case
of non-ownership. The problem was multiple calls to initializeGBRForest
still caused the code to delete a GBRForest which was not supposed to be
owned. The code was changed to use an std::shared_ptr where we use a custom
deallocator in the case of non-ownership (the deallocator does nothing).
This problem was found in the IB RelVals.
