### PR TITLE
Fix customiseForRunI for tracking-only reco sequence

### DIFF
--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -9,6 +9,7 @@ it into cmsRun for testing with a few input files etc from the command line
 
 import sys
 import getopt
+import traceback
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -95,7 +96,7 @@ class RunExpressProcessing:
             return
         except Exception as ex:
             msg = "Error creating Express Processing config:\n"
-            msg += str(ex)
+            msg += traceback.format_exc()
             raise RuntimeError(msg)
 
         process.source.fileNames = [self.inputLFN]

--- a/RecoTracker/Configuration/python/customiseForRunI.py
+++ b/RecoTracker/Configuration/python/customiseForRunI.py
@@ -16,9 +16,9 @@ def customiseForRunI(process):
     if not hasattr(process,'reconstruction'):
         return process
 
-    tgrIndex = process.globalreco.index(process.trackingGlobalReco)
+    tgrIndex = process.globalreco_tracking.index(process.trackingGlobalReco)
     tgrIndexFromReco = process.reconstruction_fromRECO.index(process.InitialStep)
-    process.globalreco.remove(process.trackingGlobalReco)
+    process.globalreco_tracking.remove(process.trackingGlobalReco)
     process.reconstruction_fromRECO.remove(process.InitialStep)
     process.reconstruction_fromRECO.remove(process.DetachedTripletStep)
     process.reconstruction_fromRECO.remove(process.LowPtTripletStep)
@@ -51,8 +51,8 @@ def customiseForRunI(process):
     # Load the new Iterative Tracking configuration
     process.load("RecoTracker.Configuration.RecoTrackerRunI_cff")
 
-    process.globalreco.insert(tgrIndex, process.trackingGlobalReco)
-    process.globalreco.insert(tgrIndex, process.recopixelvertexing)
+    process.globalreco_tracking.insert(tgrIndex, process.trackingGlobalReco)
+    process.globalreco_tracking.insert(tgrIndex, process.recopixelvertexing)
     process.reconstruction_fromRECO.insert(tgrIndexFromReco, process.iterTracking)
 
     # Now get rid of spurious reference to JetCore step
@@ -79,8 +79,8 @@ def customiseForRunI(process):
     process.pixeltrackerlocalreco.replace(process.siPixelClustersPreSplitting, process.siPixelClusters)
     process.pixeltrackerlocalreco.replace(process.siPixelRecHitsPreSplitting, process.siPixelRecHits)
     process.clusterSummaryProducer.pixelClusters = 'siPixelClusters'
-    process.globalreco.replace(process.MeasurementTrackerEventPreSplitting, process.MeasurementTrackerEvent)
-    process.globalreco.replace(process.siPixelClusterShapeCachePreSplitting, process.siPixelClusterShapeCache)
+    process.globalreco_tracking.replace(process.MeasurementTrackerEventPreSplitting, process.MeasurementTrackerEvent)
+    process.globalreco_tracking.replace(process.siPixelClusterShapeCachePreSplitting, process.siPixelClusterShapeCache)
 
     # Now restore pixelVertices wherever was not possible with an ad-hoc RunI cfg
     process.muonSeededTracksInOutClassifier.vertices = 'pixelVertices'


### PR DESCRIPTION
This PR fixes the unit test failure in `runtests_TestConfigDP` introduced by #12542. The reason for the failure was that `customiseForRunI()` was not migrated to the new reco sequence structure introduced.

I also added the traceback to the error report in `RunExpressProcessing.py`, because without it I had no clue what was going wrong (in case somebody else has to debug similar stuff later).

Tested in CMSSW_8_0_X_2015-12-09-1600, no other changes expected.

@rovere @VinInn 
