### PR TITLE
Add missing parentheses in DTTSCand::isLL()

### DIFF
--- a/L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h
+++ b/L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h
@@ -116,8 +116,8 @@ class DTTSCand {
     inline int isLH() const { return _tctrig->pvCorr() && _tctrig->pvCode()==8; }
  
     /// Return if LL
-    inline int isLL() const { return _tctrig->pvCorr() && !_tctrig->pvCode()==8 &&
-                                                          !_tctrig->pvCode()==80; }  
+    inline int isLL() const { return _tctrig->pvCorr() && !(_tctrig->pvCode()==8) &&
+                                                          !(_tctrig->pvCode()==80); }
     /// Return if H inner
     inline int isH0() const { return !_tctrig->pvCorr() && _tctrig->pvCode()==80; }
  


### PR DESCRIPTION
Logical not is applied to int value, which is a clear mistake.
The patch applies logical not to the comparison.

```
L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h:119:77: warning:
comparison of constant '8' with boolean expression is always false
[-Wbool-compare]
L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h:120:77: warning:
logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h:120:77: warning:
comparison of constant '80' with boolean expression is always false
[-Wbool-compare]
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
