### PR TITLE
Fix a bug in ShiftedJetProducerT

### DIFF
--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -114,7 +114,7 @@ template <typename T, typename Textractor>
       evt.getByToken(jetCorrTokenUpToL3Res_, jetCorrUpToL3Res);
     }
     
-    std::auto_ptr<JetCollection> shiftedJets(new JetCollection);
+    std::unique_ptr<JetCollection> shiftedJets(new JetCollection);
 
     
     if ( jetCorrPayloadName_ != "" ) {
@@ -178,7 +178,7 @@ template <typename T, typename Textractor>
       shiftedJets->push_back(shiftedJet);
     }
 
-    evt.put(shiftedJets);
+    evt.put(std::move(shiftedJets));
   }
 
   std::string moduleLabel_;

--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -105,14 +105,18 @@ template <typename T, typename Textractor>
 
     edm::Handle<JetCollection> originalJets;
     evt.getByToken(srcToken_, originalJets);
+    
     edm::Handle<reco::JetCorrector> jetCorrUpToL3;
-    evt.getByToken(jetCorrTokenUpToL3_, jetCorrUpToL3);
     edm::Handle<reco::JetCorrector> jetCorrUpToL3Res;
+    
     if ( evt.isRealData() && addResidualJES_ ) {
+      evt.getByToken(jetCorrTokenUpToL3_, jetCorrUpToL3);
       evt.getByToken(jetCorrTokenUpToL3Res_, jetCorrUpToL3Res);
     }
+    
     std::auto_ptr<JetCollection> shiftedJets(new JetCollection);
 
+    
     if ( jetCorrPayloadName_ != "" ) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
       es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);


### PR DESCRIPTION
This pull request fixes a bug in the [ShiftedJetProducerT](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h). The plugin attempts to read a jet corrector from an event even when the corrector is never used (which is the case when the flag `addResidualJES` is set to false).

The problem was introduced in commit b89c7e0f863706799d7603f658edbb2ad01580a3. In commit 745d210cbf0b0dbd346c5ad5475f069b3839e88e it was fixed for accessing one of the two jet correctors but not the other.
