### PR TITLE
Removed Principal as member data to ProductHolders

### DIFF
--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -289,7 +289,7 @@ namespace edm {
       }));
     }
     ProductHolderBase::ResolveStatus status;
-    phb->resolveProduct(status,false,nullptr,nullptr);
+    phb->resolveProduct(status,*this,false,nullptr,nullptr);
 
     return BasicHandle(phb->productData());
   }
@@ -442,7 +442,7 @@ namespace edm {
         << "This should never happen. Contact a Framework developer";
     }
     ProductHolderBase::ResolveStatus status;
-    ProductData const* productData = phb->resolveProduct(status,false,nullptr,nullptr);
+    ProductData const* productData = phb->resolveProduct(status,*this,false,nullptr,nullptr);
     if (productData == nullptr) {
       return nullptr;
     }

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -36,14 +36,16 @@ namespace edm {
   NoProcessProductHolder::~NoProcessProductHolder() {}
 
   ProductData const*
-  InputProductHolder::resolveProduct_(ResolveStatus& resolveStatus, bool,
+  InputProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                      Principal const& principal,
+                                      bool,
                                       SharedResourcesAcquirer* ,
                                       ModuleCallingContext const* mcc) const {
     if(productWasDeleted()) {
       throwProductDeletedException();
     }
     if(!productUnavailable()) {
-      principal_->readFromSource(*this, mcc);
+      principal.readFromSource(*this, mcc);
       // If the product is a dummy filler, product holder will now be marked unavailable.
       if(product() && !productUnavailable()) {
         // Found the match
@@ -57,6 +59,7 @@ namespace edm {
 
   ProductData const*
   ScheduledProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                          Principal const&,
                                           bool skipCurrentProcess,
                                           SharedResourcesAcquirer*,
                                           ModuleCallingContext const*) const {
@@ -75,6 +78,7 @@ namespace edm {
 
   ProductData const*
   SourceProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                       Principal const& principal,
                                        bool skipCurrentProcess,
                                        SharedResourcesAcquirer*,
                                        ModuleCallingContext const*) const {
@@ -93,6 +97,7 @@ namespace edm {
 
   ProductData const*
   UnscheduledProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                            Principal const& principal,
                                             bool skipCurrentProcess,
                                             SharedResourcesAcquirer* sra,
                                             ModuleCallingContext const* mcc) const {
@@ -104,7 +109,7 @@ namespace edm {
         resolveStatus = ProductFound;
         return &productData_;
       }
-      principal_->unscheduledFill(moduleLabel(), sra, mcc);
+      principal.unscheduledFill(moduleLabel(), sra, mcc);
       if(product() && product()->isPresent()) {
         resolveStatus = ProductFound;
         return &productData_;
@@ -251,10 +256,6 @@ namespace edm {
     return true;
   }
 
-  void InputProductHolder::setPrincipal_(Principal* principal) {
-    principal_ = principal;
-  }
-
   // This routine returns true if it is known that currently there is no real product.
   // If there is a real product, it returns false.
   // If it is not known if there is a real product, it returns false.
@@ -318,12 +319,6 @@ namespace edm {
     return true;
   }
 
-  void ProducedProductHolder::setPrincipal_(Principal*) {
-    throw Exception(errors::LogicError)
-      << "ProducedProductHolder::setPrincipal__() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
-  }
-
   bool
   ProductHolderBase::provenanceAvailable() const {
     // If this product is from a the current process,
@@ -369,11 +364,9 @@ namespace edm {
 
   NoProcessProductHolder::
   NoProcessProductHolder(std::vector<ProductHolderIndex> const&  matchingHolders,
-                         std::vector<bool> const& ambiguous,
-                         Principal* principal) : 
+                         std::vector<bool> const& ambiguous) :
     matchingHolders_(matchingHolders),
-    ambiguous_(ambiguous),
-    principal_(principal) {
+    ambiguous_(ambiguous) {
     assert(ambiguous_.size() == matchingHolders_.size());
   }
 
@@ -390,10 +383,11 @@ namespace edm {
   }
 
   ProductData const* NoProcessProductHolder::resolveProduct_(ResolveStatus& resolveStatus,
+                                                             Principal const& principal,
                                                              bool skipCurrentProcess,
                                                              SharedResourcesAcquirer* sra,
                                                              ModuleCallingContext const* mcc) const {
-    std::vector<unsigned int> const& lookupProcessOrder = principal_->lookupProcessOrder();
+    std::vector<unsigned int> const& lookupProcessOrder = principal.lookupProcessOrder();
     for(unsigned int k : lookupProcessOrder) {
       assert(k < ambiguous_.size());
       if(k == 0) break; // Done
@@ -402,8 +396,8 @@ namespace edm {
         return nullptr;
       }
       if (matchingHolders_[k] != ProductHolderIndexInvalid) {
-        ProductHolderBase const* productHolder = principal_->getProductHolderByIndex(matchingHolders_[k]);
-        ProductData const* pd =  productHolder->resolveProduct(resolveStatus, skipCurrentProcess, sra, mcc);
+        ProductHolderBase const* productHolder = principal.getProductHolderByIndex(matchingHolders_[k]);
+        ProductData const* pd =  productHolder->resolveProduct(resolveStatus, principal, skipCurrentProcess, sra, mcc);
         if(pd != nullptr) return pd;
       }
     }
@@ -432,14 +426,10 @@ namespace edm {
     return true;
   }
 
-  void AliasProductHolder::setPrincipal_(Principal*) {
-  }
-
   void NoProcessProductHolder::swap_(ProductHolderBase& rhs) {
     NoProcessProductHolder& other = dynamic_cast<NoProcessProductHolder&>(rhs);
     ambiguous_.swap(other.ambiguous_);
     matchingHolders_.swap(other.matchingHolders_);
-    std::swap(principal_, other.principal_);
   }
 
   void NoProcessProductHolder::resetStatus_() {
@@ -460,12 +450,6 @@ namespace edm {
 
   bool NoProcessProductHolder::singleProduct_() const {
     return false;
-  }
-
-  void NoProcessProductHolder::setPrincipal_(Principal* ) {
-    throw Exception(errors::LogicError)
-      << "NoProcessProductHolder::setPrincipal__() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
   }
 
   bool NoProcessProductHolder::onDemand_() const {


### PR DESCRIPTION
Classes that inherited from ProductHolder only needed access to the Principal during the call to resolveProduct. Therefore resolveProduct was changed to pass Principal& as an argument. This allows us to drop Principal\* as a member data to all instances of ProductHolder.
