### PR TITLE
fix rare NaN in EcalUncalibratedRecHit

### DIFF
--- a/DataFormats/EcalRecHit/src/EcalUncalibratedRecHit.cc
+++ b/DataFormats/EcalRecHit/src/EcalUncalibratedRecHit.cc
@@ -44,7 +44,7 @@ void EcalUncalibratedRecHit::setJitterError( float jitterErr )
         // has range of 5 ps - 5000 ps
         // expect input in BX units
         // all bits off --> time reco bailed out
-        if(jitterErr < 0)
+        if(jitterErr <= 0)
         {
                 aux_ = (~0xFF & aux_);
                 return;


### PR DESCRIPTION
default value for jitterErr ==0, instead of passing to log(jitterErr) where it generates a NaN

attempts to fix issue reported in #11752 

tested in CMSSW_8_0_X_2015-11-30-1100 with the following
4.17,4.22,4.29,4.37,4.38,4.39,5.1,8.0,25.0,101.0,134.702,134.703,134.705,134.802,134.803,134.805,134.911,135.4,140.51,140.53,200.0,1000.0,1001.0,1102.0,1330.0,50202.0
the 134.[78]\* were done with 200 events.
No differences were observed ... although based on #11752  I could anticipate to have some. 
