### PR TITLE
TrackCollectionFilterCloner

### DIFF
--- a/RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <algorithm>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -50,7 +51,9 @@ public:
       producer.template produces< TrajTrackAssociationCollection >().setBranchAlias( alias + "TrajectoryTrackAssociations" );
     }
 
-  }
+    }
+
+   static void fill(edm::ParameterSetDescription& desc);
 
   struct Producer {
     Producer(edm::Event& ievt, TrackCollectionCloner const & cloner);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -1,0 +1,172 @@
+#include "RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h"
+
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
+
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <iostream>
+#include <memory>
+
+#include "trackAlgoPriorityOrder.h"
+
+using namespace reco;
+
+namespace {
+class TrackCollectionFilterCloner final : public edm::global::EDProducer<> {
+ public:
+  /// constructor
+  explicit TrackCollectionFilterCloner(const edm::ParameterSet& iConfig);
+  /// destructor
+  virtual ~TrackCollectionFilterCloner();
+  
+  /// alias for container of candidate and input tracks
+  using CandidateToDuplicate = std::vector<std::pair<int, int>>;
+  
+  using RecHitContainer = edm::OwnVector<TrackingRecHit>;
+  
+  using MVACollection = std::vector<float>;
+  using QualityMaskCollection = std::vector<unsigned char>;
+ 
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  
+ private:
+  /// produce one event
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  
+ private:  
+  
+
+  TrackCollectionCloner collectionCloner;
+  TrackCollectionCloner::Tokens originalTrackSource_;
+
+  edm::EDGetTokenT<MVACollection>         originalMVAValsToken_;
+  edm::EDGetTokenT<QualityMaskCollection> originalQualValsToken_;
+
+  reco::TrackBase::TrackQuality minQuality_; 
+
+};
+}
+
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/ClusterRemovalRefSetter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+
+#include<tuple>
+#include<array>
+#include "CommonTools/Utils/interface/DynArray.h"
+
+
+namespace {
+void TrackCollectionFilterCloner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("originalSource",  edm::InputTag());
+  desc.add<edm::InputTag>("originalMVAVals", edm::InputTag());
+  desc.add<edm::InputTag>("originalQualVals",edm::InputTag());
+  desc.add<std::string>  ("minQuality",      "loose");
+  edm::ParameterSetDescription clonerDesc;
+  TrackCollectionCloner::fill(clonerDesc);
+  desc.addUntracked<edm::ParameterSetDescription>("cloner",clonerDesc);
+  descriptions.add("TrackCollectionFilterCloner", desc);  
+}
+
+TrackCollectionFilterCloner::TrackCollectionFilterCloner(const edm::ParameterSet& iConfig) :
+  collectionCloner(*this, iConfig, true)
+  , originalTrackSource_  (iConfig.getParameter<edm::InputTag>("originalSource"),consumesCollector())
+  , minQuality_           (reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("minQuality")) )
+{    
+  
+  originalMVAValsToken_  = consumes<MVACollection>        (iConfig.getParameter<edm::InputTag>("originalMVAVals") );
+  originalQualValsToken_ = consumes<QualityMaskCollection>(iConfig.getParameter<edm::InputTag>("originalQualVals"));
+
+  produces<MVACollection>("MVAValues");
+  produces<QualityMaskCollection>("QualityMasks");
+
+
+}
+
+TrackCollectionFilterCloner::~TrackCollectionFilterCloner()
+{
+}
+
+void TrackCollectionFilterCloner::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+
+  TrackCollectionCloner::Producer producer(iEvent, collectionCloner);
+ 
+  // load original tracks
+  auto const & originalsTracks = originalTrackSource_.tracks(iEvent);
+  //  auto const & originalIndices = originalTrackSource_.indicesInput(iEvent);
+  auto nTracks = originalsTracks.size();
+
+  edm::Handle<MVACollection> originalMVAStore;
+  iEvent.getByToken(originalMVAValsToken_,originalMVAStore);
+  assert((*originalMVAStore).size()==nTracks);
+
+  edm::Handle<QualityMaskCollection> originalQualStore;
+  iEvent.getByToken(originalQualValsToken_,originalQualStore);
+  assert((*originalQualStore).size()==nTracks);
+
+  // define minimum quality as set in the config file
+  unsigned char qualMask = ~0;
+  if (minQuality_!=reco::TrackBase::undefQuality) qualMask = 1<<minQuality_; 
+
+  // products
+  std::vector<unsigned int> selId;
+  auto pmvas  = std::make_unique<MVACollection>();
+  auto pquals = std::make_unique<QualityMaskCollection>();                     
+
+  auto k=0U;
+  for (auto j=0U; j<nTracks; ++j) {
+    if (! (qualMask&(* originalQualStore)[j]) ) continue;
+
+    selId.push_back(j);
+    pmvas->push_back((*originalMVAStore) [j]);
+    pquals->push_back((*originalQualStore) [j]);
+
+    ++k;
+  }
+
+  // clone selected tracks...
+  auto nsel = k;
+  auto isel = 0U;
+  assert(producer.selTracks_->size()==isel);
+  producer(originalTrackSource_,selId);
+  assert(producer.selTracks_->size()==nsel);
+
+  for (;isel<nsel;++isel) {
+    auto & otk = (*producer.selTracks_)[isel];
+    otk.setQualityMask( (*pquals)[isel] );
+  }  
+  assert(producer.selTracks_->size()==pmvas->size() );
+  assert(producer.selTracks_->size()==pquals->size());
+  
+  iEvent.put(std::move(pmvas),"MVAValues");
+  iEvent.put(std::move(pquals),"QualityMasks");
+
+
+}
+
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(TrackCollectionFilterCloner);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -53,8 +53,8 @@ class TrackCollectionFilterCloner final : public edm::global::EDProducer<> {
   TrackCollectionCloner collectionCloner;
   const TrackCollectionCloner::Tokens originalTrackSource_;
 
-  edm::EDGetTokenT<MVACollection>         originalMVAValsToken_;
-  edm::EDGetTokenT<QualityMaskCollection> originalQualValsToken_;
+  const edm::EDGetTokenT<MVACollection>         originalMVAValsToken_;
+  const edm::EDGetTokenT<QualityMaskCollection> originalQualValsToken_;
 
   const reco::TrackBase::TrackQuality minQuality_; 
 
@@ -90,12 +90,11 @@ void TrackCollectionFilterCloner::fillDescriptions(edm::ConfigurationDescription
 TrackCollectionFilterCloner::TrackCollectionFilterCloner(const edm::ParameterSet& iConfig) :
   collectionCloner(*this, iConfig, true)
   , originalTrackSource_  (iConfig.getParameter<edm::InputTag>("originalSource"),consumesCollector())
+  , originalMVAValsToken_  (consumes<MVACollection>        (iConfig.getParameter<edm::InputTag>("originalMVAVals") ) )
+  , originalQualValsToken_ (consumes<QualityMaskCollection>(iConfig.getParameter<edm::InputTag>("originalQualVals")) )
   , minQuality_           (reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("minQuality")) )
 {    
   
-  originalMVAValsToken_  = consumes<MVACollection>        (iConfig.getParameter<edm::InputTag>("originalMVAVals") );
-  originalQualValsToken_ = consumes<QualityMaskCollection>(iConfig.getParameter<edm::InputTag>("originalQualVals"));
-
   produces<MVACollection>("MVAValues");
   produces<QualityMaskCollection>("QualityMasks");
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -51,12 +51,12 @@ class TrackCollectionFilterCloner final : public edm::global::EDProducer<> {
   
 
   TrackCollectionCloner collectionCloner;
-  TrackCollectionCloner::Tokens originalTrackSource_;
+  const TrackCollectionCloner::Tokens originalTrackSource_;
 
   edm::EDGetTokenT<MVACollection>         originalMVAValsToken_;
   edm::EDGetTokenT<QualityMaskCollection> originalQualValsToken_;
 
-  reco::TrackBase::TrackQuality minQuality_; 
+  const reco::TrackBase::TrackQuality minQuality_; 
 
 };
 }

--- a/RecoTracker/FinalTrackSelectors/src/TrackCollectionCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackCollectionCloner.cc
@@ -1,5 +1,10 @@
 #include "RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h"
 
+void 
+TrackCollectionCloner::fill(edm::ParameterSetDescription& desc) {
+  desc.addUntracked<bool>("copyExtras",      true);
+  desc.addUntracked<bool>("copyTrajectories",true);  
+}
 
 TrackCollectionCloner::Producer::Producer(edm::Event& ievt, TrackCollectionCloner const & cloner) :
   copyExtras_(cloner.copyExtras_), copyTrajectories_(cloner.copyTrajectories_), evt(ievt)  {


### PR DESCRIPTION
this PR is meant for
1. add a new EDProducer which creates track collection after having applied a selection based on the track quality
2. add the fill function to the already existing TrackCollectionCloner in order to have its parameters set by the fillDescription method of EDModules which make use of the TrackCollectionCloner

this PR is needed for HLT developments for 2016
@VinInn @rovere @Martin-Grunewald @perrotta 
