### PR TITLE
make printNavType return std::string instead std::ostream

### DIFF
--- a/DetectorDescription/Core/interface/DDExpandedView.h
+++ b/DetectorDescription/Core/interface/DDExpandedView.h
@@ -137,11 +137,13 @@ protected:
   std::vector<nav_type> nextBStack_;
 };
 
-std::ostream & printNavType(std::ostream &, int const * n, size_t sz);
+std::string printNavType(int const * n, size_t sz);
 inline std::ostream & operator<<(std::ostream & os, const DDExpandedView::nav_type & n) {
-    return printNavType(os,&n.front(),n.size());
+    os << printNavType(&n.front(),n.size());
+    return os;
 }
 inline std::ostream & operator<<(std::ostream & os, const DDExpandedView::NavRange & n) {
-    return printNavType(os,n.first,n.second);
+    os << printNavType(n.first,n.second);
+    return os;
 }
 #endif

--- a/DetectorDescription/Core/src/DDExpandedView.cc
+++ b/DetectorDescription/Core/src/DDExpandedView.cc
@@ -484,11 +484,12 @@ DDExpandedView::nav_type DDExpandedView::copyNumbers() const
   return result;
 }
 
-std::ostream & printNavType(std::ostream & os, int const * n, size_t sz){
-  os << '(' ;
+std::string printNavType(int const * n, size_t sz){
+  std::ostringstream oss;
+  oss << '(' ;
   for (int const * it=n; it != n+sz; ++it) {
-    os << *it << ',';
+    oss << *it << ',';
   }
-  os << ')';
-  return os;
+  oss << ')';
+  return oss.str();
 }

--- a/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
+++ b/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
@@ -308,7 +308,7 @@ ModuleNumbering::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetu
 		  GeometricDet::nav_type detNavType = mapDetIdToGeometricDet[myDetId]->navType();
 		  //
 		  Output << "            raw Id = " << rawid << " (" << binary_detid << ")"
-			 << "\t nav type = " << printNavType(Output,&detNavType.front(),detNavType.size()) << std::endl;
+			 << "\t nav type = " << printNavType(&detNavType.front(),detNavType.size()) << std::endl;
 		  
 		  // variables
 		  fillModuleVariables(mapDetIdToGeometricDet[myDetId], polarRadius, phiRad, z);
@@ -492,7 +492,7 @@ ModuleNumbering::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetu
 		  GeometricDet::nav_type detNavType = mapDetIdToGeometricDet[myDetId]->navType();
 		  //
 		  Output << "            raw Id = " << rawid << " (" << binary_detid << ")"
-			 << "\t nav type = " << printNavType(Output,&detNavType.front(),detNavType.size()) << std::endl;
+			 << "\t nav type = " << printNavType(&detNavType.front(),detNavType.size()) << std::endl;
 		  
 		  // variables
 		  fillModuleVariables(mapDetIdToGeometricDet[myDetId], polarRadius, phiRad, z);
@@ -669,7 +669,7 @@ ModuleNumbering::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetu
 		  GeometricDet::nav_type detNavType = mapDetIdToGeometricDet[myDetId]->navType();
 		  //
 		  Output << "            raw Id = " << rawid << " (" << binary_detid << ")"
-			 << "\t nav type = " << printNavType(Output,&detNavType.front(),detNavType.size()) << std::endl;
+			 << "\t nav type = " << printNavType(&detNavType.front(),detNavType.size()) << std::endl;
 		  
 		  // variables
 		  fillModuleVariables(mapDetIdToGeometricDet[myDetId], polarRadius, phiRad, z);
@@ -880,7 +880,7 @@ ModuleNumbering::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetu
 		      GeometricDet::nav_type detNavType = mapDetIdToGeometricDet[myDetId]->navType();
 		      //
 		      Output << "            raw Id = " << rawid << " (" << binary_detid << ")"
-			     << "\t nav type = " << printNavType(Output,&detNavType.front(),detNavType.size()) << std::endl;
+			     << "\t nav type = " << printNavType(&detNavType.front(),detNavType.size()) << std::endl;
 		      
 		      // variables
 		      fillModuleVariables(mapDetIdToGeometricDet[myDetId], polarRadius, phiRad, z);


### PR DESCRIPTION
The way `printNavType` is used in `test/ModuleNumbering.cc` it attempts
to put `std::ostream` into `std::ostream`, which is not allowed by
C++11 or above.

Refactor `printNavType` to return `std::string` instead and adjust
related `operator<<`.

Needed by GCC 5.3.0.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
