### PR TITLE
avoid a crash in BTVHLTOfflineSource

### DIFF
--- a/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
@@ -177,7 +177,7 @@ BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
         }
       }
       
-     if (csvCaloTags.isValid() && v->getTriggerType() == "Calo") 
+     if (csvCaloTags.isValid() && v->getTriggerType() == "Calo" && !csvCaloTags->empty()) 
      { 
       auto iter = csvCaloTags->begin();
       


### PR DESCRIPTION
trivial fix to avoid the crash in the recent IBs and in 800pre3.
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc493/CMSSW_8_0_X_2015-12-11-1100/pyRelValMatrixLogs/run/134.805_RunMET2015C+RunMET2015C+HLTDR2_25ns+RECODR2_25nsreHLT+HARVESTDR2_25nsreHLT/step3_RunMET2015C+RunMET2015C+HLTDR2_25ns+RECODR2_25nsreHLT+HARVESTDR2_25nsreHLT.log

Since the validation code didn't change, there may actually be a problem with the inputs.
That can be resolved in a follow up or a replacement PR
