### PR TITLE
memory churn reduction and some technical CPU minimization in reco

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -52,12 +52,12 @@ public:
     std::vector<fastjet::PseudoJet> const & puppiParticles() const { return fPupParticles;}
 
 protected:
-    double  goodVar      (fastjet::PseudoJet const &iPart,std::vector<fastjet::PseudoJet> const &iParts, int iOpt,double iRCone);
+    double  goodVar      (fastjet::PseudoJet const &iPart,std::vector<fastjet::PseudoJet> const &iParts, int iOpt,const double iRCone);
     void    getRMSAvg    (int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,std::vector<fastjet::PseudoJet> const &iParticles,std::vector<fastjet::PseudoJet> const &iChargeParticles);
     void    getRawAlphas    (int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,std::vector<fastjet::PseudoJet> const &iParticles,std::vector<fastjet::PseudoJet> const &iChargeParticles);
     double  getChi2FromdZ(double iDZ);
     int     getPuppiId   ( float iPt, float iEta);
-    double  var_within_R (int iId, const std::vector<fastjet::PseudoJet> & particles, const fastjet::PseudoJet& centre, double R);  
+    double  var_within_R (int iId, const std::vector<fastjet::PseudoJet> & particles, const fastjet::PseudoJet& centre, const double R);  
     
     bool      fPuppiDiagnostics;
     std::vector<RecoObj>   fRecoParticles;

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -74,23 +74,25 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
 }
 PuppiContainer::~PuppiContainer(){}
 
-double PuppiContainer::goodVar(PseudoJet const &iPart,std::vector<PseudoJet> const &iParts, int iOpt,double iRCone) {
+double PuppiContainer::goodVar(PseudoJet const &iPart,std::vector<PseudoJet> const &iParts, int iOpt,const double iRCone) {
     double lPup = 0;
     lPup = var_within_R(iOpt,iParts,iPart,iRCone);
     return lPup;
 }
-double PuppiContainer::var_within_R(int iId, const vector<PseudoJet> & particles, const PseudoJet& centre, double R){
+double PuppiContainer::var_within_R(int iId, const vector<PseudoJet> & particles, const PseudoJet& centre, const double R){
     if(iId == -1) return 1;
 
     //this is a circle in rapidity-phi
     //it would make more sense to have var definition consistent
-    fastjet::Selector sel = fastjet::SelectorCircle(R);
-    sel.set_reference(centre);
+    //fastjet::Selector sel = fastjet::SelectorCircle(R);
+    //sel.set_reference(centre);
+    //the original code used Selector infrastructure: it is too heavy here
+    //logic of SelectorCircle is preserved below
 
     vector<double > near_dR2s;     near_dR2s.reserve(std::min(50UL, particles.size()));
     vector<double > near_pts;      near_pts.reserve(std::min(50UL, particles.size()));
     for (auto const& part : particles){
-      if ( sel(part) ){
+      if ( part.squared_distance(centre) < R*R ){
 	near_dR2s.push_back(reco::deltaR2(part, centre));
 	near_pts.push_back(part.pt());
       }

--- a/PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h
+++ b/PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h
@@ -32,6 +32,9 @@ namespace reco {
       //! check concrete extractors if it's no-op !
       virtual void fillVetos(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::TrackCollection & tracks) = 0;
 
+      //! perform some constly initialization
+      virtual void initEvent(const edm::Event & , const edm::EventSetup & ) {}
+
       //! make single IsoDeposit based on track as input
       //! purely virtual: have to implement in concrete implementations
       virtual reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup,

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.cc
@@ -102,20 +102,17 @@ void CandIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup)
   unsigned int nDeps = theMultipleDepositsFlag ? theDepositNames.size() : 1;
 
   static const unsigned int MAX_DEPS=10;
-  std::auto_ptr<reco::IsoDepositMap> depMaps[MAX_DEPS];
 
-  if (nDeps >10 ) LogError(metname)<<"Unable to handle more than 10 input deposits";
-  for (unsigned int i =0;i<nDeps; ++i){ // check if nDeps > 10??
-    depMaps[i] =  std::auto_ptr<reco::IsoDepositMap>(new reco::IsoDepositMap());
-  }
+  if (nDeps >MAX_DEPS ) LogError(metname)<<"Unable to handle more than 10 input deposits";
 
   //! OK, now we know how many deps for how many muons each we will create
   //! might linearize this at some point (lazy)
   //! do it in case some muons are there only
   size_t nMuons = hCands->size();
-  if (nMuons > 0){
-    std::vector<std::vector<IsoDeposit> > deps2D(nDeps, std::vector<IsoDeposit>(nMuons));
+  std::vector<std::vector<IsoDeposit> > deps2D(nDeps, std::vector<IsoDeposit>(nMuons));
 
+  if (nMuons > 0){
+    theExtractor->initEvent(event, eventSetup);
 
     Track dummy;
     for (size_t i=0; i<  nMuons; ++i) {
@@ -130,10 +127,9 @@ void CandIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup)
         continue;
       }
       if (!theMultipleDepositsFlag){
-	IsoDeposit dep = ( ( theTrackType == CandidateT )
+	deps2D[0][i] = ( ( theTrackType == CandidateT )
 			     ? theExtractor->deposit(event, eventSetup, c)
 			     : theExtractor->deposit(event, eventSetup, *track) );
-	deps2D[0][i] = dep;
       } else {
 	std::vector<IsoDeposit> deps = ( ( theTrackType == CandidateT )
 					   ? theExtractor->deposits(event, eventSetup, c)
@@ -141,25 +137,26 @@ void CandIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup)
 	for (unsigned int iDep=0; iDep < nDeps; ++iDep){ 	deps2D[iDep][i] =  deps[iDep];  }
       }
     }//! for(i<nMuons)
+  }//if (nMuons>0)
 
+  //! now fill in selectively
+  for (unsigned int iDep=0; iDep < nDeps; ++iDep){
+    //!some debugging stuff
+    for (unsigned int iMu = 0; iMu< nMuons; ++iMu){
+      LogTrace(metname)<<"Contents of "<<theDepositNames[iDep]
+		       <<" for a muon at index "<<iMu;
+      LogTrace(metname)<<deps2D[iDep][iMu].print();
+    }
+    
+    //! fill the maps here
+    std::unique_ptr<reco::IsoDepositMap> depMap(new reco::IsoDepositMap());    
+    reco::IsoDepositMap::Filler filler(*depMap);
+    filler.insert(hCands, deps2D[iDep].begin(), deps2D[iDep].end());
+    deps2D[iDep].clear();
+    filler.fill();
+    event.put(std::move(depMap), theDepositNames[iDep]);
+  }//! for(iDep<nDeps)
 
-    //! now fill in selectively
-    for (unsigned int iDep=0; iDep < nDeps; ++iDep){
-      //!some debugging stuff
-      for (unsigned int iMu = 0; iMu< nMuons; ++iMu){
-        LogTrace(metname)<<"Contents of "<<theDepositNames[iDep]
-                         <<" for a muon at index "<<iMu;
-        LogTrace(metname)<<deps2D[iDep][iMu].print();
-      }
-
-      //! fill the maps here
-      reco::IsoDepositMap::Filler filler(*depMaps[iDep]);
-      filler.insert(hCands, deps2D[iDep].begin(), deps2D[iDep].end());
-      filler.fill();
-    }//! for(iDep<nDeps)
-  }//! if (nMuons>0)
-
-  for (unsigned int iMap = 0; iMap < nDeps; ++iMap) event.put(depMaps[iMap], theDepositNames[iMap]);
 }
 
 DEFINE_FWK_MODULE( CandIsoDepositProducer );

--- a/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.cc
@@ -40,6 +40,11 @@ reco::IsoDeposit::Veto CandViewExtractor::veto(const reco::IsoDeposit::Direction
   return result;
 }
 
+void CandViewExtractor::initEvent(const edm::Event & ev, const edm::EventSetup & evSetup){
+  ev.getByToken(theCandViewToken, theCandViewH);
+  theCacheID = ev.cacheIdentifier();
+}
+
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.h
+++ b/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.h
@@ -35,6 +35,8 @@ public:
       const edm::EventSetup & evSetup, const reco::Track & cand) const;
 */
 
+  virtual void initEvent(const edm::Event & ev, const edm::EventSetup & evSetup);
+  
   virtual reco::IsoDeposit deposit (const edm::Event & ev,
       const edm::EventSetup & evSetup, const reco::Track & muon) const {
         return depositFromObject(ev, evSetup, muon);
@@ -55,6 +57,8 @@ private:
   // Parameter set
   edm::EDGetTokenT< edm::View<reco::Candidate> > theCandViewToken; // Track Collection Label
   std::string theDepositLabel;         // name for deposit
+  edm::Handle<edm::View<reco::Candidate> > theCandViewH; //cached handle
+  edm::Event::CacheIdentifier_t theCacheID;  //event cacheID
   double theDiff_r;                    // transverse distance to vertex
   double theDiff_z;                    // z distance to vertex
   double theDR_Max;                    // Maximum cone angle for deposits

--- a/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.icc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.icc
@@ -9,7 +9,11 @@ IsoDeposit CandViewExtractor::depositFromObject(const Event & event, const Event
     deposit.addCandEnergy(cand.pt());
 
     Handle< View<Candidate> > candViewH;
-    event.getByToken(theCandViewToken, candViewH);
+    if (theCacheID != event.cacheIdentifier()){
+        event.getByToken(theCandViewToken, candViewH);
+    } else {
+        candViewH = theCandViewH;
+    }
 
     double eta = cand.eta(), phi = cand.phi();
     reco::Particle::Point vtx = cand.vertex();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -191,7 +191,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   double discriminate(const PFTauRef& pfTau) const override;
 
-  inline  double weightedSum(std::vector<PFCandidatePtr> inColl_, double eta, double phi) const {
+  inline  double weightedSum(const std::vector<PFCandidatePtr>& inColl_, double eta, double phi) const {
     double out = 1.0;
     for (auto const & inObj_ : inColl_){
       double sum = (inObj_->pt()*inObj_->pt())/(deltaR2(eta,phi,inObj_->eta(),inObj_->phi()));
@@ -428,8 +428,8 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
       }
       LogTrace("discriminate") << "After cone cuts: " << isoPU_.size() << " " << chPV_.size() ;
     } else {
-      isoPU_ = allPU;
-      chPV_ = allNPU;
+      isoPU_ = std::move(allPU);
+      chPV_ = std::move(allNPU);
     }
   }
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -332,10 +332,10 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   std::vector<PFCandidatePtr> chPV_;
   isoCharged_.reserve(pfTau->isolationPFChargedHadrCands().size());
   isoNeutral_.reserve(pfTau->isolationPFGammaCands().size());
-  isoPU_.reserve(chargedPFCandidatesInEvent_.size());
+  isoPU_.reserve(std::min(100UL, chargedPFCandidatesInEvent_.size()));
   isoNeutralWeight_.reserve(pfTau->isolationPFGammaCands().size());
 
-  chPV_.reserve(chargedPFCandidatesInEvent_.size());
+  chPV_.reserve(std::min(50UL, chargedPFCandidatesInEvent_.size()));
 
   // Get the primary vertex associated to this tau
   reco::VertexRef pv = vertexAssociator_->associatedVertex(*pfTau);

--- a/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
@@ -41,11 +41,12 @@ std::vector<reco::PFCandidatePtr> pfCandidates(const reco::PFJet& jet,
 
 std::vector<reco::PFCandidatePtr> pfCandidates(const reco::PFJet& jet,
     const std::vector<int>& particleIds, bool sort) {
+  PFCandPtrs&& pfCands = jet.getPFConstituents();
   PFCandPtrs output;
   // Get each desired candidate type, unsorted for now
   for(std::vector<int>::const_iterator particleId = particleIds.begin();
       particleId != particleIds.end(); ++particleId) {
-    PFCandPtrs selectedPFCands = pfCandidates(jet, *particleId, false);
+    PFCandPtrs&& selectedPFCands = filterPFCandidates(pfCands.begin(), pfCands.end(), *particleId, false);
     output.insert(output.end(), selectedPFCands.begin(), selectedPFCands.end());
   }
   if (sort) std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
@@ -58,10 +59,11 @@ std::vector<reco::PFCandidatePtr> pfGammas(const reco::PFJet& jet, bool sort) {
 
 std::vector<reco::PFCandidatePtr> pfChargedCands(const reco::PFJet& jet,
                                                  bool sort) {
+  PFCandPtrs&& pfCands = jet.getPFConstituents();
   PFCandPtrs output;
-  PFCandPtrs mus = pfCandidates(jet, reco::PFCandidate::mu, false);
-  PFCandPtrs es = pfCandidates(jet, reco::PFCandidate::e, false);
-  PFCandPtrs chs = pfCandidates(jet, reco::PFCandidate::h, false);
+  PFCandPtrs&& mus = filterPFCandidates(pfCands.begin(), pfCands.end(), reco::PFCandidate::mu, false);
+  PFCandPtrs&& es = filterPFCandidates(pfCands.begin(), pfCands.end(), reco::PFCandidate::e, false);
+  PFCandPtrs&& chs = filterPFCandidates(pfCands.begin(), pfCands.end(), reco::PFCandidate::h, false);
   output.reserve(mus.size() + es.size() + chs.size());
   output.insert(output.end(), mus.begin(), mus.end());
   output.insert(output.end(), es.begin(), es.end());

--- a/RecoTauTag/TauTagTools/interface/TauTagTools.h
+++ b/RecoTauTag/TauTagTools/interface/TauTagTools.h
@@ -23,15 +23,15 @@
 
 namespace TauTagTools{
   template <class T> class sortByOpeningDistance;
-  reco::TrackRefVector filteredTracksByNumTrkHits(reco::TrackRefVector theInitialTracks, int tkminTrackerHitsn);
-  reco::TrackRefVector filteredTracks(reco::TrackRefVector theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2, reco::Vertex pV);
-  reco::TrackRefVector filteredTracks(reco::TrackRefVector theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2,double tktorefpointmaxDZ,reco::Vertex pV,double refpoint_Z);
+  reco::TrackRefVector filteredTracksByNumTrkHits(const reco::TrackRefVector& theInitialTracks, int tkminTrackerHitsn);
+  reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2, reco::Vertex pV);
+  reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2,double tktorefpointmaxDZ,reco::Vertex pV,double refpoint_Z);
 
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(std::vector<reco::PFCandidatePtr> theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn);
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, reco::Vertex pV);
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,reco::Vertex pV, double refpoint_Z);
-  std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double NeutrHadrCand_HcalclusMinEt);
-  std::vector<reco::PFCandidatePtr> filteredPFGammaCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double GammaCand_EcalclusMinEt);
+  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(const std::vector<reco::PFCandidatePtr>& theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn);
+  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, reco::Vertex pV);
+  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,reco::Vertex pV, double refpoint_Z);
+  std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt);
+  std::vector<reco::PFCandidatePtr> filteredPFGammaCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt);
   math::XYZPoint propagTrackECALSurfContactPoint(const MagneticField*,reco::TrackRef); 
 
   TFormula computeConeSizeTFormula(const std::string& ConeSizeFormula,const char* errorMessage);

--- a/RecoTauTag/TauTagTools/src/TauTagTools.cc
+++ b/RecoTauTag/TauTagTools/src/TauTagTools.cc
@@ -65,7 +65,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
 }
 
 
-  TrackRefVector filteredTracksByNumTrkHits(TrackRefVector theInitialTracks, int tkminTrackerHitsn){
+  TrackRefVector filteredTracksByNumTrkHits(const TrackRefVector& theInitialTracks, int tkminTrackerHitsn){
     TrackRefVector filteredTracks;
     for(TrackRefVector::const_iterator iTk=theInitialTracks.begin();iTk!=theInitialTracks.end();iTk++){
       if ( (**iTk).numberOfValidHits() >= tkminTrackerHitsn )
@@ -74,7 +74,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredTracks;
   }
 
-  TrackRefVector filteredTracks(TrackRefVector theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2, Vertex pv){
+  TrackRefVector filteredTracks(const TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2, Vertex pv){
     TrackRefVector filteredTracks;
     for(TrackRefVector::const_iterator iTk=theInitialTracks.begin();iTk!=theInitialTracks.end();iTk++){
       if ((**iTk).pt()>=tkminPt &&
@@ -86,7 +86,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     }
     return filteredTracks;
   }
-  TrackRefVector filteredTracks(TrackRefVector theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2,double tktorefpointmaxDZ,Vertex pv, double refpoint_Z){
+  TrackRefVector filteredTracks(const TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2,double tktorefpointmaxDZ,Vertex pv, double refpoint_Z){
     TrackRefVector filteredTracks;
     for(TrackRefVector::const_iterator iTk=theInitialTracks.begin();iTk!=theInitialTracks.end();iTk++){
       if(pv.isFake()) tktorefpointmaxDZ=30.;
@@ -101,7 +101,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredTracks;
   }
 
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(std::vector<reco::PFCandidatePtr> theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn){
+  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(const std::vector<reco::PFCandidatePtr>& theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn){
     std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
     for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
       if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h  || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::mu || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::e){
@@ -116,7 +116,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredPFChargedHadrCands;
   }
 
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, Vertex pv){
+  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, Vertex pv){
     std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
     for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
       if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h  || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::mu || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::e){
@@ -135,7 +135,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     }
     return filteredPFChargedHadrCands;
   }
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,Vertex pv, double refpoint_Z){
+  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,Vertex pv, double refpoint_Z){
     if(pv.isFake()) ChargedHadrCand_tktorefpointmaxDZ = 30.;
     std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
     for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
@@ -155,7 +155,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredPFChargedHadrCands;
   }
   
-  std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double NeutrHadrCand_HcalclusMinEt){
+  std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt){
     std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands;
     for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
       if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h0){
@@ -168,7 +168,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredPFNeutrHadrCands;
   }
   
-  std::vector<reco::PFCandidatePtr> filteredPFGammaCands(std::vector<reco::PFCandidatePtr> theInitialPFCands,double GammaCand_EcalclusMinEt){
+  std::vector<reco::PFCandidatePtr> filteredPFGammaCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt){
     std::vector<reco::PFCandidatePtr> filteredPFGammaCands;
     for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
       if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::gamma){

--- a/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
@@ -81,6 +81,10 @@ class DetIdAssociator{
 						  const double dThetaMinus,
 						  const double dPhiPlus,
 						  const double dPhiMinus) const;
+
+   /// helper to see if getDetIdsInACone is useful
+   virtual bool selectAllInACone(const double dR) const {return dR > 2*M_PI && dR > maxEta_;}
+
    /// Find DetIds that satisfy given requirements
    /// - inside eta-phi cone of radius dR
    virtual std::set<DetId> getDetIdsInACone(const std::set<DetId>&,

--- a/TrackingTools/TrackAssociator/src/DetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/src/DetIdAssociator.cc
@@ -269,7 +269,7 @@ std::set<DetId> DetIdAssociator::getDetIdsInACone(const std::set<DetId>& inset,
 					     const std::vector<GlobalPoint>& trajectory,
 					     const double dR) const
 {
-   if ( dR > 2*M_PI && dR > maxEta_ ) return inset;
+  if ( selectAllInACone(dR)) return inset;
    check_setup();
    std::set<DetId> outset;
    for(std::set<DetId>::const_iterator id_iter = inset.begin(); id_iter != inset.end(); id_iter++)


### PR DESCRIPTION
candidate isolation, tau, puppi, and track-det associator.

most changes targeted the memory churn (MEM_TOTAL).

puppi change ended up mostly CPU.

Originally developed in pre3 on top of  #12766based on production-like run of ttbar PU35@25ns (25202 without validation/dqm), there is a reduction of about 6% in event processing related  (::doEvent calls) MEM_TOTAL. There is also about 0.5% reduction in total reco+miniaod CPU as well (roughly split between tau and puppi).
Gains are smaller on 2015-like pileup, since most reduction in on algorithms with high combinatorial component (~PU^2 or worse).

tested in CMSSW_8_0_0_pre4 : 
- no differences are observed in DQM or fwlite reco comparisons
- time reduction consistent with tests in pre3 is present as well
