### PR TITLE
Improved loading of b-tag EventSetup in PAT

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -131,6 +131,10 @@ def miniAOD_customizeCommon(process):
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars
+    if not hasattr( process, 'pfImpactParameterTagInfos' ):
+        process.load('RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi')
+    if not hasattr( process, 'pfSecondaryVertexTagInfos' ):
+        process.load('RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi')
     process.patJets.userData.userFunctions = cms.vstring(
     '?(tagInfoCandSecondaryVertex("pfSecondaryVertex").nVertices()>0)?(tagInfoCandSecondaryVertex("pfSecondaryVertex").secondaryVertex(0).p4.M):(0)',
     '?(tagInfoCandSecondaryVertex("pfSecondaryVertex").nVertices()>0)?(tagInfoCandSecondaryVertex("pfSecondaryVertex").secondaryVertex(0).numberOfSourceCandidatePtrs):(0)',

--- a/RecoBTag/CTagging/python/RecoCTagging_cff.py
+++ b/RecoBTag/CTagging/python/RecoCTagging_cff.py
@@ -1,5 +1,3 @@
-from RecoBTag.CTagging.pfInclusiveSecondaryVertexFinderCvsLTagInfos_cfi import *
-from RecoBTag.CTagging.pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos_cfi import *
 from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import *
 from RecoBTag.CTagging.cTagging_cff import *
 

--- a/RecoBTag/CTagging/python/cTagging_EventSetup_cff.py
+++ b/RecoBTag/CTagging/python/cTagging_EventSetup_cff.py
@@ -1,0 +1,7 @@
+#charm tagger
+
+from RecoBTag.CTagging.candidateCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
+from RecoBTag.CTagging.candidateNegativeCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
+from RecoBTag.CTagging.candidatePositiveCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
+
+from RecoBTag.CTagging.charmTaggerProducer_cfi import * #ESSource

--- a/RecoBTag/CTagging/python/cTagging_cff.py
+++ b/RecoBTag/CTagging/python/cTagging_cff.py
@@ -1,10 +1,12 @@
 #charm tagger
-from RecoBTag.CTagging.candidateCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
+
+from RecoBTag.CTagging.cTagging_EventSetup_cff import *
+
+from RecoBTag.CTagging.pfInclusiveSecondaryVertexFinderCvsLTagInfos_cfi import *
+from RecoBTag.CTagging.pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos_cfi import *
+
 from RecoBTag.CTagging.pfCombinedSecondaryVertexSoftLeptonCvsLJetTags_cfi import *
-from RecoBTag.CTagging.candidateNegativeCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
 from RecoBTag.CTagging.pfNegativeCombinedSecondaryVertexSoftLeptonCvsLJetTags_cfi import *
-from RecoBTag.CTagging.candidatePositiveCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
 from RecoBTag.CTagging.pfPositiveCombinedSecondaryVertexSoftLeptonCvsLJetTags_cfi import *
 
-from RecoBTag.CTagging.charmTaggerProducer_cfi import * #ESSource
 from RecoBTag.CTagging.charmTagJetTags_cfi import * #EDProducer

--- a/RecoBTag/Combined/python/combinedMVA_EventSetup_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_EventSetup_cff.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.Combined.combinedMVAComputer_cfi import *
+from RecoBTag.Combined.negativeCombinedMVAComputer_cfi import *
+from RecoBTag.Combined.positiveCombinedMVAComputer_cfi import *
+
+# New candidate based fwk
+from RecoBTag.Combined.candidateCombinedMVAComputer_cfi import *
+from RecoBTag.Combined.candidateNegativeCombinedMVAComputer_cfi import *
+from RecoBTag.Combined.candidatePositiveCombinedMVAComputer_cfi import *
+
+# CombinedMVA V2
+from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *

--- a/RecoBTag/Combined/python/combinedMVA_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_cff.py
@@ -1,22 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoBTag.Combined.combinedMVAComputer_cfi import *
+from RecoBTag.Combined.combinedMVA_EventSetup_cff import *
+
 from RecoBTag.Combined.combinedMVABJetTags_cfi import *
-from RecoBTag.Combined.negativeCombinedMVAComputer_cfi import *
 from RecoBTag.Combined.negativeCombinedMVABJetTags_cfi import *
-from RecoBTag.Combined.positiveCombinedMVAComputer_cfi import *
 from RecoBTag.Combined.positiveCombinedMVABJetTags_cfi import *
 
 # New candidate based fwk
-from RecoBTag.Combined.candidateCombinedMVAComputer_cfi import *
 from RecoBTag.Combined.pfCombinedMVABJetTags_cfi import *
-from RecoBTag.Combined.candidateNegativeCombinedMVAComputer_cfi import *
 from RecoBTag.Combined.pfNegativeCombinedMVABJetTags_cfi import *
-from RecoBTag.Combined.candidatePositiveCombinedMVAComputer_cfi import *
 from RecoBTag.Combined.pfPositiveCombinedMVABJetTags_cfi import *
 
-#combined MVA V2
-from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
+# CombinedMVA V2
 from RecoBTag.Combined.combinedMVAV2BJetTags_cfi import *
-from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.pfCombinedMVAV2BJetTags_cfi import *

--- a/RecoBTag/ImpactParameter/python/impactParameter_EventSetup_cff.py
+++ b/RecoBTag/ImpactParameter/python/impactParameter_EventSetup_cff.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
+from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+# MVA
+from RecoBTag.ImpactParameter.impactParameterMVAComputer_cfi import *
+# Jet BProb
+from RecoBTag.ImpactParameter.jetBProbabilityComputer_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.jetProbabilityComputer_cfi import *
+# High Eff
+from RecoBTag.ImpactParameter.trackCounting3D2ndComputer_cfi import *
+# High Purity
+from RecoBTag.ImpactParameter.trackCounting3D3rdComputer_cfi import *
+
+# Negative Tags
+
+# Jet BProb
+from RecoBTag.ImpactParameter.negativeOnlyJetBProbabilityComputer_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.negativeOnlyJetProbabilityComputer_cfi import *
+# High Eff
+from RecoBTag.ImpactParameter.negativeTrackCounting3D2ndComputer_cfi import *
+# High Purity
+from RecoBTag.ImpactParameter.negativeTrackCounting3D3rdComputer_cfi import *
+
+# Positive-only Tags
+
+# Jet BProb
+from RecoBTag.ImpactParameter.positiveOnlyJetBProbabilityComputer_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.positiveOnlyJetProbabilityComputer_cfi import *
+
+
+# New candidate based fwk
+
+# Jet BProb
+from RecoBTag.ImpactParameter.candidateJetBProbabilityComputer_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.candidateJetProbabilityComputer_cfi import *
+# High Eff
+from RecoBTag.ImpactParameter.candidateTrackCounting3D2ndComputer_cfi import *
+# High Purity
+from RecoBTag.ImpactParameter.candidateTrackCounting3D3rdComputer_cfi import *
+
+# Negative Tags
+
+# Jet BProb
+from RecoBTag.ImpactParameter.candidateNegativeOnlyJetBProbabilityComputer_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.candidateNegativeOnlyJetProbabilityComputer_cfi import *
+# High Eff
+from RecoBTag.ImpactParameter.candidateNegativeTrackCounting3D2ndComputer_cfi import *
+# High Purity
+from RecoBTag.ImpactParameter.candidateNegativeTrackCounting3D3rdComputer_cfi import *
+
+# Positive-only Tags
+
+# Jet BProb
+from RecoBTag.ImpactParameter.candidatePositiveOnlyJetBProbabilityComputer_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.candidatePositiveOnlyJetProbabilityComputer_cfi import *

--- a/RecoBTag/ImpactParameter/python/impactParameter_cff.py
+++ b/RecoBTag/ImpactParameter/python/impactParameter_cff.py
@@ -1,87 +1,67 @@
 import FWCore.ParameterSet.Config as cms
 
-from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
+from RecoBTag.ImpactParameter.impactParameter_EventSetup_cff import *
+
 from RecoBTag.ImpactParameter.impactParameterTagInfos_cfi import *
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import *
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfosAK8_cfi import *
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfosCA15_cfi import *
-from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+
 # MVA
-from RecoBTag.ImpactParameter.impactParameterMVAComputer_cfi import *
 from RecoBTag.ImpactParameter.impactParameterMVABJetTags_cfi import *
 # Jet BProb
-from RecoBTag.ImpactParameter.jetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.jetBProbabilityBJetTags_cfi import *
 # Jet Prob
-from RecoBTag.ImpactParameter.jetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.jetProbabilityBJetTags_cfi import *
 # High Eff
-from RecoBTag.ImpactParameter.trackCounting3D2ndComputer_cfi import *
 from RecoBTag.ImpactParameter.trackCountingHighEffBJetTags_cfi import *
 # High Purity
-from RecoBTag.ImpactParameter.trackCounting3D3rdComputer_cfi import *
 from RecoBTag.ImpactParameter.trackCountingHighPurBJetTags_cfi import *
 
 # Negative Tags
 
 # Jet BProb
-from RecoBTag.ImpactParameter.negativeOnlyJetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.negativeOnlyJetBProbabilityBJetTags_cfi import *
 # Jet Prob
-from RecoBTag.ImpactParameter.negativeOnlyJetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.negativeOnlyJetProbabilityBJetTags_cfi import *
 # High Eff
-from RecoBTag.ImpactParameter.negativeTrackCounting3D2ndComputer_cfi import *
 from RecoBTag.ImpactParameter.negativeTrackCountingHighEffBJetTags_cfi import *
 # High Purity
-from RecoBTag.ImpactParameter.negativeTrackCounting3D3rdComputer_cfi import *
 from RecoBTag.ImpactParameter.negativeTrackCountingHighPurBJetTags_cfi import *
 
 # Positive-only Tags
 
 # Jet BProb
-from RecoBTag.ImpactParameter.positiveOnlyJetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.positiveOnlyJetBProbabilityBJetTags_cfi import *
 # Jet Prob
-from RecoBTag.ImpactParameter.positiveOnlyJetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.positiveOnlyJetProbabilityBJetTags_cfi import *
 
 
 # New candidate based fwk
 
 # Jet BProb
-from RecoBTag.ImpactParameter.candidateJetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.pfJetBProbabilityBJetTags_cfi import *
 # Jet Prob
-from RecoBTag.ImpactParameter.candidateJetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.pfJetProbabilityBJetTags_cfi import *
 # High Eff
-from RecoBTag.ImpactParameter.candidateTrackCounting3D2ndComputer_cfi import *
 from RecoBTag.ImpactParameter.pfTrackCountingHighEffBJetTags_cfi import *
 # High Purity
-from RecoBTag.ImpactParameter.candidateTrackCounting3D3rdComputer_cfi import *
 from RecoBTag.ImpactParameter.pfTrackCountingHighPurBJetTags_cfi import *
 
 # Negative Tags
 
 # Jet BProb
-from RecoBTag.ImpactParameter.candidateNegativeOnlyJetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.pfNegativeOnlyJetBProbabilityBJetTags_cfi import *
 # Jet Prob
-from RecoBTag.ImpactParameter.candidateNegativeOnlyJetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.pfNegativeOnlyJetProbabilityBJetTags_cfi import *
 # High Eff
-from RecoBTag.ImpactParameter.candidateNegativeTrackCounting3D2ndComputer_cfi import *
 from RecoBTag.ImpactParameter.pfNegativeTrackCountingHighEffBJetTags_cfi import *
 # High Purity
-from RecoBTag.ImpactParameter.candidateNegativeTrackCounting3D3rdComputer_cfi import *
 from RecoBTag.ImpactParameter.pfNegativeTrackCountingHighPurBJetTags_cfi import *
 
 # Positive-only Tags
 
 # Jet BProb
-from RecoBTag.ImpactParameter.candidatePositiveOnlyJetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.pfPositiveOnlyJetBProbabilityBJetTags_cfi import *
 # Jet Prob
-from RecoBTag.ImpactParameter.candidatePositiveOnlyJetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.pfPositiveOnlyJetProbabilityBJetTags_cfi import *

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVerticesFiltered_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVerticesFiltered_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.SecondaryVertex.bVertexFilter_cfi import *
+
+inclusiveSecondaryVerticesFiltered = bVertexFilter.clone()
+inclusiveSecondaryVerticesFiltered.vertexFilter.multiplicityMin = 2
+inclusiveSecondaryVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveSecondaryVertices")

--- a/RecoBTag/SecondaryVertex/python/secondaryVertex_EventSetup_cff.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertex_EventSetup_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
+from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+
+from RecoBTag.SecondaryVertex.simpleSecondaryVertex2TrkComputer_cfi import *
+from RecoBTag.SecondaryVertex.simpleSecondaryVertex3TrkComputer_cfi import *
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexComputer_cfi import *
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexV2Computer_cfi import *
+from RecoBTag.SecondaryVertex.ghostTrackComputer_cfi import *
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexSoftLeptonComputer_cfi import *
+
+# IVF
+from RecoBTag.SecondaryVertex.doubleVertex2TrkComputer_cfi import *
+
+# Negative taggers
+from RecoBTag.SecondaryVertex.negativeCombinedSecondaryVertexComputer_cfi import *
+from RecoBTag.SecondaryVertex.negativeCombinedSecondaryVertexV2Computer_cfi import *
+
+# Positive taggers
+from RecoBTag.SecondaryVertex.positiveCombinedSecondaryVertexComputer_cfi import *
+from RecoBTag.SecondaryVertex.positiveCombinedSecondaryVertexV2Computer_cfi import *
+
+# New candidate based fwk
+from RecoBTag.SecondaryVertex.candidateSimpleSecondaryVertex2TrkComputer_cfi import *
+from RecoBTag.SecondaryVertex.candidateSimpleSecondaryVertex3TrkComputer_cfi import *
+from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexComputer_cfi import *
+from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexV2Computer_cfi import *
+from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexSoftLeptonComputer_cfi import *
+from RecoBTag.SecondaryVertex.candidateBoostedDoubleSecondaryVertexAK8Computer_cfi import *
+from RecoBTag.SecondaryVertex.candidateBoostedDoubleSecondaryVertexCA15Computer_cfi import *
+
+# Negative taggers
+from RecoBTag.SecondaryVertex.candidateNegativeCombinedSecondaryVertexComputer_cfi import *
+from RecoBTag.SecondaryVertex.candidateNegativeCombinedSecondaryVertexV2Computer_cfi import *
+from RecoBTag.SecondaryVertex.candidateNegativeCombinedSecondaryVertexSoftLeptonComputer_cfi import *
+
+# Positive taggers
+from RecoBTag.SecondaryVertex.candidatePositiveCombinedSecondaryVertexComputer_cfi import *
+from RecoBTag.SecondaryVertex.candidatePositiveCombinedSecondaryVertexV2Computer_cfi import *
+from RecoBTag.SecondaryVertex.candidatePositiveCombinedSecondaryVertexSoftLeptonComputer_cfi import *

--- a/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
@@ -1,35 +1,25 @@
 import FWCore.ParameterSet.Config as cms
 
-from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
-from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+from RecoBTag.SecondaryVertex.secondaryVertex_EventSetup_cff import *
+
 from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
-from RecoBTag.SecondaryVertex.simpleSecondaryVertex2TrkComputer_cfi import *
-from RecoBTag.SecondaryVertex.simpleSecondaryVertex3TrkComputer_cfi import *
 from RecoBTag.SecondaryVertex.simpleSecondaryVertexHighEffBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.simpleSecondaryVertexHighPurBJetTags_cfi import *
-from RecoBTag.SecondaryVertex.combinedSecondaryVertexComputer_cfi import *
-from RecoBTag.SecondaryVertex.combinedSecondaryVertexV2Computer_cfi import *
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexV2BJetTags_cfi import *
 from RecoBTag.SecondaryVertex.ghostTrackVertexTagInfos_cfi import *
-from RecoBTag.SecondaryVertex.ghostTrackComputer_cfi import *
 from RecoBTag.SecondaryVertex.ghostTrackBJetTags_cfi import *
-from RecoBTag.SecondaryVertex.combinedSecondaryVertexSoftLeptonComputer_cfi import *
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexSoftLeptonBJetTags_cfi import *
 
 # IVF
 from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexV2BJetTags_cfi import *
-from RecoBTag.SecondaryVertex.bVertexFilter_cfi import *
-inclusiveSecondaryVerticesFiltered = bVertexFilter.clone()
-inclusiveSecondaryVerticesFiltered.vertexFilter.multiplicityMin = 2
-inclusiveSecondaryVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveSecondaryVertices")
+from RecoBTag.SecondaryVertex.inclusiveSecondaryVerticesFiltered_cfi import *
 from RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi import *
 from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderFilteredTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.simpleInclusiveSecondaryVertexHighEffBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.simpleInclusiveSecondaryVertexHighPurBJetTags_cfi import *
-from RecoBTag.SecondaryVertex.doubleVertex2TrkComputer_cfi import *
 from RecoBTag.SecondaryVertex.doubleSecondaryVertexHighEffBJetTags_cfi import *
 
 # Negative taggers
@@ -40,31 +30,18 @@ from RecoBTag.SecondaryVertex.negativeSimpleSecondaryVertexHighEffBJetTags_cfi i
 from RecoBTag.SecondaryVertex.negativeSimpleSecondaryVertexHighPurBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.negativeSimpleInclusiveSecondaryVertexHighEffBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.negativeSimpleInclusiveSecondaryVertexHighPurBJetTags_cfi import *
-from RecoBTag.SecondaryVertex.negativeCombinedSecondaryVertexComputer_cfi import *
-from RecoBTag.SecondaryVertex.negativeCombinedSecondaryVertexV2Computer_cfi import *
 from RecoBTag.SecondaryVertex.negativeCombinedSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.negativeCombinedSecondaryVertexV2BJetTags_cfi import *
 from RecoBTag.SecondaryVertex.negativeCombinedInclusiveSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.negativeCombinedInclusiveSecondaryVertexV2BJetTags_cfi import *
 
 # Positive taggers
-from RecoBTag.SecondaryVertex.positiveCombinedSecondaryVertexComputer_cfi import *
-from RecoBTag.SecondaryVertex.positiveCombinedSecondaryVertexV2Computer_cfi import *
 from RecoBTag.SecondaryVertex.positiveCombinedSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.positiveCombinedSecondaryVertexV2BJetTags_cfi import *
 from RecoBTag.SecondaryVertex.positiveCombinedInclusiveSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.positiveCombinedInclusiveSecondaryVertexV2BJetTags_cfi import *
 
 # New candidate based fwk
-from RecoBTag.SecondaryVertex.candidateSimpleSecondaryVertex2TrkComputer_cfi import *
-from RecoBTag.SecondaryVertex.candidateSimpleSecondaryVertex3TrkComputer_cfi import *
-from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexComputer_cfi import *
-from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexV2Computer_cfi import *
-from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexSoftLeptonComputer_cfi import *
-from RecoBTag.CTagging.candidateCombinedSecondaryVertexSoftLeptonCvsLComputer_cfi import *
-from RecoBTag.SecondaryVertex.candidateBoostedDoubleSecondaryVertexAK8Computer_cfi import *
-from RecoBTag.SecondaryVertex.candidateBoostedDoubleSecondaryVertexCA15Computer_cfi import *
-
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.pfSimpleSecondaryVertexHighEffBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.pfSimpleSecondaryVertexHighPurBJetTags_cfi import *
@@ -84,9 +61,6 @@ from RecoBTag.SecondaryVertex.pfSecondaryVertexNegativeTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderNegativeTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.pfNegativeSimpleSecondaryVertexHighEffBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.pfNegativeSimpleSecondaryVertexHighPurBJetTags_cfi import *
-from RecoBTag.SecondaryVertex.candidateNegativeCombinedSecondaryVertexComputer_cfi import *
-from RecoBTag.SecondaryVertex.candidateNegativeCombinedSecondaryVertexV2Computer_cfi import *
-from RecoBTag.SecondaryVertex.candidateNegativeCombinedSecondaryVertexSoftLeptonComputer_cfi import *
 from RecoBTag.SecondaryVertex.pfNegativeCombinedSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.pfNegativeCombinedSecondaryVertexV2BJetTags_cfi import *
 from RecoBTag.SecondaryVertex.pfNegativeCombinedInclusiveSecondaryVertexBJetTags_cfi import *
@@ -94,9 +68,6 @@ from RecoBTag.SecondaryVertex.pfNegativeCombinedInclusiveSecondaryVertexV2BJetTa
 from RecoBTag.SecondaryVertex.pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags_cfi import *
 
 # Positive taggers
-from RecoBTag.SecondaryVertex.candidatePositiveCombinedSecondaryVertexComputer_cfi import *
-from RecoBTag.SecondaryVertex.candidatePositiveCombinedSecondaryVertexV2Computer_cfi import *
-from RecoBTag.SecondaryVertex.candidatePositiveCombinedSecondaryVertexSoftLeptonComputer_cfi import *
 from RecoBTag.SecondaryVertex.pfPositiveCombinedSecondaryVertexBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.pfPositiveCombinedSecondaryVertexV2BJetTags_cfi import *
 from RecoBTag.SecondaryVertex.pfPositiveCombinedInclusiveSecondaryVertexBJetTags_cfi import *

--- a/RecoBTag/SoftLepton/python/SoftLeptonByIP2dComputers_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByIP2dComputers_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+softPFElectronByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(False),
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFElectronByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(False),
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFElectronByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(False),
+    ipSign = cms.string("positive")
+)
+
+softPFMuonByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(False),
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFMuonByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(False),
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFMuonByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(False),
+    ipSign = cms.string("positive")
+)

--- a/RecoBTag/SoftLepton/python/SoftLeptonByIP2d_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByIP2d_cff.py
@@ -4,47 +4,28 @@ softPFElectronByIP2dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFElectronByIP2dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-softPFElectronByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(False),
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFElectronByIP2dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFElectronByIP2dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-negativeSoftPFElectronByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(False),
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFElectronByIP2dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFElectronByIP2dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-positiveSoftPFElectronByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(False),
-    ipSign = cms.string("positive")
-)
+
 softPFMuonByIP2dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFMuonByIP2dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-softPFMuonByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(False),
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFMuonByIP2dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFMuonByIP2dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-negativeSoftPFMuonByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(False),
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFMuonByIP2dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFMuonByIP2dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
-)
-positiveSoftPFMuonByIP2dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(False),
-    ipSign = cms.string("positive")
 )

--- a/RecoBTag/SoftLepton/python/SoftLeptonByIP3dComputers_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByIP3dComputers_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+softPFElectronByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(True),
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFElectronByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(True),
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFElectronByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(True),
+    ipSign = cms.string("positive")
+)
+
+softPFMuonByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(True),
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFMuonByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(True),
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFMuonByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
+    use3d = cms.bool(True),
+    ipSign = cms.string("positive")
+)

--- a/RecoBTag/SoftLepton/python/SoftLeptonByIP3d_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByIP3d_cff.py
@@ -4,47 +4,28 @@ softPFElectronByIP3dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFElectronByIP3dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-softPFElectronByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(True),
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFElectronByIP3dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFElectronByIP3dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-negativeSoftPFElectronByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(True),
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFElectronByIP3dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFElectronByIP3dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-positiveSoftPFElectronByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(True),
-    ipSign = cms.string("positive")
-)
+
 softPFMuonByIP3dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFMuonByIP3dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-softPFMuonByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(True),
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFMuonByIP3dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFMuonByIP3dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-negativeSoftPFMuonByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(True),
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFMuonByIP3dBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFMuonByIP3dComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
-)
-positiveSoftPFMuonByIP3dComputer = cms.ESProducer("LeptonTaggerByIPESProducer",
-    use3d = cms.bool(True),
-    ipSign = cms.string("positive")
 )

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVAComputers_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVAComputers_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+softPFElectronCommon = cms.PSet(
+    useCondDB = cms.bool(True),
+    gbrForestLabel = cms.string("btag_SoftPFElectron_BDT"),
+    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(False)
+)
+
+softPFMuonCommon = cms.PSet(
+    useCondDB = cms.bool(True),
+    gbrForestLabel = cms.string("btag_SoftPFMuon_BDT"),
+    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(True)
+)
+
+softPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
+    softPFElectronCommon,
+    ipSign = cms.string("any"),
+)
+
+negativeSoftPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
+    softPFElectronCommon,
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
+    softPFElectronCommon,
+    ipSign = cms.string("positive")
+)
+
+softPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
+    softPFMuonCommon,
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
+    softPFMuonCommon,
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
+    softPFMuonCommon,
+    ipSign = cms.string("positive")
+)

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
@@ -1,66 +1,31 @@
 import FWCore.ParameterSet.Config as cms
 
-softPFElectronCommon = cms.PSet(
-    useCondDB = cms.bool(True),
-    gbrForestLabel = cms.string("btag_SoftPFElectron_BDT"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
-    useGBRForest = cms.bool(True),
-    useAdaBoost = cms.bool(False)
-)
-
-softPFMuonCommon = cms.PSet(
-    useCondDB = cms.bool(True),
-    gbrForestLabel = cms.string("btag_SoftPFMuon_BDT"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
-    useGBRForest = cms.bool(True),
-    useAdaBoost = cms.bool(True)
-)
-
 softPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-softPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
-    softPFElectronCommon,
-    ipSign = cms.string("any"),
-)
+
 negativeSoftPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-negativeSoftPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
-    softPFElectronCommon,
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-positiveSoftPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
-    softPFElectronCommon,
-    ipSign = cms.string("positive")
-)
+
 softPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFMuonComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-softPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
-    softPFMuonCommon,
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFMuonComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-negativeSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
-    softPFMuonCommon,
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFMuonComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
-)
-positiveSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
-    softPFMuonCommon,
-    ipSign = cms.string("positive")
 )

--- a/RecoBTag/SoftLepton/python/SoftLeptonByPtComputers_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByPtComputers_cff.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+softPFElectronByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFElectronByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFElectronByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
+    ipSign = cms.string("positive")
+)
+
+softPFMuonByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
+    ipSign = cms.string("any")
+)
+
+negativeSoftPFMuonByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
+    ipSign = cms.string("negative")
+)
+
+positiveSoftPFMuonByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
+    ipSign = cms.string("positive")
+)

--- a/RecoBTag/SoftLepton/python/SoftLeptonByPt_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByPt_cff.py
@@ -4,41 +4,28 @@ softPFElectronByPtBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFElectronByPtComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-softPFElectronByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFElectronByPtBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFElectronByPtComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-negativeSoftPFElectronByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFElectronByPtBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFElectronByPtComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
-positiveSoftPFElectronByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
-    ipSign = cms.string("positive")
-)
+
 softPFMuonByPtBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFMuonByPtComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-softPFMuonByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
-    ipSign = cms.string("any")
-)
+
 negativeSoftPFMuonByPtBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFMuonByPtComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
-negativeSoftPFMuonByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
-    ipSign = cms.string("negative")
-)
+
 positiveSoftPFMuonByPtBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFMuonByPtComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
-)
-positiveSoftPFMuonByPtComputer = cms.ESProducer("LeptonTaggerByPtESProducer",
-    ipSign = cms.string("positive")
 )

--- a/RecoBTag/SoftLepton/python/softLepton_EventSetup_cff.py
+++ b/RecoBTag/SoftLepton/python/softLepton_EventSetup_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
+from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+from RecoBTag.SoftLepton.SoftLeptonByMVAComputers_cff import *
+from RecoBTag.SoftLepton.SoftLeptonByPtComputers_cff import *
+from RecoBTag.SoftLepton.SoftLeptonByIP3dComputers_cff import *
+from RecoBTag.SoftLepton.SoftLeptonByIP2dComputers_cff import *

--- a/RecoBTag/SoftLepton/python/softLepton_cff.py
+++ b/RecoBTag/SoftLepton/python/softLepton_cff.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
-from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
-from RecoBTag.SoftLepton.softMuonTagInfos_cfi import *
+from RecoBTag.SoftLepton.softLepton_EventSetup_cff import *
+
 from RecoBTag.SoftLepton.softPFElectronTagInfos_cfi import *
 from RecoBTag.SoftLepton.softPFMuonTagInfos_cfi import *
 from RecoBTag.SoftLepton.SoftLeptonByMVA_cff import *


### PR DESCRIPTION
This PR addresses a long-standing issue with loading of the standard reco b-tagging producers when adding or switching jet collections in PAT. As a consequence, the standard reco b-tagging producers  end up being re-run even when that is not needed.

In some cases, such as the MiniAODv2 production in 74X, re-running of the standard reco b-tagging producers might be needed and for such cases the `loadStdRecoBTag` switch was added to `jetTools.py` that allows loading of the standard reco b-tagging producers.

All the code changes in this PR should be completely transparent and have no impact on the standard reconstruction.
