### PR TITLE
Make provenance handling event level thread-safe

### DIFF
--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -50,7 +50,6 @@ namespace edm {
 
     void resetProductData() {
       wrapper_.reset();
-      prov_.resetProductProvenance();
     }
     
     void setProcessHistory(ProcessHistory const& ph) {
@@ -63,10 +62,6 @@ namespace edm {
       prov_.setProcessHistory(ph);
     }
     
-    void setProductProvenance(ProductProvenance const& prov ) {
-      prov_.setProductProvenance(prov);
-    }
-
     void connectTo( ProductData const& iOther) {
       wrapper_ = iOther.wrapper_;
       // Then the product ID and the ProcessHistory
@@ -74,13 +69,6 @@ namespace edm {
       prov_.setProcessHistory(iOther.prov_.processHistory());
       // Then the store, in case the product needs reading in a subprocess.
       prov_.setStore(iOther.prov_.store());
-      // And last, the other per event provenance.
-      if(iOther.prov_.productProvenanceValid()) {
-        prov_.setProductProvenance(*iOther.prov_.productProvenance());
-      } else {
-        prov_.resetProductProvenance();
-      }
-
     }
     // NOTE: We should probably think hard about whether these
     // variables should be declared "mutable" as part of

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -43,24 +43,10 @@ namespace edm {
     ParentageID const& parentageID() const {return parentageID_;}
     Parentage const& parentage() const;
 
-    bool& noParentage() const {return transient_.noParentage_;}
-
-    void initializeTransients() const {transient_.reset();}
-
-    struct Transients {
-      Transients();
-      void reset();
-      std::shared_ptr<Parentage> parentagePtr_;
-      bool noParentage_;
-    };
-
   private:
-
-    std::shared_ptr<Parentage>& parentagePtr() const {return transient_.parentagePtr_;}
 
     BranchID branchID_;
     ParentageID parentageID_;
-    mutable Transients transient_;
   };
 
   inline

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -26,8 +26,6 @@ namespace edm {
     ProductProvenance();
     explicit ProductProvenance(BranchID const& bid);
     ProductProvenance(BranchID const& bid,
-                      std::shared_ptr<Parentage> parentagePtr);
-    ProductProvenance(BranchID const& bid,
                       ParentageID const& id);
 
     ProductProvenance(BranchID const& bid,

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -13,6 +13,7 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 
 #include <memory>
 #include <set>
+#include <atomic>
 
 /*
   ProductProvenanceRetriever
@@ -45,20 +46,18 @@ namespace edm {
       transitionIndex_=transitionIndex;
     }
 
-    typedef std::set<ProductProvenance> eiSet;
-
-    mutable eiSet entryInfoSet_;
+    mutable std::set<ProductProvenance> entryInfoSet_;
+    mutable std::atomic<std::set<ProductProvenance>*> readEntryInfoSet_;
     edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>> nextRetriever_;
     std::shared_ptr<const ProvenanceReaderBase> provenanceReader_;
     unsigned int transitionIndex_;
-    mutable bool delayedRead_;
   };
 
   class ProvenanceReaderBase {
   public:
     ProvenanceReaderBase() {}
     virtual ~ProvenanceReaderBase();
-    virtual void readProvenance(ProductProvenanceRetriever const& mapper, unsigned int transitionIndex) const = 0;
+    virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const = 0;
   };
   
 }

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -47,7 +47,7 @@ namespace edm {
     }
 
     mutable std::set<ProductProvenance> entryInfoSet_;
-    mutable std::atomic<std::set<ProductProvenance>*> readEntryInfoSet_;
+    mutable std::atomic<const std::set<ProductProvenance>*> readEntryInfoSet_;
     edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>> nextRetriever_;
     std::shared_ptr<const ProvenanceReaderBase> provenanceReader_;
     unsigned int transitionIndex_;

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -13,7 +13,6 @@ existence.
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ReleaseVersion.h"
 
 #include <memory>
@@ -39,7 +38,6 @@ namespace edm {
 
     Provenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid);
 
-    Parentage const& event() const {return parentage();}
     BranchDescription const& product() const {return *branchDescription_;}
 
     BranchDescription const& branchDescription() const {return *branchDescription_;}
@@ -47,7 +45,6 @@ namespace edm {
     std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return branchDescription_;}
 
     ProductProvenance const* productProvenance() const;
-    Parentage const& parentage() const {return productProvenance()->parentage();}
     BranchID const& branchID() const {return product().branchID();}
     std::string const& branchName() const {return product().branchName();}
     std::string const& className() const {return product().className();}
@@ -60,8 +57,6 @@ namespace edm {
     bool getProcessConfiguration(ProcessConfiguration& pc) const;
     ReleaseVersion releaseVersion() const;
     std::set<std::string> const& branchAliases() const {return product().branchAliases();}
-
-    std::vector<BranchID> const& parents() const {return parentage().parents();}
 
     void write(std::ostream& os) const;
 

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -9,11 +9,11 @@ existence.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/BranchDescription.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
+#include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ReleaseVersion.h"
 
 #include <memory>
@@ -32,6 +32,7 @@ existence.
 
 namespace edm {
   class ProductProvenance;
+  class ProductProvenanceRetriever;
   class Provenance {
   public:
     Provenance();
@@ -45,13 +46,7 @@ namespace edm {
     BranchDescription const& constBranchDescription() const {return *branchDescription_;}
     std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return branchDescription_;}
 
-    ProductProvenance const* productProvenance() const {
-      if (productProvenancePtr_) return productProvenancePtr_.get();
-      return resolve();
-    }
-    bool productProvenanceValid() const {
-      return bool(productProvenancePtr_);
-    }
+    ProductProvenance const* productProvenance() const;
     Parentage const& parentage() const {return productProvenance()->parentage();}
     BranchID const& branchID() const {return product().branchID();}
     std::string const& branchName() const {return product().branchName();}
@@ -76,8 +71,6 @@ namespace edm {
 
     ProductID const& productID() const {return productID_;}
 
-    void setProductProvenance(ProductProvenance const& prov);
-
     void setProductID(ProductID const& pid) {
       productID_ = pid;
     }
@@ -86,17 +79,12 @@ namespace edm {
       branchDescription_ = p;
     }
 
-    void resetProductProvenance();
-
     void swap(Provenance&);
 
   private:
-    ProductProvenance const* resolve() const;
-
     std::shared_ptr<BranchDescription const> branchDescription_;
     ProductID productID_;
     ProcessHistory const* processHistory_; // We don't own this
-    mutable std::shared_ptr<const ProductProvenance> productProvenancePtr_; //can be updated in resolve()
     ProductProvenanceRetriever const* store_;
   };
 

--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -8,55 +8,41 @@
 
 ----------------------------------------------------------------------*/
 
+namespace {
+  edm::Parentage const s_emptyParentage;
+}
 namespace edm {
-  ProductProvenance::Transients::Transients() :
-    parentagePtr_(),
-    noParentage_(false)
-  {}
-
-  void
-  ProductProvenance::Transients::reset() {
-    parentagePtr_.reset();
-    noParentage_ = false;
-  }
-
   ProductProvenance::ProductProvenance() :
     branchID_(),
-    parentageID_(),
-    transient_()
+    parentageID_()
   {}
 
   ProductProvenance::ProductProvenance(BranchID const& bid) :
     branchID_(bid),
-    parentageID_(),
-    transient_()
+    parentageID_()
   {}
 
    ProductProvenance::ProductProvenance(BranchID const& bid,
 				    ParentageID const& edid) :
     branchID_(bid),
-    parentageID_(edid),
-    transient_()
+    parentageID_(edid)
   {}
 
    ProductProvenance::ProductProvenance(BranchID const& bid,
 				    std::shared_ptr<Parentage> pPtr) :
     branchID_(bid),
-    parentageID_(pPtr->id()),
-    transient_() {
-       parentagePtr() = pPtr;
+    parentageID_(pPtr->id()) {
        ParentageRegistry::instance()->insertMapped(*pPtr);
   }
 
   ProductProvenance::ProductProvenance(BranchID const& bid,
 		   std::vector<BranchID> const& parents) :
     branchID_(bid),
-    parentageID_(),
-    transient_() {
-      parentagePtr() = std::make_shared<Parentage>();
-      parentagePtr()->setParents(parents);
-      parentageID_ = parentagePtr()->id();
-      ParentageRegistry::instance()->insertMapped(*parentagePtr());
+    parentageID_() {
+      Parentage p;
+      p.setParents(parents);
+      parentageID_ = p.id();
+      ParentageRegistry::instance()->insertMapped(p);
   }
 
   ProductProvenance
@@ -66,28 +52,21 @@ namespace edm {
 
   Parentage const &
   ProductProvenance::parentage() const {
-    if (!parentagePtr()) {
-      parentagePtr().reset(new Parentage);
-      ParentageRegistry::instance()->getMapped(parentageID_, *parentagePtr());
+    auto p =ParentageRegistry::instance()->getMapped(parentageID_);
+    if(p) {
+      return *p;
     }
-    return *parentagePtr();
+    return s_emptyParentage;
   }
 
   void
   ProductProvenance::write(std::ostream& os) const {
     os << "branch ID = " << branchID() << '\n';
-    if (!noParentage()) {
-      os << "entry description ID = " << parentageID() << '\n';
-    }
+    os << "entry description ID = " << parentageID() << '\n';
   }
     
   bool
   operator==(ProductProvenance const& a, ProductProvenance const& b) {
-    if (a.noParentage() != b.noParentage()) return false;
-    if (a.noParentage()) {
-      return
-        a.branchID() == b.branchID();
-    }
     return
       a.branchID() == b.branchID() && a.parentageID() == b.parentageID();
   }

--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -28,13 +28,6 @@ namespace edm {
     parentageID_(edid)
   {}
 
-   ProductProvenance::ProductProvenance(BranchID const& bid,
-				    std::shared_ptr<Parentage> pPtr) :
-    branchID_(bid),
-    parentageID_(pPtr->id()) {
-       ParentageRegistry::instance()->insertMapped(*pPtr);
-  }
-
   ProductProvenance::ProductProvenance(BranchID const& bid,
 		   std::vector<BranchID> const& parents) :
     branchID_(bid),

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -12,39 +12,54 @@
 namespace edm {
   ProductProvenanceRetriever::ProductProvenanceRetriever(unsigned int iTransitionIndex) :
       entryInfoSet_(),
+      readEntryInfoSet_(),
       nextRetriever_(),
       provenanceReader_(),
-      transitionIndex_(iTransitionIndex),
-      delayedRead_(false){
+      transitionIndex_(iTransitionIndex){
   }
 
   ProductProvenanceRetriever::ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader) :
       entryInfoSet_(),
+      readEntryInfoSet_(),
       nextRetriever_(),
       provenanceReader_(reader.release()),
-      transitionIndex_(std::numeric_limits<unsigned int>::max()),
-      delayedRead_(true)
+      transitionIndex_(std::numeric_limits<unsigned int>::max())
   {
     assert(provenanceReader_);
   }
 
-  ProductProvenanceRetriever::~ProductProvenanceRetriever() {}
+  ProductProvenanceRetriever::~ProductProvenanceRetriever() {
+    delete readEntryInfoSet_.load();
+  }
 
   void
   ProductProvenanceRetriever::readProvenance() const {
-    if(delayedRead_ && provenanceReader_) {
-      provenanceReader_->readProvenance(*this,transitionIndex_);
-      delayedRead_ = false; // only read once
+    if(nullptr == readEntryInfoSet_.load() && provenanceReader_) {
+      auto temp = std::make_unique<std::set<ProductProvenance>>(provenanceReader_->readProvenance(transitionIndex_));
+      std::set<ProductProvenance>* expected = nullptr;
+      if(readEntryInfoSet_.compare_exchange_strong(expected, temp.get())) {
+        temp.release();
+      }
     }
   }
 
   void ProductProvenanceRetriever::deepCopy(ProductProvenanceRetriever const& iFrom)
   {
+    if(iFrom.readEntryInfoSet_) {
+      if (readEntryInfoSet_) {
+        *readEntryInfoSet_ = *iFrom.readEntryInfoSet_;
+      } else {
+        readEntryInfoSet_ = new std::set<ProductProvenance>(*iFrom.readEntryInfoSet_);
+      }
+    } else {
+      if(readEntryInfoSet_) {
+        delete readEntryInfoSet_.load();
+        readEntryInfoSet_ = nullptr;
+      }
+    }
     entryInfoSet_ = iFrom.entryInfoSet_;
     provenanceReader_ = iFrom.provenanceReader_;
-    if(provenanceReader_) {
-      delayedRead_=true;
-    }
+    
     if(iFrom.nextRetriever_) {
       if(not nextRetriever_) {
         get_underlying(nextRetriever_) = std::make_shared<ProductProvenanceRetriever>(transitionIndex_);
@@ -55,8 +70,9 @@ namespace edm {
 
   void
   ProductProvenanceRetriever::reset() {
+    delete readEntryInfoSet_.load();
+    readEntryInfoSet_ = nullptr;
     entryInfoSet_.clear();
-    delayedRead_ = true;
     if(nextRetriever_) {
       nextRetriever_->reset();
     }
@@ -78,15 +94,22 @@ namespace edm {
 
   ProductProvenance const*
   ProductProvenanceRetriever::branchIDToProvenance(BranchID const& bid) const {
-    readProvenance();
     ProductProvenance ei(bid);
-    eiSet::const_iterator it = entryInfoSet_.find(ei);
+    auto it = entryInfoSet_.find(ei);
     if(it == entryInfoSet_.end()) {
+      //check in source
+      readProvenance();
+      auto ptr =readEntryInfoSet_.load();
+      if(ptr) {
+        auto it = ptr->find(ei);
+        if(it!= ptr->end()) {
+          return &*it;
+        }
+      }
       if(nextRetriever_) {
         return nextRetriever_->branchIDToProvenance(bid);
-      } else {
-        return 0;
       }
+      return nullptr;
     }
     return &*it;
   }

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -35,8 +35,8 @@ namespace edm {
   void
   ProductProvenanceRetriever::readProvenance() const {
     if(nullptr == readEntryInfoSet_.load() && provenanceReader_) {
-      auto temp = std::make_unique<std::set<ProductProvenance>>(provenanceReader_->readProvenance(transitionIndex_));
-      std::set<ProductProvenance>* expected = nullptr;
+      auto temp = std::make_unique<std::set<ProductProvenance> const>(provenanceReader_->readProvenance(transitionIndex_));
+      std::set<ProductProvenance> const* expected = nullptr;
       if(readEntryInfoSet_.compare_exchange_strong(expected, temp.get())) {
         temp.release();
       }
@@ -47,10 +47,9 @@ namespace edm {
   {
     if(iFrom.readEntryInfoSet_) {
       if (readEntryInfoSet_) {
-        *readEntryInfoSet_ = *iFrom.readEntryInfoSet_;
-      } else {
-        readEntryInfoSet_ = new std::set<ProductProvenance>(*iFrom.readEntryInfoSet_);
+        delete readEntryInfoSet_.exchange(nullptr);
       }
+      readEntryInfoSet_ = new std::set<ProductProvenance>(*iFrom.readEntryInfoSet_);
     } else {
       if(readEntryInfoSet_) {
         delete readEntryInfoSet_.load();

--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/Provenance/interface/Provenance.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-#include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 
@@ -21,22 +21,15 @@ namespace edm {
     branchDescription_(p),
     productID_(pid),
     processHistory_(),
-    productProvenancePtr_(),
     store_() {
   }
 
   ProductProvenance const*
-  Provenance::resolve() const {
+  Provenance::productProvenance() const {
     if(!store_) {
       return nullptr;
     }
-    if (!productProvenancePtr_) {
-      ProductProvenance const* prov  = store_->branchIDToProvenance(branchDescription_->branchID());
-      if (prov) {
-        productProvenancePtr_ = std::shared_ptr<ProductProvenance const>(prov, [](void const*) {}); //Do not take ownership
-      }
-    }
-    return productProvenancePtr_.get();
+    return store_->branchIDToProvenance(branchDescription_->branchID());
   }
 
   bool
@@ -66,22 +59,12 @@ namespace edm {
     return a.product() == b.product();
   }
 
-  void
-  Provenance::resetProductProvenance() {
-    productProvenancePtr_.reset();
-  }
-
-  void
-  Provenance::setProductProvenance(ProductProvenance const& prov) {
-    productProvenancePtr_ = std::make_shared<ProductProvenance>(prov);
-  }
 
   void
   Provenance::swap(Provenance& iOther) {
     branchDescription_.swap(iOther.branchDescription_);
     productID_.swap(iOther.productID_);
     std::swap(processHistory_, iOther.processHistory_);
-    productProvenancePtr_.swap(iOther.productProvenancePtr_);
     std::swap(store_,iOther.store_);
  }
 }

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -71,10 +71,8 @@
  </class>
  <class name="edm::ProductProvenance" ClassVersion="11">
   <version ClassVersion="11" checksum="3594205707"/>
-  <field name="transient_" transient="true"/>
   <version ClassVersion="10" checksum="3685381930"/>
  </class>
- <class name="edm::ProductProvenance::Transients" ClassVersion="0"/>
  <class name="std::vector<edm::ProductProvenance>"/>
  <class name="edm::StoredProductProvenance" ClassVersion="3">
    <version ClassVersion="3" checksum="1175457242"/>
@@ -199,12 +197,6 @@
  <class name="edm::ThinnedAssociationsHelper" ClassVersion="10">
   <version ClassVersion="10" checksum="3444973106"/>
  </class>
-
- <ioread sourceClass="edm::ProductProvenance" targetClass="edm::ProductProvenance" version="[1-]" source="" target="transient_">
- <![CDATA[
-	newObj->initializeTransients();
- ]]>
- </ioread>
  <ioread sourceClass="edm::ProductRegistry" targetClass="edm::ProductRegistry" version="[1-]" source="" target="transient_">
  <![CDATA[
 	newObj->initializeTransients();

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -88,9 +88,6 @@ namespace edm {
     // Retrieves pointer to the per event(lumi)(run) provenance.
     ProductProvenance const* productProvenancePtr() const { return productProvenancePtr_(); }
 
-    // Sets the the per event(lumi)(run) provenance.
-    void setProductProvenance(ProductProvenance const& prov);
-
     // Retrieves a reference to the event independent provenance.
     BranchDescription const& branchDescription() const {return branchDescription_();}
 

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -124,11 +124,8 @@ namespace edm {
     }
     assert(branchDescription().produced());
     assert(edp.get() != nullptr);
-    assert(!provenance()->productProvenanceValid());
     assert(status() != Present);
     assert(status() != Uninitialized);
-    setProductProvenance(productProvenance);
-    assert(provenance()->productProvenanceValid());
     productData().setWrapper(std::move(edp)); // ProductHolder takes ownership
     status_() = Present;
   }
@@ -137,9 +134,7 @@ namespace edm {
   ProducedProductHolder::mergeProduct_(
         std::unique_ptr<WrapperBase> edp,
         ProductProvenance const& productProvenance) {
-    assert(provenance()->productProvenanceValid());
     assert(status() == Present);
-    setProductProvenance(productProvenance);
     mergeTheProduct(std::move(edp));
   }
 
@@ -173,9 +168,6 @@ namespace edm {
         std::unique_ptr<WrapperBase> edp,
         ProductProvenance const& productProvenance) {
     assert(!product());
-    assert(!provenance()->productProvenanceValid());
-    setProductProvenance(productProvenance);
-    assert(provenance()->productProvenanceValid());
     setProduct(std::move(edp));
   }
 
@@ -261,11 +253,6 @@ namespace edm {
 
   void InputProductHolder::setPrincipal_(Principal* principal) {
     principal_ = principal;
-  }
-
-  void
-  ProductHolderBase::setProductProvenance(ProductProvenance const& prov) {
-    productData().setProductProvenance(prov);
   }
 
   // This routine returns true if it is known that currently there is no real product.

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -175,8 +175,8 @@ void test_ep::setUp() {
 
     edm::BranchDescription const branchFromRegistry(it->second);
 
-    auto entryDescriptionPtr = std::make_shared<edm::Parentage>();
-    edm::ProductProvenance prov(branchFromRegistry.branchID(), entryDescriptionPtr);
+    std::vector<edm::BranchID> const ids;
+    edm::ProductProvenance prov(branchFromRegistry.branchID(), ids);
 
     std::shared_ptr<edm::ProcessConfiguration> process(processConfigurations_[tag]);
     assert(process);

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -186,8 +186,8 @@ void testGenericHandle::getbyLabelTest() {
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp);
   edm::BranchDescription const& branchFromRegistry = it->second;
-  auto entryDescriptionPtr = std::make_shared<edm::Parentage>();
-  edm::ProductProvenance prov(branchFromRegistry.branchID(), entryDescriptionPtr);
+  std::vector<edm::BranchID> const ids;
+  edm::ProductProvenance prov(branchFromRegistry.branchID(), ids);
   edm::BranchDescription const desc(branchFromRegistry);
   ep.put(desc, std::move(pprod), prov);
 

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -304,7 +304,7 @@ namespace edmtest {
       edm::InputTag tag("thingWithMergeProducer", "event", "PROD");
       e.getByLabel(tag, h_thing);
       std::string expectedParent = expectedParents_[parentIndex_];
-      edm::BranchID actualParentBranchID = h_thing.provenance()->parentage().parents()[0];
+      edm::BranchID actualParentBranchID = h_thing.provenance()->productProvenance()->parentage().parents()[0];
 
       // There ought to be a get that uses the BranchID as an argument, but
       // there is not at the moment so we get the Provenance first and use that

--- a/FWCore/Integration/test/ProdigalAnalyzer.cc
+++ b/FWCore/Integration/test/ProdigalAnalyzer.cc
@@ -15,7 +15,7 @@ namespace edmtest {
   void ProdigalAnalyzer::analyze(edm::Event const& e, edm::EventSetup const&) {
     edm::Handle<Prodigal> h;
     assert(e.getByLabel("maker", h));
-    assert(h.provenance()->parents().empty());    
+    assert(h.provenance()->productProvenance()->parentage().parents().empty());
   }
 
 }

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
@@ -5,6 +5,7 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Common/interface/Provenance.h"
+#include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &handle, const edm::Event &iEvent) 
@@ -26,7 +27,7 @@ OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &
     configure(psetFromProvenance); 
 
     // Now we also dig out the ProcessName used for the reco::Tracks and reco::Vertices
-    std::vector<edm::BranchID> parents = prov->parents();
+    std::vector<edm::BranchID> parents = prov->productProvenance()->parentage().parents();
     bool foundTracks = false;
     bool foundBeamSpot = false;
     for (std::vector<edm::BranchID>::const_iterator it = parents.begin(), ed = parents.end(); it != ed; ++it) {


### PR DESCRIPTION
Modify how provenance is handled so once we use more than one thread per event the code will be thread-safe.
