### PR TITLE
Move tracking validation sequences to prevalidation

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -25,13 +25,15 @@ from DQMOffline.Trigger.HLTMonTau_cfi import *
  
 # additional producer sequence prior to hltvalidation
 # to evacuate producers/filters from the EndPath
-hltassociation = cms.Sequence( egammaSelectors
-                               +ExoticaValidationProdSeq )
-
-hltvalidation = cms.Sequence(
+hltassociation = cms.Sequence(
     hltMultiTrackValidation
     +hltMultiPVValidation
-    +HLTMuonVal
+    +egammaSelectors
+    +ExoticaValidationProdSeq
+    )
+
+hltvalidation = cms.Sequence(
+    HLTMuonVal
     +HLTTauVal
     +egammaValidationSequence
     +topHLTriggerOfflineDQM
@@ -57,8 +59,8 @@ if eras.phase1Pixel.isChosen():
 # probably it would be rather easy to add or fake these collections
 from Configuration.StandardSequences.Eras import eras
 if eras.fastSim.isChosen():
-    hltvalidation.remove(hltMultiTrackValidation)
-    hltvalidation.remove(hltMultiPVValidation)
+    hltassociation.remove(hltMultiTrackValidation)
+    hltassociation.remove(hltMultiPVValidation)
 
 hltvalidation_preprod = cms.Sequence(
   HLTTauVal

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -42,7 +42,8 @@ from DQMOffline.RecoB.dqmAnalyzer_cff import *
 # filter/producer "pre-" sequence for globalValidation
 globalPrevalidation = cms.Sequence( 
     simHitTPAssocProducer
-  * tracksPreValidation
+  * tracksValidation
+  * vertexValidation
   * photonPrevalidationSequence
   * produceDenoms
   * prebTagSequenceMC
@@ -58,7 +59,6 @@ globalValidation = cms.Sequence(   trackerHitsValidation
                                  + trackerRecHitsValidation 
                                  + trackingTruthValid 
                                  + trackingRecHitsValid 
-                                 + tracksValidation 
                                  + ecalSimHitsValidationSequence 
                                  + ecalDigisValidationSequence 
                                  + ecalRecHitsValidationSequence 
@@ -77,7 +77,6 @@ globalValidation = cms.Sequence(   trackerHitsValidation
                                  + mixCollectionValidation 
                                  + JetValidation 
                                  + METValidation
-                                 + vertexValidation
                                  + egammaValidation
                                  + pfJetValidationSequence
                                  + pfMETValidationSequence
@@ -127,9 +126,7 @@ globalPrevalidationLiteTracking.remove(cutsRecoTracksMuonSeededStepOutInHp)
 # Tracking-only validation
 globalPrevalidationTrackingOnly = cms.Sequence(
       simHitTPAssocProducer
-    + tracksPreValidationTrackingOnly
-)
-globalValidationTrackingOnly = cms.Sequence(
-      tracksValidationTrackingOnly
+    + tracksValidationTrackingOnly
     + vertexValidation
 )
+globalValidationTrackingOnly = cms.Sequence()

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -250,8 +250,8 @@ tracksPreValidation = cms.Sequence(
     tracksValidationTruthSignal
 )
 
-# selectors go into separate "prevalidation" sequence
 tracksValidation = cms.Sequence(
+    tracksPreValidation +
     trackValidator +
     trackValidatorFromPV +
     trackValidatorFromPVAllTP +
@@ -288,11 +288,6 @@ tracksValidationSelectorsStandalone = cms.Sequence(
     tracksValidationSelectorsByAlgoMaskStandalone +
     tracksValidationSelectorsFromPVStandalone
 )
-tracksPreValidationStandalone = cms.Sequence(
-    ak4PFL1FastL2L3CorrectorChain+
-    tracksPreValidation +
-    tracksValidationSelectorsStandalone
-)
 trackValidatorsStandalone = cms.Sequence(
     trackValidatorStandalone +
     trackValidatorFromPVStandalone +
@@ -300,8 +295,10 @@ trackValidatorsStandalone = cms.Sequence(
     trackValidatorAllTPEfficStandalone
 )
 tracksValidationStandalone = cms.Sequence(
-    tracksPreValidationStandalone+
-    trackValidatorsStandalone
+    ak4PFL1FastL2L3CorrectorChain +
+    tracksPreValidation +
+    tracksValidationSelectorsStandalone +
+    trackValidatorStandalone
 )
 
 ### TrackingOnly mode (i.e. MTV with DIGI input + tracking-only reconstruction
@@ -316,12 +313,13 @@ trackValidatorTrackingOnly.label.remove("cutsRecoTracksAK4PFJets")
 # sequences
 tracksPreValidationTrackingOnly = tracksPreValidation.copy()
 tracksPreValidationTrackingOnly.replace(tracksValidationSelectors, tracksValidationSelectorsTrackingOnly)
-tracksPreValidationTrackingOnly += tracksValidationSelectorsStandalone
 
 trackValidatorsTrackingOnly = trackValidatorsStandalone.copy()
 trackValidatorsTrackingOnly.replace(trackValidatorStandalone, trackValidatorTrackingOnly)
 
 tracksValidationTrackingOnly = cms.Sequence(
+    tracksPreValidationTrackingOnly +
+    tracksValidationSelectorsStandalone +
     trackValidatorsTrackingOnly
 )
 


### PR DESCRIPTION
This PR is a follow-up to @deguio's comment https://github.com/cms-sw/cmssw/pull/12542#issuecomment-160626639. Nothing in track+vertex validation depends on TriggerResults, so all modules are moved to the prevalidation sequence (to be run in a regular Path instead of EndPath).

Tested in CMSSW_8_0_X_2015-12-06-1100, no changes expected.

@rovere @VinInn 
