### PR TITLE
memory reduction most visible for HI processing, done mostly by dropping muon isodeposits in HI

### DIFF
--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -875,26 +875,26 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
   edm::Handle<std::vector<Trajectory> > trajCollectionHandle;
   //iEvent.getByLabel(tracksrc_,trajCollectionHandle);
   iEvent.getByToken ( tracksrcToken_, trajCollectionHandle );
-  const std::vector<Trajectory> trajColl = *(trajCollectionHandle.product());
+  const std::vector<Trajectory>& trajColl = *(trajCollectionHandle.product());
    
   //get tracks
   edm::Handle<std::vector<reco::Track> > trackCollectionHandle;
   //iEvent.getByLabel(tracksrc_,trackCollectionHandle);
   iEvent.getByToken( trackToken_, trackCollectionHandle );
 
-  const std::vector<reco::Track> trackColl = *(trackCollectionHandle.product());
+  const std::vector<reco::Track>& trackColl = *(trackCollectionHandle.product());
 
   //get the map
   edm::Handle<TrajTrackAssociationCollection> match;
   //iEvent.getByLabel(tracksrc_,match);
   iEvent.getByToken( trackAssociationToken_, match);
-  const TrajTrackAssociationCollection ttac = *(match.product());
+  const TrajTrackAssociationCollection& ttac = *(match.product());
 
   // get clusters
   edm::Handle< edmNew::DetSetVector<SiPixelCluster> >  clusterColl;
   //iEvent.getByLabel( clustersrc_, clusterColl );
   iEvent.getByToken( clustersrcToken_, clusterColl );
-  const edmNew::DetSetVector<SiPixelCluster> clustColl = *(clusterColl.product());
+  const edmNew::DetSetVector<SiPixelCluster>& clustColl = *(clusterColl.product());
 
   if(debug_){
     std::cout << "Trajectories\t : " << trajColl.size() << std::endl;
@@ -923,7 +923,7 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
     
     if(abs(d0)<15 && abs(dz)<50) crossesPixVol = true;
 
-    std::vector<TrajectoryMeasurement> tmeasColl =traj_iterator->measurements();
+    const std::vector<TrajectoryMeasurement>& tmeasColl =traj_iterator->measurements();
     std::vector<TrajectoryMeasurement>::const_iterator tmeasIt;
     //loop on measurements to find out whether there are bpix and/or fpix hits
     for(tmeasIt = tmeasColl.begin();tmeasIt!=tmeasColl.end();tmeasIt++){
@@ -947,7 +947,7 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
       
       if(crossesPixVol) meNofTracksInPixVol_->Fill(0,1);
 
-      std::vector<TrajectoryMeasurement> tmeasColl = traj_iterator->measurements();
+      const std::vector<TrajectoryMeasurement>& tmeasColl = traj_iterator->measurements();
       for(std::vector<TrajectoryMeasurement>::const_iterator tmeasIt = tmeasColl.begin(); tmeasIt!=tmeasColl.end(); tmeasIt++){   
 	if(! tmeasIt->updatedState().isValid()) continue; 
 	

--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
@@ -637,23 +637,23 @@ void PhotonAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& esup )
   // Get the PhotonId objects
   bool validloosePhotonID=true;
   Handle<edm::ValueMap<bool> > loosePhotonFlag;
-  edm::ValueMap<bool> dummyLPID;
   e.getByToken(PhotonIDLoose_token_, loosePhotonFlag);
   if ( !loosePhotonFlag.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: PhotonIDLoose_token_" << endl;
     validloosePhotonID=false;
   }
-  const edm::ValueMap<bool>& loosePhotonID(validloosePhotonID? *(loosePhotonFlag.product()) : dummyLPID);
+  //  edm::ValueMap<bool> dummyLPID;
+  //  const edm::ValueMap<bool>& loosePhotonID(validloosePhotonID? *(loosePhotonFlag.product()) : dummyLPID);
 
   bool validtightPhotonID=true;
   Handle<edm::ValueMap<bool> > tightPhotonFlag;
-  edm::ValueMap<bool> dummyTPI;
   e.getByToken(PhotonIDTight_token_, tightPhotonFlag);
   if ( !tightPhotonFlag.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: PhotonIDTight_token_" << endl;
     validtightPhotonID=false;
   }
-  const edm::ValueMap<bool>& tightPhotonID(validtightPhotonID ? *(tightPhotonFlag.product()) : dummyTPI);
+  //  edm::ValueMap<bool> dummyTPI;
+  //  const edm::ValueMap<bool>& tightPhotonID(validtightPhotonID ? *(tightPhotonFlag.product()) : dummyTPI);
 
 
   edm::Handle<reco::VertexCollection> vtxH;

--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
@@ -635,22 +635,22 @@ void PhotonAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& esup )
 
 
   // Get the PhotonId objects
-  bool validloosePhotonID=true;
+  //  bool validloosePhotonID=true;
   Handle<edm::ValueMap<bool> > loosePhotonFlag;
   e.getByToken(PhotonIDLoose_token_, loosePhotonFlag);
   if ( !loosePhotonFlag.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: PhotonIDLoose_token_" << endl;
-    validloosePhotonID=false;
+    //    validloosePhotonID=false;
   }
   //  edm::ValueMap<bool> dummyLPID;
   //  const edm::ValueMap<bool>& loosePhotonID(validloosePhotonID? *(loosePhotonFlag.product()) : dummyLPID);
 
-  bool validtightPhotonID=true;
+  //  bool validtightPhotonID=true;
   Handle<edm::ValueMap<bool> > tightPhotonFlag;
   e.getByToken(PhotonIDTight_token_, tightPhotonFlag);
   if ( !tightPhotonFlag.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: PhotonIDTight_token_" << endl;
-    validtightPhotonID=false;
+    //    validtightPhotonID=false;
   }
   //  edm::ValueMap<bool> dummyTPI;
   //  const edm::ValueMap<bool>& tightPhotonID(validtightPhotonID ? *(tightPhotonFlag.product()) : dummyTPI);

--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
@@ -615,45 +615,45 @@ void PhotonAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& esup )
   // Get the trigger results
   bool validTriggerEvent=true;
   edm::Handle<trigger::TriggerEvent> triggerEventHandle;
-  trigger::TriggerEvent triggerEvent;
+  const trigger::TriggerEvent dummyTE;
   e.getByToken(triggerEvent_token_,triggerEventHandle);
   if(!triggerEventHandle.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: triggerEvent_" << endl;
     validTriggerEvent=false;
   }
-  if(validTriggerEvent) triggerEvent = *(triggerEventHandle.product());
+  const trigger::TriggerEvent& triggerEvent(validTriggerEvent? *(triggerEventHandle.product()) : dummyTE);
 
   // Get the reconstructed photons
   //  bool validPhotons=true;
   Handle<reco::PhotonCollection> photonHandle;
-  reco::PhotonCollection photonCollection;
   e.getByToken(photon_token_ , photonHandle);
   if ( !photonHandle.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: photon_token_" << endl;
     // validPhotons=false;
   }
-  //  if(validPhotons) photonCollection = *(photonHandle.product());
+  const reco::PhotonCollection& photonCollection(*(photonHandle.product()));
+
 
   // Get the PhotonId objects
   bool validloosePhotonID=true;
   Handle<edm::ValueMap<bool> > loosePhotonFlag;
-  edm::ValueMap<bool> loosePhotonID;
+  edm::ValueMap<bool> dummyLPID;
   e.getByToken(PhotonIDLoose_token_, loosePhotonFlag);
   if ( !loosePhotonFlag.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: PhotonIDLoose_token_" << endl;
     validloosePhotonID=false;
   }
-  if (validloosePhotonID) loosePhotonID = *(loosePhotonFlag.product());
+  const edm::ValueMap<bool>& loosePhotonID(validloosePhotonID? *(loosePhotonFlag.product()) : dummyLPID);
 
   bool validtightPhotonID=true;
   Handle<edm::ValueMap<bool> > tightPhotonFlag;
-  edm::ValueMap<bool> tightPhotonID;
+  edm::ValueMap<bool> dummyTPI;
   e.getByToken(PhotonIDTight_token_, tightPhotonFlag);
   if ( !tightPhotonFlag.isValid()) {
     edm::LogInfo(fName_) << "Error! Can't get the product: PhotonIDTight_token_" << endl;
     validtightPhotonID=false;
   }
-  if (validtightPhotonID) tightPhotonID = *(tightPhotonFlag.product());
+  const edm::ValueMap<bool>& tightPhotonID(validtightPhotonID ? *(tightPhotonFlag.product()) : dummyTPI);
 
 
   edm::Handle<reco::VertexCollection> vtxH;
@@ -714,7 +714,7 @@ void PhotonAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& esup )
 
   /////////////////////////BEGIN LOOP OVER THE COLLECTION OF PHOTONS IN THE EVENT/////////////////////////
   for(unsigned int iPho=0; iPho < photonHandle->size(); iPho++) {
-    reco::PhotonRef aPho(reco::PhotonRef(photonHandle, iPho));
+    const reco::Photon* aPho = &photonCollection[iPho];
     //  for( reco::PhotonCollection::const_iterator  iPho = photonCollection.begin(); iPho != photonCollection.end(); iPho++) {
 
     //for HLT efficiency plots
@@ -1083,7 +1083,7 @@ void PhotonAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& esup )
 
     if (isIsolated && aPho->et()>=invMassEtCut_){
       for(unsigned int iPho2=iPho+1; iPho2 < photonHandle->size(); iPho2++) {
-	reco::PhotonRef aPho2(reco::PhotonRef(photonHandle, iPho2));
+	const reco::Photon* aPho2 = &photonCollection[iPho2];
 
 	//      for (reco::PhotonCollection::const_iterator iPho2=iPho+1; iPho2!=photonCollection.end(); iPho2++){
 
@@ -1178,7 +1178,7 @@ void PhotonAnalyzer::fill3DHistoVector(vector<vector<vector<MonitorElement*> > >
   histoVector[cut][type][part]->Fill(x,y);
 }
 
-bool PhotonAnalyzer::photonSelection(const reco::PhotonRef & pho)
+bool PhotonAnalyzer::photonSelection(const reco::Photon* pho)
 {
   bool result=true;
   if ( pho->pt() <  minPhoEtCut_ )          result=false;

--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.h
@@ -136,7 +136,7 @@ class PhotonAnalyzer : public DQMEDAnalyzer
   void fill3DHistoVector(std::vector<std::vector<std::vector<MonitorElement*> > >& histoVector,double x, int cut, int type, int part);
   void fill3DHistoVector(std::vector<std::vector<std::vector<MonitorElement*> > >& histoVector,double x, double y, int cut, int type, int part);
 
-  bool photonSelection(const reco::PhotonRef & p);
+  bool photonSelection(const reco::Photon* p);
   float phiNormalization(float& a);
 
   //////////

--- a/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons_matching.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons_matching.cc
@@ -183,9 +183,9 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
   // Get the Jet collection
   //----------------------------------------------------------------------------
   
-  std::vector<Jet> recoJet1;
+  std::vector<const Jet*> recoJet1;
   recoJet1.clear();
-  std::vector<Jet> recoJet2;
+  std::vector<const Jet*> recoJet2;
   recoJet2.clear();
   
   edm::Handle<CaloJetCollection>  caloJet1;
@@ -196,36 +196,36 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
   if(std::string("VsCalo") == JetType1) {
     mEvent.getByToken(caloJet1Token_, caloJet1);
-    for (unsigned ijet=0; ijet<caloJet1->size(); ++ijet) recoJet1.push_back((*caloJet1)[ijet]);
+    for (unsigned ijet=0; ijet<caloJet1->size(); ++ijet) recoJet1.push_back(&(*caloJet1)[ijet]);
   }
   if(std::string("PuCalo") == JetType1) {
     mEvent.getByToken(caloJet2Token_, caloJet1);
-    for (unsigned ijet=0; ijet<caloJet1->size(); ++ijet) recoJet1.push_back((*caloJet1)[ijet]);
+    for (unsigned ijet=0; ijet<caloJet1->size(); ++ijet) recoJet1.push_back(&(*caloJet1)[ijet]);
   }
   if(std::string("VsPF") == JetType1) {
     mEvent.getByToken(pfJetsToken_, pfJets);
-    for (unsigned ijet=0; ijet<pfJets->size(); ++ijet) recoJet1.push_back((*pfJets)[ijet]);
+    for (unsigned ijet=0; ijet<pfJets->size(); ++ijet) recoJet1.push_back(&(*pfJets)[ijet]);
   }
   if(std::string("PuPF") == JetType1) {
     mEvent.getByToken(basicJetsToken_, basicJets);
-    for (unsigned ijet=0; ijet<basicJets->size(); ++ijet) recoJet1.push_back((*basicJets)[ijet]);
+    for (unsigned ijet=0; ijet<basicJets->size(); ++ijet) recoJet1.push_back(&(*basicJets)[ijet]);
   }
 
   if(std::string("VsCalo") == JetType2) {
     mEvent.getByToken(caloJet1Token_, caloJet2);
-    for (unsigned ijet=0; ijet<caloJet2->size(); ++ijet) recoJet2.push_back((*caloJet2)[ijet]);
+    for (unsigned ijet=0; ijet<caloJet2->size(); ++ijet) recoJet2.push_back(&(*caloJet2)[ijet]);
   }
   if(std::string("PuCalo") == JetType2) {
     mEvent.getByToken(caloJet2Token_, caloJet2);
-    for (unsigned ijet=0; ijet<caloJet2->size(); ++ijet) recoJet2.push_back((*caloJet2)[ijet]);
+    for (unsigned ijet=0; ijet<caloJet2->size(); ++ijet) recoJet2.push_back(&(*caloJet2)[ijet]);
   }
   if(std::string("VsPF") == JetType2) {
     mEvent.getByToken(pfJetsToken_, pfJets);
-    for (unsigned ijet=0; ijet<pfJets->size(); ++ijet) recoJet2.push_back((*pfJets)[ijet]);
+    for (unsigned ijet=0; ijet<pfJets->size(); ++ijet) recoJet2.push_back(&(*pfJets)[ijet]);
   }
   if(std::string("PuPF") == JetType2) {
     mEvent.getByToken(basicJetsToken_, basicJets);
-    for (unsigned ijet=0; ijet<basicJets->size(); ++ijet) recoJet2.push_back((*basicJets)[ijet]);
+    for (unsigned ijet=0; ijet<basicJets->size(); ++ijet) recoJet2.push_back(&(*basicJets)[ijet]);
   }
 
   // start to perform the matching - between recoJet1 and recoJet2.
@@ -244,13 +244,13 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
   for(unsigned ijet1 = 0; ijet1 < recoJet1.size(); ++ijet1){
 
 
-    if(recoJet1[ijet1].pt() < mRecoJetPtThreshold) continue;
-    if(fabs(recoJet1[ijet1].eta()) < mRecoJetEtaCut) continue;
+    if(recoJet1[ijet1]->pt() < mRecoJetPtThreshold) continue;
+    if(fabs(recoJet1[ijet1]->eta()) < mRecoJetEtaCut) continue;
 
     MyJet JET1;
-    JET1.eta = recoJet1[ijet1].eta();
-    JET1.phi = recoJet1[ijet1].phi();
-    JET1.pt  = recoJet1[ijet1].pt();
+    JET1.eta = recoJet1[ijet1]->eta();
+    JET1.phi = recoJet1[ijet1]->phi();
+    JET1.pt  = recoJet1[ijet1]->pt();
     JET1.id  = ijet1; 
 
     vJet1.push_back(JET1);
@@ -260,13 +260,13 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
   for(unsigned ijet2 = 0; ijet2 < recoJet2.size(); ++ijet2){
 
-    if(recoJet2[ijet2].pt() < mRecoJetPtThreshold) continue;
-    if(fabs(recoJet2[ijet2].eta()) < mRecoJetEtaCut) continue;
+    if(recoJet2[ijet2]->pt() < mRecoJetPtThreshold) continue;
+    if(fabs(recoJet2[ijet2]->eta()) < mRecoJetEtaCut) continue;
 
     MyJet JET2;
-    JET2.eta = recoJet2[ijet2].eta();
-    JET2.phi = recoJet2[ijet2].phi();
-    JET2.pt  = recoJet2[ijet2].pt();
+    JET2.eta = recoJet2[ijet2]->eta();
+    JET2.phi = recoJet2[ijet2]->phi();
+    JET2.pt  = recoJet2[ijet2]->pt();
     JET2.id  = ijet2; 
 
     vJet2.push_back(JET2);
@@ -290,7 +290,7 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
       int pj = (*iJet).id;
       
-      mpT_Jet1_unmatched->Fill(recoJet1[pj].pt());
+      mpT_Jet1_unmatched->Fill(recoJet1[pj]->pt());
 
     }
 
@@ -300,7 +300,7 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
       int cj = (*iJet).id;
 
-      mpT_Jet2_unmatched->Fill(recoJet2[cj].pt());
+      mpT_Jet2_unmatched->Fill(recoJet2[cj]->pt());
     }
     
   }else if (bothJet1Jet2){
@@ -326,10 +326,10 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
       if( delr < mRecoDelRMatch && Jet1_ID[Aj.id] == 0){
 
-	mpT_ratio_Jet1Jet2->Fill((Float_t) recoJet2[Bj.id].pt()/recoJet1[Aj.id].pt());
+	mpT_ratio_Jet1Jet2->Fill((Float_t) recoJet2[Bj.id]->pt()/recoJet1[Aj.id]->pt());
 
-	mpT_Jet1_matched->Fill(recoJet1[Aj.id].pt());
-	mpT_Jet2_matched->Fill(recoJet2[Bj.id].pt());
+	mpT_Jet1_matched->Fill(recoJet1[Aj.id]->pt());
+	mpT_Jet2_matched->Fill(recoJet2[Bj.id]->pt());
 	
 	Jet1_ID[Aj.id] = 1;
 	Jet2_ID[Bj.id] = 1;
@@ -351,7 +351,7 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
       if(Jet1_ID[Aj.id] == 0) {
 
-	mpT_Jet1_unmatched->Fill(recoJet1[Aj.id].pt());
+	mpT_Jet1_unmatched->Fill(recoJet1[Aj.id]->pt());
 	unmatchedJet1++;
 	Jet1_ID[Aj.id] = 1;
 
@@ -385,7 +385,7 @@ void JetAnalyzer_HeavyIons_matching::analyze(const edm::Event& mEvent, const edm
 
       if(Jet2_ID[Bj.id] == 0) {
 
-	mpT_Jet2_unmatched->Fill(recoJet2[Bj.id].pt());
+	mpT_Jet2_unmatched->Fill(recoJet2[Bj.id]->pt());
 	unmatchedJet2++;
 	Jet2_ID[Bj.id] = 2;
 	if(std::string("VsCalo") == JetType2 || std::string("PuCalo") == JetType2){

--- a/DQMOffline/Muon/src/MuonRecoOneHLT.cc
+++ b/DQMOffline/Muon/src/MuonRecoOneHLT.cc
@@ -150,7 +150,7 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
     edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
     iEvent.getByToken(theBeamSpotLabel_,recoBeamSpotHandle);
-    reco::BeamSpot bs = *recoBeamSpotHandle;
+    const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
     posVtx = bs.position();
     errVtx(0,0) = bs.BeamWidthX();
@@ -173,12 +173,12 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   if(!muons.isValid()) return;
 
   //  Pick the leading lepton.
-  std::map<float,reco::Muon> muonMap;
+  std::map<float,const reco::Muon*> muonMap;
   for (reco::MuonCollection::const_iterator recoMu = muons->begin(); recoMu!=muons->end(); ++recoMu){
-    muonMap[recoMu->pt()] = *recoMu;
+    muonMap[recoMu->pt()] = &*recoMu;
   }
-  std::vector<reco::Muon> LeadingMuon;
-  for( std::map<float,reco::Muon>::reverse_iterator rit=muonMap.rbegin(); rit!=muonMap.rend(); ++rit){
+  std::vector<const reco::Muon*> LeadingMuon;
+  for( std::map<float,const reco::Muon*>::reverse_iterator rit=muonMap.rbegin(); rit!=muonMap.rend(); ++rit){
     LeadingMuon.push_back( (*rit).second );
   }
 
@@ -202,19 +202,19 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   //  if (_MuonEventFlag->on() && !(_MuonEventFlag->accept(iEvent,iSetup))) return;
 
   // Check if Muon is Global
-  if(LeadingMuon[0].isGlobalMuon()) {
+  if((*LeadingMuon[0]).isGlobalMuon()) {
     LogTrace(metname)<<"[MuonRecoOneHLT] The mu is global - filling the histos";
-    if(LeadingMuon[0].isTrackerMuon() && LeadingMuon[0].isStandAloneMuon())          muReco->Fill(1);
-    if(!(LeadingMuon[0].isTrackerMuon()) && LeadingMuon[0].isStandAloneMuon())       muReco->Fill(2);
-    if(!LeadingMuon[0].isStandAloneMuon())
+    if((*LeadingMuon[0]).isTrackerMuon() && (*LeadingMuon[0]).isStandAloneMuon())          muReco->Fill(1);
+    if(!((*LeadingMuon[0]).isTrackerMuon()) && (*LeadingMuon[0]).isStandAloneMuon())       muReco->Fill(2);
+    if(!(*LeadingMuon[0]).isStandAloneMuon())
       LogTrace(metname)<<"[MuonRecoOneHLT] ERROR: the mu is global but not standalone!";
 
     // get the track combinig the information from both the Tracker and the Spectrometer
-    reco::TrackRef recoCombinedGlbTrack = LeadingMuon[0].combinedMuon();
+    reco::TrackRef recoCombinedGlbTrack = (*LeadingMuon[0]).combinedMuon();
     // get the track using only the tracker data
-    reco::TrackRef recoTkGlbTrack = LeadingMuon[0].track();
+    reco::TrackRef recoTkGlbTrack = (*LeadingMuon[0]).track();
     // get the track using only the mu spectrometer data
-    reco::TrackRef recoStaGlbTrack = LeadingMuon[0].standAloneMuon();
+    reco::TrackRef recoStaGlbTrack = (*LeadingMuon[0]).standAloneMuon();
 
     etaGlbTrack[0]->Fill(recoCombinedGlbTrack->eta());
     etaGlbTrack[1]->Fill(recoTkGlbTrack->eta());
@@ -233,11 +233,11 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     ptGlbTrack[2]->Fill(recoStaGlbTrack->pt());
   }
   // Check if Muon is Tight
-  if (muon::isTightMuon(LeadingMuon[0], vtx) ) {
+  if (muon::isTightMuon((*LeadingMuon[0]), vtx) ) {
 
     LogTrace(metname)<<"[MuonRecoOneHLT] The mu is tracker only - filling the histos";
 
-    reco::TrackRef recoCombinedGlbTrack = LeadingMuon[0].combinedMuon();
+    reco::TrackRef recoCombinedGlbTrack = (*LeadingMuon[0]).combinedMuon();
 
     etaTight->Fill(recoCombinedGlbTrack->eta());
     phiTight->Fill(recoCombinedGlbTrack->phi());
@@ -246,13 +246,13 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   }
 
   // Check if Muon is Tracker but NOT Global
-  if(LeadingMuon[0].isTrackerMuon() && !(LeadingMuon[0].isGlobalMuon())) {
+  if((*LeadingMuon[0]).isTrackerMuon() && !((*LeadingMuon[0]).isGlobalMuon())) {
     LogTrace(metname)<<"[MuonRecoOneHLT] The mu is tracker only - filling the histos";
-    if(LeadingMuon[0].isStandAloneMuon())          muReco->Fill(3);
-    if(!(LeadingMuon[0].isStandAloneMuon()))        muReco->Fill(4);
+    if((*LeadingMuon[0]).isStandAloneMuon())          muReco->Fill(3);
+    if(!((*LeadingMuon[0]).isStandAloneMuon()))        muReco->Fill(4);
 
     // get the track using only the tracker data
-    reco::TrackRef recoTrack = LeadingMuon[0].track();
+    reco::TrackRef recoTrack = (*LeadingMuon[0]).track();
 
     etaTrack->Fill(recoTrack->eta());
     phiTrack->Fill(recoTrack->phi());
@@ -261,12 +261,12 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   }
 
   // Check if Muon is STA but NOT Global
-  if(LeadingMuon[0].isStandAloneMuon() && !(LeadingMuon[0].isGlobalMuon())) {
+  if((*LeadingMuon[0]).isStandAloneMuon() && !((*LeadingMuon[0]).isGlobalMuon())) {
     LogTrace(metname)<<"[MuonRecoOneHLT] The mu is STA only - filling the histos";
-    if(!(LeadingMuon[0].isTrackerMuon()))         muReco->Fill(5);
+    if(!((*LeadingMuon[0]).isTrackerMuon()))         muReco->Fill(5);
 
     // get the track using only the mu spectrometer data
-    reco::TrackRef recoStaTrack = LeadingMuon[0].standAloneMuon();
+    reco::TrackRef recoStaTrack = (*LeadingMuon[0]).standAloneMuon();
 
     etaStaTrack->Fill(recoStaTrack->eta());
     phiStaTrack->Fill(recoStaTrack->phi());
@@ -274,6 +274,6 @@ void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     ptStaTrack->Fill(recoStaTrack->pt());
   }
   // Check if Muon is Only CaloMuon
-  if(LeadingMuon[0].isCaloMuon() && !(LeadingMuon[0].isGlobalMuon()) && !(LeadingMuon[0].isTrackerMuon()) && !(LeadingMuon[0].isStandAloneMuon()))
+  if((*LeadingMuon[0]).isCaloMuon() && !((*LeadingMuon[0]).isGlobalMuon()) && !((*LeadingMuon[0]).isTrackerMuon()) && !((*LeadingMuon[0]).isStandAloneMuon()))
     muReco->Fill(6);
 }

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -454,17 +454,15 @@ HLTMuonMatchAndPlot::selectedMuons(const MuonCollection & allMuons,
   if (!hasRecoCuts)
     return MuonCollection();
 
-  MuonCollection reducedMuons(allMuons);
-  MuonCollection::iterator iter = reducedMuons.begin();
-  while (iter != reducedMuons.end()) {
+  MuonCollection reducedMuons;
+  for (auto const& mu : allMuons){
     const Track * track = 0;
-    if (iter->isTrackerMuon()) track = & * iter->innerTrack();
-    else if (iter->isStandAloneMuon()) track = & * iter->outerTrack();
-    if (track && selector(* iter) &&
+    if (mu.isTrackerMuon()) track = & * mu.innerTrack();
+    else if (mu.isStandAloneMuon()) track = & * mu.outerTrack();
+    if (track && selector(mu) &&
         fabs(track->dxy(beamSpot.position())) < d0Cut &&
         fabs(track->dz(beamSpot.position())) < z0Cut)
-      ++iter;
-    else reducedMuons.erase(iter);
+      reducedMuons.push_back(mu);
   }
 
   return reducedMuons;

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -80,7 +80,7 @@ class EcalClusterLazyToolsBase {
 
   //const EcalIntercalibConstantMap& icalMap;
   edm::ESHandle<EcalIntercalibConstants> ical;
-  EcalIntercalibConstantMap        icalMap;
+  const EcalIntercalibConstantMap*        icalMap;
   edm::ESHandle<EcalADCToGeVConstant>    agc;
   edm::ESHandle<EcalLaserDbService>      laser;
   void getIntercalibConstants( const edm::EventSetup &es );
@@ -94,7 +94,7 @@ class EcalClusterLazyToolsBase {
   inline const EcalRecHitCollection *getEcalEBRecHitCollection(void){return ebRecHits_;};
   inline const EcalRecHitCollection *getEcalEERecHitCollection(void){return eeRecHits_;};
   inline const EcalRecHitCollection *getEcalESRecHitCollection(void){return esRecHits_;};
-  inline const EcalIntercalibConstants& getEcalIntercalibConstants(void){return icalMap;};
+  inline const EcalIntercalibConstants& getEcalIntercalibConstants(void){return *icalMap;};
   inline const edm::ESHandle<EcalLaserDbService>& getLaserHandle(void){return laser;};
   
 }; // class EcalClusterLazyToolsBase

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -115,7 +115,7 @@ void EcalClusterLazyToolsBase::getIntercalibConstants( const edm::EventSetup &es
 {
   // get IC's
   es.get<EcalIntercalibConstantsRcd>().get(ical);
-  icalMap = ical->getMap();
+  icalMap = &ical->getMap();
 }
 
 
@@ -193,9 +193,9 @@ float EcalClusterLazyToolsBase::BasicClusterTime(const reco::BasicCluster &clust
       float lasercalib = 1.;
       lasercalib = laser->getLaserCorrection( detitr->first, ev.time());
       // 2) get intercalibration
-      EcalIntercalibConstantMap::const_iterator icalit = icalMap.find(detitr->first);
+      EcalIntercalibConstantMap::const_iterator icalit = icalMap->find(detitr->first);
       EcalIntercalibConstant icalconst = 1.;
-      if( icalit!=icalMap.end() ) {
+      if( icalit!=icalMap->end() ) {
 	icalconst = (*icalit);
 	// std::cout << "icalconst set to: " << icalconst << std::endl;
       } else {

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -58,7 +58,7 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
 			    const EcalRecHitCollection* ecalBarrelHits,
 			    const EcalRecHitCollection* ecalEndcapHits,
 			    const edm::Handle<CaloTowerCollection> & hcalTowersHandle,
-			    reco::VertexCollection& pvVertices,
+			    const reco::VertexCollection& pvVertices,
 			    reco::PhotonCollection & outputCollection,
 			    int& iSC);
 

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -268,25 +268,24 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
  // Get EcalRecHits
   bool validEcalRecHits=true;
   Handle<EcalRecHitCollection> barrelHitHandle;
-  EcalRecHitCollection barrelRecHits;
+  const EcalRecHitCollection dummyEB;
   theEvent.getByToken(barrelEcalHits_, barrelHitHandle);
   if (!barrelHitHandle.isValid()) {
     edm::LogError("GEDPhotonProducer") 
       << "Error! Can't get the barrelEcalHits";
     validEcalRecHits=false; 
   }
-  if (  validEcalRecHits)  barrelRecHits = *(barrelHitHandle.product());
-
+  const EcalRecHitCollection& barrelRecHits(validEcalRecHits ? *(barrelHitHandle.product()) : dummyEB);
   
   Handle<EcalRecHitCollection> endcapHitHandle;
   theEvent.getByToken(endcapEcalHits_, endcapHitHandle);
-  EcalRecHitCollection endcapRecHits;
+  const EcalRecHitCollection dummyEE;
   if (!endcapHitHandle.isValid()) {
     edm::LogError("GEDPhotonProducer") 
       << "Error! Can't get the endcapEcalHits";
     validEcalRecHits=false; 
   }
-  if( validEcalRecHits) endcapRecHits = *(endcapHitHandle.product());
+  const EcalRecHitCollection& endcapRecHits(validEcalRecHits ? *(endcapHitHandle.product()) : dummyEE);
 
 
 
@@ -338,7 +337,7 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
   // Get the primary event vertex
   Handle<reco::VertexCollection> vertexHandle;
-  reco::VertexCollection vertexCollection;
+  const reco::VertexCollection dummyVC;
   bool validVertex=true;
   if ( usePrimaryVertex_ ) {
     theEvent.getByToken(vertexProducer_, vertexHandle);
@@ -347,8 +346,9 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 	<< "Error! Can't get the product primary Vertex Collection";
       validVertex=false;
     }
-    if (validVertex) vertexCollection = *(vertexHandle.product());
   }
+  const reco::VertexCollection& vertexCollection(usePrimaryVertex_ && validVertex ? *(vertexHandle.product()) : dummyVC);
+
   //  math::XYZPoint vtx(0.,0.,0.);
   //if (vertexCollection.size()>0) vtx = vertexCollection.begin()->position();
 
@@ -429,7 +429,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
 					     const EcalRecHitCollection* ecalBarrelHits,
 					     const EcalRecHitCollection* ecalEndcapHits,
 					     const edm::Handle<CaloTowerCollection> & hcalTowersHandle, 
-					     reco::VertexCollection & vertexCollection,
+					     const reco::VertexCollection & vertexCollection,
 					     reco::PhotonCollection & outputPhotonCollection, int& iSC) {
   
   

--- a/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
@@ -10,7 +10,10 @@ hiMuons1stStep.inputCollectionLabels = [hiTracks, 'globalMuons', 'standAloneMuon
 hiMuons1stStep.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks','tev firstHit', 'tev picky', 'tev dyt']
 hiMuons1stStep.TrackExtractorPSet.inputTrackCollection = hiTracks
 hiMuons1stStep.minPt = cms.double(0.8)
+#iso deposits are not used in HI
+hiMuons1stStep.writeIsoDeposits = False
 #hiMuons1stStep.fillGlobalTrackRefits = False
+
 muonEcalDetIds.inputCollection = "hiMuons1stStep"
 
 calomuons.inputTracks = hiTracks
@@ -26,7 +29,8 @@ muonShowerInformation.muonCollection = "hiMuons1stStep"
 #standalone muon tracking is already done... so remove standalonemuontracking from muontracking
 muonreco_plus_isolation_PbPb = muonreco_plus_isolation.copyAndExclude(standalonemuontracking._seq._collection + displacedGlobalMuonTracking._seq._collection)
 muonreco_plus_isolation_PbPb.replace(muons1stStep, hiMuons1stStep)
-
+#iso deposits are not used in HI
+muonreco_plus_isolation_PbPb.remove(muIsoDeposits_muons)
 
 globalMuons.TrackerCollectionLabel = hiTracks
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -1106,11 +1106,14 @@ void MuonIdProducer::fillMuonIsolation(edm::Event& iEvent, const edm::EventSetup
    reco::IsoDeposit depHcal = caloDeps.at(1);
    reco::IsoDeposit depHo   = caloDeps.at(2);
 
-   trackDep = depTrk;
-   ecalDep = depEcal;
-   hcalDep = depHcal;
-   hoDep = depHo;
-   jetDep = depJet;
+   //no need to copy outside if we don't write them
+   if (writeIsoDeposits_){
+     trackDep = depTrk;
+     ecalDep = depEcal;
+     hcalDep = depHcal;
+     hoDep = depHo;
+     jetDep = depJet;
+   }
 
    isoR03.sumPt     = depTrk.depositWithin(0.3);
    isoR03.emEt      = depEcal.depositWithin(0.3);

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -442,24 +442,6 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    init(iEvent, iSetup);
 
-   std::auto_ptr<reco::MuonTimeExtraMap> muonTimeMap(new reco::MuonTimeExtraMap());
-   reco::MuonTimeExtraMap::Filler filler(*muonTimeMap);
-   std::auto_ptr<reco::MuonTimeExtraMap> muonTimeMapDT(new reco::MuonTimeExtraMap());
-   reco::MuonTimeExtraMap::Filler fillerDT(*muonTimeMapDT);
-   std::auto_ptr<reco::MuonTimeExtraMap> muonTimeMapCSC(new reco::MuonTimeExtraMap());
-   reco::MuonTimeExtraMap::Filler fillerCSC(*muonTimeMapCSC);
-
-   std::auto_ptr<reco::IsoDepositMap> trackDepMap(new reco::IsoDepositMap());
-   reco::IsoDepositMap::Filler trackDepFiller(*trackDepMap);
-   std::auto_ptr<reco::IsoDepositMap> ecalDepMap(new reco::IsoDepositMap());
-   reco::IsoDepositMap::Filler ecalDepFiller(*ecalDepMap);
-   std::auto_ptr<reco::IsoDepositMap> hcalDepMap(new reco::IsoDepositMap());
-   reco::IsoDepositMap::Filler hcalDepFiller(*hcalDepMap);
-   std::auto_ptr<reco::IsoDepositMap> hoDepMap(new reco::IsoDepositMap());
-   reco::IsoDepositMap::Filler hoDepFiller(*hoDepMap);
-   std::auto_ptr<reco::IsoDepositMap> jetDepMap(new reco::IsoDepositMap());
-   reco::IsoDepositMap::Filler jetDepFiller(*jetDepMap);
-
    // loop over input collections
 
    // muons first - no cleaning, take as is.
@@ -713,33 +695,27 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    if ( fillMatching_ ) fillArbitrationInfo( outputMuons.get() );
    edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(outputMuons);
 
-   filler.insert(muonHandle, combinedTimeColl.begin(), combinedTimeColl.end());
-   filler.fill();
-   fillerDT.insert(muonHandle, dtTimeColl.begin(), dtTimeColl.end());
-   fillerDT.fill();
-   fillerCSC.insert(muonHandle, cscTimeColl.begin(), cscTimeColl.end());
-   fillerCSC.fill();
-
-   iEvent.put(muonTimeMap,"combined");
-   iEvent.put(muonTimeMapDT,"dt");
-   iEvent.put(muonTimeMapCSC,"csc");
+   auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = ""){
+     typedef  edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;
+     std::unique_ptr<MapType > oMap(new MapType());
+     {
+       typename MapType::Filler filler(*oMap);
+       filler.insert(refH, vec.begin(), vec.end());
+       vec.clear();
+       filler.fill();
+     }
+     ev.put(std::move(oMap), cAl);
+   };
+   fillMap(muonHandle, combinedTimeColl, iEvent, "combined");
+   fillMap(muonHandle, dtTimeColl, iEvent, "dt");
+   fillMap(muonHandle, cscTimeColl, iEvent, "csc");
 
    if (writeIsoDeposits_ && fillIsolation_){
-     trackDepFiller.insert(muonHandle, trackDepColl.begin(), trackDepColl.end());
-     trackDepFiller.fill();
-     iEvent.put(trackDepMap, trackDepositName_);
-     ecalDepFiller.insert(muonHandle, ecalDepColl.begin(), ecalDepColl.end());
-     ecalDepFiller.fill();
-     iEvent.put(ecalDepMap,  ecalDepositName_);
-     hcalDepFiller.insert(muonHandle, hcalDepColl.begin(), hcalDepColl.end());
-     hcalDepFiller.fill();
-     iEvent.put(hcalDepMap,  hcalDepositName_);
-     hoDepFiller.insert(muonHandle, hoDepColl.begin(), hoDepColl.end());
-     hoDepFiller.fill();
-     iEvent.put(hoDepMap,    hoDepositName_);
-     jetDepFiller.insert(muonHandle, jetDepColl.begin(), jetDepColl.end());
-     jetDepFiller.fill();
-     iEvent.put(jetDepMap,  jetDepositName_);
+     fillMap(muonHandle, trackDepColl, iEvent, trackDepositName_);
+     fillMap(muonHandle, ecalDepColl, iEvent, ecalDepositName_);
+     fillMap(muonHandle, hcalDepColl, iEvent, hcalDepositName_);
+     fillMap(muonHandle, hoDepColl, iEvent, hoDepositName_);
+     fillMap(muonHandle, jetDepColl, iEvent, jetDepositName_);
    }
 
    iEvent.put(caloMuons);

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
@@ -60,8 +60,8 @@ void MuIsoDepositCopyProducer::produce(Event& event, const EventSetup& eventSetu
     Handle<reco::IsoDepositMap > inDep;
     event.getByToken(theInputTokens[iDep], inDep);
 
-    std::auto_ptr<reco::IsoDepositMap> outDep(new reco::IsoDepositMap(*inDep));
-    event.put(outDep, theDepositNames[iDep]);
+    std::unique_ptr<reco::IsoDepositMap> outDep(new reco::IsoDepositMap(*inDep));
+    event.put(std::move(outDep), theDepositNames[iDep]);
   }//! end iDep
 
   LogTrace(metname) <<" END OF EVENT " <<"================================";

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -742,7 +742,7 @@ EvaluateSingleLegMVA(const pfEGHelpers::HeavyObjectCache* hoc,
   const reco::PFBlock& block = *blockref;  
   const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();  
   //use this to store linkdata in the associatedElements function below  
-  PFBlock::LinkData linkData =  block.linkData();  
+  const PFBlock::LinkData& linkData =  block.linkData();  
   //calculate MVA Variables  
   chi2=elements[track_index].trackRef()->chi2()/elements[track_index].trackRef()->ndof(); 
   nlost=elements[track_index].trackRef()->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS); 


### PR DESCRIPTION
originally, as a follow up to cmsRun1-68 from 
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1405.html

(I)
using the heavier events from the report and igprof -mp, the muon isodeposits were found to contribute up to 400 MB/event in memory (at least an order of magnitude less is expected for more normal HI events and much less for pp events).
It turns out that the isodeposits put in the event are not used anywhere in HI workflows.
So, they are dropped.
This has the largest "long-term" impact (from the time muon id module runs to the end of the event)

(II)
In addition, modules with fairly large memory churn (MEM_TOTAL) were cleaned somewhat trivially, without changing the algorithm logic.
The net effect on the large events was about 15-20% reduction in allocations in stream::EDProducer and stream::EDAnalyzer modules.
There are only short-term (less than the module ::produce time) contributions.
The optimizations here also speed up substantially the modified modules.

Overall, for the job that failed at T0: the 8-thread configuration memory peak reduced from 15.67 GiB to 14.88 GiB.

tested in CMSSW_7_5_7_patch2: no differences were observed in monitored quantities
