### PR TITLE
Select particles and anti-particles for efficiency and fake rate.

### DIFF
--- a/Validation/RecoVertex/src/V0Validator.cc
+++ b/Validation/RecoVertex/src/V0Validator.cc
@@ -262,14 +262,14 @@ void V0Validator::doFakeRates(
                     for (TrackingVertex::tp_iterator iTP =
                              parentVertex->sourceTracks_begin();
                          iTP != parentVertex->sourceTracks_end(); iTP++) {
-                      if ((*iTP)->pdgId() == particle_pdgid) {
+                      if (abs((*iTP)->pdgId()) == particle_pdgid) {
                         CandidateStatus = 1;
                         realCandidateFound++;
                         numCandidateFound += 1.;
                         goodCandidateMass[v0_type]->Fill(mass);
                       } else {
                         CandidateStatus = 2;
-                        if ((*iTP)->pdgId() ==
+                        if (abs((*iTP)->pdgId()) ==
                             misreconstructed_particle_pdgid) {
                           CandidateStatus = 7;
                         }


### PR DESCRIPTION
An abs call was missing in the vertex validatin package while checking the
decay chain of the mother particle. This had the unpleasent effect of marking
the decays of the corresponding anti-particles as fakes. This PR fixes this
bug.

port of #12433 to 80
