### PR TITLE
Cloning of input PackedCandidates in PuppiProducer when using existing Puppi weights

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -29,6 +29,7 @@ public:
 	typedef edm::View<reco::Candidate> CandidateView;
 	typedef std::vector< reco::PFCandidate >               PFInputCollection;
 	typedef std::vector< reco::PFCandidate >  PFOutputCollection;
+	typedef std::vector< pat::PackedCandidate >            PackedOutputCollection;
 	typedef edm::View<reco::PFCandidate>                   PFView;
 
 private:
@@ -52,10 +53,12 @@ private:
 	float           fDZCut;
 	bool fUseExistingWeights;
 	bool fUseWeightsNoLep;
+	bool fClonePackedCands;
 	int fVtxNdofCut;
 	double fVtxZCut;
 	std::unique_ptr<PuppiContainer> fPuppiContainer;
 	std::vector<RecoObj> fRecoObjCollection;
         std::auto_ptr< PFOutputCollection >          fPuppiCandidates;
+	std::auto_ptr< PackedOutputCollection >      fPackedPuppiCandidates;
 };
 #endif

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -39,6 +39,7 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                        MinPuppiWeight = cms.double(0.01),
                        useExistingWeights = cms.bool(False),
                        useWeightsNoLep    = cms.bool(False),
+                       clonePackedCands   = cms.bool(False), # should only be set to True for MiniAOD
                        vtxNdofCut     = cms.int32(4),
                        vtxZCut        = cms.double(24),
                        algos          = cms.VPSet( 


### PR DESCRIPTION
This PR extends the PuppiProducer code so that it clones the input PackedCandidates when the existing Puppi weights are used, i.e., when MiniAOD is used as input.

In addition, a switch was added that enables cloning of PackedCandidates even when one wants to re-run the Puppi algorithm on MiniAOD instead of using the existing Puppi weights.

All of these changes are relevant for retaining the track-related information embedded in PackedCandidates which makes it possible to run b tagging from Puppi jets and Puppi-weighted PackedCandidates.

@imarches @rappoccio @nhanvtran
