### PR TITLE
Made API to UnscheduledHander const

### DIFF
--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -27,7 +27,7 @@ namespace edm {
       WorkerLookup() = default;
       
       using worker_container = std::vector<Worker*>;
-      using iterator = worker_container::iterator;
+      using const_iterator = worker_container::const_iterator;
 
       void add(Worker* iWorker) {
         auto const& label = iWorker->description().moduleLabel();
@@ -47,8 +47,8 @@ namespace edm {
         return m_values[found->second];
       }
       
-      iterator begin() { return m_values.begin(); }
-      iterator end() { return m_values.end(); }
+      const_iterator begin() const { return m_values.begin(); }
+      const_iterator end() const { return m_values.end(); }
       
     private:
       //second element is the index of the key in m_values
@@ -64,7 +64,7 @@ namespace edm {
 
     template <typename T, typename U>
     void runNow(typename T::MyPrincipal& p, EventSetup const& es, StreamID streamID,
-                typename T::Context const* topContext, U const* context) {
+                typename T::Context const* topContext, U const* context) const {
       //do nothing for event since we will run when requested
       if(!T::isEvent_) {
         for(auto worker: workerLookup_) {
@@ -109,7 +109,7 @@ namespace edm {
     virtual bool tryToFillImpl(std::string const& moduleLabel,
                                EventPrincipal& event,
                                EventSetup const& eventSetup,
-                               ModuleCallingContext const* mcc) {
+                               ModuleCallingContext const* mcc) const override {
       auto worker =
         workerLookup_.find(moduleLabel);
       if(worker != nullptr) {

--- a/FWCore/Framework/interface/UnscheduledHandler.h
+++ b/FWCore/Framework/interface/UnscheduledHandler.h
@@ -44,7 +44,7 @@ namespace edm {
       ///returns true if found an EDProducer and ran it
       bool tryToFill(std::string const& label,
                      EventPrincipal& iEvent,
-                     ModuleCallingContext const* mcc);
+                     ModuleCallingContext const* mcc) const;
 
       void setEventSetup(EventSetup const& iSetup) {
          m_setup = &iSetup;
@@ -54,7 +54,7 @@ namespace edm {
       virtual bool tryToFillImpl(std::string const&,
                                  EventPrincipal&,
                                  EventSetup const&,
-                                 ModuleCallingContext const* mcc) = 0;
+                                 ModuleCallingContext const* mcc) const = 0;
       // ---------- member data --------------------------------
       EventSetup const* m_setup;
    };

--- a/FWCore/Framework/src/UnscheduledHandler.cc
+++ b/FWCore/Framework/src/UnscheduledHandler.cc
@@ -25,7 +25,7 @@ namespace edm {
   bool
   UnscheduledHandler::tryToFill(std::string const& label,
                                 EventPrincipal& iEvent,
-                                ModuleCallingContext const* mcc) {
+                                ModuleCallingContext const* mcc) const {
      assert(m_setup);
      return tryToFillImpl(label, iEvent, *m_setup, mcc);
   }


### PR DESCRIPTION
Changed member functions which would be called from multiple threads simultaneously const in order to distinguish them from the members which are only going to be called serially. This should aid in checking for thread-safety.
A needed followup will be to make Worker thread-safe.
