### PR TITLE
Remove module circular dependency check from EventPrincipal

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -193,19 +193,6 @@ namespace edm {
     
   private:
 
-    class UnscheduledSentry {
-    public:
-      UnscheduledSentry(std::vector<std::string>* moduleLabelsRunning, std::string const& moduleLabel) :
-        moduleLabelsRunning_(moduleLabelsRunning) {
-        moduleLabelsRunning_->push_back(moduleLabel);
-      }
-      ~UnscheduledSentry() {
-        moduleLabelsRunning_->pop_back();
-      }
-    private:
-      std::vector<std::string>* moduleLabelsRunning_;
-    };
-
     EventAuxiliary aux_;
 
     std::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
@@ -215,8 +202,6 @@ namespace edm {
 
     // Handler for unscheduled modules
     std::shared_ptr<UnscheduledHandler> unscheduledHandler_;
-
-    mutable std::vector<std::string> moduleLabelsRunning_;
 
     EventSelectionIDVector eventSelectionIDs_;
 


### PR DESCRIPTION
We previously checked that a module wasn't indirectly calling itself in unscheduled via a run time check. With the requirements on consumes calls, we now check for circular dependencies before running the job. In addition, this implementation would not be thread safe. However, if we ever did need to add back a runtime check we could use the Context information instead.
