### PR TITLE
Fix typo affecting standalone tracking validation sequence

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -298,7 +298,7 @@ tracksValidationStandalone = cms.Sequence(
     ak4PFL1FastL2L3CorrectorChain +
     tracksPreValidation +
     tracksValidationSelectorsStandalone +
-    trackValidatorStandalone
+    trackValidatorsStandalone
 )
 
 ### TrackingOnly mode (i.e. MTV with DIGI input + tracking-only reconstruction


### PR DESCRIPTION
Fix typo in `TrackValidation_cff` affecting the standalone sequences. The effect of the bug was that the "FromPV", "FromPVAllTP", and "AllTPEffic" variants of MultiTrackValidator did not get run.

Tested in 8_0_0_pre3, no changes expected in standard workflows.

@rovere @VinInn 
