### PR TITLE
Further improve error recovery in DQMStreamerReader

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -288,33 +288,29 @@ EventMsgView const* DQMStreamerReader::prepareNextEvent() {
  * This is the actual code for checking the new event and/or deserializing it.
  */
 bool DQMStreamerReader::checkNextEvent() {
-  EventMsgView const* eview = prepareNextEvent();
-  if (eview == nullptr) {
-    return false;
-  }
+  try {
+    EventMsgView const* eview = prepareNextEvent();
+    if (eview == nullptr) {
+      return false;
+    }
 
-  // this is reachable only if eview is set
-  // and the file is openned
-  if (file_.streamFile_->newHeader()) {
-    // A new file has been opened and we must compare Headers here !!
-    // Get header/init from reader
+    // this is reachable only if eview is set
+    // and the file is openned
+    if (file_.streamFile_->newHeader()) {
+      // A new file has been opened and we must compare Headers here !!
+      // Get header/init from reader
 
-    try {
       InitMsgView const* header = getHeaderMsg();
       deserializeAndMergeWithRegistry(*header, true);
-    } catch (const cms::Exception& e) {
-      fiterator_.logFileAction(std::string("Can't deserialize registry data: ") + e.what());
-      closeFile_("data file corrupted");
-      return checkNextEvent();
     }
-  }
 
-  // try to recover from corrupted files/events
-  try {
     deserializeEvent(*eview);
   } catch (const cms::Exception& e) {
-    fiterator_.logFileAction(std::string("Can't deserialize event data: ") + e.what());
-    closeFile_("error");
+    // try to recover from corrupted files/events
+    fiterator_.logFileAction(std::string("Can't deserialize event or registry data: ") + e.what());
+    closeFile_("data file corrupted");
+
+    // this is not optimal, but hopefully we won't catch this many times in a row
     return checkNextEvent();
   }
 
@@ -381,12 +377,18 @@ bool DQMStreamerReader::acceptEvent(const EventMsgView* evtmsg) {
 }
 
 void DQMStreamerReader::skip(int toSkip) {
-  for (int i = 0; i != toSkip; ++i) {
-    EventMsgView const* evMsg = prepareNextEvent();
+  try {
+    for (int i = 0; i != toSkip; ++i) {
+      EventMsgView const* evMsg = prepareNextEvent();
 
-    if (evMsg == nullptr) {
-      return;
+      if (evMsg == nullptr) {
+        return;
+      }
     }
+  } catch (const cms::Exception& e) {
+    // try to recover from corrupted files/events
+    fiterator_.logFileAction(std::string("Can't deserialize event data: ") + e.what());
+    closeFile_("data file corrupted");
   }
 }
 


### PR DESCRIPTION
Now catches corrupt event messages, previously only corrupt headers were
handled.
