### PR TITLE
Updated GT for HI MC production.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '75X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v11',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v12',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '75X_dataRun1_v13',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of Changes
## RunII Simulation
- **Heavy Ion Scenario**: [75X_mcRun2_HeavyIon_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/75X_mcRun2_HeavyIon_v12): as [75X_mcRun2_HeavyIon_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/75X_mcRun2_HeavyIon_v11) with the following [change](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/75X_mcRun2_HeavyIon_v11/75X_mcRun2_HeavyIon_v12):
  - updated HCAL response corrections to use old HCAL time slew model.
