### PR TITLE
Fix a small bug in tracking validation scripts

### DIFF
--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -311,7 +311,7 @@ class TrackingPageSet(PageSet):
         #
         # it is bit of a hack to access trackingPlots.TrackingPlotFolder this way,
         # but it was simple and it works
-        if not plotterFolder._plotFolder.isAlgoIterative(algo):
+        if algo != "ootb" and not plotterFolder._plotFolder.isAlgoIterative(algo):
             pageName = "ootb"
             sectionName = algo
 


### PR DESCRIPTION
This PR fixes a small bug that slipped in in #12666 (the generated "Out of the box" page gets screwed up).

Tested in CMSSW_8_0_X_2015-12-07-1100. Should have no effect on standard workflows.

@rovere @VinInn 
