### PR TITLE
Fix addUserInt and addUserFloat with multiple values on the same key

### DIFF
--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -65,6 +65,7 @@ namespace edm {
       const_iterator & operator +=(difference_type d) { i += d; return *this; }
       const_iterator & operator -=(difference_type d) { i -= d; return *this; }
       reference operator[](difference_type d) const { return *const_iterator(i+d); } // for boost::iterator_range []
+      typename base::const_iterator base_iter() const { return i; }
     private:
       typename base::const_iterator i;
     };
@@ -136,6 +137,17 @@ namespace edm {
     template <typename D> void push_back(D* const& d);
     template <typename D> void push_back(std::auto_ptr<D> d);
     void push_back(T const& valueToCopy);
+
+    template <typename D> void set(size_t i, D*& d);
+    template <typename D> void set(size_t i, D* const & d);
+    template <typename D> void set(size_t i, std::auto_ptr<D> d);
+    void set(size_t i, T const& valueToCopy);
+
+    template <typename D> void insert(const_iterator i, D*& d);
+    template <typename D> void insert(const_iterator i, D* const & d);
+    template <typename D> void insert(const_iterator i, std::auto_ptr<D> d);
+    void insert(const_iterator i, T const& valueToCopy);
+
     bool is_back_safe() const;
     void pop_back();
     reference back();
@@ -308,6 +320,70 @@ namespace edm {
   inline void OwnVector<T, P>::push_back(T const& d) {
     data_.push_back(policy_type::clone(d));
   }
+
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::set(size_t i, D*& d) {
+    // see push_back for documentation
+    if (d == data_[i]) return; 
+    delete data_[i];
+    data_[i] = d;
+    d = 0;
+  }
+
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::set(size_t i, D* const& d) {
+    // see push_back for documentation
+    if (d == data_[i]) return; 
+    delete data_[i];
+    data_[i] = d;
+  }
+
+
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::set(size_t i, std::auto_ptr<D> d) {
+    if (d.get() == data_[i]) return; 
+    delete data_[i];
+    data_[i] = d.release();
+  }
+
+
+  template<typename T, typename P>
+  inline void OwnVector<T, P>::set(size_t i, T const& d) {
+    if (&d == data_[i]) return; 
+    delete data_[i];
+    data_[i] = policy_type::clone(d);
+  }
+
+
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::insert(const_iterator it, D*& d) {
+    data_.insert(it.base_iter(), d);
+    d = 0;
+  }
+
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::insert(const_iterator it, D* const& d) {
+    data_.insert(it.base_iter(), d);
+  }
+
+
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::insert(const_iterator it, std::auto_ptr<D> d) {
+    data_.insert(it.base_iter(), d.release());
+  }
+
+
+  template<typename T, typename P>
+  inline void OwnVector<T, P>::insert(const_iterator it, T const& d) {
+    data_.insert(it.base_iter(), policy_type::clone(d));
+  }
+
 
 
   template<typename T, typename P>

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -46,7 +46,6 @@ namespace edm {
       typedef T const& reference;
       typedef ptrdiff_t difference_type;
       typedef typename base::const_iterator::iterator_category iterator_category;
-      const_iterator(typename base::const_iterator const& it) : i(it) { }
       const_iterator(iterator const& it) : i(it.i) { }
       const_iterator() {}
       const_iterator& operator++() { ++i; return *this; }
@@ -65,9 +64,11 @@ namespace edm {
       const_iterator & operator +=(difference_type d) { i += d; return *this; }
       const_iterator & operator -=(difference_type d) { i -= d; return *this; }
       reference operator[](difference_type d) const { return *const_iterator(i+d); } // for boost::iterator_range []
-      typename base::const_iterator base_iter() const { return i; }
     private:
+      const_iterator(typename base::const_iterator const& it) : i(it) { }
+      typename base::const_iterator base_iter() const { return i; }
       typename base::const_iterator i;
+      friend class OwnVector<T,P>;
     };
     class iterator {
     public:
@@ -76,7 +77,6 @@ namespace edm {
       typedef T & reference;
       typedef ptrdiff_t difference_type;
       typedef typename base::iterator::iterator_category iterator_category;
-      iterator(typename base::iterator const& it) : i(it) { }
       iterator() {}
       iterator& operator++() { ++i; return *this; }
       iterator operator++(int) { iterator ci = *this; ++i; return ci; }
@@ -96,6 +96,7 @@ namespace edm {
       iterator & operator -=(difference_type d) { i -= d; return *this; }
       reference operator[](difference_type d) const { return *iterator(i+d); } // for boost::iterator_range []
     private:
+      iterator(typename base::iterator const& it) : i(it) { }
       typename base::iterator i;
       friend class const_iterator;
       friend class OwnVector<T, P>;

--- a/DataFormats/Common/test/OwnVector_t.cpp
+++ b/DataFormats/Common/test/OwnVector_t.cpp
@@ -165,6 +165,44 @@ void take_an_auto_ptr()
   assert(p.get() == 0);
 }
 
+void set_at_index()
+{
+  edm::OwnVector<Base> v1;
+  Base* p = new Derived(100);
+  Base* backup = p;
+  v1.push_back(p);
+  assert(p == 0);
+  assert(&v1[0] == backup);
+  Base* p2 = new Derived(101);
+  Base* backup2 = p2;
+  assert(backup2 != backup);
+  v1.set(0, p2);
+  assert(p2 == 0);
+  assert(&v1[0] == backup2);
+}
+
+void insert_with_iter()
+{
+  edm::OwnVector<Base> v1;
+  Base *p[3], *backup[3];
+  for (int i = 0; i < 3; ++i) {
+      backup[i] = p[i] = new Derived(100+i);
+  }
+  v1.push_back(p[0]);
+  v1.push_back(p[2]);
+  v1.insert(v1.begin()+1, p[1]);
+  assert(p[0] == 0);
+  assert(p[1] == 0);
+  assert(p[2] == 0);
+  assert(&v1[0] == backup[0]);
+  assert(&v1[1] == backup[1]);
+  assert(&v1[2] == backup[2]);
+}
+
+
+
+
+
 int main()
 {
   edm::OwnVector<Base> vec;
@@ -184,4 +222,7 @@ int main()
   take_an_rvalue();
   take_an_lvalue();
   take_an_auto_ptr();
+
+  set_at_index();
+  insert_with_iter();
 }

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -307,13 +307,15 @@ namespace pat {
       /// unless transientOnly is set to true
       template<typename T>
       void addUserData( const std::string & label, const T & data, bool transientOnly=false, bool overwrite=false ) {
-        addUserDataObject_( label, pat::UserData::make<T>(data, transientOnly), overwrite );
+        std::auto_ptr<pat::UserData> made(pat::UserData::make<T>(data, transientOnly));
+        addUserDataObject_( label, made, overwrite );
       }
 
       /// Set user-defined data. To be used only to fill from ValueMap<Ptr<UserData>>
       /// Do not use unless you know what you are doing.
       void addUserDataFromPtr( const std::string & label, const edm::Ptr<pat::UserData> & data, bool overwrite=false ) {
-        addUserDataObject_( label, data->clone(), overwrite );
+        std::auto_ptr<pat::UserData> cloned(data->clone());
+        addUserDataObject_( label, cloned, overwrite );
       }
 
       /// Get user-defined float
@@ -455,7 +457,7 @@ namespace pat {
       /// if (kinResolutions_.size() == kinResolutionLabels_.size()+1), then the first resolution has no label.
       std::vector<std::string>            kinResolutionLabels_;
 
-      void addUserDataObject_( const std::string & label, pat::UserData * value, bool overwrite = false ) ;
+      void addUserDataObject_( const std::string & label, std::auto_ptr<pat::UserData> & value, bool overwrite = false ) ;
 
     private:
       const pat::UserData *  userDataObject_(const std::string &key) const ;
@@ -768,7 +770,7 @@ namespace pat {
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::addUserDataObject_( const std::string & label, pat::UserData * data, bool overwrite ) 
+  void PATObject<ObjectType>::addUserDataObject_( const std::string & label, std::auto_ptr<pat::UserData> & data, bool overwrite ) 
   {
     auto it = std::lower_bound(userDataLabels_.begin(), userDataLabels_.end(), label);
     const auto dist = std::distance(userDataLabels_.begin(), it);

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -891,8 +891,8 @@ namespace pat {
     } else if( overwrite ) {
       userCands_[dist] = data;
     } else {
-      edm::LogWarning("addUserCand") 
-        << "Attempting to add userCand " << label << " failed, Ptr exists already!";
+      userCandLabels_.insert(it+1,label);
+      userCands_.insert(userCands_.begin()+dist+1,data);
     }    
   }
 

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -344,7 +344,7 @@ namespace pat {
       /// returns a range of values corresponding to key
       std::vector<int> userIntRange( const std::string& key ) const;
       /// Set user-defined int
-      void addUserInt( const std::string & label,  int32_t data );
+      void addUserInt( const std::string & label,  int32_t data, const bool overwrite = false );
       /// Get list of user-defined int names
       const std::vector<std::string> & userIntNames() const  { return userIntLabels_; }
       /// Return true if there is a user-defined int with a given name
@@ -799,8 +799,11 @@ namespace pat {
     if( it == userFloatLabels_.end() || *it != label ) {      
       userFloatLabels_.insert(it,label);
       userFloats_.insert(userFloats_.begin()+dist,data);
-    } else if( *it == label  ) {
+    } else if( overwrite ) {
+      userFloats_[ dist ] = data;
+    } else {
       //create a range by adding behind the first entry
+      userFloatLabels_.insert(it+1,label);
       userFloats_.insert(userFloats_.begin()+dist+1, data); 
     }
   }
@@ -830,15 +833,19 @@ namespace pat {
 
   template <class ObjectType>
   void PATObject<ObjectType>::addUserInt( const std::string &label,
-                                          int data )
+                                          int data,
+                                          bool overwrite )
   {
     auto it = std::lower_bound(userIntLabels_.begin(),userIntLabels_.end(),label);
     const auto dist = std::distance(userIntLabels_.begin(),it);
     if( it == userIntLabels_.end() || *it != label ) { 
       userIntLabels_.insert(it,label);
       userInts_.insert(userInts_.begin()+dist,data);
-    } else if( *it == label ) {
+    } else if( overwrite ) {
+      userInts_[dist] = data;
+    } else {
       //create a range by adding behind the first entry
+      userIntLabels_.insert(it+1, label);
       userInts_.insert(userInts_.begin()+dist+1,data);
     }
   }
@@ -863,7 +870,7 @@ namespace pat {
     if( it == userCandLabels_.end() || *it != label ) {      
       userCandLabels_.insert(it,label);
       userCands_.insert(userCands_.begin()+dist,data);
-    } else if( overwrite && *it == label ) {
+    } else if( overwrite ) {
       userCands_[dist] = data;
     } else {
       edm::LogWarning("addUserCand") 


### PR DESCRIPTION
#11574 didn't implement correctly the cases of multiple values on the same key:
- `addUserFloat` was ignoring the `overwrite` parameter
- the `overwrite` parameter was not present in the `addUserInt`, only in `addUserFloat`
- when not overwriting, the code was inserting the new value but not inserting a duplicate label, that was causing the label vector and value vector to go off sync.

Should not affect MiniAOD production nor MiniAOD analysis, since I believe in those workflows we never write multiple values with the same key.

If the investigation of https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3435.html reveals further problems, I will add them in this PR.

Please have a look, if satisfactory I can make also 76X backport and, if needed by HI, 75X backport.

@lgray 
