### PR TITLE
L1 HeavyIons: Take HI parameters from GT

### DIFF
--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -148,15 +148,6 @@ def customiseSimL1EmulatorForPostLS1_25ns(process):
 # -> no L1 Menu added here
 # -> common post LS1 customizations not called here
 def customiseSimL1EmulatorForPostLS1_Additional_HI(process):
-    # set the Stage 1 heavy ions-specific parameters
-    # all of these should eventually end up in a GT
-    if hasattr(process,'RCTConfigProducers'):
-        process.RCTConfigProducers.eicIsolationThreshold = cms.uint32(7)
-        process.RCTConfigProducers.hOeCut = cms.double(999)
-        process.RCTConfigProducers.eMinForHoECut = cms.double(999)
-        process.RCTConfigProducers.eMaxForHoECut = cms.double(999)
-        process.RCTConfigProducers.hMinForHoECut = cms.double(999)
-        process.RCTConfigProducers.eMinForFGCut = cms.double(999)
     if hasattr(process,'caloConfig'):
         process.caloConfig.fwVersionLayer2 = cms.uint32(1)
     return process


### PR DESCRIPTION
Don't manually override RCT calibrations (if they are present), just use the GT which is now fine.

This should not actually change any results, since the RCT calibrations would need to be manually set anyway for these to apply, but this will save some poor soul in the future who manually sets RCT calibration in the future. 

75X already has this fix. Will backport to 76X for completeness. 
