### PR TITLE
Fix putting output stream into output stream

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -74,9 +74,9 @@ void HGCFEElectronics<DFr>::runTrivialShaper(DFr &dataFrame, HGCSimHitData& char
     }
 
   if(debug) { 
-    std::stringstream msg;
+    std::ostringstream msg;
     dataFrame.print(msg);
-    edm::LogVerbatim("HGCFE") << msg << std::endl; 
+    edm::LogVerbatim("HGCFE") << msg.str() << std::endl;
   } 
 }
 
@@ -124,9 +124,9 @@ void HGCFEElectronics<DFr>::runSimpleShaper(DFr &dataFrame, HGCSimHitData& charg
     }
   
   if(debug) { 
-    std::stringstream msg;
+    std::ostringstream msg;
     dataFrame.print(msg);
-    edm::LogVerbatim("HGCFE") << msg << std::endl; 
+    edm::LogVerbatim("HGCFE") << msg.str() << std::endl;
   }
 }
 
@@ -327,9 +327,9 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
     }
 
   if(debug) { 
-    std::stringstream msg;
+    std::ostringstream msg;
     dataFrame.print(msg);
-    edm::LogVerbatim("HGCFE") << msg << std::endl; 
+    edm::LogVerbatim("HGCFE") << msg.str() << std::endl;
   }  
 }
 


### PR DESCRIPTION
Putting output stream into output stream (e.g. `std::cout << std::cout`)
was fixed in C++11 as it now allowed. This is now enforced by GCC 5.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
