### PR TITLE
Remove obsolete cms* scripts 76X( Backport of #12783)

### DIFF
--- a/Alignment/APEEstimation/test/SkimProducer/cmsRemove.sh
+++ b/Alignment/APEEstimation/test/SkimProducer/cmsRemove.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+eos="/afs/cern.ch/project/eos/installation/cms/bin/eos.select"
 
 #directory="/store/caf/user/hauk/data/mu/Run2010B_Dec22ReReco/"
 directory="/store/caf/user/ajkumar/ApeSkim/zmumu50/"
@@ -39,10 +40,10 @@ while [ $counter -le 1000 ]
 do
   fullname="${filebase}${counter}${filesuffix}"
   
-  cmsLs ${fullname}
+  $eos ls ${fullname}
   if [ $? -eq 0 ] ; then
     echo "Delete file: ${counter}";
-    cmsRm ${fullname}
+    $eos rm ${fullname}
   else
     echo "Last file reached: ${counter}"; exit 0;
   fi

--- a/Alignment/APEEstimation/test/SkimProducer/cmsRename.sh
+++ b/Alignment/APEEstimation/test/SkimProducer/cmsRename.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+eos="/afs/cern.ch/project/eos/installation/cms/bin/eos.select"
+
 if [ ! $# == 1 ]; then
   echo "Usage: $0 sample"
   exit 1
@@ -36,12 +38,12 @@ declare -i counter=1
 inputFilename="${filebase}${filesuffix}"
 outputFilename="${filebase}${counter}${filesuffix}"
 
-cmsStageIn $inputFilename $tempFile
+xrdcp root://eoscms//eos/cms${inputFilename} $tempFile
 
 if [ ! -f $tempFile ] ; then echo "Last file reached: 0"; exit 0; fi
-cmsStageOut $tempFile $outputFilename
+xrdcp $tempFile root://eoscms//eos/cms${outputFilename}
 if [ $? -eq 0 ] ; then
-  cmsRm ${filebase}${filesuffix}
+  $eos rm ${filebase}${filesuffix}
 fi
 rm $tempFile
 
@@ -53,11 +55,11 @@ do
   inputFilename="${filebase}00${counter}${filesuffix}"
   outputFilename="${filebase}${counterIncrement}${filesuffix}"
   
-  cmsStageIn $inputFilename $tempFile
+  xrdcp root://eoscms//eos/cms${inputFilename} $tempFile
   if [ ! -f $tempFile ] ; then echo "Last file reached: ${counter}"; exit 0; fi
-  cmsStageOut $tempFile $outputFilename
+  xrdcp $tempFile root://eoscms//eos/cms${outputFilename}
   if [ $? -eq 0 ] ; then
-    cmsRm $inputFilename
+    $eos rm $inputFilename
   fi
   rm $tempFile
   
@@ -75,11 +77,11 @@ do
   inputFilename="${filebase}0${counterTen}${filesuffix}"
   outputFilename="${filebase}${counterTenIncrement}${filesuffix}"
   
-  cmsStageIn $inputFilename $tempFile
+  xrdcp root://eoscms//eos/cms${inputFilename} $tempFile
   if [ ! -f $tempFile ] ; then echo "Last file reached: ${counterTen}"; exit 0; fi
-  cmsStageOut $tempFile $outputFilename
+  xrdcp $tempFile root://eoscms//eos/cms${outputFilename}
   if [ $? -eq 0 ] ; then
-    cmsRm $inputFilename
+    $eos rm $inputFilename
   fi
   rm $tempFile
   

--- a/Alignment/APEEstimation/test/batch/cp.bash
+++ b/Alignment/APEEstimation/test/batch/cp.bash
@@ -45,7 +45,7 @@ ls -l
 
 for file in *.root;
 do
-  cmsStageOut $file ${directory}${file}
+  xrdcp $file root://eoscms//eos/cms${directory}${file}
 done
 
 

--- a/Alignment/APEEstimation/test/batch/skimProducer.bash
+++ b/Alignment/APEEstimation/test/batch/skimProducer.bash
@@ -47,7 +47,7 @@ ls -l
 
 for file in *.root;
 do
-  cmsStageOut $file ${directory}${file}
+  xrdcp $file root://eoscms//eos/cms${directory}${file}
 done
 
 

--- a/Alignment/APEEstimation/test/cfgTemplate/batchSubmitTemplate.tcsh
+++ b/Alignment/APEEstimation/test/cfgTemplate/batchSubmitTemplate.tcsh
@@ -15,7 +15,7 @@ source /afs/cern.ch/cms/caf/setup.csh
 cd -
 
 
-cmsStageIn _THE_INPUTBASE__THE_NUMBER_.root reco.root
+xrdcp _THE_INPUTBASE__THE_NUMBER_.root reco.root
 
 
 cmsRun $CMSSW_BASE/src/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py_THE_COMMANDS_

--- a/Alignment/APEEstimation/test/cfgTemplate/writeSubmitScript.sh
+++ b/Alignment/APEEstimation/test/cfgTemplate/writeSubmitScript.sh
@@ -24,7 +24,7 @@ BATCH_OUTPUTBASE1="${CMSSW_BASE}/src/Alignment/APEEstimation/test/batch/workingA
 BATCH_OUTPUTSUFFIX=".tcsh"
 
 helpFile1="help1.txt"
-cat $BATCH_TEMPLATEFILE |sed "s/_THE_INPUTBASE_/${inputBase}/g" > $helpFile1
+cat $BATCH_TEMPLATEFILE |sed "s/_THE_INPUTBASE_/root:\/\/eoscms\/\/eos\/cms\/${inputBase}/g" > $helpFile1
 
 
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.pl
@@ -18,7 +18,7 @@ use Mpslib;
 
 read_db();
 
-my @cmslsoutput = `cmsLs -l $mssDir`;
+my @cmslsoutput = `$Mpslib::eos ls -l $mssDir`;
 
 # loop over FETCH jobs
 for ($i=0; $i<@JOBID; ++$i) {
@@ -156,8 +156,6 @@ for ($i=0; $i<@JOBID; ++$i) {
     # for mille jobs checks that milleBinary file is not empty
     if ( $i < $nJobs ) { # mille job!
       my $milleOut = sprintf("milleBinary%03d.dat",$i+1);
-      #$mOutSize = `nsls -l $mssDir | grep $milleOut | head -1 | awk '{print \$5}'`;
-      #$mOutSize = `cmsLs -l $mssDir | grep $milleOut | head -1 | awk '{print \$2}'`;
       my $mOutSize = 0;
       foreach my $line (@cmslsoutput)
         {

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runMille_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runMille_template.sh
@@ -6,6 +6,9 @@
 #
 # In the very beginning of this script, stager requests for the files will be added.
 
+EOS="/afs/cern.ch/project/eos/installation/cms/bin/eos.select"
+EOSPREFIX="root://eoscms//eos/cms"
+
 
 # these defaults will be overwritten by MPS
 RUNDIR=$HOME/scratch0/some/path
@@ -62,12 +65,10 @@ if [ "$MSSDIRPOOL" != "cmscafuser" ]; then
   rfcp treeFile*root         $MSSDIR/treeFileISN.root
   rfcp millePedeMonitor*root $MSSDIR/millePedeMonitorISN.root
 else
-# Using cmscafuser pool => cmsStageOut command must be used
-  . /afs/cern.ch/cms/caf/setup.sh
   MSSCAFDIR=`echo $MSSDIR | perl -pe 's/\/castor\/cern.ch\/cms//gi'`
   
-  echo "cmsStageOut -f milleBinaryISN.dat.gz $MSSCAFDIR/milleBinaryISN.dat.gz > /dev/null"
-  cmsStageOut -f milleBinaryISN.dat.gz    $MSSCAFDIR/milleBinaryISN.dat.gz  > /dev/null
-  cmsStageOut -f treeFile*root         $MSSCAFDIR/treeFileISN.root > /dev/null
-  cmsStageOut -f millePedeMonitor*root $MSSCAFDIR/millePedeMonitorISN.root > /dev/null
+  echo "xrdcp -f milleBinaryISN.dat.gz ${EOSPREFIX}${MSSCAFDIR}/milleBinaryISN.dat.gz > /dev/null"
+  xrdcp -f milleBinaryISN.dat.gz    ${EOSPREFIX}${MSSCAFDIR}/milleBinaryISN.dat.gz  > /dev/null
+  xrdcp -f treeFile*root         ${EOSPREFIX}${MSSCAFDIR}/treeFileISN.root > /dev/null
+  xrdcp -f millePedeMonitor*root ${EOSPREFIX}${MSSCAFDIR}/millePedeMonitorISN.root > /dev/null
 fi

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
@@ -7,6 +7,9 @@
 #temporary fix (?):
 #unset PYTHONHOME
 
+EOS="/afs/cern.ch/project/eos/installation/cms/bin/eos.select"
+EOSPREFIX="root://eoscms//eos/cms"
+
 cd $CMSSW_BASE/src
 eval `scramv1 runtime -sh`
 cd -
@@ -20,7 +23,7 @@ MSSDIRPOOL=
 TREEFILELIST=
 if [ "$MSSDIRPOOL" != "cmscafuser" ]; then
 else
-    TREEFILELIST=`cmsLs -l $MSSDIR | grep -i treeFile | grep -i root`
+    TREEFILELIST=`${EOS} ls -l $MSSDIR | grep -i treeFile | grep -i root`
 fi
 if [ -z "$TREEFILELIST" ]; then
     echo "\nThe list of treefiles seems to be empty.\n"
@@ -98,13 +101,10 @@ if [ "$MSSDIRPOOL" != "cmscafuser" ]; then
   stager_get -M $MSSDIR/treeFileISN.root
   copytreefile rfcp $MSSDIR/treeFileISN.root $BATCH_DIR
 else
-# Using cmscafuser pool => cmsStageIn command must be used
-  . /afs/cern.ch/cms/caf/setup.sh
-  #MSSCAFDIR=`echo $MSSDIR | awk 'sub("/castor/cern.ch/cms","")'`
   MSSCAFDIR=`echo $MSSDIR | perl -pe 's/\/castor\/cern.ch\/cms//gi'`
   
-  untilSuccess cmsStageIn $MSSCAFDIR/milleBinaryISN.dat.gz milleBinaryISN.dat.gz
-  copytreefile cmsStageIn $MSSCAFDIR/treeFileISN.root treeFileISN.root
+  untilSuccess xrdcp ${EOSPREFIX}${MSSCAFDIR}/milleBinaryISN.dat.gz milleBinaryISN.dat.gz
+  copytreefile xrdcp ${EOSPREFIX}${MSSCAFDIR}/treeFileISN.root treeFileISN.root
 fi
 
 # We have gzipped binaries, but the python config looks for .dat

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
@@ -178,6 +178,8 @@ gzip -f *.ps
 gzip -f millepede.*s
 # in case of diagonalisation zip this:
 gzip -f millepede.eve
+# zip monitoring file:
+gzip -f millepede.mon
 
 #list IOVs
 cmscond_list_iov -c sqlite_file:alignments_MP.db -t Alignments

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.pl
@@ -194,7 +194,7 @@ if ($mssDir ne "") {
   }
 
   #$testMssDir = `nsls -d $mssDir`;
-  $testMssDir = `cmsLs -d $mssDir`;
+  $testMssDir = `$Mpslib::eos ls -d $mssDir`;
   chomp $testMssDir;
   if ($testMssDir eq "") {
     print "Bad MSS directory name $mssDir\n";

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mpslib/Mpslib.pm
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mpslib/Mpslib.pm
@@ -59,6 +59,8 @@ package Mpslib;  # assumes Some/Module.pm
 		    @JOBSTATUS @JOBNTRY @JOBRUNTIME @JOBNEVT @JOBHOST @JOBINCR @JOBREMARK @JOBSP1 @JOBSP2 @JOBSP3
                    );
 
+our $eos = "/afs/cern.ch/project/eos/installation/cms/bin/eos.select";
+
 sub write_db() {
   $header = "mps database schema 3.2" ;
   $currentTime = `date +%s`;

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -306,9 +306,9 @@ def createMergeScript( path, validations ):
             repMap["haddLoop"] = validation.appendToMerge(repMap["haddLoop"])
             repMap["haddLoop"] += "tmpMergeRetCode=${?}\n"
             repMap["haddLoop"] += ("if [[ tmpMergeRetCode -eq 0 ]]; then "
-                                   "cmsStage -f "
+                                   "xrdcp -f "
                                    +validation.getRepMap()["finalOutputFile"]
-                                   +" "
+                                   +" root://eoscms//eos/cms"
                                    +validation.getRepMap()["finalResultFile"]
                                    +"; fi\n")
             repMap["haddLoop"] += ("if [[ ${tmpMergeRetCode} -gt ${mergeRetCode} ]]; then "
@@ -316,7 +316,7 @@ def createMergeScript( path, validations ):
             for f in validation.getRepMap()["outputFiles"]:
                 longName = os.path.join("/store/caf/user/$USER/",
                                         validation.getRepMap()["eosdir"], f)
-                repMap["rmUnmerged"] += "    cmsRm "+longName+"\n"
+                repMap["rmUnmerged"] += "    $eos rm "+longName+"\n"
     repMap["rmUnmerged"] += ("else\n"
                              "    echo -e \\n\"WARNING: Merging failed, unmerged"
                              " files won't be deleted.\\n"


### PR DESCRIPTION
This PR removes the usage of the following scripts in the alignment workflows:

cmsLs
cmsMkdir
cmsRm
cmsRmdir
cmsPfn
cmsStage
cmsStageIn
cmsStageOut

These will stop working in January 2016 [1] and have been replaced by supported alternatives.

Added also a commit to copy over a monitoring file for the MillePedeAlgorithm.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/cmpAnnounce/1031.html

Backport of #12783
