### PR TITLE
Monitor conversion tracks in tracking validation

### DIFF
--- a/CommonTools/RecoAlgos/plugins/TrackingParticleConversionSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackingParticleConversionSelector.cc
@@ -1,0 +1,62 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/Common/interface/EDProductfwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+
+class TrackingParticleConversionSelector: public edm::stream::EDProducer<> {
+public:
+  TrackingParticleConversionSelector(const edm::ParameterSet& iConfig);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
+};
+
+
+TrackingParticleConversionSelector::TrackingParticleConversionSelector(const edm::ParameterSet& iConfig):
+  tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("src")))
+{
+  produces<TrackingParticleCollection>();
+}
+
+void TrackingParticleConversionSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("mix", "MergedTrackTruth"));
+  descriptions.add("trackingParticleConversionSelector", desc);
+}
+
+void TrackingParticleConversionSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<TrackingParticleCollection> h_tps;
+  iEvent.getByToken(tpToken_, h_tps);
+
+  // Copy TPs because currently we can't process RefVectors of TPs in downstream
+  auto ret = std::make_unique<TrackingParticleCollection>();
+
+  // Logic is similar to Validation/RecoEgamma/plugins/PhotonValidator.cc
+  // and RecoEgamma/EgammaMCTools/src/PhotonMCTruthFinder.cc,
+  // but implemented purely in terms of TrackingParticles (simpler and works for pileup too)
+  for(const auto& tp: *h_tps) {
+    if(tp.pdgId() == 22) {
+      for(const auto& vertRef: tp.decayVertices()) {
+        for(const auto& tpRef: vertRef->daughterTracks()) {
+          if(std::abs(tpRef->pdgId()) == 11) {
+            ret->push_back(*tpRef);
+          }
+        }
+      }
+    }
+  }
+
+  iEvent.put(std::move(ret));
+}
+
+DEFINE_FWK_MODULE(TrackingParticleConversionSelector);

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -52,7 +52,7 @@ postValidation_fastsim = cms.Sequence(
 )
 
 postValidation_trackingOnly = cms.Sequence(
-      postProcessorTrackSequence
+      postProcessorTrackSequenceTrackingOnly
     + postProcessorVertex
 )
  

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackSeeding/*", "Tracking/TrackBuilding/*"),
+    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackSeeding/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -159,7 +159,7 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
 )
 
 postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackSeeding", "Tracking/TrackBuilding"),
+    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackSeeding", "Tracking/TrackBuilding", "Tracking/TrackConversion"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackSeeding/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*"),
+    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackConversion/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -159,7 +159,7 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
 )
 
 postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackSeeding", "Tracking/TrackBuilding", "Tracking/TrackConversion"),
+    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackConversion"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",
@@ -171,3 +171,10 @@ postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
 )
 
 postProcessorTrackSequence = cms.Sequence(postProcessorTrack+postProcessorTrackSummary)
+
+postProcessorTrackTrackingOnly = postProcessorTrack.clone()
+postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackSeeding/*", "Tracking/TrackBuilding/*"])
+postProcessorTrackSummaryTrackingOnly = postProcessorTrackSummary.clone()
+postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackSeeding", "Tracking/TrackBuilding"])
+
+postProcessorTrackSequenceTrackingOnly = cms.Sequence(postProcessorTrackTrackingOnly+postProcessorTrackSummaryTrackingOnly)


### PR DESCRIPTION
This PR adds MultiTrackValidator instance to monitor conversion tracks: currently `convStepTracks`, `conversionStepTracks`, `ckfInOutTracksFromConversions`, and `ckfOutInTracksFromConversions` collections.  Tracks from these collections are matched against "conversion TrackingParticles", i.e. electron/positron TrackingParticles (`abs(pdgId) == 11`) that have photon TrackingParticles as their parents (similar to  `PhotonValidator` and `PhotonMCTruthFinder`). A consequence is that a track that is matched to a non-conversion TrackingParticle is classified as a fake.

Plot script will be updated separately (to not to conflict with #12893).

On the same go I modified the seeding+building MTV instances (introduced in #12747) to be harvested only in the tracingOnly mode (where they are present) to silence printouts

```
%MSG-e DQMGenericClient:  DQMGenericClient:postProcessorTrack@endJob  11-Jan-2016 15:49:48 CET PostEndRun
 DQMGenericClient::findAllSubdirectories ==> Missing folder Tracking/TrackSeeding !!!
%MSG
%MSG-e DQMGenericClient:  DQMGenericClient:postProcessorTrack@endJob  11-Jan-2016 15:49:48 CET PostEndRun
 DQMGenericClient::findAllSubdirectories ==> Missing folder Tracking/TrackBuilding !!!
%MSG
```

Tested in CMSSW_8_0_X_2016-01-11-1100, no changes expected in existing plots.

@rovere @VinInn @slava77 @matteosan1 
