### PR TITLE
bsunanda:Run2-hcx57 Utilize a test numbering scheme for HGCal in SIM step (as in #12572)

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalDetId.h
@@ -10,14 +10,14 @@ class HGCalDetId : public DetId {
 
 public:
   static const int kHGCalCellOffset      = 0;
-  static const int kHGCalCellMask        = 0xFFFF;
-  static const int kHGCalSectorOffset    = 16;
-  static const int kHGCalSectorMask      = 0x7F;
-  static const int kHGCalSubSectorOffset = 23;
-  static const int kHGCalSubSectorMask   = 0x1;
-  static const int kHGCalLayerOffset     = 24;
-  static const int kHGCalLayerMask       = 0x7F;
-  static const int kHGCalZsideOffset     = 31;
+  static const int kHGCalCellMask        = 0xFF;
+  static const int kHGCalWaferOffset     = 8;
+  static const int kHGCalWaferMask       = 0x3FF;
+  static const int kHGCalWaferTypeOffset = 18;
+  static const int kHGCalWaferTypeMask   = 0x1;
+  static const int kHGCalLayerOffset     = 19;
+  static const int kHGCalLayerMask       = 0x1F;
+  static const int kHGCalZsideOffset     = 24;
   static const int kHGCalZsideMask       = 0x1;
 
   /** Create a null cellid*/
@@ -25,7 +25,7 @@ public:
   /** Create cellid from raw id (0=invalid tower id) */
   HGCalDetId(uint32_t rawid);
   /** Constructor from subdetector, zplus, layer, module, cell numbers */
-  HGCalDetId(ForwardSubdetector subdet, int zp, int lay, int mod, int subsec, int cell);
+  HGCalDetId(ForwardSubdetector subdet, int zp, int lay, int wafertype, int wafer, int cell);
   /** Constructor from a generic cell id */
   HGCalDetId(const DetId& id);
   /** Assignment from a generic cell id */
@@ -34,11 +34,11 @@ public:
   /// get the absolute value of the cell #'s in x and y
   int cell() const { return id_&kHGCalCellMask; }
 
-  /// get the sector #
-  int sector() const { return (id_>>kHGCalSectorOffset)&kHGCalSectorMask; }
+  /// get the wafer #
+  int wafer() const { return (id_>>kHGCalWaferOffset)&kHGCalWaferMask; }
 
-  /// get the degree subsector
-  int subsector() const { return ( (id_>>kHGCalSubSectorOffset)&kHGCalSubSectorMask ? 1 : -1); }
+  /// get the wafer type
+  int waferType() const { return (id_>>kHGCalWaferTypeOffset)&kHGCalWaferTypeMask; }
 
   /// get the layer #
   int layer() const { return (id_>>kHGCalLayerOffset)&kHGCalLayerMask; }
@@ -50,8 +50,9 @@ public:
   bool isHGCal()   const { return true; }
   bool isForward() const { return true; }
   static bool isValid(ForwardSubdetector subdet, int zp, int lay, 
-		      int mod, int subsec, int cell);
+		      int wafertype, int wafer, int cell);
 
+  static const HGCalDetId Undefined;
 };
 
 std::ostream& operator<<(std::ostream&,const HGCalDetId& id);

--- a/SimCalorimetry/HGCalSimProducers/BuildFile.xml
+++ b/SimCalorimetry/HGCalSimProducers/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="SimGeneral/MixingModule"/>
 <use   name="DataFormats/ForwardDetId"/>
+<use   name="SimDataFormats/CaloTest"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/HGCalGeometry"/>
 <use   name="hepmc"/>

--- a/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
+++ b/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
@@ -1,0 +1,52 @@
+#ifndef SimDataFormats_HGCalTestNumbering_h
+#define SimDataFormats_HGCalTestNumbering_h
+///////////////////////////////////////////////////////////////////////////////
+// File: HGCalTestNumbering.h
+// Description: Numbering scheme for high granularity calorimeter (SIM step)
+///////////////////////////////////////////////////////////////////////////////
+
+#include <boost/cstdint.hpp>
+
+class HGCalTestNumbering {
+
+public:
+  static const int kHGCalCellSOffset      = 0;
+  static const int kHGCalCellSMask        = 0xFFFF;
+  static const int kHGCalSectorSOffset    = 16;
+  static const int kHGCalSectorSMask      = 0x7F;
+  static const int kHGCalSubSectorSOffset = 23;
+  static const int kHGCalSubSectorSMask   = 0x1;
+  static const int kHGCalLayerSOffset     = 24;
+  static const int kHGCalLayerSMask       = 0x7F;
+  static const int kHGCalZsideSOffset     = 31;
+  static const int kHGCalZsideSMask       = 0x1;
+
+  static const int kHGCalCellHOffset      = 0;
+  static const int kHGCalCellHMask        = 0xFF;
+  static const int kHGCalCellTypHOffset   = 8;
+  static const int kHGCalCellTypHMask     = 0x1;
+  static const int kHGCalWaferHOffset     = 9;
+  static const int kHGCalWaferHMask       = 0x1FF;
+  static const int kHGCalLayerHOffset     = 18;
+  static const int kHGCalLayerHMask       = 0x7F;
+  static const int kHGCalZsideHOffset     = 25;
+  static const int kHGCalZsideHMask       = 0x1;
+  static const int kHGCalSubdetHOffset    = 30;
+  static const int kHGCalSubdetHMask      = 0x7;
+  HGCalTestNumbering() {}
+  virtual ~HGCalTestNumbering() {}
+  static uint32_t  packSquareIndex(int z, int lay, int sec, int subsec,
+				   int cell);
+  static uint32_t  packHexagonIndex(int subdet, int z, int lay, int wafer, 
+				    int celltyp, int cell);
+  static void      unpackSquareIndex(const uint32_t& idx, int& z, int& lay, 
+				     int& sec, int& subsec, int& cell);
+  static void      unpackHexagonIndex(const uint32_t& idx, int& subdet, int& z,
+				      int& lay, int& wafer, int& celltyp, 
+				      int& cell);
+  static bool      isValidSquare(int z, int lay, int sec, int subsec, int cell);
+  static bool      isValidHexagon(int subdet, int z, int lay, int wafer, 
+				  int celltyp, int cell);
+};
+
+#endif

--- a/SimDataFormats/CaloTest/src/HGCalTestNumbering.cc
+++ b/SimDataFormats/CaloTest/src/HGCalTestNumbering.cc
@@ -1,0 +1,124 @@
+#include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
+#include <iostream>
+
+//#define DebugLog
+
+uint32_t HGCalTestNumbering::packSquareIndex(int zp, int lay, int sec, 
+					     int subsec, int cell) {
+
+  if (cell > kHGCalCellSMask || sec>kHGCalSectorSMask || 
+      subsec > kHGCalSubSectorSMask || lay>kHGCalLayerSMask ) {
+#ifdef DebugLog
+    std::cout << "[HGCalTestNumbering] request for new id for layer=" << lay
+              << " zp=" << zp 
+              << " sector=" << sec 
+              << " subsec=" << subsec 
+              << " cell=" << cell 
+              << " has one or more fields out of bounds and will be reset" 
+              << std::endl;
+#endif
+    zp = lay = sec = subsec = cell = 0;
+  }
+
+  uint32_t rawid=0;
+  rawid |= ((cell   & kHGCalCellSMask)        << kHGCalCellSOffset);
+  rawid |= ((sec    & kHGCalSectorSMask)      << kHGCalSectorSOffset);
+  if (subsec<0) subsec=0;
+  rawid |= ((subsec & kHGCalSubSectorSMask)   << kHGCalSubSectorSOffset);
+  rawid |= ((lay    & kHGCalLayerSMask)       << kHGCalLayerSOffset);
+  if (zp>0) rawid |= ((zp & kHGCalZsideSMask) << kHGCalZsideSOffset);
+  return rawid;
+}
+
+uint32_t HGCalTestNumbering::packHexagonIndex(int subdet, int zp, int lay, 
+					      int wafer,  int celltyp, 
+					      int cell) {
+
+  if (cell > kHGCalCellHMask || celltyp>kHGCalCellTypHMask || 
+      wafer > kHGCalWaferHMask || lay>kHGCalLayerSMask || 
+      subdet > kHGCalSubdetHMask) {
+#ifdef DebugLog
+    std::cout << "[HGCalTestNumbering] request for new id for layer=" << lay
+              << " zp=" << zp 
+              << " wafer=" << wafer
+              << " celltyp=" << celltyp 
+              << " cell=" << cell 
+              << " for subdet=" << subdet 
+              << " has one or more fields out of bounds and will be reset" 
+              << std::endl;
+#endif
+    subdet = zp = lay = wafer = celltyp = cell = 0;
+  }
+
+  uint32_t rawid=0;
+  rawid |= ((cell   & kHGCalCellHMask)        << kHGCalCellHOffset);
+  rawid |= ((celltyp& kHGCalCellTypHMask)     << kHGCalCellTypHOffset);
+  rawid |= ((wafer  & kHGCalWaferHMask)       << kHGCalWaferHOffset);
+  rawid |= ((lay    & kHGCalLayerHMask)       << kHGCalLayerHOffset);
+  if (zp>0) rawid |= ((zp & kHGCalZsideHMask) << kHGCalZsideHOffset);
+  rawid |= ((subdet & kHGCalSubdetHMask)      << kHGCalSubdetHOffset);
+  return rawid;
+}
+
+void HGCalTestNumbering::unpackSquareIndex(const uint32_t& idx, int& zp,
+					   int& lay, int& sec, int& subsec,
+					   int& cell) {
+
+  cell   = (idx>>kHGCalCellSOffset)&kHGCalCellSMask;
+  subsec = ((idx>>kHGCalSubSectorSOffset)&kHGCalSubSectorSMask ? 1 : -1);
+  sec    = (idx>>kHGCalSectorSOffset)&kHGCalSectorSMask;
+  lay    = (idx>>kHGCalLayerSOffset)&kHGCalLayerSMask;
+  zp     = ((idx>>kHGCalZsideSOffset) & kHGCalZsideSMask ? 1 : -1); 
+}
+
+
+void HGCalTestNumbering::unpackHexagonIndex(const uint32_t& idx, int& subdet,
+					    int& zp, int& lay, int& wafer,
+					    int& celltyp, int& cell) {
+  cell   = (idx>>kHGCalCellHOffset)&kHGCalCellHMask;
+  celltyp= (idx>>kHGCalCellTypHOffset)&kHGCalCellTypHMask;
+  wafer  = (idx>>kHGCalWaferHOffset)&kHGCalWaferHMask;
+  lay    = (idx>>kHGCalLayerHOffset)&kHGCalLayerHMask;
+  zp     = ((idx>>kHGCalZsideHOffset) & kHGCalZsideHMask ? 1 : -1); 
+  subdet = (idx>>kHGCalSubdetHOffset)&kHGCalSubdetHMask;
+}
+
+bool HGCalTestNumbering::isValidSquare(int zp, int lay, int sec, int subsec,
+				       int cell) {
+
+  if (cell > kHGCalCellSMask || sec>kHGCalSectorSMask || 
+      subsec > kHGCalSubSectorSMask || lay>kHGCalLayerSMask ) {
+#ifdef DebugLog
+    std::cout << "[HGCalTestNumbering] request for new id for layer=" << lay
+              << " zp=" << zp 
+              << " sector=" << sec 
+              << " subsec=" << subsec 
+              << " cell=" << cell 
+              << " has one or more fields out of bounds and will be reset" 
+              << std::endl;
+#endif
+    return false;
+  }
+  return true;
+}
+
+bool HGCalTestNumbering::isValidHexagon(int subdet, int zp, int lay, int wafer,
+					int celltyp, int cell) {
+
+  if (cell > kHGCalCellHMask || celltyp>kHGCalCellTypHMask || 
+      wafer > kHGCalWaferHMask || lay>kHGCalLayerSMask || 
+      subdet > kHGCalSubdetHMask) {
+#ifdef DebugLog
+    std::cout << "[HGCalTestNumbering] request for new id for layer=" << lay
+              << " zp=" << zp 
+              << " wafer=" << wafer
+              << " celltyp=" << celltyp 
+              << " cell=" << cell 
+              << " for subdet=" << subdet 
+              << " has one or more fields out of bounds and will be reset" 
+              << std::endl;
+#endif
+    return false;
+  }
+  return true;
+}

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -3,11 +3,13 @@
 // Description: Numbering scheme for High Granularity Calorimeter
 ///////////////////////////////////////////////////////////////////////////////
 #include "SimG4CMS/Calo/interface/HGCNumberingScheme.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
 #include "DataFormats/Math/interface/FastMath.h"
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include <iostream>
+
+//#define DebugLog
 
 HGCNumberingScheme::HGCNumberingScheme(const DDCompactView & cpv, 
 				       std::string & name, bool check,
@@ -29,10 +31,10 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer, int
   int icell     = phicell.second;
   
   //build the index
-  uint32_t index = HGCalDetId(subdet,iz,layer,sector,phiSector,icell).rawId();
+  uint32_t index = HGCalTestNumbering::packSquareIndex(iz,layer,sector,phiSector,icell);
   
   //check if it fits
-  if ((!HGCalDetId::isValid(subdet,iz,layer,sector,phiSector,icell)) ||
+  if ((!HGCalTestNumbering::isValidSquare(iz,layer,sector,phiSector,icell)) ||
       (!hgcons->isValid(layer,sector,icell,false))) {
     index = 0;
     if (check_ && icell != -1) {
@@ -44,11 +46,13 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer, int
 			      << "," << pos.y() << "," << pos.z() << ")";
     }
   }    
+#ifdef DebugLog
   if (verbosity > 0)
     std::cout << "HGCNumberingScheme::i/p " << subdet << ":" << layer << ":" 
 	      << sector << ":" << iz << ":" << pos << " o/p " << phiSector 
-	      << ":" << icell << ":" << std::hex << index << std::dec << " " 
-	      << HGCalDetId(index) << std::endl;
+	      << ":" << icell << ":" << std::hex << index << std::dec 
+	      << std::endl;
+#endif
   return index;
 }
 


### PR DESCRIPTION
To avoid the garbage history information which got collected for bsunanda:Run2-hcx53. 
This is the first step for SIM for hexgonal cell for HGCal 
