### PR TITLE
initialize isYokeVol in SteppingHelix state constructor

### DIFF
--- a/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h
+++ b/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h
@@ -50,7 +50,7 @@ class SteppingHelixStateInfo {
   static const std::string ResultName[MAX_RESULT];
 
   SteppingHelixStateInfo(): 
-    path_(0), radPath_(0), dir(0), magVol(0), field(0), dEdx(0), dEdXPrime(0), radX0(1e12),
+    path_(0), radPath_(0), dir(0), magVol(0), isYokeVol(false), field(0), dEdx(0), dEdXPrime(0), radX0(1e12),
     isComplete(0), isValid_(0), hasErrorPropagated_(0), status_(UNDEFINED) {}
   SteppingHelixStateInfo(const FreeTrajectoryState& fts);
 

--- a/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixStateInfo.cc
+++ b/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixStateInfo.cc
@@ -31,7 +31,7 @@ const std::string SteppingHelixStateInfo::ResultName[MAX_RESULT] = {
 };
 
 SteppingHelixStateInfo::SteppingHelixStateInfo(const FreeTrajectoryState& fts): 
-  path_(0), radPath_(0), dir(0), magVol(0), field(0), dEdx(0), dEdXPrime(0), radX0(1e12),
+  path_(0), radPath_(0), dir(0), magVol(0), isYokeVol(false), field(0), dEdx(0), dEdXPrime(0), radX0(1e12),
   status_(UNDEFINED)
 {
   p3.set(fts.momentum().x(), fts.momentum().y(), fts.momentum().z());


### PR DESCRIPTION
fix issue reported in  #11763
separate runs of valgrind actually do not reveal a problem

tested in CMSSW_8_0_X_2015-11-30-1100
with 4.17,4.22,4.29,4.37,4.38,4.39,5.1,8.0,25.0,101.0,134.702,134.703,134.705,134.802,134.803,134.805,134.911,135.4,140.51,140.53,200.0,1000.0,1001.0,1102.0,1330.0,50202.0
(134.[78]\* with 200 events)
there are no differences in comparisons
