### PR TITLE
Fixing GTs for Run1 workflows to contain conditions for HcalQIETypes

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '80X_mcRun1_design_v0',
+    'run1_design'       :   '80X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '80X_mcRun1_realistic_v0',
+    'run1_mc'           :   '80X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v0',
+    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '80X_mcRun1_pA_v0',
+    'run1_mc_pa'        :   '80X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '80X_mcRun2_design_v0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2


### PR DESCRIPTION
This PR complements https://github.com/cms-sw/cmssw/pull/12832, to allow also the Run1 worfklow Global Tags to contain conditions for the new `HcalQIETypes` CondFormat.
# List of Changes in Global Tag
## RunI simulation
- **RunI Ideal scenario** : [80X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_design_v1) as [80X_mcRun1_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_design_v1/80X_mcRun1_design_v0): 
  - added new Hcal record (`HcalQIETypesRcd`) providing a per-HCAL-readout flag of the FE QIE electronics type
- **RunI Heavy Ions scenario** : [80X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_HeavyIon_v1) as [80X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_HeavyIon_v1/80X_mcRun1_HeavyIon_v0): 
  - added new Hcal record (`HcalQIETypesRcd`) providing a per-HCAL-readout flag of the FE QIE electronics type
- **RunI Realistic scenario** : [80X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_realistic_v1) as [80X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_realistic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_realistic_v1/80X_mcRun1_realistic_v0): 
  - added new Hcal record (`HcalQIETypesRcd`) providing a per-HCAL-readout flag of the FE QIE electronics type
- **RunI Proton-Lead scenario** : [80X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_pA_v1) as [80X_mcRun1_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_pA_v1/80X_mcRun1_pA_v0): 
  - added new Hcal record (`HcalQIETypesRcd`) providing a per-HCAL-readout flag of the FE QIE electronics type
