### PR TITLE
Fix logical not in PFTauSelectorDefinition::select

### DIFF
--- a/RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h
+++ b/RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h
@@ -70,7 +70,7 @@ struct PFTauSelectorDefinition {
       // Check if it passed all the discrimiantors
       BOOST_FOREACH(const DiscCutPair &disc, discriminators_) {
         // Check this discriminator passes
-        if (!(*disc.handle)[tau] > disc.cut) {
+        if (!((*disc.handle)[tau] > disc.cut)) {
           passed = false;
           break;
         }


### PR DESCRIPTION
Logical not is applied to a float, which is wrong:

```
RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h:73:34:
warning: logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
```

While tracking the change I went to CVS archive to figure out what the
correct condition in if-statement. To my surprise there was a change in
PFTauSelectorDefinition.h (incl. the fix to this issue) which was not in
GIT migration. GIT migration was done using CMSSW_6_2_0_pre8 and this is
post-CMSSW_6_2_0_pre8 change in CVS.

The changeset:
http://cvs.web.cern.ch/cvs/cgi-bin/viewcvs.cgi/CMSSW/RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h?r1=1.10&r2=1.11

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
