### PR TITLE
Fix logical not in RecoJets/{JetAlgorithms,JetProducers}

### DIFF
--- a/RecoJets/JetAlgorithms/interface/CMSTopTagger.h
+++ b/RecoJets/JetAlgorithms/interface/CMSTopTagger.h
@@ -133,7 +133,7 @@ inline PseudoJet CMSTopTagger::result(const PseudoJet & jet) const{
 
   // warn if the jet has not been clustered with a Cambridge/Aachen
   // algorithm
-  if (! jet.validated_cs()->jet_def().jet_algorithm() == cambridge_algorithm)
+  if (jet.validated_cs()->jet_def().jet_algorithm() != cambridge_algorithm)
     _warnings_nonca.warn("CMSTopTagger should only be applied on jets from a Cambridge/Aachen clustering; use it with other algorithms at your own risk.");
 
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -24,7 +24,7 @@ public:
     if (! j.has_pieces()) return _Rmax;
 
     std::vector<fastjet::PseudoJet> pieces = j.pieces();
-    if (! pieces.size()==2) return _Rmax;
+    if (pieces.size() != 2) return _Rmax;
 
     double deltaR = pieces[0].delta_R(pieces[1]);
     return std::min(_Rmax, _deltaR_factor * deltaR);


### PR DESCRIPTION
Logical not was wrongly applied:

```
RecoJets/JetProducers/plugins/FastjetJetProducer.h:27:24: warning:
logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
RecoJets/JetProducers/plugins/FastjetJetProducer.h:27:24: warning:
comparison of constant '2' with boolean expression is always false
[-Wbool-compare]
RecoJets/JetAlgorithms/interface/CMSTopTagger.h:136:55: warning:
logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
```

The patch addresses this issue.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
