### PR TITLE
Remove unneeded member data from ProductRegistry::Transients

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -98,11 +98,6 @@ namespace edm {
 
     bool anyProducts(BranchType const brType) const;
 
-    ConstProductList& constProductList() {
-       //throwIfNotFrozen();
-       return transient_.constProductList_;
-    }
-
     std::shared_ptr<ProductHolderIndexHelper> const& productLookup(BranchType branchType) const;
 
     // returns the appropriate ProductHolderIndex else ProductHolderIndexInvalid if no BranchID is available
@@ -133,7 +128,6 @@ namespace edm {
       Transients();
       void reset();
       bool frozen_;
-      ConstProductList constProductList_;
       // Is at least one (run), (lumi), (event) product produced this process?
       boost::array<bool, NumBranchTypes> productProduced_;
       bool anyProductProduced_;
@@ -161,7 +155,6 @@ namespace edm {
 
     void freezeIt(bool frozen = true) {transient_.frozen_ = frozen;}
 
-    void updateConstProductRegistry();
     void initializeLookupTables();
     virtual void addCalled(BranchDescription const&, bool iFromListener);
     void throwIfNotFrozen() const;

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -43,7 +43,6 @@ namespace edm {
 
   ProductRegistry::Transients::Transients() :
       frozen_(false),
-      constProductList_(),
       productProduced_(),
       anyProductProduced_(false),
       eventProductLookup_(new ProductHolderIndexHelper),
@@ -61,7 +60,6 @@ namespace edm {
   void
   ProductRegistry::Transients::reset() {
     frozen_ = false;
-    constProductList_.clear();
     for(bool& isProduced : productProduced_) isProduced = false;
     anyProductProduced_ = false;
     eventProductLookup_.reset(new ProductHolderIndexHelper);
@@ -255,17 +253,7 @@ namespace edm {
         ++j;
       }
     }
-    updateConstProductRegistry();
     return differences.str();
-  }
-
-  void ProductRegistry::updateConstProductRegistry() {
-    constProductList().clear();
-    for(auto const& product : productList_) {
-      auto const& key = product.first;
-      auto const& desc = product.second;
-      constProductList().insert(std::make_pair(key, BranchDescription(desc)));
-    }
   }
 
   void ProductRegistry::initializeLookupTables() {
@@ -274,13 +262,9 @@ namespace edm {
     TypeSet missingDicts;
 
     transient_.branchIDToIndex_.clear();
-    constProductList().clear();
 
     for(auto const& product : productList_) {
-      auto const& key = product.first;
       auto const& desc = product.second;
-
-      constProductList().insert(std::make_pair(key, BranchDescription(desc)));
 
       if(desc.produced()) {
         setProductProduced(desc.branchType());


### PR DESCRIPTION
The Transients data member held a copy of the productList_ with the only difference being the value were const. This data member was kept in synch with productList_ but the data member itself was never used for any operations.
