### PR TITLE
add protection in customs functions for miniAOD-only relval workflows

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -85,7 +85,7 @@ def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common_withStage1(process)
 
     import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    if hasattr(process,'process.hcalRecAlgos'):
+    if hasattr(process,'hcalRecAlgos'):
         HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
         HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -85,8 +85,9 @@ def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common_withStage1(process)
 
     import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
+    if hasattr(process,'process.hcalRecAlgos'):
+        HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
+        HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -212,8 +212,9 @@ def customise_csc_LocalReco(process):
     process = customise_csc_Indexing(process)
 
     # Turn off some flags for CSCRecHitD that are turned ON in default config
-    process.csc2DRecHits.readBadChannels = cms.bool(False)
-    process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
+    if hasattr(process, 'csc2DRecHits'):
+        process.csc2DRecHits.readBadChannels = cms.bool(False)
+        process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
 
     return process
 


### PR DESCRIPTION
add protection in customs functions for miniAOD-only relval workflows
needed by https://github.com/cms-sw/cmssw/pull/12720
