### PR TITLE
Const correct Principal

### DIFF
--- a/DataFormats/Common/interface/BasicHandle.h
+++ b/DataFormats/Common/interface/BasicHandle.h
@@ -53,8 +53,8 @@ namespace edm {
       whyFailedFactory_(h.whyFailedFactory_){}
 
     explicit BasicHandle(ProductData const& productData) :
-      product_(productData.wrapper_.get()),
-      prov_(&productData.prov_) {
+      product_(productData.wrapper()),
+      prov_(&productData.provenance()) {
     }
 
 #if defined( __GXX_EXPERIMENTAL_CXX0X__)

--- a/DataFormats/Common/interface/OutputHandle.h
+++ b/DataFormats/Common/interface/OutputHandle.h
@@ -49,7 +49,7 @@ namespace edm {
       productProvenance_(h.productProvenance_),
       whyFailed_(h.whyFailed_){}
 
-    OutputHandle(WrapperBase const* product, BranchDescription const* desc, ProductProvenance* productProvenance) :
+    OutputHandle(WrapperBase const* product, BranchDescription const* desc, ProductProvenance const* productProvenance) :
       product_(product),
       desc_(desc),
       productProvenance_(productProvenance) {}
@@ -105,7 +105,7 @@ namespace edm {
   private:
     WrapperBase const* product_;
     BranchDescription const* desc_;
-    ProductProvenance* productProvenance_;
+    ProductProvenance const* productProvenance_;
     std::shared_ptr<cms::Exception> whyFailed_;
   };
 

--- a/DataFormats/Common/src/ProductData.cc
+++ b/DataFormats/Common/src/ProductData.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/Common/interface/ProductData.h"
 
 #include "DataFormats/Provenance/interface/ProductID.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
 #include "FWCore/Utilities/interface/do_nothing_deleter.h"
 
 namespace edm {
@@ -25,5 +26,14 @@ namespace edm {
   void
   ProductData::resetBranchDescription(std::shared_ptr<BranchDescription const> bd) {
     prov_.setBranchDescription(bd);
+  }
+
+  void ProductData::setWrapper(std::unique_ptr<WrapperBase> iValue) {
+    wrapper_ = std::move(iValue);
+  }
+  
+  //Not const thread-safe update
+  void ProductData::unsafe_setWrapper(std::unique_ptr<WrapperBase> iValue) const {
+    wrapper_ = std::move(iValue);
   }
 }

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -9,11 +9,8 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
-#include "boost/scoped_ptr.hpp"
-#include "boost/utility.hpp"
-
-#include <iosfwd>
 #include <memory>
 #include <set>
 
@@ -24,10 +21,12 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 namespace edm {
   class ProvenanceReaderBase;
 
-  class ProductProvenanceRetriever : private boost::noncopyable {
+  class ProductProvenanceRetriever {
   public:
     explicit ProductProvenanceRetriever(unsigned int iTransitionIndex);
     explicit ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader);
+    
+    ProductProvenanceRetriever& operator=(ProductProvenanceRetriever const&) = delete;
 
     ~ProductProvenanceRetriever();
 
@@ -37,7 +36,7 @@ namespace edm {
 
     void mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other);
 
-    void deepSwap(ProductProvenanceRetriever&);
+    void deepCopy(ProductProvenanceRetriever const&);
     
     void reset();
   private:
@@ -49,8 +48,8 @@ namespace edm {
     typedef std::set<ProductProvenance> eiSet;
 
     mutable eiSet entryInfoSet_;
-    std::shared_ptr<ProductProvenanceRetriever> nextRetriever_;
-    mutable std::shared_ptr<ProvenanceReaderBase> provenanceReader_;
+    edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>> nextRetriever_;
+    std::shared_ptr<const ProvenanceReaderBase> provenanceReader_;
     unsigned int transitionIndex_;
     mutable bool delayedRead_;
   };

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -45,13 +45,12 @@ namespace edm {
     BranchDescription const& constBranchDescription() const {return *branchDescription_;}
     std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return branchDescription_;}
 
-    ProductProvenance* resolve() const;
-    ProductProvenance* productProvenance() const {
-      if (productProvenanceValid_) return productProvenancePtr_.get();
+    ProductProvenance const* productProvenance() const {
+      if (productProvenancePtr_) return productProvenancePtr_.get();
       return resolve();
     }
     bool productProvenanceValid() const {
-      return productProvenanceValid_;
+      return bool(productProvenancePtr_);
     }
     Parentage const& parentage() const {return productProvenance()->parentage();}
     BranchID const& branchID() const {return product().branchID();}
@@ -61,7 +60,7 @@ namespace edm {
     std::string const& processName() const {return product().processName();}
     std::string const& productInstanceName() const {return product().productInstanceName();}
     std::string const& friendlyClassName() const {return product().friendlyClassName();}
-    std::shared_ptr<ProductProvenanceRetriever> const& store() const {return store_;}
+    ProductProvenanceRetriever const* store() const {return store_;}
     ProcessHistory const& processHistory() const {return *processHistory_;}
     bool getProcessConfiguration(ProcessConfiguration& pc) const;
     ReleaseVersion releaseVersion() const;
@@ -71,13 +70,13 @@ namespace edm {
 
     void write(std::ostream& os) const;
 
-    void setStore(std::shared_ptr<ProductProvenanceRetriever> store) const {store_ = store;}
+    void setStore(ProductProvenanceRetriever const* store) {store_ = store;}
 
     void setProcessHistory(ProcessHistory const& ph) {processHistory_ = &ph;}
 
     ProductID const& productID() const {return productID_;}
 
-    void setProductProvenance(ProductProvenance const& prov) const;
+    void setProductProvenance(ProductProvenance const& prov);
 
     void setProductID(ProductID const& pid) {
       productID_ = pid;
@@ -87,17 +86,18 @@ namespace edm {
       branchDescription_ = p;
     }
 
-    void resetProductProvenance() const;
+    void resetProductProvenance();
 
     void swap(Provenance&);
 
   private:
+    ProductProvenance const* resolve() const;
+
     std::shared_ptr<BranchDescription const> branchDescription_;
     ProductID productID_;
     ProcessHistory const* processHistory_; // We don't own this
-    mutable bool productProvenanceValid_;
-    mutable std::shared_ptr<ProductProvenance> productProvenancePtr_;
-    mutable std::shared_ptr<ProductProvenanceRetriever> store_;
+    mutable std::shared_ptr<const ProductProvenance> productProvenancePtr_; //can be updated in resolve()
+    ProductProvenanceRetriever const* store_;
   };
 
   inline

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -38,18 +38,18 @@ namespace edm {
     }
   }
 
-  void ProductProvenanceRetriever::deepSwap(ProductProvenanceRetriever& iFrom)
+  void ProductProvenanceRetriever::deepCopy(ProductProvenanceRetriever const& iFrom)
   {
-    entryInfoSet_.swap(iFrom.entryInfoSet_);
+    entryInfoSet_ = iFrom.entryInfoSet_;
     provenanceReader_ = iFrom.provenanceReader_;
     if(provenanceReader_) {
       delayedRead_=true;
     }
     if(iFrom.nextRetriever_) {
       if(not nextRetriever_) {
-        nextRetriever_.reset(new ProductProvenanceRetriever(transitionIndex_));
+        get_underlying(nextRetriever_) = std::make_shared<ProductProvenanceRetriever>(transitionIndex_);
       }
-      nextRetriever_->deepSwap(*(iFrom.nextRetriever_));
+      nextRetriever_->deepCopy(*(iFrom.nextRetriever_));
     }
   }
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -72,7 +72,7 @@ namespace edm {
                             ProcessHistoryRegistry const& processHistoryRegistry,
                             EventSelectionIDVector&& eventSelectionIDs,
                             BranchListIndexes&& branchListIndexes,
-                            ProductProvenanceRetriever& provRetriever,
+                            ProductProvenanceRetriever const& provRetriever,
                             DelayedReader* reader = nullptr);
 
     
@@ -134,10 +134,10 @@ namespace edm {
 
     RunPrincipal const& runPrincipal() const;
 
-    std::shared_ptr<ProductProvenanceRetriever> productProvenanceRetrieverPtr() const {return provRetrieverPtr_;}
+    ProductProvenanceRetriever const* productProvenanceRetrieverPtr() const {return provRetrieverPtr_.get();}
 
     void setUnscheduledHandler(std::shared_ptr<UnscheduledHandler> iHandler);
-    std::shared_ptr<UnscheduledHandler> unscheduledHandler() const;
+    std::shared_ptr<const UnscheduledHandler> unscheduledHandler() const;
 
     EventSelectionIDVector const& eventSelectionIDs() const;
 
@@ -168,7 +168,7 @@ namespace edm {
     ProductID branchIDToProductID(BranchID const& bid) const;
 
     void mergeProvenanceRetrievers(EventPrincipal const& other) {
-      provRetrieverPtr_->mergeProvenanceRetrievers(other.productProvenanceRetrieverPtr());
+      provRetrieverPtr_->mergeProvenanceRetrievers(get_underlying(other.provRetrieverPtr_));
     }
 
     using Base::getProvenance;
@@ -195,13 +195,13 @@ namespace edm {
 
     EventAuxiliary aux_;
 
-    std::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
+    edm::propagate_const<std::shared_ptr<LuminosityBlockPrincipal>> luminosityBlockPrincipal_;
 
     // Pointer to the 'retriever' that will get provenance information from the persistent store.
-    std::shared_ptr<ProductProvenanceRetriever> provRetrieverPtr_;
+    edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>> provRetrieverPtr_;
 
     // Handler for unscheduled modules
-    std::shared_ptr<UnscheduledHandler> unscheduledHandler_;
+    std::shared_ptr<UnscheduledHandler const> unscheduledHandler_;
 
     EventSelectionIDVector eventSelectionIDs_;
 

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -17,6 +17,7 @@ is the DataBlock.
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Framework/interface/Principal.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 
@@ -100,7 +101,7 @@ namespace edm {
         std::unique_ptr<WrapperBase> edp);
 
 
-    void readImmediate() const;
+    void readImmediate();
 
     void setComplete() {
       complete_ = true;
@@ -116,11 +117,11 @@ namespace edm {
 
     virtual unsigned int transitionIndex_() const override;
 
-    void resolveProductImmediate(ProductHolderBase const& phb) const;
+    void resolveProductImmediate(ProductHolderBase& phb);
 
-    std::shared_ptr<RunPrincipal> runPrincipal_;
+    edm::propagate_const<std::shared_ptr<RunPrincipal>> runPrincipal_;
 
-    std::shared_ptr<LuminosityBlockAuxiliary> aux_;
+    edm::propagate_const<std::shared_ptr<LuminosityBlockAuxiliary>> aux_;
 
     LuminosityBlockIndex index_;
     

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -81,13 +81,15 @@ namespace edm {
     bool productWasDeleted() const {return productWasDeleted_();}
 
     // Retrieves a pointer to the wrapper of the product.
-    WrapperBase* product() const { return getProductData().wrapper_.get(); }
+    WrapperBase const * product() const { return getProductData().wrapper(); }
+
+    WrapperBase * product() { return getProductData().wrapper(); }
 
     // Retrieves pointer to the per event(lumi)(run) provenance.
-    ProductProvenance* productProvenancePtr() const { return productProvenancePtr_(); }
+    ProductProvenance const* productProvenancePtr() const { return productProvenancePtr_(); }
 
     // Sets the the per event(lumi)(run) provenance.
-    void setProductProvenance(ProductProvenance const& prov) const;
+    void setProductProvenance(ProductProvenance const& prov);
 
     // Retrieves a reference to the event independent provenance.
     BranchDescription const& branchDescription() const {return branchDescription_();}
@@ -115,10 +117,10 @@ namespace edm {
     std::string const& processName() const {return branchDescription().processName();}
 
     // Retrieves pointer to a class containing both the event independent and the per even provenance.
-    Provenance* provenance() const;
+    Provenance const* provenance() const;
 
     // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the provRetriever.
-    void setProvenance(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
+    void setProvenance(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
 
     // Initializes the process history.
     void setProcessHistory(ProcessHistory const& ph) { setProcessHistory_(ph); }
@@ -132,7 +134,7 @@ namespace edm {
     TypeID productType() const;
 
     // Retrieves the product ID of the product.
-    ProductID const& productID() const {return getProductData().prov_.productID();}
+    ProductID const& productID() const {return getProductData().provenance().productID();}
 
     // Puts the product and its per event(lumi)(run) provenance into the ProductHolder.
     void putProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) {
@@ -150,16 +152,16 @@ namespace edm {
     }
 
     // merges the product with the pre-existing product
-    void mergeProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance& productProvenance) {
+    void mergeProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance const & productProvenance) {
       mergeProduct_(std::move(edp), productProvenance);
     }
 
-    void mergeProduct(std::unique_ptr<WrapperBase> edp) const {
+    void mergeProduct(std::unique_ptr<WrapperBase> edp) {
       mergeProduct_(std::move(edp));
     }
 
     // Merges two instances of the product.
-    void mergeTheProduct(std::unique_ptr<WrapperBase> edp) const;
+    void mergeTheProduct(std::unique_ptr<WrapperBase> edp);
 
     void reallyCheckType(WrapperBase const& prod) const;
 
@@ -184,8 +186,8 @@ namespace edm {
     virtual bool productWasDeleted_() const = 0;
     virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) = 0;
     virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
-    virtual void mergeProduct_(std::unique_ptr<WrapperBase>  edp, ProductProvenance& productProvenance) = 0;
-    virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
+    virtual void mergeProduct_(std::unique_ptr<WrapperBase>  edp, ProductProvenance const& productProvenance) = 0;
+    virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) = 0;
     virtual bool putOrMergeProduct_() const = 0;
     virtual void checkType_(WrapperBase const& prod) const = 0;
     virtual void resetStatus_() = 0;
@@ -193,9 +195,9 @@ namespace edm {
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
-    virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
+    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
     virtual void setProcessHistory_(ProcessHistory const& ph) = 0;
-    virtual ProductProvenance* productProvenancePtr_() const = 0;
+    virtual ProductProvenance const* productProvenancePtr_() const = 0;
     virtual void resetProductData_() = 0;
     virtual bool singleProduct_() const = 0;
     virtual void setPrincipal_(Principal* principal) = 0;
@@ -234,8 +236,8 @@ namespace edm {
                                                  ModuleCallingContext const* mcc) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance& productProvenance) override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override;
       virtual bool putOrMergeProduct_() const override;
       virtual void checkType_(WrapperBase const&) const override {}
       virtual void resetStatus_() override {productIsUnavailable_ = false;
@@ -249,9 +251,9 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const override {return *productData().branchDescription();}
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+      virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
       virtual void setProcessHistory_(ProcessHistory const& ph) override;
-      virtual ProductProvenance* productProvenancePtr_() const override;
+      virtual ProductProvenance const* productProvenancePtr_() const override;
       virtual void resetProductData_() override;
       virtual bool singleProduct_() const override;
       virtual void setPrincipal_(Principal* principal) override;
@@ -286,8 +288,8 @@ namespace edm {
     private:
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance& productProvenance) override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override;
       virtual bool putOrMergeProduct_() const override;
       virtual void checkType_(WrapperBase const& prod) const override {
         reallyCheckType(prod);
@@ -299,9 +301,9 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const override {return *productData().branchDescription();}
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+      virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
       virtual void setProcessHistory_(ProcessHistory const& ph) override;
-      virtual ProductProvenance* productProvenancePtr_() const override;
+      virtual ProductProvenance const* productProvenancePtr_() const override;
       virtual void resetProductData_() override;
       virtual bool singleProduct_() const override;
       virtual void setPrincipal_(Principal* principal) override;
@@ -421,10 +423,10 @@ namespace edm {
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override {
         realProduct_.putProduct(std::move(edp));
       }
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance& productProvenance) override {
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override {
         realProduct_.mergeProduct(std::move(edp), productProvenance);
       }
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override {
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override {
         realProduct_.mergeProduct(std::move(edp));
       }
       virtual bool putOrMergeProduct_() const override {
@@ -433,9 +435,9 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const override {return *bd_;}
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
       virtual std::string const& resolvedModuleLabel_() const override {return realProduct_.moduleLabel();}
-      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+      virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
       virtual void setProcessHistory_(ProcessHistory const& ph) override;
-      virtual ProductProvenance* productProvenancePtr_() const override;
+      virtual ProductProvenance const* productProvenancePtr_() const override;
       virtual void resetProductData_() override;
       virtual bool singleProduct_() const override;
       virtual void setPrincipal_(Principal* principal) override;
@@ -464,8 +466,8 @@ namespace edm {
       virtual bool productWasDeleted_() const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance& productProvenance) override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override;
       virtual bool putOrMergeProduct_() const override;
       virtual void checkType_(WrapperBase const& prod) const override;
       virtual void resetStatus_() override;
@@ -473,9 +475,9 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const override;
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
       virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+      virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
       virtual void setProcessHistory_(ProcessHistory const& ph) override;
-      virtual ProductProvenance* productProvenancePtr_() const override;
+      virtual ProductProvenance const* productProvenancePtr_() const override;
       virtual void resetProductData_() override;
       virtual bool singleProduct_() const override;
       virtual void setPrincipal_(Principal* principal) override;

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -92,7 +92,7 @@ namespace edm {
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp);
 
-    void readImmediate() const;
+    void readImmediate();
 
     void setComplete() {
       complete_ = true;
@@ -108,9 +108,9 @@ namespace edm {
 
     virtual unsigned int transitionIndex_() const override;
 
-    void resolveProductImmediate(ProductHolderBase const& phb) const;
+    void resolveProductImmediate(ProductHolderBase& phb);
 
-    std::shared_ptr<RunAuxiliary> aux_;
+    edm::propagate_const<std::shared_ptr<RunAuxiliary>> aux_;
     ProcessHistoryID m_reducedHistoryID;
     RunIndex index_;
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -69,7 +69,7 @@ namespace edm {
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------
-      const ModuleDescription& moduleDescription() { return moduleDescription_;}
+      const ModuleDescription& moduleDescription() const { return moduleDescription_;}
       
       std::string workerType() const { return "WorkerT<EDAnalyzerAdaptorBase>";}
       void

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -70,7 +70,7 @@ namespace edm {
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------
-      const ModuleDescription& moduleDescription() { return moduleDescription_;}
+      const ModuleDescription& moduleDescription() const { return moduleDescription_;}
       
       void
       registerProductsAndCallbacks(ProducingModuleAdaptorBase const*, ProductRegistry* reg);

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -53,7 +53,7 @@ namespace edm {
   EventPrincipal::clearEventPrincipal() {
     clearPrincipal();
     aux_ = EventAuxiliary();
-    luminosityBlockPrincipal_.reset();
+    get_underlying(luminosityBlockPrincipal_).reset();
     provRetrieverPtr_->reset();
     unscheduledHandler_.reset();
     branchListIndexToProcessIndex_.clear();
@@ -64,10 +64,10 @@ namespace edm {
         ProcessHistoryRegistry const& processHistoryRegistry,
         EventSelectionIDVector&& eventSelectionIDs,
         BranchListIndexes&& branchListIndexes,
-        ProductProvenanceRetriever& provRetriever,
+        ProductProvenanceRetriever const& provRetriever,
         DelayedReader* reader) {
     eventSelectionIDs_ = eventSelectionIDs;
-    provRetrieverPtr_->deepSwap(provRetriever);
+    provRetrieverPtr_->deepCopy(provRetriever);
     branchListIndexes_ = branchListIndexes;
     if(branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
@@ -416,7 +416,7 @@ namespace edm {
     unscheduledHandler_ = iHandler;
   }
 
-  std::shared_ptr<UnscheduledHandler>
+  std::shared_ptr<const UnscheduledHandler>
   EventPrincipal::unscheduledHandler() const {
      return unscheduledHandler_;
   }
@@ -446,7 +446,7 @@ namespace edm {
     if (productData == nullptr) {
       return nullptr;
     }
-    WrapperBase const* product = productData->wrapper_.get();
+    WrapperBase const* product = productData->wrapper();
     if(!(typeid(edm::ThinnedAssociation) == product->dynamicTypeInfo())) {
       throw Exception(errors::LogicError)
         << "EventPrincipal::getThinnedProduct, product has wrong type, not a ThinnedAssociation.\n";

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -53,9 +53,9 @@ namespace edm {
   }
 
   void
-  LuminosityBlockPrincipal::readImmediate() const {
-    for(auto const& prod : *this) {
-      ProductHolderBase const& phb = *prod;
+  LuminosityBlockPrincipal::readImmediate() {
+    for(auto & prod : *this) {
+      ProductHolderBase & phb = *prod;
       if(phb.singleProduct() && !phb.branchDescription().produced()) {
         if(!phb.productUnavailable()) {
           resolveProductImmediate(phb);
@@ -65,7 +65,7 @@ namespace edm {
   }
 
   void
-  LuminosityBlockPrincipal::resolveProductImmediate(ProductHolderBase const& phb) const {
+  LuminosityBlockPrincipal::resolveProductImmediate(ProductHolderBase& phb)  {
     if(phb.branchDescription().produced()) return; // nothing to do.
     if(!reader()) return; // nothing to do.
 

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -849,7 +849,7 @@ namespace edm {
   }
 
   void
-  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase const* phb) const {
+  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase* phb) {
     bool willBePut = phb->putOrMergeProduct();
     if(willBePut) {
       checkUniquenessAndType(prod.get(), phb);
@@ -861,7 +861,7 @@ namespace edm {
   }
 
   void
-  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance& prov, ProductHolderBase* phb) {
+  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance&& prov, ProductHolderBase* phb) {
     bool willBePut = phb->putOrMergeProduct();
     if(willBePut) {
       checkUniquenessAndType(prod.get(), phb);

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -48,9 +48,9 @@ namespace edm {
   }
 
   void
-  RunPrincipal::readImmediate() const {
-    for(auto const& prod : *this) {
-      ProductHolderBase const& phb = *prod;
+  RunPrincipal::readImmediate() {
+    for(auto& prod : *this) {
+      ProductHolderBase& phb = *prod;
       if(phb.singleProduct() && !phb.branchDescription().produced()) {
         if(!phb.productUnavailable()) {
           resolveProductImmediate(phb);
@@ -60,7 +60,7 @@ namespace edm {
   }
 
   void
-  RunPrincipal::resolveProductImmediate(ProductHolderBase const& phb) const {
+  RunPrincipal::resolveProductImmediate(ProductHolderBase& phb) {
     if(phb.branchDescription().produced()) return; // nothing to do.
     if(!reader()) return; // nothing to do.
 

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -595,23 +595,12 @@ namespace edm {
       ProductHolderBase const* parentProductHolder = parentPrincipal.getProductHolder(item->branchID());
       if(parentProductHolder != nullptr) {
         ProductData const& parentData = parentProductHolder->productData();
-        ProductHolderBase const* productHolder = principal.getProductHolder(item->branchID());
+        ProductHolderBase* productHolder = principal.getModifiableProductHolder(item->branchID());
         if(productHolder != nullptr) {
-          ProductData& thisData = const_cast<ProductData&>(productHolder->productData());
+          ProductData& thisData = productHolder->productData();
           //Propagate the per event(run)(lumi) data for this product to the subprocess.
           //First, the product itself.
-          thisData.wrapper_ = parentData.wrapper_;
-          // Then the product ID and the ProcessHistory 
-          thisData.prov_.setProductID(parentData.prov_.productID());
-          thisData.prov_.setProcessHistory(parentData.prov_.processHistory());
-          // Then the store, in case the product needs reading in a subprocess.
-          thisData.prov_.setStore(parentData.prov_.store());
-          // And last, the other per event provenance.
-          if(parentData.prov_.productProvenanceValid()) {
-            thisData.prov_.setProductProvenance(*parentData.prov_.productProvenance());
-          } else {
-            thisData.prov_.resetProductProvenance();
-          }
+          thisData.connectTo(parentData);
           // Sets unavailable flag, if known that product is not available
           (void)productHolder->productUnavailable();
         }

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -95,7 +95,7 @@ namespace edm{
     };
   }
   
-  UnscheduledHandler* getUnscheduledHandler(EventPrincipal const& ep) {
+  UnscheduledHandler const* getUnscheduledHandler(EventPrincipal const& ep) {
     return ep.unscheduledHandler().get();
   }
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -12,6 +12,7 @@ WorkerT: Code common to all workers.
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerParams.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>
@@ -26,7 +27,7 @@ namespace edm {
   class ProductRegistry;
   class ThinnedAssociationsHelper;
 
-  UnscheduledHandler* getUnscheduledHandler(EventPrincipal const& ep);
+  UnscheduledHandler const* getUnscheduledHandler(EventPrincipal const& ep);
 
   template<typename T>
   class WorkerT : public Worker {
@@ -133,7 +134,7 @@ namespace edm {
 
     virtual std::vector<ProductHolderIndexAndSkipBit> const& itemsToGetFromEvent() const override { return module_->itemsToGetFromEvent(); }
 
-    std::shared_ptr<T> module_;
+    edm::propagate_const<std::shared_ptr<T>> module_;
   };
 
 }

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -106,7 +106,7 @@ namespace edm {
    void
    ProvenanceCheckerOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
       //check ProductProvenance's parents to see if they are in the ProductProvenance list
-      std::shared_ptr<ProductProvenanceRetriever> mapperPtr = e.productProvenanceRetrieverPtr();
+      auto mapperPtr = e.productProvenanceRetrieverPtr();
 
       std::map<BranchID, bool> seenParentInPrincipal;
       std::set<BranchID> missingFromMapper;

--- a/FWCore/Utilities/interface/propagate_const.h
+++ b/FWCore/Utilities/interface/propagate_const.h
@@ -1,0 +1,93 @@
+#ifndef FWCore_Utilities_propagate_const_h
+#define FWCore_Utilities_propagate_const_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     propagate_const
+// 
+/**\class propagate_const propagate_const.h "FWCore/Utilities/interface/propagate_const.h"
+
+ Description: propagate const to pointer like objects. Based on C++ experimental std::propagate_const.
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 18 Dec 2015 14:56:12 GMT
+//
+
+// system include files
+#include <type_traits>
+#include <utility>
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+
+  template<typename T>
+  class propagate_const;
+
+  template<typename T> T& get_underlying( propagate_const<T>& );
+  template<typename T> T const& get_underlying( propagate_const<T> const& );
+  
+  
+  template<typename T>
+  class propagate_const
+  {
+    
+  public:
+    friend T& get_underlying<T>( propagate_const<T>& );
+    friend T const& get_underlying<T>( propagate_const<T> const& );
+    
+    using element_type = typename std::remove_reference<decltype(*std::declval<T&>())>::type;
+    
+    propagate_const() = default;
+    
+    propagate_const( propagate_const<T>&&) = default;
+    propagate_const( propagate_const<T> const&) = delete;
+    template<typename U>
+    propagate_const( U&& iValue) : m_value(std::forward<U>(iValue)) {}
+
+    
+    propagate_const<T>& operator=(propagate_const&&) = default;
+    propagate_const<T>& operator=(propagate_const<T> const&) = delete;
+    
+    template<typename U>
+    propagate_const& operator=(U&& iValue) {
+      m_value = std::forward<U>(iValue);
+      return *this;
+    }
+    
+    
+    
+    // ---------- const member functions ---------------------
+    element_type const* get() const { return &(*m_value); }
+    element_type const* operator->() const { return this->get(); }
+    element_type const& operator*() const { return *m_value; }
+    
+    operator element_type const* () const { return this->get(); }
+    
+    // ---------- member functions ---------------------------
+    element_type* get() { return &(*m_value); }
+    element_type* operator->() { return this->get(); }
+    element_type& operator*() { return *m_value; }
+
+    operator element_type* () { return this->get(); }
+    
+  private:
+    
+    // ---------- member data --------------------------------
+    T m_value;
+  };
+  
+  template<typename T> T& get_underlying( propagate_const<T>& iP) { return iP.m_value;}
+  template<typename T> T const& get_underlying( propagate_const<T> const& iP ) {return iP.m_value;}
+
+}
+
+
+#endif

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -35,7 +35,7 @@
 <bin   file="MallocOpts_t.cpp">
   <use   name="cppunit"/>
 </bin>
-<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp">
+<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
 

--- a/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
+++ b/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
@@ -1,0 +1,88 @@
+/*----------------------------------------------------------------------
+
+Test program for edm::propagate_const class.
+
+ ----------------------------------------------------------------------*/
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <memory>
+#include "FWCore/Utilities/interface/propagate_const.h"
+
+class test_propagate_const: public CppUnit::TestFixture
+{
+CPPUNIT_TEST_SUITE(test_propagate_const);
+
+CPPUNIT_TEST(test);
+
+CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp(){}
+  void tearDown(){}
+
+  void test();
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(test_propagate_const);
+
+namespace {
+   class ConstChecker {
+   public:
+      int value() { return 0;}
+      
+      int const value() const { return 1;}
+      
+   };
+}
+
+
+void test_propagate_const::test()
+{
+   {
+      ConstChecker checker;
+      edm::propagate_const<ConstChecker*> pChecker(&checker);
+
+      CPPUNIT_ASSERT(0 == pChecker.get()->value());
+      CPPUNIT_ASSERT( pChecker.get()->value() == pChecker->value());
+      CPPUNIT_ASSERT( pChecker.get()->value() == (*pChecker).value());
+
+      const edm::propagate_const<ConstChecker*> pConstChecker(&checker);
+
+      CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
+      CPPUNIT_ASSERT( pConstChecker.get()->value() == pConstChecker->value());
+      CPPUNIT_ASSERT( pConstChecker.get()->value() == (*pConstChecker).value());
+   }
+   
+   {
+      auto checker = std::make_shared<ConstChecker>();
+      edm::propagate_const<std::shared_ptr<ConstChecker>> pChecker(checker);
+      
+      CPPUNIT_ASSERT(0 == pChecker.get()->value());
+      CPPUNIT_ASSERT( pChecker.get()->value() == pChecker->value());
+      CPPUNIT_ASSERT( pChecker.get()->value() == (*pChecker).value());
+      
+      const edm::propagate_const<std::shared_ptr<ConstChecker>> pConstChecker(checker);
+      
+      CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
+      CPPUNIT_ASSERT( pConstChecker.get()->value() == pConstChecker->value());
+      CPPUNIT_ASSERT( pConstChecker.get()->value() == (*pConstChecker).value());
+      
+   }
+   
+   {
+      auto checker = std::make_unique<ConstChecker>();
+      edm::propagate_const<std::unique_ptr<ConstChecker>> pChecker(std::move(checker));
+      
+      CPPUNIT_ASSERT(0 == pChecker.get()->value());
+      CPPUNIT_ASSERT( pChecker.get()->value() == pChecker->value());
+      CPPUNIT_ASSERT( pChecker.get()->value() == (*pChecker).value());
+      
+      const edm::propagate_const<std::unique_ptr<ConstChecker>> pConstChecker(std::make_unique<ConstChecker>());
+      
+      CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
+      CPPUNIT_ASSERT( pConstChecker.get()->value() == pConstChecker->value());
+      CPPUNIT_ASSERT( pConstChecker.get()->value() == (*pConstChecker).value());
+      
+   }
+
+}

--- a/HLTriggerOffline/Egamma/interface/EmDQMReco.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQMReco.h
@@ -24,6 +24,7 @@
 #include "DataFormats/Common/interface/AssociationMap.h"
 
 #include <boost/ptr_container/ptr_vector.hpp>
+#include <boost/scoped_ptr.hpp>
 
 class EmDQMReco;
 


### PR DESCRIPTION
Improved the const correctness of the internal classes used by Principal. This should help reason about the thread-safety of those classes.

Added our own version of `propagate_const` which is under consideration for `C++17` as is in the `experimental` namespace for gcc and clang. This allows one force pointer like objects to only give `const` access to their pointed to object when using a `const` pointer.
