### PR TITLE
Activate access to HcalQIETypesRcd in the EventSetup

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_FrontierConditions_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_FrontierConditions_cff.py
@@ -27,7 +27,11 @@ es_pool = cms.ESSource("PoolDBESSource",
         cms.PSet(
             record = cms.string('HcalQIEDataRcd'),
             tag = cms.string('qie_normalmode_v6.01')
-        ), 
+        ),
+        cms.PSet(
+            record = cms.string('HcalQIETypesRcd'),
+            tag = cms.string('HcalQIETypes_test_v0')
+        ),
         cms.PSet(
             record = cms.string('HcalChannelQualityRcd'),
             tag = cms.string('hcal_channelStatus_trivial_mc')

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -54,6 +54,7 @@ HcalDbProducer::HcalDbProducer( const edm::ParameterSet& fConfig)
 			  &HcalDbProducer::PFCorrsCallback &
 			  &HcalDbProducer::timeCorrsCallback &
 			  &HcalDbProducer::QIEDataCallback &
+                          &HcalDbProducer::QIETypesCallback &
 			  &HcalDbProducer::gainWidthsCallback &
 			  &HcalDbProducer::channelQualityCallback &
 			  &HcalDbProducer::zsThresholdsCallback &
@@ -199,6 +200,24 @@ void HcalDbProducer::QIEDataCallback (const HcalQIEDataRcd& fRecord) {
   if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("QIEData")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL QIEData set" << std::endl;
     HcalDbASCIIIO::dumpObject (*mDumpStream, *(mQIEData));
+  }
+}
+
+void HcalDbProducer::QIETypesCallback (const HcalQIETypesRcd& fRecord) {
+  edm::ESTransientHandle <HcalQIETypes> item;
+  fRecord.get (item);
+
+  mQIETypes.reset( new HcalQIETypes(*item) );
+
+  edm::ESHandle<HcalTopology> htopo;
+  fRecord.getRecord<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* topo=&(*htopo);
+  mQIETypes->setTopo(topo);
+
+  mService->setData (mQIETypes.get());
+  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("QIETypes")) != mDumpRequest.end()) {
+    *mDumpStream << "New HCAL QIETypes set" << std::endl;
+    HcalDbASCIIIO::dumpObject (*mDumpStream, *(mQIETypes));
   }
 }
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
@@ -47,6 +47,7 @@ class HcalDbProducer : public edm::ESProducer {
   void gainsCallback (const HcalGainsRcd& fRecord);
   void gainWidthsCallback (const HcalGainWidthsRcd& fRecord);
   void QIEDataCallback (const HcalQIEDataRcd& fRecord);
+  void QIETypesCallback (const HcalQIETypesRcd& fRecord);
   void channelQualityCallback (const HcalChannelQualityRcd& fRecord);
   void zsThresholdsCallback (const HcalZSThresholdsRcd& fRecord);
   void respCorrsCallback (const HcalRespCorrsRcd& fRecord);
@@ -68,6 +69,7 @@ class HcalDbProducer : public edm::ESProducer {
   std::unique_ptr<HcalGains> mGains;
   std::unique_ptr<HcalGainWidths> mGainWidths;
   std::unique_ptr<HcalQIEData> mQIEData;
+  std::unique_ptr<HcalQIETypes> mQIETypes;
   std::unique_ptr<HcalRespCorrs> mRespCorrs;
   std::unique_ptr<HcalLUTCorrs> mLUTCorrs;
   std::unique_ptr<HcalPFCorrs> mPFCorrs;

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -28,7 +28,7 @@
 
 class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation <HcalDbRecord,  
   boost::mpl::vector<IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
-  HcalQIEDataRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
+  HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
   HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd,
   HcalLutMetadataRcd > > {}; 
 

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -49,12 +49,14 @@ class HcalDbService {
   const HcalLUTCorr* getHcalLUTCorr (const HcalGenericDetId& fId) const;
   const HcalPFCorr* getHcalPFCorr (const HcalGenericDetId& fId) const;
   const HcalLutMetadata* getHcalLutMetadata () const;
+  const HcalQIEType* getHcalQIEType (const HcalGenericDetId& fId) const;
 
   void setData (const HcalPedestals* fItem) {mPedestals = fItem; mCalibSet = nullptr;}
   void setData (const HcalPedestalWidths* fItem) {mPedestalWidths = fItem; mCalibWidthSet = nullptr;}
   void setData (const HcalGains* fItem) {mGains = fItem; mCalibSet = nullptr; }
   void setData (const HcalGainWidths* fItem) {mGainWidths = fItem; mCalibWidthSet = nullptr; }
   void setData (const HcalQIEData* fItem) {mQIEData = fItem; mCalibSet=nullptr; mCalibWidthSet=nullptr;}
+  void setData (const HcalQIETypes* fItem) {mQIETypes = fItem; mCalibSet = nullptr; }
   void setData (const HcalChannelQuality* fItem) {mChannelQuality = fItem;}
   void setData (const HcalElectronicsMap* fItem) {mElectronicsMap = fItem;}
   void setData (const HcalRespCorrs* fItem) {mRespCorrs = fItem; mCalibSet = nullptr; }
@@ -77,6 +79,7 @@ class HcalDbService {
   const HcalGains* mGains;
   const HcalGainWidths* mGainWidths;
   const HcalQIEData* mQIEData;
+  const HcalQIETypes* mQIETypes;
   const HcalChannelQuality* mChannelQuality;
   const HcalElectronicsMap* mElectronicsMap;
   const HcalRespCorrs* mRespCorrs;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -17,6 +17,7 @@ HcalDbService::HcalDbService (const edm::ParameterSet& cfg):
   mPedestals (0), mPedestalWidths (0),
   mGains (0), mGainWidths (0),  
   mQIEData(0),
+  mQIETypes(0),
   mElectronicsMap(0),
   mRespCorrs(0),
   mL1TriggerObjects(0),
@@ -31,6 +32,7 @@ const HcalTopology* HcalDbService::getTopologyUsed() const {
   if (mPedestals && mPedestals->topo()) return mPedestals->topo();
   if (mGains && mGains->topo()) return mGains->topo();
   if (mRespCorrs && mRespCorrs->topo()) return mRespCorrs->topo();
+  if (mQIETypes && mQIETypes->topo()) return mQIETypes->topo();
   if (mL1TriggerObjects && mL1TriggerObjects->topo()) return mL1TriggerObjects->topo();
   if (mLutMetadata && mLutMetadata->topo()) return mLutMetadata->topo();
   return 0;
@@ -51,7 +53,7 @@ const HcalCalibrationWidths& HcalDbService::getHcalCalibrationWidths(const HcalG
 
 void HcalDbService::buildCalibrations() const {
   // we use the set of ids for pedestals as the master list
-  if ((!mPedestals) || (!mGains) || (!mQIEData) || (!mRespCorrs) || (!mTimeCorrs) || (!mLUTCorrs) ) return;
+  if ((!mPedestals) || (!mGains) || (!mQIEData) || (!mQIETypes) || (!mRespCorrs) || (!mTimeCorrs) || (!mLUTCorrs) ) return;
 
   if (!mCalibSet.load(std::memory_order_acquire)) {
 
@@ -180,6 +182,12 @@ bool HcalDbService::makeHcalCalibrationWidth (const HcalGenericDetId& fId,
   return false;
 }  
 
+const HcalQIEType* HcalDbService::getHcalQIEType (const HcalGenericDetId& fId) const {
+  if (mQIETypes) {
+    return mQIETypes->getValues (fId);
+  }
+  return 0;
+}
 
 const HcalRespCorr* HcalDbService::getHcalRespCorr (const HcalGenericDetId& fId) const {
   if (mRespCorrs) {


### PR DESCRIPTION
Activate access to HcalQIETypesRcd [1] in the EventSetup [2] _without_ even actually using the record(s) in the user (DIGI) code (planned to be used of it in 80X Digitization for 2016 MC)

[1] This DB container will provide per-HCAL-readout flag of the FE QIE electronics type for choosing a corresponding ADC coder in DIGI/RECO.
https://github.com/cms-sw/cmssw/pull/12473

 [2] in HCAL DB-related code
CalibCalorimetry/HcalPlugins/python/Hcal_FrontierConditions_cff.py
CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
CalibFormats/HcalObjects/interface/HcalDbRecord.h
CalibFormats/HcalObjects/interface/HcalDbService.h
CalibFormats/HcalObjects/src/HcalDbService.cc
