### PR TITLE
Electron validation miniAOD V0 80X

### DIFF
--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -35,4 +35,4 @@ genHarvesting = cms.Path(postValidation_gen)
 
 alcaHarvesting = cms.Path()
 
-validationHarvestingMiniAOD = cms.Path(JetPostProcessor*METPostProcessorHarvesting)
+validationHarvestingMiniAOD = cms.Path( JetPostProcessor * METPostProcessorHarvesting * postValidationMiniAOD )

--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -35,4 +35,4 @@ genHarvesting = cms.Path(postValidation_gen)
 
 alcaHarvesting = cms.Path()
 
-validationHarvestingMiniAOD = cms.Path( JetPostProcessor * METPostProcessorHarvesting * postValidationMiniAOD )
+validationHarvestingMiniAOD = cms.Path(JetPostProcessor*METPostProcessorHarvesting*postValidationMiniAOD)

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -29,11 +29,16 @@ from Validation.EventGenerator.BasicGenValidation_cff import *
 # miniAOD
 from Validation.RecoParticleFlow.miniAODValidation_cff import *
 from Validation.RecoEgamma.photonMiniAODValidationSequence_cff import *
+from Validation.RecoEgamma.egammaValidationMiniAOD_cff import *
 
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
+<<<<<<< HEAD
 prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence)
+=======
+prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * JetValidationMiniAOD * type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD * METValidationMiniAOD * egammaValidationMiniAOD )
+>>>>>>> miniAOD electron modification
 
 
 validation = cms.Sequence(cms.SequencePlaceholder("mix")

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -34,11 +34,7 @@ from Validation.RecoEgamma.egammaValidationMiniAOD_cff import *
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
-<<<<<<< HEAD
-prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence)
-=======
-prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * JetValidationMiniAOD * type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD * METValidationMiniAOD * egammaValidationMiniAOD )
->>>>>>> miniAOD electron modification
+prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * egammaValidationMiniAOD)
 
 
 validation = cms.Sequence(cms.SequencePlaceholder("mix")

--- a/DQMOffline/EGamma/scripts/electronCompare.py
+++ b/DQMOffline/EGamma/scripts/electronCompare.py
@@ -72,7 +72,6 @@ if __name__ == "__main__":
   parser.add_option("-b", "--blue-name", dest="blue", action="store", default="",
     help="short name of the blue histograms")  
   (options, args) = parser.parse_args()
-#  print "options : ",options
   
   if len(args)<2:
     print "[electronStore.py] I NEED AT LEAST TWO ARGUMENTS."
@@ -80,19 +79,23 @@ if __name__ == "__main__":
     
   red_file = args.pop(0)
   web_dir = args.pop()
-  web_url = web_dir.replace('/afs/cern.ch/cms/','http://cmsdoc.cern.ch/',1)
+#  print 'WEB DIR 1 =',web_dir
+  if not '/afs/cern.ch/cms/' in web_dir:
+    print "local : ", web_dir
+    web_url = web_dir
+  else:
+    web_url = web_dir.replace('/afs/cern.ch/cms/','http://cmsdoc.cern.ch/',1)
   if len(args)>0 :
     blue_file = args.pop(0)
   else :
     blue_file = ''
-      
-      
+
   #===================================================
   # prepare output directories and check input files
   #===================================================
 
   # destination dir
-  print 'WEB DIR =',web_dir
+#  print 'WEB DIR =',web_dir
   if os.path.exists(web_dir+'/gifs')==False:
     os.makedirs(web_dir+'/gifs')
     

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -10,6 +10,7 @@ from Validation.HcalRecHits.hcalRecHitsPostProcessor_cff import *
 from Validation.EventGenerator.PostProcessor_cff import *
 from Validation.RecoEgamma.photonPostProcessor_cff import *
 from Validation.RecoEgamma.electronPostValidationSequence_cff import *
+from Validation.RecoEgamma.electronPostValidationSequenceMiniAOD_cff import *
 from Validation.RecoParticleFlow.PFValidationClient_cff import *
 from Validation.RPCRecHits.postValidation_cfi import *
 from Validation.RecoTau.DQMMCValidation_cfi import *
@@ -27,7 +28,7 @@ postValidation = cms.Sequence(
     + hcalSimHitsPostProcessor
     + hcaldigisPostProcessor
     + hcalrechitsPostProcessor
-    + electronPostValidationSequence + photonPostProcessor
+    + electronPostValidationSequence + electronPostValidationSequenceMiniAOD + photonPostProcessor
     + pfJetClient + pfMETClient + pfJetResClient + pfElectronClient
     + rpcRecHitPostValidation_step
     + runTauEff + makeBetterPlots
@@ -62,4 +63,8 @@ postValidation_gen = cms.Sequence(
 
 postValidationCosmics = cms.Sequence(
       postProcessorMuonMultiTrack
+)
+
+postValidationMiniAOD = cms.Sequence(
+      electronPostValidationSequenceMiniAOD
 )

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -28,7 +28,7 @@ postValidation = cms.Sequence(
     + hcalSimHitsPostProcessor
     + hcaldigisPostProcessor
     + hcalrechitsPostProcessor
-    + electronPostValidationSequence + electronPostValidationSequenceMiniAOD + photonPostProcessor
+    + electronPostValidationSequence + photonPostProcessor
     + pfJetClient + pfMETClient + pfJetResClient + pfElectronClient
     + rpcRecHitPostValidation_step
     + runTauEff + makeBetterPlots

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.cc
@@ -1,0 +1,39 @@
+
+#include "Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.h" 
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+ElectronMcSignalPostValidatorMiniAOD::ElectronMcSignalPostValidatorMiniAOD( const edm::ParameterSet & conf )
+ : ElectronDqmHarvesterBase(conf)
+ {
+  // histos bining and limits
+
+  edm::ParameterSet histosSet = conf.getParameter<edm::ParameterSet>("histosCfg") ;
+
+  set_EfficiencyFlag=histosSet.getParameter<bool>("EfficiencyFlag");
+  set_StatOverflowFlag=histosSet.getParameter<bool>("StatOverflowFlag");
+ }
+
+ElectronMcSignalPostValidatorMiniAOD::~ElectronMcSignalPostValidatorMiniAOD()
+ {}
+
+void ElectronMcSignalPostValidatorMiniAOD::finalize( DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter )
+ {
+
+  setBookIndex(-1) ;
+  setBookPrefix("h_ele") ;
+  setBookEfficiencyFlag(set_EfficiencyFlag);
+  setBookStatOverflowFlag( set_StatOverflowFlag ) ;
+  
+  // profiles from 2D histos
+  profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
+  profileX(iBooker, iGetter, "sigmaIetaIetaVsPt","SigmaIetaIeta vs pt","p_{T} (GeV/c)","SigmaIetaIeta");
+  profileX(iBooker, iGetter, "foundHitsVsEta","mean ele track # found hits vs eta","#eta","<N_{hits}>");
+  profileX(iBooker, iGetter, "foundHitsVsEta_mAOD","mean ele track # found hits vs eta","#eta","<N_{hits}>");
+/**/
+
+
+
+}
+
+

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.cc
@@ -24,7 +24,7 @@ void ElectronMcSignalPostValidatorMiniAOD::finalize( DQMStore::IBooker & iBooker
   setBookPrefix("h_ele") ;
   setBookEfficiencyFlag(set_EfficiencyFlag);
   setBookStatOverflowFlag( set_StatOverflowFlag ) ;
-  
+
   // profiles from 2D histos
   profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "sigmaIetaIetaVsPt","SigmaIetaIeta vs pt","p_{T} (GeV/c)","SigmaIetaIeta");

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.h
@@ -1,0 +1,33 @@
+
+#ifndef Validation_RecoEgamma_ElectronMcSignalPostValidatorMiniAOD_h
+#define Validation_RecoEgamma_ElectronMcSignalPostValidatorMiniAOD_h
+
+#include "DQMOffline/EGamma/interface/ElectronDqmHarvesterBase.h" 
+
+class ElectronMcSignalPostValidatorMiniAOD : public ElectronDqmHarvesterBase
+ {
+  public:
+    explicit ElectronMcSignalPostValidatorMiniAOD( const edm::ParameterSet & conf ) ;
+    virtual ~ElectronMcSignalPostValidatorMiniAOD() ;
+    virtual void finalize( DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter ) ; 
+
+  private:
+    std::string inputFile_ ;
+    std::string outputFile_ ;
+    std::vector<int> matchingIDs_;
+    std::vector<int> matchingMotherIDs_;
+    std::string inputInternalPath_ ;
+    std::string outputInternalPath_ ;
+
+    // histos limits and binning
+    bool set_EfficiencyFlag ; bool set_StatOverflowFlag ;
+
+    // histos
+//    MonitorElement *h1_ele_xOverX0VsEta ;
+	
+ } ;
+
+#endif
+
+
+

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.h
@@ -24,7 +24,7 @@ class ElectronMcSignalPostValidatorMiniAOD : public ElectronDqmHarvesterBase
 
     // histos
 //    MonitorElement *h1_ele_xOverX0VsEta ;
-	
+
  } ;
 
 #endif

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -371,18 +371,23 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
             if (bestGsfElectron.isEE()) h1_ele_fbrem_mAOD_endcaps->Fill( bestGsfElectron.fbrem() );
 
         // -- pflow over pT
-            h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
-            if (bestGsfElectron.isEB()) h1_ele_chargedHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
-            if (bestGsfElectron.isEE()) h1_ele_chargedHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+            double one_over_pt = 1. / bestGsfElectron.pt());
 
-            h1_ele_neutralHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
-//          h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIso_.sumNeutralHadronEt / bestGsfElectron.pt());
-            if (bestGsfElectron.isEB()) h1_ele_neutralHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
-            if (bestGsfElectron.isEE()) h1_ele_neutralHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+            h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt * one_over_pt );
+            h1_ele_neutralHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt * one_over_pt );
+            h1_ele_photonRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt * one_over_pt );
 
-            h1_ele_photonRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
-            if (bestGsfElectron.isEB()) h1_ele_photonRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
-            if (bestGsfElectron.isEE()) h1_ele_photonRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEB()) {
+                h1_ele_chargedHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt * one_over_pt );
+                h1_ele_neutralHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt * one_over_pt );
+                h1_ele_photonRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt * one_over_pt );
+            }
+
+            if (bestGsfElectron.isEE()) {
+                h1_ele_chargedHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt * one_over_pt );
+                h1_ele_neutralHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt * one_over_pt );
+                h1_ele_photonRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt * one_over_pt );
+            }
         }
 
     } // fin boucle size_t i

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -1,0 +1,392 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h" 
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "TMath.h"
+#include "TFile.h"
+#include "TH1F.h"
+#include "TH1I.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TTree.h"
+#include <vector>
+#include <iostream>
+#include <typeinfo>
+
+using namespace reco;
+using namespace pat;
+
+ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::ParameterSet& iConfig) : ElectronDqmAnalyzerBase(iConfig)
+{
+    mcTruthCollection_ = consumes<edm::View<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("mcTruthCollection"));
+    electronToken_ = consumes<pat::ElectronCollection>(iConfig.getParameter<edm::InputTag>("electrons"));
+
+  maxPt_ = iConfig.getParameter<double>("MaxPt");
+  maxAbsEta_ = iConfig.getParameter<double>("MaxAbsEta");
+  deltaR_ = iConfig.getParameter<double>("DeltaR");
+  deltaR2_ = deltaR_ * deltaR_;
+  matchingIDs_ = iConfig.getParameter<std::vector<int> >("MatchingID");
+  matchingMotherIDs_ = iConfig.getParameter<std::vector<int> >("MatchingMotherID");
+  outputInternalPath_ = iConfig.getParameter<std::string>("OutputFolderName") ;
+
+  // histos bining and limits
+
+   edm::ParameterSet histosSet = iConfig.getParameter<edm::ParameterSet>("histosCfg") ;
+
+   xyz_nbin=histosSet.getParameter<int>("Nbinxyz");
+
+   pt_nbin=histosSet.getParameter<int>("Nbinpt");
+   pt2D_nbin=histosSet.getParameter<int>("Nbinpt2D");
+   pteff_nbin=histosSet.getParameter<int>("Nbinpteff");
+   pt_max=histosSet.getParameter<double>("Ptmax");
+
+   fhits_nbin=histosSet.getParameter<int>("Nbinfhits");
+   fhits_max=histosSet.getParameter<double>("Fhitsmax");
+
+   eta_nbin=histosSet.getParameter<int>("Nbineta");
+   eta2D_nbin=histosSet.getParameter<int>("Nbineta2D");
+   eta_min=histosSet.getParameter<double>("Etamin");
+   eta_max=histosSet.getParameter<double>("Etamax");
+
+   detamatch_nbin=histosSet.getParameter<int>("Nbindetamatch");
+   detamatch2D_nbin=histosSet.getParameter<int>("Nbindetamatch2D");
+   detamatch_min=histosSet.getParameter<double>("Detamatchmin");
+   detamatch_max=histosSet.getParameter<double>("Detamatchmax");
+
+   dphi_nbin=histosSet.getParameter<int>("Nbindphi");
+   dphi_min=histosSet.getParameter<double>("Dphimin");
+   dphi_max=histosSet.getParameter<double>("Dphimax");
+
+   dphimatch_nbin=histosSet.getParameter<int>("Nbindphimatch");
+   dphimatch2D_nbin=histosSet.getParameter<int>("Nbindphimatch2D");
+   dphimatch_min=histosSet.getParameter<double>("Dphimatchmin");
+   dphimatch_max=histosSet.getParameter<double>("Dphimatchmax");
+
+   hoe_nbin= histosSet.getParameter<int>("Nbinhoe");
+   hoe_min=histosSet.getParameter<double>("Hoemin");
+   hoe_max=histosSet.getParameter<double>("Hoemax");
+
+   mee_nbin= histosSet.getParameter<int>("Nbinmee");
+   mee_min=histosSet.getParameter<double>("Meemin");
+   mee_max=histosSet.getParameter<double>("Meemax");
+
+   poptrue_nbin= histosSet.getParameter<int>("Nbinpoptrue");
+   poptrue_min=histosSet.getParameter<double>("Poptruemin");
+   poptrue_max=histosSet.getParameter<double>("Poptruemax");
+
+   set_EfficiencyFlag=histosSet.getParameter<bool>("EfficiencyFlag");
+   set_StatOverflowFlag=histosSet.getParameter<bool>("StatOverflowFlag");
+
+   // so to please coverity...
+
+   h1_recEleNum = 0 ;
+
+   h1_ele_vertexPt = 0 ;
+   h1_ele_vertexEta = 0 ;
+   h1_ele_vertexPt_nocut = 0 ;
+
+   h1_scl_SigIEtaIEta_mAOD = 0 ;
+   h1_scl_SigIEtaIEta_mAOD_barrel = 0 ;
+   h1_scl_SigIEtaIEta_mAOD_endcaps = 0 ;
+
+   h2_ele_foundHitsVsEta = 0 ;
+   h2_ele_foundHitsVsEta_mAOD = 0 ;
+
+   h2_ele_PoPtrueVsEta = 0 ;
+   h2_ele_sigmaIetaIetaVsPt = 0 ;
+
+   h1_ele_HoE_mAOD = 0 ;
+   h1_ele_HoE_mAOD_barrel = 0 ;
+   h1_ele_HoE_mAOD_endcaps = 0 ;
+   h1_ele_mee_all = 0 ;
+   h1_ele_mee_os = 0 ;
+
+   h1_ele_fbrem_mAOD = 0 ;
+   h1_ele_fbrem_mAOD_barrel = 0 ;
+   h1_ele_fbrem_mAOD_endcaps = 0 ;
+   
+   h1_ele_dEtaSc_propVtx_mAOD = 0 ;
+   h1_ele_dEtaSc_propVtx_mAOD_barrel = 0 ;
+   h1_ele_dEtaSc_propVtx_mAOD_endcaps = 0 ;
+   h1_ele_dPhiCl_propOut_mAOD = 0 ;
+   h1_ele_dPhiCl_propOut_mAOD_barrel = 0 ;
+   h1_ele_dPhiCl_propOut_mAOD_endcaps = 0 ;
+
+   h1_ele_chargedHadronRelativeIso_mAOD = 0 ;
+   h1_ele_chargedHadronRelativeIso_mAOD_barrel = 0 ;
+   h1_ele_chargedHadronRelativeIso_mAOD_endcaps = 0 ;
+   h1_ele_neutralHadronRelativeIso_mAOD = 0 ;
+   h1_ele_neutralHadronRelativeIso_mAOD_barrel = 0 ;
+   h1_ele_neutralHadronRelativeIso_mAOD_endcaps = 0 ;
+   h1_ele_photonRelativeIso_mAOD = 0 ;
+   h1_ele_photonRelativeIso_mAOD_barrel = 0 ;
+   h1_ele_photonRelativeIso_mAOD_endcaps = 0 ;
+
+
+}
+
+ElectronMcSignalValidatorMiniAOD::~ElectronMcSignalValidatorMiniAOD()
+{
+}
+
+void ElectronMcSignalValidatorMiniAOD::bookHistograms( DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const & )
+ {
+  iBooker.setCurrentFolder(outputInternalPath_) ;
+
+  setBookIndex(-1) ;
+  setBookPrefix("h") ;
+  setBookEfficiencyFlag(set_EfficiencyFlag);
+  setBookStatOverflowFlag( set_StatOverflowFlag ) ;
+
+  // rec event collections sizes
+  h1_recEleNum = bookH1(iBooker, "recEleNum","# rec electrons",11, -0.5,10.5,"N_{ele}");
+  // matched electrons
+  setBookPrefix("h_mc") ;
+  setBookPrefix("h_ele") ;
+  h1_ele_vertexPt = bookH1withSumw2(iBooker, "vertexPt","ele transverse momentum",pt_nbin,0.,pt_max,"p_{T vertex} (GeV/c)");
+  h1_ele_vertexEta = bookH1withSumw2(iBooker, "vertexEta","ele momentum eta",eta_nbin,eta_min,eta_max,"#eta");
+  h1_ele_vertexPt_nocut = bookH1withSumw2(iBooker, "vertexPt_nocut","pT of prunned electrons",pt_nbin,0.,20.,"p_{T vertex} (GeV/c)");
+  h2_ele_PoPtrueVsEta = bookH2withSumw2(iBooker, "PoPtrueVsEta","ele momentum / gen momentum vs eta",eta2D_nbin,eta_min,eta_max,50,poptrue_min,poptrue_max);
+//  h2_ele_sigmaIetaIetaVsPt = bookH2(iBooker,"sigmaIetaIetaVsPt","SigmaIetaIeta vs pt",pt_nbin,0.,pt_max,100,0.,0.05);
+  h2_ele_sigmaIetaIetaVsPt = bookH2(iBooker,"sigmaIetaIetaVsPt","SigmaIetaIeta vs pt",100,0.,pt_max,100,0.,0.05);
+
+  // all electrons
+  setBookPrefix("h_ele") ;
+  h1_ele_mee_all = bookH1withSumw2(iBooker, "mee_all","ele pairs invariant mass, all reco electrons",mee_nbin, mee_min, mee_max,"m_{ee} (GeV/c^{2})","Events","ELE_LOGY E1 P");
+  h1_ele_mee_os = bookH1withSumw2(iBooker, "mee_os","ele pairs invariant mass, opp. sign",mee_nbin, mee_min, mee_max,"m_{e^{+}e^{-}} (GeV/c^{2})","Events","ELE_LOGY E1 P");
+
+  // matched electron, superclusters
+  setBookPrefix("h_scl") ;
+  h1_scl_SigIEtaIEta_mAOD = bookH1withSumw2(iBooker, "SigIEtaIEta_mAOD","ele supercluster sigma ieta ieta",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
+  h1_scl_SigIEtaIEta_mAOD_barrel = bookH1withSumw2(iBooker, "SigIEtaIEta_mAOD_barrel","ele supercluster sigma ieta ieta, barrel",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
+  h1_scl_SigIEtaIEta_mAOD_endcaps = bookH1withSumw2(iBooker, "SigIEtaIEta_mAOD_endcaps","ele supercluster sigma ieta ieta, endcaps",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
+ 
+  // matched electron, gsf tracks
+  setBookPrefix("h_ele") ;
+  h2_ele_foundHitsVsEta = bookH2(iBooker, "foundHitsVsEta","ele track # found hits vs eta",eta2D_nbin,eta_min,eta_max,fhits_nbin,0.,fhits_max);
+  h2_ele_foundHitsVsEta_mAOD = bookH2(iBooker, "foundHitsVsEta_mAOD","ele track # found hits vs eta",eta2D_nbin,eta_min,eta_max,fhits_nbin,0.,fhits_max);
+
+  // matched electrons, matching
+  setBookPrefix("h_ele") ;
+  h1_ele_HoE_mAOD = bookH1withSumw2(iBooker, "HoE_mAOD","ele hadronic energy / em energy",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
+  h1_ele_HoE_mAOD_barrel = bookH1withSumw2(iBooker, "HoE_mAOD_barrel","ele hadronic energy / em energy, barrel",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
+  h1_ele_HoE_mAOD_endcaps = bookH1withSumw2(iBooker, "HoE_mAOD_endcaps","ele hadronic energy / em energy, endcaps",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
+  h1_ele_dEtaSc_propVtx_mAOD = bookH1withSumw2(iBooker, "dEtaSc_propVtx_mAOD","ele #eta_{sc} - #eta_{tr}, prop from vertex",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
+  h1_ele_dEtaSc_propVtx_mAOD_barrel = bookH1withSumw2(iBooker, "dEtaSc_propVtx_mAOD_barrel","ele #eta_{sc} - #eta_{tr}, prop from vertex, barrel",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
+  h1_ele_dEtaSc_propVtx_mAOD_endcaps = bookH1withSumw2(iBooker, "dEtaSc_propVtx_mAOD_endcaps","ele #eta_{sc} - #eta_{tr}, prop from vertex, endcaps",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
+  h1_ele_dPhiCl_propOut_mAOD = bookH1withSumw2(iBooker, "dPhiCl_propOut_mAOD","ele #phi_{cl} - #phi_{tr}, prop from outermost",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
+  h1_ele_dPhiCl_propOut_mAOD_barrel = bookH1withSumw2(iBooker, "dPhiCl_propOut_mAOD_barrel","ele #phi_{cl} - #phi_{tr}, prop from outermost, barrel",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
+  h1_ele_dPhiCl_propOut_mAOD_endcaps = bookH1withSumw2(iBooker, "dPhiCl_propOut_mAOD_endcaps","ele #phi_{cl} - #phi_{tr}, prop from outermost, endcaps",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
+
+  // fbrem
+  h1_ele_fbrem_mAOD = bookH1withSumw2(iBooker, "fbrem_mAOD","ele brem fraction, mode of GSF components",100,0.,1.,"P_{in} - P_{out} / P_{in}");
+  h1_ele_fbrem_mAOD_barrel = bookH1withSumw2(iBooker, "fbrem_mAOD_barrel","ele brem fraction for barrel, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
+  h1_ele_fbrem_mAOD_endcaps = bookH1withSumw2(iBooker, "fbrem_mAOD_endcaps", "ele brem franction for endcaps, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
+
+  // -- pflow over pT
+  h1_ele_chargedHadronRelativeIso_mAOD = bookH1withSumw2(iBooker, "chargedHadronRelativeIso_mAOD","chargedHadronRelativeIso",100,0.0,2.,"chargedHadronRelativeIso","Events","ELE_LOGY E1 P");
+  h1_ele_chargedHadronRelativeIso_mAOD_barrel = bookH1withSumw2(iBooker, "chargedHadronRelativeIso_mAOD_barrel","chargedHadronRelativeIso for barrel",100,0.0,2.,"chargedHadronRelativeIso_barrel","Events","ELE_LOGY E1 P");
+  h1_ele_chargedHadronRelativeIso_mAOD_endcaps = bookH1withSumw2(iBooker, "chargedHadronRelativeIso_mAOD_endcaps","chargedHadronRelativeIso for endcaps",100,0.0,2.,"chargedHadronRelativeIso_endcaps","Events","ELE_LOGY E1 P");
+  h1_ele_neutralHadronRelativeIso_mAOD = bookH1withSumw2(iBooker, "neutralHadronRelativeIso_mAOD","neutralHadronRelativeIso",100,0.0,2.,"neutralHadronRelativeIso","Events","ELE_LOGY E1 P");
+  h1_ele_neutralHadronRelativeIso_mAOD_barrel = bookH1withSumw2(iBooker, "neutralHadronRelativeIso_mAOD_barrel","neutralHadronRelativeIso for barrel",100,0.0,2.,"neutralHadronRelativeIso_barrel","Events","ELE_LOGY E1 P");
+  h1_ele_neutralHadronRelativeIso_mAOD_endcaps = bookH1withSumw2(iBooker, "neutralHadronRelativeIso_mAOD_endcaps","neutralHadronRelativeIso for endcaps",100,0.0,2.,"neutralHadronRelativeIso_endcaps","Events","ELE_LOGY E1 P");
+  h1_ele_photonRelativeIso_mAOD = bookH1withSumw2(iBooker, "photonRelativeIso_mAOD","photonRelativeIso",100,0.0,2.,"photonRelativeIso","Events","ELE_LOGY E1 P");
+  h1_ele_photonRelativeIso_mAOD_barrel = bookH1withSumw2(iBooker, "photonRelativeIso_mAOD_barrel","photonRelativeIso for barrel",100,0.0,2.,"photonRelativeIso_barrel","Events","ELE_LOGY E1 P");
+  h1_ele_photonRelativeIso_mAOD_endcaps = bookH1withSumw2(iBooker, "photonRelativeIso_mAOD_endcaps","photonRelativeIso for endcaps",100,0.0,2.,"photonRelativeIso_endcaps","Events","ELE_LOGY E1 P");
+
+ }
+ 
+void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+    // get collections
+    edm::Handle<pat::ElectronCollection> electrons;
+    iEvent.getByToken(electronToken_, electrons);
+    
+    edm::Handle<edm::View<reco::GenParticle> > genParticles ;
+    iEvent.getByToken(mcTruthCollection_, genParticles) ;  
+
+    edm::LogInfo("ElectronMcMiniAODSignalValidator::analyze")
+      <<"Treating event "<<iEvent.id()
+      <<" with "<<electrons.product()->size()<<" electrons" ;
+    h1_recEleNum->Fill((*electrons).size()) ;
+
+    //===============================================
+    // all rec electrons
+    //===============================================
+
+    pat::Electron gsfElectron ;
+
+//    for(std::vector<pat::Electron>::const_iterator el1=electrons->begin(); el1!=electrons->end(); el1++) {
+    pat::ElectronCollection::const_iterator el1 ;
+    pat::ElectronCollection::const_iterator el2 ;
+    for(el1=electrons->begin(); el1!=electrons->end(); el1++) {
+//        for (std::vector<pat::Electron>::const_iterator el2=el1+1 ; el2!=electrons->end() ; el2++ )
+        for (el2=el1+1 ; el2!=electrons->end() ; el2++ )
+        {
+            math::XYZTLorentzVector p12 = el1->p4()+el2->p4();
+            float mee2 = p12.Dot(p12);
+            h1_ele_mee_all->Fill(sqrt(mee2));
+            if ( el1->charge() * el2->charge() < 0. )
+            {
+                h1_ele_mee_os->Fill(sqrt(mee2));
+            }
+        }
+    }
+
+    //===============================================
+    // charge mis-ID
+    //===============================================
+
+    int mcNum=0, gamNum=0, eleNum=0 ;
+//    bool matchingID;//, matchingMotherID ;
+    bool matchingMotherID ;
+
+    //===============================================
+    // association mc-reco
+    //===============================================
+
+    for(size_t i=0; i<genParticles->size(); i++) {  
+        // number of mc particles
+        mcNum++ ;
+
+        // counts photons
+        if ( (*genParticles)[i].pdgId() == 22 )
+            { gamNum++ ; }
+
+        // select requested mother matching gen particle
+        // always include single particle with no mother
+        const Candidate * mother = (*genParticles)[i].mother(0) ;
+        matchingMotherID = false ;
+        for ( unsigned int ii=0 ; ii<matchingMotherIDs_.size() ; ii++ ) {
+            if ( (mother == 0) || ((mother != 0) &&  mother->pdgId() == matchingMotherIDs_[ii]) )
+                { matchingMotherID = true ; 
+//			std::cout << "matchingMotherID :" << matchingMotherIDs_[ii] << std::endl ;
+            }
+        }
+        if (!matchingMotherID) continue ;
+
+        // electron preselection
+        if ((*genParticles)[i].pt()> maxPt_ || std::abs((*genParticles)[i].eta())> maxAbsEta_)
+            { continue ; }
+        eleNum++;
+
+        // find best matched electron
+        bool okGsfFound = false ;
+        bool passMiniAODSelection = true ;
+        double gsfOkRatio = 999999. ;
+        pat::Electron bestGsfElectron ;
+        for (const pat::Electron &el : *electrons ) {
+            double dphi = el.phi()-(*genParticles)[i].phi() ;
+            if (std::abs(dphi)>CLHEP::pi)
+                { dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
+            double deltaR2 = (el.eta()-(*genParticles)[i].eta()) * (el.eta()-(*genParticles)[i].eta()) + dphi * dphi;
+            if ( deltaR2 < deltaR2_ )
+            {
+                if ( ( ((*genParticles)[i].pdgId() == 11) && (el.charge() < 0.) ) ||
+                ( ((*genParticles)[i].pdgId() == -11) && (el.charge() > 0.) ) )
+                {
+                    double tmpGsfRatio = el.p()/(*genParticles)[i].p() ;
+                    if ( std::abs(tmpGsfRatio-1) < std::abs(gsfOkRatio-1) )
+                        {
+                        gsfOkRatio = tmpGsfRatio;
+                        bestGsfElectron=el;
+                        okGsfFound = true;
+                    }
+                }
+            }
+        }
+     
+        if (! okGsfFound) continue ;
+
+        //------------------------------------
+        // analysis when the mc track is found
+        //------------------------------------
+        passMiniAODSelection = bestGsfElectron.pt() >= 5.;
+
+        // electron related distributions
+        h1_ele_vertexPt->Fill( bestGsfElectron.pt() );
+        h1_ele_vertexEta->Fill( bestGsfElectron.eta() );
+        if ( (bestGsfElectron.scSigmaIEtaIEta()==0.) && (bestGsfElectron.fbrem()==0.) ) h1_ele_vertexPt_nocut->Fill( bestGsfElectron.pt() );
+    
+        // generated distributions for matched electrons
+        h2_ele_PoPtrueVsEta->Fill( bestGsfElectron.eta(), bestGsfElectron.p()/(*genParticles)[i].p());
+        if ( passMiniAODSelection ) { // Pt > 5.
+            h2_ele_sigmaIetaIetaVsPt->Fill( bestGsfElectron.pt(), bestGsfElectron.scSigmaIEtaIEta());
+        }
+
+        // supercluster related distributions
+        if ( passMiniAODSelection ) { // Pt > 5.
+            h1_scl_SigIEtaIEta_mAOD->Fill(bestGsfElectron.scSigmaIEtaIEta());
+            if (bestGsfElectron.isEB()) h1_scl_SigIEtaIEta_mAOD_barrel->Fill(bestGsfElectron.scSigmaIEtaIEta());
+            if (bestGsfElectron.isEE()) h1_scl_SigIEtaIEta_mAOD_endcaps->Fill(bestGsfElectron.scSigmaIEtaIEta());
+
+            h1_ele_dEtaSc_propVtx_mAOD->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+            if (bestGsfElectron.isEB()) h1_ele_dEtaSc_propVtx_mAOD_barrel->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+            if (bestGsfElectron.isEE())h1_ele_dEtaSc_propVtx_mAOD_endcaps->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+        
+            h1_ele_dPhiCl_propOut_mAOD->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+            if (bestGsfElectron.isEB()) h1_ele_dPhiCl_propOut_mAOD_barrel->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+            if (bestGsfElectron.isEE()) h1_ele_dPhiCl_propOut_mAOD_endcaps->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+        }
+   
+        // track related distributions
+        h2_ele_foundHitsVsEta->Fill( bestGsfElectron.eta(), bestGsfElectron.gsfTrack()->numberOfValidHits() );
+        if (passMiniAODSelection) { // Pt > 5.
+            h2_ele_foundHitsVsEta_mAOD->Fill( bestGsfElectron.eta(), bestGsfElectron.gsfTrack()->numberOfValidHits() );
+        }
+
+      // match distributions
+        if (passMiniAODSelection) { // Pt > 5.
+            h1_ele_HoE_mAOD->Fill(bestGsfElectron.hcalOverEcal());
+            if (bestGsfElectron.isEB()) h1_ele_HoE_mAOD_barrel->Fill(bestGsfElectron.hcalOverEcal());
+            if (bestGsfElectron.isEE()) h1_ele_HoE_mAOD_endcaps->Fill(bestGsfElectron.hcalOverEcal());
+        }
+
+        // fbrem
+
+        //    double fbrem_mode =  bestGsfElectron.fbrem();
+        if (passMiniAODSelection) { // Pt > 5.
+            h1_ele_fbrem_mAOD->Fill( bestGsfElectron.fbrem() );
+            if (bestGsfElectron.isEB()) h1_ele_fbrem_mAOD_barrel->Fill( bestGsfElectron.fbrem() );
+            if (bestGsfElectron.isEE()) h1_ele_fbrem_mAOD_endcaps->Fill( bestGsfElectron.fbrem() );
+
+        // -- pflow over pT
+            h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEB()) h1_ele_chargedHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEE()) h1_ele_chargedHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+
+            h1_ele_neutralHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+//          h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIso_.sumNeutralHadronEt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEB()) h1_ele_neutralHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEE()) h1_ele_neutralHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+
+            h1_ele_photonRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEB()) h1_ele_photonRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+            if (bestGsfElectron.isEE()) h1_ele_photonRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+        }
+
+    } // fin boucle size_t i
+
+//    std::cout << ("fin analyze\n");
+}
+

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -371,7 +371,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
             if (bestGsfElectron.isEE()) h1_ele_fbrem_mAOD_endcaps->Fill( bestGsfElectron.fbrem() );
 
         // -- pflow over pT
-            double one_over_pt = 1. / bestGsfElectron.pt());
+            double one_over_pt = 1. / bestGsfElectron.pt();
 
             h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt * one_over_pt );
             h1_ele_neutralHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt * one_over_pt );

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -225,7 +225,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
     edm::Handle<edm::View<reco::GenParticle> > genParticles ;
     iEvent.getByToken(mcTruthCollection_, genParticles) ;  
 
-    edm::LogInfo("ElectronMcMiniAODSignalValidator::analyze")
+    edm::LogInfo("ElectronMcSignalValidatorMiniAOD::analyze")
       <<"Treating event "<<iEvent.id()
       <<" with "<<electrons.product()->size()<<" electrons" ;
     h1_recEleNum->Fill((*electrons).size()) ;

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -1,0 +1,119 @@
+#ifndef Validation_RecoEgamma_ElectronMcSignalValidatorMiniAOD_h 
+#define Validation_RecoEgamma_ElectronMcSignalValidatorMiniAOD_h
+
+#include "DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h"
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+
+//
+// class declaration
+//
+class ElectronMcSignalValidatorMiniAOD : public ElectronDqmAnalyzerBase {
+   public:
+      explicit ElectronMcSignalValidatorMiniAOD(const edm::ParameterSet&);
+      virtual ~ElectronMcSignalValidatorMiniAOD();
+      bool isAncestor(const reco::Candidate * ancestor, const reco::Candidate * particle);
+      
+   private:
+      virtual void bookHistograms( DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) ;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+      // ----------member data ---------------------------
+      edm::EDGetTokenT<edm::View<reco::GenParticle> > mcTruthCollection_;
+      edm::EDGetTokenT<pat::ElectronCollection> electronToken_;
+ 
+      double maxPt_;
+      double maxAbsEta_;
+      double deltaR_, deltaR2_;
+      std::vector<int> matchingIDs_;
+      std::vector<int> matchingMotherIDs_;
+      std::string outputInternalPath_ ;
+
+      // histos limits and binning
+
+      int xyz_nbin ;
+      int pt_nbin ; int pt2D_nbin ; int pteff_nbin ; double pt_max ;
+      int fhits_nbin ; double fhits_max ;
+      int eta_nbin ; int eta2D_nbin ; double eta_min ; double eta_max ;
+      int deta_nbin ; double deta_min ; double deta_max ;
+      int detamatch_nbin ; int detamatch2D_nbin ; double detamatch_min ; double detamatch_max ;
+      int phi_nbin ; int phi2D_nbin ; double phi_min ; double phi_max ;
+      int dphi_nbin ; double dphi_min ; double dphi_max ;
+      int dphimatch_nbin ; int    dphimatch2D_nbin ; double dphimatch_min ; double dphimatch_max ;
+      int mee_nbin ; double mee_min ; double mee_max ;
+      int hoe_nbin ; double hoe_min ; double hoe_max ;
+      int poptrue_nbin ; double poptrue_min ; double poptrue_max ;
+      bool set_EfficiencyFlag ; bool set_StatOverflowFlag ;
+      
+    // histos
+
+    MonitorElement *h1_recEleNum;
+
+    MonitorElement *h1_ele_vertexPt;
+    MonitorElement *h1_ele_vertexEta;
+    MonitorElement *h1_ele_vertexPt_nocut;
+
+    MonitorElement *h1_scl_SigIEtaIEta_mAOD;
+    MonitorElement *h1_scl_SigIEtaIEta_mAOD_barrel;
+    MonitorElement *h1_scl_SigIEtaIEta_mAOD_endcaps;
+
+    MonitorElement *h2_ele_foundHitsVsEta;
+    MonitorElement *h2_ele_foundHitsVsEta_mAOD;
+
+    MonitorElement *h2_ele_PoPtrueVsEta;
+    MonitorElement *h2_ele_sigmaIetaIetaVsPt;
+
+    MonitorElement *h1_ele_HoE_mAOD;
+    MonitorElement *h1_ele_HoE_mAOD_barrel;
+    MonitorElement *h1_ele_HoE_mAOD_endcaps;
+    MonitorElement *h1_ele_mee_all;
+    MonitorElement *h1_ele_mee_os;
+
+    MonitorElement *h1_ele_dEtaSc_propVtx_mAOD;
+    MonitorElement *h1_ele_dEtaSc_propVtx_mAOD_barrel;
+    MonitorElement *h1_ele_dEtaSc_propVtx_mAOD_endcaps;
+    MonitorElement *h1_ele_dPhiCl_propOut_mAOD;
+    MonitorElement *h1_ele_dPhiCl_propOut_mAOD_barrel;
+    MonitorElement *h1_ele_dPhiCl_propOut_mAOD_endcaps;
+
+    MonitorElement *h1_ele_fbrem_mAOD;
+    MonitorElement *h1_ele_fbrem_mAOD_barrel;
+    MonitorElement *h1_ele_fbrem_mAOD_endcaps;
+
+	// -- pflow over pT
+	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD;
+	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_endcaps;
+	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD;
+	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_endcaps;
+	MonitorElement *h1_ele_photonRelativeIso_mAOD;
+	MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
+    
+};
+
+#endif

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -36,7 +36,7 @@ class ElectronMcSignalValidatorMiniAOD : public ElectronDqmAnalyzerBase {
       explicit ElectronMcSignalValidatorMiniAOD(const edm::ParameterSet&);
       virtual ~ElectronMcSignalValidatorMiniAOD();
       bool isAncestor(const reco::Candidate * ancestor, const reco::Candidate * particle);
-      
+
    private:
       virtual void bookHistograms( DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) ;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -59,7 +59,6 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
     h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
   }/**/
 
-  
   // profiles from 2D histos
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}", 0.8);
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices_barrel","E/Etrue vs number of primary vertices , barrel","N_{primary vertices}","E/E_{true}", 0.8);
@@ -67,6 +66,7 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
 
   profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi","mean ele momentum / gen momentum vs phi","#phi (rad)","<P/P_{gen}>");
+  profileX(iBooker, iGetter, "sigmaIetaIetaVsPt","SigmaIetaIeta vs pt","p_{T} (GeV/c)","SigmaIetaIeta");
   profileX(iBooker, iGetter, "EoEtruePfVsEg","mean pflow sc energy / true energy vs e/g sc energy","E/E_{gen} (e/g)","<E/E_{gen}> (pflow)") ;
   profileY(iBooker, iGetter, "EoEtruePfVsEg","mean e/g sc energy / true energy vs pflow sc energy","E/E_{gen} (pflow)","<E/E_{gen}> (eg)") ;
   profileX(iBooker, iGetter, "EtaMnEtaTrueVsEta","mean ele eta - gen eta vs eta","#eta","<#eta_{rec} - #eta_{gen}>");
@@ -87,6 +87,7 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   profileX(iBooker, iGetter, "chi2VsPhi","mean ele track chi2 vs phi","#phi (rad)","<#Chi^{2}>");
   profileX(iBooker, iGetter, "ambiguousTracksVsEta","mean ele # ambiguous tracks  vs eta","#eta","<N_{ambiguous}>");
   profileX(iBooker, iGetter, "foundHitsVsEta","mean ele track # found hits vs eta","#eta","<N_{hits}>");
+  profileX(iBooker, iGetter, "foundHitsVsEta_mAOD","mean ele track # found hits vs eta","#eta","<N_{hits}>");
   profileX(iBooker, iGetter, "foundHitsVsPhi","mean ele track # found hits vs phi","#phi (rad)","<N_{hits}>");
   profileX(iBooker, iGetter, "lostHitsVsEta","mean ele track # lost hits vs eta","#eta","<N_{hits}>");
   profileX(iBooker, iGetter, "lostHitsVsPhi","mean ele track # lost hits vs phi","#phi (rad)","<N_{hits}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -39,6 +39,7 @@
 #include "TTree.h"
 #include <vector>
 #include <iostream>
+#include <typeinfo>
 
 using namespace reco;
 
@@ -84,6 +85,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   maxPt_ = conf.getParameter<double>("MaxPt");
   maxAbsEta_ = conf.getParameter<double>("MaxAbsEta");
   deltaR_ = conf.getParameter<double>("DeltaR");
+  deltaR2_ = deltaR_ * deltaR_;
   matchingIDs_ = conf.getParameter<std::vector<int> >("MatchingID");
   matchingMotherIDs_ = conf.getParameter<std::vector<int> >("MatchingMotherID");
   inputFile_ = conf.getParameter<std::string>("InputFile") ;
@@ -246,6 +248,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h2_ele_chargeVsPt = 0 ;
   h1_ele_vertexP = 0 ;
   h1_ele_vertexPt = 0 ;
+  h1_ele_vertexPt_nocut = 0 ;
   h1_ele_Et = 0 ;
   h2_ele_vertexPtVsEta = 0 ;
   h2_ele_vertexPtVsPhi = 0 ;
@@ -295,6 +298,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_SigIEtaIEta = 0 ;
   h1_scl_SigIEtaIEta_barrel = 0 ;
   h1_scl_SigIEtaIEta_endcaps = 0 ;
+  h1_scl_SigIEtaIEta_mAOD = 0 ;
+  h1_scl_SigIEtaIEta_mAOD_barrel = 0 ;
+  h1_scl_SigIEtaIEta_mAOD_endcaps = 0 ;
   h1_scl_full5x5_sigmaIetaIeta = 0 ;
   h1_scl_full5x5_sigmaIetaIeta_barrel = 0 ;
   h1_scl_full5x5_sigmaIetaIeta_endcaps = 0 ;
@@ -307,9 +313,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_E5x5 = 0 ;
   h1_scl_E5x5_barrel = 0 ;
   h1_scl_E5x5_endcaps = 0 ;
-  h1_scl_bcl_EtotoEtrue = 0 ; // new 2015.18.05
-  h1_scl_bcl_EtotoEtrue_barrel = 0 ; // new 2015.18.05
-  h1_scl_bcl_EtotoEtrue_endcaps = 0 ; // new 2015.18.05
+  h1_scl_bcl_EtotoEtrue = 0 ;
+  h1_scl_bcl_EtotoEtrue_barrel = 0 ;
+  h1_scl_bcl_EtotoEtrue_endcaps = 0 ;
 
   h1_ele_ambiguousTracks = 0 ;
   h2_ele_ambiguousTracksVsEta = 0 ;
@@ -319,6 +325,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_ele_foundHits_barrel = 0 ;
   h1_ele_foundHits_endcaps = 0 ;
   h2_ele_foundHitsVsEta = 0 ;
+  h2_ele_foundHitsVsEta_mAOD = 0 ;
   h2_ele_foundHitsVsPhi = 0 ;
   h2_ele_foundHitsVsPt = 0 ;
   h1_ele_lostHits = 0 ;
@@ -341,6 +348,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h2_ele_PoPtrueVsEta = 0 ;
   h2_ele_PoPtrueVsPhi = 0 ;
   h2_ele_PoPtrueVsPt = 0 ;
+  h2_ele_sigmaIetaIetaVsPt = 0 ;
 
   h1_ele_PoPtrue_golden_barrel = 0 ;
   h1_ele_PoPtrue_golden_endcaps = 0 ;
@@ -407,6 +415,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_ele_dEtaSc_propVtx = 0 ;
   h1_ele_dEtaSc_propVtx_barrel = 0 ;
   h1_ele_dEtaSc_propVtx_endcaps = 0 ;
+  h1_ele_dEtaSc_propVtx_mAOD = 0 ;
+  h1_ele_dEtaSc_propVtx_mAOD_barrel = 0 ;
+  h1_ele_dEtaSc_propVtx_mAOD_endcaps = 0 ;
   h2_ele_dEtaScVsEta_propVtx = 0 ;
   h2_ele_dEtaScVsPhi_propVtx = 0 ;
   h2_ele_dEtaScVsPt_propVtx = 0 ;
@@ -425,6 +436,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_ele_dPhiCl_propOut = 0 ;
   h1_ele_dPhiCl_propOut_barrel = 0 ;
   h1_ele_dPhiCl_propOut_endcaps = 0 ;
+  h1_ele_dPhiCl_propOut_mAOD = 0 ;
+  h1_ele_dPhiCl_propOut_mAOD_barrel = 0 ;
+  h1_ele_dPhiCl_propOut_mAOD_endcaps = 0 ;
   h2_ele_dPhiClVsEta_propOut = 0 ;
   h2_ele_dPhiClVsPhi_propOut = 0 ;
   h2_ele_dPhiClVsPt_propOut = 0 ;
@@ -472,11 +486,20 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h2_ele_HoEVsEta = 0 ;
   h2_ele_HoEVsPhi = 0 ;
   h2_ele_HoEVsE = 0 ;
+  h1_ele_HoE_mAOD = 0 ;
+  h1_ele_HoE_mAOD_barrel = 0 ;
+  h1_ele_HoE_mAOD_endcaps = 0 ;
 
   h1_ele_fbrem = 0 ;
+  h1_ele_fbrem_barrel = 0 ;
+  h1_ele_fbrem_endcaps = 0 ;
   p1_ele_fbremVsEta_mode = 0 ;
   p1_ele_fbremVsEta_mean = 0 ;
+  h1_ele_fbrem_mAOD = 0 ;
+  h1_ele_fbrem_mAOD_barrel = 0 ;
+  h1_ele_fbrem_mAOD_endcaps = 0 ;
   h1_ele_superclusterfbrem = 0 ;
+
   h1_ele_superclusterfbrem_barrel = 0 ;
   h1_ele_superclusterfbrem_endcaps = 0 ;
   h2_ele_PinVsPoutGolden_mode = 0 ;
@@ -527,6 +550,18 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_ele_convDcot_all = 0 ;
   h1_ele_convRadius = 0 ;
   h1_ele_convRadius_all = 0 ;
+  
+  // PF
+  h1_ele_chargedHadronRelativeIso_mAOD = 0 ;
+  h1_ele_chargedHadronRelativeIso_mAOD_barrel = 0 ;
+  h1_ele_chargedHadronRelativeIso_mAOD_endcaps = 0 ;
+  h1_ele_neutralHadronRelativeIso_mAOD = 0 ;
+  h1_ele_neutralHadronRelativeIso_mAOD_barrel = 0 ;
+  h1_ele_neutralHadronRelativeIso_mAOD_endcaps = 0 ;
+  h1_ele_photonRelativeIso_mAOD = 0 ;
+  h1_ele_photonRelativeIso_mAOD_barrel = 0 ;
+  h1_ele_photonRelativeIso_mAOD_endcaps = 0 ;
+
  }
 
 void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const & )
@@ -549,7 +584,7 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_recCoreNum = bookH1(iBooker, "recCoreNum","# rec electron cores",21, -0.5,20.5,"N_{core}");
   h1_recTrackNum = bookH1(iBooker, "recTrackNum","# rec gsf tracks",41, -0.5,40.5,"N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum","# rec electron seeds",101, -0.5,100.5,"N_{seed}");
-  h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}"); 
+  h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}");
   h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "scl_EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
   h2_scl_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "scl_EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
   h2_scl_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "scl_EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
@@ -637,6 +672,7 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h2_ele_chargeVsPt = bookH2(iBooker, "chargeVsPt","ele charge vs pt",pt_nbin,0.,100.,5,-2.,2.);
   h1_ele_vertexP = bookH1withSumw2(iBooker, "vertexP","ele momentum",p_nbin,0.,p_max,"p_{vertex} (GeV/c)");
   h1_ele_vertexPt = bookH1withSumw2(iBooker, "vertexPt","ele transverse momentum",pt_nbin,0.,pt_max,"p_{T vertex} (GeV/c)");
+  h1_ele_vertexPt_nocut = bookH1withSumw2(iBooker, "vertexPt_nocut","pT of prunned electrons",pt_nbin,0.,pt_max,"p_{T vertex} (GeV/c)");
   h1_ele_Et = bookH1withSumw2(iBooker, "Et","ele ecal E_{T}",pt_nbin,0.,pt_max,"E_{T} (GeV)");
   h2_ele_vertexPtVsEta = bookH2(iBooker, "vertexPtVsEta","ele transverse momentum vs eta",eta2D_nbin,eta_min,eta_max,pt2D_nbin,0.,pt_max);
   h2_ele_vertexPtVsPhi = bookH2(iBooker, "vertexPtVsPhi","ele transverse momentum vs phi",phi2D_nbin,phi_min,phi_max,pt2D_nbin,0.,pt_max);
@@ -656,6 +692,8 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h2_ele_PoPtrueVsEta = bookH2withSumw2(iBooker, "PoPtrueVsEta","ele momentum / gen momentum vs eta",eta2D_nbin,eta_min,eta_max,50,poptrue_min,poptrue_max);
   h2_ele_PoPtrueVsPhi = bookH2(iBooker, "PoPtrueVsPhi","ele momentum / gen momentum vs phi",phi2D_nbin,phi_min,phi_max,50,poptrue_min,poptrue_max);
   h2_ele_PoPtrueVsPt = bookH2(iBooker, "PoPtrueVsPt","ele momentum / gen momentum vs eta",pt2D_nbin,0.,pt_max,50,poptrue_min,poptrue_max);
+//  h2_ele_sigmaIetaIetaVsPt = bookH2(iBooker,"sigmaIetaIetaVsPt","SigmaIetaIeta vs pt",pt_nbin,0.,pt_max,100,0.,0.05);
+  h2_ele_sigmaIetaIetaVsPt = bookH2(iBooker,"sigmaIetaIetaVsPt","SigmaIetaIeta vs pt",100,0.,pt_max,100,0.,0.05);
   h1_ele_PoPtrue_golden_barrel = bookH1withSumw2(iBooker, "PoPtrue_golden_barrel","ele momentum / gen momentum, golden, barrel",poptrue_nbin,poptrue_min,poptrue_max,"P/P_{gen}");
   h1_ele_PoPtrue_golden_endcaps = bookH1withSumw2(iBooker, "PoPtrue_golden_endcaps","ele momentum / gen momentum, golden, endcaps",poptrue_nbin,poptrue_min,poptrue_max,"P/P_{gen}");
   h1_ele_PoPtrue_showering_barrel = bookH1withSumw2(iBooker, "PoPtrue_showering_barrel","ele momentum / gen momentum, showering, barrel",poptrue_nbin,poptrue_min,poptrue_max,"P/P_{gen}");
@@ -712,6 +750,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_SigIEtaIEta = bookH1withSumw2(iBooker, "sigietaieta","ele supercluster sigma ieta ieta",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_SigIEtaIEta_barrel = bookH1withSumw2(iBooker, "sigietaieta_barrel","ele supercluster sigma ieta ieta, barrel",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_SigIEtaIEta_endcaps = bookH1withSumw2(iBooker, "sigietaieta_endcaps","ele supercluster sigma ieta ieta, endcaps",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
+  h1_scl_SigIEtaIEta_mAOD = bookH1withSumw2(iBooker, "SigIEtaIEta_mAOD","ele supercluster sigma ieta ieta",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
+  h1_scl_SigIEtaIEta_mAOD_barrel = bookH1withSumw2(iBooker, "SigIEtaIEta_mAOD_barrel","ele supercluster sigma ieta ieta, barrel",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
+  h1_scl_SigIEtaIEta_mAOD_endcaps = bookH1withSumw2(iBooker, "SigIEtaIEta_mAOD_endcaps","ele supercluster sigma ieta ieta, endcaps",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_full5x5_sigmaIetaIeta = bookH1withSumw2(iBooker, "full5x5_sigietaieta","ele supercluster full5x5 sigma ieta ieta",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_full5x5_sigmaIetaIeta_barrel = bookH1withSumw2(iBooker, "full5x5_sigietaieta_barrel","ele supercluster full5x5 sigma ieta ieta, barrel",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_full5x5_sigmaIetaIeta_endcaps = bookH1withSumw2(iBooker, "full5x5_sigietaieta_endcaps","ele supercluster full5x5 sigma ieta ieta, endcaps",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
@@ -739,6 +780,7 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_ele_foundHits_barrel = bookH1withSumw2(iBooker, "foundHits_barrel","ele track # found hits, barrel",fhits_nbin,0.,fhits_max,"N_{hits}");
   h1_ele_foundHits_endcaps = bookH1withSumw2(iBooker, "foundHits_endcaps","ele track # found hits, endcaps",fhits_nbin,0.,fhits_max,"N_{hits}");
   h2_ele_foundHitsVsEta = bookH2(iBooker, "foundHitsVsEta","ele track # found hits vs eta",eta2D_nbin,eta_min,eta_max,fhits_nbin,0.,fhits_max);
+  h2_ele_foundHitsVsEta_mAOD = bookH2(iBooker, "foundHitsVsEta_mAOD","ele track # found hits vs eta",eta2D_nbin,eta_min,eta_max,fhits_nbin,0.,fhits_max);
   h2_ele_foundHitsVsPhi = bookH2(iBooker, "foundHitsVsPhi","ele track # found hits vs phi",phi2D_nbin,phi_min,phi_max,fhits_nbin,0.,fhits_max);
   h2_ele_foundHitsVsPt = bookH2(iBooker, "foundHitsVsPt","ele track # found hits vs pt",pt2D_nbin,0.,pt_max,fhits_nbin,0.,fhits_max);
   h1_ele_lostHits = bookH1withSumw2(iBooker, "lostHits","ele track # lost hits",       5,0.,5.,"N_{lost hits}");
@@ -797,6 +839,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_ele_dEtaSc_propVtx = bookH1withSumw2(iBooker, "dEtaSc_propVtx","ele #eta_{sc} - #eta_{tr}, prop from vertex",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
   h1_ele_dEtaSc_propVtx_barrel = bookH1withSumw2(iBooker, "dEtaSc_propVtx_barrel","ele #eta_{sc} - #eta_{tr}, prop from vertex, barrel",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
   h1_ele_dEtaSc_propVtx_endcaps = bookH1withSumw2(iBooker, "dEtaSc_propVtx_endcaps","ele #eta_{sc} - #eta_{tr}, prop from vertex, endcaps",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
+  h1_ele_dEtaSc_propVtx_mAOD = bookH1withSumw2(iBooker, "dEtaSc_propVtx_mAOD","ele #eta_{sc} - #eta_{tr}, prop from vertex",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
+  h1_ele_dEtaSc_propVtx_mAOD_barrel = bookH1withSumw2(iBooker, "dEtaSc_propVtx_mAOD_barrel","ele #eta_{sc} - #eta_{tr}, prop from vertex, barrel",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
+  h1_ele_dEtaSc_propVtx_mAOD_endcaps = bookH1withSumw2(iBooker, "dEtaSc_propVtx_mAOD_endcaps","ele #eta_{sc} - #eta_{tr}, prop from vertex, endcaps",detamatch_nbin,detamatch_min,detamatch_max,"#eta_{sc} - #eta_{tr}","Events","ELE_LOGY E1 P");
   h2_ele_dEtaScVsEta_propVtx = bookH2(iBooker, "dEtaScVsEta_propVtx","ele #eta_{sc} - #eta_{tr} vs eta, prop from vertex",eta2D_nbin,eta_min,eta_max,detamatch2D_nbin,detamatch_min,detamatch_max);
   h2_ele_dEtaScVsPhi_propVtx = bookH2(iBooker, "dEtaScVsPhi_propVtx","ele #eta_{sc} - #eta_{tr} vs phi, prop from vertex",phi2D_nbin,phi_min,phi_max,detamatch2D_nbin,detamatch_min,detamatch_max);
   h2_ele_dEtaScVsPt_propVtx = bookH2(iBooker, "dEtaScVsPt_propVtx","ele #eta_{sc} - #eta_{tr} vs pt, prop from vertex",pt2D_nbin,0.,pt_max,detamatch2D_nbin,detamatch_min,detamatch_max);
@@ -815,6 +860,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_ele_dPhiCl_propOut = bookH1withSumw2(iBooker, "dPhiCl_propOut","ele #phi_{cl} - #phi_{tr}, prop from outermost",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
   h1_ele_dPhiCl_propOut_barrel = bookH1withSumw2(iBooker, "dPhiCl_propOut_barrel","ele #phi_{cl} - #phi_{tr}, prop from outermost, barrel",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
   h1_ele_dPhiCl_propOut_endcaps = bookH1withSumw2(iBooker, "dPhiCl_propOut_endcaps","ele #phi_{cl} - #phi_{tr}, prop from outermost, endcaps",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
+  h1_ele_dPhiCl_propOut_mAOD = bookH1withSumw2(iBooker, "dPhiCl_propOut_mAOD","ele #phi_{cl} - #phi_{tr}, prop from outermost",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
+  h1_ele_dPhiCl_propOut_mAOD_barrel = bookH1withSumw2(iBooker, "dPhiCl_propOut_mAOD_barrel","ele #phi_{cl} - #phi_{tr}, prop from outermost, barrel",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
+  h1_ele_dPhiCl_propOut_mAOD_endcaps = bookH1withSumw2(iBooker, "dPhiCl_propOut_mAOD_endcaps","ele #phi_{cl} - #phi_{tr}, prop from outermost, endcaps",dphimatch_nbin,dphimatch_min,dphimatch_max,"#phi_{seedcl} - #phi_{tr} (rad)","Events","ELE_LOGY E1 P");
   h2_ele_dPhiClVsEta_propOut = bookH2(iBooker, "dPhiClVsEta_propOut","ele #phi_{cl} - #phi_{tr} vs eta, prop from out",eta2D_nbin,eta_min,eta_max,dphimatch2D_nbin,dphimatch_min,dphimatch_max);
   h2_ele_dPhiClVsPhi_propOut = bookH2(iBooker, "dPhiClVsPhi_propOut","ele #phi_{cl} - #phi_{tr} vs phi, prop from out",phi2D_nbin,phi_min,phi_max,dphimatch2D_nbin,dphimatch_min,dphimatch_max);
   h2_ele_dPhiClVsPt_propOut = bookH2(iBooker, "dPhiSClsPt_propOut","ele #phi_{cl} - #phi_{tr} vs pt, prop from out",pt2D_nbin,0.,pt_max,dphimatch2D_nbin,dphimatch_min,dphimatch_max);
@@ -833,6 +881,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_ele_HoE = bookH1withSumw2(iBooker, "HoE","ele hadronic energy / em energy",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
   h1_ele_HoE_barrel = bookH1withSumw2(iBooker, "HoE_barrel","ele hadronic energy / em energy, barrel",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
   h1_ele_HoE_endcaps = bookH1withSumw2(iBooker, "HoE_endcaps","ele hadronic energy / em energy, endcaps",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
+  h1_ele_HoE_mAOD = bookH1withSumw2(iBooker, "HoE_mAOD","ele hadronic energy / em energy",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
+  h1_ele_HoE_mAOD_barrel = bookH1withSumw2(iBooker, "HoE_mAOD_barrel","ele hadronic energy / em energy, barrel",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
+  h1_ele_HoE_mAOD_endcaps = bookH1withSumw2(iBooker, "HoE_mAOD_endcaps","ele hadronic energy / em energy, endcaps",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
   h1_ele_HoE_bc = bookH1withSumw2(iBooker, "HoE_bc","ele hadronic energy / em energy behind cluster",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
   h1_ele_HoE_bc_barrel = bookH1withSumw2(iBooker, "HoE_bc_barrel","ele hadronic energy / em energy, behind cluster barrel",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
   h1_ele_HoE_bc_endcaps = bookH1withSumw2(iBooker, "HoE_bc_endcaps","ele hadronic energy / em energy, behind cluster, endcaps",hoe_nbin, hoe_min, hoe_max,"H/E","Events","ELE_LOGY E1 P") ;
@@ -936,6 +987,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_ele_fbrem = bookH1withSumw2(iBooker, "fbrem","ele brem fraction, mode of GSF components",100,0.,1.,"P_{in} - P_{out} / P_{in}");
   h1_ele_fbrem_barrel = bookH1withSumw2(iBooker, "fbrem_barrel","ele brem fraction for barrel, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
   h1_ele_fbrem_endcaps = bookH1withSumw2(iBooker, "fbrem_endcaps", "ele brem franction for endcaps, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
+  h1_ele_fbrem_mAOD = bookH1withSumw2(iBooker, "fbrem_mAOD","ele brem fraction, mode of GSF components",100,0.,1.,"P_{in} - P_{out} / P_{in}");
+  h1_ele_fbrem_mAOD_barrel = bookH1withSumw2(iBooker, "fbrem_mAOD_barrel","ele brem fraction for barrel, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
+  h1_ele_fbrem_mAOD_endcaps = bookH1withSumw2(iBooker, "fbrem_mAOD_endcaps", "ele brem franction for endcaps, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
   h1_ele_superclusterfbrem = bookH1withSumw2(iBooker, "superclusterfbrem","supercluster brem fraction, mode of GSF components",100,0.,1.,"P_{in} - P_{out} / P_{in}");
   h1_ele_superclusterfbrem_barrel = bookH1withSumw2(iBooker, "superclusterfbrem_barrel","supercluster brem fraction for barrel, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
   h1_ele_superclusterfbrem_endcaps = bookH1withSumw2(iBooker, "superclusterfbrem_endcaps", "supercluster brem franction for endcaps, mode of GSF components", 100, 0.,1.,"P_{in} - P_{out} / P_{in}");
@@ -974,6 +1028,15 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_ele_photonRelativeIso = bookH1withSumw2(iBooker, "photonRelativeIso","photonRelativeIso",100,0.0,2.,"photonRelativeIso","Events","ELE_LOGY E1 P");
   h1_ele_photonRelativeIso_barrel = bookH1withSumw2(iBooker, "photonRelativeIso_barrel","photonRelativeIso for barrel",100,0.0,2.,"photonRelativeIso_barrel","Events","ELE_LOGY E1 P");
   h1_ele_photonRelativeIso_endcaps = bookH1withSumw2(iBooker, "photonRelativeIso_endcaps","photonRelativeIso for endcaps",100,0.0,2.,"photonRelativeIso_endcaps","Events","ELE_LOGY E1 P");
+  h1_ele_chargedHadronRelativeIso_mAOD = bookH1withSumw2(iBooker, "chargedHadronRelativeIso_mAOD","chargedHadronRelativeIso",100,0.0,2.,"chargedHadronRelativeIso","Events","ELE_LOGY E1 P");
+  h1_ele_chargedHadronRelativeIso_mAOD_barrel = bookH1withSumw2(iBooker, "chargedHadronRelativeIso_mAOD_barrel","chargedHadronRelativeIso for barrel",100,0.0,2.,"chargedHadronRelativeIso_barrel","Events","ELE_LOGY E1 P");
+  h1_ele_chargedHadronRelativeIso_mAOD_endcaps = bookH1withSumw2(iBooker, "chargedHadronRelativeIso_mAOD_endcaps","chargedHadronRelativeIso for endcaps",100,0.0,2.,"chargedHadronRelativeIso_endcaps","Events","ELE_LOGY E1 P");
+  h1_ele_neutralHadronRelativeIso_mAOD = bookH1withSumw2(iBooker, "neutralHadronRelativeIso_mAOD","neutralHadronRelativeIso",100,0.0,2.,"neutralHadronRelativeIso","Events","ELE_LOGY E1 P");
+  h1_ele_neutralHadronRelativeIso_mAOD_barrel = bookH1withSumw2(iBooker, "neutralHadronRelativeIso_mAOD_barrel","neutralHadronRelativeIso for barrel",100,0.0,2.,"neutralHadronRelativeIso_barrel","Events","ELE_LOGY E1 P");
+  h1_ele_neutralHadronRelativeIso_mAOD_endcaps = bookH1withSumw2(iBooker, "neutralHadronRelativeIso_mAOD_endcaps","neutralHadronRelativeIso for endcaps",100,0.0,2.,"neutralHadronRelativeIso_endcaps","Events","ELE_LOGY E1 P");
+  h1_ele_photonRelativeIso_mAOD = bookH1withSumw2(iBooker, "photonRelativeIso_mAOD","photonRelativeIso",100,0.0,2.,"photonRelativeIso","Events","ELE_LOGY E1 P");
+  h1_ele_photonRelativeIso_mAOD_barrel = bookH1withSumw2(iBooker, "photonRelativeIso_mAOD_barrel","photonRelativeIso for barrel",100,0.0,2.,"photonRelativeIso_barrel","Events","ELE_LOGY E1 P");
+  h1_ele_photonRelativeIso_mAOD_endcaps = bookH1withSumw2(iBooker, "photonRelativeIso_mAOD_endcaps","photonRelativeIso for endcaps",100,0.0,2.,"photonRelativeIso_endcaps","Events","ELE_LOGY E1 P");
 
   // conversion rejection information
   h1_ele_convFlags = bookH1withSumw2(iBooker, "convFlags","conversion rejection flag",5,-1.5,3.5);
@@ -1054,29 +1117,15 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
   //===============================================
 
   reco::GsfElectronCollection::const_iterator gsfIter ;
+  // mee only
   for ( gsfIter=gsfElectrons->begin() ; gsfIter!=gsfElectrons->end() ; gsfIter++ )
    {
     // preselect electrons
-    if (gsfIter->pt()>maxPt_ || std::abs(gsfIter->eta())>maxAbsEta_) continue ;
+//    if (gsfIter->pt()>maxPt_ || std::abs(gsfIter->eta())>maxAbsEta_) continue ;
 
     //
-    h1_ele_EoverP_all->Fill(gsfIter->eSuperClusterOverP()) ;
-    h1_ele_EseedOP_all->Fill(gsfIter->eSeedClusterOverP()) ;
-    h1_ele_EoPout_all->Fill(gsfIter->eSeedClusterOverPout()) ;
-    h1_ele_EeleOPout_all->Fill( gsfIter->eEleClusterOverPout()) ;
-    h1_ele_dEtaSc_propVtx_all->Fill(gsfIter->deltaEtaSuperClusterTrackAtVtx()) ;
-    h1_ele_dPhiSc_propVtx_all->Fill(gsfIter->deltaPhiSuperClusterTrackAtVtx()) ;
-    h1_ele_dEtaCl_propOut_all->Fill(gsfIter->deltaEtaSeedClusterTrackAtCalo()) ;
-    h1_ele_dPhiCl_propOut_all->Fill(gsfIter->deltaPhiSeedClusterTrackAtCalo()) ;
-    h1_ele_HoE_all->Fill(gsfIter->hcalOverEcal()) ;
-    h1_ele_HoE_bc_all->Fill(gsfIter->hcalOverEcalBc()) ;
-    h1_ele_TIP_all->Fill( EleRelPoint(gsfIter->vertex(),theBeamSpot->position()).perp() );
-    h1_ele_vertexEta_all->Fill( gsfIter->eta() );
-    h1_ele_vertexPt_all->Fill( gsfIter->pt() );
-    h1_ele_Et_all->Fill( gsfIter->ecalEnergy()/cosh(gsfIter->superCluster()->eta()));
     float enrj1=gsfIter->ecalEnergy();
 
-    // mee
     reco::GsfElectronCollection::const_iterator gsfIter2 ;
     for ( gsfIter2=gsfIter+1 ; gsfIter2!=gsfElectrons->end() ; gsfIter2++ )
      {
@@ -1109,6 +1158,29 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
          { h1_ele_mee_os_gb->Fill(sqrt(mee2)) ; }
        }
      }
+
+   }
+
+     for ( gsfIter=gsfElectrons->begin() ; gsfIter!=gsfElectrons->end() ; gsfIter++ )
+   {
+    // preselect electrons
+    if (gsfIter->pt()>maxPt_ || std::abs(gsfIter->eta())>maxAbsEta_) continue ;
+
+    //
+    h1_ele_EoverP_all->Fill(gsfIter->eSuperClusterOverP()) ;
+    h1_ele_EseedOP_all->Fill(gsfIter->eSeedClusterOverP()) ;
+    h1_ele_EoPout_all->Fill(gsfIter->eSeedClusterOverPout()) ;
+    h1_ele_EeleOPout_all->Fill( gsfIter->eEleClusterOverPout()) ;
+    h1_ele_dEtaSc_propVtx_all->Fill(gsfIter->deltaEtaSuperClusterTrackAtVtx()) ;
+    h1_ele_dPhiSc_propVtx_all->Fill(gsfIter->deltaPhiSuperClusterTrackAtVtx()) ;
+    h1_ele_dEtaCl_propOut_all->Fill(gsfIter->deltaEtaSeedClusterTrackAtCalo()) ;
+    h1_ele_dPhiCl_propOut_all->Fill(gsfIter->deltaPhiSeedClusterTrackAtCalo()) ;
+    h1_ele_HoE_all->Fill(gsfIter->hcalOverEcal()) ;
+    h1_ele_HoE_bc_all->Fill(gsfIter->hcalOverEcalBc()) ;
+    h1_ele_TIP_all->Fill( EleRelPoint(gsfIter->vertex(),theBeamSpot->position()).perp() );
+    h1_ele_vertexEta_all->Fill( gsfIter->eta() );
+    h1_ele_vertexPt_all->Fill( gsfIter->pt() );
+    h1_ele_Et_all->Fill( gsfIter->ecalEnergy()/cosh(gsfIter->superCluster()->eta()));
 
     // conversion rejection
     int flags = gsfIter->convFlags() ;
@@ -1173,8 +1245,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
           double dphi = gsfIter->phi()-mcIter->phi() ;
           if (std::abs(dphi)>CLHEP::pi)
            { dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
-          double deltaR = sqrt(pow((gsfIter->eta()-mcIter->eta()),2) + pow(dphi,2)) ;
-          if ( deltaR < deltaR_ )
+//          double deltaR = sqrt(pow((gsfIter->eta()-mcIter->eta()),2) + pow(dphi,2)) ;
+          double deltaR2 = (gsfIter->eta()-mcIter->eta()) * (gsfIter->eta()-mcIter->eta()) + dphi * dphi ;
+          if ( deltaR2 < deltaR2_ )
            {
             double mc_charge = mcIter->pdgId() == 11 ? -1. : 1. ;
             h1_ele_ChargeMnChargeTrue->Fill( std::abs(gsfIter->charge()-mc_charge));
@@ -1261,6 +1334,7 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
 
     // find best matched electron
     bool okGsfFound = false ;
+    bool passMiniAODSelection = true ;
     double gsfOkRatio = 999999. ;
     reco::GsfElectron bestGsfElectron ;
     reco::GsfElectronRef bestGsfElectronRef ;
@@ -1268,11 +1342,13 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     reco::GsfElectronCollection::size_type iElectron ;
     for ( gsfIter=gsfElectrons->begin(), iElectron=0 ; gsfIter!=gsfElectrons->end() ; gsfIter++, iElectron++ )
      {
+		// temporary cut for pt < 5.
       double dphi = gsfIter->phi()-mcIter->phi() ;
       if (std::abs(dphi)>CLHEP::pi)
        { dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
-      double deltaR = sqrt(pow((gsfIter->eta()-mcIter->eta()),2) + pow(dphi,2));
-      if ( deltaR < deltaR_ )
+//      double deltaR = sqrt(pow((gsfIter->eta()-mcIter->eta()),2) + pow(dphi,2));
+      double deltaR2 = (gsfIter->eta()-mcIter->eta()) * (gsfIter->eta()-mcIter->eta()) + dphi * dphi;
+      if ( deltaR2 < deltaR2_ )
        {
         if ( ( (mcIter->pdgId() == 11) && (gsfIter->charge() < 0.) ) ||
              ( (mcIter->pdgId() == -11) && (gsfIter->charge() > 0.) ) )
@@ -1293,6 +1369,7 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     //------------------------------------
     // analysis when the mc track is found
     //------------------------------------
+    passMiniAODSelection = bestGsfElectron.pt() >= 5.;
 
     // electron related distributions
     h1_ele_charge->Fill( bestGsfElectron.charge() );
@@ -1301,6 +1378,7 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_chargeVsPt->Fill( bestGsfElectron.pt(),bestGsfElectron.charge() );
     h1_ele_vertexP->Fill( bestGsfElectron.p() );
     h1_ele_vertexPt->Fill( bestGsfElectron.pt() );
+    if (bestGsfElectron.scSigmaIEtaIEta()==0.) h1_ele_vertexPt_nocut->Fill( bestGsfElectron.pt() );
     h1_ele_Et->Fill( bestGsfElectron.ecalEnergy()/cosh(bestGsfElectron.superCluster()->eta()));
     h2_ele_vertexPtVsEta->Fill(  bestGsfElectron.eta(),bestGsfElectron.pt() );
     h2_ele_vertexPtVsPhi->Fill(  bestGsfElectron.phi(),bestGsfElectron.pt() );
@@ -1348,6 +1426,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_PoPtrueVsEta->Fill( bestGsfElectron.eta(), bestGsfElectron.p()/mcIter->p());
     h2_ele_PoPtrueVsPhi->Fill( bestGsfElectron.phi(), bestGsfElectron.p()/mcIter->p());
     h2_ele_PoPtrueVsPt->Fill( bestGsfElectron.py(), bestGsfElectron.p()/mcIter->p());
+    if (passMiniAODSelection) { // Pt > 5.
+        h2_ele_sigmaIetaIetaVsPt->Fill( bestGsfElectron.pt(), bestGsfElectron.scSigmaIEtaIEta());
+    }
     if (bestGsfElectron.isEB()) h1_ele_PoPtrue_barrel->Fill( bestGsfElectron.p()/mcIter->p());
     if (bestGsfElectron.isEE()) h1_ele_PoPtrue_endcaps->Fill( bestGsfElectron.p()/mcIter->p());
     if (bestGsfElectron.isEB() && bestGsfElectron.classification() == GsfElectron::GOLDEN) h1_ele_PoPtrue_golden_barrel->Fill( bestGsfElectron.p()/mcIter->p());
@@ -1396,6 +1477,11 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h1_scl_SigIEtaIEta->Fill(bestGsfElectron.scSigmaIEtaIEta());
     if (bestGsfElectron.isEB()) h1_scl_SigIEtaIEta_barrel->Fill(bestGsfElectron.scSigmaIEtaIEta());
     if (bestGsfElectron.isEE()) h1_scl_SigIEtaIEta_endcaps->Fill(bestGsfElectron.scSigmaIEtaIEta());
+    if (passMiniAODSelection) { // Pt > 5.
+        h1_scl_SigIEtaIEta_mAOD->Fill(bestGsfElectron.scSigmaIEtaIEta());
+        if (bestGsfElectron.isEB()) h1_scl_SigIEtaIEta_mAOD_barrel->Fill(bestGsfElectron.scSigmaIEtaIEta());
+        if (bestGsfElectron.isEE()) h1_scl_SigIEtaIEta_mAOD_endcaps->Fill(bestGsfElectron.scSigmaIEtaIEta());
+    }
     h1_scl_full5x5_sigmaIetaIeta->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
     if (bestGsfElectron.isEB()) h1_scl_full5x5_sigmaIetaIeta_barrel->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
     if (bestGsfElectron.isEE()) h1_scl_full5x5_sigmaIetaIeta_endcaps->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
@@ -1433,6 +1519,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
       if (bestGsfElectron.isEB()) h1_ele_foundHits_barrel->Fill( bestGsfElectron.gsfTrack()->numberOfValidHits() );
       if (bestGsfElectron.isEE()) h1_ele_foundHits_endcaps->Fill( bestGsfElectron.gsfTrack()->numberOfValidHits() );
       h2_ele_foundHitsVsEta->Fill( bestGsfElectron.eta(), bestGsfElectron.gsfTrack()->numberOfValidHits() );
+      if (passMiniAODSelection) { // Pt > 5.
+        h2_ele_foundHitsVsEta_mAOD->Fill( bestGsfElectron.eta(), bestGsfElectron.gsfTrack()->numberOfValidHits() );
+      }
       h2_ele_foundHitsVsPhi->Fill( bestGsfElectron.phi(), bestGsfElectron.gsfTrack()->numberOfValidHits() );
       h2_ele_foundHitsVsPt->Fill( bestGsfElectron.pt(), bestGsfElectron.gsfTrack()->numberOfValidHits() );
       h1_ele_lostHits->Fill( bestGsfElectron.gsfTrack()->numberOfLostHits() );
@@ -1537,8 +1626,15 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_EeleOPoutVsPhi->Fill( bestGsfElectron.phi(), bestGsfElectron.eEleClusterOverPout() );
     h2_ele_EeleOPoutVsE->Fill( bestGsfElectron.caloEnergy(), bestGsfElectron.eEleClusterOverPout() );
     h1_ele_dEtaSc_propVtx->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+    if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_dEtaSc_propVtx_mAOD->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+    }
     if (bestGsfElectron.isEB()) h1_ele_dEtaSc_propVtx_barrel->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
     if (bestGsfElectron.isEE())h1_ele_dEtaSc_propVtx_endcaps->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+    if (passMiniAODSelection) { // Pt > 5.
+        if (bestGsfElectron.isEB()) h1_ele_dEtaSc_propVtx_mAOD_barrel->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+        if (bestGsfElectron.isEE())h1_ele_dEtaSc_propVtx_mAOD_endcaps->Fill(bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
+    }
     h2_ele_dEtaScVsEta_propVtx->Fill( bestGsfElectron.eta(),bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
     h2_ele_dEtaScVsPhi_propVtx->Fill(bestGsfElectron.phi(),bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
     h2_ele_dEtaScVsPt_propVtx->Fill(bestGsfElectron.pt(),bestGsfElectron.deltaEtaSuperClusterTrackAtVtx());
@@ -1555,8 +1651,15 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_dEtaClVsPhi_propOut->Fill(bestGsfElectron.phi(),bestGsfElectron.deltaEtaSeedClusterTrackAtCalo());
     h2_ele_dEtaClVsPt_propOut->Fill(bestGsfElectron.pt(),bestGsfElectron.deltaEtaSeedClusterTrackAtCalo());
     h1_ele_dPhiCl_propOut->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+    if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_dPhiCl_propOut_mAOD->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+    }
     if (bestGsfElectron.isEB()) h1_ele_dPhiCl_propOut_barrel->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
     if (bestGsfElectron.isEE()) h1_ele_dPhiCl_propOut_endcaps->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+    if (passMiniAODSelection) { // Pt > 5.
+        if (bestGsfElectron.isEB()) h1_ele_dPhiCl_propOut_mAOD_barrel->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+        if (bestGsfElectron.isEE()) h1_ele_dPhiCl_propOut_mAOD_endcaps->Fill(bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
+    }
     h2_ele_dPhiClVsEta_propOut->Fill( bestGsfElectron.eta(),bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
     h2_ele_dPhiClVsPhi_propOut->Fill(bestGsfElectron.phi(),bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
     h2_ele_dPhiClVsPt_propOut->Fill(bestGsfElectron.pt(),bestGsfElectron.deltaPhiSeedClusterTrackAtCalo());
@@ -1573,11 +1676,18 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_dPhiEleClVsPhi_propOut->Fill(bestGsfElectron.phi(),bestGsfElectron.deltaPhiEleClusterTrackAtCalo());
     h2_ele_dPhiEleClVsPt_propOut->Fill(bestGsfElectron.pt(),bestGsfElectron.deltaPhiEleClusterTrackAtCalo());
     h1_ele_HoE->Fill(bestGsfElectron.hcalOverEcal());
+    if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_HoE_mAOD->Fill(bestGsfElectron.hcalOverEcal());
+    }
     h1_ele_HoE_bc->Fill(bestGsfElectron.hcalOverEcalBc());
     if (bestGsfElectron.isEB()) h1_ele_HoE_bc_barrel->Fill(bestGsfElectron.hcalOverEcalBc());
     if (bestGsfElectron.isEE()) h1_ele_HoE_bc_endcaps->Fill(bestGsfElectron.hcalOverEcalBc());
     if (bestGsfElectron.isEB()) h1_ele_HoE_barrel->Fill(bestGsfElectron.hcalOverEcal());
     if (bestGsfElectron.isEE()) h1_ele_HoE_endcaps->Fill(bestGsfElectron.hcalOverEcal());
+    if (passMiniAODSelection) { // Pt > 5.
+        if (bestGsfElectron.isEB()) h1_ele_HoE_mAOD_barrel->Fill(bestGsfElectron.hcalOverEcal());
+        if (bestGsfElectron.isEE()) h1_ele_HoE_mAOD_endcaps->Fill(bestGsfElectron.hcalOverEcal());
+    }
     if (!bestGsfElectron.isEBEtaGap() && !bestGsfElectron.isEBPhiGap()&& !bestGsfElectron.isEBEEGap() &&
         !bestGsfElectron.isEERingGap() && !bestGsfElectron.isEEDeeGap()) h1_ele_HoE_fiducial->Fill(bestGsfElectron.hcalOverEcal());
     h2_ele_HoEVsEta->Fill( bestGsfElectron.eta(),bestGsfElectron.hcalOverEcal());
@@ -1604,17 +1714,25 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
 
     double fbrem_mode =  bestGsfElectron.fbrem();
     h1_ele_fbrem->Fill(fbrem_mode);
-
+    if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_fbrem_mAOD->Fill(fbrem_mode);
+    }
     if (bestGsfElectron.isEB())
      {
       double fbrem_mode_barrel = bestGsfElectron.fbrem();
       h1_ele_fbrem_barrel->Fill(fbrem_mode_barrel);
+      if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_fbrem_mAOD_barrel->Fill(fbrem_mode_barrel);
+      }
      }
 
     if (bestGsfElectron.isEE())
      {
       double fbrem_mode_endcaps = bestGsfElectron.fbrem();
       h1_ele_fbrem_endcaps->Fill(fbrem_mode_endcaps);
+      if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_fbrem_mAOD_endcaps->Fill(fbrem_mode_endcaps);
+      }
      }
 
     double superclusterfbrem_mode =  bestGsfElectron.superClusterFbrem();
@@ -1702,14 +1820,29 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
 	h1_ele_chargedHadronRelativeIso->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
 	if (bestGsfElectron.isEB()) h1_ele_chargedHadronRelativeIso_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
 	if (bestGsfElectron.isEE()) h1_ele_chargedHadronRelativeIso_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+    if (passMiniAODSelection) { // Pt > 5.
+	h1_ele_chargedHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+        if (bestGsfElectron.isEB()) h1_ele_chargedHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+        if (bestGsfElectron.isEE()) h1_ele_chargedHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumChargedHadronPt / bestGsfElectron.pt());
+    }
 
     h1_ele_neutralHadronRelativeIso->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
     if (bestGsfElectron.isEB()) h1_ele_neutralHadronRelativeIso_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
     if (bestGsfElectron.isEE()) h1_ele_neutralHadronRelativeIso_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+    if (passMiniAODSelection) { // Pt > 5.
+        h1_ele_neutralHadronRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+        if (bestGsfElectron.isEB()) h1_ele_neutralHadronRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+        if (bestGsfElectron.isEE()) h1_ele_neutralHadronRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumNeutralHadronEt / bestGsfElectron.pt());
+    }
 
     h1_ele_photonRelativeIso->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
     if (bestGsfElectron.isEB()) h1_ele_photonRelativeIso_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
     if (bestGsfElectron.isEE()) h1_ele_photonRelativeIso_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+    if (passMiniAODSelection) { // Pt > 5.
+    h1_ele_photonRelativeIso_mAOD->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+        if (bestGsfElectron.isEB()) h1_ele_photonRelativeIso_mAOD_barrel->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+        if (bestGsfElectron.isEE()) h1_ele_photonRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt / bestGsfElectron.pt());
+    }
 
     // isolation
     h1_ele_tkSumPt_dr03->Fill(bestGsfElectron.dr03TkSumPt());

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -36,7 +36,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     edm::EDGetTokenT<reco::GsfElectronCoreCollection> electronCoreCollection_;
     edm::EDGetTokenT<reco::GsfTrackCollection> electronTrackCollection_;
     edm::EDGetTokenT<reco::ElectronSeedCollection> electronSeedCollection_;
-    edm::EDGetTokenT<reco::VertexCollection> offlineVerticesCollection_; 
+    edm::EDGetTokenT<reco::VertexCollection> offlineVerticesCollection_;
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_ ;
     bool readAOD_;
 
@@ -58,7 +58,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
 
     double maxPt_;
     double maxAbsEta_;
-    double deltaR_;
+    double deltaR_, deltaR2_;
     std::vector<int> matchingIDs_;
     std::vector<int> matchingMotherIDs_;
     std::string inputFile_ ;
@@ -96,7 +96,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_recCoreNum;
     MonitorElement *h1_recTrackNum;
     MonitorElement *h1_recSeedNum;
-    MonitorElement *h1_recOfflineVertices; 
+    MonitorElement *h1_recOfflineVertices;
     MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices; // new 2015.15.05
     MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_barrel; // new 2015.15.05
     MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_endcaps; // new 2015.15.05
@@ -175,6 +175,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_ele_chargeVsPt;
     MonitorElement *h1_ele_vertexP;
     MonitorElement *h1_ele_vertexPt;
+    MonitorElement *h1_ele_vertexPt_nocut;
     MonitorElement *h1_ele_Et;
     MonitorElement *h2_ele_vertexPtVsEta;
     MonitorElement *h2_ele_vertexPtVsPhi;
@@ -227,6 +228,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_scl_SigIEtaIEta;
     MonitorElement *h1_scl_SigIEtaIEta_barrel;
     MonitorElement *h1_scl_SigIEtaIEta_endcaps;
+    MonitorElement *h1_scl_SigIEtaIEta_mAOD;
+    MonitorElement *h1_scl_SigIEtaIEta_mAOD_barrel;
+    MonitorElement *h1_scl_SigIEtaIEta_mAOD_endcaps;
     MonitorElement *h1_scl_full5x5_sigmaIetaIeta; 
     MonitorElement *h1_scl_full5x5_sigmaIetaIeta_barrel; 
     MonitorElement *h1_scl_full5x5_sigmaIetaIeta_endcaps; 
@@ -251,6 +255,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_ele_foundHits_barrel;
     MonitorElement *h1_ele_foundHits_endcaps;
     MonitorElement *h2_ele_foundHitsVsEta;
+    MonitorElement *h2_ele_foundHitsVsEta_mAOD;
     MonitorElement *h2_ele_foundHitsVsPhi;
     MonitorElement *h2_ele_foundHitsVsPt;
     MonitorElement *h1_ele_lostHits;
@@ -300,7 +305,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_ele_PinMnPoutVsPt_mode;
     MonitorElement *h2_ele_PinMnPoutVsE_mode;
     MonitorElement *h2_ele_PinMnPoutVsChi2_mode;
-
+    MonitorElement *h2_ele_sigmaIetaIetaVsPt;
     MonitorElement *h1_ele_outerP;
     MonitorElement *h1_ele_outerP_mode;
     MonitorElement *h2_ele_outerPVsEta_mode;
@@ -337,6 +342,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_ele_dEtaSc_propVtx;
     MonitorElement *h1_ele_dEtaSc_propVtx_barrel;
     MonitorElement *h1_ele_dEtaSc_propVtx_endcaps;
+    MonitorElement *h1_ele_dEtaSc_propVtx_mAOD;
+    MonitorElement *h1_ele_dEtaSc_propVtx_mAOD_barrel;
+    MonitorElement *h1_ele_dEtaSc_propVtx_mAOD_endcaps;
     MonitorElement *h2_ele_dEtaScVsEta_propVtx;
     MonitorElement *h2_ele_dEtaScVsPhi_propVtx;
     MonitorElement *h2_ele_dEtaScVsPt_propVtx;
@@ -355,6 +363,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_ele_dPhiCl_propOut;
     MonitorElement *h1_ele_dPhiCl_propOut_barrel;
     MonitorElement *h1_ele_dPhiCl_propOut_endcaps;
+    MonitorElement *h1_ele_dPhiCl_propOut_mAOD;
+    MonitorElement *h1_ele_dPhiCl_propOut_mAOD_barrel;
+    MonitorElement *h1_ele_dPhiCl_propOut_mAOD_endcaps;
     MonitorElement *h2_ele_dPhiClVsEta_propOut;
     MonitorElement *h2_ele_dPhiClVsPhi_propOut;
     MonitorElement *h2_ele_dPhiClVsPt_propOut;
@@ -405,14 +416,19 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_ele_HoEVsEta;
     MonitorElement *h2_ele_HoEVsPhi;
     MonitorElement *h2_ele_HoEVsE;
+    MonitorElement *h1_ele_HoE_mAOD;
+    MonitorElement *h1_ele_HoE_mAOD_barrel;
+    MonitorElement *h1_ele_HoE_mAOD_endcaps;
 
     MonitorElement *h1_ele_fbrem;
     MonitorElement *h1_ele_fbrem_barrel;
     MonitorElement *h1_ele_fbrem_endcaps;
+    MonitorElement *h1_ele_fbrem_mAOD;
+    MonitorElement *h1_ele_fbrem_mAOD_barrel;
+    MonitorElement *h1_ele_fbrem_mAOD_endcaps;
     MonitorElement *h1_ele_superclusterfbrem; 
     MonitorElement *h1_ele_superclusterfbrem_barrel; 
     MonitorElement *h1_ele_superclusterfbrem_endcaps; 
-
     MonitorElement *p1_ele_fbremVsEta_mode;
     MonitorElement *p1_ele_fbremVsEta_mean;
 
@@ -459,7 +475,15 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
 	MonitorElement *h1_ele_photonRelativeIso;
 	MonitorElement *h1_ele_photonRelativeIso_barrel;
     MonitorElement *h1_ele_photonRelativeIso_endcaps;
-
+	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD;
+	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_endcaps;
+	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD;
+	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_endcaps;
+	MonitorElement *h1_ele_photonRelativeIso_mAOD;
+	MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
     // isolation
     MonitorElement *h1_ele_tkSumPt_dr03;
     MonitorElement *h1_ele_tkSumPt_dr03_barrel;

--- a/Validation/RecoEgamma/plugins/SealModule.cc
+++ b/Validation/RecoEgamma/plugins/SealModule.cc
@@ -12,9 +12,13 @@
 #include "Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h"
 #include "Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.h"
 #include "Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.h"
+#include "Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h"
+#include "Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalPostValidator.h"
 
 
 DEFINE_FWK_MODULE(EgammaObjects);
+DEFINE_FWK_MODULE(ElectronMcSignalValidatorMiniAOD);
+DEFINE_FWK_MODULE(ElectronMcSignalPostValidatorMiniAOD);
 DEFINE_FWK_MODULE(PhotonValidator);
 DEFINE_FWK_MODULE(PhotonValidatorMiniAOD);
 DEFINE_FWK_MODULE(TkConvValidator);

--- a/Validation/RecoEgamma/python/ElectronMcSignalPostValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalPostValidatorMiniAOD_cfi.py
@@ -1,0 +1,21 @@
+
+import FWCore.ParameterSet.Config as cms
+
+electronMcSignalHistosCfg = cms.PSet(
+  EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
+)
+
+electronMcSignalPostValidatorMiniAOD = cms.EDAnalyzer("ElectronMcSignalPostValidatorMiniAOD",
+
+  Verbosity = cms.untracked.int32(0),
+  FinalStep = cms.string("AtJobEnd"),
+  InputFile = cms.string(""),
+  OutputFile = cms.string(""),
+  InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"),
+  OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"),
+    
+  histosCfg = cms.PSet(electronMcSignalHistosCfg)
+)
+
+
+

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+electronMcSignalHistosCfg = cms.PSet(
+  Nbinxyz = cms.int32(50),
+  Nbinpt = cms.int32(50), Nbinpt2D = cms.int32(50), Nbinpteff = cms.int32(19),Ptmax = cms.double(100.0),
+  Nbinfhits = cms.int32(30), Fhitsmax = cms.double(30.0),
+  Nbineta = cms.int32(50), Nbineta2D = cms.int32(50),Etamin = cms.double(-2.5), Etamax = cms.double(2.5),
+  Nbindeta = cms.int32(100), Detamin = cms.double(-0.005), Detamax = cms.double(0.005), 
+  Nbindetamatch = cms.int32(100), Nbindetamatch2D = cms.int32(50), Detamatchmin = cms.double(-0.05), Detamatchmax = cms.double(0.05),
+  Nbinphi = cms.int32(64), Nbinphi2D = cms.int32(32), Phimin = cms.double(-3.2), Phimax = cms.double(3.2),
+  Nbindphi = cms.int32(100), Dphimin = cms.double(-0.01), Dphimax = cms.double(0.01),
+  Nbindphimatch = cms.int32(100), Nbindphimatch2D = cms.int32(50), Dphimatchmin = cms.double(-0.2), Dphimatchmax = cms.double(0.2),
+  Nbinmee = cms.int32(100), Meemin = cms.double(0.0), Meemax = cms.double(150.),
+  Nbinhoe = cms.int32(100), Hoemin = cms.double(0.0), Hoemax = cms.double(0.5),
+  Nbinpoptrue = cms.int32(75), Poptruemin = cms.double(0.0), Poptruemax = cms.double(1.5),
+  EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
+)
+
+electronMcSignalValidatorMiniAOD = cms.EDAnalyzer("ElectronMcSignalValidatorMiniAOD",
+
+    Verbosity = cms.untracked.int32(0),
+    FinalStep = cms.string("AtJobEnd"),
+    InputFile = cms.string(""),
+    OutputFile = cms.string(""),
+    InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"), # 
+    OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"), # 
+
+    mcTruthCollection = cms.InputTag("prunedGenParticles"),
+    electrons = cms.InputTag("slimmedElectrons"),
+
+    MaxPt = cms.double(100.0),
+    DeltaR = cms.double(0.05),
+    MaxAbsEta = cms.double(2.5),
+    MatchingID = cms.vint32(11,-11),
+    MatchingMotherID = cms.vint32(23,24,-24,32),
+    histosCfg = cms.PSet(electronMcSignalHistosCfg)
+)

--- a/Validation/RecoEgamma/python/egammaPostValidationMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/egammaPostValidationMiniAOD_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoEgamma.electronPostValidationSequenceMiniAOD_cff import *
+
+egammaPostValidationMiniAOD = cms.Sequence(electronPostValidationSequenceMiniAOD)

--- a/Validation/RecoEgamma/python/egammaPostValidationMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/egammaPostValidationMiniAOD_cff.py
@@ -2,4 +2,4 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoEgamma.electronPostValidationSequenceMiniAOD_cff import *
 
-egammaPostValidationMiniAOD = cms.Sequence(electronPostValidationSequenceMiniAOD)
+egammaPostValidationMiniAOD = cms.Sequence( electronPostValidationSequenceMiniAOD )

--- a/Validation/RecoEgamma/python/egammaPostValidation_cff.py
+++ b/Validation/RecoEgamma/python/egammaPostValidation_cff.py
@@ -4,4 +4,3 @@ from Validation.RecoEgamma.photonPostProcessor_cff import *
 from Validation.RecoEgamma.electronPostValidationSequence_cff import *
 
 egammaPostValidation = cms.Sequence(photonPostProcessor+electronPostValidationSequence)
-egammaPostValidationMiniAOD = cms.Sequence(electronPostValidationSequenceMiniAOD)

--- a/Validation/RecoEgamma/python/egammaPostValidation_cff.py
+++ b/Validation/RecoEgamma/python/egammaPostValidation_cff.py
@@ -4,3 +4,4 @@ from Validation.RecoEgamma.photonPostProcessor_cff import *
 from Validation.RecoEgamma.electronPostValidationSequence_cff import *
 
 egammaPostValidation = cms.Sequence(photonPostProcessor+electronPostValidationSequence)
+egammaPostValidationMiniAOD = cms.Sequence(electronPostValidationSequenceMiniAOD)

--- a/Validation/RecoEgamma/python/egammaValidationMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/egammaValidationMiniAOD_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoEgamma.electronValidationSequenceMiniAOD_cff import *
+
+egammaValidationMiniAOD = cms.Sequence(electronValidationSequenceMiniAOD)

--- a/Validation/RecoEgamma/python/egammaValidationMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/egammaValidationMiniAOD_cff.py
@@ -2,4 +2,4 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoEgamma.electronValidationSequenceMiniAOD_cff import *
 
-egammaValidationMiniAOD = cms.Sequence(electronValidationSequenceMiniAOD)
+egammaValidationMiniAOD = cms.Sequence( electronValidationSequenceMiniAOD )

--- a/Validation/RecoEgamma/python/egammaValidation_cff.py
+++ b/Validation/RecoEgamma/python/egammaValidation_cff.py
@@ -9,3 +9,4 @@ pfPhotonValidation.isRunCentrally = True
 tkConversionValidation.isRunCentrally = True
 
 egammaValidation = cms.Sequence(electronValidationSequence+photonValidationSequence)
+egammaValidationMiniAOD = cms.Sequence(electronValidationSequenceMiniAOD)

--- a/Validation/RecoEgamma/python/egammaValidation_cff.py
+++ b/Validation/RecoEgamma/python/egammaValidation_cff.py
@@ -9,4 +9,3 @@ pfPhotonValidation.isRunCentrally = True
 tkConversionValidation.isRunCentrally = True
 
 egammaValidation = cms.Sequence(electronValidationSequence+photonValidationSequence)
-egammaValidationMiniAOD = cms.Sequence(electronValidationSequenceMiniAOD)

--- a/Validation/RecoEgamma/python/electronPostValidationSequenceMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/electronPostValidationSequenceMiniAOD_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoEgamma.ElectronMcSignalPostValidatorMiniAOD_cfi import *
+
+electronPostValidationSequenceMiniAOD = cms.Sequence(electronMcSignalPostValidatorMiniAOD)
+

--- a/Validation/RecoEgamma/python/electronPostValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/electronPostValidationSequence_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoEgamma.ElectronMcSignalPostValidator_cfi import *
 from Validation.RecoEgamma.ElectronMcFakePostValidator_cfi import *
 from Validation.RecoEgamma.ElectronMcSignalPostValidatorPt1000_cfi import *
+from Validation.RecoEgamma.ElectronMcSignalPostValidatorMiniAOD_cfi import *
 
 electronPostValidationSequence = cms.Sequence(electronMcSignalPostValidator+electronMcFakePostValidator+electronMcSignalPostValidatorPt1000)
-
+electronPostValidationSequenceMiniAOD = cms.Sequence(electronMcSignalPostValidatorMiniAOD)

--- a/Validation/RecoEgamma/python/electronPostValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/electronPostValidationSequence_cff.py
@@ -3,7 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoEgamma.ElectronMcSignalPostValidator_cfi import *
 from Validation.RecoEgamma.ElectronMcFakePostValidator_cfi import *
 from Validation.RecoEgamma.ElectronMcSignalPostValidatorPt1000_cfi import *
-from Validation.RecoEgamma.ElectronMcSignalPostValidatorMiniAOD_cfi import *
 
 electronPostValidationSequence = cms.Sequence(electronMcSignalPostValidator+electronMcFakePostValidator+electronMcSignalPostValidatorPt1000)
-electronPostValidationSequenceMiniAOD = cms.Sequence(electronMcSignalPostValidatorMiniAOD)

--- a/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi import * 
+ 
+electronValidationSequenceMiniAOD = cms.Sequence(electronMcSignalValidatorMiniAOD)
+

--- a/Validation/RecoEgamma/python/electronValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/electronValidationSequence_cff.py
@@ -4,6 +4,8 @@ from Validation.RecoEgamma.electronIsoFromDeps_cff import *
 from Validation.RecoEgamma.ElectronMcSignalValidator_gedGsfElectrons_cfi import *
 from Validation.RecoEgamma.ElectronMcFakeValidator_gedGsfElectrons_cfi import *
 from Validation.RecoEgamma.ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi import *
-
+from Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi import * 
+ 
 electronValidationSequence = cms.Sequence(electronIsoFromDeps+electronMcSignalValidator+electronMcFakeValidator+electronMcSignalValidatorPt1000)
+electronValidationSequenceMiniAOD = cms.Sequence(electronMcSignalValidatorMiniAOD)
 

--- a/Validation/RecoEgamma/python/electronValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/electronValidationSequence_cff.py
@@ -4,8 +4,6 @@ from Validation.RecoEgamma.electronIsoFromDeps_cff import *
 from Validation.RecoEgamma.ElectronMcSignalValidator_gedGsfElectrons_cfi import *
 from Validation.RecoEgamma.ElectronMcFakeValidator_gedGsfElectrons_cfi import *
 from Validation.RecoEgamma.ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi import *
-from Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi import * 
  
 electronValidationSequence = cms.Sequence(electronIsoFromDeps+electronMcSignalValidator+electronMcFakeValidator+electronMcSignalValidatorPt1000)
-electronValidationSequenceMiniAOD = cms.Sequence(electronMcSignalValidatorMiniAOD)
 

--- a/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
@@ -35,7 +35,9 @@ process.electronMcFakePostValidator.InputFolderName = cms.string("EgammaV/Electr
 process.electronMcFakePostValidator.OutputFolderName = cms.string("EgammaV/ElectronMcFakeValidator")
 
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'
 process.dqmsave_step = cms.Path(process.DQMSaver)

--- a/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
@@ -32,6 +32,7 @@ from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
@@ -29,8 +29,9 @@ process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-
+#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -117,6 +117,7 @@ ElectronMcSignalValidator/h_ele_hcalDepth2OverEcalBc		    1 1 0 0
 ElectronMcSignalValidator/h_ele_hcalDepth2OverEcalBc_barrel	    1 1 0 0
 ElectronMcSignalValidator/h_ele_hcalDepth2OverEcalBc_endcaps        1 1 1 0
 ElectronMcSignalValidator/h_ele_HoE_fiducial                1 1 1 0
+ElectronMcSignalValidator/h_ele_sigmaIetaIetaVsPt_pfx           1 1 1 0
 ElectronMcSignalValidator/h_scl_sigietaieta                 1 1 0 0
 ElectronMcSignalValidator/h_scl_sigietaieta_barrel          1 1 0 0
 ElectronMcSignalValidator/h_scl_sigietaieta_endcaps         1 1 1 0

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistosMiniAOD.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistosMiniAOD.txt
@@ -1,0 +1,62 @@
+
+Collections sizes
+
+ElectronMcSignalValidatorMiniAOD/h_recEleNum                       1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_recEleNum                       1 1 1 1
+
+Basic electron quantities
+
+ElectronMcSignalValidatorMiniAOD/h_ele_vertexPt                    1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_vertexEta                   1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_vertexPt_nocut              1 1 1 1
+
+Comparison with MC truth (residuals)
+
+ElectronMcSignalValidatorMiniAOD/h_ele_PoPtrueVsEta_pfx            0 1 1 1
+
+Track-cluster matching observables
+
+ElectronMcSignalValidatorMiniAOD/h_ele_dEtaSc_propVtx_mAOD                  1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_dEtaSc_propVtx_mAOD_barrel          1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_dEtaSc_propVtx_mAOD_endcaps         1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_dPhiCl_propOut_mAOD                1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_dPhiCl_propOut_mAOD_barrel         1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_dPhiCl_propOut_mAOD_endcaps   1 1 1 1
+
+Electron Cluster shapes
+
+ElectronMcSignalValidatorMiniAOD/h_ele_HoE_mAOD                         1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_HoE_mAOD_barrel                  1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_HoE_mAOD_endcaps                 1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_sigmaIetaIetaVsPt_pfx            1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_scl_SigIEtaIEta_mAOD                 1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_scl_SigIEtaIEta_mAOD_barrel          1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_scl_SigIEtaIEta_mAOD_endcaps         1 1 1 1
+
+Electron track variables
+
+ElectronMcSignalValidatorMiniAOD/h_ele_foundHitsVsEta_pfx          0 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_foundHitsVsEta_mAOD_pfx          0 1 1 1
+
+Brem fraction and related distributions
+
+ElectronMcSignalValidatorMiniAOD/h_ele_fbrem_mAOD                       1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_fbrem_mAOD_barrel                1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_fbrem_mAOD_endcaps               1 1 1 1
+
+Distributions for all reconstructed electrons (i.e. not requiring a match with mc truth)
+
+ElectronMcSignalValidatorMiniAOD/h_ele_mee_all             1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_mee_os              1 1 1 1
+
+pflow variables
+
+ElectronMcSignalValidatorMiniAOD/h_ele_chargedHadronRelativeIso_mAOD           1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_chargedHadronRelativeIso_mAOD_barrel    1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_chargedHadronRelativeIso_mAOD_endcaps   1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_neutralHadronRelativeIso_mAOD           1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_neutralHadronRelativeIso_mAOD_barrel    1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_neutralHadronRelativeIso_mAOD_endcaps   1 1 1 0
+ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD           1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD_barrel    1 1 0 0
+ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD_endcaps   1 1 1 0

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -36,8 +36,8 @@ localFileInput = os.environ['TEST_HISTOS_FILE'].replace(".root", "_a.root") #
 process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:" + localFileInput),
 secondaryFileNames = cms.untracked.vstring(),)
 
-process.electronMcMiniAODSignalPostValidator.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
-process.electronMcMiniAODSignalPostValidator.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
+process.electronMcSignalPostValidatorMiniAOD.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
+process.electronMcSignalPostValidatorMiniAOD.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("electronPostValidation")
 
 process.options = cms.untracked.PSet( 
-#    SkipEvent = cms.untracked.vstring('ProductNotFound') 
+#    SkipEvent = cms.untracked.vstring('ProductNotFound'),
 #    Rethrow = cms.untracked.vstring('ProductNotFound')
 )
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -1,0 +1,56 @@
+
+import sys
+import os
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("electronPostValidation")
+
+process.options = cms.untracked.PSet( 
+#    SkipEvent = cms.untracked.vstring('ProductNotFound') 
+#    Rethrow = cms.untracked.vstring('ProductNotFound')
+)
+
+process.DQMStore = cms.Service("DQMStore")
+process.load("Validation.RecoEgamma.ElectronMcSignalPostValidatorMiniAOD_cfi")
+process.load("DQMServices.Components.DQMStoreStats_cfi")
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff")
+# import DQMStore service
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+
+# actually read in the DQM root file
+process.load("DQMServices.Components.DQMFileReader_cfi")
+
+from DQMServices.Components.DQMStoreStats_cfi import *
+dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+t1 = os.environ['TEST_HISTOS_FILE'].split('.')
+localFileInput = os.environ['TEST_HISTOS_FILE'].replace(".root", "_a.root") #
+# Source
+process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:" + localFileInput),
+secondaryFileNames = cms.untracked.vstring(),)
+
+process.electronMcMiniAODSignalPostValidator.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
+process.electronMcMiniAODSignalPostValidator.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
+
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
+process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+process.p = cms.Path(process.EDMtoME * process.electronMcSignalPostValidatorMiniAOD * process.dqmStoreStats)
+
+# Schedule
+process.schedule = cms.Schedule(
+                                process.p,
+                                process.dqmsave_step,
+)

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
@@ -38,6 +38,7 @@ from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'
 process.dqmsave_step = cms.Path(process.DQMSaver)
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
@@ -35,8 +35,9 @@ process.electronMcSignalPostValidatorPt1000.InputFolderName = cms.string("Egamma
 process.electronMcSignalPostValidatorPt1000.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorPt1000")
 
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-
+#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'
 process.dqmsave_step = cms.Path(process.DQMSaver)
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -36,7 +36,8 @@ process.electronMcSignalPostValidator.OutputFolderName = cms.string("EgammaV/Ele
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-
+#process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'
 process.dqmsave_step = cms.Path(process.DQMSaver)
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -38,6 +38,7 @@ from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 #process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'
 process.dqmsave_step = cms.Path(process.DQMSaver)
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ElectronValidation")
 
 process.options = cms.untracked.PSet( 
-    SkipEvent = cms.untracked.vstring('ProductNotFound') 
+#    SkipEvent = cms.untracked.vstring('ProductNotFound'),
 #    Rethrow = cms.untracked.vstring('ProductNotFound')
 )
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -1,0 +1,80 @@
+
+import sys
+import os
+import DQMOffline.EGamma.electronDataDiscovery as dd
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ElectronValidation")
+
+process.options = cms.untracked.PSet( 
+    SkipEvent = cms.untracked.vstring('ProductNotFound') 
+#    Rethrow = cms.untracked.vstring('ProductNotFound')
+)
+
+process.DQMStore = cms.Service("DQMStore")
+process.load("DQMServices.Components.DQMStoreStats_cfi")
+from DQMServices.Components.DQMStoreStats_cfi import *
+dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
+
+# OLD WAY
+
+print "reading files ..."
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
+process.source.fileNames.extend(dd.search())
+print "done"
+
+# NEW WAY
+#print "reading files ..."
+#readFiles = cms.untracked.vstring()
+#secFiles = cms.untracked.vstring() 
+#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+#process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+#process.source.fileNames.extend(dd.search())
+#DD_SOURCE_TEMP = os.environ['DD_SOURCE']
+#TEMP = os.environ['DD_SOURCE'].replace("MINIAODSIM", "GEN-SIM-RECO" ) 
+#os.environ['DD_SOURCE'] = os.environ['DD_SOURCE'].replace("MINIAODSIM", "GEN-SIM-RECO" ) 
+#process.source.secondaryFileNames.extend(dd.search2())
+#os.environ['DD_SOURCE'] = DD_SOURCE_TEMP
+#print "done"
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new 
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
+# FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
+# CONFIGURATION
+process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")
+process.load("Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi")
+
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+process.EDM = cms.OutputModule("PoolOutputModule",
+outputCommands = cms.untracked.vstring('drop *',"keep *_MEtoEDMConverter_*_*"),
+fileName = cms.untracked.string(os.environ['TEST_HISTOS_FILE'].replace(".root", "_a.root"))
+)
+
+process.electronMcSignalValidatorMiniAOD.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
+process.electronMcSignalValidatorMiniAOD.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
+
+process.p = cms.Path(process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
+
+process.outpath = cms.EndPath(
+process.EDM,
+)

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
@@ -32,6 +32,7 @@ from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
@@ -29,8 +29,9 @@ process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-
+#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -32,6 +32,7 @@ from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 #process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
+
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -30,7 +30,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-
+#process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,50 +1,25 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_0_0_pre2_miniAOD_dev">
-<var name="TEST_REF" value="8_0_0_pre2_std">
+<var name="TEST_NEW" value="8_0_0_pre4_pmx_DQM_std">
+<var name="TEST_REF" value="8_0_0_pre4">
 
-<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
+<var name="TAG_STARTUP" value="76X_mcRun2_startup_v12">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
+<var name="DD_COND_REF" value="PU50ns_76X_mcRun2_startup_v12-v1">
 
-<!--var name="DD_RELEASE" value="${CMSSW_VERSION}"-->
-<var name="DD_RELEASE" value="CMSSW_8_0_0_pre2">
+<var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
-<var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
-<var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
+<var name="STORE_DIR" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_0_0_pre4_ValELE/src/Validation/RecoEgamma/test/8_0_0_pre4">
+<var name="STORE_REF" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_0_0_pre4_ValELE/src/Validation/RecoEgamma/test/8_0_0_pre4">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
-
-<!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
-<!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
 
 The value of OVAL_ENVNAME is automatically set by Oval to the name
 of the current environment, before running any executable. Using it below,
 we have an output file name which is unique for each execution.
 
-<var name="TEST_HISTOS_FILE" value="electronHistos.${OVAL_ENVNAME}.root">
 <var name="TEST_OUTPUT_LOGS" value="*.${OVAL_ENVNAME}.olog">
-<!--var name="TEST_HISTOS_FILE" value="DQM_V0001_R000000001__${DD_SAMPLE}__${DD_RELEASE}-${DD_COND}__DQM.root"-->
-<!--difffile name="electronHistos.root"-->
-
-The DD_* variables are configuration variables for the script electronDataDiscovery.py,
-which prepares and send a query to the Data Discovery web server,
-and receive as a result the corresponding list of input data files.
-<!--var name="DD_SOURCE" value="das"-->
-
-The tags below are to be used when DAS seems not up-to-date,
-as compared to what you see within castor directories.
-These parameters have been added to each RelVal sample environment
-<!--var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}"-->
-<!--var name="DD_TIER" value="GEN-SIM-RECO"-->
-  
-  
-The tags below are to be used when you want to process some files
-made with a modified code, and generated locally, thanks to the
-targets RedoFrom% defined later on.
-<!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
-<!--var name="DD_COND" value="STARTUP"-->
 
 Oval is able to check the output channel of an execution and compare it with a reference output.
 The tags below are defining which are lines to be compared. The currently specification is a
@@ -61,27 +36,6 @@ first draft, and we do not yet check the differences that Oval could raise.
 <diffnumber expr="^h_\S+ has \d+ entries of mean value (\S+)$" tolerance="10%">
 <!diffvar name="HISTO" expr="^TH1.Print Name = [a-zA-Z_]+, Entries= \d+, Total sum= (\S+)$" tolerance="10%">
 
-The file defined below is used by the script electronDataDiscovery.py when we want to analyze
-some RelVal reco files which have been regenerated locally.
-
-<var name="TEST_AFS_DIR" value="/afs/cern.ch/cms/CAF/CMSPHYS/PHYS_EGAMMA/electrons/chamont/ReleaseValidationTmp/SeedsRemaker3">
-<!--var name="TEST_AFS_DIR" value="/afs/cern.ch/user/a/archiron/private/Root_Regress"-->
-<file name="electronInputDataFiles.txt">
-file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-RECO.root
-file:${TEST_AFS_DIR}/RelValSingleElectronPt35-STARTUP-RECO.root
-file:${TEST_AFS_DIR}/RelValTTbar-STARTUP-RECO.root
-file:${TEST_AFS_DIR}/RelValZEE-STARTUP-RECO.root
-file:${TEST_AFS_DIR}/RelValQCD_Pt_80_120-STARTUP-RECO.root
-</file>
-  
-Here comes the concrete executables to run. They are split among few different
-environments, each one defining the relevant variales for a given scenario and/or
-data sample. Running electronDataDiscovery.py is only usefull to check the correctness
-of the list of input data files returned by the data discovery web server. We guess
-that from time to time we will have to upgrade the values DD_* variable so to keep in
-touch with changes in data catalog structure.
-
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ================================================================================
 FullSim
@@ -93,92 +47,59 @@ FullSim
   This set of targets is currently used for the validation of electrons.
 
   Used if DD_source=/eos/...
-  <!--var name="DD_TIER" value="GEN-SIM-RECO"-->
-  <var name="DD_TIER" value="MINIAODSIM">
-  
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistosMiniAOD.txt">
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorMiniAOD">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorMiniAOD">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidationMiniAOD_cfg">
-  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationMiniAOD_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationMiniAOD_cfg">
-      
-  <environment name="ValFullStdStatsStartup">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <environment name="ValFullTTbarStartup_13_gedGsfE">
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-    </environment>
-  
-    <environment name="ValFullZEEStartup_13_gedGsfE">    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
-    </environment>
-  
-    <environment name="ValFullPt10Startup_UP15_gedGsfE">    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
-    </environment>
-  
-  <environment name="ValFullgedvsged">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+  <var name="DD_TIER" value="GEN-SIM-RECO">
 
-    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
-      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-    </environment>
-  
-    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">  
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
-      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
+  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
+
+  <environment name="ValPileUpStartup">
+
+    <var name="TAG_STARTUP" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+
+    <environment name="Valdummy">
+
+      <var name="DD_SAMPLE" value="dummy">
+
+        <var name="RED_FILE" value="DQM_DUMMY.root">
+ <var name="BLUE_FILE" value="DQM_DUMMY.root">
+ <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
     </environment>
 
-    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-    </environment>
+    <var name="DD_COND" value="PUpmx50ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+
+    <var name="DD_COND_REF" value="PU50ns_76X_mcRun2_startup_v12-v1">
+
+      <environment name="ValPileUpTTbarStartup_gedGsfE">
+
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+
+      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_0_0_pre4-PUpmx50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
+      <var name="BLUE_FILE" value="8_0_0_pre4/DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_0_0_pre4-PU50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed_${TEST_REF}/PUpmx50ns_${DD_SAMPLE}_gedGsfE_Startup'>
+
+      </environment>
+
+    <var name="DD_COND" value="PUpmx50ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+
+    <var name="DD_COND_REF" value="PU50ns_76X_mcRun2_startup_v12-v1">
+
+      <environment name="ValPileUpZEEStartup_gedGsfE">
+
+        <var name="DD_SAMPLE" value="RelValZEE_13">
+
+      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_0_0_pre4-PUpmx50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
+      <var name="BLUE_FILE" value="8_0_0_pre4/DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_0_0_pre4-PU50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed_${TEST_REF}/PUpmx50ns_${DD_SAMPLE}_gedGsfE_Startup'>
+
+      </environment>
 
   </environment>
- 
-  </environment>
-    
+
 </environment>
-
-

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,19 +1,19 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="7_5_0_pre5_std">
-<var name="TEST_REF" value="7_5_0_pre4_std">
+<var name="TEST_NEW" value="8_0_0_pre2_dev">
+<var name="TEST_REF" value="8_0_0_pre2_std">
 
-<var name="TAG_STARTUP" value="MCRUN2_75_V5">
+<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="MCRUN2_75_V1-v1">
+<var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
-
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+ 
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
@@ -158,7 +158,7 @@ FullSim
       <target name="wget" cmd="electronWget.py castor">
       
       <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_cfg.py">
+      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_cfg.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
@@ -238,8 +238,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
@@ -256,8 +256,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       
     </environment>
     
@@ -278,8 +278,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
@@ -296,8 +296,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
   
@@ -314,8 +314,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
   
     </environment>
 
@@ -328,6 +328,7 @@ FullSim
       <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
       <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
       <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -337,8 +338,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>  
   
@@ -539,7 +540,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
@@ -552,7 +553,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
       
     </environment>
     
@@ -570,7 +571,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
@@ -583,7 +584,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
   
@@ -596,7 +597,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
   
     </environment>
 
@@ -615,7 +616,7 @@ FullSim
       <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
       
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>  
   

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,5 +1,5 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_0_0_pre2_dev">
+<var name="TEST_NEW" value="8_0_0_pre2_miniAOD_dev">
 <var name="TEST_REF" value="8_0_0_pre2_std">
 
 <var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
@@ -8,11 +8,12 @@
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
 <var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
-<var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="${CMSSW_VERSION}"-->
+<var name="DD_RELEASE" value="CMSSW_8_0_0_pre2">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
- 
+
 <var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
@@ -91,956 +92,93 @@ FullSim
 
   This set of targets is currently used for the validation of electrons.
 
-  Used if DD_SOURCE=das
-  <!--var name="DD_TIER" value="*RECO*"-->
-
   Used if DD_source=/eos/...
-  <var name="DD_TIER" value="GEN-SIM-RECO">
+  <!--var name="DD_TIER" value="GEN-SIM-RECO"-->
+  <var name="DD_TIER" value="MINIAODSIM">
   
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
+  <var name="VAL_HISTOS" value="ElectronMcSignalHistosMiniAOD.txt">
+  <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorMiniAOD">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorMiniAOD">
+  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationMiniAOD_cfg">
       
   <environment name="ValFullStdStatsStartup">
   
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
     
-    <!--var name="DD_COND" value="STARTUP"-->
-    <environment name="ValFullPt10Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullPt35Startup_UP15">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-            
-    </environment>
-
-    <environment name="ValFullPt1000Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullTTbarStartup_13">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullZEEStartup_13">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup_13">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
-    </environment>
-
-    <environment name="ValFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      
-    </environment>
-    
-    <environment name="ValFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
-      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
-    </environment>
-
     <environment name="ValFullTTbarStartup_13_gedGsfE">
-  
       <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <target name="dqm" cmd="electronDataDiscovery.py castor">
       <target name="wget" cmd="electronWget.py castor">
-      
       <target name="dd" cmd="electronDataDiscovery.py">
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
     </environment>
   
-    <environment name="ValFullZEEStartup_13_gedGsfE">
-    
+    <environment name="ValFullZEEStartup_13_gedGsfE">    
       <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
+      <target name="wget" cmd="electronWget.py castor">      
       <target name="dd" cmd="electronDataDiscovery.py">
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
     </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
+  
+    <environment name="ValFullPt10Startup_UP15_gedGsfE">    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
+      <target name="wget" cmd="electronWget.py castor">      
       <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
-    </environment>  
-  
-  </environment>
-
-  <environment name="ValFullGsfvsGsf">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
-    <environment name="ValGsfvsGsfFullPt10Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
     </environment>
-
-    <environment name="ValGsfvsGsfFullPt35Startup_UP15">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-            
-    </environment>
-
-    <environment name="ValGsfvsGsfFullPt1000Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullTTbarStartup_13">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullZEEStartup_13">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullZEEStartup_13.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullQcdPt80Pt120Startup_13">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
-      
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-  </environment>
-  
-  <environment name="ValFullgedvsGsf">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
-
-    <environment name="ValgedvsGsfFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsGsfFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-      
-    </environment>
-    
-    <environment name="ValgedvsGsfFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsGsfFullTTbarStartup_13_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
-    <environment name="ValgedvsGsfFullZEEStartup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-  
-    </environment>
-
-    <environment name="ValgedvsGsfFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
-
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>  
-  
-  </environment>
   
   <environment name="ValFullgedvsged">
   
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
 
-    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsgedFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-      
-    </environment>
-    
-    <environment name="ValgedvsgedFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="VAL_HISTOS" value="ElectronMcSignalHistosPt1000.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
-      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">
-  
+    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">  
       <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
     </environment>
   
-    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">
-    
+    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">  
       <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
       <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-  
     </environment>
 
-    <environment name="ValgedvsgedFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
+    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>  
-  
-  </environment>
-
-  <environment name="ValPileUpStartup">
-    
-    <var name="TAG_STARTUP" value="PU_${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValPileUpTTbarStartup">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
-      </environment>
-
-    <environment name="ValPileUpZEEStartup">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} /${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
     </environment>
 
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-	
-	    <var name="BLUE_FILE" value="electronHistos.ValPileUpTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValPileUpTTbarStartup_gedGsfE.root">
+  </environment>
  
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
-    <environment name="ValPileUpZEEStartup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-     
-      <var name="BLUE_FILE" value="electronHistos.ValPileUpZEEStartup.root">
-      <var name="RED_FILE" value="electronHistos.ValPileUpZEEStartup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
   </environment>
     
 </environment>
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-FastSim
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="FastSim">
-
-  <var name="DD_TIER" value="GEN-SIM-DIGI-RECO">
-
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
- 
-  <environment name="ValFast">
-
-    <environment name="ValFastStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="/${TEST_GLOBAL_TAG}_FastSim-${DATA_VERSION}">
-      
-      <environment name="ValFastTTbarStartup">
-      
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SAMPLE" value="RelValTTbar">
-	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
-	
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-        
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-        
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        
-      </environment>
-    
-      <environment name="ValFastZEEStartup">
-      
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SAMPLE" value="RelValZEE">
-	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
-	
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-        
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-        
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
-  <environment name="ValFastVsFast">
-  
-    <environment name="ValFastVsFastStartup">
-    
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}*FastSim*-${DATA_VERSION}">
-
-      <environment name="ValFastVsFastTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
-      </environment>
-      
-      <environment name="ValFastVsFastZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
-      </environment>
-        
-    </environment>
-    
-  </environment>
-  
-  <environment name="ValFastVsFull">
-  
-    <environment name="ValFastVsFullStartup">
-    
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValFastVsFullTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
-      </environment>
-      
-      <environment name="ValFastVsFullZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
-      </environment>
-      
-    </environment>
-        
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to redo the electrons
-with the local modified code.
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Redo">
-
-  <environment name="SeedsRemaker">
-
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-    <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      
-    <environment name="SeedsRemakerStep1">
-
-      <var name="DD_TIER" value="*RAW*">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-FIRST-RECO.root">
-
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 -s RAW2DIGI,L1Reco,RECO,VALIDATION,DQM --conditions auto:startup --datatier GEN-SIM-RECO,DQM --eventcontent RECOSIM,DQM --filein=Dummy-STARTUP-RAW.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.storeseed --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="reco" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      
-    </environment>
-  
-    <environment name="SeedsRemakerStep2">
-    
-      <var name="DD_TIER" value="*FIRST-RECO*">
-      <var name="DD_SOURCE" value="electronInputDataFiles.txt">
-      <var name="DD_COND" value="STARTUP">
-      <file name="electronInputDataFiles.txt">
-      file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-FIRST-RECO.root
-      </file>
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 --process reRECO --filtername RECOfromRECO -s RECO:reconstruction_fromRECO_noTrackingTest --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-STARTUP-RECO.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.reseed+regenseed+reconv --python_filename=SeedsRemaker_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun SeedsRemaker_cfg.py">
-      
-    </environment>
-
-  </environment>
-  
-  <environment name="RedoFromTrackSeeds">
-
-    <var name="VAL_CONFIGURATION" value="ElectronRedoFromTrackSeeds_cfg">
-    
-    <environment name="RedoFromTrackSeedsPt35">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsQcdPt80Pt120">
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsPt10">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-  </environment>
-
-  <environment name="RedoFromCore">
-
-    <environment name="RedoFromCoreStartup">
-  
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="RedoFromCoreZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <executable name="electronDataDiscovery.py">
-        <executable name="cmsRun" args="ElectronRedoFromCore_cfg.py">
-      </environment>
-    
-    </environment>
-        
-  </environment>
-
-  <environment name="RedoFromRaw">
-
-    <var name="DD_TIER" value="*RAW*">
-
-    <!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
-    <file name="electronInputDataFiles.txt">
-    ${TEST_AFS_DIR}/RelValSingleElectronPt10-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValSingleElectronPt35-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValTTbar-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-STARTUP-RAW.root
-    ${TEST_AFS_DIR}/RelValQCD_Pt_80_120-IDEAL-RAW.root
-    </file>
-
-    <environment name="RedoFromRawStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-      <!--var name="DD_COND" value="STARTUP"-->
-
-      <target name="cfg" cmd="cmsDriver.py reco -s RAW2DIGI,RECO -n -1 --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-RAW.root --fileout=Dummy-STARTUP-RECO.root --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-
-      <environment name="RedoFromRawPt35Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawQcdPt80Pt120Startup">
-        <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawPt10Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-  
-      <environment name="RedoFromRawZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to test cmsDriver.py steps
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Validation">
-
-  <target name="step1" cmd="cmsDriver.py SingleElectronPt35_cfi.py -s GEN,SIM,DIGI,L1,DIGI2RAW,HLT:GRun -n 10 --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RAW.root">
-  <target name="step2" cmd="cmsDriver.py step2 -s RAW2DIGI,RECO,VALIDATION,DQM -n 10 --filein file:SingleElectronPt35-10-IDEAL-RAW.root --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RECO.root">
-  <target name="step3" cmd="cmsDriver.py step3 -s HARVESTING:validationHarvesting+dqmHarvesting --harvesting AtRunEnd --conditions auto:mc --filein file:SingleElectronPt35-10-IDEAL-RECO.root --mc">
-
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Process uncleaned superclusters
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Uncleaned">
-
-  <var name="DD_TIER" value="*RAW*">
-  <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-  <var name="TEST_HISTOS_FILE" value="${DD_SAMPLE}-IDEAL-UNCLEANED-RECO.root">
-  
-  <target name="dd" cmd="electronDataDiscovery.py">
-  <target name="py" cmd="python ElectronFromUncleanedOnly_cfg.py">
-  <target name="reco" cmd="cmsRun ElectronFromUncleanedOnly_cfg.py">
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Photons
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Photons">
-
-  Those few photons datasets are checked so to compare
-  size and performance with electrons.
-
-  <var name="DD_TIER_SECONDARY" value="*RAW*">
-  <!--var name="DD_RELEASE" value="LOCAL"-->
-  <!--var name="DD_COND" value=""-->
-
-  <environment name="PhotonPt35">
-    <var name="DD_SAMPLE" value="RelValSingleGammaPt35">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-  <environment name="PhotonQcdPt80-120">
-    <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-</environment>

--- a/Validation/RecoEgamma/test/OvalFile.FAST
+++ b/Validation/RecoEgamma/test/OvalFile.FAST
@@ -149,8 +149,8 @@ FastSim
         <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
         <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
         
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
         
       </environment>
     
@@ -168,8 +168,8 @@ FastSim
         <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
         <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
         
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
         
       </environment>
     
@@ -206,7 +206,7 @@ FastSim
 	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root"-->
         <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFast_${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFast_${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
       </environment>
       
       <environment name="ValFastVsFastZEEStartup_gedGsfE">
@@ -214,7 +214,7 @@ FastSim
 	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root"-->
         <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFast_${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFast_${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
       </environment>
         
     </environment>

--- a/Validation/RecoEgamma/test/OvalFile.GED
+++ b/Validation/RecoEgamma/test/OvalFile.GED
@@ -8,7 +8,8 @@
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
 <var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
-<var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="${CMSSW_VERSION}"-->
+<var name="DD_RELEASE" value="CMSSW_8_0_0_pre2">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">

--- a/Validation/RecoEgamma/test/OvalFile.GED
+++ b/Validation/RecoEgamma/test/OvalFile.GED
@@ -1,19 +1,19 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="7_5_0_pre5_std">
-<var name="TEST_REF" value="7_5_0_pre4_std">
+<var name="TEST_NEW" value="8_0_0_pre2_dev">
+<var name="TEST_REF" value="8_0_0_pre2_std">
 
-<var name="TAG_STARTUP" value="MCRUN2_75_V5">
+<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="MCRUN2_75_V1-v1">
+<var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
-
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+ 
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
@@ -238,8 +238,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
@@ -256,8 +256,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       
     </environment>
     
@@ -278,8 +278,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
@@ -296,8 +296,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
   
@@ -314,8 +314,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
   
     </environment>
 
@@ -328,6 +328,7 @@ FullSim
       <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
       <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
       <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -337,8 +338,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>  
   
@@ -539,7 +540,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
@@ -552,7 +553,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
       
     </environment>
     
@@ -570,7 +571,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
@@ -583,7 +584,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
   
@@ -596,7 +597,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
   
     </environment>
 
@@ -615,7 +616,7 @@ FullSim
       <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
       
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>  
   

--- a/Validation/RecoEgamma/test/OvalFile.GED
+++ b/Validation/RecoEgamma/test/OvalFile.GED
@@ -1,20 +1,20 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_0_0_pre2_dev">
+<var name="TEST_NEW" value="8_0_0_pre4_std">
 <var name="TEST_REF" value="8_0_0_pre2_std">
 
-<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
+<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v13">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
 <var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
-<!--var name="DD_RELEASE" value="${CMSSW_VERSION}"-->
-<var name="DD_RELEASE" value="CMSSW_8_0_0_pre2">
+<var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
  
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->

--- a/Validation/RecoEgamma/test/OvalFile.PU
+++ b/Validation/RecoEgamma/test/OvalFile.PU
@@ -172,9 +172,9 @@ FullSim
         <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
         <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'>
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'>
 
       </environment>
 
@@ -194,9 +194,9 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
   

--- a/Validation/RecoEgamma/test/OvalFile.Pt1000
+++ b/Validation/RecoEgamma/test/OvalFile.Pt1000
@@ -244,8 +244,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
@@ -263,8 +263,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       
     </environment>
     
@@ -285,8 +285,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_gedGsfElectrons_cfg.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
@@ -304,8 +304,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
   
@@ -323,8 +323,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
   
     </environment>
 
@@ -346,8 +346,8 @@ FullSim
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
       <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
       
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>  
   
@@ -549,7 +549,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
@@ -563,7 +563,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
       
     </environment>
     
@@ -581,7 +581,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
@@ -595,7 +595,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
   
@@ -609,7 +609,7 @@ FullSim
       <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
   
     </environment>
 
@@ -628,7 +628,7 @@ FullSim
       <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
       
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>  
   

--- a/Validation/RecoEgamma/test/OvalFile.miniAOD
+++ b/Validation/RecoEgamma/test/OvalFile.miniAOD
@@ -1,20 +1,20 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_0_0_pre2_miniAOD_std">
-<var name="TEST_REF" value="8_0_0_pre2_std">
+<var name="TEST_NEW" value="8_0_0_pre4_miniAOD_std">
+<var name="TEST_REF" value="8_0_0_pre4_std">
 
-<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
+<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v13">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
 <var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
-<!--var name="DD_RELEASE" value="${CMSSW_VERSION}"-->
-<var name="DD_RELEASE" value="CMSSW_8_0_0_pre2">
+<var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->

--- a/Validation/RecoEgamma/test/OvalFile.miniAOD
+++ b/Validation/RecoEgamma/test/OvalFile.miniAOD
@@ -1,0 +1,183 @@
+<var name="TEST_COMMENT" value="">
+<var name="TEST_NEW" value="8_0_0_pre2_miniAOD_dev">
+<var name="TEST_REF" value="8_0_0_pre2_dev">
+
+<var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
+<var name="DATA_VERSION" value="v1">
+
+TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
+<var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
+
+<var name="DD_RELEASE" value="${CMSSW_VERSION}">
+
+<var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
+<var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
+
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
+
+<!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
+<!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
+
+The value of OVAL_ENVNAME is automatically set by Oval to the name
+of the current environment, before running any executable. Using it below,
+we have an output file name which is unique for each execution.
+
+<var name="TEST_HISTOS_FILE" value="electronHistos.${OVAL_ENVNAME}.root">
+<var name="TEST_OUTPUT_LOGS" value="*.${OVAL_ENVNAME}.olog">
+<!--var name="TEST_HISTOS_FILE" value="DQM_V0001_R000000001__${DD_SAMPLE}__${DD_RELEASE}-${DD_COND}__DQM.root"-->
+<!--difffile name="electronHistos.root"-->
+
+The DD_* variables are configuration variables for the script electronDataDiscovery.py,
+which prepares and send a query to the Data Discovery web server,
+and receive as a result the corresponding list of input data files.
+<!--var name="DD_SOURCE" value="das"-->
+
+The tags below are to be used when DAS seems not up-to-date,
+as compared to what you see within castor directories.
+These parameters have been added to each RelVal sample environment
+<!--var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}"-->
+<!--var name="DD_TIER" value="GEN-SIM-RECO"-->
+  
+  
+The tags below are to be used when you want to process some files
+made with a modified code, and generated locally, thanks to the
+targets RedoFrom% defined later on.
+<!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
+<!--var name="DD_COND" value="STARTUP"-->
+
+Oval is able to check the output channel of an execution and compare it with a reference output.
+The tags below are defining which are lines to be compared. The currently specification is a
+first draft, and we do not yet check the differences that Oval could raise.
+
+<diffnumber expr="^dataset has (\d+) files:$" tolerance="1">
+<error expr="^dataset has 0 files:$">
+
+<diffline expr="^(TH1.Print Name = [a-zA-Z_]+, Entries= ).*$">
+<diffnumber expr="^TH1.Print Name = [a-zA-Z_]+, Entries= (\d+),.*$" tolerance="20%">
+<diffnumber expr="^TH1.Print Name = [a-zA-Z_]+, Entries= \d+, Total sum= (\S+)$" tolerance="10%">
+<diffline expr="^(h_\S+ has )\d+ entries of mean value \S+$">
+<diffnumber expr="^h_\S+ has (\d+) entries of mean value \S+$" tolerance="20%">
+<diffnumber expr="^h_\S+ has \d+ entries of mean value (\S+)$" tolerance="10%">
+<!diffvar name="HISTO" expr="^TH1.Print Name = [a-zA-Z_]+, Entries= \d+, Total sum= (\S+)$" tolerance="10%">
+
+The file defined below is used by the script electronDataDiscovery.py when we want to analyze
+some RelVal reco files which have been regenerated locally.
+
+<var name="TEST_AFS_DIR" value="/afs/cern.ch/cms/CAF/CMSPHYS/PHYS_EGAMMA/electrons/chamont/ReleaseValidationTmp/SeedsRemaker3">
+<!--var name="TEST_AFS_DIR" value="/afs/cern.ch/user/a/archiron/private/Root_Regress"-->
+<file name="electronInputDataFiles.txt">
+file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValSingleElectronPt35-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValTTbar-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValZEE-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValQCD_Pt_80_120-STARTUP-RECO.root
+</file>
+  
+Here comes the concrete executables to run. They are split among few different
+environments, each one defining the relevant variales for a given scenario and/or
+data sample. Running electronDataDiscovery.py is only usefull to check the correctness
+of the list of input data files returned by the data discovery web server. We guess
+that from time to time we will have to upgrade the values DD_* variable so to keep in
+touch with changes in data catalog structure.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+================================================================================
+FullSim
+================================================================================
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+<environment name="FullStdStats">
+
+  This set of targets is currently used for the validation of electrons.
+
+  Used if DD_source=/eos/...
+  <!--var name="DD_TIER" value="GEN-SIM-RECO"-->
+  <var name="DD_TIER" value="MINIAODSIM">
+  
+  <var name="VAL_HISTOS" value="ElectronMcMiniAODSignalHistos.txt">
+  <var name="VAL_ANALYZER" value="ElectronMcMiniAODSignalValidator">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcMiniAODSignalPostValidator">
+  <var name="VAL_CONFIGURATION" value="ElectronMiniAODMcSignalValidation_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMiniAODMcSignalValidation_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMiniAODMcSignalPostValidation_cfg">
+      
+  <environment name="ValFullStdStatsStartup">
+  
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <environment name="ValFullTTbarStartup_13_gedGsfE">
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+    </environment>
+  
+    <environment name="ValFullZEEStartup_13_gedGsfE">    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
+    </environment>
+  
+    <environment name="ValFullPt10Startup_UP15_gedGsfE">    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
+    </environment>
+  
+  <environment name="ValFullgedvsged">
+  
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+
+    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
+      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+    </environment>
+  
+    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">  
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
+      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+    </environment>
+
+    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+    </environment>
+
+  </environment>
+ 
+  </environment>
+    
+</environment>
+
+

--- a/Validation/RecoEgamma/test/OvalFile.miniAOD
+++ b/Validation/RecoEgamma/test/OvalFile.miniAOD
@@ -1,6 +1,6 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_0_0_pre2_miniAOD_dev">
-<var name="TEST_REF" value="8_0_0_pre2_dev">
+<var name="TEST_NEW" value="8_0_0_pre2_miniAOD_std">
+<var name="TEST_REF" value="8_0_0_pre2_std">
 
 <var name="TAG_STARTUP" value="76X_mcRun2_asymptotic_v12">
 <var name="DATA_VERSION" value="v1">
@@ -8,7 +8,8 @@
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
 <var name="DD_COND_REF" value="76X_mcRun2_asymptotic_v12-v1">
 
-<var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="${CMSSW_VERSION}"-->
+<var name="DD_RELEASE" value="CMSSW_8_0_0_pre2">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
@@ -95,12 +96,12 @@ FullSim
   <!--var name="DD_TIER" value="GEN-SIM-RECO"-->
   <var name="DD_TIER" value="MINIAODSIM">
   
-  <var name="VAL_HISTOS" value="ElectronMcMiniAODSignalHistos.txt">
-  <var name="VAL_ANALYZER" value="ElectronMcMiniAODSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcMiniAODSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMiniAODMcSignalValidation_cfg">
-  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMiniAODMcSignalValidation_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMiniAODMcSignalPostValidation_cfg">
+  <var name="VAL_HISTOS" value="ElectronMcSignalHistosMiniAOD.txt">
+  <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorMiniAOD">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorMiniAOD">
+  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationMiniAOD_cfg">
       
   <environment name="ValFullStdStatsStartup">
   

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -436,7 +436,6 @@ int electronCompare()
    // after 740pre8  : DQMData/Run 1/EgammaV/Run summary/ ElectronMcSignalValidatorPt1000/ histo name
       histo_full_path_Pt1000 = file_ref_dir ; histo_full_path_Pt1000 += Pt1000_path_extension; histo_full_path_Pt1000 += histo_name ; // for Pt1000 
    // END WARNING
-//      std::cout << "histo_full_path ref : " << histo_full_path << std::endl ;
 
       histo_ref = (TH1 *)file_ref->Get(histo_full_path) ;
       if (histo_ref!=0)
@@ -444,7 +443,6 @@ int electronCompare()
         // renaming those histograms avoid very strange bugs because they
         // have the same names as the ones loaded from the new file
         histo_ref->SetName(TString(histo_ref->GetName())+"_ref") ;
-//        std::cout << "histo_ref Name : " << histo_ref->GetName() << " - histo_new Name : " << histo_name << std::endl ; // A.C. to be removed
       }
       else // no histo
       {
@@ -465,9 +463,6 @@ int electronCompare()
     // search histo_new
     histo_full_path = file_new_dir ; histo_full_path += histo_path.c_str() ;
     histo_new = (TH1 *)file_new->Get(histo_full_path) ;
-//    std::cout << "histo_new Name : " << histo_new->GetName() << std::endl ; // A.C. to be removed
-//    std::cout << "histo_full_path new : " << histo_full_path << std::endl ;
-//    std::cout << "histo_path.cstr new : " << histo_path.c_str() << std::endl ;
 
     // special treatments
     if ((scaled==1)&&(histo_new!=0)&&(histo_ref!=0)&&(histo_ref->GetEntries()!=0))
@@ -484,8 +479,6 @@ int electronCompare()
         histo_ref->Scale(rescale_factor) ;
        }
      }
-//    std::cout << "histo_ref get Min : " << histo_ref->GetMinimum() << " - histo_ref get Max : " << histo_ref->GetMaximum() << std::endl ; // 
-//    std::cout << "histo_new get Min : " << histo_new->GetMinimum() << " - histo_new get Max : " << histo_new->GetMaximum() << std::endl ; // 
     if ((histo_new!=0)&&(histo_ref!=0)&&(histo_ref->GetMaximum()>histo_new->GetMaximum()))
      { histo_new->SetMaximum(histo_ref->GetMaximum()*1.1) ; }
 
@@ -500,7 +493,6 @@ int electronCompare()
        { n_ele_charge = histo_new->GetEntries() ; }
 
       // draw histo_new
-//      std::cout << histo_name << " drawing histos new" << std::endl ; // 
       TString newDrawOptions(err==1?"E1 P":"hist") ;
       gErrorIgnoreLevel = kWarning ;
       if (divide!=0)
@@ -522,7 +514,6 @@ int electronCompare()
       st_new->SetTextColor(kRed) ;
 
       // draw histo_ref
-//      std::cout << histo_name << " drawing histos ref" << std::endl ; // 
       if (histo_ref!=0)
        {
         if (divide!=0)
@@ -578,10 +569,8 @@ int electronCompare()
         <<" has "<<histo_new->GetEffectiveEntries()<<" entries"
 //        <<" of mean value "<<histo_new->GetMean()
         <<std::endl ; 
-//      std::cout << histo_name << " appel canvas->SaveAs" << std::endl ;
       canvas->SaveAs(gif_path.Data()) ;
       web_page<<"<a href=\""<<gif_name<<"\"><img border=\"0\" class=\"image\" width=\"440\" src=\""<<gif_name<<"\"></a><br>" ;
-//      std::cout << histo_name << " fin boucle else \n" << std::endl ;
      }
 
 //    else if ((file_ref!=0)&&(histo_ref!=0))
@@ -605,7 +594,7 @@ int electronCompare()
        } while (cat.empty()) ;
      }
    }
-  std::cout << "on ferme le fichier" << std::endl;
+  std::cout << "on ferme le fichier : " << histo_file2 << std::endl;
   histo_file2.close() ;
   web_page<<"</td></tr></table>\n" ;
 
@@ -614,4 +603,5 @@ int electronCompare()
   web_page.close() ;
   std::cout << "page fermee" << std::endl;
 return 0;
+
  }

--- a/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
@@ -108,9 +108,10 @@ then
 	fi
 else
     echo "FULL"
-    list="Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
+#    list="Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
 #	list="Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
 #	list="Pt1000Startup_UP15 "
+	list="Pt10Startup_UP15 TTbarStartup_13 ZEEStartup_13 "
     for element in $list    
     do   
         echo "element =" $element   


### PR DESCRIPTION
New version of the PR12272. All was made with CMSSW_8_0_0_pre4

miniAOD validation is introduced. New modules have been added (electronMcMiniAODSignalValidator and electronMcMiniAODSignalPostValidator) with _cfg files and _cfi files.
BuildFile.xml and SealModule.cc were updated.
Minor implementations were added into ElectronMcSignalValidator.cc to take into account miniAOD differences. With this histos, it is possible to compare miniAOD vs RECO .

Some minors corrections have been made on "classical" files sur as OvalFile, electronCompare.C..

@beaudett
