### PR TITLE
Fixing AlCa Matrix 80X

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -1,23 +1,33 @@
-AlCaRecoMatrix = {'ExpressCosmics' : 'SiStripCalZeroBias+TkAlCosmics0T',
-                  'StreamExpress'  : 'SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+DtCalib+Hotline',
-                  'StreamExpressHI': 'SiStripCalZeroBias+TkAlMinBiasHI+SiStripPCLHistos+SiStripCalMinBias+DtCalibHI',
-                  'MinimumBias'    : 'SiStripCalMinBias+TkAlMinBias',
+AlCaRecoMatrix = {'AlCaLumiPixels' : 'LumiPixels',
+                  'Charmonium'     : 'TkAlJpsiMuMu',
                   'Commissioning'  : 'HcalCalIsoTrk',
-                  'SingleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+TkAlMuonIsolated+DtCalib',
-                  'DoubleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+DtCalib+TkAlZMuMu',
-                  'MuOnia'         : 'TkAlJpsiMuMu+TkAlUpsilonMuMu',
-                  'SingleElectron' : 'EcalCalWElectron+EcalUncalWElectron',
-                  'DoubleElectron' : 'EcalCalZElectron+EcalUncalZElectron',
-                  'AlCaLumiPixels' : 'LumiPixels',
-                  'DoubleMuParked' : 'MuAlCalIsolatedMu+MuAlOverlaps+DtCalib+TkAlZMuMu',
-                  'MuOniaParked'   : 'TkAlJpsiMuMu+TkAlUpsilonMuMu',
                   'Cosmics'        : 'TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics',
+                  'DoubleEG'       : 'EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym',
+                  'DoubleElectron' : 'EcalCalZElectron+EcalUncalZElectron',
+                  'DoubleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+DtCalib+TkAlZMuMu',
+                  'DoubleMuon'     : 'TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+DtCalib',
+                  'DoubleMuParked' : 'MuAlCalIsolatedMu+MuAlOverlaps+DtCalib+TkAlZMuMu',
+                  'HLTPhysics'     : 'SiStripCalMinBias+TkAlMinBias',
+                  'JetHT'          : 'HcalCalDijets',
+                  'MET'            : 'HcalCalNoise',
+                  'MinimumBias'    : 'SiStripCalMinBias+TkAlMinBias',
+                  'MuOnia'         : 'TkAlJpsiMuMu+TkAlUpsilonMuMu',
+                  'MuOniaParked'   : 'TkAlJpsiMuMu+TkAlUpsilonMuMu',
+                  'SingleElectron' : 'EcalCalWElectron+EcalUncalWElectron+EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym',
+                  'SingleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+TkAlMuonIsolated+DtCalib+MuAlZMuMu',
+                  'SingleMuon'     : 'TkAlMuonIsolated+DtCalib+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalIterativePhiSym',
+                  'SinglePhoton'   : 'HcalCalGammaJet',
+                  'ZeroBias'       : 'SiStripCalZeroBias+TkAlMinBias+LumiPixelsMinBias+SiStripCalMinBias', 
+                  'StreamExpress'  : 'SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+DtCalib+Hotline+LumiPixelsMinBias',
+                  'StreamExpressHI': 'SiStripCalZeroBias+TkAlMinBiasHI+SiStripPCLHistos+SiStripCalMinBias+DtCalibHI',
+                  'ExpressCosmics' : 'SiStripCalZeroBias+TkAlCosmics0T',
                   # These two cannot run on RAW, they are just meant to run on the dedicated AlcaRAW so they do not enter the allForPrompt list
                   'AlCaP0'         : '',
                   # ---------------------------------------------------------------------------------------------------------------------------
                   'HcalNZS'        : 'HcalCalMinBias'
                   # This is in the AlCaRecoMatrix, but no RelVals are produced
-                  # 'TestEnablesTracker' : 'TkAlLAS'
+                  # 'TestEnablesTracker'  : 'TkAlLAS'
+                  # 'TestEnablesEcalHcal' : 'HcalCalPedestal'
                   }
 
 def buildList(pdList, matrix):
@@ -36,7 +46,7 @@ def buildList(pdList, matrix):
     return stringList
 
 # Update the lists anytime a new PD is added to the matrix
-autoAlca = { 'allForPrompt'         : buildList(['MinimumBias', 'Commissioning', 'SingleMu', 'DoubleMu', 'MuOnia', 'DoubleMuParked', 'MuOniaParked', 'SingleElectron', 'DoubleElectron', 'HcalNZS'], AlCaRecoMatrix),
+autoAlca = { 'allForPrompt'         : buildList(['Charmonium', 'Commissioning', 'DoubleEG', 'DoubleElectron', 'DoubleMu', 'DoubleMuParked', 'DoubleMuon', 'HLTPhysics', 'HcalNZS', 'JetHT', 'MET', 'MinimumBias', 'MuOnia', 'MuOniaParked', 'SingleElectron', 'SingleMu', 'SingleMuon', 'SinglePhoton', 'ZeroBias'], AlCaRecoMatrix),
              'allForExpress'        : buildList(['StreamExpress'], AlCaRecoMatrix),
              'allForExpressHI'      : buildList(['StreamExpressHI'], AlCaRecoMatrix),
              'allForPromptCosmics'  : buildList(['Cosmics'], AlCaRecoMatrix),

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -18,9 +18,9 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v12',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v15',
+    'run1_data'         :   '80X_dataRun1_v0',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v15',
+    'run2_data'         :   '80X_dataRun2_v0',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v10',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
As in #12716 with:
- updated TriggerBit in GT to allow `LumiPixelsMinBias` to run in Express workflow
- updated TriggerBit in GT to allow `HcalCalIterativePhiSym` to in Prompt workflow
  AlcaReco Matrix used: [twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/AlCaRecoMatrix#25_ns_7e33_collisions_13_TeV)
# Changes in GT
## RunI data
- **RunI Offline processing** : [80X_dataRun1_v0](https://cms-conddb.cern.ch/browser/#list/Prod/gts/80X_dataRun1_v0) as [76X_dataRun1_v15](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun1_v15) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/80X_dataRun1_v0/76X_dataRun1_v15): 
  - updated AlCaRecoTriggerBits to allow  `LumiPixelsMinBias` and `HcalCalIterativePhiSym`  to be run in the IB tests
## RunI data
- **RunII Offline processing** : [80X_dataRun2_v10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/80X_dataRun2_v10) as [76X_dataRun2_v15](https://cms-conddb.cern.ch/browser/#list/Prod/gts/76X_dataRun2_v15) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/80X_dataRun2_v10/76X_dataRun2_v15): 
  - updated AlCaRecoTriggerBits to allow  `LumiPixelsMinBias` and `HcalCalIterativePhiSym`  to be run in the IB tests.
