### PR TITLE
Add HGCal to CaloRecHit and ParticleFlowReco enums in DataFormats

### DIFF
--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -29,7 +29,7 @@ namespace reco {
   class CaloCluster {
   public:
     
-    enum AlgoId { island = 0, hybrid = 1, fixedMatrix = 2, dynamicHybrid = 3, multi5x5 = 4, particleFlow = 5,  undefined = 1000};
+    enum AlgoId { island = 0, hybrid = 1, fixedMatrix = 2, dynamicHybrid = 3, multi5x5 = 4, particleFlow = 5,  hgcal_em = 6, hgcal_had = 7, hgcal_mixed = 8, undefined = 1000};
 
     // super-cluster flags
     enum SCFlags { cleanOnly = 0, common = 100, uncleanOnly = 200 };

--- a/DataFormats/CaloRecHit/interface/CaloID.h
+++ b/DataFormats/CaloRecHit/interface/CaloID.h
@@ -29,6 +29,7 @@ namespace reco {
       DET_HF_EM,
       DET_HF_HAD,
       DET_HO,
+      DET_HGCAL_ENDCAP,
       DET_NONE
     };
 

--- a/DataFormats/CaloRecHit/src/CaloRecHit.cc
+++ b/DataFormats/CaloRecHit/src/CaloRecHit.cc
@@ -9,7 +9,7 @@ CaloRecHit::CaloRecHit(const DetId& id, float energy, float time, uint32_t flags
 }
 
 
-static const uint32_t masks[] = {
+constexpr uint32_t masks[] = {
   0x00000000u,0x00000001u,0x00000003u,0x00000007u,0x0000000fu,0x0000001fu,
   0x0000003fu,0x0000007fu,0x000000ffu,0x000001ffu,0x000003ffu,0x000007ffu,
   0x00000fffu,0x00001fffu,0x00003fffu,0x00007fffu,0x0000ffffu,0x0001ffffu,

--- a/DataFormats/ParticleFlowReco/interface/PFLayer.h
+++ b/DataFormats/ParticleFlowReco/interface/PFLayer.h
@@ -37,7 +37,9 @@ class PFLayer {
               HCAL_BARREL2 = 2,
               HCAL_ENDCAP  = 3,
               HF_EM        = 11,
-              HF_HAD       = 12};
+              HF_HAD       = 12,
+              HGCAL        = 13  // HGCal, could be EM or HAD
+  };
 
   static reco::CaloID  toCaloID( Layer layer);
   

--- a/DataFormats/ParticleFlowReco/src/PFLayer.cc
+++ b/DataFormats/ParticleFlowReco/src/PFLayer.cc
@@ -20,6 +20,7 @@ CaloID  PFLayer::toCaloID( Layer layer) {
   case HCAL_ENDCAP   : return  CaloID(CaloID::DET_HCAL_ENDCAP); 
   case HF_EM         : return  CaloID(CaloID::DET_HF_EM); 
   case HF_HAD        : return  CaloID(CaloID::DET_HF_HAD); 
+  case HGCAL         : return  CaloID(CaloID::DET_HGCAL_ENDCAP);
   default            : return  CaloID();
   }
 }
@@ -42,6 +43,7 @@ PFLayer::Layer   PFLayer::fromCaloID( const CaloID& id) {
   case CaloID::DET_HF_EM         : return  HF_EM;
   case CaloID::DET_HF_HAD        : return  HF_HAD;
   case CaloID::DET_HO            : return  HCAL_BARREL2; 
+  case CaloID::DET_HGCAL_ENDCAP  : return  HGCAL;
   default                        : return  NONE;
   }
 }


### PR DESCRIPTION
Inform low level calorimeter classes that the HGCal exists.
There is only one HGCal detector partition label at this level of interpretation, it is expected that there is a baseline embedded guess from the initial clustering if something is EM-like or HAD-like.

This update is purely technical, no changes expected/observed.
