### PR TITLE
Optimize provenance constructors using move semantics

### DIFF
--- a/DataFormats/Provenance/interface/Parentage.h
+++ b/DataFormats/Provenance/interface/Parentage.h
@@ -27,7 +27,14 @@ namespace edm {
     Parentage();
 
     explicit Parentage(std::vector<BranchID> const& parents);
+    explicit Parentage(std::vector<BranchID>&& parents);
 
+    Parentage(Parentage const&) = default;
+    Parentage(Parentage&&) = default;
+
+    Parentage& operator=(Parentage const&) = default;
+    Parentage& operator=(Parentage&&) = default;
+    
     ~Parentage() {}
 
     ParentageID id() const;

--- a/DataFormats/Provenance/interface/ParentageRegistry.h
+++ b/DataFormats/Provenance/interface/ParentageRegistry.h
@@ -38,6 +38,7 @@ namespace edm
     /// value_type object, and 'false' if the
     /// value_type object was already present.
     bool insertMapped(value_type const& v);
+    bool insertMapped(value_type&& v);
     
     ///Not thread safe
     void clear();

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -31,6 +31,9 @@ namespace edm {
     ProductProvenance(BranchID const& bid,
                       std::vector<BranchID> const& parents);
 
+    ProductProvenance(BranchID const& bid,
+                      std::vector<BranchID>&& parents);
+
     ~ProductProvenance() {}
 
     ProductProvenance makeProductProvenance() const;

--- a/DataFormats/Provenance/src/Parentage.cc
+++ b/DataFormats/Provenance/src/Parentage.cc
@@ -15,6 +15,10 @@ namespace edm {
     parents_(parents) {
   }
 
+  Parentage::Parentage(std::vector<BranchID>&& parents) :
+  parents_(std::move(parents)) {
+  }
+
   ParentageID
   Parentage::id() const {
     std::ostringstream oss;

--- a/DataFormats/Provenance/src/ParentageRegistry.cc
+++ b/DataFormats/Provenance/src/ParentageRegistry.cc
@@ -30,7 +30,12 @@ namespace edm {
   ParentageRegistry::insertMapped(value_type const& v) {
     return m_map.insert(std::make_pair(v.id(),v)).second;
   }
-  
+
+  bool
+  ParentageRegistry::insertMapped(value_type&& v) {
+    return m_map.emplace(v.id(),std::move(v)).second;
+  }
+
   void
   ParentageRegistry::clear() {
     m_map.clear();

--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -38,6 +38,16 @@ namespace edm {
       ParentageRegistry::instance()->insertMapped(p);
   }
 
+  ProductProvenance::ProductProvenance(BranchID const& bid,
+                                       std::vector<BranchID>&& parents) :
+  branchID_(bid),
+  parentageID_() {
+    Parentage p;
+    p.setParents(std::move(parents));
+    parentageID_ = p.id();
+    ParentageRegistry::instance()->insertMapped(std::move(p));
+  }
+
   ProductProvenance
   ProductProvenance::makeProductProvenance() const {
     return *this;

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -168,13 +168,13 @@ namespace edm {
     while(pit != pie) {
       // set provenance
       if(!sameAsPrevious) {
-        ProductProvenance prov(pit->second->branchID(), gotBranchIDVector);
+        ProductProvenance prov(pit->second->branchID(), std::move(gotBranchIDVector));
         *previousParentageId = prov.parentageID();
-  	ep.put(*pit->second, std::move(pit->first), prov);
+        ep.put(*pit->second, std::move(pit->first), prov);
         sameAsPrevious = true;
       } else {
         ProductProvenance prov(pit->second->branchID(), *previousParentageId);
-  	ep.put(*pit->second, std::move(pit->first), prov);
+        ep.put(*pit->second, std::move(pit->first), prov);
       }
       ++pit;
     }


### PR DESCRIPTION
Use move semantics to avoid copying the BranchID parent list.
