### PR TITLE
Address outstanding comments from  #12654 (1x1 HF TP)

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -4,7 +4,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 #include <fstream>
 #include <math.h>
@@ -36,8 +35,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
         edm::LogError("CaloTPGTranscoderULUT") << "Analytic compression expects 10-bit LUT; found LUT with " << OUTPUT_LUT_SIZE << " entries instead";
 
     if (!theTopology) {
-        edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
-        assert(theTopology);
+        throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
     }
 
     std::vector<unsigned int> analyticalLUT(OUTPUT_LUT_SIZE, 0);
@@ -177,24 +175,21 @@ void CaloTPGTranscoderULUT::rctJetUncompress(const HcalTrigTowerDetId& hid, cons
 bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
 	HcalTrigTowerDetId id(ieta, iphiin);
 	if (!theTopology) {
-		edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
-		assert(theTopology);
+		throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
 	}
 	return theTopology->validHT(id);
 }
 
 int CaloTPGTranscoderULUT::getOutputLUTId(const HcalTrigTowerDetId& id) const {
     if (!theTopology) {
-        edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
-        assert(theTopology);
+        throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
     }
     return theTopology->detId2denseIdHT(id);
 }
 
 int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
 	if (!theTopology) {
-		edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
-		assert(theTopology);
+		throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
 	}
 	HcalTrigTowerDetId id(ieta, iphiin);
 	return theTopology->detId2denseIdHT(id);

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -18,7 +18,8 @@ using namespace std;
 
 CaloTPGTranscoderULUT::CaloTPGTranscoderULUT(const std::string& compressionFile,
                                              const std::string& decompressionFile)
-                                                : nominal_gain_(0.), rctlsb_factor_(0.),
+                                                : theTopology(0),
+                                                  nominal_gain_(0.), rctlsb_factor_(0.),
                                                   compressionFile_(compressionFile),
                                                   decompressionFile_(decompressionFile)
 {
@@ -33,6 +34,11 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
     // Initialize analytical compression LUT's here
     if (OUTPUT_LUT_SIZE != (unsigned int) 0x400)
         edm::LogError("CaloTPGTranscoderULUT") << "Analytic compression expects 10-bit LUT; found LUT with " << OUTPUT_LUT_SIZE << " entries instead";
+
+    if (!theTopology) {
+        edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
+        assert(theTopology);
+    }
 
     std::vector<unsigned int> analyticalLUT(OUTPUT_LUT_SIZE, 0);
     std::vector<unsigned int> identityLUT(OUTPUT_LUT_SIZE, 0);
@@ -170,19 +176,31 @@ void CaloTPGTranscoderULUT::rctJetUncompress(const HcalTrigTowerDetId& hid, cons
 
 bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
 	HcalTrigTowerDetId id(ieta, iphiin);
+	if (!theTopology) {
+		edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
+		assert(theTopology);
+	}
 	return theTopology->validHT(id);
 }
 
 int CaloTPGTranscoderULUT::getOutputLUTId(const HcalTrigTowerDetId& id) const {
+    if (!theTopology) {
+        edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
+        assert(theTopology);
+    }
     return theTopology->detId2denseIdHT(id);
 }
 
 int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
+	if (!theTopology) {
+		edm::LogError("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
+		assert(theTopology);
+	}
 	HcalTrigTowerDetId id(ieta, iphiin);
 	return theTopology->detId2denseIdHT(id);
 }
 
-std::vector<unsigned int> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id) const {
+const std::vector<unsigned int>& CaloTPGTranscoderULUT::getCompressionLUT(const HcalTrigTowerDetId& id) const {
    int itower = getOutputLUTId(id);
    return outputLUT_[itower];
 }

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -38,8 +38,8 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
         throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
     }
 
-    std::vector<unsigned int> analyticalLUT(OUTPUT_LUT_SIZE, 0);
-    std::vector<unsigned int> identityLUT(OUTPUT_LUT_SIZE, 0);
+    std::array<unsigned int, OUTPUT_LUT_SIZE> analyticalLUT;
+    std::array<unsigned int, OUTPUT_LUT_SIZE> identityLUT;
 
     // Compute compression LUT
     for (unsigned int i=0; i < OUTPUT_LUT_SIZE; i++) {

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -47,8 +47,11 @@ public:
   // Constant
   static const int NOUTLUTS = 4176;
   static const unsigned int OUTPUT_LUT_SIZE = 1024;
-  static const int TPGMAX = 256;
+  static const unsigned int TPGMAX = 256;
   static const bool newHFphi = true;
+
+  static constexpr float LSB_HBHE = 0.25f;
+  static constexpr float LSB_HF = 0.5f;
 
   // Member functions
   void loadHCALCompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical compression tables

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -33,7 +33,7 @@ public:
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
   virtual bool HTvalid(const int ieta, const int iphi) const;
-  virtual std::vector<unsigned int> getCompressionLUT(HcalTrigTowerDetId id) const;
+  virtual const std::vector<unsigned int>& getCompressionLUT(const HcalTrigTowerDetId& id) const;
   virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&);
   virtual int getOutputLUTId(const HcalTrigTowerDetId& id) const;
   virtual int getOutputLUTId(const int ieta, const int iphi) const;


### PR DESCRIPTION
Quoting from @diguida in [the comments](https://github.com/cms-sw/cmssw/pull/12654#issuecomment-164026877):

> - improvements in the interface in order to avoid un-necessary copies, see #12654 (comment)
> - cleaner pointer handling
> -  remove magic numbers

Fixes this and additional comment by @davidlange6 on using `std::array` instead of `std::vector`.
