### PR TITLE
FastSim: use default reconstruction in the scenario 'HeavyIons'. 

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1016,7 +1016,15 @@ class ConfigBuilder(object):
             self.VALIDATIONDefaultSeq=''
             self.EVTCONTDefaultCFF="Configuration/EventContent/EventContentHeavyIons_cff"
             self.RECODefaultCFF="Configuration/StandardSequences/ReconstructionHeavyIons_cff"
-            self.RECODefaultSeq='reconstructionHeavyIons'
+	    if self._options.fast:
+		    print "###########"
+		    print "WARNING"
+		    print "You are using fastsim in the scenario 'HeavyIons'."
+		    print "Fastsim has no heavy ion reconstruction sequence."
+		    print "Therefore the default reconstruction sequence is used instead."
+		    print "###########"
+	    else:
+		    self.RECODefaultSeq='reconstructionHeavyIons'
             self.ALCADefaultCFF = "Configuration/StandardSequences/AlCaRecoStreamsHeavyIons_cff"
             self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineHeavyIons_cff"
             self.DQMDefaultSeq='DQMOfflineHeavyIons'


### PR DESCRIPTION
@Martin-Grunewald 

Solves the issue that occurs since #12728
that cmsdriver crashes on the combination of options
--fast and --scenario HeavyIons

The old behaviour for this case is restored
(default reconstruction is run)
and a warning message is printed.
