### PR TITLE
Set hierarchy constraints as default in Millepede

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/python/AlignmentParameterStore_cfi.py
+++ b/Alignment/CommonAlignmentAlgorithm/python/AlignmentParameterStore_cfi.py
@@ -8,7 +8,7 @@ AlignmentParameterStore = cms.PSet(
             MaxUpdates = cms.int32(5000)
         ),
         UseExtendedCorrelations = cms.untracked.bool(False),
-        TypeOfConstraints = cms.string('approximate_averaging'),
+        TypeOfConstraints = cms.string('hierarchy'),
     )
 )
 

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
@@ -42,16 +42,14 @@ AlignmentParameterStore::AlignmentParameterStore( const align::Alignables &alis,
   const std::string cfgStrTypeOfConstraints(config.getParameter<std::string>("TypeOfConstraints"));
   if( cfgStrTypeOfConstraints == "hierarchy" ) {
     theTypeOfConstraints = HIERARCHY_CONSTRAINTS;
-    edm::LogWarning("Alignment") << "@SUB=AlignmentParameterStore"
-				 << "\n\n\n******* WARNING ******************************************\n"
-				 << "Using hierarchy constraints that have a not-understood bug.\n"
-				 << "It is strongly recommended to use averaging constraints for\n"
-				 << "the time being!\n\n\n";
-    
   } else if( cfgStrTypeOfConstraints == "approximate_averaging" ) {
     theTypeOfConstraints = APPROX_AVERAGING_CONSTRAINTS;
     edm::LogWarning("Alignment") << "@SUB=AlignmentParameterStore"
-				 << "Using approximate implementation of averaging constraints";
+				 << "\n\n\n******* WARNING ******************************************\n"
+				 << "Using approximate implementation of averaging constraints."
+				 << "This is not recommended."
+				 << "Consider to use 'hierarchy' constraints:"
+				 << "  AlignmentProducer.ParameterStore.TypeOfConstraints = cms.string('hierarchy')\n\n\n";
   } else {
     edm::LogError("BadArgument") << "@SUB=AlignmentParameterStore"
 				 << "Unknown type of hierarchy constraints '" << cfgStrTypeOfConstraints << "'"; 


### PR DESCRIPTION
This sets back the default way constraints are treated in Millepede to using hierarchy constraints, and reverts the temporary changes introduced with #6254. Previous problems were found to be due to numerical effects in pede. These are solved in >=rev137, which uses 'elimination' instead of lagrangian multipliers. Rev 140 is indeed in 80X externals.
Forward port of #9750 
