### PR TITLE
Expand Hcal DetId (supersedes #12829)

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h
@@ -6,6 +6,7 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include <iostream>
@@ -20,16 +21,14 @@ public:
 
 void prefillMap(const HcalTopology & topology){
 
-  for (int det = 1; det < 5; det++) {
-    for (int eta = -63; eta < 64; eta++) {
-      for (int phi = 0; phi < 128; phi++) {
-	for (int depth = 1; depth < 5; depth++) {
+  for (int det = 1; det <= HcalForward; det++) {
+    for (int eta = -HcalDetId::kHcalEtaMask2; eta <= HcalDetId::kHcalEtaMask2; eta++) {
+      for (int phi = 1; phi <= HcalDetId::kHcalPhiMask2; phi++) {
+	for (int depth = 1; depth <= HcalDetId::kHcalDepthMask2; depth++) {
 
 	  try {
 	    HcalDetId hcaldetid ((HcalSubdetector) det, eta, phi, depth);
-	    if (topology.valid(hcaldetid))
-	    //	    mapHcal_.setValue(hcaldetid.rawId(),1.0);
-	    {
+	    if (topology.valid(hcaldetid)) {
 	      mapHcal_[hcaldetid.rawId()]=1.0; 
 	      //	      std::cout << "Valid cell found: " << det << " " << eta << " " << phi << " " << depth << std::endl;
 	    }

--- a/CalibCalorimetry/CastorCalib/src/CastorDbHardcode.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorDbHardcode.cc
@@ -378,7 +378,7 @@ void CastorDbHardcode::makeHardcodeMap(CastorElectronicsMap& emap) {
 	      if (ieta==0) { // unmapped 
 		emap.mapEId2chId(elId,DetId(HcalDetId::Undefined));
 	      } else {
-		HcalDetId hId(HcalOuter,ieta*iside,iphi,idepth+3); // HO is officially "depth=4"
+		HcalDetId hId(HcalOuter,ieta*iside,iphi,4); // HO is officially "depth=4"
 		emap.mapEId2chId(elId,hId);
 	      }
 	      // printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -6,13 +6,12 @@
 #include <memory>
 #include <iostream>
 
-#include "HcalHardcodeCalibrations.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h"
 
@@ -23,6 +22,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "HcalHardcodeCalibrations.h"
 
 // class decleration
 //
@@ -42,11 +42,11 @@ namespace {
   */
 
     if (result.size () <= 0) {
-      for (int eta = -HcalHardcodeCalibrations::kHcalEtaMask2; 
-	   eta <= HcalHardcodeCalibrations::kHcalEtaMask2; eta++) {
-	for (int phi = 0; phi <= HcalHardcodeCalibrations::kHcalPhiMask2; phi++) {
-	  for (int depth = 1; depth < maxDepthHB + maxDepthHE; depth++) {
-	    for (int det = 1; det <= HcalForward; det++) {
+      for (int eta = -HcalDetId::kHcalEtaMask2; 
+           eta <= HcalDetId::kHcalEtaMask2; eta++) {
+        for (int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
+          for (int depth = 1; depth < maxDepthHB + maxDepthHE; depth++) {
+            for (int det = 1; det <= HcalForward; det++) {
 	      HcalDetId cell ((HcalSubdetector) det, eta, phi, depth);
 	      if (hcaltopology.valid(cell)) result.push_back (cell);
 
@@ -89,13 +89,13 @@ namespace {
       // - As no valid(cell) check found for HcalTrigTowerDetId 
       // to create HT cells (ieta=1-28, iphi=1-72)&(ieta=29-32, iphi=1,5,... 69)
 
-      for (int vers=0; vers<=HcalHardcodeCalibrations::kHcalVersMask; ++vers) {
-	for (int depth=0; depth<=HcalHardcodeCalibrations::kHcalDepthMask; ++depth) {
-	  for (int eta = -HcalHardcodeCalibrations::kHcalEtaMask; 
-	       eta <= HcalHardcodeCalibrations::kHcalEtaMask; eta++) {
-	    for (int phi = 1; phi <= HcalHardcodeCalibrations::kHcalPhiMask; phi++) {
-	      HcalTrigTowerDetId cell(eta, phi,depth,vers); 
-	      if (hcaltopology.validHT(cell)) result.push_back (cell);
+      for (int vers=0; vers<=HcalTrigTowerDetId::kHcalVersMask; ++vers) {
+        for (int depth=0; depth<=HcalTrigTowerDetId::kHcalDepthMask; ++depth) {
+          for (int eta = -HcalTrigTowerDetId::kHcalEtaMask; 
+               eta <= HcalTrigTowerDetId::kHcalEtaMask; eta++) {
+            for (int phi = 1; phi <= HcalTrigTowerDetId::kHcalPhiMask; phi++) {
+              HcalTrigTowerDetId cell(eta, phi,depth,vers); 
+              if (hcaltopology.validHT(cell)) result.push_back (cell);
 	    }
 	  }
 	}

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -44,14 +44,6 @@ class HcalCholeskyMatricesRcd;
 class HcalCovarianceMatricesRcd;
 
 class HcalHardcodeCalibrations : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
-public:
-  static const int kHcalPhiMask2       = 0x3FF;
-  static const int kHcalEtaMask2       = 0x1FF;
-  static const int kHcalDepthMask2     = 0xF;
-  static const int kHcalPhiMask        = 0x7F;
-  static const int kHcalEtaMask        = 0x3F;
-  static const int kHcalDepthMask      = 0x7;
-  static const int kHcalVersMask       = 0x7;
 
 public:
   HcalHardcodeCalibrations (const edm::ParameterSet& );

--- a/DataFormats/HcalDetId/interface/HcalDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalDetId.h
@@ -8,12 +8,9 @@
 
 /** \class HcalDetId
  *  Cell identifier class for the HCAL subdetectors, precision readout cells only
- *
- *  \author J. Mans - Minnesota
- *
- *  Rev.1.11: A.Kubik,R.Ofierzynski: add the hashed_index
  */
 class HcalDetId : public DetId {
+
 public:
   static const int kHcalPhiMask1       = 0x7F;
   static const int kHcalPhiMask2       = 0x3FF;
@@ -30,6 +27,9 @@ public:
   static const int kHcalDepthSet1      = 0x1C000;
   static const int kHcalDepthSet2      = 0xF00000;
   static const int kHcalIdFormat2      = 0x1000000;
+  static const int kHcalIdMask         = 0xFE000000;
+
+public:
   /** Create a null cellid*/
   HcalDetId();
   /** Create cellid from raw id (0=invalid tower id) */
@@ -40,21 +40,34 @@ public:
   HcalDetId(const DetId& id);
   /** Assignment from a generic cell id */
   HcalDetId& operator=(const DetId& id);
+  /** Comparison operator */
+  bool operator==(DetId id) const;
+  bool operator!=(DetId id) const;
+  bool operator<(DetId id) const;
 
   /// get the subdetector
   HcalSubdetector subdet() const { return (HcalSubdetector)(subdetId()); }
+  bool oldFormat() const { return ((id_&kHcalIdFormat2)==0)?(true):(false); }
   /// get the z-side of the cell (1/-1)
-  int zside() const { return (id_&kHcalZsideMask1)?(1):(-1); }
+  int zside() const;
   /// get the absolute value of the cell ieta
-  int ietaAbs() const { return (id_>>kHcalEtaOffset1)&kHcalEtaMask1; }
+  int ietaAbs() const;
   /// get the cell ieta
   int ieta() const { return zside()*ietaAbs(); }
   /// get the cell iphi
-  int iphi() const { return id_&kHcalPhiMask1; }
+  int iphi() const;
   /// get the tower depth
-  int depth() const { return (id_>>kHcalDepthOffset1)&kHcalDepthMask1; }
+  int depth() const;
+  /// get full depth information for HF
+  int hfdepth() const;
   /// get the tower depth
-  uint32_t maskDepth() const { return (id_ | kHcalDepthSet1); }
+  uint32_t maskDepth() const;
+  /// change format
+  uint32_t otherForm() const;
+  void changeForm();
+  uint32_t newForm() const;
+  static uint32_t newForm(const uint32_t&);
+
   /// get the smallest crystal_ieta of the crystal in front of this tower (HB and HE tower 17 only)
   int crystal_ieta_low() const { return ((ieta()-zside())*5)+zside(); }
   /// get the largest crystal_ieta of the crystal in front of this tower (HB and HE tower 17 only)
@@ -66,6 +79,10 @@ public:
 
   static const HcalDetId Undefined;
 
+private:
+
+  void newFromOld(const uint32_t&);
+  static void unpackId(const uint32_t&, int&, int&, int&, int&);
 };
 
 std::ostream& operator<<(std::ostream&,const HcalDetId& id);

--- a/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
@@ -13,6 +13,15 @@ Cell id for an Calo Trigger tower
 */
 class HcalTrigTowerDetId : public DetId {
 public:
+  static const int kHcalPhiMask       = 0x7F;
+  static const int kHcalEtaOffset     = 7;
+  static const int kHcalEtaMask       = 0x3F;
+  static const int kHcalZsideMask     = 0x2000;
+  static const int kHcalDepthOffset   = 14;
+  static const int kHcalDepthMask     = 0x7;
+  static const int kHcalVersOffset    = 17;
+  static const int kHcalVersMask      = 0x7;
+ public:
    /** Constructor of a null id */
   HcalTrigTowerDetId();
   /** Constructor from a raw value */
@@ -37,17 +46,17 @@ public:
   /// get the subdetector
   HcalSubdetector subdet() const { return (HcalSubdetector)(subdetId()); }
   /// get the z-side of the tower (1/-1)
-  int zside() const { return (id_&0x2000)?(1):(-1); }
+  int zside() const { return (id_&kHcalZsideMask)?(1):(-1); }
   /// get the absolute value of the tower ieta
-  int ietaAbs() const { return (id_>>7)&0x3f; }
+  int ietaAbs() const { return (id_>>kHcalEtaOffset)&kHcalEtaMask; }
   /// get the tower ieta
   int ieta() const { return zside()*ietaAbs(); }
   /// get the tower iphi
-  int iphi() const { return id_&0x7F; }
+  int iphi() const { return id_&kHcalPhiMask; }
   /// get the depth (zero for LHC Run 1, may be nonzero for later runs)
-  int depth() const { return (id_>>14)&0x7; }
+  int depth() const { return (id_>>kHcalDepthOffset)&kHcalDepthMask; }
   /// get the version code for the trigger tower
-  int version() const { return (id_>>17)&0x7; }
+  int version() const { return (id_>>kHcalVersOffset)&kHcalVersMask; }
 
   static const HcalTrigTowerDetId Undefined;
 

--- a/DataFormats/HcalDetId/src/HcalDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalDetId.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <ostream>
+#include <iostream>
 
 const HcalDetId HcalDetId::Undefined(HcalEmpty,0,0,0);
 
@@ -12,9 +13,9 @@ HcalDetId::HcalDetId(uint32_t rawid) : DetId(rawid) {
 
 HcalDetId::HcalDetId(HcalSubdetector subdet, int tower_ieta, int tower_iphi, int depth) : DetId(Hcal,subdet) {
   // (no checking at this point!)
-  id_ |= ((depth&kHcalDepthMask1)<<kHcalDepthOffset1) |
-    ((tower_ieta>0)?(kHcalZsideMask1|(tower_ieta<<kHcalEtaOffset1)):((-tower_ieta)<<kHcalEtaOffset1)) |
-    (tower_iphi&kHcalPhiMask1);
+  id_ |= (kHcalIdFormat2) | ((depth&kHcalDepthMask2)<<kHcalDepthOffset2) |
+    ((tower_ieta>0)?(kHcalZsideMask2|(tower_ieta<<kHcalEtaOffset2)):((-tower_ieta)<<kHcalEtaOffset2)) |
+    (tower_iphi&kHcalPhiMask2);
 }
 
 HcalDetId::HcalDetId(const DetId& gen) {
@@ -26,9 +27,11 @@ HcalDetId::HcalDetId(const DetId& gen) {
 	 subdet!=HcalTriggerTower && subdet!=HcalOther)) {
       throw cms::Exception("Invalid DetId") << "Cannot initialize HcalDetId from " << std::hex << gen.rawId() << std::dec; 
     }  
+    id_ = newForm(gen.rawId());
+  } else {
+    id_ = gen.rawId();
   }
-  id_=gen.rawId();
-}
+ }
 
 HcalDetId& HcalDetId::operator=(const DetId& gen) {
   if (!gen.null()) {
@@ -38,10 +41,117 @@ HcalDetId& HcalDetId::operator=(const DetId& gen) {
 	 subdet!=HcalOuter && subdet!=HcalForward &&
 	 subdet!=HcalTriggerTower && subdet!=HcalOther)) {
       throw cms::Exception("Invalid DetId") << "Cannot assign HcalDetId from " << std::hex << gen.rawId() << std::dec; 
-    }  
+    }
+    id_ = newForm(gen.rawId());
+  } else {
+    id_ = gen.rawId();
   }
-  id_=gen.rawId();
   return (*this);
+}
+
+bool HcalDetId::operator==(DetId gen) const {
+  uint32_t rawid = gen.rawId();
+  if (rawid == id_) return true;
+  int zsid, eta, phi, dep;
+  unpackId(rawid, zsid, eta, phi, dep);
+  bool result=(zsid==zside() && eta==ietaAbs() && phi==iphi() && dep==depth());
+  return result;
+}
+
+bool HcalDetId::operator!=(DetId gen) const {
+  uint32_t rawid = gen.rawId();
+  if (rawid == id_) return false;
+  int zsid, eta, phi, dep;
+  unpackId(rawid, zsid, eta, phi, dep);
+  bool result=(zsid!=zside() || eta!=ietaAbs() || phi!=iphi() || dep!=depth());
+  return result;
+}
+
+bool HcalDetId::operator<(DetId gen) const {
+  uint32_t rawid = gen.rawId();
+  if ((rawid&kHcalIdFormat2)==(id_&kHcalIdFormat2)) {
+    return id_<rawid;
+  } else {
+    int zsid, eta, phi, dep;
+    unpackId(rawid, zsid, eta, phi, dep);
+    rawid &= kHcalIdMask;
+    if (oldFormat()) {
+      rawid |= ((dep&kHcalDepthMask1)<<kHcalDepthOffset1) |
+	((zsid>0)?(kHcalZsideMask1|(eta<<kHcalEtaOffset1)):((eta)<<kHcalEtaOffset1)) |
+	(phi&kHcalPhiMask1);
+    } else {
+      rawid |= (kHcalIdFormat2) | ((dep&kHcalDepthMask2)<<kHcalDepthOffset2) |
+	((zsid>0)?(kHcalZsideMask2|(eta<<kHcalEtaOffset2)):((eta)<<kHcalEtaOffset2)) |
+	(phi&kHcalPhiMask2);
+    }
+    return (id_<rawid);
+  }
+}
+
+int HcalDetId::zside() const {
+  if (oldFormat()) return (id_&kHcalZsideMask1)?(1):(-1);
+  else             return (id_&kHcalZsideMask2)?(1):(-1);
+}
+
+int HcalDetId::ietaAbs() const { 
+  if (oldFormat()) return (id_>>kHcalEtaOffset1)&kHcalEtaMask1; 
+  else             return (id_>>kHcalEtaOffset2)&kHcalEtaMask2;
+}
+  
+int HcalDetId::iphi() const { 
+  if (oldFormat()) return id_&kHcalPhiMask1; 
+  else             return id_&kHcalPhiMask2;
+}
+
+int HcalDetId::depth() const {
+  if (oldFormat())  return (id_>>kHcalDepthOffset1)&kHcalDepthMask1;
+  else              return (id_>>kHcalDepthOffset2)&kHcalDepthMask2;
+}
+
+int HcalDetId::hfdepth() const {
+  int dep = depth();
+  if (subdet() == HcalForward) {
+    if (dep > 2) dep -= 2;
+  }
+  return dep;
+}
+
+uint32_t HcalDetId::maskDepth() const {
+  if (oldFormat())  return (id_|kHcalDepthSet1);
+  else              return (id_|kHcalDepthSet2);
+}
+
+uint32_t HcalDetId::otherForm() const {
+  uint32_t rawid = (id_&kHcalIdMask);
+  if (oldFormat()) {
+    rawid = newForm(id_);
+  } else {
+    rawid |= ((depth()&kHcalDepthMask1)<<kHcalDepthOffset1) |
+      ((ieta()>0)?(kHcalZsideMask1|(ieta()<<kHcalEtaOffset1)):((-ieta())<<kHcalEtaOffset1)) |
+      (iphi()&kHcalPhiMask1);
+  }
+  return rawid;
+}
+
+void HcalDetId::changeForm() {
+  id_ = otherForm();
+}
+
+uint32_t HcalDetId::newForm() const {
+  return newForm(id_);
+}
+
+uint32_t HcalDetId::newForm(const uint32_t& inpid) {
+  uint32_t rawid(inpid);
+  if ((rawid&kHcalIdFormat2)==0) {
+    int zsid, eta, phi, dep;
+    unpackId(rawid, zsid, eta, phi, dep);
+    rawid    = inpid&kHcalIdMask;
+    rawid   |= (kHcalIdFormat2) | ((dep&kHcalDepthMask2)<<kHcalDepthOffset2) |
+      ((zsid>0)?(kHcalZsideMask2|(eta<<kHcalEtaOffset2)):((eta)<<kHcalEtaOffset2)) |
+      (phi&kHcalPhiMask2);
+  }
+  return rawid;
 }
 
 int HcalDetId::crystal_iphi_low() const { 
@@ -54,6 +164,25 @@ int HcalDetId::crystal_iphi_high() const {
   int simple_iphi=((iphi()-1)*5)+5; 
   simple_iphi+=10;
   return ((simple_iphi>360)?(simple_iphi-360):(simple_iphi));
+}
+
+void HcalDetId::newFromOld(const uint32_t& rawid) {
+  id_ = newForm(rawid);
+}
+
+void HcalDetId::unpackId(const uint32_t& rawid, int& zsid, int& eta, int& phi,
+			 int& dep) {
+  if ((rawid&kHcalIdFormat2)==0) {
+    zsid = (rawid&kHcalZsideMask1)?(1):(-1);
+    eta  = (rawid>>kHcalEtaOffset1)&kHcalEtaMask1;
+    phi  = rawid&kHcalPhiMask1;
+    dep  = (rawid>>kHcalDepthOffset1)&kHcalDepthMask1;
+  } else {
+    zsid = (rawid&kHcalZsideMask2)?(1):(-1);
+    eta  = (rawid>>kHcalEtaOffset2)&kHcalEtaMask2;
+    phi  = rawid&kHcalPhiMask2;
+    dep  = (rawid>>kHcalDepthOffset2)&kHcalDepthMask2;
+  }
 }
 
 std::ostream& operator<<(std::ostream& s,const HcalDetId& id) {

--- a/DataFormats/HcalDetId/src/HcalDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalDetId.cc
@@ -8,7 +8,7 @@ const HcalDetId HcalDetId::Undefined(HcalEmpty,0,0,0);
 HcalDetId::HcalDetId() : DetId() {
 }
 
-HcalDetId::HcalDetId(uint32_t rawid) : DetId(rawid) {
+HcalDetId::HcalDetId(uint32_t rawid) : DetId(newForm(rawid)) {
 }
 
 HcalDetId::HcalDetId(HcalSubdetector subdet, int tower_ieta, int tower_iphi, int depth) : DetId(Hcal,subdet) {

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -12,8 +12,8 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(uint32_t rawid) : DetId(rawid) {
 }
 
 HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi) : DetId(Hcal,HcalTriggerTower) {
-  id_|=((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
-    (iphi&0x7F);
+  id_|=((ieta>0)?(kHcalZsideMask|(ieta<<kHcalEtaOffset)):((-ieta)<<kHcalEtaOffset)) |
+    (iphi&kHcalPhiMask);
 // Default to depth = 0 & version = 0
 }
 
@@ -23,23 +23,23 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth) : DetId(Hc
   // version convension   0 : default for 3x2 TP; 1, 2, 3 : for future & currently version = 1 is for 1x1 TP
   // Note that in this conversion, depth can take values from 0 to 9 for different purpose 
   // -> so depth should be = ones!
-  id_|=((ones&0x7)<<14) |
-    ((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
-    (iphi&0x7F);
+  id_|=((ones&kHcalDepthMask)<<kHcalDepthOffset) |
+    ((ieta>0)?(kHcalZsideMask|(ieta<<kHcalEtaOffset)):((-ieta)<<kHcalEtaOffset)) |
+    (iphi&kHcalPhiMask);
 
   const int version = tens;
   if( version > 9 ){ // do NOT envision to have versions over 9...  
      edm::LogError("HcalTrigTowerDetId")<<"in its ctor using depth, version larger than 9 (too many of it!)?"<<std::endl;
   }
 
-  id_|=((version&0x7)<<17);
+  id_|=((version&kHcalVersMask)<<kHcalVersOffset);
 }
 
 HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth, int version) : DetId(Hcal,HcalTriggerTower) {
-  id_|=((depth&0x7)<<14) |
-    ((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
-    (iphi&0x7F);
-  id_|=((version&0x7)<<17);
+  id_|=((depth&kHcalDepthMask)<<kHcalDepthOffset) |
+    ((ieta>0)?(kHcalZsideMask|(ieta<<kHcalEtaOffset)):((-ieta)<<kHcalEtaOffset)) |
+    (iphi&kHcalPhiMask);
+  id_|=((version&kHcalVersMask)<<kHcalVersOffset);
 }
  
 HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
@@ -50,7 +50,7 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
 }
 
 void HcalTrigTowerDetId::setVersion(int version) {
-  id_|=((version&0x7)<<17);
+  id_|=((version&kHcalVersMask)<<kHcalVersOffset);
 }
 
 HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
@@ -64,7 +64,6 @@ HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
 std::ostream& operator<<(std::ostream& s,const HcalTrigTowerDetId& id) {
   s << "(HcalTrigTower v" << id.version() << ": " << id.ieta() << ',' << id.iphi();
   if (id.depth()>0) s << ',' << id.depth();
-  
   return s << ')';
 }
 

--- a/DataFormats/HcalDetId/src/classes_def.xml
+++ b/DataFormats/HcalDetId/src/classes_def.xml
@@ -5,9 +5,15 @@
   <class name="HcalFrontEndId" ClassVersion="10">
    <version ClassVersion="10" checksum="1241522245"/>
   </class>
-  <class name="HcalDetId" ClassVersion="11">
+  <class name="HcalDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1604420376"/>
    <version ClassVersion="11" checksum="1604420376"/>
    <version ClassVersion="10" checksum="193306378"/>
+   <ioread sourceClass = "HcalDetId" version="[-11]" targetClass="HcalDetId" source="uint32_t DetId::id_;" target="DetId::id_">
+    <![CDATA[
+      newFromOld(onfile.rawId());
+    ]]>
+   </ioread>
   </class>
   <class name="HcalTrigTowerDetId" ClassVersion="11">
    <version ClassVersion="11" checksum="1583611399"/>

--- a/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
@@ -175,28 +175,19 @@ HcalDDDGeometry::newCell( const GlobalPoint& f1 ,
 
   HcalDetId hId(detId);
 
-  if( hId.subdet()==HcalBarrel )
-  {
+  if( hId.subdet()==HcalBarrel ) {
     m_hbCellVec[ din ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-  }
-  else
-  {
-    if( hId.subdet()==HcalEndcap )
-    {
+  } else {
+    if( hId.subdet()==HcalEndcap ) {
       const unsigned int index ( din - m_hbCellVec.size() ) ;
       m_heCellVec[ index ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-    }
-    else
-    {
-      if( hId.subdet()==HcalOuter )
-      {
+    } else  {
+      if( hId.subdet()==HcalOuter )  {
 	const unsigned int index ( din 
 				   - m_hbCellVec.size() 
 				   - m_heCellVec.size() ) ;
 	m_hoCellVec[ index ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-      }
-      else
-      { // assuming HcalForward here!
+      } else { // assuming HcalForward here!
 	const unsigned int index ( din 
 				   - m_hbCellVec.size() 
 				   - m_heCellVec.size() 

--- a/RecoHI/HiJetAlgos/src/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/src/ParticleTowerProducer.cc
@@ -85,7 +85,7 @@ ParticleTowerProducer::~ParticleTowerProducer()
  
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
-
+  delete random_;
 }
 
 
@@ -165,7 +165,8 @@ ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
    for ( std::map< DetId, double >::const_iterator iter = towers_.begin();
 	 iter != towers_.end(); ++iter ){
      
-     CaloTowerDetId newTowerId(iter->first.rawId());
+     HcalDetId id = HcalDetId(iter->first);
+     CaloTowerDetId newTowerId(id.ieta(),id.iphi());
      double et = iter->second;
 
      if(et>0){

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -154,9 +154,9 @@ class PFHFRecHitCreator :  public  PFRecHitCreatorBase {
 					    temp,
 					    [](const reco::PFRecHit& a, 
 					       const reco::PFRecHit& b){
-					      return a.detId() < b.detId();
+					      return (HcalDetId)(a.detId()) < (HcalDetId)(b.detId());
 					    });
-	  if( found_hit != tmpOut.end() && found_hit->detId() == shortID.rawId() ) {
+	  if( found_hit != tmpOut.end() && (HcalDetId)(found_hit->detId()) == (HcalDetId)(shortID.rawId()) ) {
 	    sHORT = found_hit->energy();
 	    //Ask for fraction
 	    double energy = lONG-sHORT;
@@ -191,10 +191,10 @@ class PFHFRecHitCreator :  public  PFRecHitCreatorBase {
 					    temp,
 					    [](const reco::PFRecHit& a, 
 					       const reco::PFRecHit& b){
-					      return a.detId() < b.detId();
+					      return (HcalDetId)(a.detId()) < (HcalDetId)(b.detId());
 					    });
 	  double energy = 2*sHORT;
-	  if( found_hit != tmpOut.end() && found_hit->detId() == longID.rawId() ) {
+	  if( found_hit != tmpOut.end() && (HcalDetId)(found_hit->detId()) == (HcalDetId)(longID.rawId()) ) {
 	    lONG = found_hit->energy();
 	    //Ask for fraction
 
@@ -250,8 +250,9 @@ class PFHFRecHitCreator :  public  PFRecHitCreatorBase {
 
       bool operator()(const reco::PFRecHit& a,
 		     const reco::PFRecHit& b) {
-      return a.detId() < b.detId();
-    }
+	if (DetId(a.detId()).det() == DetId::Hcal || DetId(b.detId()).det() == DetId::Hcal) return (HcalDetId)(a.detId()) < (HcalDetId)(b.detId());
+	else return a.detId() < b.detId();
+      }
 
     };
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -125,11 +125,15 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
 				      temp,
 				      [](const reco::PFRecHit& a, 
 					 const reco::PFRecHit& b){
-					return a.detId() < b.detId();
+					if (DetId(a.detId()).det() == DetId::Hcal || DetId(b.detId()).det() == DetId::Hcal) return (HcalDetId)(a.detId()) < (HcalDetId)(b.detId());
+
+					else return a.detId() < b.detId();
 				      });
 
 
-    if (found_hit != hits->end() && found_hit->detId() == id.rawId()) {
+    if (found_hit != hits->end() && ((found_hit->detId() == id.rawId()) ||
+				     ((id.det()==DetId::Hcal) &&
+				      ((HcalDetId)(found_hit->detId()) == (HcalDetId)(id))))) {
       sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) + _timeResolutionCalc->timeResolution2(found_hit->energy());
       const double deltaTime = hit.time()-found_hit->time();
       if(deltaTime*deltaTime<sigmaCut2_*sigma2) {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -6,7 +6,6 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 #include <iostream>
-using namespace std;
 
 //
 //  Quality test that checks threshold

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -6,6 +6,7 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 #include <iostream>
+using namespace std;
 
 //
 //  Quality test that checks threshold

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -462,14 +462,12 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const
 #ifdef DebugLog
 	std::cout << "HcalDigitizer format " << hid.oldFormat() << " for " << hid << std::endl;
 #endif
-	if (hid.oldFormat()) {
-	  DetId newid = DetId(hid.newForm());
+        DetId newid = DetId(hid.newForm());
 #ifdef DebugLog
 	  std::cout << "Hit " << i << " out of " << hcalHits.size() << " " << std::hex << id.rawId() << " --> " << newid.rawId() << std::dec << " " << HcalDetId(newid.rawId()) << '\n';
 #endif
-	  hcalHitsOrig[i].setID(newid.rawId());
-	}
-	hcalHits.push_back(hcalHitsOrig[i]);
+        hcalHitsOrig[i].setID(newid.rawId());
+        hcalHits.push_back(hcalHitsOrig[i]);
       }
     }
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -37,6 +37,8 @@
 #include "SimDataFormats/CaloTest/interface/HcalTestNumbering.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
+#define DebugLog
+
 namespace HcalDigitizerImpl {
 
   template<typename SIPMDIGITIZER>
@@ -451,13 +453,22 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const
     }
     
     //eliminate bad hits
-    for ( unsigned int i=0; i< hcalHitsOrig.size(); i++) {
+    for (unsigned int i=0; i< hcalHitsOrig.size(); i++) {
       DetId id(hcalHitsOrig[i].id());
       HcalDetId hid(id);
-      if ( !htopoP->validHcal(hid) )
+      if (!htopoP->validHcal(hid)) {
 	edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
-      else
+      } else {
+	std::cout << "HcalDigitizer format " << hid.oldFormat() << " for " << hid << std::endl;
+	if (hid.oldFormat()) {
+	  DetId newid = DetId(hid.newForm());
+#ifdef DebugLog
+	  std::cout << "Hit " << i << " out of " << hcalHits.size() << " " << std::hex << id.rawId() << " --> " << newid.rawId() << std::dec << " " << HcalDetId(newid.rawId()) << '\n';
+#endif
+	  hcalHitsOrig[i].setID(newid.rawId());
+	}
 	hcalHits.push_back(hcalHitsOrig[i]);
+      }
     }
 
     if(theHitCorrection != 0) {
@@ -547,8 +558,9 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
     if(theHBHESiPMDigitizer)    theHBHESiPMDigitizer->run(*hbheResult, engine);
     if(theHBHEUpgradeDigitizer) {
       theHBHEUpgradeDigitizer->run(*hbheupgradeResult, engine);
-
-//      std::cout << "HcalDigitizer::finalizeEvent  theHBHEUpgradeDigitizer->run" << std::endl;     
+#ifdef DebugLog
+      std::cout << "HcalDigitizer::finalizeEvent  theHBHEUpgradeDigitizer->run" << std::endl; 
+#endif
     }
   }
   if(isHCAL&&hogeo) {
@@ -570,7 +582,7 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   edm::LogInfo("HcalDigitizer") << "HCAL HBHE upgrade digis : " << hbheupgradeResult->size();
   edm::LogInfo("HcalDigitizer") << "HCAL HF upgrade digis : " << hfupgradeResult->size();
 
-  /*
+#ifdef DebugLog
   std::cout << std::endl;
   std::cout << "HCAL HBHE digis : " << hbheResult->size() << std::endl;
   std::cout << "HCAL HO   digis : " << hoResult->size() << std::endl;
@@ -580,7 +592,7 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
 	    << std::endl;
   std::cout << "HCAL HF   upgrade digis : " << hfupgradeResult->size()
 	    << std::endl;
-  */
+#endif
 
   // Step D: Put outputs into event
   e.put(hbheResult);
@@ -589,9 +601,9 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   e.put(zdcResult);
   e.put(hbheupgradeResult,"HBHEUpgradeDigiCollection");
   e.put(hfupgradeResult, "HFUpgradeDigiCollection");
-
-//  std::cout << std::endl << "========>  HcalDigitizer e.put " << std::endl <<  std::endl;
-
+#ifdef DebugLog
+  std::cout << std::endl << "========>  HcalDigitizer e.put " << std::endl <<  std::endl;
+#endif
   if(theHitCorrection) {
     theHitCorrection->clear();
   }
@@ -659,8 +671,9 @@ void  HcalDigitizer::updateGeometry(const edm::EventSetup & eventSetup) {
   theZDCDigitizer->setDetIds(zdcCells); 
   if(theHBHEUpgradeDigitizer) {
     theHBHEUpgradeDigitizer->setDetIds(theHBHEDetIds);
-
-//    std::cout << " HcalDigitizer::updateGeometry  theHBHEUpgradeDigitizer->setDetIds(theHBHEDetIds)"<< std::endl;   
+#ifdef DebugLog
+    std::cout << " HcalDigitizer::updateGeometry  theHBHEUpgradeDigitizer->setDetIds(theHBHEDetIds)"<< std::endl;   
+#endif
   }
 
 }

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -37,7 +37,7 @@
 #include "SimDataFormats/CaloTest/interface/HcalTestNumbering.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-#define DebugLog
+//#define DebugLog
 
 namespace HcalDigitizerImpl {
 
@@ -459,7 +459,9 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const
       if (!htopoP->validHcal(hid)) {
 	edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << std::endl;
       } else {
+#ifdef DebugLog
 	std::cout << "HcalDigitizer format " << hid.oldFormat() << " for " << hid << std::endl;
+#endif
 	if (hid.oldFormat()) {
 	  DetId newid = DetId(hid.newForm());
 #ifdef DebugLog

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -629,10 +629,10 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
     validhcalHits = false;
   }  
 
-  MapType fHBEnergySimHits;
-  MapType fHEEnergySimHits;
-  MapType fHOEnergySimHits;
-  MapType fHFEnergySimHits;
+  std::map<HcalDetId,float> fHBEnergySimHits;
+  std::map<HcalDetId,float> fHEEnergySimHits;
+  std::map<HcalDetId,float> fHOEnergySimHits;
+  std::map<HcalDetId,float> fHFEnergySimHits;
   if (validhcalHits) {
     const edm::PCaloHitContainer *simhitResult = hcalHits.product();
   
@@ -641,19 +641,18 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
 	 ++simhits) {
       
       HcalDetId detId(simhits->id());
-      uint32_t cellid = detId.rawId();
       
       if (detId.subdet() == sdHcalBrl){  
-	fHBEnergySimHits[cellid] += simhits->energy(); 
+	fHBEnergySimHits[detId] += simhits->energy(); 
       }
       if (detId.subdet() == sdHcalEC){  
-	fHEEnergySimHits[cellid] += simhits->energy(); 
+	fHEEnergySimHits[detId] += simhits->energy(); 
       }    
       if (detId.subdet() == sdHcalOut){  
-	fHOEnergySimHits[cellid] += simhits->energy(); 
+	fHOEnergySimHits[detId] += simhits->energy(); 
       }    
       if (detId.subdet() == sdHcalFwd){  
-	fHFEnergySimHits[cellid] += simhits->energy(); 
+	fHFEnergySimHits[detId] += simhits->energy(); 
       }    
     }
   }
@@ -738,7 +737,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
 	  if (deltaphi > PI) { deltaphi = 2.0 * PI - deltaphi;}
 	  
 	  mehHcalRes[0]->Fill(jhbhe->energy() - 
-			      fHBEnergySimHits[cell.rawId()]);
+			      fHBEnergySimHits[cell]);
 	}
 	
 	if (cell.subdet() == sdHcalEC) {
@@ -753,7 +752,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
 	  if (fPhi > maxHEPhi) { deltaphi = fPhi - maxHEPhi;}
 	  if (deltaphi > PI) { deltaphi = 2.0 * PI - deltaphi;}
 	  mehHcalRes[1]->Fill(jhbhe->energy() - 
-			      fHEEnergySimHits[cell.rawId()]);
+			      fHEEnergySimHits[cell]);
 	}
       }
     } // end loop through collection
@@ -824,7 +823,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
 	  if (fPhi > maxHFPhi) { deltaphi = fPhi - maxHFPhi;}
 	  if (deltaphi > PI) { deltaphi = 2.0 * PI - deltaphi;}
 	  
-	  mehHcalRes[2]->Fill(jhf->energy()-fHFEnergySimHits[cell.rawId()]);
+	  mehHcalRes[2]->Fill(jhf->energy()-fHFEnergySimHits[cell]);
 	}
       }
     } // end loop through collection
@@ -870,7 +869,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
 	  float deltaphi = maxHOPhi - fPhi;
 	  if (fPhi > maxHOPhi) { deltaphi = fPhi - maxHOPhi;}
 	  if (deltaphi > PI) { deltaphi = 2.0 * PI - deltaphi;}
-	  mehHcalRes[3]->Fill(jho->energy()-fHOEnergySimHits[cell.rawId()]);
+	  mehHcalRes[3]->Fill(jho->energy()-fHOEnergySimHits[cell]);
 	}
       }
     } // end loop through collection


### PR DESCRIPTION
This (hopefully) fixes the pileup problem observed in #12829 by enforcing the new form of the HcalDetId consistently in HcalDigitizer and the HcalDetId constructor. Also, merge conflicts were resolved.

@slava77 @bsunanda - can you start the tests?
