### PR TITLE
Let eras deal with all postLS1 customs common for mixing and premixing

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-import muonCustoms
 
 def customise_csc_PostLS1(process):
-    process=muonCustoms.customise_csc_PostLS1(process)
 
     if hasattr(process,'simCscTriggerPrimitiveDigis'):
         process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'mixData', 'MuonCSCComparatorDigisDM')

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
@@ -2,13 +2,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from SLHCUpgradeSimulations.Configuration.muonCustomsPreMixing import customise_csc_PostLS1
-import postLS1Customs
-
 
 def customisePostLS1(process):
 
-    # apply the general 25 ns post-LS1 customisation
-    process = postLS1Customs.customisePostLS1(process)
     # deal with premixing-specific CSC changes separately
     process = customise_csc_PostLS1(process)
 
@@ -17,8 +13,6 @@ def customisePostLS1(process):
 
 def customisePostLS1_50ns(process):
 
-    # apply the general 25 ns post-LS1 customisation
-    process = postLS1Customs.customisePostLS1_50ns(process)
     # deal with premixing-specific CSC changes separately
     process = customise_csc_PostLS1(process)
 
@@ -27,8 +21,6 @@ def customisePostLS1_50ns(process):
 
 def customisePostLS1_HI(process):
 
-    # apply the general 25 ns post-LS1 customisation
-    process = postLS1Customs.customisePostLS1_HI(process)
     # deal with premixing-specific CSC changes separately
     process = customise_csc_PostLS1(process)
 


### PR DESCRIPTION
Premixing workflows still make use of the cmsDriver --customise option to apply postLS1 modifications. (customiseForPremixingInput.customiseForPreMixingInput). 
This customisation is applied on top of the era customisation.
This has 2 negative impacts:
i) some modification is applied twice (needles)
ii) the customisation functions may get out of sync with the era modifications and overwrite the era modifications in the wrong way

The latter is the cause of the long-lasting issue that the L1 emulator does not properly work with FastSim premixing. 

With this pull request, the only modifications applied outside the eras are the very premixing specific ones.

CAUTION: this pull request has some unexpected consequences on dumped configurations for simulation + premixing. Probably because the customisation functions are no longer maintained and got out of sync with the era modifications.

@mdhildreth , you probably want to have a look at this one
