### PR TITLE
DQMServices/Components: definite static const int members

### DIFF
--- a/DQMServices/Components/src/DQMProvInfo.cc
+++ b/DQMServices/Components/src/DQMProvInfo.cc
@@ -25,6 +25,9 @@
 // The 2 lines in the EventInfo (HV) plot which show beam status info will be
 // hidden.
 
+const int DQMProvInfo::MAX_VBINS;
+const int DQMProvInfo::MAX_LUMIS;
+
 // Constructor
 DQMProvInfo::DQMProvInfo(const edm::ParameterSet& ps) {
   // Initialization of DQM parameters


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
