### PR TITLE
Make BTVHLTOfflineSource safe from empty container

### DIFF
--- a/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
@@ -177,7 +177,7 @@ BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
         }
       }
       
-     if (csvCaloTags.isValid() && v->getTriggerType() == "Calo") 
+     if (csvCaloTags.isValid() && v->getTriggerType() == "Calo" && csvCaloTags->size()>0) 
      { 
       auto iter = csvCaloTags->begin();
       


### PR DESCRIPTION
Make sure the container has entries before attempting to use the
begin iterator.
