### PR TITLE
add playback info in RECO and AOD

### DIFF
--- a/SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
@@ -2,24 +2,21 @@ import FWCore.ParameterSet.Config as cms
 
 HiMixRAW = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_heavyIon_*_*'
-#        'keep *_mix_MergedTrackTruth_*',
-#        'drop CrossingFramePlaybackInfoExtended_mix_*_*',
-#        'keep *_mix_*_SIM',
+        'keep CrossingFramePlaybackInfoNew_mix_*_*',
+        'keep *_heavyIon_*_*',
     )
 )
 
 HiMixRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_heavyIon_*_*'
-#        'keep *_mix_MergedTrackTruth_*',
-#        'drop CrossingFramePlaybackInfoExtended_mix_*_*',
-#        'keep *_mix_*_SIM',
+        'keep CrossingFramePlaybackInfoNew_mix_*_*',
+        'keep *_heavyIon_*_*',
     )
 )
 
 HiMixAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
+        'keep CrossingFramePlaybackInfoNew_mix_*_*',
         'keep *_heavyIon_*_*'
     )
 )


### PR DESCRIPTION
HI needs playback info in RECO and AOD, we need this information to analyze the statistical uncertainties related to the background events in analysis level. This was the original intent, however the event content adjustment has been mistakenly dropped in the earlier pull-requests about the new mixing workflow.
We need this for the RECO campaign of the upcoming MC production, best to include it in CMSSW_7_5_7_patch4 so that it matches the DIGI campaign.
