### PR TITLE
[RFC] Fix logical not in HLTHiggsPlotter::analyze

### DIFF
--- a/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
@@ -214,14 +214,14 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & so
         {
             maxPt = "MaxPt";
             maxPt += (countobjects[objType]+1);
-            if( ! objType == EVTColContainer::PFJET || nMinOne[maxPt.Data()] ) {
+            if( objType != EVTColContainer::PFJET || nMinOne[maxPt.Data()] ) {
                 this->fillHist(isPassTrigger,source,objTypeStr,maxPt.Data(),pt);
             }
             ++(countobjects[objType]);
             ++counttotal;
         } 
         else continue; // if not needed (minCandidates == _NptPlots if _useNminOneCuts 
-        if( ! objType == EVTColContainer::PFJET || passAllCuts ) {
+        if( objType != EVTColContainer::PFJET || passAllCuts ) {
             this->fillHist(isPassTrigger,source,objTypeStr,"Eta",eta);
             this->fillHist(isPassTrigger,source,objTypeStr,"Phi",phi);
         }


### PR DESCRIPTION
logical not is applied to unsigned int, which is a mistake:

```
HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc:217:27: warning:
logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc:217:27: warning:
comparison of constant '6' with boolean expression is always false
[-Wbool-compare]
HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc:224:23: warning:
logical not is only applied to the left hand side of comparison
[-Wlogical-not-parentheses]
HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc:224:23: warning:
comparison of constant '6' with boolean expression is always false
[-Wbool-compare]
```

The patch attempts to resolve it.

I am not sure if logical not should be applied only to `objType == EVTColContainer::PFJET` or a full condition in if-statement. My current assumption is that author intended to apply this for `objType == EVTColContainer::PFJET` only. This is why it's marked as RFC.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
