### PR TITLE
Speeding up Seeding

### DIFF
--- a/DataFormats/Math/interface/approx_asin.h
+++ b/DataFormats/Math/interface/approx_asin.h
@@ -79,6 +79,15 @@ inline float unsafe_asin71(float x) {
   return  pihalf - unsafe_acos71<DEGREE>(x);
 }
 
+template<int DEGREE>
+inline float unsafe_asin(float x) {
+  return (x<0.71f) ? unsafe_asin07<DEGREE>(x) : unsafe_asin71<DEGREE>(x);
+}
+
+template<int DEGREE>
+inline float unsafe_acos(float x) {
+  return (x<0.71f) ? unsafe_acos07<DEGREE>(x) :	unsafe_acos71<DEGREE>(x);
+}
 
 
 #endif

--- a/DataFormats/Math/interface/approx_asin.h
+++ b/DataFormats/Math/interface/approx_asin.h
@@ -81,12 +81,12 @@ inline float unsafe_asin71(float x) {
 
 template<int DEGREE>
 inline float unsafe_asin(float x) {
-  return (x<0.71f) ? unsafe_asin07<DEGREE>(x) : unsafe_asin71<DEGREE>(x);
+  return (std::abs(x)<0.71f) ? unsafe_asin07<DEGREE>(x) : unsafe_asin71<DEGREE>(x);
 }
 
 template<int DEGREE>
 inline float unsafe_acos(float x) {
-  return (x<0.71f) ? unsafe_acos07<DEGREE>(x) :	unsafe_acos71<DEGREE>(x);
+  return (std::abs(x)<0.71f) ? unsafe_acos07<DEGREE>(x) :	unsafe_acos71<DEGREE>(x);
 }
 
 

--- a/DataFormats/Math/interface/approx_atan2.h
+++ b/DataFormats/Math/interface/approx_atan2.h
@@ -99,7 +99,6 @@ inline float unsafe_atan2f_impl(float y, float x) {
 
   return ( (y < 0)) ? - angle : angle ;
 
-
 }
 
 template<int DEGREE>
@@ -108,11 +107,11 @@ inline float unsafe_atan2f(float y, float x) {
 
 }
 
+
 template<int DEGREE>
 inline float safe_atan2f(float y, float x) {
   return unsafe_atan2f_impl<DEGREE>( y, (y==0.f)&(x==0.f) ? 0.2f :  x);
   // return (y==0.f)&(x==0.f) ? 0.f :  unsafe_atan2f_impl<DEGREE>( y, x);
-
 }
 
 

--- a/DataFormats/Math/test/arc.cpp
+++ b/DataFormats/Math/test/arc.cpp
@@ -32,6 +32,8 @@ int main() {
       << unsafe_acos07<5>(std::cos(c)) << ' '
       << unsafe_asin71<5>(std::sin(c)) << ' '
       << unsafe_acos71<5>(std::cos(c)) << ' '
+      << unsafe_asin<5>(std::sin(c)) << ' '
+      << unsafe_acos<5>(std::cos(c)) << ' '
       << std::endl;
 
    return 0;

--- a/Geometry/TrackerGeometryBuilder/test/TrackerDigiGeometryAnalyzer.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerDigiGeometryAnalyzer.cc
@@ -51,6 +51,10 @@
 // class decleration
 //
 
+
+// #define PRINT(X) edm::LogInfo(X)
+#define PRINT(X) std::cout << X << ':'
+
 class TrackerDigiGeometryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
@@ -79,43 +83,42 @@ void
 TrackerDigiGeometryAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
 
-   edm::LogInfo("TrackerDigiGeometryAnalyzer")<< "Here I am";
+   PRINT("TrackerDigiGeometryAnalyzer")<< "Here I am";
    //
    // get the TrackerGeom
    //
    edm::ESHandle<TrackerGeometry> pDD;
    iSetup.get<TrackerDigiGeometryRecord>().get( pDD );     
-   edm::LogInfo("TrackerDigiGeometryAnalyzer")<< " Geometry node for TrackerGeom is  "<<&(*pDD);   
-   edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" I have "<<pDD->detUnits().size() <<" detectors";
-   edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" I have "<<pDD->detTypes().size() <<" types";
+   PRINT("TrackerDigiGeometryAnalyzer")<< " Geometry node for TrackerGeom is  "<<&(*pDD) <<'\n';   
+   PRINT("TrackerDigiGeometryAnalyzer")<<" I have "<<pDD->detUnits().size() <<" detectors"<<'\n';
+   PRINT("TrackerDigiGeometryAnalyzer")<<" I have "<<pDD->detTypes().size() <<" types"<<'\n';
 
-   for(TrackingGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
-       if(dynamic_cast<const PixelGeomDetUnit*>((*it))!=0){
-	const BoundPlane& p = (dynamic_cast<const PixelGeomDetUnit*>((*it)))->specificSurface();
-	edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" RadLeng Pixel "<<p.mediumProperties().radLen();
-	edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" Xi Pixel "<<p.mediumProperties().xi();
+   for(auto const & it : pDD->detUnits()){
+       if(dynamic_cast<const PixelGeomDetUnit*>((it))!=0){
+	const BoundPlane& p = (dynamic_cast<const PixelGeomDetUnit*>((it)))->specificSurface();
+	PRINT("TrackerDigiGeometryAnalyzer") << it->geographicalId()
+              <<" RadLeng Pixel "<<p.mediumProperties().radLen()<<' ' <<" Xi Pixel "<<p.mediumProperties().xi()<<'\n';
        } 
 
-       if(dynamic_cast<const StripGeomDetUnit*>((*it))!=0){
-	const BoundPlane& s = (dynamic_cast<const StripGeomDetUnit*>((*it)))->specificSurface();
-	edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" RadLeng Strip "<<s.mediumProperties().radLen();
-	edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" Xi Strip "<<s.mediumProperties().xi();
+       if(dynamic_cast<const StripGeomDetUnit*>((it))!=0){
+	const BoundPlane& s = (dynamic_cast<const StripGeomDetUnit*>((it)))->specificSurface();
+	PRINT("TrackerDigiGeometryAnalyzer")<< it->geographicalId()
+             << " RadLeng Strip "<<s.mediumProperties().radLen() <<" Xi Strip "<<s.mediumProperties().xi()<<'\n';
        }
        
-       //analyseTrapezoidal(**it);
+       //analyseTrapezoidal(*it);
 
     }	
 
-   for (TrackingGeometry::DetTypeContainer::const_iterator it = pDD->detTypes().begin(); it != pDD->detTypes().end(); it ++){
-     if (dynamic_cast<const PixelGeomDetType*>((*it))!=0){
-       edm::LogInfo("TrackerDigiGeometryAnalyzer")<<" PIXEL Det";
-       const PixelTopology& p = (dynamic_cast<const PixelGeomDetType*>((*it)))->specificTopology();
-       edm::LogInfo("TrackerDigiGeometryAnalyzer")<<"    Rows    "<<p.nrows();
-       edm::LogInfo("TrackerDigiGeometryAnalyzer")<<"    Columns "<<p.ncolumns();
+   for (auto const & it  :pDD->detTypes() ){
+     if (dynamic_cast<const PixelGeomDetType*>((it))!=0){
+       const PixelTopology& p = (dynamic_cast<const PixelGeomDetType*>((it)))->specificTopology();
+       PRINT("TrackerDigiGeometryAnalyzer")<<" PIXEL Det " // << it->geographicalId()
+                      <<"    Rows    "<<p.nrows() <<"    Columns "<<p.ncolumns()<<'\n';
      }else{
-       edm::LogInfo("TrackerDigiGeometryAnalyzer") <<" STRIP Det";
-       const StripTopology& p = (dynamic_cast<const StripGeomDetType*>((*it)))->specificTopology();
-       edm::LogInfo("TrackerDigiGeometryAnalyzer")<<"    Strips    "<<p.nstrips();
+       const StripTopology& p = (dynamic_cast<const StripGeomDetType*>((it)))->specificTopology();
+       PRINT("TrackerDigiGeometryAnalyzer") <<" STRIP Det " // << it->geographicalId()
+                                            <<"    Strips    "<<p.nstrips()<<'\n';
      }
    }
 }

--- a/RecoPixelVertexing/PixelTriplets/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/BuildFile.xml
@@ -11,8 +11,9 @@
 <use   name="RecoTracker/TkSeedingLayers"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
 <use   name="RecoTracker/TkSeedGenerator"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>
 
-<flags   CXXFLAGS="-O3 -fno-math-errno"/>
+<flags   CXXFLAGS="-Ofast -fno-math-errno"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -74,8 +74,10 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   
   #ifdef __clang__
   std::vector<ThirdHitRZPrediction<PixelRecoLineRZ>> preds(size);
+  std::vector<ThirdHitCorrection> corrections(size);
   #else
   ThirdHitRZPrediction<PixelRecoLineRZ> preds[size];
+  ThirdHitCorrection corrections[size];
   #endif
   
   const RecHitsSortedInPhi * thirdHitMap[size];
@@ -101,7 +103,9 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
     ThirdHitRZPrediction<PixelRecoLineRZ> & pred = preds[il];
     pred.initLayer(thirdLayers[il].detLayer());
     pred.initTolerance(extraHitRZtolerance);
-    
+
+    corrections[il].init(es, region.ptMin(), *doublets.detLayer(HitDoublets::inner), *doublets.detLayer(HitDoublets::outer), *thirdLayers[il].detLayer(), useMScat, useBend);
+
     layerTree.clear();
     float minv=999999.0, maxv= -999999.0; // Initialise to extreme values in case no hits
     float maxErr=0.0f;
@@ -161,9 +165,11 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
       const DetLayer * layer = thirdLayers[il].detLayer();
       auto barrelLayer = layer->isBarrel();
 
-      ThirdHitCorrection correction(es, region.ptMin(), layer, line, point2, outSeq, useMScat, useBend); 
+      auto & correction = corrections[il];
+
+      correction.init(line, point2, outSeq); 
       
-      ThirdHitRZPrediction<PixelRecoLineRZ> & predictionRZ =  preds[il];
+      auto & predictionRZ =  preds[il];
       
       predictionRZ.initPropagator(&line);
       Range rzRange = predictionRZ();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -97,14 +97,15 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   float maxphi = Geom::ftwoPi(), minphi = -maxphi; // increase to cater for any range
   
   // fill the prediction vector
-  for (int il=0; il!=size; ++il) {
+  for (int il=0; il<size; ++il) {
     thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
     auto const & hits = *thirdHitMap[il];
     ThirdHitRZPrediction<PixelRecoLineRZ> & pred = preds[il];
     pred.initLayer(thirdLayers[il].detLayer());
     pred.initTolerance(extraHitRZtolerance);
 
-    corrections[il].init(es, region.ptMin(), *doublets.detLayer(HitDoublets::inner), *doublets.detLayer(HitDoublets::outer), *thirdLayers[il].detLayer(), useMScat, useBend);
+    corrections[il].init(es, region.ptMin(), *doublets.detLayer(HitDoublets::inner), *doublets.detLayer(HitDoublets::outer), 
+                         *thirdLayers[il].detLayer(), useMScat, useBend);
 
     layerTree.clear();
     float minv=999999.0, maxv= -999999.0; // Initialise to extreme values in case no hits

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -35,6 +35,7 @@ namespace {
     ThirdHitRZPrediction<PixelRecoLineRZ> line;
     ThirdHitRZPrediction<HelixRZ> helix1, helix2;
     MatchedHitRZCorrectionFromBending rzPositionFixup;
+    ThirdHitCorrection correction;
   };
 }
 
@@ -126,7 +127,9 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
     predRZ.helix1.initTolerance(extraHitRZtolerance);
     predRZ.helix2.initTolerance(extraHitRZtolerance);
     predRZ.rzPositionFixup = MatchedHitRZCorrectionFromBending(layer,tTopo);
-    
+    predRZ.correction.init(es, region.ptMin(), *doublets.detLayer(HitDoublets::inner), *doublets.detLayer(HitDoublets::outer), *thirdLayers[il].detLayer(), useMScat, false);
+
+
     layerTree.clear();
     float minv=999999.0; float maxv = -999999.0; // Initialise to extreme values in case no hits
     float maxErr=0.0f;
@@ -176,11 +179,14 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       bool barrelLayer = layer->isBarrel();
       
       Range curvature = generalCurvature;
-      ThirdHitCorrection correction(es, region.ptMin(), layer, line, point2,  outSeq, useMScat);
-      
+
       LayerRZPredictions &predRZ = mapPred[il];
       predRZ.line.initPropagator(&line);
-      
+
+      auto & correction = predRZ.correction;
+      correction.init(line, point2,  outSeq);
+
+
       Range rzRange;
       if (useBend) {
         // For the barrel region:

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
@@ -1,7 +1,8 @@
 #include "ThirdHitCorrection.h"
 
-#include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"
-#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
+
 
 using namespace pixelrecoutilities;
 
@@ -9,44 +10,95 @@ namespace {
   template <class T> inline T sqr( T t) {return t*t;}
 }
 
-//namespace pixelrecoutilities { class LongitudinalBendingCorrection; }
-//class MultipleScatteringParametrisation;
-//  const MultipleScatteringParametrisation * theScattering;
-//  const pixelrecoutilities::LongitudinalBendingCorrection * theBenging;
-
 using pixelrecoutilities::LongitudinalBendingCorrection;
 
-void ThirdHitCorrection::init(const edm::EventSetup& es, 
-			      float pt,
-			      const DetLayer * layer,
-			      const PixelRecoLineRZ & line,
-			      const PixelRecoPointRZ & constraint, int il,
-			      bool useMultipleScattering,
-			      bool useBendingCorrection) {
-  
+
+
+void ThirdHitCorrection::init(
+      const edm::EventSetup &es,
+      float pt,
+      const DetLayer & layer3,
+      bool useMultipleScattering,
+      bool useBendingCorrection) {
+
   theUseMultipleScattering = useMultipleScattering;
   theUseBendingCorrection = useBendingCorrection;
-  theLine = line;
-  theMultScattCorrRPhi =0;
+  if (useBendingCorrection)  theBendingCorrection.init(pt,es);
+
+  theMultScattCorrRPhi=0;
   theMScoeff=0;
 
-  theBarrel = layer->isBarrel();
+  theBarrel = layer3.isBarrel();
+  thePt = pt;
+  outLayer = &layer3;
 
-  if (theUseMultipleScattering) {
-    MultipleScatteringParametrisation sigmaRPhi(layer, es);
-    theMultScattCorrRPhi = 3.f*sigmaRPhi(pt, line.cotLine(), constraint, il);
+  if (theUseMultipleScattering) sigmaRPhi.init(&layer3,es);
+}
+
+
+
+void
+ThirdHitCorrection::init(
+      const edm::EventSetup &es,
+      float pt,
+      const DetLayer & layer1,
+      const DetLayer & layer2,
+      const DetLayer & layer3,
+      bool useMultipleScattering,
+      bool useBendingCorrection) {
+
+  init(es,pt,layer3, useMultipleScattering, useBendingCorrection);
+
+  if (!theUseMultipleScattering) return;
+
+  auto point3 = [&]()->PixelRecoPointRZ { 
+    if(theBarrel) {
+      const BarrelDetLayer& bl = static_cast<const BarrelDetLayer&>(layer3);
+      float rLayer = bl.specificSurface().radius();
+      auto zmax = 0.5f*layer3.surface().bounds().length();
+      return PixelRecoPointRZ(rLayer, zmax);
+    } else {
+      const ForwardDetLayer &fl = static_cast<const ForwardDetLayer&>(layer3);
+      auto maxR = fl.specificSurface().outerRadius();
+      auto layerZ = layer3.position().z();
+      return PixelRecoPointRZ(maxR, layerZ);
+    }
+  };
+
+  PixelRecoPointRZ zero(0., 0.);
+  SimpleLineRZ line(zero,point3());
+ 
+  auto point2 = [&]()->PixelRecoPointRZ {
+    if (layer2.isBarrel()) {
+      const BarrelDetLayer& bl = static_cast<const BarrelDetLayer&>(layer2);
+      float rLayer = bl.specificSurface().radius();
+      return PixelRecoPointRZ(rLayer, line.zAtR(rLayer));
+    } else {
+      auto layerZ = layer2.position().z();
+      return PixelRecoPointRZ(line.rAtZ(layerZ), layerZ);
+    }
+  };
+
+  theMultScattCorrRPhi = 3.f*sigmaRPhi(pt, line.cotLine(), point2(), layer2.seqNum());
+}
+
+void ThirdHitCorrection::init( 
+      const PixelRecoLineRZ & line,
+      const PixelRecoPointRZ & constraint, int il) {
+
+  if (!theUseMultipleScattering) return;
+
+    // auto newCorr = theMultScattCorrRPhi;
+    theMultScattCorrRPhi = 3.f*sigmaRPhi(thePt, line.cotLine(), constraint, il);
+    // std::cout << "ThirdHitCorr " << theMultScattCorrRPhi << ' ' << newCorr << ' ' << newCorr/theMultScattCorrRPhi << std::endl;
     float overSinTheta = std::sqrt(1.f+sqr(line.cotLine()));
     if (theBarrel) {
       theMScoeff =  theMultScattCorrRPhi*overSinTheta; 
     } else {
       float overCosTheta = std::abs(line.cotLine()) < 1.e-4f ? 
           1.e4f : overSinTheta/std::abs(line.cotLine());
-      theMScoeff =  theMultScattCorrRPhi*overCosTheta;
-      
+      theMScoeff =  theMultScattCorrRPhi*overCosTheta;      
     }
-  }
-
-  if (useBendingCorrection)  theBendingCorrection.init(pt,es);
 
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
@@ -30,7 +30,6 @@ void ThirdHitCorrection::init(
 
   theBarrel = layer3.isBarrel();
   thePt = pt;
-  outLayer = &layer3;
 
   if (theUseMultipleScattering) sigmaRPhi.init(&layer3,es);
 }
@@ -86,11 +85,12 @@ void ThirdHitCorrection::init(
       const PixelRecoLineRZ & line,
       const PixelRecoPointRZ & constraint, int il) {
 
+  theLine = line;
   if (!theUseMultipleScattering) return;
 
     // auto newCorr = theMultScattCorrRPhi;
     theMultScattCorrRPhi = 3.f*sigmaRPhi(thePt, line.cotLine(), constraint, il);
-    // std::cout << "ThirdHitCorr " << theMultScattCorrRPhi << ' ' << newCorr << ' ' << newCorr/theMultScattCorrRPhi << std::endl;
+    // std::cout << "ThirdHitCorr " << (theBarrel ? "B " : "F " )<< theMultScattCorrRPhi << ' ' << newCorr << ' ' << newCorr/theMultScattCorrRPhi << std::endl;
     float overSinTheta = std::sqrt(1.f+sqr(line.cotLine()));
     if (theBarrel) {
       theMScoeff =  theMultScattCorrRPhi*overSinTheta; 

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
@@ -3,6 +3,7 @@
 
 namespace edm {class EventSetup; }
 #include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
 
 class DetLayer;
 
@@ -17,6 +18,25 @@ public:
 
   ThirdHitCorrection(){}
 
+  void init(
+      const edm::EventSetup &es,
+      float pt,
+      const DetLayer & layer1,
+      const DetLayer & layer2,
+      const DetLayer & layer3,
+      bool useMultipleScattering,
+      bool useBendingCorrection
+  );
+
+  void init(
+      const edm::EventSetup &es,
+      float pt,
+      const DetLayer & layer3,
+      bool useMultipleScattering,
+      bool useBendingCorrection
+  );
+
+
   ThirdHitCorrection( 
       const edm::EventSetup &es, 
       float pt, 
@@ -24,20 +44,15 @@ public:
       const PixelRecoLineRZ & line,
       const PixelRecoPointRZ & constraint, int ol,
       bool useMultipleScattering,
-      bool useBendingCorrection = false) 
+      bool useBendingCorrection) 
   { 
-    init(es, pt, layer, line, constraint, ol, useMultipleScattering, useBendingCorrection);
+    init(es, pt, *layer, useMultipleScattering, useBendingCorrection);
+    init(line, constraint, ol);
   }
 
   void init( 
-	    const edm::EventSetup &es, 
-      float pt, 
-      const DetLayer * layer,
       const PixelRecoLineRZ & line,
-      const PixelRecoPointRZ & constraint, int ol,
-      bool useMultipleScattering,
-      bool useBendingCorrection = false);
-
+      const PixelRecoPointRZ & constraint, int ol);
 
  
   void correctRPhiRange( Range & range) const {
@@ -56,8 +71,11 @@ private:
   PixelRecoLineRZ theLine;
   float theMultScattCorrRPhi=0;
   float theMScoeff=0;
+  float thePt;
+  const DetLayer * outLayer=nullptr;
 
   pixelrecoutilities::LongitudinalBendingCorrection theBendingCorrection;
+  MultipleScatteringParametrisation sigmaRPhi;
   
 };
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
@@ -72,7 +72,6 @@ private:
   float theMultScattCorrRPhi=0;
   float theMScoeff=0;
   float thePt;
-  const DetLayer * outLayer=nullptr;
 
   pixelrecoutilities::LongitudinalBendingCorrection theBendingCorrection;
   MultipleScatteringParametrisation sigmaRPhi;

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
@@ -11,6 +11,13 @@
 
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
 
+#include "DataFormats/Math/interface/approx_atan2.h"
+namespace {
+  inline
+  float f_atan2f(float y, float x) { return unsafe_atan2f<7>(y,x); }
+  template<typename V> inline float f_phi(V v) { return f_atan2f(v.y(),v.x());}
+}
+
 namespace {
   template <class T> inline T sqr( T t) {return t*t;}
 }
@@ -79,7 +86,7 @@ ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius, int icharge) const
     findPointAtCurve(radius,ipv[i],u[i],v[i]);
 
   // 
-  Scalar phi1 = theRotation.rotateBack(Point2D(u[0],v[0])).barePhi();
+  Scalar phi1 = f_phi(theRotation.rotateBack(Point2D(u[0],v[0])));
   Scalar phi2 = phi1+(v[1]-v[0]); 
   
   if (ip.empty()) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
@@ -102,55 +102,6 @@ ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius, int icharge) const
 }
 
 
-namespace {
-
-  // original from chephes single precision version
-  template<typename T>
-  inline T atan2_fast( T y, T x ) {
-  
-   constexpr T PIO4F = 0.7853981633974483096;
-   constexpr T PIF = 3.141592653589793238;
-   constexpr T PIO2F = 1.5707963267948966192;
-
-    // move in first octant
-    T xx = std::abs(x);
-    T yy = std::abs(y);
-    T tmp = T(0);
-    if (yy>xx) {
-      tmp = yy;
-      yy=xx; xx=tmp;
-    }
-    T t=yy/xx;
-    T z = 
-      ( t > T(0.4142135623730950) ) ?  // * tan pi/8 
-      (t-T(1.0))/(t+T(1.0)) : t;
-     
-
-    //printf("%e %e %e %e\n",yy,xx,t,z);
-    T z2 = z * z;
-    T ret = // (y==0) ? 0 :  // no protection for (0,0)
-      (((  T(8.05374449538e-2) * z2
-	   - T(1.38776856032E-1)) * z2
-	+ T(1.99777106478E-1)) * z2
-       - T(3.33329491539E-1)) * z2 * z
-      + z;
-
-    // move back in place
-    if( t > T(0.4142135623730950) ) ret += PIO4F;
-    if (tmp!=0) ret = PIO2F - ret;
-    if (x<0) ret = PIF - ret;
-    if (y<0) ret = -ret;
-    
-    return ret;
-
-  }
-
-
-
-
-}
-
-
 ThirdHitPredictionFromInvParabola::Range
 ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius) const
 {
@@ -182,25 +133,12 @@ ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius) const
   for (int i=0; i<2; ++i) {
     auto x =  xr[0]*u[i] + yr[0]*v[i];
     auto y =  xr[1]*u[i] + yr[1]*v[i];
-    phi1[i] = atan2_fast(y,x);
+    phi1[i] = f_atan2f(y,x);
     phi2[i] = phi1[i]+(v[i+2]-v[i]); 
   }
 
 
   return getRange(phi1[1],phi2[1],emptyM).sum(getRange(phi1[0],phi2[0],emptyP));
-
-  /*
-  Scalar phi1P = theRotation.rotateBack(Point2D(u[0],v[0])).barePhi();
-  Scalar phi2P= phi1P+(v[2]-v[0]); 
-
-  Scalar phi1M = theRotation.rotateBack(Point2D(u[1],v[1])).barePhi();
-  Scalar phi2M = phi1M+(v[3]-v[1]); 
-
-
-  return getRange(phi1M,phi2M,emptyM).sum(getRange(phi1P,phi2P,emptyP));
-
-  */
-
 }
 
 

--- a/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
@@ -8,15 +8,49 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
+#include<iostream>
+#include<algorithm>
+
 // there are tons of safety checks.
 // Try to move all of the out the regular control flow using gcc magic
+namespace {
+  struct Stat {
+
+   float xmin=1.1;
+   float xmax=-1.1;
+   int nt=0;
+   int nn=0;
+   int nl=0;
+
+   ~Stat() { std::cout << "ASIN " << xmin <<',' << xmax <<',' << nt <<','<< nn <<','<< nl << std::endl;}
+
+  };
+
+  Stat stat;
+
+}
+
+namespace {
+  template <class T> 
+  inline T cropped_asin(T x) {
+    stat.nt++;
+    if (x<0.f) stat.nn++;
+    if (x>0.7f) stat.nl++;
+    stat.xmin = std::min(float(x),stat.xmin);
+    stat.xmax =	std::max(float(x),stat.xmax);
+    
+    return std::abs(x) <= 1 ? std::asin(x) : (x > 0 ? T(M_PI/2) : -T(M_PI/2));
+  }
+}
 
 
 namespace {
   template<class T> inline T sqr(T t) { return t * t; }
   template<class T> inline T sgn(T t) { return std::signbit(t) ? -T(1.) : T(1.); }
-  template<class T> inline T clamped_acos(T t)
-  { return unlikely(t <= T(-1)) ? T(M_PI) : unlikely(t >= T(1)) ? T(0) : std::acos(t); }
+  template<class T> inline T clamped_acos(T x) {
+    return T(M_PI/2) - cropped_asin(x);
+  }
+//  { return unlikely(t <= T(-1)) ? T(M_PI) : unlikely(t >= T(1)) ? T(0) : std::acos(t); }
   template<class T> inline T clamped_sqrt(T t)
   { return likely(t > 0) ? std::sqrt(t) : T(0); }
 }

--- a/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
@@ -11,6 +11,8 @@
 #include<iostream>
 #include<algorithm>
 
+#include "DataFormats/Math/interface/approx_asin.h"
+
 // there are tons of safety checks.
 // Try to move all of the out the regular control flow using gcc magic
 namespace {
@@ -48,11 +50,11 @@ namespace {
   template<class T> inline T sqr(T t) { return t * t; }
   template<class T> inline T sgn(T t) { return std::signbit(t) ? -T(1.) : T(1.); }
   template<class T> inline T clamped_acos(T x) {
-    return T(M_PI/2) - cropped_asin(x);
+    x = std::min(T(1.),std::max(-T(1.),x));
+    return unsafe_acos<5>(x);
   }
-//  { return unlikely(t <= T(-1)) ? T(M_PI) : unlikely(t >= T(1)) ? T(0) : std::acos(t); }
-  template<class T> inline T clamped_sqrt(T t)
-  { return likely(t > 0) ? std::sqrt(t) : T(0); }
+
+  template<class T> inline T clamped_sqrt(T t) { return std::sqrt(std::max(T(0),t)); }
 }
 
 ThirdHitPredictionFromCircle::ThirdHitPredictionFromCircle( 

--- a/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
@@ -15,34 +15,11 @@
 
 // there are tons of safety checks.
 // Try to move all of the out the regular control flow using gcc magic
+#include "DataFormats/Math/interface/approx_atan2.h"
 namespace {
-  struct Stat {
-
-   float xmin=1.1;
-   float xmax=-1.1;
-   int nt=0;
-   int nn=0;
-   int nl=0;
-
-   ~Stat() { std::cout << "ASIN " << xmin <<',' << xmax <<',' << nt <<','<< nn <<','<< nl << std::endl;}
-
-  };
-
-  Stat stat;
-
-}
-
-namespace {
-  template <class T> 
-  inline T cropped_asin(T x) {
-    stat.nt++;
-    if (x<0.f) stat.nn++;
-    if (x>0.7f) stat.nl++;
-    stat.xmin = std::min(float(x),stat.xmin);
-    stat.xmax =	std::max(float(x),stat.xmax);
-    
-    return std::abs(x) <= 1 ? std::asin(x) : (x > 0 ? T(M_PI/2) : -T(M_PI/2));
-  }
+  inline
+  float f_atan2f(float y, float x) { return unsafe_atan2f<7>(y,x); }
+  template<typename V> inline float f_phi(V v) { return f_atan2f(v.y(),v.x());}
 }
 
 
@@ -81,9 +58,9 @@ float ThirdHitPredictionFromCircle::phi(float curvature, float radius) const
     float orthog = clamped_sqrt(radius2 - delta2);
     Basic2DVector<float> lcenter = Basic2DVector<float>(center) - sign * orthog *  Basic2DVector<float>(axis);
     float rc2 = lcenter.mag2();
-    float cos = (rc2 + sqr(radius) - radius2) /
-      (2.f *std:: sqrt(rc2) * radius);
-    phi = lcenter.barePhi() + sign * clamped_acos(cos);
+    float r2 = sqr(radius);
+    float cos = (rc2 + r2 - radius2)/std::sqrt(4.f*rc2*r2);
+    phi = f_phi(lcenter) + sign * clamped_acos(cos);
  }
 
   while(unlikely(phi >= float(M_PI))) phi -= float(2. * M_PI);

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -39,6 +39,7 @@ pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = cms.InputTag(
 pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 0.6
 pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 0.015
 pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.fixedError = 0.03
+pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.useMultipleScattering = True
 pixelPairStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('pixelPairStepSeedLayers')
 
 pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(

--- a/RecoTracker/TkDetLayers/BuildFile.xml
+++ b/RecoTracker/TkDetLayers/BuildFile.xml
@@ -10,3 +10,4 @@
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="FWCore/MessageLogger"/>
+<use   name="TrackingTools/KalmanUpdators"/>

--- a/RecoTracker/TkDetLayers/BuildFile.xml
+++ b/RecoTracker/TkDetLayers/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <export>
   <lib   name="1"/>
 </export>
@@ -10,4 +11,3 @@
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="TrackingTools/KalmanUpdators"/>

--- a/RecoTracker/TkDetLayers/src/TkDetUtil.cc
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.cc
@@ -4,6 +4,13 @@
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
+#include "DataFormats/Math/interface/approx_atan2.h"
+
+namespace {
+  inline
+  float f_atan2f(float y, float x) { return unsafe_atan2f<9>(y,x); }
+}
+
 namespace tkDetUtil {
 
   float computeWindowSize( const GeomDet* det, 
@@ -35,18 +42,20 @@ namespace tkDetUtil {
       if (y0<maxDistance.y() && x0<maxDistance.x()) return M_PI;
 
       if (y0>maxDistance.y()) {
-        auto phimax = std::atan2(y0 + (x0<maxDistance.x() ? -maxDistance.y() : maxDistance.y()), x0 - maxDistance.x() );
-        auto phimin = std::atan2(y0 - maxDistance.y(), x0 + maxDistance.x() );
-        if (phimin>phimax) std::cout << "phimess x " << phimin<<','<<phimax << " " << x0 << ',' << maxDistance.x() << " " << y0 << ',' << maxDistance.y() << std::endl;
+        auto phimax = f_atan2f(y0 + (x0<maxDistance.x() ? -maxDistance.y() : maxDistance.y()), x0 - maxDistance.x() );
+        auto phimin = f_atan2f(y0 - maxDistance.y(), x0 + maxDistance.x() );
+        // if (phimin>phimax) std::cout << "phimess x " << phimin<<','<<phimax << " " << x0 << ',' << maxDistance.x() << " " << y0 << ',' << maxDistance.y() << std::endl;
         dphi=phimax-phimin;
       } else {
-        auto phimax = std::atan2(x0 - maxDistance.x(), -y0 - maxDistance.y() );
-        auto phimin = std::atan2(x0 - maxDistance.x(), -y0 + maxDistance.y() );
-        if (phimin>phimax) std::cout << "phimess y  " << phimin<<','<<phimax << std::endl;
+        auto phimax = f_atan2f(x0 - maxDistance.x(), -y0 - maxDistance.y() );
+        auto phimin = f_atan2f(x0 - maxDistance.x(), -y0 + maxDistance.y() );
+        // if (phimin>phimax) std::cout << "phimess y  " << phimin<<','<<phimax << std::endl;
         dphi=phimax-phimin;
       }
       return dphi;
     }
+
+    // generic algo
     float corners[]  =  { plane.toGlobal(LocalPoint( start.x()+maxDistance.x(), start.y()+maxDistance.y() )).barePhi(),
 			  plane.toGlobal(LocalPoint( start.x()-maxDistance.x(), start.y()+maxDistance.y() )).barePhi(),
 			  plane.toGlobal(LocalPoint( start.x()-maxDistance.x(), start.y()-maxDistance.y() )).barePhi(),

--- a/RecoTracker/TkDetLayers/src/TkDetUtil.cc
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-
 namespace tkDetUtil {
 
   float computeWindowSize( const GeomDet* det, 
@@ -12,19 +11,42 @@ namespace tkDetUtil {
 			   const MeasurementEstimator& est)
   {
     const Plane& startPlane = det->surface();  
-    MeasurementEstimator::Local2DVector maxDistance = 
-      est.maximalLocalDisplacement( tsos, startPlane);
+    auto maxDistance =  est.maximalLocalDisplacement( tsos, startPlane);
     return calculatePhiWindow( maxDistance, tsos, startPlane);
   }
 
 
   float 
-  calculatePhiWindow( const MeasurementEstimator::Local2DVector& maxDistance, 
+  calculatePhiWindow( const MeasurementEstimator::Local2DVector & imaxDistance, 
 		      const TrajectoryStateOnSurface& ts, 
 		      const Plane& plane)
   {
-    
+    MeasurementEstimator::Local2DVector maxDistance(std::abs(imaxDistance.x()),std::abs(imaxDistance.y()));
+
+    constexpr float tollerance=1.e-6;
     LocalPoint start = ts.localPosition();
+    //     std::cout << "plane z " << plane.normalVector() << std::endl;
+    float dphi=0;
+    if likely(std::abs(1.f-std::abs(plane.normalVector().z()))<tollerance) {
+      auto ori = plane.toLocal(GlobalPoint(0.,0.,0.));
+      auto x0 = std::abs(start.x() - ori.x());
+      auto y0 = std::abs(start.y() - ori.y());
+      
+      if (y0<maxDistance.y() && x0<maxDistance.x()) return M_PI;
+
+      if (y0>maxDistance.y()) {
+        auto phimax = std::atan2(y0 + (x0<maxDistance.x() ? -maxDistance.y() : maxDistance.y()), x0 - maxDistance.x() );
+        auto phimin = std::atan2(y0 - maxDistance.y(), x0 + maxDistance.x() );
+        if (phimin>phimax) std::cout << "phimess x " << phimin<<','<<phimax << " " << x0 << ',' << maxDistance.x() << " " << y0 << ',' << maxDistance.y() << std::endl;
+        dphi=phimax-phimin;
+      } else {
+        auto phimax = std::atan2(x0 - maxDistance.x(), -y0 - maxDistance.y() );
+        auto phimin = std::atan2(x0 - maxDistance.x(), -y0 + maxDistance.y() );
+        if (phimin>phimax) std::cout << "phimess y  " << phimin<<','<<phimax << std::endl;
+        dphi=phimax-phimin;
+      }
+      return dphi;
+    }
     float corners[]  =  { plane.toGlobal(LocalPoint( start.x()+maxDistance.x(), start.y()+maxDistance.y() )).barePhi(),
 			  plane.toGlobal(LocalPoint( start.x()-maxDistance.x(), start.y()+maxDistance.y() )).barePhi(),
 			  plane.toGlobal(LocalPoint( start.x()-maxDistance.x(), start.y()-maxDistance.y() )).barePhi(),
@@ -40,7 +62,7 @@ namespace tkDetUtil {
     }
     float phiWindow = phimax - phimin;
     if ( phiWindow < 0.) { phiWindow +=  2.*Geom::pi();}
-    
+    // std::cout << "phiWindow " << phiWindow << ' ' << dphi << ' ' << dphi-phiWindow  << std::endl;
     return phiWindow;
   }
 

--- a/RecoTracker/TkDetLayers/test/BuildFile.xml
+++ b/RecoTracker/TkDetLayers/test/BuildFile.xml
@@ -4,6 +4,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="RecoTracker/TkDetLayers"/>
 <use   name="Geometry/Records"/>
-<flags   EDM_PLUGIN="1"/>
-# <library   file="TkDetLayersAnalyzer.cc" name="testRecoTrackerTkDetLayers">
-#</library>
+<flags   EDM_PLUGIN="1"/> 
+<library   file="TkDetLayersAnalyzer.cc" name="testRecoTrackerTkDetLayers">
+</library>

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -218,12 +218,32 @@ TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
   }
 
 
+    // ------------- END -------------------------
+
 
   
   // -------- here it constructs the whole GeometricSearchTracker --------------
   GeometricSearchTrackerBuilder myTrackerBuilder;
   GeometricSearchTracker* testTracker = myTrackerBuilder.build( &(*pDD),&(*pTrackerGeometry), &(*tTopo));
   edm::LogInfo("TkDetLayersAnalyzer") << "testTracker: " << testTracker ;
+
+  for (auto const & l : testTracker->allLayers()) {
+     auto const & layer = *l;
+     std::cout << layer.seqNum() << ' ' << layer.subDetector() << ' ' << layer.basicComponents().size() <<'\n';
+     //auto mx = std::minmax_element (layer.basicComponents().begin(),layer.basicComponents().end(),[](    );
+      auto m_min(std::numeric_limits<float>::max());
+      auto m_max(std::numeric_limits<float>::min());
+     for (auto const & c : layer.basicComponents()) {
+       auto const &det = *c;
+       auto xi = det.specificSurface().mediumProperties().xi();
+       m_min=std::min(m_min,xi);m_max=std::max(m_max,xi);
+       // std::cout <<  det.specificSurface().mediumProperties().xi() <<',';
+     }	
+     std::cout << "xi " << m_min<<'/'<<m_max;
+     std::cout << std::endl;
+
+  }
+
 
 
   // ------------- END -------------------------

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -15,6 +15,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
@@ -116,8 +117,9 @@ TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
     << " And Contains  Daughters: "<< (*pDD).components().size() ;   
 
   ESHandle<TrackerTopology> tTopo;
-  iSetup.get<IdealGeometryRecord>().get(tTopo);
+  iSetup.get<TrackerTopologyRcd>().get(tTopo);
 
+  /*
 
   // -------- here it constructs only a TOBLayer -------------------------
   vector<const GeometricDet*> geometricDetLayers = (*pDD).components();
@@ -136,6 +138,8 @@ TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
 
   edm::LogInfo("TkDetLayersAnalyzer") << "this Tob layer has: " << geometricDetTOBlayer->components().size() << " daughter" ;
 
+  */
+  
   /*
     vector<const GeometricDet*> geometricDetTOBlayer3Strings = geometricDetTOBlayer3->components();
     for(vector<const GeometricDet*>::const_iterator it=geometricDetTOBlayer3Strings.begin();
@@ -148,9 +152,13 @@ TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
     }
   */
   
+
+   /*
   TOBLayerBuilder myTOBBuilder;
   TOBLayer* testTOBLayer = myTOBBuilder.build(geometricDetTOBlayer,&(*pTrackerGeometry),&(*tTopo));
   edm::LogInfo("TkDetLayersAnalyzer") << "testTOBLayer: " << testTOBLayer;
+
+  */
   // ------------- END -------------------------
 
 
@@ -214,8 +222,10 @@ TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
   
   // -------- here it constructs the whole GeometricSearchTracker --------------
   GeometricSearchTrackerBuilder myTrackerBuilder;
-  GeometricSearchTracker* testTracker = myTrackerBuilder.build( &(*pDD),&(*pTrackerGeometry));
+  GeometricSearchTracker* testTracker = myTrackerBuilder.build( &(*pDD),&(*pTrackerGeometry), &(*tTopo));
   edm::LogInfo("TkDetLayersAnalyzer") << "testTracker: " << testTracker ;
+
+
   // ------------- END -------------------------
   
 

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.py
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.py
@@ -6,23 +6,24 @@ process.maxEvents = cms.untracked.PSet(  input = cms.untracked.int32(1) )
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load("Configuration.StandardSequences.Reconstruction_cff")
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = 'STARTUP_V1::All'
-process.GlobalTag.globaltag = 'IDEAL_V9::All'
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'DEBUG'
-process.MessageLogger.categories = ('TkDetLayers')
+# process.MessageLogger.categories = ['TkDetLayers']
 process.MessageLogger.debugModules = ['analyzer']
-process.MessageLogger.cerr.DEBUG = cms.untracked.PSet(
+#process.MessageLogger.cerr.DEBUG = cms.untracked.PSet(
 #    threshold = cms.untracked.string('DEBUG'),
-    default          = cms.untracked.PSet( limit = cms.untracked.int32(0)  ),
-    TkDetLayers = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
-    )
+#    default          = cms.untracked.PSet( limit = cms.untracked.int32(0)  )
+#    TkDetLayers = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
+#    )
 
 #cat debug | grep -v MSG | grep -v "Run:" | grep -v analyzer > debug.readable
 

--- a/RecoTracker/TkHitPairs/BuildFile.xml
+++ b/RecoTracker/TkHitPairs/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags   CXXFLAGS="-Ofast"/>
+
 <use   name="clhep"/>
 <use   name="boost"/>
 <use   name="RecoTracker/Record"/>

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -112,6 +112,7 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& regio
   // constexpr float nSigmaRZ = std::sqrt(12.f);
   constexpr float nSigmaPhi = 3.f;
   for (int io = 0; io!=int(outerHitsMap.theHits.size()); ++io) {
+    if (!deltaPhi.prefilter(outerHitsMap.x[io],outerHitsMap.y[io])) continue;
     Hit const & ohit =  outerHitsMap.theHits[io].hit();
     PixelRecoRange<float> phiRange = deltaPhi(outerHitsMap.x[io],
 					      outerHitsMap.y[io],

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -43,20 +43,22 @@ namespace {
 }
 
 namespace {
-  // valid only for 0<x<0.5
+  // valid only for |x|<0.5 then degrades...
   template<typename T>
-  inline T f_asin05f(T x)  {
-    x = x>0 ? x : 0;
-    x = x> 0.5f ? 0.5f : x;
+  inline T f_asin05f(T xx)  {
+    auto x = xx>0 ? xx : -xx;
+    // x = x> 0.5f ? 0.5f : x;
 
     auto z = x * x;
     
-    return (((( 4.2163199048E-2f * z
+    z =  (((( 4.2163199048E-2f * z
             + 2.4181311049E-2f) * z
             + 4.5470025998E-2f) * z
             + 7.4953002686E-2f) * z
             + 1.6666752422E-1f) * z * x
             + x;
+
+    return xx>0 ? z : -z;
   }
 
   typedef float __attribute__( ( vector_size( 16 ) ) ) float32x4_t;
@@ -196,23 +198,23 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
   // this factor should be taken in computation of eror projection
   auto cosCross = std::abs( dHit.unit().dot(crossing.unit()));
 
-  /*
+  
   float32x4_t num{dHitmag,dLayer,theROrigin * (dHitmag-dLayer),1.f};
   float32x4_t den{2*theRCurvature,2*theRCurvature,dHitmag*dLayer,1.f};
   auto phis = f_asin05f(num/den);
   phis = phis*dLayer/(rLayer*cosCross);
   auto deltaPhi = std::abs(phis[0]-phis[1]);
   auto deltaPhiOrig = phis[2];
-  */
   
+  /*
   auto alphaHit = cropped_asin( dHitmag/(2*theRCurvature)); 
-  auto deltaPhi = std::abs( alphaHit - cropped_asin( dLayer/(2*theRCurvature)));
-  deltaPhi *= dLayer/(rLayer*cosCross);  
+  auto OdeltaPhi = std::abs( alphaHit - cropped_asin( dLayer/(2*theRCurvature)));
+  OdeltaPhi *= dLayer/(rLayer*cosCross);  
   // compute additional delta phi due to origin radius
-  auto deltaPhiOrig = cropped_asin( theROrigin * (dHitmag-dLayer) / (dHitmag*dLayer));
-  deltaPhiOrig *= dLayer/(rLayer*cosCross);
-  // std::cout << "dphi " << OdeltaPhi<<'/'<<OdeltaPhiOrig << ' ' << deltaPhi<<'/'<<deltaPhiOrig << std::endl;
-  
+  auto OdeltaPhiOrig = cropped_asin( theROrigin * (dHitmag-dLayer) / (dHitmag*dLayer));
+  OdeltaPhiOrig *= dLayer/(rLayer*cosCross);
+  std::cout << "dphi " << OdeltaPhi<<'/'<<OdeltaPhiOrig << ' ' << deltaPhi<<'/'<<deltaPhiOrig << std::endl;
+  */
 
   // additinal angle due to not perpendicular stright line crossing  (for displaced beam)
   //  double dPhiCrossing = (cosCross > 0.9999) ? 0 : dL *  sqrt(1-sqr(cosCross))/ rLayer;

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -64,6 +64,7 @@ namespace {
 namespace {
   inline
   float f_atan2f(float y, float x) { return unsafe_atan2f<7>(y,x); }
+  template<typename V> inline float f_phi(V v) { return f_atan2f(v.y(),v.x());}
 }
 
 namespace {
@@ -237,8 +238,8 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
   // additinal angle due to not perpendicular stright line crossing  (for displaced beam)
   //  double dPhiCrossing = (cosCross > 0.9999) ? 0 : dL *  sqrt(1-sqr(cosCross))/ rLayer;
   Point2D crossing2 = theVtx + dHit.unit()* (dLayer+dL);
-  auto phicross2 = f_atan2f(crossing2.y(),crossing2.x());  
-  auto phicross1 = f_atan2f(crossing.y(),crossing.x());
+  auto phicross2 = f_phi(crossing2);
+  auto phicross1 = f_phi(crossing);
   auto dphicross = phicross2-phicross1;
   if (dphicross < -float(M_PI)) dphicross += float(2*M_PI);
   if (dphicross >  float(M_PI)) dphicross -= float(2*M_PI);

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -43,22 +43,14 @@ namespace {
 }
 
 namespace {
-  // valid only for |x|<0.5 then degrades...
+  // reasonable (5.e-4) only for |x|<0.7 then degrades..
   template<typename T>
-  inline T f_asin05f(T xx)  {
-    auto x = xx>0 ? xx : -xx;
-    // x = x> 0.5f ? 0.5f : x;
+  inline T f_asin07f(T x)  {
 
-    auto z = x * x;
-    
-    z =  (((( 4.2163199048E-2f * z
-            + 2.4181311049E-2f) * z
-            + 4.5470025998E-2f) * z
-            + 7.4953002686E-2f) * z
-            + 1.6666752422E-1f) * z * x
-            + x;
+   auto ret = 
+       1.f + (x*x) * (0.157549798488616943359375f + (x*x)*0.125192224979400634765625f);
 
-    return xx>0 ? z : -z;
+   return x*ret;
   }
 
   typedef float __attribute__( ( vector_size( 16 ) ) ) float32x4_t;
@@ -71,7 +63,7 @@ namespace {
 
 namespace {
   inline
-  float f_atan2f(float y, float x) { return unsafe_atan2f<9>(y,x); }
+  float f_atan2f(float y, float x) { return unsafe_atan2f<7>(y,x); }
 }
 
 namespace {
@@ -201,7 +193,7 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
   
   float32x4_t num{dHitmag,dLayer,theROrigin * (dHitmag-dLayer),1.f};
   float32x4_t den{2*theRCurvature,2*theRCurvature,dHitmag*dLayer,1.f};
-  auto phis = f_asin05f(num/den);
+  auto phis = f_asin07f(num/den);
   phis = phis*dLayer/(rLayer*cosCross);
   auto deltaPhi = std::abs(phis[0]-phis[1]);
   auto deltaPhiOrig = phis[2];

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -6,7 +6,11 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionBase.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
+#include "DataFormats/Math/interface/ExtVec.h"
 
+#if !defined(__INTEL_COMPILER)
+#define USE_VECTORS_HERE
+#endif
 
 using namespace std;
 
@@ -56,10 +60,6 @@ namespace {
 
    return x*ret;
   }
-
-#if defined(__GNUC__) 
-  typedef float __attribute__( ( vector_size( 16 ) ) ) float32x4_t;
-#endif
 
 }
 
@@ -222,7 +222,7 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
     dL = theThickness/cosCross; 
   }
 
-#if defined(__GNUC__) 
+#ifdef USE_VECTORS_HERE 
   float32x4_t num{dHitmag,dLayer,theROrigin * (dHitmag-dLayer),1.f};
   float32x4_t den{2*theRCurvature,2*theRCurvature,dHitmag*dLayer,1.f};
   auto phis = f_asin07f(num/den);
@@ -230,7 +230,7 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
   auto deltaPhi = std::abs(phis[0]-phis[1]);
   auto deltaPhiOrig = phis[2];
 #else
-//  #warning no vector!  
+#warning no vector!  
   auto alphaHit = cropped_asin( dHitmag/(2*theRCurvature)); 
   auto OdeltaPhi = std::abs( alphaHit - cropped_asin( dLayer/(2*theRCurvature)));
   OdeltaPhi *= dLayer/(rLayer*cosCross);  

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
@@ -2,12 +2,15 @@
 #define InnerDeltaPhi_H
 
 /** predict phi bending in layer for the tracks constratind by outer hit r-z */ 
-#include <fstream>
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
+
+#include "FWCore/Utilities/interface/Visibility.h"
+#include "FWCore/Utilities/interface/Likely.h"
+
+
 
 class DetLayer;
 template<class T> class PixelRecoRange;
@@ -26,19 +29,26 @@ public:
                  float extraTolerance = 0.f);
 
 
+  bool prefilter( float xHit, float yHit) const {
+   return xHit*xHit + yHit*yHit > theRLayer*theRLayer;
+  }
+
   PixelRecoRange<float> operator()( float xHit, float yHit, float zHit, float errRPhi) const {
     return phiRange( Point2D(xHit,yHit), zHit, errRPhi); 
   }
 
 private:
 
-  bool theRDefined;
+  bool innerIsBarrel;
+  bool outerIsBarrel;
   bool thePrecise;
   int ol;
 
   float theROrigin;
   float theRLayer;
   float theThickness;
+  float theScatt0;
+  float theDeltaScatt;
 
   float theRCurvature;
   float theExtraTolerance;
@@ -58,9 +68,10 @@ private:
 
   void initBarrelLayer( const DetLayer& layer);
   void initForwardLayer( const DetLayer& layer, float zMinOrigin, float zMaxOrigin);
+  void initBarrelMS(const DetLayer& outLayer);
+  void initForwardMS(const DetLayer& outLayer);
 
   PixelRecoRange<float> phiRange( const Point2D & hitXY, float zHit, float errRPhi) const;
-  float minRadius( float hitR, float hitZ) const;
 
 };
 

--- a/RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h
+++ b/RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h
@@ -26,9 +26,17 @@ public:
   enum X0Source { useDetLayer=0, useX0AtEta=1, useX0DataAveraged=2 };
   enum Consecutive { notAssumeConsecutive, useConsecutive };
 
+  MultipleScatteringParametrisation(){}
+
   MultipleScatteringParametrisation( const DetLayer* layer, 
 				     const edm::EventSetup &iSetup,
-                                     X0Source x0source = useX0AtEta);
+                                     X0Source x0source = useX0AtEta) {
+       init(layer,iSetup,x0source);
+  }
+
+  void init( const DetLayer* layer, const edm::EventSetup &iSetup,
+        X0Source x0source = useX0AtEta);
+
 
 
   /// MS sigma  at the layer for which parametrisation is initialised;
@@ -68,7 +76,7 @@ public:
 private:
 
   MSLayer theLayer;
-  MSLayersKeeper const * theLayerKeeper;
+  MSLayersKeeper const * theLayerKeeper=nullptr;
   static const float x0ToSigma;
 
 };

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
@@ -52,10 +52,10 @@ void MultipleScatteringParametrisation::initKeepers(const edm::EventSetup &iSetu
 
 //using namespace PixelRecoUtilities;
 //----------------------------------------------------------------------
-MultipleScatteringParametrisation::
-MultipleScatteringParametrisation( const DetLayer* layer,const edm::EventSetup &iSetup, X0Source x0Source) :
-  theLayerKeeper(keepers(x0Source))
-{
+void MultipleScatteringParametrisation::
+init( const DetLayer* layer,const edm::EventSetup &iSetup, X0Source x0Source) {
+
+  theLayerKeeper = keepers(x0Source);
 
   // FIXME not thread safe: move elsewhere...
   initKeepers(iSetup);

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -319,6 +319,9 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
     SimpleLineRZ line(PixelRecoPointRZ(gp0.perp(),gp0.z()), PixelRecoPointRZ(gp1.perp(),gp1.z()));
     ThirdHitPredictionFromCircle predictionRPhi(gp0, gp1, extraHitRPhitolerance);
 
+    auto toPos = std::signbit(gp1.z()-gp0.z());
+
+
     //gc: this is the curvature of the two hits assuming the region
     Range pairCurvature = predictionRPhi.curvature(region.originRBound());
     //gc: intersect not only returns a bool but may change pairCurvature to intersection with curv
@@ -343,6 +346,9 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 
       const DetLayer *layer = thirdLayers[il].detLayer();
       bool barrelLayer = layer->location() == GeomDetEnumerators::barrel;
+
+      if ( (!barrelLayer) & (toPos != std::signbit(layer->position().z())) ) continue;
+
 
       LayerRZPredictions &predRZ = mapPred.find(thirdLayers[il].name())->second;
       predRZ.line.initPropagator(&line);

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -29,6 +29,7 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "CommonTools/Utils/interface/DynArray.h"
 
 #include <algorithm>
 #include <iostream>
@@ -169,11 +170,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   std::vector<KDTreeNodeInfo<RecHitsSortedInPhi::HitIter> > layerTree; // re-used throughout
   std::vector<RecHitsSortedInPhi::HitIter> foundNodes; // re-used thoughout
   foundNodes.reserve(100);
-  #ifdef __clang__
-  std::vector<KDTreeLinkerAlgo<RecHitsSortedInPhi::HitIter>> hitTree(size);
-  #else
-  KDTreeLinkerAlgo<RecHitsSortedInPhi::HitIter> hitTree[size];
-  #endif
+  declareDynArray(KDTreeLinkerAlgo<RecHitsSortedInPhi::HitIter>,size, hitTree);
   float rzError[size]; //save maximum errors
   double maxphi = Geom::twoPi(), minphi = -maxphi; //increase to cater for any range
 

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -20,10 +20,10 @@ public:
    *  in the transverse plane. 
    */
   GlobalTrackingRegion ( float ptMin, const GlobalPoint & origin, 
-      float originRadius, float originHalfLength, bool precise=false)
+      float originRadius, float originHalfLength, bool precise=false, bool useMS=false)
     :  TrackingRegionBase(GlobalVector( 0, 0, 0), origin,
       Range( -1/ptMin, 1/ptMin), originRadius, originHalfLength),
-      thePrecise(precise) { }
+      thePrecise(precise), theUseMS(useMS) { }
 
   // obsolete constructor
   GlobalTrackingRegion ( float ptMin = 1., float originRadius = 0.2, 
@@ -53,6 +53,7 @@ public:
   virtual std::string print() const;
 
 private:
-  bool  thePrecise;
+  bool  thePrecise=false;
+  bool  theUseMS=false;
 };
 #endif

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducerFromBeamSpot.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducerFromBeamSpot.h
@@ -30,6 +30,8 @@ public:
     theOriginHalfLength = (regionPSet.existsAs<double>("originHalfLength") ? regionPSet.getParameter<double>("originHalfLength") : 0.0);
     token_beamSpot      = iC.consumes<reco::BeamSpot>(regionPSet.getParameter<edm::InputTag>("beamSpot"));
     thePrecise          = regionPSet.getParameter<bool>("precise");
+    theUseMS           = (regionPSet.existsAs<bool>("useMultipleScattering") ? regionPSet.getParameter<bool>("useMultipleScattering") : false);
+
   }
 
   virtual ~GlobalTrackingRegionProducerFromBeamSpot(){}
@@ -45,7 +47,7 @@ public:
       GlobalPoint origin(bs.x0(), bs.y0(), bs.z0()); 
 
       result.push_back( std::make_unique<GlobalTrackingRegion>(
-          thePtMin, origin, theOriginRadius, std::max(theNSigmaZ*bs.sigmaZ(), theOriginHalfLength), thePrecise));
+          thePtMin, origin, theOriginRadius, std::max(theNSigmaZ*bs.sigmaZ(), theOriginHalfLength), thePrecise,theUseMS));
 
     }
     return result;
@@ -58,6 +60,7 @@ private:
   double theNSigmaZ;
   edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 
   bool thePrecise;
+  bool theUseMS;
 };
 
 #endif

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
@@ -26,6 +26,7 @@ public:
     theNSigmaZ          = regionPSet.getParameter<double>("nSigmaZ");
     token_beamSpot      = iC.consumes<reco::BeamSpot>(regionPSet.getParameter<edm::InputTag>("beamSpot"));
     thePrecise          = regionPSet.getParameter<bool>("precise"); 
+    theUseMS           = (regionPSet.existsAs<bool>("useMultipleScattering") ? regionPSet.getParameter<bool>("useMultipleScattering") : false);
 
     theSigmaZVertex     = regionPSet.getParameter<double>("sigmaZVertex");
     theFixedError       = regionPSet.getParameter<double>("fixedError");
@@ -65,17 +66,17 @@ public:
           if (iV->isFake() && !(theUseFakeVertices && theUseFixedError)) continue;
 	  GlobalPoint theOrigin_       = GlobalPoint(iV->x(),iV->y(),iV->z());
 	  double theOriginHalfLength_ = (theUseFixedError ? theFixedError : (iV->zError())*theSigmaZVertex); 
-	  result.push_back( std::make_unique<GlobalTrackingRegion>(thePtMin, theOrigin_, theOriginRadius, theOriginHalfLength_, thePrecise) );
+	  result.push_back( std::make_unique<GlobalTrackingRegion>(thePtMin, theOrigin_, theOriginRadius, theOriginHalfLength_, thePrecise, theUseMS) );
       }
       
       if (result.empty()) {
-        result.push_back( std::make_unique<GlobalTrackingRegion>(thePtMin, theOrigin, theOriginRadius, bsSigmaZ, thePrecise) );
+        result.push_back( std::make_unique<GlobalTrackingRegion>(thePtMin, theOrigin, theOriginRadius, bsSigmaZ, thePrecise, theUseMS) );
       }
     }
     else
     {
       result.push_back(
-        std::make_unique<GlobalTrackingRegion>(thePtMin, theOrigin, theOriginRadius, bsSigmaZ, thePrecise) );
+        std::make_unique<GlobalTrackingRegion>(thePtMin, theOrigin, theOriginRadius, bsSigmaZ, thePrecise, theUseMS) );
     }
 
     return result;
@@ -90,6 +91,7 @@ private:
   double theSigmaZVertex;
   double theFixedError;
   bool thePrecise;
+  bool theUseMS;
   
   bool theUseFoundVertices;
   bool theUseFakeVertices;

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionFromBeamSpot_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionFromBeamSpot_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 RegionPsetFomBeamSpotBlock = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
-       	useMultipleScattering = cms.bool(True),
+       	useMultipleScattering = cms.bool(False),
         nSigmaZ = cms.double(4.0),
         originRadius = cms.double(0.2),
         ptMin = cms.double(0.9),
@@ -14,7 +14,7 @@ RegionPsetFomBeamSpotBlock = cms.PSet(
 RegionPsetFomBeamSpotBlockFixedZ = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
-       	useMultipleScattering = cms.bool(True),
+       	useMultipleScattering = cms.bool(False),
         originHalfLength = cms.double(21.2),
         originRadius = cms.double(0.2),
         ptMin = cms.double(0.9),

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionFromBeamSpot_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionFromBeamSpot_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 RegionPsetFomBeamSpotBlock = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
+       	useMultipleScattering = cms.bool(True),
         nSigmaZ = cms.double(4.0),
         originRadius = cms.double(0.2),
         ptMin = cms.double(0.9),
@@ -13,6 +14,7 @@ RegionPsetFomBeamSpotBlock = cms.PSet(
 RegionPsetFomBeamSpotBlockFixedZ = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
+       	useMultipleScattering = cms.bool(True),
         originHalfLength = cms.double(21.2),
         originRadius = cms.double(0.2),
         ptMin = cms.double(0.9),

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
@@ -1,27 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-# moving to block.  Will delete this one
-# when transition is done
-# NO: must be completely removed, as the CFI is included at top level
-#     otherwise we get duplicate definitions
-# PSet RegionPSet = {
-#   double ptMin = 0.9
-#   double originRadius = 0.2
-#   double nSigmaZ = 3.0
-#   InputTag beamSpot = "offlineBeamSpot"
-#   bool precise = true
-# 
-#   bool useFoundVertices =  true
-#   string VertexCollection = "pixelVertices"
-# 
-#   double sigmaZVertex = 3.0
-#   bool useFixedError = true
-#   double fixedError = 0.2
-# }
 RegionPSetWithVerticesBlock = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
-        useMultipleScattering = cms.bool(True),
+        useMultipleScattering = cms.bool(False),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         useFixedError = cms.bool(True),
         originRadius = cms.double(0.2),

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
@@ -21,6 +21,7 @@ import FWCore.ParameterSet.Config as cms
 RegionPSetWithVerticesBlock = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
+        useMultipleScattering = cms.bool(True),
         beamSpot = cms.InputTag("offlineBeamSpot"),
         useFixedError = cms.bool(True),
         originRadius = cms.double(0.2),

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegion_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegion_cfi.py
@@ -15,6 +15,7 @@ import FWCore.ParameterSet.Config as cms
 RegionPSetBlock = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
+       	useMultipleScattering = cms.bool(True),
         originHalfLength = cms.double(21.2),
         originRadius = cms.double(0.2),
         originYPos = cms.double(0.0),

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegion_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegion_cfi.py
@@ -1,21 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-# deprecated.  Changing over to the block
-# NO: must be completely removed, as the CFI is included at top level
-# otherwise we get duplicate definitions
-# PSet RegionPSet = {
-#   double ptMin = 0.9
-#   double originRadius = 0.2
-#   double originHalfLength = 15.9
-#   double originXPos = 0.0
-#   double originYPos = 0.0
-#   double originZPos = 0.0
-#   bool precise = true
-# }
 RegionPSetBlock = cms.PSet(
     RegionPSet = cms.PSet(
         precise = cms.bool(True),
-       	useMultipleScattering = cms.bool(True),
+       	useMultipleScattering = cms.bool(False),
         originHalfLength = cms.double(21.2),
         originRadius = cms.double(0.2),
         originYPos = cms.double(0.0),

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -43,8 +43,8 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
   bool isPixel = (layer->subDetector() == PixelBarrel || layer->subDetector() == PixelEndcap);
   
   if unlikely(!outerlayer) {
-      GlobalPoint ohit =  outerHit->globalPosition();
-	lr = sqrt( sqr(ohit.x()-origin().x())+sqr(ohit.y()-origin().y()) );
+        GlobalPoint ohit =  outerHit->globalPosition();
+        lr = std::sqrt( sqr(ohit.x()-origin().x())+sqr(ohit.y()-origin().y()) );
 	gz = ohit.z();
 	dr = outerHit->errorGlobalR();
 	dz = outerHit->errorGlobalZ();
@@ -62,8 +62,8 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
     : PixelRecoPointRZ( originRBound(), origin().z()-originZBound()); 
 
   if unlikely((!thePrecise) &&(isPixel )) {
-    double VcotMin = PixelRecoLineRZ( vtxR, outerred).cotLine();
-    double VcotMax = PixelRecoLineRZ( vtxL, outerred).cotLine();
+    auto VcotMin = PixelRecoLineRZ( vtxR, outerred).cotLine();
+    auto VcotMax = PixelRecoLineRZ( vtxL, outerred).cotLine();
     return new HitEtaCheck(isBarrel, outerred, VcotMax, VcotMin);
   }
   
@@ -71,9 +71,9 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
  
   dr *= nSigmaPhi;
   dz *= nSigmaPhi;
-  PixelRecoPointRZ  outerL, outerR;
 
-  if (layer->isBarrel()) {
+  PixelRecoPointRZ  outerL, outerR;
+  if (isBarrel) {
     outerL = PixelRecoPointRZ(lr, gz-dz);
     outerR = PixelRecoPointRZ(lr, gz+dz);
   } 
@@ -86,45 +86,32 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
     outerR = PixelRecoPointRZ(lr+dr, gz);
   }
   
-  // MultipleScatteringParametrisation iSigma(layer,iSetup);
-  PixelRecoPointRZ vtxMean(0.,origin().z());
+  auto corr = isBarrel ? dz : dr;
 
-  /*
-  float innerScatt=0;
-  if (outerlayer) {
-    innerScatt = 3.f * iSigma( ptMin(), vtxMean, outerred);
-    float anew = 3.f * iSigma( ptMin(), vtxMean, outerred, outerlayer->seqNum());
-    if (std::abs( (innerScatt-anew)/innerScatt) > .05)  
-    std::cout << "MS old/new in " << outerlayer->seqNum() << " " << layer->seqNum()
-              << ": " << innerScatt <<  " / " <<   anew
-             << std::endl;
-  } else
-  innerScatt = 3.f * iSigma( ptMin(), vtxMean, outerred);
-  */
-
-
-  float innerScatt = 0.;
-  /*
-  3.f * ( outerlayer ?
-     iSigma( ptMin(), vtxMean, outerred, outerlayer->seqNum())
-    :  iSigma( ptMin(), vtxMean, outerred) ) ;
-  */
-
-  //
-  //
-  //
   SimpleLineRZ leftLine( vtxL, outerL);
   SimpleLineRZ rightLine( vtxR, outerR);
   HitRZConstraint rzConstraint(leftLine, rightLine);
-  float cotTheta = SimpleLineRZ(vtxMean,outerred).cotLine();
 
-  if (isBarrel) {
-    float sinTheta = 1/std::sqrt(1+sqr(cotTheta));
-    float corrZ = innerScatt/sinTheta + dz;
-    return new HitZCheck(rzConstraint, HitZCheck::Margin(corrZ,corrZ));
-  } else {
-    float cosTheta = 1/std::sqrt(1+sqr(1/cotTheta));
-    float corrR = innerScatt/cosTheta + dr;
-    return new HitRCheck( rzConstraint, HitRCheck::Margin(corrR,corrR));
+
+  if unlikely(theUseMS) {
+    MultipleScatteringParametrisation iSigma(layer,iSetup);
+    PixelRecoPointRZ vtxMean(0.,origin().z());
+
+    float innerScatt = 3.f * ( outerlayer ?
+     iSigma( ptMin(), vtxMean, outerred, outerlayer->seqNum())
+    :  iSigma( ptMin(), vtxMean, outerred) ) ;
+  
+    float cotTheta = SimpleLineRZ(vtxMean,outerred).cotLine();
+
+    if (isBarrel) {
+      float sinTheta = 1/std::sqrt(1+sqr(cotTheta));
+      corr = innerScatt/sinTheta + dz;
+     } else {
+      float cosTheta = 1/std::sqrt(1+sqr(1/cotTheta));
+      corr = innerScatt/cosTheta + dr;
+    }
   }
+
+  return isBarrel ? (HitRZCompatibility*)(new HitZCheck(rzConstraint, HitZCheck::Margin(corr,corr))) :
+                    (HitRZCompatibility*)(new HitRCheck(rzConstraint, HitRCheck::Margin(corr,corr)));
 }

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -86,7 +86,7 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
     outerR = PixelRecoPointRZ(lr+dr, gz);
   }
   
-  MultipleScatteringParametrisation iSigma(layer,iSetup);
+  // MultipleScatteringParametrisation iSigma(layer,iSetup);
   PixelRecoPointRZ vtxMean(0.,origin().z());
 
   /*
@@ -103,10 +103,12 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
   */
 
 
-  float innerScatt = 3.f * ( outerlayer ?
+  float innerScatt = 0.;
+  /*
+  3.f * ( outerlayer ?
      iSigma( ptMin(), vtxMean, outerred, outerlayer->seqNum())
     :  iSigma( ptMin(), vtxMean, outerred) ) ;
-
+  */
 
   //
   //


### PR DESCRIPTION
Major speedup of seeding (33%)
Besides usual numerical performance improvements obtained reducing accuracy, the major contribution to the speed up are:
1) remove MultipleScattering (MS) contribution from GlobalRegion but for PixelPairs
2) use average MS for doublet-building
3) do not consider a forward layer if the doublet points in the opposite direction (sic)
this last improvement shows that some more pre-filtering at doublet-level may produce even more speedup....

minor regression observed in ttbar PU15
http://innocent.home.cern.ch/innocent/RelVal/pu15_80_msSpeed21/
(out of the box does not work due to a bug whose correction is still pending..)
my personal opinion is that on the tracking side it does not look worse than before

took the opportunity for some cleanup
