### PR TITLE
New GT for all scenarios, including Heavy Ion Run2 simulation changes already deployed in 75X and 80X.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,33 +2,33 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '76X_mcRun1_design_v10',
+    'run1_design'       :   '76X_mcRun1_design_v11',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '76X_mcRun1_realistic_v10',
+    'run1_mc'           :   '76X_mcRun1_realistic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v10',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v11',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '76X_mcRun1_pA_v10',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '76X_mcRun2_design_v13',
+    'run2_design'       :   '76X_mcRun2_design_v14',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '76X_mcRun2_startup_v12',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v13',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '76X_mcRun2_asymptotic_v13',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v14',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v12',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v14',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '76X_dataRun1_v15',
+    'run1_data'         :   '76X_dataRun1_v16',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '76X_dataRun2_v15',
+    'run2_data'         :   '76X_dataRun2_v16',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v10',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v10',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '76X_dataRun2_HLTHI_v1',
+    'run2_hlt_hi'       :   '76X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '76X_upgrade2017_design_v8',
+    'phase1_2017_design' :  '76X_upgrade2017_design_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
The new GT for Heavy Ion Run2 simulation required #12180 to be approved.
# Summary of Changes
## RunI Simulation
- **Ideal scenario**: [`76X_mcRun1_design_v11`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_design_v11): As [`76X_mcRun1_design_v10`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_design_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun1_design_v10/76X_mcRun1_design_v11):
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`, `CombinedSVRecoVertex`, `CombinedSVPseudoVertex`, `CombinedSVNoVertex` (as used by HLT data collection in 2015).
- **Realistic scenario**: [`76X_mcRun1_realistic_v11`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_realistic_v11): As [`76X_mcRun1_realistic_v10`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_realistic_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun1_realistic_v10/76X_mcRun1_realistic_v11):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Heavy Ion scenario**: [`76X_mcRun1_HeavyIon_v11`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_HeavyIon_v11): As [`76X_mcRun1_HeavyIon_v10`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_HeavyIon_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun1_HeavyIon_v10/76X_mcRun1_HeavyIon_v11):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Proton-Lead scenario**: [`76X_mcRun1_pA_v11`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_pA_v11): As [`76X_mcRun1_pA_v10`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun1_pA_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun1_pA_v10/76X_mcRun1_pA_v11):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
## RunII Simulation
- **Ideal scenario**: [`76X_mcRun2_design_v14`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_design_v14): As [`76X_mcRun2_design_v13`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_design_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun2_design_v13/76X_mcRun2_design_v14):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Startup scenario**: [`76X_mcRun2_startup_v13`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_startup_v13): As [`76X_mcRun2_startup_v12`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_startup_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun2_startup_v12/76X_mcRun2_startup_v13):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Asymptotic scenario**: [`76X_mcRun2_asymptotic_v14`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_asymptotic_v14): As [`76X_mcRun2_asymptotic_v13`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_asymptotic_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun2_asymptotic_v13/76X_mcRun2_asymptotic_v14):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Heavy Ion scenario**: [`76X_mcRun2_HeavyIon_v14`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_HeavyIon_v14): As [`76X_mcRun2_HeavyIon_v12`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_mcRun2_HeavyIon_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_mcRun2_HeavyIon_v12/76X_mcRun2_HeavyIon_v14):
  - added additional labels for castor sim geometry
  - introduced L1T calo params configuration for HI
  - updated L1T menu with the version used in PbPb collisions
  - updated Castor Gains in order to avoid a lot of saturation (on digi level) in PbPb simulations in CASTOR
  - updated centrality table for HFtowers in 200 bins
  - updated underlying event table with latest estimations from PbPb first collisions
  - updated JEC with HI tracking including L1FastJet corrections set to 1, in order to avoid crashes
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, Combin\
    edSVNoVertex (as used by HLT data collection in 2015).
## RunI Data
- **HLT processing**: [`76X_dataRun1_HLT_frozen_v11`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_HLT_frozen_v11): As [`76X_dataRun1_HLT_frozen_v10`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_HLT_frozen_v10) (snapshot time set to 2015-12-18 17:00:00 UTC) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun1_HLT_frozen_v10/76X_dataRun1_HLT_frozen_v11):
  - added HLT label for PF hadron calibration in order to replicate 2015 HLT performance
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Offline processing**: [`76X_dataRun1_v16`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_v16): As [`76X_dataRun1_v15`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun1_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun1_v15/76X_dataRun1_v16):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
## RunII Data
- **HLT processing**: [`76X_dataRun2_HLT_frozen_v11`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLT_frozen_v11): As [`76X_dataRun2_HLT_frozen_v10`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLT_frozen_v10) (snapshot time set to 2015-12-18 17:00:00 UTC) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun2_HLT_frozen_v10/76X_dataRun2_HLT_frozen_v11):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **HLT Heavy Ion processing**: [`76X_dataRun2_HLTHI_frozen_v2`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLTHI_v2): As [`76X_dataRun2_HLTHI_v1`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_HLTHI_v1) (snapshot time set to 2015-12-18 17:00:00 UTC) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun2_HLTHI_v1/76X_dataRun2_HLTHI_v2):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
- **Offline processing**: [`76X_dataRun2_v16`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_v16): As [`76X_dataRun2_v15`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_dataRun2_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_dataRun2_v15/76X_dataRun2_v16):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
## Upgrade 2017 simulation
- **Ideal scenario**: [`76X_upgrade2017_design_v9`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_upgrade2017_design_v9): As [`76X_upgrade2017_design_v8`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/76X_upgrade2017_design_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/76X_upgrade2017_design_v8/76X_upgrade2017_design_v9):
  - updated B tag discriminators for HLT with the following taggers: CombinedSVIVFV2RecoVertex, CombinedSVIVFV2PseudoVertex, CombinedSVIVFV2NoVertex, CombinedSVRecoVertex, CombinedSVPseudoVertex, CombinedSVNoVertex (as used by HLT data collection in 2015).
