### PR TITLE
New GT for all scenarios: updating b-tagging discriminators for HLT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,33 +2,33 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '80X_mcRun1_design_v1',
+    'run1_design'       :   '80X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '80X_mcRun1_realistic_v1',
+    'run1_mc'           :   '80X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '80X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '80X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v0',
+    'run2_design'       :   '80X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v0',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v0',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v0',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v1',
+    'run1_data'         :   '80X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v1',
+    'run2_data'         :   '80X_dataRun2_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v0',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v0',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v0',
+    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v0',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Changes in Global Tag
## RunI simulation
- **RunI Ideal scenario** : [80X_mcRun1_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_design_v2) as [80X_mcRun1_design_v1](https://cms-conddb.
  cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_design_v2/80X_mcRun1_design_v1): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunI Heavy Ions scenario** : [80X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_HeavyIon_v2) as [80X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_HeavyIon_v2/80X_mcRun1_HeavyIon_v1): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunI Realistic scenario** : [80X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_realistic_v2) as [80X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_realistic_v2/80X_mcRun1_realistic_v1): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunI Proton-Lead scenario** : [80X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_pA_v2) as [80X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_pA_v2/80X_mcRun1_pA_v1): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v1) as [80X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v1/80X_mcRun2_design_v0): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v1) as [80X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v1/80X_mcRun2_asymptotic_v0): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunII Startup scenario** : [80X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v1) as [80X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v1/80X_mcRun2_startup_v0): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunII Heavy Ions scenario** : [80X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v1) as [80X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_HeavyIon_v1/80X_mcRun2_HeavyIon_v0): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
## RunI data
- **RunI Offline processing** : [80X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v2) as [80X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v2/80X_dataRun2_v1): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunI HLT processing** : [80X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v1) as [80X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v1/80X_dataRun2_HLT_frozen_v0) (snapshot time set to 2015-01-13 22:00:00 UTC) : 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_v2) as [80X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v2/80X_dataRun2_v1): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v1) as [80X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v1/80X_dataRun2_HLT_frozen_v0) (snapshot time set to 2015-01-13 22:00:00 UTC) : 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
- **RunII HLT Heavy Ion processing** :  [80X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v1) as [80X_dataRun2_HLTHI_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLTHI_frozen_v1/80X_dataRun2_HLTHI_frozen_v0) (snapshot time set to 2015-01-13 22:00:00 UTC) : 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v1) as [80X_upgrade2017_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v1/80X_upgrade2017_design_v0): 
  - updated B tag discriminators for HLT with the following taggers: `CombinedSVIVFV2RecoVertex`, `CombinedSVIVFV2PseudoVertex`, `CombinedSVIVFV2NoVertex`
