### PR TITLE
remove unnecessary circular python dependency

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -15,7 +15,6 @@ from Modules import _Module
 from SequenceTypes import *
 from SequenceTypes import _ModuleSequenceType, _Sequenceable  #extend needs it
 from SequenceVisitors import PathValidator, EndPathValidator
-from Utilities import *
 import DictTypes
 
 from ExceptionHandling import *


### PR DESCRIPTION
In FWCore/ParameterSet/python, Utilities.py is dependent on Config.py, while Config.py was declared dependent on Utilities.py. However, Config.py does not actually use anything in Utilities.py, so the circular dependency is bogus, and removing one import statement removes the circular dependency.
I wasted a lot of time figuring this out, because I assumed that "Utilities" should be the lowest level package given its name. I suggest that Utilities.py be renamed to something else to avoid future confusion.
