### PR TITLE
Set phase1 track algorithms properly

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/src/LhcTrackAnalyzer.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/LhcTrackAnalyzer.cc
@@ -170,6 +170,12 @@ LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	  if(track->algo()==reco::TrackBase::pixelLessStep)myalgo=9;
 	  if(track->algo()==reco::TrackBase::tobTecStep)myalgo=10;
 	  if(track->algo()==reco::TrackBase::jetCoreRegionalStep)myalgo=11;
+	  // This class is pending the migration to Phase1 tracks
+	  if(track->algo() == reco::TrackBase::highPtTripletStep ||
+	     track->algo() == reco::TrackBase::lowPtQuadStep ||
+	     track->algo() == reco::TrackBase::detachedQuadStep) {
+	    throw cms::Exception("Not implemented") << "LhcTrackAnalyzer does not yet support phase1 tracks, encountered one from algo " << reco::TrackBase::algoName(track->algo());
+	  }
 	  trkAlgo_[nTracks_]  = myalgo;
 
 	  int myquality=-99;

--- a/PhysicsTools/UtilAlgos/interface/AdHocNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/AdHocNTupler.h
@@ -999,6 +999,8 @@ class AdHocNTupler : public NTupler {
      trkalgo = trk->algo();
      switch(trkalgo) {
      case reco::TrackBase::initialStep:
+     case reco::TrackBase::highPtTripletStep:
+     case reco::TrackBase::lowPtQuadStep:
      case reco::TrackBase::lowPtTripletStep:
      case reco::TrackBase::pixelPairStep:
        ++n_iterPixelTrks;
@@ -1017,6 +1019,8 @@ class AdHocNTupler : public NTupler {
        i_trkphi = std::max(0,std::min(phibins-1,(int) ((trk->phi()+piconst)/phibinsize)));
        switch(trkalgo) {
        case reco::TrackBase::initialStep:
+       case reco::TrackBase::highPtTripletStep:
+       case reco::TrackBase::lowPtQuadStep:
        case reco::TrackBase::lowPtTripletStep:
        case reco::TrackBase::pixelPairStep:
          ++phiIterPixelTrks[i_trkphi][zside];

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -6,10 +6,13 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::ctf:
     case reco::TrackBase::duplicateMerge:
     case reco::TrackBase::initialStep:
+    case reco::TrackBase::highPtTripletStep:
+    case reco::TrackBase::lowPtQuadStep:
     case reco::TrackBase::lowPtTripletStep:
     case reco::TrackBase::pixelPairStep:
     case reco::TrackBase::jetCoreRegionalStep:
       return cuts[0];
+    case reco::TrackBase::detachedQuadStep:
     case reco::TrackBase::detachedTripletStep:
       return cuts[1];
     case reco::TrackBase::mixedTripletStep:
@@ -44,10 +47,13 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::ctf:
     case reco::TrackBase::duplicateMerge:
     case reco::TrackBase::initialStep:
+    case reco::TrackBase::highPtTripletStep:
+    case reco::TrackBase::lowPtQuadStep:
     case reco::TrackBase::lowPtTripletStep:
     case reco::TrackBase::pixelPairStep:
     case reco::TrackBase::jetCoreRegionalStep:
       return cuts[0];
+    case reco::TrackBase::detachedQuadStep:
     case reco::TrackBase::detachedTripletStep:
       return cuts[1];
     case reco::TrackBase::mixedTripletStep:
@@ -82,11 +88,14 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::ctf:
     case reco::TrackBase::duplicateMerge:
     case reco::TrackBase::initialStep:
+    case reco::TrackBase::highPtTripletStep:
+    case reco::TrackBase::lowPtQuadStep:
     case reco::TrackBase::lowPtTripletStep:
     case reco::TrackBase::pixelPairStep:
     case reco::TrackBase::jetCoreRegionalStep:
     case reco::TrackBase::muonSeededStepInOut:
     case reco::TrackBase::muonSeededStepOutIn:
+    case reco::TrackBase::detachedQuadStep:
     case reco::TrackBase::detachedTripletStep:
     case reco::TrackBase::mixedTripletStep:
     case reco::TrackBase::hltIter0:
@@ -113,9 +122,12 @@ bool isGoodForEGM(const reco::TrackBase::TrackAlgorithm& algo){
   case reco::TrackBase::ctf:
   case reco::TrackBase::duplicateMerge:
   case reco::TrackBase::initialStep:
+  case reco::TrackBase::highPtTripletStep:
+  case reco::TrackBase::lowPtQuadStep:
   case reco::TrackBase::lowPtTripletStep:
   case reco::TrackBase::pixelPairStep:
   case reco::TrackBase::jetCoreRegionalStep:
+  case reco::TrackBase::detachedQuadStep:
   case reco::TrackBase::detachedTripletStep:
   case reco::TrackBase::mixedTripletStep:
   case reco::TrackBase::muonSeededStepInOut:
@@ -139,8 +151,11 @@ bool isGoodForEGMPrimary(const reco::TrackBase::TrackAlgorithm& algo){
   case reco::TrackBase::duplicateMerge:
   case reco::TrackBase::cosmics:
   case reco::TrackBase::initialStep:
+  case reco::TrackBase::highPtTripletStep:
+  case reco::TrackBase::lowPtQuadStep:
   case reco::TrackBase::lowPtTripletStep:
   case reco::TrackBase::pixelPairStep:
+  case reco::TrackBase::detachedQuadStep:
   case reco::TrackBase::detachedTripletStep:
   case reco::TrackBase::mixedTripletStep:
     return true;
@@ -155,9 +170,12 @@ bool isFifthStep(const reco::TrackBase::TrackAlgorithm& algo){
   case reco::TrackBase::ctf:
   case reco::TrackBase::duplicateMerge:
   case reco::TrackBase::initialStep:
+  case reco::TrackBase::highPtTripletStep:
+  case reco::TrackBase::lowPtQuadStep:
   case reco::TrackBase::lowPtTripletStep:
   case reco::TrackBase::pixelPairStep:
   case reco::TrackBase::jetCoreRegionalStep:
+  case reco::TrackBase::detachedQuadStep:
   case reco::TrackBase::detachedTripletStep:
   case reco::TrackBase::mixedTripletStep:
   case reco::TrackBase::pixelLessStep:
@@ -182,8 +200,11 @@ bool isFifthStep(const reco::TrackBase::TrackAlgorithm& algo){
 bool highQuality(const reco::TrackBase::TrackAlgorithm& algo){
   switch (algo) {
   case reco::TrackBase::initialStep:
+  case reco::TrackBase::highPtTripletStep:
+  case reco::TrackBase::lowPtQuadStep:
   case reco::TrackBase::lowPtTripletStep:
   case reco::TrackBase::pixelPairStep:
+  case reco::TrackBase::detachedQuadStep:
   case reco::TrackBase::detachedTripletStep:
   case reco::TrackBase::duplicateMerge:
   case reco::TrackBase::jetCoreRegionalStep:

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_DetachedQuadStep_cff.py
@@ -129,10 +129,7 @@ detachedQuadStepTrackCandidates.TrajectoryCleaner = 'detachedQuadStepTrajectoryC
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    # Algorithm name changed from detachedQuadStep (was iter4) to mixedTripletStep in order
-    # to keep backward compatibility as detachedQuadStep would be unknown.
-    # In the future, a new enum or alias may be added to support iteration name aliases.
-    AlgorithmName = cms.string('mixedTripletStep'), 
+    AlgorithmName = cms.string('detachedQuadStep'),
     src = 'detachedQuadStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
     TTRHBuilder=cms.string('WithTrackAngle')

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_HighPtTripletStep_cff.py
@@ -100,10 +100,7 @@ highPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 import RecoTracker.TrackProducer.TrackProducer_cfi
 highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'highPtTripletStepTrackCandidates',
-    # Algorithm name changed from highPtTripletStep (was iter1) to lowPtTripletStep in order
-    # to keep backward compatibility as detachedQuadStep would be unknown.
-    # In the future, a new enum or alias may be added to support iteration name aliases.
-    AlgorithmName = cms.string('lowPtTripletStep'),
+    AlgorithmName = cms.string('highPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
     TTRHBuilder=cms.string('WithTrackAngle')
     )

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
@@ -111,10 +111,7 @@ lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckf
 import RecoTracker.TrackProducer.TrackProducer_cfi
 lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'lowPtQuadStepTrackCandidates',
-    # Algorithm name changed from lowPtQuadStep (was iter2) to pixelPairStep in order
-    # to keep backward compatibility as detachedQuadStep would be unknown.
-    # In the future, a new enum or alias may be added to support iteration name aliases.
-    AlgorithmName = cms.string('pixelPairStep'),
+    AlgorithmName = cms.string('lowPtQuadStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
     TTRHBuilder=cms.string('WithTrackAngle')
     )

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_DetachedQuadStep_cff.py
@@ -130,10 +130,7 @@ detachedQuadStepTrackCandidates.TrajectoryCleaner = 'detachedQuadStepTrajectoryC
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    # Algorithm name changed from detachedQuadStep (was iter4) to mixedTripletStep in order
-    # to keep backward compatibility as detachedQuadStep would be unknown.
-    # In the future, a new enum or alias may be added to support iteration name aliases.
-    AlgorithmName = cms.string('mixedTripletStep'),
+    AlgorithmName = cms.string('detachedQuadStep'),
     src = 'detachedQuadStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
     TTRHBuilder=cms.string('WithTrackAngle')

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_HighPtTripletStep_cff.py
@@ -100,10 +100,7 @@ highPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 import RecoTracker.TrackProducer.TrackProducer_cfi
 highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'highPtTripletStepTrackCandidates',
-    # Algorithm name changed from highPtTripletStep (was iter1) to lowPtTripletStep in order
-    # to keep backward compatibility as detachedQuadStep would be unknown.
-    # In the future, a new enum or alias may be added to support iteration name aliases.
-    AlgorithmName = cms.string('lowPtTripletStep'),
+    AlgorithmName = cms.string('highPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
     TTRHBuilder=cms.string('WithTrackAngle')
     )

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
@@ -108,10 +108,7 @@ lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckf
 import RecoTracker.TrackProducer.TrackProducer_cfi
 lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'lowPtQuadStepTrackCandidates',
-    # Algorithm name changed from lowPtQuadStep (was iter2) to pixelPairStep in order
-    # to keep backward compatibility as detachedQuadStep would be unknown.
-    # In the future, a new enum or alias may be added to support iteration name aliases.
-    AlgorithmName = cms.string('pixelPairStep'),
+    AlgorithmName = cms.string('lowPtQuadStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
     TTRHBuilder=cms.string('WithTrackAngle')
     )


### PR DESCRIPTION
This PR sets the phase1-specific track algos properly in the Phase1PU70 and Phase1PU140 tracking configurations.

Following migrations are included (should cover everything except tracking validation and DQM):
- The use of track algos in PF is migrated. The initial guess is to treat the new quadruplet iterations as the (current) triplet iterations. @bachtis @arizzi @gpetruc feel free to double-check.
- `LhcTrackAnalyzer` is supposedly not used, and is thus modified to throw if it encounters a track with phase1-specific algo, as agreed with alignment (@tlampen @mschrode).
- `AdHocNtupler` was straightforward to migrate.

Tracking validation and DQM will be migrated separately (need the phase1 era for that, see e.g. #12806).

Tested in 8_0_0_pre4, no changes expected in Run2 workflows.

@rovere @VinInn 
