### PR TITLE
stop overriding GT for CaloParams

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2CentralityAlgorithm.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2CentralityAlgorithm.cc
@@ -97,18 +97,20 @@ void l1t::Stage1Layer2CentralityAlgorithm::processEvent(const std::vector<l1t::C
   // Begin MB Trigger //
   std::vector<int> thresholds = params_->minimumBiasThresholds();
   int numOverThresh[4] = {0};
-  for(std::vector<CaloRegion>::const_iterator region = regions.begin(); region != regions.end(); region++) {
-    if(region->hwEta() < 4) {
-      if(region->hwPt() >= thresholds.at(0))
-	numOverThresh[0]++;
-      if(region->hwPt() >= thresholds.at(2))
-	numOverThresh[2]++;
-    }
-    if(region->hwEta() > 17) {
-      if(region->hwPt() >= thresholds.at(1))
-	numOverThresh[1]++;
-      if(region->hwPt() >= thresholds.at(3))
-	numOverThresh[3]++;
+  if(thresholds.size() >= 4){ // guard against malformed/old GT
+    for(std::vector<CaloRegion>::const_iterator region = regions.begin(); region != regions.end(); region++) {
+      if(region->hwEta() < 4) {
+	if(region->hwPt() >= thresholds.at(0))
+	  numOverThresh[0]++;
+	if(region->hwPt() >= thresholds.at(2))
+	  numOverThresh[2]++;
+      }
+      if(region->hwEta() > 17) {
+	if(region->hwPt() >= thresholds.at(1))
+	  numOverThresh[1]++;
+	if(region->hwPt() >= thresholds.at(3))
+	  numOverThresh[3]++;
+      }
     }
   }
 

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -13,7 +13,6 @@ def customiseSimL1EmulatorForStage1(process):
     process.load("EventFilter.L1TRawToDigi.caloStage1Digis_cfi")
     process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
 
-    process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
     process.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
     process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
 


### PR DESCRIPTION
During the recent 758_patch1 relvals sanity testing I noticed that the L1 results were not matching those obtained by manually setting the HI values. After double checking the GT those values were fine. I tracked it down to this line, which was removed already in 76X and 80X, but 75X was missed. This is necessary for both reference pp and PbPb MC production in 75X.

Testing on a small local re-RECOed sample shows agreement again with the GT settings.

@mandrenguyen @mulhearn you are interested in this.
