### PR TITLE
Fix for SiStripErrors in HI repacking (porting PR #12674)

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -8,7 +8,9 @@ import EventFilter.SiStripRawToDigi.SiStripDigiToRaw_cfi
 SiStripDigiToZSRaw = EventFilter.SiStripRawToDigi.SiStripDigiToRaw_cfi.SiStripDigiToRaw.clone(
     InputModuleLabel = 'siStripZeroSuppression',
     InputDigiLabel = cms.string('VirginRaw'),
-    FedReadoutMode = cms.string('ZERO_SUPPRESSED')
+    FedReadoutMode = cms.string('ZERO_SUPPRESSED'),
+    CopyBufferHeader = cms.bool(True),
+    RawDataTag = cms.InputTag('rawDataCollector')
     )
 
 SiStripRawDigiToVirginRaw = SiStripDigiToZSRaw.clone(

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -429,6 +429,9 @@ namespace sistrip {
       virtual void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status) = 0;
       virtual void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address) = 0;
       virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister) = 0;
+      virtual void setDAQRegister(const uint32_t daqRegister) = 0;
+      virtual void setDAQRegister2(const uint32_t daqRegister2) = 0;
+      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister) = 0;
       virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length) = 0;
       void setChannelStatus(const uint8_t internalFEUnitNum, const uint8_t internalFEUnitChannelNum, const FEDChannelStatus status);
     };
@@ -453,6 +456,9 @@ namespace sistrip {
       virtual void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status);
       virtual void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address);
       virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister);
+      virtual void setDAQRegister(const uint32_t daqRegister);
+      virtual void setDAQRegister2(const uint32_t daqRegister2);
+      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister);
       virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length);
     private:
       static const size_t APV_ERROR_HEADER_SIZE_IN_64BIT_WORDS = 3;
@@ -503,7 +509,11 @@ namespace sistrip {
       virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister);
       virtual void setDAQRegister(const uint32_t daqRegister);
       virtual void setDAQRegister2(const uint32_t daqRegister2);
+      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister);
       virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length);
+      static uint32_t get32BitWordFrom(const uint8_t* startOfWord);
+      const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
+      uint8_t* feWord(const uint8_t internalFEUnitNum);
       FEDFullDebugHeader(const std::vector<uint16_t>& feUnitLengths = std::vector<uint16_t>(FEUNITS_PER_FED,0),
                          const std::vector<uint8_t>& feMajorityAddresses = std::vector<uint8_t>(FEUNITS_PER_FED,0),
                          const std::vector<FEDChannelStatus>& channelStatus = std::vector<FEDChannelStatus>(FEDCH_PER_FED,CHANNEL_STATUS_NO_PROBLEMS),
@@ -511,10 +521,7 @@ namespace sistrip {
                          const uint32_t daqRegister = 0, const uint32_t daqRegister2 = 0);
     private:
       bool getBit(const uint8_t internalFEDChannelNum, const uint8_t bit) const;
-      static uint32_t get32BitWordFrom(const uint8_t* startOfWord);
       static void set32BitWordAt(uint8_t* startOfWord, const uint32_t value);
-      const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
-      uint8_t* feWord(const uint8_t internalFEUnitNum);
       void setBit(const uint8_t internalFEDChannelNum, const uint8_t bit, const bool value);
       
       //These methods return true if there was an error of the appropriate type (ie if the error bit is 0).

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -9,7 +9,9 @@
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "FWCore/Utilities/interface/CRC16.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <vector>
 
@@ -63,10 +65,44 @@ namespace sistrip {
 				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
     createFedBuffers_(event, cabling, collection, buffers, false);
   }
+
+  //with copy of headers from initial raw data collection (raw->digi->raw)
+  void DigiToRaw::createFedBuffers( edm::Event& event,
+				    edm::ESHandle<SiStripFedCabling>& cabling,
+				    edm::Handle<FEDRawDataCollection> & rawbuffers,
+				    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
+				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+    createFedBuffers_(event, cabling, rawbuffers, collection, buffers, true);
+  }
   
+  void DigiToRaw::createFedBuffers( edm::Event& event,
+				    edm::ESHandle<SiStripFedCabling>& cabling,
+				    edm::Handle<FEDRawDataCollection> & rawbuffers,
+				    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
+				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+    createFedBuffers_(event, cabling, rawbuffers, collection, buffers, false);
+  }
+
+
+
+
   template<class Digi_t>
   void DigiToRaw::createFedBuffers_( edm::Event& event,
 				     edm::ESHandle<SiStripFedCabling>& cabling,
+				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
+				     std::auto_ptr<FEDRawDataCollection>& buffers,
+				     bool zeroSuppressed) {
+
+    edm::Handle<FEDRawDataCollection> rawbuffers;
+    //CAMM initialise to some dummy empty buffers??? Or OK like this ?
+    createFedBuffers_(event,cabling,rawbuffers,collection,buffers,zeroSuppressed);
+
+  }
+
+  template<class Digi_t>
+  void DigiToRaw::createFedBuffers_( edm::Event& event,
+				     edm::ESHandle<SiStripFedCabling>& cabling,
+				     edm::Handle<FEDRawDataCollection> & rawbuffers,
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
 				     std::auto_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
@@ -74,83 +110,319 @@ namespace sistrip {
       
       //set the L1ID to use in the buffers
       bufferGenerator_.setL1ID(0xFFFFFF & event.id().event());
-      
       auto fed_ids = cabling->fedIds();
-      for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
-        
-        auto conns = cabling->fedConnections(*ifed);
-        
-	//for special mode premix raw, data is zero-suppressed but not converted to 8 bit
-	//zeroSuppressed here means converted to 8 bit...
-	if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
-        FEDStripData fedData(zeroSuppressed);
-        
-	for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
-          
-	  // Determine FED key from cabling
-	  uint32_t fed_key = ( ( iconn->fedId() & sistrip::invalid_ ) << 16 ) | ( iconn->fedCh() & sistrip::invalid_ );
+
+      //copy header if valid rawbuffers handle
+      if (rawbuffers.isValid()){
+	if ( edm::isDebugEnabled() ) {
+	  edm::LogWarning("DigiToRaw")
+	    << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    << " Valid raw buffers, getting headers from them..."
+	    << " Number of feds: " << fed_ids.size() << " between "
+	    << *(fed_ids.begin()) << " and " << *(fed_ids.end());
+	}
 	
-	  // Determine whether DetId or FED key should be used to index digi containers
-	  uint32_t key = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? fed_key : iconn->detId();
-          
-          // Check key is non-zero and valid
-	  if ( !key || ( key == sistrip::invalid32_ ) ) { continue; }
+	const FEDRawDataCollection& rawDataCollection = *rawbuffers;
 
-	  // Determine APV pair number (needed only when using DetId)
-	  uint16_t ipair = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? 0 : iconn->apvPairNumber();
-          
-          FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
+	for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
+	  const FEDRawData& rawfedData = rawDataCollection.FEDData(*ifed);
 
-	  // Find digis for DetID in collection
-	  typename std::vector< edm::DetSet<Digi_t> >::const_iterator digis = collection->find( key );
-	  if (digis == collection->end()) { continue; } 
-
-	  typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
-	  for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
-	    
-	    if ( STRIP(idigi, digis_begin) < ipair*256 ||
-		 STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
-	    const unsigned short strip = STRIP(idigi, digis_begin) % 256;
-
-	    if ( strip >= STRIPS_PER_FEDCH ) {
-	      if ( edm::isDebugEnabled() ) {
-		std::stringstream ss;
-		ss << "[sistrip::DigiToRaw::createFedBuffers]"
-		   << " strip >= strips_per_fedCh";
-		edm::LogWarning("DigiToRaw") << ss.str();
-	      }
-	      continue;
-	    }
-	  
-	    // check if value already exists
-	    if ( edm::isDebugEnabled() ) {
-              const uint16_t value = 0;//chanData[strip];
-	      if ( value && value != (*idigi).adc() ) {
-		std::stringstream ss; 
-		ss << "[sistrip::DigiToRaw::createFedBuffers]" 
-		   << " Incompatible ADC values in buffer!"
-		   << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
-		   << "  DetStrip: " << STRIP(idigi, digis_begin)
-		   << "  FedChStrip: " << strip
-		   << "  AdcValue: " << (*idigi).adc()
-		   << "  RawData[" << strip << "]: " << value;
-		edm::LogWarning("DigiToRaw") << ss.str();
-	      }
-	    }
-
-	    // Add digi to buffer
-	    chanData[strip] = (*idigi).adc();
-
+	  if ( edm::isDebugEnabled() ) {
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << "Fed " << *ifed << " : size of buffer = " << rawfedData.size();
 	  }
-	  // if ((*idigi).strip() >= (ipair+1)*256) break;
+	  
+	  //need to construct full object to copy full header
+	  std::auto_ptr<const sistrip::FEDBuffer> fedbuffer;
+	  //std::auto_ptr<const sistrip::FEDBufferBase> bufferBase;
+	  try {
+	    fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(),rawfedData.size(),true));
+	    //bufferBase.reset(new sistrip::FEDBufferBase(rawfedData.data(),rawfedData.size()));
+	  } catch (const cms::Exception& e) {
+	    edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+		      << " Invalid raw data, cannot get buffer..."
+		      << std::endl;
+	  }
+	  
+	  if ( edm::isDebugEnabled() ) {
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " Original header type: " << fedbuffer->headerType();
+	  }
+
+	  bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_FULL_DEBUG);
+	  //fedbuffer->headerType());
+	  bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
+	  bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
+	  
+	  bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
+	  bufferGenerator_.setReadoutMode(mode_);
+
+	  if ( edm::isDebugEnabled() ) {
+	    std::ostringstream debugStream;
+	    if(ifed==fed_ids.begin()){  bufferGenerator_.trackerSpecialHeader().print(std::cout); std::cout << std::endl;}
+	    bufferGenerator_.trackerSpecialHeader().print(debugStream);
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " Tracker special header apveAddress: " << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apveAddress())
+	      << " - event type = " << bufferGenerator_.getDAQEventType()
+	      << " - buffer format = " << bufferGenerator_.getBufferFormat() << "\n"
+	      << " - SpecialHeader bufferformat " << bufferGenerator_.trackerSpecialHeader().bufferFormat()
+	      << " - headertype " << bufferGenerator_.trackerSpecialHeader().headerType()
+	      << " - readoutmode " << bufferGenerator_.trackerSpecialHeader().readoutMode()
+	      << " - apvaddrregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apvAddressErrorRegister())
+	      << " - feenabledregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feEnableRegister())
+	      << " - feoverflowregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feOverflowRegister())
+	      << " - statusregister " << bufferGenerator_.trackerSpecialHeader().fedStatusRegister() << "\n"
+	      << " SpecialHeader: " << debugStream.str();
+	  }
+
+	  std::auto_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
+	  FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
+	  if ( edm::isDebugEnabled() ) {
+	    std::ostringstream debugStream;
+	    if(ifed==fed_ids.begin()){  std::cout << "FEHeader before transfer: " << std::endl;fedFeHeader->print(std::cout);std::cout  <<std::endl;}
+	    fedFeHeader->print(debugStream);
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
+	      << debugStream.str();
+	  }
+          //status registers
+          (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
+          (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
+          (bufferGenerator_.feHeader()).setDAQRegister(fedFeHeader->daqRegister());
+          for(uint8_t iFE=1; iFE<6; iFE++) {
+            (bufferGenerator_.feHeader()).set32BitReservedRegister(iFE,fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE)+10));
+          }
+
+          std::vector<bool> feEnabledVec;
+	  feEnabledVec.resize(FEUNITS_PER_FED,true);
+	  for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
+            feEnabledVec[iFE]=fedbuffer->trackerSpecialHeader().feEnabled(iFE);  
+            (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE,fedFeHeader->feUnitMajorityAddress(iFE));
+	    for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
+	      (bufferGenerator_.feHeader()).setChannelStatus(iFE,iFEUnitChannel,fedFeHeader->getChannelStatus(iFE,iFEUnitChannel));
+	    }//loop on channels
+	  }//loop on fe units
+          bufferGenerator_.setFEUnitEnables(feEnabledVec);
+
+	  if ( edm::isDebugEnabled() ) {
+	    std::ostringstream debugStream;
+	    if(ifed==fed_ids.begin()){  std::cout << "\nFEHeader after transfer: " << std::endl;bufferGenerator_.feHeader().print(std::cout); std::cout << std::endl;}
+	    bufferGenerator_.feHeader().print(debugStream);
+	    edm::LogWarning("DigiToRaw")
+	      << "[sistrip::DigiToRaw::createFedBuffers_]"
+	      << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+	      << debugStream.str();
+	  }
+          auto conns = cabling->fedConnections(*ifed);
+          
+          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
+          //zeroSuppressed here means converted to 8 bit...
+          if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
+          FEDStripData fedData(zeroSuppressed);
+          
+          
+          for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
+            
+            // Determine FED key from cabling
+            uint32_t fed_key = ( ( iconn->fedId() & sistrip::invalid_ ) << 16 ) | ( iconn->fedCh() & sistrip::invalid_ );
+            
+            // Determine whether DetId or FED key should be used to index digi containers
+            uint32_t key = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? fed_key : iconn->detId();
+            
+            // Check key is non-zero and valid
+            if ( !key || ( key == sistrip::invalid32_ ) ) { continue; }
+            
+            // Determine APV pair number (needed only when using DetId)
+            uint16_t ipair = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? 0 : iconn->apvPairNumber();
+            
+            FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
+
+            // Find digis for DetID in collection
+            if (!collection.isValid()){
+              if ( edm::isDebugEnabled() ) {
+                edm::LogWarning("DigiToRaw") 
+          	<< "[DigiToRaw::createFedBuffers] " 
+          	<< "digis collection is not valid...";
+              }
+              break;
+            }
+            typename std::vector< edm::DetSet<Digi_t> >::const_iterator digis = collection->find( key );
+            if (digis == collection->end()) { continue; } 
+
+            typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
+            for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
+              
+              if ( STRIP(idigi, digis_begin) < ipair*256 ||
+          	 STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
+              const unsigned short strip = STRIP(idigi, digis_begin) % 256;
+              
+              if ( strip >= STRIPS_PER_FEDCH ) {
+                if ( edm::isDebugEnabled() ) {
+          	std::stringstream ss;
+          	ss << "[sistrip::DigiToRaw::createFedBuffers]"
+          	   << " strip >= strips_per_fedCh";
+          	edm::LogWarning("DigiToRaw") << ss.str();
+                }
+                continue;
+              }
+              
+              // check if value already exists
+              if ( edm::isDebugEnabled() ) {
+                const uint16_t value = 0;//chanData[strip];
+                if ( value && value != (*idigi).adc() ) {
+          	std::stringstream ss; 
+          	ss << "[sistrip::DigiToRaw::createFedBuffers]" 
+          	   << " Incompatible ADC values in buffer!"
+          	   << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
+          	   << "  DetStrip: " << STRIP(idigi, digis_begin)
+          	   << "  FedChStrip: " << strip
+          	   << "  AdcValue: " << (*idigi).adc()
+          	   << "  RawData[" << strip << "]: " << value;
+          	edm::LogWarning("DigiToRaw") << ss.str();
+                }
+              }
+              
+              // Add digi to buffer
+              chanData[strip] = (*idigi).adc();
+            }
+          }
+          // if ((*idigi).strip() >= (ipair+1)*256) break;
+          
+          if ( edm::isDebugEnabled() ) {
+            edm::LogWarning("DigiToRaw") 
+              << "DigiToRaw::createFedBuffers] " 
+              << "Almost at the end...";
+          }
+          //create the buffer
+          FEDRawData& fedrawdata = buffers->FEDData( *ifed );
+          bufferGenerator_.generateBuffer(&fedrawdata,fedData,*ifed);
+
+          if ( edm::isDebugEnabled() ) {
+            std::ostringstream debugStream;
+            bufferGenerator_.feHeader().print(debugStream);
+            edm::LogWarning("DigiToRaw")
+              << "[sistrip::DigiToRaw::createFedBuffers_]"
+              << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+              << debugStream.str();
+          }
+	}//loop on fedids
+	if ( edm::isDebugEnabled() ) {
+	  edm::LogWarning("DigiToRaw")
+	    << "[sistrip::DigiToRaw::createFedBuffers_]"
+	    << "end of first loop on feds";
 	}
 
-        //create the buffer
-        FEDRawData& fedrawdata = buffers->FEDData( *ifed );
-        bufferGenerator_.generateBuffer(&fedrawdata,fedData,*ifed);
-        
-       }
-    }
+      }//end of workflow for copying header, below is workflow without copying header
+      else{     
+        if ( edm::isDebugEnabled() ) {
+          edm::LogWarning("DigiToRaw")
+            << "[sistrip::DigiToRaw::createFedBuffers_]"
+            << "Now getting the digis..."
+            << " Number of feds: " << fed_ids.size() << " between "
+            << *(fed_ids.begin()) << " and " << *(fed_ids.end());
+        }
+
+        for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
+          
+          auto conns = cabling->fedConnections(*ifed);
+          
+          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
+          //zeroSuppressed here means converted to 8 bit...
+          if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
+          FEDStripData fedData(zeroSuppressed);
+          
+          
+          for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
+            
+            // Determine FED key from cabling
+            uint32_t fed_key = ( ( iconn->fedId() & sistrip::invalid_ ) << 16 ) | ( iconn->fedCh() & sistrip::invalid_ );
+            
+            // Determine whether DetId or FED key should be used to index digi containers
+            uint32_t key = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? fed_key : iconn->detId();
+            
+            // Check key is non-zero and valid
+            if ( !key || ( key == sistrip::invalid32_ ) ) { continue; }
+            
+            // Determine APV pair number (needed only when using DetId)
+            uint16_t ipair = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? 0 : iconn->apvPairNumber();
+            
+            FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
+
+            // Find digis for DetID in collection
+            if (!collection.isValid()){
+              if ( edm::isDebugEnabled() ) {
+                edm::LogWarning("DigiToRaw") 
+          	<< "[DigiToRaw::createFedBuffers] " 
+          	<< "digis collection is not valid...";
+              }
+              break;
+            }
+            typename std::vector< edm::DetSet<Digi_t> >::const_iterator digis = collection->find( key );
+            if (digis == collection->end()) { continue; } 
+
+            typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
+            for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
+              
+              if ( STRIP(idigi, digis_begin) < ipair*256 ||
+          	 STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
+              const unsigned short strip = STRIP(idigi, digis_begin) % 256;
+              
+              if ( strip >= STRIPS_PER_FEDCH ) {
+                if ( edm::isDebugEnabled() ) {
+          	std::stringstream ss;
+          	ss << "[sistrip::DigiToRaw::createFedBuffers]"
+          	   << " strip >= strips_per_fedCh";
+          	edm::LogWarning("DigiToRaw") << ss.str();
+                }
+                continue;
+              }
+              
+              // check if value already exists
+              if ( edm::isDebugEnabled() ) {
+                const uint16_t value = 0;//chanData[strip];
+                if ( value && value != (*idigi).adc() ) {
+          	std::stringstream ss; 
+          	ss << "[sistrip::DigiToRaw::createFedBuffers]" 
+          	   << " Incompatible ADC values in buffer!"
+          	   << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
+          	   << "  DetStrip: " << STRIP(idigi, digis_begin)
+          	   << "  FedChStrip: " << strip
+          	   << "  AdcValue: " << (*idigi).adc()
+          	   << "  RawData[" << strip << "]: " << value;
+          	edm::LogWarning("DigiToRaw") << ss.str();
+                }
+              }
+              
+              // Add digi to buffer
+              chanData[strip] = (*idigi).adc();
+            }
+          }
+          // if ((*idigi).strip() >= (ipair+1)*256) break;
+          
+          if ( edm::isDebugEnabled() ) {
+            edm::LogWarning("DigiToRaw") 
+              << "DigiToRaw::createFedBuffers] " 
+              << "Almost at the end...";
+          }
+          //create the buffer
+          FEDRawData& fedrawdata = buffers->FEDData( *ifed );
+          bufferGenerator_.generateBuffer(&fedrawdata,fedData,*ifed);
+
+          if ( edm::isDebugEnabled() ) {
+            std::ostringstream debugStream;
+            bufferGenerator_.feHeader().print(debugStream);
+            edm::LogWarning("DigiToRaw")
+              << "[sistrip::DigiToRaw::createFedBuffers_]"
+              << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+              << debugStream.str();
+          }
+        }//loop on feds
+      }//end if-else for copying header
+    }//try
     catch (const std::exception& e) {
       if ( edm::isDebugEnabled() ) {
 	edm::LogWarning("DigiToRaw") 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
@@ -32,12 +32,25 @@ namespace sistrip {
     DigiToRaw( FEDReadoutMode, bool use_fed_key );
     ~DigiToRaw();
     
+    //digi to raw with default headers
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
 			   edm::Handle< edm::DetSetVector<SiStripDigi> >& digis,
 			   std::auto_ptr<FEDRawDataCollection>& buffers );
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
+			   edm::Handle< edm::DetSetVector<SiStripRawDigi> >& digis,
+			   std::auto_ptr<FEDRawDataCollection>& buffers);
+
+    //with input raw data for copying header   
+    void createFedBuffers( edm::Event&, 
+			   edm::ESHandle<SiStripFedCabling>& cabling,
+			   edm::Handle<FEDRawDataCollection> & rawbuffers,
+			   edm::Handle< edm::DetSetVector<SiStripDigi> >& digis,
+			   std::auto_ptr<FEDRawDataCollection>& buffers );
+    void createFedBuffers( edm::Event&, 
+			   edm::ESHandle<SiStripFedCabling>& cabling,
+			   edm::Handle<FEDRawDataCollection> & rawbuffers,
 			   edm::Handle< edm::DetSetVector<SiStripRawDigi> >& digis,
 			   std::auto_ptr<FEDRawDataCollection>& buffers);
     
@@ -51,6 +64,17 @@ namespace sistrip {
 			    edm::Handle< edm::DetSetVector<Digi_t> >& digis,
 			    std::auto_ptr<FEDRawDataCollection>& buffers,
 			    bool zeroSuppressed);
+
+    template<class Digi_t>
+    void createFedBuffers_( edm::Event&, 
+			    edm::ESHandle<SiStripFedCabling>& cabling,
+			    edm::Handle<FEDRawDataCollection> & rawbuffers,
+			    edm::Handle< edm::DetSetVector<Digi_t> >& digis,
+			    std::auto_ptr<FEDRawDataCollection>& buffers,
+			    bool zeroSuppressed);
+
+
+
     uint16_t STRIP(const edm::DetSet<SiStripDigi>::const_iterator& it, const edm::DetSet<SiStripDigi>::const_iterator& begin) const;
     uint16_t STRIP(const edm::DetSet<SiStripRawDigi>::const_iterator& it, const edm::DetSet<SiStripRawDigi>::const_iterator& begin) const;
     

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -3,12 +3,16 @@
 #define EventFilter_SiStripRawToDigi_SiStripDigiToRawModule_H
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "boost/cstdint.hpp"
 #include <string>
+namespace edm {
+  class ConfigurationDescriptions;
+}
 
 namespace sistrip {
 
@@ -21,7 +25,7 @@ namespace sistrip {
      @brief A plug-in module that takes StripDigis as input from the
      Event and creates an EDProduct comprising a FEDRawDataCollection.
   */
-  class dso_hidden DigiToRawModule final : public edm::EDProducer {
+  class dso_hidden DigiToRawModule final : public edm::stream::EDProducer<> {
   
   public:
   
@@ -32,17 +36,22 @@ namespace sistrip {
     virtual void endJob() {}
   
     virtual void produce( edm::Event&, const edm::EventSetup& );
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
   private:
 
     std::string inputModuleLabel_;
     std::string inputDigiLabel_;
+    //CAMM can we do without this bool based on the mode ?
+    bool copyBufferHeader_;
     FEDReadoutMode mode_;
     bool rawdigi_;
     DigiToRaw* digiToRaw_;
     uint32_t eventCounter_;
     edm::EDGetTokenT< edm::DetSetVector<SiStripRawDigi> > tokenRawDigi;
     edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > tokenDigi;
+    edm::InputTag rawDataTag_;
+    edm::EDGetTokenT<FEDRawDataCollection> tokenRawBuffer;
 
   };
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -3,7 +3,7 @@
 #define EventFilter_SiStripRawToDigi_SiStripDigiToRawModule_H
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
@@ -25,7 +25,7 @@ namespace sistrip {
      @brief A plug-in module that takes StripDigis as input from the
      Event and creates an EDProduct comprising a FEDRawDataCollection.
   */
-  class dso_hidden DigiToRawModule final : public edm::stream::EDProducer<> {
+  class dso_hidden DigiToRawModule final : public edm::EDProducer {
   
   public:
   

--- a/EventFilter/SiStripRawToDigi/python/SiStripDigiToRaw_cfi.py
+++ b/EventFilter/SiStripRawToDigi/python/SiStripDigiToRaw_cfi.py
@@ -6,6 +6,8 @@ SiStripDigiToRaw = cms.EDProducer(
     InputDigiLabel = cms.string('ZeroSuppressed'),
     FedReadoutMode = cms.string('ZERO_SUPPRESSED'),
     UseFedKey = cms.bool(False),
-    UseWrongDigiType = cms.bool(False)
+    UseWrongDigiType = cms.bool(False),
+    CopyBufferHeader = cms.bool(False),
+    RawDataTag = cms.InputTag('rawDataCollector')
     )
 

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1096,6 +1096,18 @@ namespace sistrip {
   {
     return;
   }
+  void FEDAPVErrorHeader::setDAQRegister(const uint32_t daqRegister)
+  {
+    return;
+  }
+  void FEDAPVErrorHeader::setDAQRegister2(const uint32_t daqRegister2)
+  {
+    return;
+  }
+  void FEDAPVErrorHeader::set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister)
+  {
+    return;
+  }
   void FEDAPVErrorHeader::setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length)
   {
     return;
@@ -1230,6 +1242,12 @@ namespace sistrip {
   void FEDFullDebugHeader::setDAQRegister2(const uint32_t daqRegister2)
   {
     set32BitWordAt(feWord(6)+10,daqRegister2);
+  }
+
+  //used by DigiToRaw to copy reserved registers in internalFEUnit buffers 1 through 5
+  void FEDFullDebugHeader::set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister)
+  {
+    set32BitWordAt(feWord(internalFEUnitNum)+10,reservedRegister);
   }
   
   void FEDFullDebugHeader::setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length)


### PR DESCRIPTION
This is a port of PR #12674 into 8_0_X .  Used for fixing the heavy ion repacking that is run in the HLT for the SiStrips.  Also needed to store SiStrip error info is on disk and show it in the DQM.
