### PR TITLE
Adapting MuIsoDepositProducer to 80X

### DIFF
--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
@@ -34,7 +34,7 @@ private:
   bool theExtractForCandidate;
 
   std::string theMuonTrackRefType;
-  edm::InputTag theMuonCollectionTag;
+  edm::EDGetToken theMuonCollectionTag;
   std::vector<std::string> theDepositNames;
   bool theMultipleDepositsFlag;
   reco::isodeposit::IsoDepositExtractor * theExtractor;


### PR DESCRIPTION
As already done for 76X: moving theMuonCollectionTag from an InputTag to a EDGetToken and adapting the code for the three different possible collections.

@gpetruc
