### PR TITLE
Update SiPixelRawToDigi.h

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -60,5 +60,6 @@ private:
   int nwords;
   bool usePilotBlade;
   bool usePhase1;
+  std::string CablingMapLabel;
 };
 #endif


### PR DESCRIPTION
Adding the option for Cabling Map to have a label (default is no label of course)
