### PR TITLE
Fix phi windows computation

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -408,7 +408,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	  const TrajectoryStateOnSurface tsosTEC9 = itm->updatedState();
 	  
 	  // check if track on positive or negative z
-	  if (!iidd ==  StripSubdetector::TEC) cout << "there is a problem with TEC 9 extrapolation" << endl;
+	  if (!(iidd ==  StripSubdetector::TEC)) cout << "there is a problem with TEC 9 extrapolation" << endl;
 	  
 	  //cout << " tec9 id = " << iidd << " and side = " << tTopo->tecSide(iidd) << endl;
 	  vector<TrajectoryMeasurement> tmp;

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -408,7 +408,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	  const TrajectoryStateOnSurface tsosTEC9 = itm->updatedState();
 	  
 	  // check if track on positive or negative z
-	  if (!(iidd ==  StripSubdetector::TEC)) cout << "there is a problem with TEC 9 extrapolation" << endl;
+	  if (DEBUG)  if (!(iidd ==  StripSubdetector::TEC)) cout << "there is a problem with TEC 9 extrapolation" << endl;
 	  
 	  //cout << " tec9 id = " << iidd << " and side = " << tTopo->tecSide(iidd) << endl;
 	  vector<TrajectoryMeasurement> tmp;

--- a/DataFormats/Math/interface/approx_asin.h
+++ b/DataFormats/Math/interface/approx_asin.h
@@ -69,10 +69,12 @@ inline float unsafe_acos07(float x) {
 // for |x|> 0.71 use slower
 template<int DEGREE>
 inline float unsafe_acos71(float x) {
+  constexpr float pi = M_PI;
   auto z=1.f-x*x;
-  return std::copysign(std::sqrt(z),x)*approx_asin_P<DEGREE>(z);
+  z= std::sqrt(z)*approx_asin_P<DEGREE>(z);
+  return x>0 ? z : pi-z;
 }
- 
+
 template<int DEGREE>
 inline float unsafe_asin71(float x) {
   constexpr float pihalf = M_PI/2;

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -1,11 +1,30 @@
 #ifndef Math_notmalizedPhi_h
 #define Math_notmalizedPhi_h
 #include "DataFormats/Math/interface/deltaPhi.h"
-/* return a value of phi into interval [-pi,+pi]
- *
- */
+
+// return a value of phi into interval [-pi,+pi]
 template<typename T>
 inline
 T normalizedPhi(T phi) { return reco::reduceRange(phi);}
+
+// cernlib V306
+template<typename T>
+inline 
+T proxim(T b, T a) {
+        constexpr T c1 = 2.*M_PI;
+        constexpr T c2 = 1/c1;
+        return b+c1*std::round(c2*(a-b));
+}
+
+template<typename T>
+inline
+bool checkPhiInRange(T phi, T phi1, T phi2) {
+    constexpr T c1 = 2.*M_PI;
+    phi1 = normalizedPhi(phi1);
+    phi2 = proxim(phi2,phi1);
+    // phi & phi1 are in [-pi,pi] range...
+    return ( (phi1 <= phi) && (phi <= phi2) ) ||
+           ( (phi1 <= phi+c1) && (phi+c1 <= phi2) );
+}
 
 #endif

--- a/DataFormats/Math/test/arc.cpp
+++ b/DataFormats/Math/test/arc.cpp
@@ -36,6 +36,13 @@ int main() {
       << unsafe_acos<5>(std::cos(c)) << ' '
       << std::endl;
 
+   for (float c=-1; c<1.05; c+=0.1) {
+    auto d=std::acos(c)-unsafe_acos<11>(c);
+    auto e=std::asin(c)-unsafe_asin<11>(c);
+    std::cout << c << ' ' << d << ' ' << e << std::endl;
+   }
+
+
    return 0;
 
 }

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectronCkfTrackCandidateMaker_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectronCkfTrackCandidateMaker_cff.py
@@ -43,6 +43,7 @@ TrajectoryBuilderForPixelMatchGsfElectrons.updator = 'KFUpdator'
 gsfElectronChi2.ComponentName = 'gsfElectronChi2'
 gsfElectronChi2.MaxChi2 = 100000.
 gsfElectronChi2.nSigma = 3.
+gsfElectronChi2.MaxDispacement = 100
 gsfElectronChi2.MaxSagitta = -1
 
 TrajectoryFilterForPixelMatchGsfElectrons = cms.PSet(

--- a/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForInOutFit_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForInOutFit_cfi.py
@@ -5,4 +5,5 @@ Chi2MeasurementEstimatorForInOut = TrackingTools.KalmanUpdators.Chi2MeasurementE
 Chi2MeasurementEstimatorForInOut.ComponentName = 'Chi2ForInOut'
 Chi2MeasurementEstimatorForInOut.MaxChi2 = 100.
 Chi2MeasurementEstimatorForInOut.nSigma = 3.
+Chi2MeasurementEstimatorForInOut.MaxDispacement = 100
 Chi2MeasurementEstimatorForInOut.MaxSagitta=-1

--- a/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForOutInFit_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForOutInFit_cfi.py
@@ -5,5 +5,6 @@ Chi2MeasurementEstimatorForOutIn = TrackingTools.KalmanUpdators.Chi2MeasurementE
 Chi2MeasurementEstimatorForOutIn.ComponentName = 'Chi2ForOutIn'
 Chi2MeasurementEstimatorForOutIn.MaxChi2 = 500.
 Chi2MeasurementEstimatorForOutIn.nSigma = 3.
+Chi2MeasurementEstimatorForOutIn.MaxDispacement = 100
 Chi2MeasurementEstimatorForOutIn.MaxSagitta = -1. 
 

--- a/RecoEgamma/EgammaPhotonProducers/python/looseChi2Estimator_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/looseChi2Estimator_cfi.py
@@ -5,4 +5,5 @@ chi2CutForConversionTrajectoryBuilder = TrackingTools.KalmanUpdators.Chi2Measure
 chi2CutForConversionTrajectoryBuilder.ComponentName = 'eleLooseChi2'
 chi2CutForConversionTrajectoryBuilder.MaxChi2 = 100000.
 chi2CutForConversionTrajectoryBuilder.nSigma = 3.
+chi2CutForConversionTrajectoryBuilder.MaxDispacement = 100.
 chi2CutForConversionTrajectoryBuilder.MaxSagitta = -1

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -250,8 +250,14 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 
 
       if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
-      if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
+      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
 
+      if (prmax-prmin>maxDelphi) {
+        auto prm = phiRange.mean();
+        prmin = prm - 0.5f*maxDelphi;
+        prmax = prm + 0.5f*maxDelphi;
+      }
+ 
       if (barrelLayer)
 	{
 	  Range regMax = predictionRZ.detRange();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -210,9 +210,6 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 	  rPhi2.second /= radius.min();
         }
 
-        // if (rPhi1.empty()) std::cout << "rphi1 empty " <<  rPhi1.second << ' ' << rPhi1.first << ' ' << radius.min() << ' ' << radius.max() <<std::endl;
-        // if (rPhi2.empty()) std::cout << "rphi2 empty " <<  rPhi2.second << ' ' << rPhi2.first << ' ' << radius.min() << ' ' << radius.max() <<std::endl;
-
         if (ok1) { 
           rPhi1.first = normalizedPhi(rPhi1.first);
           rPhi1.second = proxim(rPhi1.second,rPhi1.first);
@@ -227,30 +224,14 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
           phiRange=rPhi2;
         } else continue;
    
-        // if (std::abs(rPhi1.second-rPhi1.first) > maxDelphi) std::cout << "rphi1 " <<  rPhi1.second << ' ' << rPhi1.first << std::endl; 
-       	// if (std::abs(rPhi2.second-rPhi2.first) > maxDelphi) std::cout << "rphi2 " <<  rPhi2.second << ' ' << rPhi2.first << std::endl;
-
-        // if (std::abs(rPhi2.first-rPhi1.first) > maxDelphi) std::cout << "rphi1 " <<  rPhi1.second << ' ' << rPhi1.first << " rphi2 " <<  rPhi2.second << ' ' << rPhi2.first<< std::endl;
-        // if (!rPhi1.hasIntersection(rPhi2)) {
-        //        std::cout << " no int rphi1 " <<  rPhi1.second << ' ' << rPhi1.first << " rphi2 " <<  rPhi2.second << ' ' << rPhi2.first 
-        //                  << ' ' << radius.min() << ' ' << radius.max() << std::endl;
-        // }
-
       }
 
-      // if (std::abs(phiRange.first)>float(M_PI)) std::cout << "bha1 " << phiRange.first << ' ' << phiRange.second << std::endl;
-      if (std::abs(phiRange.first)>float(M_PI) && std::abs(phiRange.second)>float(M_PI)) std::cout << "bha2 " << phiRange.first << ' ' << phiRange.second << std::endl;
-      
-      
       constexpr float nSigmaRZ = 3.46410161514f; // std::sqrt(12.f); // ...and continue as before
       constexpr float nSigmaPhi = 3.f;
       
       foundNodes.clear(); // Now recover hits in bounding box...
       float prmin=phiRange.min(), prmax=phiRange.max();
 
-
-      if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
-      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
 
       if (prmax-prmin>maxDelphi) {
         auto prm = phiRange.mean();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -91,7 +91,6 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 
 
   const float maxDelphi = region.ptMin() < 0.3f ? float(M_PI)/4.f : float(M_PI)/8.f; // FIXME move to config?? 
-
   const float maxphi = M_PI+maxDelphi, minphi = -maxphi; // increase to cater for any range
   const float safePhi = M_PI-maxDelphi; // sideband
 
@@ -108,7 +107,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
                          *thirdLayers[il].detLayer(), useMScat, useBend);
 
     layerTree.clear();
-    float minv=999999.0, maxv= -999999.0; // Initialise to extreme values in case no hits
+    float minv=999999.0f, maxv= -minv; // Initialise to extreme values in case no hits
     float maxErr=0.0f;
     for (unsigned int i=0; i!=hits.size(); ++i) {
       auto angle = hits.phi(i);
@@ -195,27 +194,6 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 	if (radius.empty()) continue;
 
 	// std::cout << "++R " << radius.min() << " " << radius.max()  << std::endl;
-
-	/*
-	Range rPhi1m = predictionRPhitmp(radius.max(), -1);
-	Range rPhi1p = predictionRPhitmp(radius.max(),  1);
-	Range rPhi2m = predictionRPhitmp(radius.min(), -1);
-	Range rPhi2p = predictionRPhitmp(radius.min(),  1);
-	Range rPhi1 = rPhi1m.sum(rPhi1p);
-	Range rPhi2 = rPhi2m.sum(rPhi2p);
-	
-	
-	auto rPhi1N = predictionRPhitmp(radius.max());
-	auto rPhi2N = predictionRPhitmp(radius.min());
-
-	std::cout << "VI " 
-		  << rPhi1N.first <<'/'<< rPhi1.first << ' '
-		  << rPhi1N.second <<'/'<< rPhi1.second << ' '
-		  << rPhi2N.first <<'/'<< rPhi2.first << ' '
-		  << rPhi2N.second <<'/'<< rPhi2.second
-		  << std::endl;
-	
-	*/
 
 	auto rPhi1 = predictionRPhitmp(radius.max());
         bool ok1 = !rPhi1.empty();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -321,7 +321,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
       }
     }
   }
-  std::cout << "triplets " << result.size() << std::endl;
+  // std::cout << "triplets " << result.size() << std::endl;
 }
 
 bool PixelTripletHLTGenerator::checkPhiInRange(float phi, float phi1, float phi2) const

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -32,11 +32,6 @@ public:
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:
-  bool checkPhiInRange(float phi, float phi1, float phi2) const;
-  std::pair<float,float> mergePhiRanges(
-      const std::pair<float,float> &r1, const std::pair<float,float> &r2) const; 
-
-private:
   bool useFixedPreFiltering;
   float extraHitRZtolerance;
   float extraHitRPhitolerance;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -32,12 +32,12 @@ public:
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:
-  bool useFixedPreFiltering;
-  float extraHitRZtolerance;
-  float extraHitRPhitolerance;
-  bool useMScat;
-  bool useBend;
-  float dphi;
+  const bool useFixedPreFiltering;
+  const float extraHitRZtolerance;
+  const float extraHitRPhitolerance;
+  const bool useMScat;
+  const bool useBend;
+  const float dphi;
   std::unique_ptr<SeedComparitor> theComparitor;
 
 };

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -107,7 +107,10 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   declareDynArray(LayerRZPredictions, size, mapPred);
 
   float rzError[size]; //save maximum errors
-  float maxphi = Geom::ftwoPi(), minphi = -maxphi; //increase to cater for any range
+
+  const float maxDelphi = M_PI/8; // FIXME move to config
+  const float maxphi = M_PI+maxDelphi, minphi = -maxphi; // increase to cater for any range
+  const float safePhi = M_PI-maxDelphi; // sideband
 
 
   const RecHitsSortedInPhi * thirdHitMap[size];
@@ -139,10 +142,9 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       float myerr = hits.dv[i];
       maxErr = std::max(maxErr,myerr);
       layerTree.emplace_back(i, angle, v); // save it
-      if (angle < 0)  // wrap all points in phi
-	{ layerTree.emplace_back(i, angle+Geom::ftwoPi(), v);}
-      else
-	{ layerTree.emplace_back(i, angle-Geom::ftwoPi(), v);}
+      // populate side-bands
+      if (angle>safePhi) layerTree.emplace_back(i, angle-Geom::ftwoPi(), v);
+      else if (angle<-safePhi) layerTree.emplace_back(i, angle+Geom::ftwoPi(), v);
     }
     KDTreeBox phiZ(minphi, maxphi, minv-0.01f, maxv+0.01f);  // declare our bounds
     //add fudge factors in case only one hit and also for floating-point inaccuracy
@@ -279,13 +281,30 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       
       foundNodes.clear(); // Now recover hits in bounding box...
       float prmin=phiRange.min(), prmax=phiRange.max(); //get contiguous range
-      if ((prmax-prmin) > Geom::ftwoPi())
-	{ prmax=Geom::fpi(); prmin = -Geom::fpi();}
-      else
-	{ while (prmax>maxphi) { prmin -= Geom::ftwoPi(); prmax -= Geom::ftwoPi();}
-	  while (prmin<minphi) { prmin += Geom::ftwoPi(); prmax += Geom::ftwoPi();}
-	  // This needs range -twoPi to +twoPi to work
-	}
+
+      auto reduceRange = [](float x) {
+       using T=float;
+       constexpr T o2pi = 1./(2.*M_PI);
+       if (std::abs(x) <= T(M_PI)) return x;
+       T n = std::round(x*o2pi);
+       return x - n*T(2.*M_PI);
+      };
+  
+      // cernlib V306
+      auto proxim = [](float b, float a) {
+        using T=float;
+        constexpr T c1 = 2.*M_PI;
+        constexpr T c2 = 1/c1;
+        return b+c1*std::round(c2*(a-b));
+      };
+
+      prmin = reduceRange(prmin);
+      prmax = proxim(prmax,prmin);
+      if (prmin>prmax) std::swap(prmax,prmin);
+
+      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
+
+
       if (barrelLayer) {
 	Range regMax = predRZ.line.detRange();
 	Range regMin = predRZ.line(regMax.min());

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -107,7 +107,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 
   float rzError[size]; //save maximum errors
 
-  const float maxDelphi = region.ptMin() < 0.3f ? float(M_PI)/4.f : float(M_PI)/8.f; // FIXME move to config??
+  const float maxDelphi = region.ptMin() < 1.0f ? float(M_PI)/4.f : float(M_PI)/8.f; // FIXME move to config??
   const float maxphi = M_PI+maxDelphi, minphi = -maxphi; // increase to cater for any range
   const float safePhi = M_PI-maxDelphi; // sideband
 
@@ -305,7 +305,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       float prmin=phiRange.min(), prmax=phiRange.max(); //get contiguous range
 
       if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
-      if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
+      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
 
 
       if (barrelLayer) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -107,7 +107,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 
   float rzError[size]; //save maximum errors
 
-  const float maxDelphi = region.ptMin() < 1.0f ? float(M_PI)/4.f : float(M_PI)/8.f; // FIXME move to config??
+  const float maxDelphi = region.ptMin() < 0.3f ? float(M_PI)/4.f : float(M_PI)/8.f; // FIXME move to config??
   const float maxphi = M_PI+maxDelphi, minphi = -maxphi; // increase to cater for any range
   const float safePhi = M_PI-maxDelphi; // sideband
 
@@ -307,6 +307,11 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
       // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
 
+      if (prmax-prmin>maxDelphi) {
+        auto prm = phiRange.mean();
+        prmin = prm - 0.5f*maxDelphi;
+        prmax =	prm + 0.5f*maxDelphi;
+      }
 
       if (barrelLayer) {
 	Range regMax = predRZ.line.detRange();
@@ -314,7 +319,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 	regMax = predRZ.line(regMax.max());
 	correction.correctRZRange(regMin);
 	correction.correctRZRange(regMax);
-	if (regMax.min() < regMin.min()) { swap(regMax, regMin);}
+	if (regMax.min() < regMin.min()) { std::swap(regMax, regMin);}
 	KDTreeBox phiZ(prmin, prmax,
 		       regMin.min()-fnSigmaRZ*rzError[il],
 		       regMax.max()+fnSigmaRZ*rzError[il]);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -265,37 +265,6 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
             continue;
         }
          
-	/*
-        auto rPhi1 = predictionRPhi(curvature, radius.first);
-        bool ok1 = !rPhi1.empty();
-        if (ok1) {
-          correction.correctRPhiRange(rPhi1);
-          rPhi1.first  /= radius.max();
-          rPhi1.second /= radius.max();
-        }
-        auto rPhi2 = predictionRPhi(curvature, radius.second);
-        bool ok2 = !rPhi2.empty();
-        if (ok2) {
-          correction.correctRPhiRange(rPhi2);
-          rPhi2.first  /= radius.min();
-          rPhi2.second /= radius.min();
-        }
-
-        if (ok1) {
-          rPhi1.first = normalizedPhi(rPhi1.first);
-          rPhi1.second = proxim(rPhi1.second,rPhi1.first);
-          if(ok2) {
-            rPhi2.first = proxim(rPhi2.first,rPhi1.first);
-            rPhi2.second = proxim(rPhi2.second,rPhi1.first);
-            phiRange = rPhi1.sum(rPhi2);
-          } else phiRange=rPhi1;
-        } else if(ok2) {
-          rPhi2.first = normalizedPhi(rPhi2.first);
-          rPhi2.second = proxim(rPhi2.second,rPhi2.first);
-          phiRange=rPhi2;
-        } else continue;
-        */
-
         //gc: predictionRPhi uses the cosine rule to find the phi of the 3rd point at radius, assuming the pairCurvature range [-c,+c]
         if ( (curvature.first<0.0f) & (curvature.second<0.0f) ) {
           radius.swap();
@@ -315,16 +284,10 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       	phiRange.first /= rmean;
         phiRange.second /= rmean;
 
-        // if (std::abs(phiRange.first)>float(M_PI)) std::cout << "bha1 " << phiRange.first << ' ' << phiRange.second << std::endl;
-        if (std::abs(phiRange.first)>float(M_PI) && std::abs(phiRange.second)>float(M_PI)) std::cout << "bha2 " << phiRange.first << ' ' << phiRange.second << std::endl;
-
       }
       
       foundNodes.clear(); // Now recover hits in bounding box...
       float prmin=phiRange.min(), prmax=phiRange.max(); //get contiguous range
-
-      if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
-      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
 
       if (prmax-prmin>maxDelphi) {
         auto prm = phiRange.mean();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
@@ -31,19 +31,12 @@ public:
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:
-
-  bool checkPhiInRange(float phi, float phi1, float phi2) const;
-  std::pair<float,float> mergePhiRanges(
-      const std::pair<float,float> &r1, const std::pair<float,float> &r2) const;
-
-
-private:
-  bool useFixedPreFiltering;
-  float extraHitRZtolerance;
-  float extraHitRPhitolerance;
-  bool useMScat;
-  bool useBend;
-  float dphi;
+  const bool useFixedPreFiltering;
+  const float extraHitRZtolerance;
+  const float extraHitRPhitolerance;
+  const bool useMScat;
+  const bool useBend;
+  const float dphi;
 };
 #endif
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
@@ -137,7 +137,6 @@ ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius) const
     phi2[i] = phi1[i]+(v[i+2]-v[i]); 
   }
 
-
   return getRange(phi1[1],phi2[1],emptyM).sum(getRange(phi1[0],phi2[0],emptyP));
 }
 

--- a/RecoPixelVertexing/PixelTriplets/python/PixelTripletHLTGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/PixelTripletHLTGenerator_cfi.py
@@ -7,30 +7,16 @@ PixelTripletHLTGenerator = cms.PSet(
     useFixedPreFiltering = cms.bool(False),
     ComponentName = cms.string('PixelTripletHLTGenerator'),
     extraHitRPhitolerance = cms.double(0.032),
-    useMultScattering = cms.bool(True),
-    phiPreFiltering = cms.double(0.3), ## can be removed if !useFixedPreFiltering
-    
-    #double extraHitRZtolerance   = 0.207     # ok for strips
-    #double extraHitRPhitolerance = 0.102     # ok for strips
     extraHitRZtolerance = cms.double(0.037),
+    useMultScattering = cms.bool(True),
+    phiPreFiltering = cms.double(0.3),
     SeedComparitorPSet = cms.PSet(
      ComponentName = cms.string('none')
      )
 )
 
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-PixelTripletHLTGeneratorWithFilter = cms.PSet(
-   maxElement = cms.uint32(100000),
-    useBending = cms.bool(True),
-    useFixedPreFiltering = cms.bool(False),
-    ComponentName = cms.string('PixelTripletHLTGenerator'),
-    extraHitRPhitolerance = cms.double(0.032),
-    useMultScattering = cms.bool(True),
-    phiPreFiltering = cms.double(0.3), ## can be removed if !useFixedPreFiltering
-    
-    #double extraHitRZtolerance   = 0.207     # ok for strips
-    #double extraHitRPhitolerance = 0.102     # ok for strips
-    extraHitRZtolerance = cms.double(0.037),
-    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
-)
+PixelTripletHLTGeneratorWithFilter = PixelTripletHLTGenerator.clone()
+PixelTripletHLTGeneratorWithFilter.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+
 

--- a/RecoPixelVertexing/PixelTriplets/python/PixelTripletLargeTipGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/PixelTripletLargeTipGenerator_cfi.py
@@ -6,12 +6,9 @@ PixelTripletLargeTipGenerator = cms.PSet(
     useBending = cms.bool(True),
     useFixedPreFiltering = cms.bool(False),
     ComponentName = cms.string('PixelTripletLargeTipGenerator'),
-    extraHitRPhitolerance = cms.double(0.032),
     useMultScattering = cms.bool(True),
-    phiPreFiltering = cms.double(0.3), ## can be removed if !useFixedPreFiltering
-
-    #double extraHitRZtolerance   = 0.207     # ok for strips
-    #double extraHitRPhitolerance = 0.102     # ok for strips
+    phiPreFiltering = cms.double(0.3),
+    extraHitRPhitolerance = cms.double(0.032),
     extraHitRZtolerance = cms.double(0.037)
 )
 

--- a/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
@@ -11,6 +11,7 @@
 #include<iostream>
 #include<algorithm>
 
+#include "DataFormats/Math/interface/normalizedPhi.h"
 #include "DataFormats/Math/interface/approx_asin.h"
 
 // there are tons of safety checks.
@@ -62,11 +63,7 @@ float ThirdHitPredictionFromCircle::phi(float curvature, float radius) const
     float cos = (rc2 + r2 - radius2)/std::sqrt(4.f*rc2*r2);
     phi = f_phi(lcenter) + sign * clamped_acos(cos);
  }
-
-  while(unlikely(phi >= float(M_PI))) phi -= float(2. * M_PI);
-  while(unlikely(phi < -float(M_PI))) phi += float(2. * M_PI);
-
-  return phi;
+  return phi;  // not normalized
 }
 
 float ThirdHitPredictionFromCircle::angle(float curvature, float radius) const
@@ -88,10 +85,9 @@ float ThirdHitPredictionFromCircle::angle(float curvature, float radius) const
 ThirdHitPredictionFromCircle::Range
 ThirdHitPredictionFromCircle::operator()(Range curvature, float radius) const
 {
-  float phi1 = phi(curvature.second, radius);
-  float phi2 = phi(curvature.first, radius);
-
-  while(unlikely(phi2 <  phi1)) phi2 += float(2. * M_PI); 
+  float phi1 = normalizedPhi(phi(curvature.second, radius));
+  float phi2 = proxim(phi(curvature.first, radius),phi1);
+  if(phi2 < phi1) std::swap(phi2,phi1);
 
   return Range(phi1 * radius - theTolerance, phi2 * radius + theTolerance);
 }

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -225,6 +225,7 @@ convStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.
     ComponentName = cms.string('convStepChi2Est'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(30.0),
+    MaxDispacement = cms.double(100),
     MaxSagitta = cms.double(-1.),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )

--- a/RecoTracker/MeasurementDet/python/Chi2ChargeMeasurementEstimator_cfi.py
+++ b/RecoTracker/MeasurementDet/python/Chi2ChargeMeasurementEstimator_cfi.py
@@ -6,6 +6,7 @@ Chi2ChargeMeasurementEstimator = cms.ESProducer("Chi2ChargeMeasurementEstimatorE
     ComponentName        = cms.string('Chi2Charge'),
     nSigma               = cms.double(3.0),
     MaxChi2              = cms.double(30.0),
+    MaxDispacement = cms.double(0.5),
     MaxSagitta = cms.double(2),
     MinimalTolerance = cms.double(0.5),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),

--- a/RecoTracker/TkDetLayers/src/TkDetUtil.cc
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.cc
@@ -41,6 +41,9 @@ namespace tkDetUtil {
       auto x1 = hori ? xc + maxDistance.x() : -yc + maxDistance.y();
 
       dphi = std::acos( (x0*x1+y0*y1)/std::sqrt((x0*x0+y0*y0)*(x1*x1+y1*y1)) );
+
+      // if (dphi>0.5*M_PI) std::cout << "large dphi " << dphi << ' ' << ts.localDirection() << ' ' << ts.globalMomentum().perp() << ' ' << maxDistance << std::endl;
+
       return dphi;
     }
     

--- a/RecoTracker/TkDetLayers/src/TkDetUtil.cc
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.cc
@@ -12,7 +12,7 @@ namespace tkDetUtil {
   {
     const Plane& startPlane = det->surface();  
     auto maxDistance =  est.maximalLocalDisplacement( tsos, startPlane);
-    return calculatePhiWindow( maxDistance, tsos, startPlane);
+    return std::copysign(calculatePhiWindow(maxDistance, tsos, startPlane),maxDistance.x()); 
   }
 
 

--- a/RecoTracker/TkDetLayers/src/TkDetUtil.cc
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.cc
@@ -44,8 +44,6 @@ namespace tkDetUtil {
       sp = std::min(std::max(sp,-1.f),1.f);
       dphi = std::acos(sp);      
 
-      // if (dphi>0.5*M_PI) std::cout << "large dphi " << dphi << ' ' << ts.localDirection() << ' ' << ts.globalMomentum().perp() << ' ' << maxDistance << std::endl;
-
       return dphi;
     }
     

--- a/RecoTracker/TkMSParametrization/interface/PixelRecoRange.h
+++ b/RecoTracker/TkMSParametrization/interface/PixelRecoRange.h
@@ -16,8 +16,8 @@ public:
   PixelRecoRange() { }
 
 
-template<class U>
-PixelRecoRange(PixelRecoRange<U> other) : 
+  template<class U>
+  PixelRecoRange(PixelRecoRange<U> other) : 
   std::pair<T,T> (other.min(),other.max()) { }
 
 
@@ -54,7 +54,7 @@ PixelRecoRange(PixelRecoRange<U> other) :
                         ); 
   }
 
-  void sort() { if (empty() ) std::swap(this->first,this->second); }
+  PixelRecoRange<T> & sort() { if (empty() ) std::swap(this->first,this->second); return *this;}
 };
 
 template <class T> std::ostream & operator<<( 

--- a/RecoTracker/TkMSParametrization/interface/PixelRecoRange.h
+++ b/RecoTracker/TkMSParametrization/interface/PixelRecoRange.h
@@ -33,8 +33,11 @@ public:
 
   bool empty() const { return (this->second < this->first); }
 
+  PixelRecoRange<T> & swap() { std::swap(this->second,this->first); return *this;}
+
+
   bool inside(const T & value) const {
-    return !(value < this->first || this->second < value);
+    return !( (value < this->first) | (this->second < value) );
   }
 
   bool hasIntersection( const PixelRecoRange<T> & r) const {
@@ -55,6 +58,7 @@ public:
   }
 
   PixelRecoRange<T> & sort() { if (empty() ) std::swap(this->first,this->second); return *this;}
+
 };
 
 template <class T> std::ostream & operator<<( 

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -653,9 +653,9 @@ void MultiHitGeneratorFromChi2::refit2Hits(HitOwnPtr & hit1,
 
   FastCircle theCircle(gp2,gp1,gp0);
   GlobalPoint cc(theCircle.x0(),theCircle.y0(),0);
-  float tesla0 = 0.1*nomField;
+  float tesla0 = 0.1f*nomField;
   float rho = theCircle.rho();
-  float cm2GeV = 0.01 * 0.3*tesla0;
+  float cm2GeV = 0.01f * 0.3f*tesla0;
   float pt = cm2GeV * rho;
 
   GlobalVector vec20 = gp2-gp0;
@@ -676,9 +676,10 @@ void MultiHitGeneratorFromChi2::refit2Hits(HitOwnPtr & hit1,
   }
 
   //now set z component
-  p0 = GlobalVector(p0.x(),p0.y(),p0.perp()/tan(vec20.theta()));
-  p1 = GlobalVector(p1.x(),p1.y(),p1.perp()/tan(vec20.theta()));
-  p2 = GlobalVector(p2.x(),p2.y(),p2.perp()/tan(vec20.theta()));
+  auto zv = vec20.z()/vec20.perp();
+  p0 = GlobalVector(p0.x(),p0.y(),p0.perp()*zv);
+  p1 = GlobalVector(p1.x(),p1.y(),p1.perp()*zv);
+  p2 = GlobalVector(p2.x(),p2.y(),p2.perp()*zv);
 
   //get charge from vectorial product
   TrackCharge q = 1;

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -395,10 +395,6 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
       }
        
       float prmin=phiRange.min(), prmax=phiRange.max();
-      
-      
-      if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
-      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
  
       if (prmax-prmin>maxDelphi) {
         auto prm = phiRange.mean();

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -217,7 +217,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 	    if (myerr > maxErr) { maxErr = myerr;}
 	    layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle, myz)); // save it
             // populate side-bands
-           if (angle>safePhi) layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle-Geom::twoPi(), myz));
+            if (angle>safePhi) layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle-Geom::twoPi(), myz));
             else if (angle<-safePhi) layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle+Geom::twoPi(), myz));
 	  }
       }
@@ -383,7 +383,8 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 	//gc: predictionRPhi uses the cosine rule to find the phi of the 3rd point at radius, assuming the pairCurvature range [-c,+c]
 	if (pairCurvature.first<0. && pairCurvature.second<0.) {
           radius.swap();
-	} else if (pairCurvature.first>=0. && pairCurvature.second>=0.) {
+	} else if (pairCurvature.first>=0. && pairCurvature.second>=0.) {;}
+        else {
 	  radius.first=radius.second;
         }
         auto phi12 = predictionRPhi.phi(pairCurvature.first,radius.first);
@@ -397,9 +398,15 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
       
       
       if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
-      if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
+      // if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
  
-      
+      if (prmax-prmin>maxDelphi) {
+        auto prm = phiRange.mean();
+        prmin = prm - 0.5f*maxDelphi;
+        prmax = prm + 0.5f*maxDelphi;
+      }
+
+
       //gc: this is the place where hits in the compatible region are put in the foundNodes
       using Hit=RecHitsSortedInPhi::Hit;
       foundNodes.clear(); // Now recover hits in bounding box...

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -3,7 +3,7 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitRZPrediction.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include <FWCore/Utilities/interface/ESInputTag.h>
+#include "FWCore/Utilities/interface/ESInputTag.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -27,6 +27,10 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+
+
+#include "DataFormats/Math/interface/normalizedPhi.h"
+
 
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "CommonTools/Utils/interface/DynArray.h"
@@ -172,9 +176,12 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   foundNodes.reserve(100);
   declareDynArray(KDTreeLinkerAlgo<RecHitsSortedInPhi::HitIter>,size, hitTree);
   float rzError[size]; //save maximum errors
-  double maxphi = Geom::twoPi(), minphi = -maxphi; //increase to cater for any range
 
-  map<std::string, LayerRZPredictions> mapPred;//need to use the name as map key since we may have more than one SeedingLayer per DetLayer (e.g. TID and MTID)
+  const float maxDelphi = region.ptMin() < 0.3f ? float(M_PI)/4.f : float(M_PI)/8.f; // FIXME move to config??
+  const float maxphi = M_PI+maxDelphi, minphi = -maxphi; // increase to cater for any range
+  const float safePhi = M_PI-maxDelphi; // sideband
+
+  std::map<std::string, LayerRZPredictions> mapPred;//need to use the name as map key since we may have more than one SeedingLayer per DetLayer (e.g. TID and MTID)
   const RecHitsSortedInPhi * thirdHitMap[size];//gc: this comes from theLayerCache
 
   //gc: loop over each layer
@@ -189,15 +196,15 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
     //gc: now we take all hits in the layer and fill the KDTree    
     RecHitsSortedInPhi::Range hitRange = thirdHitMap[il]->all(); // Get iterators
     layerTree.clear();
-    double minz=999999.0, maxz= -999999.0; // Initialise to extreme values in case no hits
+    float minz=999999.0f, maxz= -minz; // Initialise to extreme values in case no hits
     float maxErr=0.0f;
     bool barrelLayer = (thirdLayers[il].detLayer()->location() == GeomDetEnumerators::barrel);
     if (hitRange.first != hitRange.second)
       { minz = barrelLayer? hitRange.first->hit()->globalPosition().z() : hitRange.first->hit()->globalPosition().perp();
 	maxz = minz; //In case there's only one hit on the layer
 	for (RecHitsSortedInPhi::HitIter hi=hitRange.first; hi != hitRange.second; ++hi)
-	  { double angle = hi->phi();
-	    double myz = barrelLayer? hi->hit()->globalPosition().z() : hi->hit()->globalPosition().perp();
+	  { auto angle = hi->phi();
+	    auto myz = barrelLayer? hi->hit()->globalPosition().z() : hi->hit()->globalPosition().perp();
 
             IfLogTrace(hi->hit()->rawId()==debug_Id2, "MultiHitGeneratorFromChi2") << "filling KDTree with hit in id=" << debug_Id2
                                                                                    << " with pos: " << hi->hit()->globalPosition()
@@ -206,16 +213,15 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
                                                                                    << " r=" << hi->hit()->globalPosition().perp();
 	    //use (phi,r) for endcaps rather than (phi,z)
 	    if (myz < minz) { minz = myz;} else { if (myz > maxz) {maxz = myz;}}
-	    float myerr = barrelLayer? hi->hit()->errorGlobalZ(): hi->hit()->errorGlobalR();
+	    auto myerr = barrelLayer? hi->hit()->errorGlobalZ(): hi->hit()->errorGlobalR();
 	    if (myerr > maxErr) { maxErr = myerr;}
 	    layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle, myz)); // save it
-	    if (angle < 0)  // wrap all points in phi
-	      { layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle+Geom::twoPi(), myz));}
-	    else
-	      { layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle-Geom::twoPi(), myz));}
+            // populate side-bands
+           if (angle>safePhi) layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle-Geom::twoPi(), myz));
+            else if (angle<-safePhi) layerTree.push_back(KDTreeNodeInfo<RecHitsSortedInPhi::HitIter>(hi, angle+Geom::twoPi(), myz));
 	  }
       }
-    KDTreeBox phiZ(minphi, maxphi, minz-0.01, maxz+0.01);  // declare our bounds
+    KDTreeBox phiZ(minphi, maxphi, minz-0.01f, maxz+0.01f);  // declare our bounds
     //add fudge factors in case only one hit and also for floating-point inaccuracy
     hitTree[il].build(layerTree, phiZ); // make KDtree
     rzError[il] = maxErr; //save error
@@ -223,7 +229,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   //gc: now we have initialized the KDTrees and we are out of the layer loop
   
   //gc: this sets the minPt of the triplet
-  double curv = PixelRecoUtilities::curvature(1. / region.ptMin(), es);
+  auto curv = PixelRecoUtilities::curvature(1. / region.ptMin(), es);
 
   LogTrace("MultiHitGeneratorFromChi2") << "pair size=" << pairs.size() << std::endl;
 
@@ -376,35 +382,30 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
       } else {	
 	//gc: predictionRPhi uses the cosine rule to find the phi of the 3rd point at radius, assuming the pairCurvature range [-c,+c]
 	if (pairCurvature.first<0. && pairCurvature.second<0.) {
-	  float phi12 = predictionRPhi.phi(pairCurvature.first,radius.second);
-	  float phi21 = predictionRPhi.phi(pairCurvature.second,radius.first);
-	  while(unlikely(phi12 <  phi21)) phi12 += float(2. * M_PI); 
-	  phiRange = Range(phi21,phi12);
+          radius.swap();
 	} else if (pairCurvature.first>=0. && pairCurvature.second>=0.) {
-	  float phi11 = predictionRPhi.phi(pairCurvature.first,radius.first);
-	  float phi22 = predictionRPhi.phi(pairCurvature.second,radius.second);
-	  while(unlikely(phi11 <  phi22)) phi11 += float(2. * M_PI); 
-	  phiRange = Range(phi22,phi11);
-	} else {
-	  float phi12 = predictionRPhi.phi(pairCurvature.first,radius.second);
-	  float phi22 = predictionRPhi.phi(pairCurvature.second,radius.second);
-	  while(unlikely(phi12 <  phi22)) phi12 += float(2. * M_PI); 
-	  phiRange = Range(phi22,phi12);
-	}
+	  radius.first=radius.second;
+        }
+        auto phi12 = predictionRPhi.phi(pairCurvature.first,radius.first);
+	auto phi22 = predictionRPhi.phi(pairCurvature.second,radius.second);
+        phi12 = normalizedPhi(phi12);
+        phi22 = proxim(phi22,phi12);
+	phiRange = Range(phi12,phi22); phiRange.sort();
       }
+       
+      float prmin=phiRange.min(), prmax=phiRange.max();
+      
+      
+      if (prmax<prmin)  std::cout << "aarg " << phiRange.first << ' ' << phiRange.second << std::endl;
+      if (prmax-prmin>maxDelphi) std::cout << "delphi " << ' ' << prmin << '/' << prmax << std::endl;
+ 
       
       //gc: this is the place where hits in the compatible region are put in the foundNodes
-      typedef RecHitsSortedInPhi::Hit Hit;
+      using Hit=RecHitsSortedInPhi::Hit;
       foundNodes.clear(); // Now recover hits in bounding box...
-      // This needs range -twoPi to +twoPi to work
-      float prmin=phiRange.min(), prmax=phiRange.max(); //get contiguous range
-      if ((prmax-prmin) > Geom::twoPi()) { 
-	prmax=Geom::pi(); prmin = -Geom::pi();
-      } else {
-	while (prmax>maxphi) { prmin -= Geom::twoPi(); prmax -= Geom::twoPi();}
-	while (prmin<minphi) { prmin += Geom::twoPi(); prmax += Geom::twoPi();}
-      }
-      
+
+
+
       IfLogTrace(debugPair, "MultiHitGeneratorFromChi2") << "defining kd tree box";
 
       if (barrelLayer) {
@@ -628,23 +629,6 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 
   }//loop over pairs
   LogTrace("MultiHitGeneratorFromChi2") << "triplet size=" << result.size();
-}
-
-bool MultiHitGeneratorFromChi2::checkPhiInRange(float phi, float phi1, float phi2) const
-{ while (phi > phi2) phi -= 2. * M_PI;
-  while (phi < phi1) phi += 2. * M_PI;
-  return phi <= phi2;
-}  
-
-std::pair<float, float>
-MultiHitGeneratorFromChi2::mergePhiRanges(const std::pair<float, float> &r1,
-					      const std::pair<float, float> &r2) const
-{ float r2Min = r2.first;
-  float r2Max = r2.second;
-  while (r1.first - r2Min > +M_PI) r2Min += 2. * M_PI, r2Max += 2. * M_PI;
-  while (r1.first - r2Min < -M_PI) r2Min -= 2. * M_PI, r2Max -= 2. * M_PI;
-  //LogTrace("MultiHitGeneratorFromChi2")  << "mergePhiRanges " << fabs(r1.first-r2Min) << " " <<  fabs(r1.second-r2Max);
-  return std::make_pair(min(r1.first, r2Min), max(r1.second, r2Max));
 }
 
 void MultiHitGeneratorFromChi2::refit2Hits(HitOwnPtr & hit1,

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
@@ -43,10 +43,6 @@ public:
 private:
   using HitOwnPtr = mayown_ptr<BaseTrackerRecHit>;
 
-  bool checkPhiInRange(float phi, float phi1, float phi2) const;
-  std::pair<float,float> mergePhiRanges(
-      const std::pair<float,float> &r1, const std::pair<float,float> &r2) const;
-
   void refit2Hits(HitOwnPtr & hit0,
 		  HitOwnPtr & hit1,
 		  TrajectoryStateOnSurface& tsos0,

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -158,16 +158,17 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
 					  const Propagator* prop, const MeasurementTrackerEvent* measTk,
                                           const TrackerTopology* ttopo){
   using namespace std;
-  /// have to clone the propagator in order to change its propagation direction. Have to remember to delete the clone!!
-  Propagator* localProp = prop->clone();
+  /// have to clone the propagator in order to change its propagation direction.
+  std::unique_ptr<Propagator> localProp(prop->clone());
 
   //use negative sigma=-3.0 in order to use a more conservative definition of isInside() for Bounds classes.
-  Chi2MeasurementEstimator estimator(30.,-3.0);
+  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5);  // same as defauts....
 
   // WARNING: At the moment the trajectories has the measurements with reversed sorting after the track smoothing. 
   // Therefore the lastMeasurement is the inner one (for LHC-like tracks)
-  if(traj->firstMeasurement().updatedState().isValid() &&
-     traj->lastMeasurement().updatedState().isValid()){
+  if(!traj->firstMeasurement().updatedState().isValid() ||
+      !traj->lastMeasurement().updatedState().isValid()) return;
+
     const FreeTrajectoryState*  outerState = traj->firstMeasurement().updatedState().freeState();    
     const FreeTrajectoryState*  innerState = traj->lastMeasurement().updatedState().freeState(); 
     TrajectoryStateOnSurface const & outerTSOS = traj->firstMeasurement().updatedState();
@@ -199,9 +200,9 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
     // we will take care of OutIn only where it matters (MISSING_INNER vs _OUTER)
     
     LogDebug("TrackProducer") << "calling inner compLayers()...";
-    auto innerCompLayers = (*theSchool).compatibleLayers(*innerLayer,*innerState,dirForInnerLayers);
+    auto const & innerCompLayers = (*theSchool).compatibleLayers(*innerLayer,*innerState,dirForInnerLayers);
     LogDebug("TrackProducer") << "calling outer compLayers()...";
-    auto outerCompLayers = (*theSchool).compatibleLayers(*outerLayer,*outerState,dirForOuterLayers);
+    auto const & outerCompLayers = (*theSchool).compatibleLayers(*outerLayer,*outerState,dirForOuterLayers);
 
     LogDebug("TrackProducer")
       << "inner DetLayer  sub: " 
@@ -216,14 +217,15 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
       << "innerLayers: " << innerCompLayers.size() << "\n"
       << "outerLayers: " << outerCompLayers.size() << "\n";
 
-    for(vector<const DetLayer *>::const_iterator it=innerCompLayers.begin(); it!=innerCompLayers.end(); ++it){
-        if ((*it)->basicComponents().empty()) {
+
+    auto loopOverLayer = [&](decltype(innerCompLayers) compLayers, TrajectoryStateOnSurface const & tsos) {
+      for(auto it : compLayers){
+        if (it->basicComponents().empty()) {
 	        //this should never happen. but better protect for it
 	        edm::LogWarning("TrackProducer")<<"a detlayer with no components: I cannot figure out a DetId from this layer. please investigate.";
 	        continue;
         }
-        localProp->setPropagationDirection(oppositeToMomentum);
-        vector< GeometricSearchDet::DetWithState > detWithState = (*it)->compatibleDets(innerTSOS,*localProp,estimator);
+        auto const & detWithState = it->compatibleDets(tsos,*localProp,estimator);
         if(!detWithState.size()) continue;
         DetId id = detWithState.front().first->geographicalId();
         MeasurementDetWithData measDet = measTk->idToDet(id);
@@ -235,35 +237,16 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
         }else{
 	        //cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;
         }
-    }//end loop over layers
-    
-    for(vector<const DetLayer *>::const_iterator it=outerCompLayers.begin(); it!=outerCompLayers.end(); ++it){
-        if ((*it)->basicComponents().empty()){
-            //this should never happen. but better protect for it
-            edm::LogWarning("TrackProducer")<<"a detlayer with no components: I cannot figure out a DetId from this layer. please investigate.";
-            continue;
-      }
- 
-      localProp->setPropagationDirection(alongMomentum);
-      vector< GeometricSearchDet::DetWithState > detWithState = (*it)->compatibleDets(outerTSOS,*localProp,estimator);
-      if(!detWithState.size()) continue;
-      DetId id = detWithState.front().first->geographicalId();
-      MeasurementDetWithData measDet = measTk->idToDet(id);	
-      //if(measDet->isActive() && !measDet->hasBadComponents(detWithState.front().second)){	
-      if(measDet.isActive()){
-          InvalidTrackingRecHit tmpHit(*detWithState.front().first, outIn ? TrackingRecHit::missing_inner : TrackingRecHit::missing_outer);
-          track.appendHitPattern(tmpHit, *ttopo);
-	      //cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
-      }else{
-	      //cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;
-      }
-    }
-  }else{
-    cout << "inner or outer state was invalid" << endl;
-  }
-  
+      } //end loop over layers
+    }; // end lambda
 
-  delete localProp;
+   localProp->setPropagationDirection(oppositeToMomentum);
+   loopOverLayer(innerCompLayers,innerTSOS);
+
+   localProp->setPropagationDirection(alongMomentum);
+   outIn = !outIn;  // if inOut should mark missing_outer
+   loopOverLayer(outerCompLayers,outerTSOS);
+
 }
 
 

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -6,6 +6,7 @@ ElectronChi2 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2Mea
 ElectronChi2.ComponentName = 'ElectronChi2'
 ElectronChi2.MaxChi2 = 2000.
 ElectronChi2.nSigma = 3.
+ElectronChi2.MaxDispacement = 100
 ElectronChi2.MaxSagitta = -1
 
 # Trajectory Filter

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h
@@ -9,6 +9,7 @@
  */
 
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
+#include<limits>
 
 class Chi2MeasurementEstimatorBase : public MeasurementEstimator {
 public:
@@ -18,7 +19,7 @@ public:
    *  The errors of the trajectory state are multiplied by nSigma 
    *  to define acceptance of Plane and maximalLocalDisplacement.
    */
-  explicit Chi2MeasurementEstimatorBase(double maxChi2, double nSigma = 3., float maxDisp=100.) : 
+  explicit Chi2MeasurementEstimatorBase(double maxChi2, double nSigma = 3., float maxDisp=std::numeric_limits<float>::max()) : 
     theMaxChi2(maxChi2), theNSigma(nSigma), theMaxDisplacement(maxDisp) {}
 
   Chi2MeasurementEstimatorBase(double maxChi2, double nSigma, float maxDisp,

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h
@@ -18,12 +18,13 @@ public:
    *  The errors of the trajectory state are multiplied by nSigma 
    *  to define acceptance of Plane and maximalLocalDisplacement.
    */
-  explicit Chi2MeasurementEstimatorBase(double maxChi2, double nSigma = 3.) : 
-    theMaxChi2(maxChi2), theNSigma(nSigma) {}
+  explicit Chi2MeasurementEstimatorBase(double maxChi2, double nSigma = 3., float maxDisp=100.) : 
+    theMaxChi2(maxChi2), theNSigma(nSigma), theMaxDisplacement(maxDisp) {}
 
-  Chi2MeasurementEstimatorBase(double maxChi2, double nSigma, float maxSag, float minToll) : 
+  Chi2MeasurementEstimatorBase(double maxChi2, double nSigma, float maxDisp,
+                               float maxSag, float minToll) : 
     MeasurementEstimator(maxSag,minToll),
-    theMaxChi2(maxChi2), theNSigma(nSigma) {}
+    theMaxChi2(maxChi2), theNSigma(nSigma), theMaxDisplacement(maxDisp)  {}
 
 
   virtual std::pair<bool, double> estimate(const TrajectoryStateOnSurface& ts,
@@ -46,8 +47,9 @@ protected:
   }
 
 private:
-  double theMaxChi2;
-  double theNSigma;
+  const double theMaxChi2;
+  const double theNSigma;
+  const float  theMaxDisplacement;
 };
 
 #endif

--- a/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
@@ -40,10 +40,11 @@ boost::shared_ptr<Chi2MeasurementEstimatorBase>
 Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
   auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
   auto nSigma  = m_pset.getParameter<double>("nSigma");
+  auto maxDis  = m_pset.existsAs<double>("MaxDispacement") ? m_pset.getParameter<double>("MaxDispacement") : 100.;
   auto maxSag  = m_pset.existsAs<double>("MaxSagitta") ? m_pset.getParameter<double>("MaxSagitta") : -1.;
   auto minTol = m_pset.existsAs<double>("MinimalTolerance") ?  m_pset.getParameter<double>("MinimalTolerance") : 10;
    
-  m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(new Chi2MeasurementEstimator(maxChi2,nSigma, maxSag, minTol));
+  m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(new Chi2MeasurementEstimator(maxChi2,nSigma, maxDis, maxSag, minTol));
   return m_estimator;
 }
 
@@ -52,6 +53,7 @@ void Chi2MeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDesc
   desc.add<std::string>("ComponentName","Chi2");
   desc.add<double>("MaxChi2",30);
   desc.add<double>("nSigma",3);
+  desc.add<double>("MaxDispacement",0.5); 
   desc.add<double>("MaxSagitta",2.);
   desc.add<double>("MinimalTolerance",0.5);
   descriptions.add("Chi2MeasurementEstimator", desc);

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimatorBase.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimatorBase.cc
@@ -17,10 +17,10 @@ MeasurementEstimator::Local2DVector
 Chi2MeasurementEstimatorBase::maximalLocalDisplacement( const TrajectoryStateOnSurface& ts,
 							const Plane& plane) const
 {
-  constexpr float emax=100.;   // 0.5; 
+  const float emax = theMaxDisplacement;
   if ( ts.hasError()) {
     LocalError le = ts.localError().positionError();
     return Local2DVector( std::min(emax,std::sqrt(float(le.xx())))*nSigmaCut(), std::min(emax,std::sqrt(float(le.yy())))*nSigmaCut());
   }
-  else return Local2DVector(0,0);
+  else return Local2DVector(emax,emax);
 }

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimatorBase.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimatorBase.cc
@@ -17,9 +17,10 @@ MeasurementEstimator::Local2DVector
 Chi2MeasurementEstimatorBase::maximalLocalDisplacement( const TrajectoryStateOnSurface& ts,
 							const Plane& plane) const
 {
+  constexpr float emax=100.;   // 0.5; 
   if ( ts.hasError()) {
     LocalError le = ts.localError().positionError();
-    return Local2DVector( sqrt(le.xx())*nSigmaCut(), sqrt(le.yy())*nSigmaCut());
+    return Local2DVector( std::min(emax,std::sqrt(float(le.xx())))*nSigmaCut(), std::min(emax,std::sqrt(float(le.yy())))*nSigmaCut());
   }
   else return Local2DVector(0,0);
 }


### PR DESCRIPTION
This PR is a continuation of my two last ones.
1) fix phi window computation in seeding: it also adds a maximal phi window mostly to avoid crazy seeds that may eventually generate Nans
2) Introduce a MaximalDisplacement in Chi2Estimator again to avoid crazy trajectory and the generation of Nans: Conversions should be unaffected
3) fix long standing bug in  computeWindowSize (was not retiring a negative window when required)

took the opportunity for some minor cleanup
A Major cleanup and refactoring of the three major seeding routines is badly needed.
(may occur in time for 8_0_0 if resources available)

Minor regression, timing improvement observed
MTV for the usual 1000 ttbar events PU35 at
http://innocent.home.cern.ch/innocent/RelVal/pu35_80_Xwin21/
(compared to current IB)
