### PR TITLE
Factorization of Track Iteration selections in PF

### DIFF
--- a/RecoParticleFlow/Benchmark/BuildFile.xml
+++ b/RecoParticleFlow/Benchmark/BuildFile.xml
@@ -8,6 +8,8 @@
 <use   name="DataFormats/Math"/>
 <use   name="FWCore/Utilities"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="RecoParticleFlow/PFTracking"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
@@ -1,4 +1,6 @@
 #include "RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
+
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -129,7 +131,6 @@ void PFJetBenchmark::setup(
   BOOK2D(NCH4vsEta,"N_{Charged} vs #eta, iter 4",200, -5., 5., 200,0.,200.);
   BOOK2D(NCH5vsEta,"N_{Charged} vs #eta, iter 5",200, -5., 5., 200,0.,200.);
   BOOK2D(NCH6vsEta,"N_{Charged} vs #eta, iter 6",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH7vsEta,"N_{Charged} vs #eta, iter 7",200, -5., 5., 200,0.,200.);
   // delta Pt or E quantities for Barrel
   DBOOK1D(RPt,#DeltaP_{T}/P_{T},80,-1,1);
   DBOOK1D(RCHE,#DeltaE/E (charged had),80,-2,2);
@@ -150,7 +151,7 @@ void PFJetBenchmark::setup(
   DBOOK2D(NCH4vsPt, N_{charged} vs P_{T} iter 4,250,0,500,200,0.,200.);
   DBOOK2D(NCH5vsPt, N_{charged} vs P_{T} iter 5,250,0,500,200,0.,200.);
   DBOOK2D(NCH6vsPt, N_{charged} vs P_{T} iter 6,250,0,500,200,0.,200.);
-  DBOOK2D(NCH7vsPt, N_{charged} vs P_{T} iter 7,250,0,500,200,0.,200.);
+
   
 
   DBOOK2D(RNEUTvsP,#DeltaE/E (ECAL+HCAL) vs P,250, 0, 1000, 150,-1.5,1.5);
@@ -313,42 +314,7 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
 	  //	    << " has no track ref.." << std::endl;
 	  continue;
 	}
-	unsigned int iter = 0; 
-	switch (trackRef->algo()) {
-	case TrackBase::ctf:
-        case TrackBase::duplicateMerge:
-	case TrackBase::initialStep:
-	  iter = 0;
-	  break;
-	case TrackBase::lowPtTripletStep:
-	  iter = 1;
-	  break;
-	case TrackBase::pixelPairStep:
-	  iter = 2;
-	  break;
-	case TrackBase::detachedTripletStep:
-	  iter = 3;
-	  break;
-	case TrackBase::mixedTripletStep:
-	  iter = 4;
-	  break;
-	case TrackBase::pixelLessStep:
-	  iter = 5;
-	  break;
-	case TrackBase::tobTecStep:
-	  iter = 6;
-	  break;
-	case TrackBase::conversionStep:
-	  iter = 7;
-	  //std::cout << "Warning in entry " << entry_ << " : iter = " << trackRef->algo() << std::endl;
-	  //std::cout << ic << " " << *(constituents[ic]) << std::endl;
-	  break;
-	default:
-	  iter = 8;
-	  std::cout << "Warning in entry " << entry_ << " : iter = " << trackRef->algo() << std::endl;
-	  std::cout << ic << " " << *(constituents[ic]) << std::endl;
-	  break;
-	}
+	unsigned int iter = PFTrackAlgoTools::getAlgoCategory(trackRef->algo()); 
 	++(chMult[iter]);
       }
 

--- a/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
@@ -314,7 +314,7 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
 	  //	    << " has no track ref.." << std::endl;
 	  continue;
 	}
-	unsigned int iter = PFTrackAlgoTools::getAlgoCategory(trackRef->algo()); 
+	unsigned int iter = trackRef->algo()>6 ? 6: trackRef->algo();
 	++(chMult[iter]);
       }
 

--- a/RecoParticleFlow/Configuration/test/BuildFile.xml
+++ b/RecoParticleFlow/Configuration/test/BuildFile.xml
@@ -10,6 +10,7 @@
 <library   name="PFChargedHadronAnalyzer" file="PFChargedHadronAnalyzer.cc">
   <use   name="DataFormats/ParticleFlowCandidate"/>
   <use   name="DataFormats/ParticleFlowReco"/>
+  <use   name="RecoParticleFlow/PFTracking"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/MessageLogger"/>
   <use   name="FWCore/ParameterSet"/>

--- a/RecoParticleFlow/Configuration/test/PFChargedHadronAnalyzer.cc
+++ b/RecoParticleFlow/Configuration/test/PFChargedHadronAnalyzer.cc
@@ -1,4 +1,5 @@
 #include "RecoParticleFlow/Configuration/test/PFChargedHadronAnalyzer.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
@@ -229,26 +230,14 @@ PFChargedHadronAnalyzer::analyze(const Event& iEvent,
     unsigned int pxbN = 0;
     unsigned int pxdN = 0;
     const reco::HitPattern& hp = et.trackRef()->hitPattern();
-    switch ( et.trackRef()->algo() ) {
-    case TrackBase::initialStep:
-    case TrackBase::lowPtTripletStep:
-    case TrackBase::pixelPairStep:
-    case TrackBase::detachedTripletStep:
+
+    if (PFTrackAlgoTools::highQuality(et.trackRef()->algo())) {
       tobN += hp.numberOfValidStripTOBHits();
       tecN += hp.numberOfValidStripTECHits();
       tibN += hp.numberOfValidStripTIBHits();
       tidN += hp.numberOfValidStripTIDHits();
       pxbN += hp.numberOfValidPixelBarrelHits(); 
       pxdN += hp.numberOfValidPixelEndcapHits(); 
-      break;
-    case TrackBase::mixedTripletStep:
-    case TrackBase::pixelLessStep:
-    case TrackBase::tobTecStep:
-    case TrackBase::jetCoreRegionalStep:
-    case TrackBase::muonSeededStepInOut:
-    case TrackBase::muonSeededStepOutIn:
-    default:
-      break;
     }
     int inner = pxbN+pxdN;
     int outer = tibN+tobN+tidN+tecN;

--- a/RecoParticleFlow/PFProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFProducer/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="DataFormats/MuonReco"/>
 <use   name="DataFormats/EcalDetId"/>
 <use   name="RecoParticleFlow/PFClusterTools"/>
+<use   name="RecoParticleFlow/PFTracking"/>
 <use   name="RecoEcal/EgammaCoreTools"/>
 <use   name="RecoEgamma/ElectronIdentification"/>
 <use   name="boost"/>

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -284,7 +284,7 @@ private:
   // ------ end of new stuff 
   
   
-  unsigned int whichTrackAlgo(const reco::TrackRef& trackRef);
+
 
   bool isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
 		      const reco::PFBlockElementGsfTrack& GsfEl);  

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -54,7 +54,7 @@ class PFEGammaFilters {
 
  private:
 
-  unsigned int whichTrackAlgo(const reco::TrackRef& trackRef);
+
 
   // Photon selections
   float ph_Et_;

--- a/RecoParticleFlow/PFProducer/interface/PFElectronAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFElectronAlgo.h
@@ -104,7 +104,7 @@ class PFElectronAlgo {
 		 AssMap& associatedToEcal_,
 		 std::vector<bool>& active);
   
-  unsigned int whichTrackAlgo(const reco::TrackRef& trackRef);
+
 
   bool isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
 		      const reco::PFBlockElementGsfTrack& GsfEl);

--- a/RecoParticleFlow/PFProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFProducer/plugins/BuildFile.xml
@@ -39,6 +39,7 @@
   <use   name="FWCore/Utilities"/>
   <use   name="RecoParticleFlow/PFClusterTools"/>
   <use   name="RecoParticleFlow/PFProducer"/>
+  <use   name="RecoParticleFlow/PFTracking"/>
   <use   name="RecoEcal/EgammaCoreTools"/>
   <use   name="Geometry/CaloTopology"/>
   <use   name="RecoEgamma/EgammaIsolationAlgos"/>
@@ -87,6 +88,7 @@
   <use   name="FWCore/Utilities"/>
   <use   name="RecoParticleFlow/PFClusterTools"/>
   <use   name="RecoParticleFlow/PFProducer"/>
+  <use   name="RecoParticleFlow/PFTracking"/>
   <use   name="RecoEcal/EgammaCoreTools"/>
   <use   name="Geometry/CaloTopology"/>
   <use   name="RecoEgamma/EgammaIsolationAlgos"/>

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -6,6 +6,7 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
 class GeneralTracksImporter : public BlockElementImporterBase {
 public:
@@ -158,54 +159,10 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   const double sigmaHad = sqrt(1.20*1.20/P+0.06*0.06) / (1.+LostHits);
 
   // iteration 1,2,3,4,5 correspond to algo = 1/4,5,6,7,8,9
-  unsigned int Algo = 0; 
-  switch (trackref->algo()) {
-  case reco::TrackBase::ctf:
-  case reco::TrackBase::duplicateMerge:
-  case reco::TrackBase::initialStep:
-  case reco::TrackBase::lowPtTripletStep:
-  case reco::TrackBase::pixelPairStep:
-  case reco::TrackBase::jetCoreRegionalStep:
-    Algo = 0;
-    break;
-  case reco::TrackBase::detachedTripletStep:
-    Algo = 1;
-    break;
-  case reco::TrackBase::mixedTripletStep:
-    Algo = 2;
-    break;
-  case reco::TrackBase::pixelLessStep:
-    Algo = 3;
-    break;
-  case reco::TrackBase::tobTecStep:
-    Algo = 4;
-    break;
-  case reco::TrackBase::muonSeededStepInOut:
-  case reco::TrackBase::muonSeededStepOutIn:
-    Algo = 5;
-    break;
-  case reco::TrackBase::hltIter0:
-  case reco::TrackBase::hltIter1:
-  case reco::TrackBase::hltIter2:
-    Algo = _useIterTracking ? 0 : 0;
-    break;
-  case reco::TrackBase::hltIter3:
-    Algo = _useIterTracking ? 1 : 0;
-    break;
-  case reco::TrackBase::hltIter4:
-    Algo = _useIterTracking ? 2 : 0;
-    break;
-  case reco::TrackBase::hltIterX:
-    Algo = _useIterTracking ? 0 : 0;
-    break;
-  default:
-    Algo = _useIterTracking ? 6 : 0;
-    break;
-  }
+  unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trackref->algo(),_useIterTracking); 
 
   // Protection against 0 momentum tracks
   if ( P < 0.05 ) return false;
-
  
   if (_debug) std::cout << " PFBlockAlgo: PFrecTrack->Track Pt= "
 		   << Pt << " DPt = " << DPt << std::endl;

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -158,26 +158,28 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   const unsigned int LostHits = trackref->numberOfLostHits();
   const double sigmaHad = sqrt(1.20*1.20/P+0.06*0.06) / (1.+LostHits);
 
-  // iteration 1,2,3,4,5 correspond to algo = 1/4,5,6,7,8,9
-  unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trackref->algo(),_useIterTracking); 
-
   // Protection against 0 momentum tracks
   if ( P < 0.05 ) return false;
  
   if (_debug) std::cout << " PFBlockAlgo: PFrecTrack->Track Pt= "
 		   << Pt << " DPt = " << DPt << std::endl;
-  if ( ( _DPtovPtCut[Algo] > 0. && 
-	 DPt/Pt > _DPtovPtCut[Algo]*sigmaHad ) || 
-       NHit < _NHitCut[Algo] ) { 
+
+
+  double dptCut = PFTrackAlgoTools::dPtCut(trackref->algo(),_DPtovPtCut,_useIterTracking);
+  unsigned int nhitCut    = PFTrackAlgoTools::nHitCut(trackref->algo(),_NHitCut,_useIterTracking);
+
+  if ( ( dptCut > 0. && 
+	 DPt/Pt > dptCut*sigmaHad ) || 
+       NHit < nhitCut ) { 
     if (_debug) std::cout << " PFBlockAlgo: skip badly measured track"
 		     << ", P = " << P 
 		     << ", Pt = " << Pt 
 		     << " DPt = " << DPt 
 		     << ", N(hits) = " << NHit << " (Lost : " << LostHits << "/" << NLostHit << ")"
-		     << ", Algo = " << Algo
+			  << ", Algo = " << trackref->algo()
 		     << std::endl;
-    if (_debug) std::cout << " cut is DPt/Pt < " << _DPtovPtCut[Algo] * sigmaHad << std::endl;
-    if (_debug) std::cout << " cut is NHit >= " << _NHitCut[Algo] << std::endl;
+    if (_debug) std::cout << " cut is DPt/Pt < " << dptCut * sigmaHad << std::endl;
+    if (_debug) std::cout << " cut is NHit >= " << nhitCut << std::endl;
     return false;
   }
 

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1137,9 +1137,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
       if ( rejectTracks_Step45_ && ecalElems.empty() && 
 	   trackMomentum > 30. && Dpt > 0.5 && 
-	   ( trackRef->algo() == TrackBase::mixedTripletStep || 
-	     trackRef->algo() == TrackBase::pixelLessStep || 
-	     trackRef->algo() == TrackBase::tobTecStep ) ) {
+	   ( PFTrackAlgoTools::step45(trackRef->algo())) ) {  
 
 	double dptRel = Dpt/trackRef->pt()*100;
 	bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
@@ -2362,20 +2360,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
 	if (isPrimaryOrSecondary && dptRel < dptRel_DispVtx_) continue;
 
-	switch (trackref->algo()) {
-	case TrackBase::ctf:
-        case TrackBase::duplicateMerge:
-	case TrackBase::initialStep:
-	case TrackBase::lowPtTripletStep:
-	case TrackBase::pixelPairStep:
-	case TrackBase::detachedTripletStep:
-	case TrackBase::mixedTripletStep:
-	case TrackBase::jetCoreRegionalStep:
-	case TrackBase::muonSeededStepInOut:
-	case TrackBase::muonSeededStepOutIn:
-	  break;
-	case TrackBase::pixelLessStep:
-	case TrackBase::tobTecStep:
+	if (PFTrackAlgoTools::step5(trackref->algo())) {
 	  active[iTrack] = false;	
 	  totalChargedMomentum -= trackref->p();
 	  
@@ -2383,20 +2368,12 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	    std::cout << "\tElement  " << elements[iTrack] 
 		      << " rejected (Dpt = " << -it->first 
 		      << " GeV/c, algo = " << trackref->algo() << ")" << std::endl;
-	  break;
-	case reco::TrackBase::hltIter0:
-	case reco::TrackBase::hltIter1:
-	case reco::TrackBase::hltIter2:
-	case reco::TrackBase::hltIter3:
-	case reco::TrackBase::hltIter4:
-	case reco::TrackBase::hltIterX:
-	  break;	  
-	default:
-	  break;
+
 	}
       }
-    }
 
+    }
+  
     // New determination of the calo and track resolution avec track deletion/rescaling.
     Caloresolution = neutralHadronEnergyResolution( totalChargedMomentum, hclusterref->positionREP().Eta());    
     Caloresolution *= totalChargedMomentum;

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -5,6 +5,7 @@
 #include "RecoParticleFlow/PFProducer/interface/PFElectronAlgo.h"  
 #include "RecoParticleFlow/PFProducer/interface/PFPhotonAlgo.h"    
 #include "RecoParticleFlow/PFProducer/interface/PFElectronExtraEqual.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibrationHF.h"
@@ -1934,36 +1935,18 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       // ... tracks first (in case it's needed)
       double Dpt = trackRef->ptError();
       double blowError = 1.;
-      switch (trackRef->algo()) {
-      case TrackBase::ctf:
-      case TrackBase::duplicateMerge:
-      case TrackBase::initialStep:
-      case TrackBase::lowPtTripletStep:
-      case TrackBase::pixelPairStep:
-      case TrackBase::detachedTripletStep:
-      case TrackBase::mixedTripletStep:
-      case TrackBase::jetCoreRegionalStep:
-      case TrackBase::muonSeededStepInOut:
-      case TrackBase::muonSeededStepOutIn:
+      switch (PFTrackAlgoTools::getAlgoCategory(trackRef->algo())) {
+      case 0:
+      case 1:
+      case 5:
 	blowError = 1.;
 	break;
-      case TrackBase::pixelLessStep:
+      case 2:
+      case 3:
 	blowError = factors45_[0];
 	break;
-      case TrackBase::tobTecStep:
+      case 4:
 	blowError = factors45_[1];
-	break;
-      case reco::TrackBase::hltIter0:
-      case reco::TrackBase::hltIter1:
-      case reco::TrackBase::hltIter2:
-      case reco::TrackBase::hltIter3:
-	blowError = 1.;
-	break;
-      case reco::TrackBase::hltIter4:
-	blowError = factors45_[0];
-	break;
-      case reco::TrackBase::hltIterX:
-	blowError = 1.;
 	break;
       default:
 	blowError = 1E9;

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1934,24 +1934,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       // ... blow up errors of 5th anf 4th iteration, to reject those
       // ... tracks first (in case it's needed)
       double Dpt = trackRef->ptError();
-      double blowError = 1.;
-      switch (PFTrackAlgoTools::getAlgoCategory(trackRef->algo())) {
-      case 0:
-      case 1:
-      case 5:
-	blowError = 1.;
-	break;
-      case 2:
-      case 3:
-	blowError = factors45_[0];
-	break;
-      case 4:
-	blowError = factors45_[1];
-	break;
-      default:
-	blowError = 1E9;
-	break;
-      }
+      double blowError = PFTrackAlgoTools::errorScale(trackRef->algo(),factors45_);
       // except if it is from an interaction
       bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
 

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1395,6 +1395,7 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
 	   const reco::PFBlockElementTrack * kfEle = 
 	     docast(const reco::PFBlockElementTrack*,kftrack.first);
 	   const reco::TrackRef trackref = kfEle->trackRef();
+
 	   const reco::TrackBase::TrackAlgorithm Algo = trackref->algo();
 	   const int nexhits = 
 	     trackref->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -16,6 +16,7 @@
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyResolution.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
 #include "RecoParticleFlow/PFProducer/interface/PFElectronExtraEqual.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 #include "RecoEcal/EgammaCoreTools/interface/Mustache.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
@@ -2429,7 +2430,7 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
     NotCloserToOther<reco::PFBlockElement::TRACK,reco::PFBlockElement::HCAL>
       tracksToHCALs(_currentblock,_currentlinks,secd_kf->first);
     reco::TrackRef trkRef =   secd_kf->first->trackRef();
-    const unsigned int Algo = whichTrackAlgo(trkRef);
+    const unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trkRef->algo());
     const float secpin = trkRef->p();       
     
     for( auto ecal = ecal_begin; ecal != ecal_end; ++ecal ) {
@@ -2464,7 +2465,7 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
 	    dynamic_cast<const reco::PFBlockElementCluster*>(hcalclus->first); 
 	  const double hcalenergy = clusthcal->clusterRef()->energy();	  
 	  const double hpluse = ecalenergy+hcalenergy;
-	  const bool isHoHE = ( (hcalenergy / hpluse ) > 0.1 && Algo < 3 );
+	  const bool isHoHE = ( (hcalenergy / hpluse ) > 0.1 && (Algo < 3 ||Algo==5) );
 	  const bool isHoE  = ( hcalenergy > ecalenergy );
 	  const bool isPoHE = ( secpin > hpluse );	
 	  if( cluster_in_sc[clus_idx] ) {
@@ -2505,37 +2506,7 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
 }
 
 
-unsigned int PFEGammaAlgo::whichTrackAlgo(const reco::TrackRef& trackRef) {
-  unsigned int Algo = 0; 
-  switch (trackRef->algo()) {
-  case TrackBase::ctf:
-  case TrackBase::duplicateMerge:
-  case TrackBase::initialStep:
-  case TrackBase::lowPtTripletStep:
-  case TrackBase::pixelPairStep:
-  case TrackBase::jetCoreRegionalStep:
-  case TrackBase::muonSeededStepInOut:
-  case TrackBase::muonSeededStepOutIn:
-    Algo = 0;
-    break;
-  case TrackBase::detachedTripletStep:
-    Algo = 1;
-    break;
-  case TrackBase::mixedTripletStep:
-    Algo = 2;
-    break;
-  case TrackBase::pixelLessStep:
-    Algo = 3;
-    break;
-  case TrackBase::tobTecStep:
-    Algo = 4;
-    break;
-  default:
-    Algo = 5;
-    break;
-  }
-  return Algo;
-}
+
 bool PFEGammaAlgo::isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
 				    const reco::PFBlockElementGsfTrack& GsfEl) {
   bool isPrimary = false;

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -2430,7 +2430,8 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
     NotCloserToOther<reco::PFBlockElement::TRACK,reco::PFBlockElement::HCAL>
       tracksToHCALs(_currentblock,_currentlinks,secd_kf->first);
     reco::TrackRef trkRef =   secd_kf->first->trackRef();
-    const unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trkRef->algo());
+
+    bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trkRef->algo());
     const float secpin = trkRef->p();       
     
     for( auto ecal = ecal_begin; ecal != ecal_end; ++ecal ) {
@@ -2465,7 +2466,7 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
 	    dynamic_cast<const reco::PFBlockElementCluster*>(hcalclus->first); 
 	  const double hcalenergy = clusthcal->clusterRef()->energy();	  
 	  const double hpluse = ecalenergy+hcalenergy;
-	  const bool isHoHE = ( (hcalenergy / hpluse ) > 0.1 && (Algo < 3 ||Algo==5) );
+	  const bool isHoHE = ( (hcalenergy / hpluse ) > 0.1 && goodTrack );
 	  const bool isHoE  = ( hcalenergy > ecalenergy );
 	  const bool isPoHE = ( secpin > hpluse );	
 	  if( cluster_in_sc[clus_idx] ) {
@@ -2478,7 +2479,7 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
 		<< " HCAL ENE " << hcalenergy
 		<< " ECAL ENE " << ecalenergy
 		<< " secPIN " << secpin 
-		<< " Algo Track " << Algo << std::endl;
+		<< " Algo Track " << trkRef->algo() << std::endl;
 	      remove_this_kf = true;
 	    }
 	  } else {
@@ -2491,7 +2492,7 @@ unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
 		<< " HCAL ENE " << hcalenergy
 		<< " ECAL ENE " << ecalenergy
 		<< " secPIN " << secpin 
-		<< " Algo Track " << Algo << std::endl;
+		<< " Algo Track " <<trkRef->algo() << std::endl;
 	      remove_this_kf = true;
 	    }
 	  }  

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -189,7 +189,8 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
       cout << " My track element number " <<  itrk->second << endl;
     if(pfele.type()==reco::PFBlockElement::TRACK) {
       reco::TrackRef trackref = pfele.trackRef();
-      unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trackref->algo());
+
+      bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trackref->algo());
       // iter0, iter1, iter2, iter3 = Algo < 3
       // algo 4,5,6,7
       int nexhits = trackref->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS); 
@@ -203,7 +204,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
       }
       
       // probably we could now remove the algo request?? 
-      if((Algo < 3 ||Algo==5) && nexhits == 0 && trackIsFromPrimaryVertex) {
+      if(goodTrack && nexhits == 0 && trackIsFromPrimaryVertex) {
 	float p_trk = trackref->p();
 	SumExtraKfP += p_trk;
 	iextratrack++;
@@ -219,7 +220,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
 	}
 	if(debugSafeForJetMET) 
 	  cout << " The ecalGsf cluster is not isolated: >0 KF extra with algo < 3" 
-	       << " Algo " << Algo
+	       << " Algo " << trackref->algo()
 	       << " nexhits " << nexhits
 	       << " trackIsFromPrimaryVertex " << trackIsFromPrimaryVertex << endl;
 	if(debugSafeForJetMET) 
@@ -229,7 +230,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
       else {
 	if(debugSafeForJetMET) 
 	  cout << " Tracks from PU " 
-	       << " Algo " << Algo
+	       << " Algo " << trackref->algo()
 	       << " nexhits " << nexhits
 	       << " trackIsFromPrimaryVertex " << trackIsFromPrimaryVertex << endl;
 	if(debugSafeForJetMET) 

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -2,6 +2,7 @@
 // Original Authors: Nicholas Wardle, Florian Beaudette
 //
 #include "RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
@@ -188,7 +189,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
       cout << " My track element number " <<  itrk->second << endl;
     if(pfele.type()==reco::PFBlockElement::TRACK) {
       reco::TrackRef trackref = pfele.trackRef();
-      unsigned int Algo = whichTrackAlgo(trackref);
+      unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trackref->algo());
       // iter0, iter1, iter2, iter3 = Algo < 3
       // algo 4,5,6,7
       int nexhits = trackref->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS); 
@@ -202,9 +203,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
       }
       
       // probably we could now remove the algo request?? 
-      if(Algo < 3 && nexhits == 0 && trackIsFromPrimaryVertex) {
-
-
+      if((Algo < 3 ||Algo==5) && nexhits == 0 && trackIsFromPrimaryVertex) {
 	float p_trk = trackref->p();
 	SumExtraKfP += p_trk;
 	iextratrack++;
@@ -361,34 +360,4 @@ bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon & photon, const r
 
   return isSafeForJetMET;
 }
-unsigned int PFEGammaFilters::whichTrackAlgo(const reco::TrackRef& trackRef) {
-  unsigned int Algo = 0; 
-  switch (trackRef->algo()) {
-  case TrackBase::ctf:
-  case TrackBase::duplicateMerge:
-  case TrackBase::initialStep:
-  case TrackBase::lowPtTripletStep:
-  case TrackBase::pixelPairStep:
-  case TrackBase::jetCoreRegionalStep:
-  case TrackBase::muonSeededStepInOut:
-  case TrackBase::muonSeededStepOutIn:
-    Algo = 0;
-    break;
-  case TrackBase::detachedTripletStep:
-    Algo = 1;
-    break;
-  case TrackBase::mixedTripletStep:
-    Algo = 2;
-    break;
-  case TrackBase::pixelLessStep:
-    Algo = 3;
-    break;
-  case TrackBase::tobTecStep:
-    Algo = 4;
-    break;
-  default:
-    Algo = 5;
-    break;
-  }
-  return Algo;
-}
+

--- a/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
@@ -270,9 +270,10 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      
 	      int nexhits = refKf->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
 	      
-	      unsigned int  Algo=6;
+	      bool isGoodTrack=false;
 	      if (refKf.isNonnull()) 
-		Algo = PFTrackAlgoTools::getAlgoCategory(refKf->algo());
+		isGoodTrack = PFTrackAlgoTools::isGoodForEGM(refKf->algo());
+
 	      
 	      bool trackIsFromPrimaryVertex = false;
 	      for (Vertex::trackRef_iterator trackIt = primaryVertex.tracks_begin(); trackIt != primaryVertex.tracks_end(); ++trackIt) {
@@ -282,7 +283,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 		}
 	      }
       
-	      if((Algo <2  || Algo>=5 )
+	      if(isGoodTrack
 	         && nexhits == 0 && trackIsFromPrimaryVertex) {
 		localactive[ecalKf_index] = false;
 	      } else {
@@ -782,8 +783,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      // Further Cleaning: DANIELE This could be improved!
 	      TrackRef trkRef =   TrkEl->trackRef();
 	      // iter0, iter1, iter2, iter3 = Algo < 3
-	      unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trkRef->algo());
-
+	      bool isGoodTrack = PFTrackAlgoTools::isGoodForEGM(trkRef->algo());
 	      float secpin = trkRef->p();	
 	      
 	      const reco::PFBlockElementCluster * clust =  
@@ -810,7 +810,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 		  dynamic_cast<const reco::PFBlockElementCluster*>((&elements[(hcalConvElems.begin()->second)])); 
 		enehcalclust  =clusthcal->clusterRef()->energy();
 		// NOTE: DANIELE? Are you sure you want to use the Algo type here? 
-		if( (enehcalclust / (enehcalclust+eneclust) ) > 0.1 && (Algo < 3 || Algo==5)) {
+		if( (enehcalclust / (enehcalclust+eneclust) ) > 0.1 && isGoodTrack) {
 		  isHoHE = true;
 		  if(enehcalclust > eneclust) 
 		    isHoE = true;
@@ -831,7 +831,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 			 << " HCAL ENE " << enehcalclust 
 			 << " ECAL ENE " << eneclust 
 			 << " secPIN " << secpin 
-			 << " Algo Track " << Algo << endl;
+			 << " Algo Track " << trkRef->algo() << endl;
 		  continue;
 		}
 
@@ -859,7 +859,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 			 << " HCAL ENE " << enehcalclust 
 			 << " ECAL ENE " << eneclust 
 			 << " secPIN " << secpin 
-			 << " Algo Track " << Algo << endl;
+			 << " Algo Track " << trkRef->algo() << endl;
 		  continue;
 		}
 
@@ -1754,7 +1754,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 		
 		
 		reco::TrackRef trackref =  kfTk->trackRef();
-		unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trackref->algo());
+		bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trackref->algo());
 		// iter0, iter1, iter2, iter3 = Algo < 3
 		// algo 4,5,6,7
 		int nexhits = trackref->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
@@ -1768,7 +1768,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 		}
 		
 		// probably we could now remove the algo request?? 
-		if((Algo < 3||Algo==5)  && nexhits == 0 && trackIsFromPrimaryVertex) {
+		if(goodTrack  && nexhits == 0 && trackIsFromPrimaryVertex) {
 		  //if(Algo < 3) 
 		  if(DebugIDOutputs) 
 		    cout << " The ecalGsf cluster is not isolated: >0 KF extra with algo < 3" << endl;

--- a/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
@@ -4,6 +4,7 @@
 
 #include "RecoParticleFlow/PFProducer/interface/PFElectronAlgo.h"
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 //#include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"
@@ -269,9 +270,9 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      
 	      int nexhits = refKf->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
 	      
-	      reco::TrackBase::TrackAlgorithm Algo = reco::TrackBase::undefAlgorithm;
+	      unsigned int  Algo=6;
 	      if (refKf.isNonnull()) 
-		Algo = refKf->algo(); 
+		Algo = PFTrackAlgoTools::getAlgoCategory(refKf->algo());
 	      
 	      bool trackIsFromPrimaryVertex = false;
 	      for (Vertex::trackRef_iterator trackIt = primaryVertex.tracks_begin(); trackIt != primaryVertex.tracks_end(); ++trackIt) {
@@ -280,16 +281,8 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 		  break;
 		}
 	      }
-	      
-	      if((Algo == reco::TrackBase::undefAlgorithm ||
-	          Algo == reco::TrackBase::ctf ||
-	          Algo == reco::TrackBase::duplicateMerge ||
-	          Algo == reco::TrackBase::cosmics ||
-	          Algo == reco::TrackBase::initialStep ||
-	          Algo == reco::TrackBase::lowPtTripletStep ||
-	          Algo == reco::TrackBase::pixelPairStep ||
-	          Algo == reco::TrackBase::detachedTripletStep ||
-	          Algo == reco::TrackBase::mixedTripletStep)
+      
+	      if((Algo <2  || Algo>=5 )
 	         && nexhits == 0 && trackIsFromPrimaryVertex) {
 		localactive[ecalKf_index] = false;
 	      } else {
@@ -789,7 +782,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      // Further Cleaning: DANIELE This could be improved!
 	      TrackRef trkRef =   TrkEl->trackRef();
 	      // iter0, iter1, iter2, iter3 = Algo < 3
-	      unsigned int Algo = whichTrackAlgo(trkRef);
+	      unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trkRef->algo());
 
 	      float secpin = trkRef->p();	
 	      
@@ -817,7 +810,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 		  dynamic_cast<const reco::PFBlockElementCluster*>((&elements[(hcalConvElems.begin()->second)])); 
 		enehcalclust  =clusthcal->clusterRef()->energy();
 		// NOTE: DANIELE? Are you sure you want to use the Algo type here? 
-		if( (enehcalclust / (enehcalclust+eneclust) ) > 0.1 && Algo < 3) {
+		if( (enehcalclust / (enehcalclust+eneclust) ) > 0.1 && (Algo < 3 || Algo==5)) {
 		  isHoHE = true;
 		  if(enehcalclust > eneclust) 
 		    isHoE = true;
@@ -1761,7 +1754,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 		
 		
 		reco::TrackRef trackref =  kfTk->trackRef();
-		unsigned int Algo = whichTrackAlgo(trackref);
+		unsigned int Algo = PFTrackAlgoTools::getAlgoCategory(trackref->algo());
 		// iter0, iter1, iter2, iter3 = Algo < 3
 		// algo 4,5,6,7
 		int nexhits = trackref->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
@@ -1775,7 +1768,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 		}
 		
 		// probably we could now remove the algo request?? 
-		if(Algo < 3 && nexhits == 0 && trackIsFromPrimaryVertex) {
+		if((Algo < 3||Algo==5)  && nexhits == 0 && trackIsFromPrimaryVertex) {
 		  //if(Algo < 3) 
 		  if(DebugIDOutputs) 
 		    cout << " The ecalGsf cluster is not isolated: >0 KF extra with algo < 3" << endl;
@@ -2671,37 +2664,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
 void PFElectronAlgo::setEGElectronCollection(const reco::GsfElectronCollection & egelectrons) {
   theGsfElectrons_ = & egelectrons;
 }
-unsigned int PFElectronAlgo::whichTrackAlgo(const reco::TrackRef& trackRef) {
-  unsigned int Algo = 0; 
-  switch (trackRef->algo()) {
-  case TrackBase::ctf:
-  case TrackBase::duplicateMerge:
-  case TrackBase::initialStep:
-  case TrackBase::lowPtTripletStep:
-  case TrackBase::pixelPairStep:
-  case TrackBase::jetCoreRegionalStep:
-  case TrackBase::muonSeededStepInOut:
-  case TrackBase::muonSeededStepOutIn:
-    Algo = 0;
-    break;
-  case TrackBase::detachedTripletStep:
-    Algo = 1;
-    break;
-  case TrackBase::mixedTripletStep:
-    Algo = 2;
-    break;
-  case TrackBase::pixelLessStep:
-    Algo = 3;
-    break;
-  case TrackBase::tobTecStep:
-    Algo = 4;
-    break;
-  default:
-    Algo = 5;
-    break;
-  }
-  return Algo;
-}
+
 bool PFElectronAlgo::isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
 				    const reco::PFBlockElementGsfTrack& GsfEl) {
   bool isPrimary = false;

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -74,7 +74,7 @@ class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<c
       int FindPfRef(const reco::PFRecTrackCollection & PfRTkColl, 
 		    const reco::GsfTrack&, bool);
       
-      bool isFifthStep(reco::PFRecTrackRef pfKfTrack);
+
 
       bool applySelection(const reco::GsfTrack&);
       

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -1,0 +1,5 @@
+#include "DataFormats/TrackReco/interface/Track.h"
+namespace PFTrackAlgoTools  {
+//used in general tracks importer and in PFAlgo
+  unsigned int getAlgoCategory(const reco::TrackBase::TrackAlgorithm& algo,bool hltIterativeTracking  = true );
+}

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -1,5 +1,13 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 namespace PFTrackAlgoTools  {
-//used in general tracks importer and in PFAlgo
-  unsigned int getAlgoCategory(const reco::TrackBase::TrackAlgorithm& algo,bool hltIterativeTracking  = true );
+
+
+  double dPtCut(const reco::TrackBase::TrackAlgorithm& , const std::vector<double>&,bool);
+  unsigned int  nHitCut(const reco::TrackBase::TrackAlgorithm& , const std::vector<unsigned int>&,bool) ;
+  double errorScale(const reco::TrackBase::TrackAlgorithm&,const std::vector<double>&);
+  bool isGoodForEGM(const reco::TrackBase::TrackAlgorithm&);
+  bool isFifthStep(const reco::TrackBase::TrackAlgorithm&) ;
+
+  bool nonIterative(const reco::TrackBase::TrackAlgorithm&);
+  bool step45(const reco::TrackBase::TrackAlgorithm&);
 }

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -9,5 +9,7 @@ namespace PFTrackAlgoTools  {
   bool isFifthStep(const reco::TrackBase::TrackAlgorithm&) ;
 
   bool nonIterative(const reco::TrackBase::TrackAlgorithm&);
+  bool highQuality(const reco::TrackBase::TrackAlgorithm&);
   bool step45(const reco::TrackBase::TrackAlgorithm&);
+  bool step5(const reco::TrackBase::TrackAlgorithm&);
 }

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -188,9 +188,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
       if( useFifthStepForEcalDriven_ == false
 	  || useFifthStepForTrackDriven_ == false) {
 	
-
-	unsigned int algo = PFTrackAlgoTools::getAlgoCategory(kf_ref->trackRef()->algo());
-	bool isFifthStepTrack = algo==4 || algo>5;
+	bool isFifthStepTrack = PFTrackAlgoTools::isFifthStep(kf_ref->trackRef()->algo());
 	bool isEcalDriven = true;
 	bool isTrackerDriven = true;
 	

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -32,6 +32,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "RecoParticleFlow/PFClusterTools/interface/LinkByRecHit.h"
 #include "RecoParticleFlow/PFClusterTools/interface/ClusterClusterMapping.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
 #include "TMath.h"
 using namespace std;
@@ -186,7 +187,10 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
       // remove fifth step tracks
       if( useFifthStepForEcalDriven_ == false
 	  || useFifthStepForTrackDriven_ == false) {
-	bool isFifthStepTrack = isFifthStep(kf_ref);
+	
+
+	unsigned int algo = PFTrackAlgoTools::getAlgoCategory(kf_ref->trackRef()->algo());
+	bool isFifthStepTrack = algo==4 || algo>5;
 	bool isEcalDriven = true;
 	bool isTrackerDriven = true;
 	
@@ -467,47 +471,7 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
   }
   return -1;
 }
-bool PFElecTkProducer::isFifthStep(reco::PFRecTrackRef pfKfTrack) {
 
-  bool isFithStep = false;
-  
-
-  TrackRef kfref = pfKfTrack->trackRef();
-  unsigned int Algo = 0; 
-  switch (kfref->algo()) {
-  case TrackBase::undefAlgorithm:
-  case TrackBase::ctf:
-  case TrackBase::duplicateMerge:
-  case TrackBase::initialStep:
-  case TrackBase::lowPtTripletStep:
-  case TrackBase::pixelPairStep:
-  case TrackBase::jetCoreRegionalStep:
-  case TrackBase::muonSeededStepInOut:
-  case TrackBase::muonSeededStepOutIn:
-    Algo = 0;
-    break;
-  case TrackBase::detachedTripletStep:
-    Algo = 1;
-    break;
-  case TrackBase::mixedTripletStep:
-    Algo = 2;
-    break;
-  case TrackBase::pixelLessStep:
-    Algo = 3;
-    break;
-  case TrackBase::tobTecStep:
-    Algo = 4;
-    break;
-  default:
-    Algo = 5;
-    break;
-  }
-  if ( Algo >= 4 ) {
-    isFithStep = true;
-  }
-
-  return isFithStep;
-}
 // -- method to apply gsf electron selection to EcalDriven seeds
 bool 
 PFElecTkProducer::applySelection(const reco::GsfTrack& gsftk) {

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -286,10 +286,11 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
     TransientTrack tmpTk( *((*ie).get()), magField_, globTkGeomHandle_);
     transTracksRaw.push_back( tmpTk );
     transTracksRefRaw.push_back( *ie );
-    unsigned int algo = PFTrackAlgoTools::getAlgoCategory((*ie)->algo());
-    if (algo ==1 ||algo==2) //why not TOB-TEC here as well???  
+    bool nonIt = PFTrackAlgoTools::nonIterative((*ie)->algo());
+    bool step45 = PFTrackAlgoTools::step45((*ie)->algo());
+    if (step45)
       nStep45++;
-    else if (algo >5)
+    if (nonIt)
       nNotIterative++;
   }
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -288,10 +288,16 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
     transTracksRefRaw.push_back( *ie );
     bool nonIt = PFTrackAlgoTools::nonIterative((*ie)->algo());
     bool step45 = PFTrackAlgoTools::step45((*ie)->algo());
+    bool highQ = PFTrackAlgoTools::highQuality((*ie)->algo());   
     if (step45)
       nStep45++;
-    if (nonIt)
+    else if (nonIt)
       nNotIterative++;
+    else if (!highQ) {
+      nNotIterative++;
+      nStep45++;
+    }
+
   }
 
   if (rho > 25 && nStep45 + nNotIterative < 1){

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -1,4 +1,5 @@
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -285,28 +286,11 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
     TransientTrack tmpTk( *((*ie).get()), magField_, globTkGeomHandle_);
     transTracksRaw.push_back( tmpTk );
     transTracksRefRaw.push_back( *ie );
-    switch((*ie)->algo()) {
-    case reco::TrackBase::undefAlgorithm:
-    case reco::TrackBase::ctf:
-    case reco::TrackBase::cosmics:
-      nNotIterative++;
-      break;
-    case reco::TrackBase::initialStep:
-    case reco::TrackBase::lowPtTripletStep:
-    case reco::TrackBase::pixelPairStep:
-    case reco::TrackBase::detachedTripletStep:
-    case reco::TrackBase::duplicateMerge:
-      break;
-    case reco::TrackBase::mixedTripletStep:
-    case reco::TrackBase::pixelLessStep:
+    unsigned int algo = PFTrackAlgoTools::getAlgoCategory((*ie)->algo());
+    if (algo ==1 ||algo==2) //why not TOB-TEC here as well???  
       nStep45++;
-      break;
-    default:
+    else if (algo >5)
       nNotIterative++;
-      nStep45++; // why this should be increased for these cases?
-      break;
-    };
-
   }
 
   if (rho > 25 && nStep45 + nNotIterative < 1){

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -207,7 +207,7 @@ bool step45(const reco::TrackBase::TrackAlgorithm& algo){
 
 
 bool step5(const reco::TrackBase::TrackAlgorithm& algo){
-  return algo==reco::TrackBase::tobTecStep;
+  return algo==(reco::TrackBase::tobTecStep||reco::TrackBase::pixelLessStep);
 }
 
 }

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -1,0 +1,38 @@
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
+namespace PFTrackAlgoTools {
+unsigned int getAlgoCategory(const reco::TrackBase::TrackAlgorithm& algo,bool hltIterativeTracking) {
+  switch (algo) {
+  case reco::TrackBase::ctf:
+  case reco::TrackBase::duplicateMerge:
+  case reco::TrackBase::initialStep:
+  case reco::TrackBase::lowPtTripletStep:
+  case reco::TrackBase::pixelPairStep:
+  case reco::TrackBase::jetCoreRegionalStep:
+    return 0;
+  case reco::TrackBase::detachedTripletStep:
+    return 1;
+  case reco::TrackBase::mixedTripletStep:
+    return 2;
+  case reco::TrackBase::pixelLessStep:
+    return 3;
+  case reco::TrackBase::tobTecStep:
+    return 4;
+  case reco::TrackBase::muonSeededStepInOut:
+  case reco::TrackBase::muonSeededStepOutIn:
+    return 5;
+  case reco::TrackBase::hltIter0:
+  case reco::TrackBase::hltIter1:
+  case reco::TrackBase::hltIter2:
+    return 0;
+  case reco::TrackBase::hltIter3:
+    return  hltIterativeTracking ? 1 : 0;
+  case reco::TrackBase::hltIter4:
+    return  hltIterativeTracking ? 2 : 0;
+  case reco::TrackBase::hltIterX:
+    return  0;
+  default:
+    return hltIterativeTracking ? 6:0;
+  }
+
+}
+}

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -163,6 +163,22 @@ bool isFifthStep(const reco::TrackBase::TrackAlgorithm& algo){
 }
 
 
+bool highQuality(const reco::TrackBase::TrackAlgorithm& algo){
+  switch (algo) {
+  case reco::TrackBase::initialStep:
+  case reco::TrackBase::lowPtTripletStep:
+  case reco::TrackBase::pixelPairStep:
+  case reco::TrackBase::detachedTripletStep:
+  case reco::TrackBase::duplicateMerge:
+  case reco::TrackBase::jetCoreRegionalStep:
+    return true;
+  default:
+    return false;
+  }
+
+}
+
+
 bool nonIterative(const reco::TrackBase::TrackAlgorithm& algo){
   switch (algo) {
   case reco::TrackBase::undefAlgorithm:
@@ -181,6 +197,7 @@ bool step45(const reco::TrackBase::TrackAlgorithm& algo){
   switch (algo) {
   case reco::TrackBase::mixedTripletStep:
   case reco::TrackBase::pixelLessStep:
+  case reco::TrackBase::tobTecStep:
     return true;
   default:
     return false;
@@ -189,8 +206,8 @@ bool step45(const reco::TrackBase::TrackAlgorithm& algo){
 }
 
 
-
-
-
+bool step5(const reco::TrackBase::TrackAlgorithm& algo){
+  return algo==reco::TrackBase::tobTecStep;
+}
 
 }

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -1,6 +1,114 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 namespace PFTrackAlgoTools {
-unsigned int getAlgoCategory(const reco::TrackBase::TrackAlgorithm& algo,bool hltIterativeTracking) {
+
+  double dPtCut(const reco::TrackBase::TrackAlgorithm& algo,const std::vector<double>& cuts,bool hltIterativeTracking = true){
+    switch (algo) {
+    case reco::TrackBase::ctf:
+    case reco::TrackBase::duplicateMerge:
+    case reco::TrackBase::initialStep:
+    case reco::TrackBase::lowPtTripletStep:
+    case reco::TrackBase::pixelPairStep:
+    case reco::TrackBase::jetCoreRegionalStep:
+      return cuts[0];
+    case reco::TrackBase::detachedTripletStep:
+      return cuts[1];
+    case reco::TrackBase::mixedTripletStep:
+      return cuts[2];
+    case reco::TrackBase::pixelLessStep:
+      return cuts[3];
+    case reco::TrackBase::tobTecStep:
+      return cuts[4];
+    case reco::TrackBase::muonSeededStepInOut:
+    case reco::TrackBase::muonSeededStepOutIn:
+      return cuts[5];
+    case reco::TrackBase::hltIter0:
+    case reco::TrackBase::hltIter1:
+    case reco::TrackBase::hltIter2:
+      return cuts[0];
+    case reco::TrackBase::hltIter3:
+      return  hltIterativeTracking ? cuts[1] : cuts[0];
+    case reco::TrackBase::hltIter4:
+      return  hltIterativeTracking ? cuts[2] : cuts[0];
+    case reco::TrackBase::hltIterX:
+      return  cuts[0];
+    default:
+      return hltIterativeTracking ? cuts[6]:cuts[0];
+
+    }
+  }
+
+
+
+  unsigned int  nHitCut(const reco::TrackBase::TrackAlgorithm& algo,const std::vector<unsigned int>& cuts,bool hltIterativeTracking = true){
+    switch (algo) {
+    case reco::TrackBase::ctf:
+    case reco::TrackBase::duplicateMerge:
+    case reco::TrackBase::initialStep:
+    case reco::TrackBase::lowPtTripletStep:
+    case reco::TrackBase::pixelPairStep:
+    case reco::TrackBase::jetCoreRegionalStep:
+      return cuts[0];
+    case reco::TrackBase::detachedTripletStep:
+      return cuts[1];
+    case reco::TrackBase::mixedTripletStep:
+      return cuts[2];
+    case reco::TrackBase::pixelLessStep:
+      return cuts[3];
+    case reco::TrackBase::tobTecStep:
+      return cuts[4];
+    case reco::TrackBase::muonSeededStepInOut:
+    case reco::TrackBase::muonSeededStepOutIn:
+      return cuts[5];
+    case reco::TrackBase::hltIter0:
+    case reco::TrackBase::hltIter1:
+    case reco::TrackBase::hltIter2:
+      return cuts[0];
+    case reco::TrackBase::hltIter3:
+      return  hltIterativeTracking ? cuts[1] : cuts[0];
+    case reco::TrackBase::hltIter4:
+      return  hltIterativeTracking ? cuts[2] : cuts[0];
+    case reco::TrackBase::hltIterX:
+      return  cuts[0];
+    default:
+      return hltIterativeTracking ? cuts[6]:cuts[0];
+
+    }
+  }
+
+
+
+  double  errorScale(const reco::TrackBase::TrackAlgorithm& algo,const std::vector<double>& errorScale){
+    switch (algo) {
+    case reco::TrackBase::ctf:
+    case reco::TrackBase::duplicateMerge:
+    case reco::TrackBase::initialStep:
+    case reco::TrackBase::lowPtTripletStep:
+    case reco::TrackBase::pixelPairStep:
+    case reco::TrackBase::jetCoreRegionalStep:
+    case reco::TrackBase::muonSeededStepInOut:
+    case reco::TrackBase::muonSeededStepOutIn:
+    case reco::TrackBase::detachedTripletStep:
+    case reco::TrackBase::mixedTripletStep:
+    case reco::TrackBase::hltIter0:
+    case reco::TrackBase::hltIter1:
+    case reco::TrackBase::hltIter2:
+    case reco::TrackBase::hltIter3:
+    case reco::TrackBase::hltIter4:
+    case reco::TrackBase::hltIterX:
+      return 1.0;
+    case reco::TrackBase::pixelLessStep:
+      return errorScale[0];
+    case reco::TrackBase::tobTecStep:
+      return errorScale[1];
+    default:
+      return 1E9;
+    }
+  }
+
+
+bool isGoodForEGM(const reco::TrackBase::TrackAlgorithm& algo){
+
+
   switch (algo) {
   case reco::TrackBase::ctf:
   case reco::TrackBase::duplicateMerge:
@@ -8,31 +116,81 @@ unsigned int getAlgoCategory(const reco::TrackBase::TrackAlgorithm& algo,bool hl
   case reco::TrackBase::lowPtTripletStep:
   case reco::TrackBase::pixelPairStep:
   case reco::TrackBase::jetCoreRegionalStep:
-    return 0;
   case reco::TrackBase::detachedTripletStep:
-    return 1;
   case reco::TrackBase::mixedTripletStep:
-    return 2;
-  case reco::TrackBase::pixelLessStep:
-    return 3;
-  case reco::TrackBase::tobTecStep:
-    return 4;
   case reco::TrackBase::muonSeededStepInOut:
   case reco::TrackBase::muonSeededStepOutIn:
-    return 5;
   case reco::TrackBase::hltIter0:
   case reco::TrackBase::hltIter1:
   case reco::TrackBase::hltIter2:
-    return 0;
   case reco::TrackBase::hltIter3:
-    return  hltIterativeTracking ? 1 : 0;
   case reco::TrackBase::hltIter4:
-    return  hltIterativeTracking ? 2 : 0;
   case reco::TrackBase::hltIterX:
-    return  0;
+    return true;
   default:
-    return hltIterativeTracking ? 6:0;
+    return false;
   }
 
 }
+
+
+bool isFifthStep(const reco::TrackBase::TrackAlgorithm& algo){
+  switch (algo) {
+  case reco::TrackBase::ctf:
+  case reco::TrackBase::duplicateMerge:
+  case reco::TrackBase::initialStep:
+  case reco::TrackBase::lowPtTripletStep:
+  case reco::TrackBase::pixelPairStep:
+  case reco::TrackBase::jetCoreRegionalStep:
+  case reco::TrackBase::detachedTripletStep:
+  case reco::TrackBase::mixedTripletStep:
+  case reco::TrackBase::pixelLessStep:
+  case reco::TrackBase::muonSeededStepInOut:
+  case reco::TrackBase::muonSeededStepOutIn:
+  case reco::TrackBase::hltIter0:
+  case reco::TrackBase::hltIter1:
+  case reco::TrackBase::hltIter2:
+  case reco::TrackBase::hltIter3:
+  case reco::TrackBase::hltIter4:
+  case reco::TrackBase::hltIterX:
+    return false;
+  case reco::TrackBase::tobTecStep:
+    return true;
+  default:
+    return true;
+  }
+
+}
+
+
+bool nonIterative(const reco::TrackBase::TrackAlgorithm& algo){
+  switch (algo) {
+  case reco::TrackBase::undefAlgorithm:
+  case reco::TrackBase::ctf:
+  case reco::TrackBase::cosmics:
+    return true;
+  default:
+    return false;
+
+  }
+
+}
+
+
+bool step45(const reco::TrackBase::TrackAlgorithm& algo){
+  switch (algo) {
+  case reco::TrackBase::mixedTripletStep:
+  case reco::TrackBase::pixelLessStep:
+    return true;
+  default:
+    return false;
+  }
+
+}
+
+
+
+
+
+
 }

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -207,7 +207,7 @@ bool step45(const reco::TrackBase::TrackAlgorithm& algo){
 
 
 bool step5(const reco::TrackBase::TrackAlgorithm& algo){
-  return algo==(reco::TrackBase::tobTecStep||reco::TrackBase::pixelLessStep);
+  return (algo==reco::TrackBase::tobTecStep||algo==reco::TrackBase::pixelLessStep);
 }
 
 }


### PR DESCRIPTION
"Almost" technical PR  that defines a common place of the treatment of the track iterations in Particle Flow

Almost -> the PFDisplacedVertexFinder seems to be very out-dated wrt the iterations added therefore
I updated it . In the future we should assign this module to a POG (probably BTV)

@lgray @matteosan1  please have a look at the EGM modules . I think I changed them correctly
One other EGM action item is to clean up the PF EGM code that we dont use . I think 80X is a good place to do this so please make sure somebody does it at some point 

 @VinInn @makortel @rovere   you can start from here to add new iterations
Major issue for tracking: You can-NOT just add iterations in the file as it was done in #12577 
All the MET tails we had in 2015 was due to tracking so if one iteration introduces MET tails it needs to have some Dpt/pt cuts . So for every PR that has new iterations one should look at the PFMET distribution before and after in RelVal FlatQCD and even one additional event in the tail is enough to tell you there are problems. 
So looking forward to see this in the future

@arizzi  @gpetruc FYI
