### PR TITLE
Ccctf tuning

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -222,6 +222,29 @@ def customiseFor12346(process):
            delattr(process.hltMetCleanUsingJetID, 'usePt')
     return process
 
+def customiseForXXXYYY(process):
+    if hasattr(process, 'HLTPSetMuonCkfTrajectoryFilter'):
+        process.HLTPSetMuonCkfTrajectoryFilter.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTIter0PSetTrajectoryFilterIT'):
+        process.HLTIter0PSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTIter1PSetTrajectoryFilterIT'):
+        process.HLTIter1PSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTIter2PSetTrajectoryFilterIT'):
+        process.HLTIter2PSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTPSetTrajectoryFilterForElectrons'):
+        process.HLTPSetTrajectoryFilterForElectrons.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'process.HLTIter2HighPtTkMuPSetTrajectoryFilterIT'):
+        process.HLTIter2HighPtTkMuPSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTIter2HighPtTkMuPSetTrajectoryFilterIT'):
+        process.HLTIter2HighPtTkMuPSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTPSetMuTrackJpsiTrajectoryFilter'):
+        process.HLTPSetMuTrackJpsiTrajectoryFilter.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTIter4PSetTrajectoryFilterIT'):
+        process.HLTIter4PSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    if hasattr(process, 'HLTIter3PSetTrajectoryFilterIT'):
+        process.HLTIter3PSetTrajectoryFilterIT.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
+    return process
+
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
@@ -230,6 +253,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     if cmsswVersion >= "CMSSW_8_0":
         process = customiseFor12346(process)
         process = customiseFor11920(process)
+        process = customiseForXXXYYY(process)
     if cmsswVersion >= "CMSSW_7_6":
         process = customiseFor10418(process)
         process = customiseFor10353(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -222,7 +222,7 @@ def customiseFor12346(process):
            delattr(process.hltMetCleanUsingJetID, 'usePt')
     return process
 
-def customiseForXXXYYY(process):
+def customiseFor12718(process):
     if hasattr(process, 'HLTPSetMuonCkfTrajectoryFilter'):
         process.HLTPSetMuonCkfTrajectoryFilter.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
     if hasattr(process, 'HLTIter0PSetTrajectoryFilterIT'):
@@ -253,7 +253,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     if cmsswVersion >= "CMSSW_8_0":
         process = customiseFor12346(process)
         process = customiseFor11920(process)
-        process = customiseForXXXYYY(process)
+        process = customiseFor12718(process)
     if cmsswVersion >= "CMSSW_7_6":
         process = customiseFor10418(process)
         process = customiseFor10353(process)

--- a/RecoEgamma/EgammaPhotonProducers/python/trajectoryFilterForConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/trajectoryFilterForConversions_cfi.py
@@ -12,6 +12,6 @@ TrajectoryFilterForConversions = TrackingTools.TrajectoryFiltering.TrajectoryFil
     nSigmaMinPt = cms.double(5.0),
     minimumNumberOfHits = cms.int32(3),
     maxCCCLostHits = cms.int32(9999),
-    minGoodStripCharge = cms.double(-1)
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
 )
 

--- a/RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h
@@ -4,7 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include<iostream>
 
-float clusterChargeCut(const edm::ParameterSet& conf, const char * name="clusterChargeCut") {
+inline float clusterChargeCut(const edm::ParameterSet& conf, const char * name="clusterChargeCut") {
    return conf.getParameter<edm::ParameterSet>(name).getParameter<double>("value");
 }
 

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
@@ -4,6 +4,10 @@ SiStripClusterChargeCutNone = cms.PSet(
     value     = cms.double(-1.0)
 )
   
+SiStripClusterChargeCutTiny = cms.PSet(
+    value     = cms.double(800.0)
+)
+
 SiStripClusterChargeCutLoose = cms.PSet(
     value     = cms.double(1620.0) 
 )

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -70,7 +70,7 @@ detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEst
     ComponentName = cms.string('detachedTripletStepChi2Est'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(9.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -53,7 +53,7 @@ detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Traj
 #    constantValueForLostHitsFractionFilter = cms.double(0.701),
     minimumNumberOfHits = 3,
     minPt = 0.075,
-    maxCCCLostHits = 1,
+    maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -52,7 +52,9 @@ detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Traj
 #    maxLostHitsFraction = cms.double(1./10.),
 #    constantValueForLostHitsFractionFilter = cms.double(0.701),
     minimumNumberOfHits = 3,
-    minPt = 0.075
+    minPt = 0.075,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 detachedTripletStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -38,7 +38,7 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 initialStepTrajectoryFilterBasePreSplitting = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.2,
-    maxCCCLostHits = 1,
+    maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -37,7 +37,9 @@ initialStepSeedsPreSplitting.ClusterCheckPSet.PixelClusterCollectionLabel = 'siP
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 initialStepTrajectoryFilterBasePreSplitting = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.2
+    minPt = 0.2,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 initialStepTrajectoryFilterShapePreSplitting = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -53,7 +53,7 @@ initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasuremen
     ComponentName = cms.string('initialStepChi2EstPreSplitting'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(30.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -51,7 +51,7 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorES
     ComponentName = cms.string('initialStepChi2Est'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(30.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -35,7 +35,7 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.2,
-    maxCCCLostHits = 1,
+    maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -34,8 +34,11 @@ initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoP
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.2
+    minPt = 0.2,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
+
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 initialStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
 initialStepTrajectoryFilter = cms.PSet(

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -44,7 +44,7 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.075,
-    maxCCCLostHits = 2,
+    maxCCCLostHits = 1,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -43,7 +43,9 @@ lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = 
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.075
+    minPt = 0.075,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -59,7 +59,7 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     ComponentName = cms.string('lowPtTripletStepChi2Est'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(9.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -44,7 +44,7 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.075,
-    maxCCCLostHits = 1,
+    maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -55,7 +55,9 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     seedPairPenalty =0,
-    minPt = 0.1
+    minPt = 0.1,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 pixelPairStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -74,7 +74,7 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     ComponentName = cms.string('pixelPairStepChi2Est'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(9.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -56,7 +56,7 @@ pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Trajectory
     minimumNumberOfHits = 3,
     seedPairPenalty =0,
     minPt = 0.1,
-    maxCCCLostHits = 1,
+    maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -20,7 +20,7 @@ TrajectoryFilterForElectrons = TrackingTools.TrajectoryFiltering.TrajectoryFilte
     nSigmaMinPt = cms.double(5.0),
     minimumNumberOfHits = cms.int32(5),
     maxCCCLostHits = cms.int32(9999),
-    minGoodStripCharge = cms.double(-1)
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
 )
 
 # Trajectory Builder

--- a/TrackingTools/TrajectoryFiltering/BuildFile.xml
+++ b/TrackingTools/TrajectoryFiltering/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="TrackingTools/PatternTools"/>

--- a/TrackingTools/TrajectoryFiltering/BuildFile.xml
+++ b/TrackingTools/TrajectoryFiltering/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="TrackingTools/PatternTools"/>

--- a/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
@@ -1,7 +1,6 @@
 #ifndef MaxCCCLostHitsTrajectoryFilter_H
 #define MaxCCCLostHitsTrajectoryFilter_H
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h"
@@ -17,7 +16,7 @@ public:
   explicit MaxCCCLostHitsTrajectoryFilter (
       const edm::ParameterSet & pset, edm::ConsumesCollector& iC) :
       theMaxCCCLostHits_(pset.existsAs<int>("maxCCCLostHits") ? pset.getParameter<int>("maxCCCLostHits") : 9999),
-      minGoodStripCharge_(clusterChargeCut(pset.getParameter<edm::ParameterSet>("minGoodStripCharge"))) {}
+      minGoodStripCharge_(clusterChargeCut(pset, "minGoodStripCharge")) {}
 
   virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
   virtual bool qualityFilter( const TempTrajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }

--- a/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
@@ -1,8 +1,10 @@
 #ifndef MaxCCCLostHitsTrajectoryFilter_H
 #define MaxCCCLostHitsTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
+#include "RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h"
 
 class MaxCCCLostHitsTrajectoryFilter final : public TrajectoryFilter {
 public:
@@ -15,7 +17,7 @@ public:
   explicit MaxCCCLostHitsTrajectoryFilter (
       const edm::ParameterSet & pset, edm::ConsumesCollector& iC) :
       theMaxCCCLostHits_(pset.existsAs<int>("maxCCCLostHits") ? pset.getParameter<int>("maxCCCLostHits") : 9999),
-      minGoodStripCharge_(pset.existsAs<double>("minGoodStripCharge") ? pset.getParameter<double>("minGoodStripCharge") : -1.) {}
+      minGoodStripCharge_(clusterChargeCut(pset.getParameter<edm::ParameterSet>("minGoodStripCharge"))) {}
 
   virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
   virtual bool qualityFilter( const TempTrajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+
 CkfBaseTrajectoryFilter_block = cms.PSet(
     ComponentType = cms.string('CkfBaseTrajectoryFilter'),
 
@@ -39,7 +41,7 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
 
 # Cut on CCC hits
     maxCCCLostHits = cms.int32(9999),
-    minGoodStripCharge = cms.double(-1.)
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
 )
 
 
@@ -82,6 +84,6 @@ ThresholdPtTrajectoryFilter_block = cms.PSet(
 MaxCCCLostHitsTrajectoryFilter_block = cms.PSet(
     ComponentType = cms.string('MaxCCCLostHitsTrajectoryFilter'),
     maxCCCLostHits = cms.int32(3),
-    minGoodStripCharge = cms.double(1620)
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
 


### PR DESCRIPTION
## Executive Summary

This PR is the first tuning of the cluster charge cut (CCC) that tries to recover hits-on-track on real data, while keeping the same performances in terms of efficiency, fake-rate and timing on Monte Carlo.

It is not excluded that some minor fine tuning will be needed in the course of the release, depending also on the outcome of the full release validation with this first set of changes.
### Monte Carlo

The standard set of tracking MTV validation plots for a TTBar sample (35PU@25ns) that compares this PR against a recent IB are available at this [link](https://roverepublic.web.cern.ch/roverepublic/MTV_ProposedTuning2/). The main points to notice are:
- overall the performance in terms of efficiency is quite the same, except for a small loss at very low pt (could be a further fine-tune will come trying to recover also this tiny fraction) [see here](https://roverepublic.web.cern.ch/roverepublic/MTV_ProposedTuning2/plots_summary_highPurity/summary.pdf)
- The fake-rate increase from an ~8% to a ~10%, but this, in a sense, is kind of unavoidable, given the nature of this PR (recovering hits implies also adding some fake ones, unfortunately). Again, [see here](https://roverepublic.web.cern.ch/roverepublic/MTV_ProposedTuning2/plots_summary_highPurity/summary.pdf) for plots. Anyway we believe this level of fake is still ok, especially since it is computed with quite loose requirements. And we do not want to hold this any further.
- in terms of timing, from private measurements, the reco time goes from 7.9 sec/ev to 8 sec/ev, so basically we do not observe any slowdown.
- Unfortunately the MC simulation does not properly simulate the loss of hit-collection-efficiency we see on data: in order to see the real effects, we also privately reconstructed 1K event from 260627.
### Data (SingleMuon, Run 260627)
#### Hits on Track

The results are nicely summarized [here](https://www.dropbox.com/s/07wcxcccy5m1nxh/hits.png?dl=0)
- Legend:
  - black: this PR
  - blue: an intermediate tuning
  - orange: recent IB w/o this PR
  - red: prompt-reco on the full statistics
- Comments
  - this PR recovers ~2 hits on track on the full eta range (black vs orange).
  - the red is above the orange simply because it integrates the full run, including the last part at "low-lumi"
#### Hit Efficiency

The plot is available [here](https://www.dropbox.com/s/hqdfptbbpr12la3/globalEfficiencies.png?dl=0). There are clear improvements in all SiStrip detectors, especially in TIB and TOB. More plots available from within CERN only [here](http://mrovere-dqmgui-slc6.cern.ch:8060/dqm/dev/start?runnr=260627;dataset=/SingleMuon/ReReco260627_ProposedTuning2_80X/DQMIO;sampletype=offline_data;filter=all;referencepos=overlay;referenceshow=all;referenceobj1=other%3A%3A/RelValTTbar/CMSSW_8_0_0_ProposedTuning2/DQMIO%3A;referenceobj2=other%3A%3A/SingleMuon/ReReco260627_ProposedTuning_80X/DQMIO%3A;referenceobj3=other%3A%3A/SingleMuon/ReReco260627_80X/DQMIO%3A;referenceobj4=other%3A%3A/SingleMuon/Run2015D-PromptReco-v4/DQMIO%3A;search=effi;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=Tracking/TrackParameters/highPurityTracks/pt_1/HitEffFromHitPattern;focus=;zoom=no;).
#### SiStrip Cluster Charge Plots

Few plots are available [here for TIB](https://www.dropbox.com/s/uef4x5izi8k5075/TIB_Charge.png?dl=0) and [here for TOB](https://www.dropbox.com/s/hgyhxziw3l84cy1/TOB_Charge.png?dl=0). From these plots it is quite clear the effect of the current PR.
#### Timing

Timing wise, I observed no significant slowdown comparing 80X vanilla reco and 80X+this PR reco.
## New CCC Logic

The cluster charge cut is now applied in 2 different ways:
- as en estimator, while deciding if a hit is compatible or not. This is the CCC that we have been using during 2015@25ns data taking. For the first 4 iterations the threshold of this cut has been lowered to 800 (was 1620/1945), while for all the latter, the thresholds are identical to what was already there.
- as a trajectory filter. The first 4 iterations will accept at most 2 hits (either consecutive or not) whose charge is in the range 800;1620 (the current Loose threshold). The exception is the LowPt iteration, that will only accept one such hit (the reason being that there is not much gain in pushing it up to 2 for this iteration).
- All the logic beyond the first 4 iterations has been unchanged, in order to contain timing and fake-rate.
## Miscellanea

This PR contains also a customise for HLT in order to avoid crashes@HLT due to the fact that a parameter has been changed from a simple double to a refToPset_, in order to keep the symmetry with all other CCC cuts. I leave the "integration" of the customize into the HLT Menu to HLT experts

@mtosi 
