### PR TITLE
Fix DQM standalone compilation

### DIFF
--- a/DQMServices/Core/interface/Standalone.h
+++ b/DQMServices/Core/interface/Standalone.h
@@ -1,6 +1,7 @@
 #ifndef DQMSERVICES_CORE_STANDALONE_H
 # define DQMSERVICES_CORE_STANDALONE_H
 # if !WITHOUT_CMS_FRAMEWORK
+#  include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #  include "FWCore/ParameterSet/interface/ParameterSet.h"
 #  include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #  include "FWCore/ServiceRegistry/interface/Service.h"
@@ -56,9 +57,11 @@ namespace edm
     T &operator*(void) { return * operator->(); }
   };
 
-  struct SystemBounds {
-    unsigned int maxNumberOfStreams() const { return 0; }
-  };
+  namespace service {
+    struct SystemBounds {
+      unsigned int maxNumberOfStreams() const { return 0; }
+    };
+  }
 
   struct PreallocationSignal {
     template <typename T>

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -1,4 +1,3 @@
-#include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #include "DQMServices/Core/interface/Standalone.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/QReport.h"


### PR DESCRIPTION
DQM core code needs to be compiled outside of the CMSSW FWK into the
DQMGUI code. This PR fixes few bugs that have been introduced in the
past (commit
https://github.com/cms-sw/cmssw/commit/197ddb37826148fe40a09a22f05146180266d2d0,
PR https://github.com/cms-sw/cmssw/pull/3411). All the include files
that are CMSSW related should never be added directly in DQMStore.cc,
but to Standalone.h protected by the WITHOUT_CMS_FRAMEWORK condition. A
required edm::service namespace was missing, and this bug allowed the
original compilation of the code that would have otherwise correctly
failed to compile. This indicates that a better way of testing the
standalong compilation should be found, but that's not extremely urgent.
