### PR TITLE
Add missing parentheses

### DIFF
--- a/Validation/MuonGEMRecHits/src/GEMRecHitsValidation.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitsValidation.cc
@@ -124,7 +124,7 @@ void GEMRecHitsValidation::analyze(const edm::Event& e,
       continue;
     }
 
-    if (!(abs(hits-> particleType())) == 13) continue;
+    if (!(abs(hits-> particleType()) == 13)) continue;
 
     //const LocalPoint p0(0., 0., 0.);
     //const GlobalPoint Gp0(GEMGeometry_->idToDet(hits->detUnitId())->surface().toGlobal(p0));


### PR DESCRIPTION
Logical not is applied to int type, which is clearly a mistake. Add the
missing parentheses to apply it for the comparison.

```
Validation/MuonGEMRecHits/src/GEMRecHitsValidation.cc:127:39:
warning: logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
Validation/MuonGEMRecHits/src/GEMRecHitsValidation.cc:127:39:
warning: comparison of constant '13' with boolean expression is always
false [-Wbool-compare]
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
