### PR TITLE
Making the boosted double SV tagger thread-safe

### DIFF
--- a/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
@@ -15,7 +15,6 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 #include "fastjet/PseudoJet.hh"
-#include "fastjet/contrib/Njettiness.hh"
 
 class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
 
@@ -34,8 +33,6 @@ class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
 
     const double beta_;
     const double R0_;
-    // N-subjettiness calculator
-    fastjet::contrib::Njettiness njettiness_;
 
     const double maxSVDeltaRToJet_;
     const bool useCondDB_;

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -14,11 +14,11 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
+#include "fastjet/contrib/Njettiness.hh"
 
 CandidateBoostedDoubleSecondaryVertexComputer::CandidateBoostedDoubleSecondaryVertexComputer(const edm::ParameterSet & parameters) :
   beta_(parameters.getParameter<double>("beta")),
   R0_(parameters.getParameter<double>("R0")),
-  njettiness_(fastjet::contrib::OnePass_KT_Axes(), fastjet::contrib::NormalizedMeasure(beta_,R0_)),
   maxSVDeltaRToJet_(parameters.getParameter<double>("maxSVDeltaRToJet")),
   useCondDB_(parameters.getParameter<bool>("useCondDB")),
   gbrForestLabel_(parameters.existsAs<std::string>("gbrForestLabel") ? parameters.getParameter<std::string>("gbrForestLabel") : ""),
@@ -583,10 +583,13 @@ void CandidateBoostedDoubleSecondaryVertexComputer::calcNsubjettiness(const reco
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
   }
 
+  // N-subjettiness calculator
+  fastjet::contrib::Njettiness njettiness(fastjet::contrib::OnePass_KT_Axes(), fastjet::contrib::NormalizedMeasure(beta_,R0_));
+
   // calculate N-subjettiness
-  tau1 = njettiness_.getTau(1, fjParticles);
-  tau2 = njettiness_.getTau(2, fjParticles);
-  currentAxes = njettiness_.currentAxes();
+  tau1 = njettiness.getTau(1, fjParticles);
+  tau2 = njettiness.getTau(2, fjParticles);
+  currentAxes = njettiness.currentAxes();
 }
 
 


### PR DESCRIPTION
`fastjet::contrib::Njettiness` is not thread-safe and therefore should not be used as a data member of an ESProducer. This PR addresses the problem by defining a local instance of `fastjet::contrib::Njettiness` instead of using a global instance defined as a data member of the `CandidateBoostedDoubleSecondaryVertexComputer` class.

This PR is **urgent** since it fixes CMSSW crashes occurring in the multi-threaded jobs.
