### PR TITLE
adjust sequence names and imports to avoid conflicts in cosmic reco and alca

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #restarting from ECAL RAW to reconstruct amplitudes and energies
 # create uncalib recHit collections
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalCalIsolElectron_cff import *
-from Configuration.StandardSequences.RawToDigi_Data_cff import *
+from Configuration.StandardSequences.RawToDigi_Data_cff import ecalDigis,ecalPreshowerDigis
 from RecoLocalCalo.Configuration.ecalLocalRecoSequence_cff import *
 
 from RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi import *

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -46,9 +46,9 @@ from RecoEgamma.Configuration.RecoEgammaCosmics_cff import *
 # local reco
 trackerCosmics = cms.Sequence(offlineBeamSpot*trackerlocalreco*MeasurementTrackerEvent*tracksP5)
 hbhereco = hbheprereco.clone()
-calolocalreco.replace(hbheprereco,hbhereco)
-caloCosmics = cms.Sequence(calolocalreco*ecalClusters)
-caloCosmics_HcalNZS = cms.Sequence(calolocalrecoNZS*ecalClusters)
+calolocalrecoCosmics.replace(hbheprereco,hbhereco)
+caloCosmics = cms.Sequence(calolocalrecoCosmics*ecalClustersCosmics)
+caloCosmics_HcalNZS = cms.Sequence(calolocalrecoCosmicsNZS*ecalClustersCosmics)
 muonsLocalRecoCosmics = cms.Sequence(muonlocalreco+muonlocalrecoT0Seg)
 
 localReconstructionCosmics         = cms.Sequence(bunchSpacingProducer*trackerCosmics*caloCosmics*muonsLocalRecoCosmics*vertexrecoCosmics+lumiProducer)

--- a/RecoEcal/Configuration/python/RecoEcalCosmics_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcalCosmics_cff.py
@@ -17,5 +17,5 @@ from RecoEcal.EgammaClusterProducers.hybridClusteringSequence_cff import *
 from RecoEcal.EgammaClusterProducers.cosmicClusteringSequence_cff import *
 # create path with all clustering algos
 # NB: preshower MUST be run after island clustering in the endcap
-ecalClusters = cms.Sequence(hybridClusteringSequence*cosmicClusteringSequence)
+ecalClustersCosmics = cms.Sequence(hybridClusteringSequence*cosmicClusteringSequence)
 

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -21,7 +21,7 @@ from RecoLocalCalo.Configuration.hcalLocalReco_cff import *
 #
 # sequence CaloLocalReco and CaloGlobalReco
 #
-calolocalreco = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence)
+calolocalrecoCosmics = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence)
 hbheprereco.puCorrMethod = 0 
 hbheprereco.firstSample = 0
 hbheprereco.samplesToAdd = 10
@@ -54,4 +54,4 @@ zdcreco.correctionPhaseNS = 10.
 # R.Ofierzynski (29.Oct.2009): add NZS sequence
 #
 from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
-calolocalrecoNZS = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 
+calolocalrecoCosmicsNZS = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 

--- a/RecoLocalCalo/Configuration/python/ecalLocalRecoSequenceCosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalRecoSequenceCosmics_cff.py
@@ -15,7 +15,7 @@ from RecoLocalCalo.EcalRecProducers.ecalFixedAlphaBetaFitUncalibRecHit_cfi impor
 from RecoLocalCalo.EcalRecProducers.ecalRecHit_cfi import *
 from RecoLocalCalo.EcalRecProducers.ecalPreshowerRecHit_cfi import *
 from RecoLocalCalo.EcalRecProducers.ecalDetIdToBeRecovered_cfi import *
-ecalLocalRecoSequence = cms.Sequence(ecalFixedAlphaBetaFitUncalibRecHit*ecalWeightUncalibRecHit*ecalDetIdToBeRecovered*ecalRecHit+ecalPreshowerRecHit)
+ecalLocalRecoSequenceCosmics = cms.Sequence(ecalFixedAlphaBetaFitUncalibRecHit*ecalWeightUncalibRecHit*ecalDetIdToBeRecovered*ecalRecHit+ecalPreshowerRecHit)
 ecalRecHit.EBuncalibRecHitCollection = 'ecalFixedAlphaBetaFitUncalibRecHit:EcalUncalibRecHitsEB'
 ecalRecHit.EEuncalibRecHitCollection = 'ecalFixedAlphaBetaFitUncalibRecHit:EcalUncalibRecHitsEE'
 ecalRecHit.ChannelStatusToBeExcluded = [


### PR DESCRIPTION
Fixes problems found in 1307.0  and 1308.0  matrix.
- For reco sequences in cosmics follow the logic that the sequence modified from the default (pp) content should have a different name (append Cosmics to the name).
- minimize wildcarded imports in ALCARECOEcalUncalIsolElectron.

It looks like the issue was introduced to the cosmics workflows by EcalUncalIsolElectron ALCA with #8306 , but somehow the framework has covered up for this by inlining the first loaded sequence with the same label.
