### PR TITLE
Use configured name for TransientTrackingRecHitBuilder instead of hard-coded one in MuonTrackLoader

### DIFF
--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -546,14 +546,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     theService->eventSetup().get<TrajectoryFitter::Record>().get(theSmootherName,aSmoother);
     theSmoother.reset(aSmoother->clone());
     edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
-    try {
-      std::string theTrackerRecHitBuilderName("WithAngleAndTemplate");  // to be moved to cfg in another PR
-      theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
-      theTrackerRecHitBuilder.product();
-    } catch(...) {
-      std::string theTrackerRecHitBuilderName("hltESPTTRHBWithTrackAngle");  // FIXME FIXME
-      theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
-    }
+    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
     hitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product())->cloner();
     theSmoother->setHitCloner(&hitCloner);
   }


### PR DESCRIPTION
The title says it all. The configured name is already used elsewhere in the class.

Tested in 8_0_0_pre2, no changes expected.

@rovere @VinInn 
