### PR TITLE
During event processing only call const methods of Principal

### DIFF
--- a/CondFormats/GeometryObjects/src/T_EventSetup_PHGCalParameters.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PHGCalParameters.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/GeometryObjects/interface/PHGCalParameters.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(PHGCalParameters);

--- a/CondFormats/GeometryObjects/src/T_EventSetup_PHGCalParameters.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PHGCalParameters.cc
@@ -1,4 +1,0 @@
-#include "CondFormats/GeometryObjects/interface/PHGCalParameters.h"
-#include "FWCore/Utilities/interface/typelookup.h"
-
-TYPELOOKUP_DATA_REG(PHGCalParameters);

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -32,6 +32,7 @@ namespace edm {
     
     WrapperBase const* wrapper() const { return wrapper_.get();}
     WrapperBase* wrapper() { return wrapper_.get(); }
+    WrapperBase* unsafe_wrapper() const { return wrapper_.get(); }
     std::shared_ptr<WrapperBase const> sharedConstWrapper() const {
       return wrapper_;
     }
@@ -51,7 +52,11 @@ namespace edm {
     void resetProductData() {
       wrapper_.reset();
     }
-    
+
+    void unsafe_resetProductData() const {
+      wrapper_.reset();
+    }
+
     void setProcessHistory(ProcessHistory const& ph) {
       prov_.setProcessHistory(ph);
     }

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -52,19 +52,19 @@ namespace edm {
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
   private:    
-    bool doEvent(EventPrincipal& ep, EventSetup const& c,
+    bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();    
-    void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal& rp, EventSetup const& c,
+    void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                   ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -49,19 +49,19 @@ namespace edm {
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
   private:
-    bool doEvent(EventPrincipal& ep, EventSetup const& c,
+    bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
-    void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal& rp, EventSetup const& c,
+    void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                   ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -63,7 +63,7 @@ namespace edm {
 
   class Event : public EventBase {
   public:
-    Event(EventPrincipal& ep, ModuleDescription const& md,
+    Event(EventPrincipal const& ep, ModuleDescription const& md,
           ModuleCallingContext const*);
     virtual ~Event();
     
@@ -236,9 +236,6 @@ namespace edm {
 
     EventPrincipal const&
     eventPrincipal() const;
-
-    EventPrincipal&
-    eventPrincipal();
 
     ProductID
     makeProductID(BranchDescription const& desc) const;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -86,7 +86,7 @@ namespace edm {
       return *luminosityBlockPrincipal_;
     }
 
-    bool luminosityBlockPrincipalPtrValid() {
+    bool luminosityBlockPrincipalPtrValid() const {
       return (luminosityBlockPrincipal_) ? true : false;
     }
 
@@ -152,12 +152,12 @@ namespace edm {
     void put(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance);
+        ProductProvenance const& productProvenance) const;
 
     void putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance);
+        ProductProvenance const& productProvenance) const;
 
     virtual WrapperBase const* getIt(ProductID const& pid) const override;
     virtual WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -44,7 +44,7 @@ namespace edm {
 
   class LuminosityBlock : public LuminosityBlockBase {
   public:
-    LuminosityBlock(LuminosityBlockPrincipal& lbp, ModuleDescription const& md,
+    LuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
                     ModuleCallingContext const*);
     ~LuminosityBlock();
 
@@ -139,9 +139,6 @@ namespace edm {
   private:
     LuminosityBlockPrincipal const&
     luminosityBlockPrincipal() const;
-
-    LuminosityBlockPrincipal&
-    luminosityBlockPrincipal();
 
     // Override version from LuminosityBlockBase class
     virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -101,8 +101,6 @@ namespace edm {
         std::unique_ptr<WrapperBase> edp) const;
 
 
-    void readImmediate();
-
     void setComplete() {
       complete_ = true;
     }
@@ -116,8 +114,6 @@ namespace edm {
                                  ModuleCallingContext const*) const override {return false;}
 
     virtual unsigned int transitionIndex_() const override;
-
-    void resolveProductImmediate(ProductHolderBase& phb);
 
     edm::propagate_const<std::shared_ptr<RunPrincipal>> runPrincipal_;
 

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -98,7 +98,7 @@ namespace edm {
 
     void put(
         BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp);
+        std::unique_ptr<WrapperBase> edp) const;
 
 
     void readImmediate();

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -193,6 +193,8 @@ namespace edm {
       readFromSource_(phb, mcc);
     }
 
+    void readAllFromSourceAndMergeImmediately();
+    
     virtual bool unscheduledFill(std::string const& moduleLabel,
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const = 0;
@@ -216,10 +218,8 @@ namespace edm {
     // throws if the pointed to product is already in the Principal.
     void checkUniquenessAndType(WrapperBase const* prod, ProductHolderBase const* productHolder) const;
 
-    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase* productHolder) const;
-
-    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance&& prov, ProductHolderBase* productHolder) const;
-
+    void putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase>  edp) const;
+    
   private:
 
     virtual WrapperBase const* getIt(ProductID const&) const override;
@@ -251,9 +251,13 @@ namespace edm {
                                           ModuleCallingContext const* mcc) const;
 
     virtual void readFromSource_(ProductHolderBase const& /* phb */, ModuleCallingContext const* /* mcc */) const {}
-
+    
+    void resolveProductImmediately(ProductHolderBase& phb);
+    
     virtual bool isComplete_() const {return true;}
-
+    
+    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase const* productHolder) const;
+    
     std::shared_ptr<ProcessHistory const> processHistoryPtr_;
 
     ProcessHistoryID processHistoryID_;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -90,7 +90,7 @@ namespace edm {
 
     void clearPrincipal();
 
-    void deleteProduct(BranchID const& id);
+    void deleteProduct(BranchID const& id) const;
     
     EDProductGetter const* prodGetter() const {return this;}
 
@@ -210,15 +210,15 @@ namespace edm {
     // data.
     void addProduct_(std::unique_ptr<ProductHolderBase> phb);
     void addProductOrThrow(std::unique_ptr<ProductHolderBase> phb);
-    ProductHolderBase* getExistingProduct(BranchID const& branchID);
-    ProductHolderBase* getExistingProduct(ProductHolderBase const& phb);
+    ProductHolderBase* getExistingProduct(BranchID const& branchID) const;
+    ProductHolderBase* getExistingProduct(ProductHolderBase const& phb) const;
 
     // throws if the pointed to product is already in the Principal.
     void checkUniquenessAndType(WrapperBase const* prod, ProductHolderBase const* productHolder) const;
 
-    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase* productHolder);
+    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase* productHolder) const;
 
-    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance&& prov, ProductHolderBase* productHolder);
+    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance&& prov, ProductHolderBase* productHolder) const;
 
   private:
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -49,13 +49,14 @@ namespace edm {
   class SharedResourcesAcquirer;
 
   struct FilledProductPtr {
-    bool operator()(std::shared_ptr<ProductHolderBase> const& iObj) { return bool(iObj);}
+    bool operator()(propagate_const<std::shared_ptr<ProductHolderBase>> const& iObj) { return bool(iObj);}
   };
 
   class Principal : public EDProductGetter {
   public:
-    typedef std::vector<std::shared_ptr<ProductHolderBase> > ProductHolderCollection;
+    typedef std::vector<propagate_const<std::shared_ptr<ProductHolderBase>> > ProductHolderCollection;
     typedef boost::filter_iterator<FilledProductPtr, ProductHolderCollection::const_iterator> const_iterator;
+    typedef boost::filter_iterator<FilledProductPtr, ProductHolderCollection::iterator> iterator;
     typedef ProcessHistory::const_iterator ProcessNameConstIterator;
     typedef ProductHolderBase const* ConstProductHolderPtr;
     typedef std::vector<BasicHandle> BasicHandleVec;
@@ -167,6 +168,9 @@ namespace edm {
     const_iterator begin() const {return boost::make_filter_iterator<FilledProductPtr>(productHolders_.begin(), productHolders_.end());}
     const_iterator end() const {return  boost::make_filter_iterator<FilledProductPtr>(productHolders_.end(), productHolders_.end());}
 
+    iterator begin() {return boost::make_filter_iterator<FilledProductPtr>(productHolders_.begin(), productHolders_.end());}
+    iterator end() {return  boost::make_filter_iterator<FilledProductPtr>(productHolders_.end(), productHolders_.end());}
+
     Provenance getProvenance(BranchID const& bid,
                              ModuleCallingContext const* mcc) const;
 
@@ -212,8 +216,9 @@ namespace edm {
     // data.
     void addProduct_(std::unique_ptr<ProductHolderBase> phb);
     void addProductOrThrow(std::unique_ptr<ProductHolderBase> phb);
-    ProductHolderBase* getExistingProduct(BranchID const& branchID) const;
-    ProductHolderBase* getExistingProduct(ProductHolderBase const& phb) const;
+    ProductHolderBase* getExistingProduct(BranchID const& branchID);
+    ProductHolderBase const* getExistingProduct(BranchID const& branchID) const;
+    ProductHolderBase const* getExistingProduct(ProductHolderBase const& phb) const;
 
     // throws if the pointed to product is already in the Principal.
     void checkUniquenessAndType(WrapperBase const* prod, ProductHolderBase const* productHolder) const;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -127,7 +127,7 @@ namespace edm {
   }
   class PrincipalGetAdapter {
   public:
-    PrincipalGetAdapter(Principal & pcpl,
+    PrincipalGetAdapter(Principal const& pcpl,
 		 ModuleDescription const& md);
 
     ~PrincipalGetAdapter();
@@ -159,7 +159,6 @@ namespace edm {
     ProcessHistory const&
     processHistory() const;
 
-    Principal& principal() {return principal_;}
     Principal const& principal() const {return principal_;}
 
     BranchDescription const&
@@ -229,7 +228,7 @@ namespace edm {
 
     // Each PrincipalGetAdapter must have an associated Principal, used as the
     // source of all 'gets' and the target of 'puts'.
-    Principal & principal_;
+    Principal const& principal_;
 
     // Each PrincipalGetAdapter must have a description of the module executing the
     // "transaction" which the PrincipalGetAdapter represents.

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -64,8 +64,8 @@ namespace edm {
 
     void resetProductData() { resetProductData_(); }
 
-    void deleteProduct() {
-      getProductData().resetProductData();
+    void unsafe_deleteProduct() const {
+      getProductData().unsafe_resetProductData();
       setProductDeleted_();
     }
     
@@ -133,7 +133,7 @@ namespace edm {
     ProductID const& productID() const {return getProductData().provenance().productID();}
 
     // Puts the product and its per event(lumi)(run) provenance into the ProductHolder.
-    void putProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) {
+    void putProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const {
       putProduct_(std::move(edp), productProvenance);
     }
 
@@ -148,16 +148,16 @@ namespace edm {
     }
 
     // merges the product with the pre-existing product
-    void mergeProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance const & productProvenance) {
+    void mergeProduct(std::unique_ptr<WrapperBase> edp, ProductProvenance const & productProvenance) const {
       mergeProduct_(std::move(edp), productProvenance);
     }
 
-    void mergeProduct(std::unique_ptr<WrapperBase> edp) {
+    void mergeProduct(std::unique_ptr<WrapperBase> edp) const {
       mergeProduct_(std::move(edp));
     }
 
     // Merges two instances of the product.
-    void mergeTheProduct(std::unique_ptr<WrapperBase> edp);
+    void mergeTheProduct(std::unique_ptr<WrapperBase> edp) const;
 
     void reallyCheckType(WrapperBase const& prod) const;
 
@@ -170,6 +170,8 @@ namespace edm {
     void throwProductDeletedException() const;
 
   private:
+    WrapperBase * unsafe_product() const { return getProductData().unsafe_wrapper(); }
+
     virtual ProductData const& getProductData() const = 0;
     virtual ProductData& getProductData() = 0;
     virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
@@ -181,14 +183,14 @@ namespace edm {
     virtual bool onDemand_() const = 0;
     virtual bool productUnavailable_() const = 0;
     virtual bool productWasDeleted_() const = 0;
-    virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) = 0;
+    virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const = 0;
     virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
-    virtual void mergeProduct_(std::unique_ptr<WrapperBase>  edp, ProductProvenance const& productProvenance) = 0;
-    virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) = 0;
+    virtual void mergeProduct_(std::unique_ptr<WrapperBase>  edp, ProductProvenance const& productProvenance) const = 0;
+    virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
     virtual bool putOrMergeProduct_() const = 0;
     virtual void checkType_(WrapperBase const& prod) const = 0;
     virtual void resetStatus_() = 0;
-    virtual void setProductDeleted_() = 0;
+    virtual void setProductDeleted_() const = 0;
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
@@ -231,10 +233,10 @@ namespace edm {
                                                  bool skipCurrentProcess,
                                                  SharedResourcesAcquirer* sra,
                                                  ModuleCallingContext const* mcc) const override;
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
+      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override;
       virtual bool putOrMergeProduct_() const override;
       virtual void checkType_(WrapperBase const&) const override {}
       virtual void resetStatus_() override {productIsUnavailable_ = false;
@@ -244,7 +246,7 @@ namespace edm {
       virtual bool productWasDeleted_() const override {return productHasBeenDeleted_;}
       virtual ProductData const& getProductData() const override {return productData_;}
       virtual ProductData& getProductData() override {return productData_;}
-      virtual void setProductDeleted_() override {productHasBeenDeleted_ = true;}
+      virtual void setProductDeleted_() const override {productHasBeenDeleted_ = true;}
       virtual BranchDescription const& branchDescription_() const override {return *productData().branchDescription();}
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
@@ -281,10 +283,10 @@ namespace edm {
       void producerCompleted();
       ProductStatus& status() const {return status_();}
     private:
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
+      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override;
       virtual bool putOrMergeProduct_() const override;
       virtual void checkType_(WrapperBase const& prod) const override {
         reallyCheckType(prod);
@@ -292,7 +294,7 @@ namespace edm {
       virtual ProductStatus& status_() const = 0;
       virtual bool productUnavailable_() const override;
       virtual bool productWasDeleted_() const override;
-      virtual void setProductDeleted_() override;
+      virtual void setProductDeleted_() const override;
       virtual BranchDescription const& branchDescription_() const override {return *productData().branchDescription();}
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
@@ -413,17 +415,17 @@ namespace edm {
       virtual void checkType_(WrapperBase const& prod) const override {realProduct_.checkType(prod);}
       virtual ProductData const& getProductData() const override {return realProduct_.productData();}
       virtual ProductData& getProductData() override {return realProduct_.productData();}
-      virtual void setProductDeleted_() override {realProduct_.setProductDeleted();}
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override {
+      virtual void setProductDeleted_() const override {realProduct_.setProductDeleted();}
+      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override {
         realProduct_.putProduct(std::move(edp), productProvenance);
       }
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override {
         realProduct_.putProduct(std::move(edp));
       }
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override {
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override {
         realProduct_.mergeProduct(std::move(edp), productProvenance);
       }
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override {
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override {
         realProduct_.mergeProduct(std::move(edp));
       }
       virtual bool putOrMergeProduct_() const override {
@@ -460,14 +462,14 @@ namespace edm {
       virtual bool onDemand_() const override;
       virtual bool productUnavailable_() const override;
       virtual bool productWasDeleted_() const override;
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
+      virtual void putProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) override;
-      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp, ProductProvenance const& productProvenance) const override;
+      virtual void mergeProduct_(std::unique_ptr<WrapperBase> edp) const override;
       virtual bool putOrMergeProduct_() const override;
       virtual void checkType_(WrapperBase const& prod) const override;
       virtual void resetStatus_() override;
-      virtual void setProductDeleted_() override;
+      virtual void setProductDeleted_() const override;
       virtual BranchDescription const& branchDescription_() const override;
       virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
       virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -42,7 +42,7 @@ namespace edm {
 
   class Run : public RunBase {
   public:
-    Run(RunPrincipal& rp, ModuleDescription const& md,
+    Run(RunPrincipal const& rp, ModuleDescription const& md,
         ModuleCallingContext const*);
     ~Run();
 
@@ -152,9 +152,6 @@ namespace edm {
   private:
     RunPrincipal const&
     runPrincipal() const;
-
-    RunPrincipal&
-    runPrincipal();
 
     // Override version from RunBase class
     virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -92,8 +92,6 @@ namespace edm {
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp) const;
 
-    void readImmediate();
-
     void setComplete() {
       complete_ = true;
     }
@@ -107,8 +105,6 @@ namespace edm {
                                  ModuleCallingContext const*) const override {return false;}
 
     virtual unsigned int transitionIndex_() const override;
-
-    void resolveProductImmediate(ProductHolderBase& phb);
 
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> aux_;
     ProcessHistoryID m_reducedHistoryID;

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -90,7 +90,7 @@ namespace edm {
 
     void put(
         BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp);
+        std::unique_ptr<WrapperBase> edp) const;
 
     void readImmediate();
 

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -107,7 +107,7 @@ namespace edm {
 
   private:
     virtual bool tryToFillImpl(std::string const& moduleLabel,
-                               EventPrincipal& event,
+                               EventPrincipal const& event,
                                EventSetup const& eventSetup,
                                ModuleCallingContext const* mcc) const override {
       auto worker =

--- a/FWCore/Framework/interface/UnscheduledHandler.h
+++ b/FWCore/Framework/interface/UnscheduledHandler.h
@@ -43,7 +43,7 @@ namespace edm {
       // ---------- member functions ---------------------------
       ///returns true if found an EDProducer and ran it
       bool tryToFill(std::string const& label,
-                     EventPrincipal& iEvent,
+                     EventPrincipal const & iEvent,
                      ModuleCallingContext const* mcc) const;
 
       void setEventSetup(EventSetup const& iSetup) {
@@ -52,7 +52,7 @@ namespace edm {
    private:
 
       virtual bool tryToFillImpl(std::string const&,
-                                 EventPrincipal&,
+                                 EventPrincipal const&,
                                  EventSetup const&,
                                  ModuleCallingContext const* mcc) const = 0;
       // ---------- member data --------------------------------

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -61,7 +61,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     private:
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
@@ -71,30 +71,30 @@ namespace edm {
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
-                            RunPrincipal& ep,
+                            RunPrincipal const& ep,
                             EventSetup const& c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
-                          RunPrincipal& ep,
+                          RunPrincipal const& ep,
                           EventSetup const& c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
+                                        LuminosityBlockPrincipal const& ep,
                                         EventSetup const& c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
+                                      LuminosityBlockPrincipal const& ep,
                                       EventSetup const& c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -63,7 +63,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     private:
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
@@ -73,30 +73,30 @@ namespace edm {
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
-                            RunPrincipal& ep,
+                            RunPrincipal const& ep,
                             EventSetup const& c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
-                          RunPrincipal& ep,
+                          RunPrincipal const& ep,
                           EventSetup const& c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
+                                        LuminosityBlockPrincipal const& ep,
                                         EventSetup const& c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
+                                      LuminosityBlockPrincipal const& ep,
                                       EventSetup const& c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -66,7 +66,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     private:
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
@@ -76,30 +76,30 @@ namespace edm {
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
-                            RunPrincipal& ep,
+                            RunPrincipal const& ep,
                             EventSetup const& c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
-                          RunPrincipal& ep,
+                          RunPrincipal const& ep,
                           EventSetup const& c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
+                                        LuminosityBlockPrincipal const& ep,
                                         EventSetup const& c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
+                                      LuminosityBlockPrincipal const& ep,
                                       EventSetup const& c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -66,20 +66,20 @@ namespace edm {
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 
     private:
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();
       void doEndJob();
       
-      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -64,20 +64,20 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     private:
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();
       void doEndJob();
       
-      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -64,20 +64,20 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     private:
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();
       void doEndJob();
 
-      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
 
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -109,7 +109,7 @@ namespace edm {
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd,iLumi,iES,s);
       }
 
-      void doBeginRun(RunPrincipal& rp,
+      void doBeginRun(RunPrincipal const& rp,
                       EventSetup const& c,
                       ModuleCallingContext const* mcc) override final {
         if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
@@ -122,7 +122,7 @@ namespace edm {
           MyGlobalRunSummary::beginRun(cnstR,c,&rc,m_runSummaries[ri]);
         }
       }
-      void doEndRun(RunPrincipal& rp,
+      void doEndRun(RunPrincipal const& rp,
                     EventSetup const& c,
                     ModuleCallingContext const* mcc) override final
       {
@@ -138,7 +138,7 @@ namespace edm {
         }
       }
 
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                   EventSetup const& c,
                                   ModuleCallingContext const* mcc) override final
       {
@@ -155,7 +155,7 @@ namespace edm {
         }
         
       }
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                 EventSetup const& c,
                                 ModuleCallingContext const* mcc) override final {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -109,7 +109,7 @@ namespace edm {
       
       const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&); // stop default
       
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
       void doPreallocate(PreallocationConfiguration const&);
@@ -121,34 +121,34 @@ namespace edm {
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
-                            RunPrincipal& ep,
+                            RunPrincipal const& ep,
                             EventSetup const& c,
                             ModuleCallingContext const*);
       virtual void setupRun(EDAnalyzerBase*, RunIndex) = 0;
       void doStreamEndRun(StreamID id,
-                          RunPrincipal& ep,
+                          RunPrincipal const& ep,
                           EventSetup const& c,
                           ModuleCallingContext const*);
       virtual void streamEndRunSummary(EDAnalyzerBase*,edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
+                                        LuminosityBlockPrincipal const& ep,
                                         EventSetup const& c,
                                         ModuleCallingContext const*);
       virtual void setupLuminosityBlock(EDAnalyzerBase*, LuminosityBlockIndex) = 0;
       void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
+                                      LuminosityBlockPrincipal const& ep,
                                       EventSetup const& c,
                                       ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(EDAnalyzerBase*,edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
 
-      virtual void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      virtual void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                               ModuleCallingContext const*)=0;
-      virtual void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      virtual void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                             ModuleCallingContext const*)=0;
-      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                           ModuleCallingContext const*)=0;
-      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                         ModuleCallingContext const*)=0;
 
       void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -67,7 +67,7 @@ namespace edm {
       
       const EDFilterAdaptorBase& operator=(const EDFilterAdaptorBase&) =delete; // stop default
       
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
     };

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -67,7 +67,7 @@ namespace edm {
       
       const EDProducerAdaptorBase& operator=(const EDProducerAdaptorBase&) =delete; // stop default
       
-      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
     };

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -103,7 +103,7 @@ namespace edm {
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd,iLumi,iES,s);
       }
 
-      void doBeginRun(RunPrincipal& rp,
+      void doBeginRun(RunPrincipal const& rp,
                       EventSetup const& c,
                       ModuleCallingContext const* mcc) override final {
         if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer) {
@@ -120,7 +120,7 @@ namespace edm {
           }
         }
       }
-      void doEndRun(RunPrincipal& rp,
+      void doEndRun(RunPrincipal const& rp,
                     EventSetup const& c,
                     ModuleCallingContext const* mcc) override final
       {
@@ -140,7 +140,7 @@ namespace edm {
         }
       }
 
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const* mcc) override final
       {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kBeginLuminosityBlockProducer) {
@@ -160,7 +160,7 @@ namespace edm {
         }
         
       }
-      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                 EventSetup const& c,
                                 ModuleCallingContext const* mcc) override final {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kEndLuminosityBlockProducer) {

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -129,36 +129,36 @@ namespace edm {
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
-                            RunPrincipal& ep,
+                            RunPrincipal const& ep,
                             EventSetup const& c,
                             ModuleCallingContext const*);
       virtual void setupRun(T*, RunIndex) = 0;
       void doStreamEndRun(StreamID id,
-                          RunPrincipal& ep,
+                          RunPrincipal const& ep,
                           EventSetup const& c,
                           ModuleCallingContext const*);
       virtual void streamEndRunSummary(T*,edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
+                                        LuminosityBlockPrincipal const& ep,
                                         EventSetup const& c,
                                         ModuleCallingContext const*);
       virtual void setupLuminosityBlock(T*, LuminosityBlockIndex) = 0;
       void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
+                                      LuminosityBlockPrincipal const& ep,
                                       EventSetup const& c,
                                       ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(T*,edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
       
       
-      virtual void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+      virtual void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                               ModuleCallingContext const*)=0;
-      virtual void doEndRun(RunPrincipal& rp, EventSetup const& c,
+      virtual void doEndRun(RunPrincipal const& rp, EventSetup const& c,
                             ModuleCallingContext const*)=0;
-      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp,
+      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                           EventSetup const& c,
                                           ModuleCallingContext const*)=0;
-      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp,
+      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                         EventSetup const& c,
                                         ModuleCallingContext const*)=0;
       

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -33,7 +33,7 @@ namespace edm {
   EDAnalyzer::doEvent(EventPrincipal const& ep, EventSetup const& c,
                       ActivityRegistry* act,
                       ModuleCallingContext const* mcc) {
-    Event e(const_cast<EventPrincipal&>(ep), moduleDescription_, mcc);
+    Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     {
       std::lock_guard<std::mutex> guard(mutex_);
@@ -61,7 +61,7 @@ namespace edm {
   bool
   EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                          ModuleCallingContext const* mcc) {
-    Run r(const_cast<RunPrincipal&>(rp), moduleDescription_, mcc);
+    Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
     this->beginRun(r, c);
     return true;
@@ -70,7 +70,7 @@ namespace edm {
   bool
   EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                        ModuleCallingContext const* mcc) {
-    Run r(const_cast<RunPrincipal&>(rp), moduleDescription_, mcc);
+    Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
     this->endRun(r, c);
     return true;
@@ -79,7 +79,7 @@ namespace edm {
   bool
   EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                      ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(const_cast<LuminosityBlockPrincipal&>(lbp), moduleDescription_, mcc);
+    LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
     this->beginLuminosityBlock(lb, c);
     return true;
@@ -88,7 +88,7 @@ namespace edm {
   bool
   EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(const_cast<LuminosityBlockPrincipal&>(lbp), moduleDescription_, mcc);
+    LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
     this->endLuminosityBlock(lb, c);
     return true;

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -27,7 +27,7 @@ namespace edm {
   }
 
   bool
-  EDFilter::doEvent(EventPrincipal& ep, EventSetup const& c,
+  EDFilter::doEvent(EventPrincipal const& ep, EventSetup const& c,
                     ActivityRegistry* act,
                     ModuleCallingContext const* mcc) {
     bool rc = false;
@@ -59,7 +59,7 @@ namespace edm {
   }
 
   void
-  EDFilter::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+  EDFilter::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                        ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
@@ -70,7 +70,7 @@ namespace edm {
   }
 
   void
-  EDFilter::doEndRun(RunPrincipal& rp, EventSetup const& c,
+  EDFilter::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                      ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
@@ -81,7 +81,7 @@ namespace edm {
   }
 
   void
-  EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
@@ -91,7 +91,7 @@ namespace edm {
   }
 
   void
-  EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -28,7 +28,7 @@ namespace edm {
   EDProducer::~EDProducer() { }
 
   bool
-  EDProducer::doEvent(EventPrincipal& ep, EventSetup const& c,
+  EDProducer::doEvent(EventPrincipal const& ep, EventSetup const& c,
                       ActivityRegistry* act,
                       ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
@@ -59,7 +59,7 @@ namespace edm {
   }
 
   void
-  EDProducer::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+  EDProducer::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                          ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
@@ -69,7 +69,7 @@ namespace edm {
   }
 
   void
-  EDProducer::doEndRun(RunPrincipal& rp, EventSetup const& c,
+  EDProducer::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                        ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
@@ -79,7 +79,7 @@ namespace edm {
   }
 
   void
-  EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                      ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
@@ -89,7 +89,7 @@ namespace edm {
   }
 
   void
-  EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);

--- a/FWCore/Framework/src/EarlyDeleteHelper.cc
+++ b/FWCore/Framework/src/EarlyDeleteHelper.cc
@@ -66,7 +66,7 @@ nPathsOn_(0)
 // member functions
 //
 void 
-EarlyDeleteHelper::moduleRan(EventPrincipal& iEvent) {
+EarlyDeleteHelper::moduleRan(EventPrincipal const& iEvent) {
   pathsLeftToComplete_=0;
   for(auto it = pBeginIndex_; it != pEndIndex_;++it) {
     auto& count = (*pBranchCounts_)[*it];
@@ -79,7 +79,7 @@ EarlyDeleteHelper::moduleRan(EventPrincipal& iEvent) {
 }
 
 void 
-EarlyDeleteHelper::pathFinished(EventPrincipal& iEvent) {
+EarlyDeleteHelper::pathFinished(EventPrincipal const& iEvent) {
   if(pathsLeftToComplete_>0 && --pathsLeftToComplete_ == 0) {
     //we can never reach this module now so declare it as run
     moduleRan(iEvent);

--- a/FWCore/Framework/src/EarlyDeleteHelper.h
+++ b/FWCore/Framework/src/EarlyDeleteHelper.h
@@ -45,8 +45,8 @@ namespace edm {
     
     // ---------- member functions ---------------------------
     void reset() {pathsLeftToComplete_ = nPathsOn_;}
-    void moduleRan(EventPrincipal&);
-    void pathFinished(EventPrincipal&);
+    void moduleRan(EventPrincipal const&);
+    void pathFinished(EventPrincipal const&);
     void addedToPath() { ++nPathsOn_;}
     void appendIndex(unsigned int index);
     void shiftIndexPointers(unsigned int iShift);

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -14,7 +14,7 @@ namespace edm {
 
   std::string const Event::emptyString_;
 
-  Event::Event(EventPrincipal& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext) :
+  Event::Event(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext) :
       provRecorder_(ep, md),
       aux_(ep.aux()),
       luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md, moduleCallingContext) : nullptr),
@@ -45,11 +45,6 @@ namespace edm {
     const_cast<LuminosityBlock*>(luminosityBlock_.get())->setSharedResourcesAcquirer(iResourceAcquirer);
   }
 
-
-  EventPrincipal&
-  Event::eventPrincipal() {
-    return dynamic_cast<EventPrincipal&>(provRecorder_.principal());
-  }
 
   EventPrincipal const&
   Event::eventPrincipal() const {
@@ -123,7 +118,7 @@ namespace edm {
   Event::commit_aux(Event::ProductPtrVec& products, bool record_parents,
                     std::vector<BranchID>* previousParentage, ParentageID* previousParentageId) {
     // fill in guts of provenance here
-    EventPrincipal& ep = eventPrincipal();
+    auto& ep = eventPrincipal();
 
     ProductPtrVec::iterator pit(products.begin());
     ProductPtrVec::iterator pie(products.end());

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -117,7 +117,7 @@ namespace edm {
     }
 
     // Fill in the product ID's in the product holders.
-    for(auto const& prod : *this) {
+    for(auto& prod : *this) {
       if (prod->singleProduct()) {
         // If an alias is in the same process as the original then isAlias will be true.
         //  Under that condition, we want the ProductID to be the same as the original.
@@ -163,7 +163,7 @@ namespace edm {
         << "\n";
     }
     productProvenanceRetrieverPtr()->insertIntoSet(productProvenance);
-    ProductHolderBase* phb = getExistingProduct(bd.branchID());
+    auto phb = getExistingProduct(bd.branchID());
     assert(phb);
     checkUniquenessAndType(edp.get(), phb);
     // ProductHolder assumes ownership
@@ -178,7 +178,7 @@ namespace edm {
 
     assert(!bd.produced());
     productProvenanceRetrieverPtr()->insertIntoSet(productProvenance);
-    ProductHolderBase* phb = getExistingProduct(bd.branchID());
+    auto phb = getExistingProduct(bd.branchID());
     assert(phb);
     checkUniquenessAndType(edp.get(), phb);
     // ProductHolder assumes ownership

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -153,7 +153,7 @@ namespace edm {
   EventPrincipal::put(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) {
+        ProductProvenance const& productProvenance) const {
 
     // assert commented out for DaqSource.  When DaqSource no longer uses put(), the assert can be restored.
     //assert(produced());
@@ -174,7 +174,7 @@ namespace edm {
   EventPrincipal::putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) {
+        ProductProvenance const& productProvenance) const {
 
     assert(!bd.produced());
     productProvenanceRetrieverPtr()->insertIntoSet(productProvenance);
@@ -471,7 +471,7 @@ namespace edm {
         postModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
       });
       auto handlerCall = [this,&moduleLabel,&mcc]() {
-        unscheduledHandler_->tryToFill(moduleLabel, *const_cast<EventPrincipal*>(this), mcc);
+        unscheduledHandler_->tryToFill(moduleLabel, *this, mcc);
       };
       if (sra) {
         sra->temporaryUnlock(handlerCall);

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -141,7 +141,7 @@ namespace edm {
 
     
     template<typename T>
-    void runNow(typename T::MyPrincipal& p, EventSetup const& es,
+    void runNow(typename T::MyPrincipal const& p, EventSetup const& es,
                 GlobalContext const* context);
 
     /// returns the action table
@@ -194,7 +194,7 @@ namespace edm {
   }
   template <typename T>
   void
-  GlobalSchedule::runNow(typename T::MyPrincipal& p, EventSetup const& es,
+  GlobalSchedule::runNow(typename T::MyPrincipal const& p, EventSetup const& es,
               GlobalContext const* context) {
     //do nothing for event since we will run when requested
     for(auto & worker: allWorkers()) {

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -8,7 +8,7 @@ namespace edm {
 
   std::string const LuminosityBlock::emptyString_;
 
-  LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal& lbp, ModuleDescription const& md,
+  LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
                                    ModuleCallingContext const* moduleCallingContext) :
         provRecorder_(lbp, md),
         aux_(lbp.aux()),
@@ -28,11 +28,6 @@ namespace edm {
   LuminosityBlock::cacheIdentifier() const {return luminosityBlockPrincipal().cacheIdentifier();}
 
   
-  LuminosityBlockPrincipal&
-  LuminosityBlock::luminosityBlockPrincipal() {
-    return dynamic_cast<LuminosityBlockPrincipal&>(provRecorder_.principal());
-  }
-
   void
   LuminosityBlock::setConsumer(EDConsumerBase const* iConsumer) {
     provRecorder_.setConsumer(iConsumer);
@@ -65,7 +60,7 @@ namespace edm {
 
   void
   LuminosityBlock::commit_() {
-    LuminosityBlockPrincipal& lbp = luminosityBlockPrincipal();
+    LuminosityBlockPrincipal const& lbp = luminosityBlockPrincipal();
     ProductPtrVec::iterator pit(putProducts().begin());
     ProductPtrVec::iterator pie(putProducts().end());
 

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -30,7 +30,7 @@ namespace edm {
 
     fillPrincipal(aux_->processHistoryID(), processHistoryRegistry, reader);
 
-    for(auto const& prod : *this) {
+    for(auto& prod : *this) {
       prod->setProcessHistory(processHistory());
     }
   }

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -38,7 +38,7 @@ namespace edm {
   void
   LuminosityBlockPrincipal::put(
         BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp) {
+        std::unique_ptr<WrapperBase> edp) const {
 
     assert(bd.produced());
     if(edp.get() == nullptr) {

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -39,44 +39,7 @@ namespace edm {
   LuminosityBlockPrincipal::put(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp) const {
-
-    assert(bd.produced());
-    if(edp.get() == nullptr) {
-      throw edm::Exception(edm::errors::InsertFailure,"Null Pointer")
-        << "put: Cannot put because unique_ptr to product is null."
-        << "\n";
-    }
-    ProductHolderBase* phb = getExistingProduct(bd.branchID());
-    assert(phb);
-    // ProductHolder assumes ownership
-    putOrMerge(std::move(edp), phb);
-  }
-
-  void
-  LuminosityBlockPrincipal::readImmediate() {
-    for(auto & prod : *this) {
-      ProductHolderBase & phb = *prod;
-      if(phb.singleProduct() && !phb.branchDescription().produced()) {
-        if(!phb.productUnavailable()) {
-          resolveProductImmediate(phb);
-        }
-      }
-    }
-  }
-
-  void
-  LuminosityBlockPrincipal::resolveProductImmediate(ProductHolderBase& phb)  {
-    if(phb.branchDescription().produced()) return; // nothing to do.
-    if(!reader()) return; // nothing to do.
-
-    // must attempt to load from persistent store
-    BranchKey const bk = BranchKey(phb.branchDescription());
-    std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this));
-
-    // Now fix up the ProductHolder
-    if(edp.get() != nullptr) {
-      putOrMerge(std::move(edp), &phb);
-    }
+    putOrMerge(bd,std::move(edp));
   }
 
   unsigned int

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -204,7 +204,7 @@ namespace edm {
 
   Trig OutputModule::getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventPrincipal const& ep, ModuleCallingContext const* mcc) const {
     //This cast is safe since we only call const functions of the EventPrincipal after this point
-    PrincipalGetAdapter adapter(const_cast<EventPrincipal&>(ep), moduleDescription_);
+    PrincipalGetAdapter adapter(ep, moduleDescription_);
     adapter.setConsumer(this);
     Trig result;
     auto bh = adapter.getByToken_(TypeID(typeid(TriggerResults)),PRODUCT_TYPE, token, mcc);

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -179,7 +179,7 @@ namespace edm {
   }
 
   void
-  Path::handleEarlyFinish(EventPrincipal& iEvent) {
+  Path::handleEarlyFinish(EventPrincipal const& iEvent) {
     for(auto helper: earlyDeleteHelpers_) {
       helper->pathFinished(iEvent);
     }

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -56,7 +56,7 @@ namespace edm {
     Path(Path const&);
 
     template <typename T>
-    void processOneOccurrence(typename T::MyPrincipal&, EventSetup const&,
+    void processOneOccurrence(typename T::MyPrincipal const&, EventSetup const&,
                               StreamID const&, typename T::Context const*);
 
     int bitPosition() const { return bitpos_; }
@@ -122,9 +122,9 @@ namespace edm {
     void recordStatus(int nwrwue, bool isEvent);
     void updateCounters(bool succeed, bool isEvent);
     
-    void handleEarlyFinish(EventPrincipal&);
-    void handleEarlyFinish(RunPrincipal&) {}
-    void handleEarlyFinish(LuminosityBlockPrincipal&) {}
+    void handleEarlyFinish(EventPrincipal const&);
+    void handleEarlyFinish(RunPrincipal const&) {}
+    void handleEarlyFinish(LuminosityBlockPrincipal const&) {}
   };
 
   namespace {
@@ -151,7 +151,7 @@ namespace edm {
   }
 
   template <typename T>
-  void Path::processOneOccurrence(typename T::MyPrincipal& ep, EventSetup const& es,
+  void Path::processOneOccurrence(typename T::MyPrincipal const& ep, EventSetup const& es,
                                   StreamID const& streamID, typename T::Context const* context) {
 
     int nwrwue = -1;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -327,7 +327,7 @@ namespace edm {
   }
 
   void
-  Principal::deleteProduct(BranchID const& id) {
+  Principal::deleteProduct(BranchID const& id) const {
     ProductHolderBase* phb = getExistingProduct(id);
     assert(nullptr != phb);
     auto itFound = productPtrs_.find(phb->product());
@@ -395,7 +395,7 @@ namespace edm {
   }
 
   ProductHolderBase*
-  Principal::getExistingProduct(BranchID const& branchID) {
+  Principal::getExistingProduct(BranchID const& branchID) const {
     ProductHolderIndex index = preg_->indexFrom(branchID);
     assert(index != ProductHolderIndexInvalid);
     SharedProductPtr ptr = productHolders_.at(index);
@@ -403,7 +403,7 @@ namespace edm {
   }
 
   ProductHolderBase*
-  Principal::getExistingProduct(ProductHolderBase const& productHolder) {
+  Principal::getExistingProduct(ProductHolderBase const& productHolder) const {
     ProductHolderBase* phb = getExistingProduct(productHolder.branchDescription().branchID());
     if(nullptr != phb && BranchKey(productHolder.branchDescription()) != BranchKey(phb->branchDescription())) {
       BranchDescription const& newProduct = phb->branchDescription();
@@ -848,7 +848,7 @@ namespace edm {
   }
 
   void
-  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase* phb) {
+  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductHolderBase* phb) const {
     bool willBePut = phb->putOrMergeProduct();
     if(willBePut) {
       checkUniquenessAndType(prod.get(), phb);
@@ -860,7 +860,7 @@ namespace edm {
   }
 
   void
-  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance&& prov, ProductHolderBase* phb) {
+  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance&& prov, ProductHolderBase* phb) const {
     bool willBePut = phb->putOrMergeProduct();
     if(willBePut) {
       checkUniquenessAndType(prod.get(), phb);

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -17,7 +17,7 @@
 
 namespace edm {
 
-  PrincipalGetAdapter::PrincipalGetAdapter(Principal & pcpl,
+  PrincipalGetAdapter::PrincipalGetAdapter(Principal const& pcpl,
 	ModuleDescription const& md)  :
     //putProducts_(),
     principal_(pcpl),

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -122,7 +122,7 @@ namespace edm {
   void
   ProducedProductHolder::putProduct_(
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) {
+        ProductProvenance const& productProvenance) const {
     if(product()) {
       throw Exception(errors::InsertFailure)
           << "Attempt to insert more than one product on branch " << branchDescription().branchName() << "\n";
@@ -131,14 +131,14 @@ namespace edm {
     assert(edp.get() != nullptr);
     assert(status() != Present);
     assert(status() != Uninitialized);
-    productData().setWrapper(std::move(edp)); // ProductHolder takes ownership
+    productData().unsafe_setWrapper(std::move(edp)); // ProductHolder takes ownership
     status_() = Present;
   }
 
   void
   ProducedProductHolder::mergeProduct_(
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) {
+        ProductProvenance const& productProvenance) const {
     assert(status() == Present);
     mergeTheProduct(std::move(edp));
   }
@@ -149,7 +149,7 @@ namespace edm {
   }
 
   void
-  ProducedProductHolder::mergeProduct_(std::unique_ptr<WrapperBase> edp) {
+  ProducedProductHolder::mergeProduct_(std::unique_ptr<WrapperBase> edp) const {
     assert(status() == Present);
     mergeTheProduct(std::move(edp));
   }
@@ -171,7 +171,7 @@ namespace edm {
   void
   InputProductHolder::putProduct_(
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) {
+        ProductProvenance const& productProvenance) const {
     assert(!product());
     setProduct(std::move(edp));
   }
@@ -179,12 +179,12 @@ namespace edm {
   void
   InputProductHolder::mergeProduct_(
         std::unique_ptr<WrapperBase>,
-        ProductProvenance const&) {
+        ProductProvenance const&) const {
     assert(nullptr);
   }
 
   void
-  InputProductHolder::mergeProduct_(std::unique_ptr<WrapperBase> edp) {
+  InputProductHolder::mergeProduct_(std::unique_ptr<WrapperBase> edp) const {
     mergeTheProduct(std::move(edp));
   }
 
@@ -200,9 +200,9 @@ namespace edm {
   }
 
   void
-  ProductHolderBase::mergeTheProduct(std::unique_ptr<WrapperBase> edp) {
+  ProductHolderBase::mergeTheProduct(std::unique_ptr<WrapperBase> edp) const {
     if(product()->isMergeable()) {
-      product()->mergeProduct(edp.get());
+      unsafe_product()->mergeProduct(edp.get());
     } else if(product()->hasIsProductEqual()) {
       if(!product()->isProductEqual(edp.get())) {
         LogError("RunLumiMerging")
@@ -294,7 +294,7 @@ namespace edm {
   }
 
   void 
-  ProducedProductHolder::setProductDeleted_() {
+  ProducedProductHolder::setProductDeleted_() const {
     status() = ProductDeleted;
   }
 
@@ -470,7 +470,7 @@ namespace edm {
       << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductHolder::putProduct_(std::unique_ptr<WrapperBase> , ProductProvenance const& ) {
+  void NoProcessProductHolder::putProduct_(std::unique_ptr<WrapperBase> , ProductProvenance const& ) const {
     throw Exception(errors::LogicError)
       << "NoProcessProductHolder::putProduct_() not implemented and should never be called.\n"
       << "Contact a Framework developer\n";
@@ -482,13 +482,13 @@ namespace edm {
       << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductHolder::mergeProduct_(std::unique_ptr<WrapperBase> , ProductProvenance const& ) {
+  void NoProcessProductHolder::mergeProduct_(std::unique_ptr<WrapperBase> , ProductProvenance const& ) const {
     throw Exception(errors::LogicError)
       << "NoProcessProductHolder::mergeProduct_() not implemented and should never be called.\n"
       << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductHolder::mergeProduct_(std::unique_ptr<WrapperBase>) {
+  void NoProcessProductHolder::mergeProduct_(std::unique_ptr<WrapperBase>) const {
     throw Exception(errors::LogicError)
       << "NoProcessProductHolder::mergeProduct_() not implemented and should never be called.\n"
       << "Contact a Framework developer\n";
@@ -506,7 +506,7 @@ namespace edm {
       << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductHolder::setProductDeleted_() {
+  void NoProcessProductHolder::setProductDeleted_() const {
     throw Exception(errors::LogicError)
       << "NoProcessProductHolder::setProductDeleted_() not implemented and should never be called.\n"
       << "Contact a Framework developer\n";

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -7,7 +7,7 @@ namespace edm {
 
   std::string const Run::emptyString_;
 
-  Run::Run(RunPrincipal& rp, ModuleDescription const& md,
+  Run::Run(RunPrincipal const& rp, ModuleDescription const& md,
            ModuleCallingContext const* moduleCallingContext) :
         provRecorder_(rp, md),
         aux_(rp.aux()),
@@ -22,11 +22,6 @@ namespace edm {
 
   RunIndex Run::index() const { return runPrincipal().index();}
   
-  RunPrincipal&
-  Run::runPrincipal() {
-    return dynamic_cast<RunPrincipal&>(provRecorder_.principal());
-  }
-
   RunPrincipal const&
   Run::runPrincipal() const {
     return dynamic_cast<RunPrincipal const&>(provRecorder_.principal());
@@ -81,7 +76,7 @@ namespace edm {
 
   void
   Run::commit_() {
-    RunPrincipal& rp = runPrincipal();
+    RunPrincipal const& rp = runPrincipal();
     ProductPtrVec::iterator pit(putProducts().begin());
     ProductPtrVec::iterator pie(putProducts().end());
 

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -24,7 +24,7 @@ namespace edm {
     m_reducedHistoryID = processHistoryRegistry.reducedProcessHistoryID(aux_->processHistoryID());
     fillPrincipal(aux_->processHistoryID(), processHistoryRegistry, reader);
 
-    for(auto const& prod : *this) {
+    for(auto& prod : *this) {
       prod->setProcessHistory(processHistory());
     }
   }

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -32,7 +32,7 @@ namespace edm {
   void
   RunPrincipal::put(
         BranchDescription const& bd,
-        std::unique_ptr<WrapperBase>  edp) {
+        std::unique_ptr<WrapperBase>  edp) const {
 
     // Assert commented out for LHESource.
     // assert(bd.produced());

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -33,45 +33,7 @@ namespace edm {
   RunPrincipal::put(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase>  edp) const {
-
-    // Assert commented out for LHESource.
-    // assert(bd.produced());
-    if(edp.get() == nullptr) {
-      throw edm::Exception(edm::errors::InsertFailure,"Null Pointer")
-        << "put: Cannot put because unique_ptr to product is null."
-        << "\n";
-    }
-    ProductHolderBase* phb = getExistingProduct(bd.branchID());
-    assert(phb);
-    // ProductHolder assumes ownership
-    putOrMerge(std::move(edp), phb);
-  }
-
-  void
-  RunPrincipal::readImmediate() {
-    for(auto& prod : *this) {
-      ProductHolderBase& phb = *prod;
-      if(phb.singleProduct() && !phb.branchDescription().produced()) {
-        if(!phb.productUnavailable()) {
-          resolveProductImmediate(phb);
-        }
-      }
-    }
-  }
-
-  void
-  RunPrincipal::resolveProductImmediate(ProductHolderBase& phb) {
-    if(phb.branchDescription().produced()) return; // nothing to do.
-    if(!reader()) return; // nothing to do.
-
-    // must attempt to load from persistent store
-    BranchKey const bk = BranchKey(phb.branchDescription());
-    std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this));
-
-    // Now fix up the ProductHolder
-    if(edp.get() != nullptr) {
-      putOrMerge(std::move(edp), &phb);
-    }
+    putOrMerge(bd,std::move(edp));
   }
 
   unsigned int

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -289,10 +289,10 @@ namespace edm {
     void resetAll();
 
     template <typename T>
-    bool runTriggerPaths(typename T::MyPrincipal&, EventSetup const&, typename T::Context const*);
+    bool runTriggerPaths(typename T::MyPrincipal const&, EventSetup const&, typename T::Context const*);
 
     template <typename T>
-    void runEndPaths(typename T::MyPrincipal&, EventSetup const&, typename T::Context const*);
+    void runEndPaths(typename T::MyPrincipal const&, EventSetup const&, typename T::Context const*);
 
     void reportSkipped(EventPrincipal const& ep) const;
 
@@ -471,7 +471,7 @@ namespace edm {
 
   template <typename T>
   bool
-  StreamSchedule::runTriggerPaths(typename T::MyPrincipal& ep, EventSetup const& es, typename T::Context const* context) {
+  StreamSchedule::runTriggerPaths(typename T::MyPrincipal const& ep, EventSetup const& es, typename T::Context const* context) {
     for(auto& p : trig_paths_) {
       p.processOneOccurrence<T>(ep, es, streamID_, context);
     }
@@ -480,7 +480,7 @@ namespace edm {
 
   template <typename T>
   void
-  StreamSchedule::runEndPaths(typename T::MyPrincipal& ep, EventSetup const& es, typename T::Context const* context) {
+  StreamSchedule::runEndPaths(typename T::MyPrincipal const& ep, EventSetup const& es, typename T::Context const* context) {
     // Note there is no state-checking safety controlling the
     // activation/deactivation of endpaths.
     for(auto& p : end_paths_) {

--- a/FWCore/Framework/src/UnscheduledHandler.cc
+++ b/FWCore/Framework/src/UnscheduledHandler.cc
@@ -24,7 +24,7 @@ namespace edm {
 
   bool
   UnscheduledHandler::tryToFill(std::string const& label,
-                                EventPrincipal& iEvent,
+                                EventPrincipal const& iEvent,
                                 ModuleCallingContext const* mcc) const {
      assert(m_setup);
      return tryToFillImpl(label, iEvent, *m_setup, mcc);

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -181,12 +181,12 @@ private:
     }
   }
 
-  void Worker::pathFinished(EventPrincipal& iEvent) {
+  void Worker::pathFinished(EventPrincipal const& iEvent) {
     if(earlyDeleteHelper_) {
       earlyDeleteHelper_->pathFinished(iEvent);
     }
   }
-  void Worker::postDoEvent(EventPrincipal& iEvent) {
+  void Worker::postDoEvent(EventPrincipal const& iEvent) {
     if(earlyDeleteHelper_) {
       earlyDeleteHelper_->moduleRan(iEvent);
     }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -76,7 +76,7 @@ namespace edm {
     Worker& operator=(Worker const&) = delete; // Disallow copying and moving
 
     template <typename T>
-    bool doWork(typename T::MyPrincipal&, EventSetup const& c,
+    bool doWork(typename T::MyPrincipal const&, EventSetup const& c,
                 StreamID stream,
                 ParentContext const& parentContext,
                 typename T::Context const* context);
@@ -93,8 +93,8 @@ namespace edm {
 
     void reset() { state_ = Ready; }
 
-    void pathFinished(EventPrincipal&);
-    void postDoEvent(EventPrincipal&);
+    void pathFinished(EventPrincipal const&);
+    void postDoEvent(EventPrincipal const&);
 
     ModuleDescription const& description() const {return *(moduleCallingContext_.moduleDescription());}
     ModuleDescription const* descPtr() const {return moduleCallingContext_.moduleDescription(); }
@@ -134,26 +134,26 @@ namespace edm {
   protected:
     template<typename O> friend class workerhelper::CallImpl;
     virtual std::string workerType() const = 0;
-    virtual bool implDo(EventPrincipal&, EventSetup const& c,
+    virtual bool implDo(EventPrincipal const&, EventSetup const& c,
                         ModuleCallingContext const* mcc) = 0;
     virtual bool implDoPrePrefetchSelection(StreamID id,
-                                            EventPrincipal& ep,
+                                            EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoBegin(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoEnd(RunPrincipal const& rp, EventSetup const& c,
                            ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                              ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                            ModuleCallingContext const* mcc) = 0;
     virtual void implBeginJob() = 0;
     virtual void implEndJob() = 0;
@@ -281,7 +281,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Arg;
       static bool call(Worker* iWorker, StreamID,
-                       EventPrincipal& ep, EventSetup const& es,
+                       EventPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* /* actReg */,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* /* context*/) {
@@ -289,7 +289,7 @@ namespace edm {
         return iWorker->implDo(ep,es, mcc);
       }
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return iWorker->implDoPrePrefetchSelection(id,ep,mcc);
       }
@@ -300,7 +300,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       RunPrincipal& ep, EventSetup const& es,
+                       RunPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -308,7 +308,7 @@ namespace edm {
         return iWorker->implDoBegin(ep,es, mcc);
       }
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -318,7 +318,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       RunPrincipal& ep, EventSetup const& es,
+                       RunPrincipal const & ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -326,7 +326,7 @@ namespace edm {
         return iWorker->implDoStreamBegin(id,ep,es, mcc);
       }
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -336,7 +336,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       RunPrincipal& ep, EventSetup const& es,
+                       RunPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -344,7 +344,7 @@ namespace edm {
         return iWorker->implDoEnd(ep,es, mcc);
       }
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -354,7 +354,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       RunPrincipal& ep, EventSetup const& es,
+                       RunPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -362,7 +362,7 @@ namespace edm {
         return iWorker->implDoStreamEnd(id,ep,es, mcc);
       }
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -373,7 +373,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -382,7 +382,7 @@ namespace edm {
       }
 
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -392,7 +392,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -401,7 +401,7 @@ namespace edm {
       }
 
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -412,7 +412,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -420,7 +420,7 @@ namespace edm {
         return iWorker->implDoEnd(ep,es, mcc);
       }
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -431,7 +431,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -440,7 +440,7 @@ namespace edm {
       }
       
       static bool prePrefetchSelection(Worker* iWorker,StreamID id,
-                                       typename Arg::MyPrincipal & ep,
+                                       typename Arg::MyPrincipal const& ep,
                                        ModuleCallingContext const* mcc) {
         return true;
       }
@@ -448,7 +448,7 @@ namespace edm {
   }
 
   template <typename T>
-  bool Worker::doWork(typename T::MyPrincipal& ep,
+  bool Worker::doWork(typename T::MyPrincipal const& ep,
                       EventSetup const& es,
                       StreamID streamID,
                       ParentContext const& parentContext,

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -27,7 +27,7 @@ namespace edm {
     WorkerInPath(Worker*, FilterAction theAction, unsigned int placeInPath);
 
     template <typename T>
-    bool runWorker(typename T::MyPrincipal&, EventSetup const&,
+    bool runWorker(typename T::MyPrincipal const&, EventSetup const&,
 		   StreamID streamID,
                    typename T::Context const* context);
 
@@ -58,7 +58,7 @@ namespace edm {
   };
 
   template <typename T>
-  bool WorkerInPath::runWorker(typename T::MyPrincipal & ep, EventSetup const & es,
+  bool WorkerInPath::runWorker(typename T::MyPrincipal const& ep, EventSetup const & es,
                                StreamID streamID,
                                typename T::Context const* context) {
 

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -78,7 +78,7 @@ namespace edm{
 
     template<typename T, typename P>
     struct DoStreamBeginTrans {
-      inline void operator() (WorkerT<T>* iWorker, StreamID id, P& rp,
+      inline void operator() (WorkerT<T>* iWorker, StreamID id, P const& rp,
                               EventSetup const& c,
                               ModuleCallingContext const* mcc) {
         iWorker->callWorkerStreamBegin(0,id,rp,c, mcc);
@@ -87,7 +87,7 @@ namespace edm{
 
     template<typename T, typename P>
     struct DoStreamEndTrans {
-      inline void operator() (WorkerT<T>* iWorker, StreamID id, P& rp,
+      inline void operator() (WorkerT<T>* iWorker, StreamID id, P const& rp,
                               EventSetup const& c,
                               ModuleCallingContext const* mcc) {
         iWorker->callWorkerStreamEnd(0,id,rp,c, mcc);
@@ -115,7 +115,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDo(EventPrincipal& ep, EventSetup const& c, ModuleCallingContext const* mcc) {
+  WorkerT<T>::implDo(EventPrincipal const& ep, EventSetup const& c, ModuleCallingContext const* mcc) {
     std::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
     return module_->doEvent(ep, c, activityRegistry(), mcc);
   }
@@ -124,7 +124,7 @@ namespace edm{
   inline
   bool
   WorkerT<T>::implDoPrePrefetchSelection(StreamID id,
-                                          EventPrincipal& ep,
+                                          EventPrincipal const& ep,
                                          ModuleCallingContext const* mcc) {
     return true;
   }
@@ -133,7 +133,7 @@ namespace edm{
   inline
   bool
   WorkerT<OutputModule>::implDoPrePrefetchSelection(StreamID id,
-                                         EventPrincipal& ep,
+                                         EventPrincipal const& ep,
                                          ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
   }
@@ -142,7 +142,7 @@ namespace edm{
   inline
   bool
   WorkerT<edm::one::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
-                                                    EventPrincipal& ep,
+                                                    EventPrincipal const& ep,
                                                     ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
   }
@@ -151,7 +151,7 @@ namespace edm{
   inline
   bool
   WorkerT<edm::global::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
-                                                    EventPrincipal& ep,
+                                                    EventPrincipal const& ep,
                                                     ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
   }
@@ -159,7 +159,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoBegin(RunPrincipal& rp, EventSetup const& c, ModuleCallingContext const* mcc) {
+  WorkerT<T>::implDoBegin(RunPrincipal const& rp, EventSetup const& c, ModuleCallingContext const* mcc) {
     module_->doBeginRun(rp, c, mcc);
     return true;
   }
@@ -167,7 +167,7 @@ namespace edm{
   template<typename T>
   template<typename D>
   void
-  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, RunPrincipal& rp,
+  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, RunPrincipal const& rp,
                                     EventSetup const& c,
                                     ModuleCallingContext const* mcc) {
     module_->doStreamBeginRun(id, rp, c, mcc);
@@ -176,7 +176,7 @@ namespace edm{
   template<typename T>
   template<typename D>
   void
-  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, RunPrincipal& rp,
+  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, RunPrincipal const& rp,
                                     EventSetup const& c,
                                     ModuleCallingContext const* mcc) {
     module_->doStreamEndRun(id, rp, c, mcc);
@@ -186,10 +186,10 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,
+  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                 ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
-    workerimpl::DoStreamBeginTrans<T,RunPrincipal>,
+    workerimpl::DoStreamBeginTrans<T,RunPrincipal const>,
     workerimpl::DoNothing>::type might_call;
     might_call(this,id,rp,c, mcc);
     return true;
@@ -198,10 +198,10 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c,
+  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                               ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
-    workerimpl::DoStreamEndTrans<T,RunPrincipal>,
+    workerimpl::DoStreamEndTrans<T,RunPrincipal const>,
     workerimpl::DoNothing>::type might_call;
     might_call(this,id,rp,c, mcc);
     return true;
@@ -210,7 +210,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoEnd(RunPrincipal& rp, EventSetup const& c,
+  WorkerT<T>::implDoEnd(RunPrincipal const& rp, EventSetup const& c,
                         ModuleCallingContext const* mcc) {
     module_->doEndRun(rp, c, mcc);
     return true;
@@ -219,7 +219,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                           ModuleCallingContext const* mcc) {
     module_->doBeginLuminosityBlock(lbp, c, mcc);
     return true;
@@ -228,7 +228,7 @@ namespace edm{
   template<typename T>
   template<typename D>
   void
-  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal& rp,
+  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal const& rp,
                                     EventSetup const& c,
                                     ModuleCallingContext const* mcc) {
     module_->doStreamBeginLuminosityBlock(id, rp, c, mcc);
@@ -237,7 +237,7 @@ namespace edm{
   template<typename T>
   template<typename D>
   void
-  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal& rp,
+  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal const& rp,
                                   EventSetup const& c,
                                   ModuleCallingContext const* mcc) {
     module_->doStreamEndLuminosityBlock(id, rp, c, mcc);
@@ -247,7 +247,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-    WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                   ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
     workerimpl::DoStreamBeginTrans<T,LuminosityBlockPrincipal>,
@@ -259,7 +259,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                               ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
     workerimpl::DoStreamEndTrans<T,LuminosityBlockPrincipal>,
@@ -272,7 +272,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                         ModuleCallingContext const* mcc) {
     module_->doEndLuminosityBlock(lbp, c, mcc);
     return true;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -56,19 +56,19 @@ namespace edm {
     template<typename D>
     void callWorkerEndStream(D, StreamID);
     template<typename D>
-    void callWorkerStreamBegin(D, StreamID id, RunPrincipal& rp,
+    void callWorkerStreamBegin(D, StreamID id, RunPrincipal const& rp,
                                EventSetup const& c,
                                ModuleCallingContext const* mcc);
     template<typename D>
-    void callWorkerStreamEnd(D, StreamID id, RunPrincipal& rp,
+    void callWorkerStreamEnd(D, StreamID id, RunPrincipal const& rp,
                              EventSetup const& c,
                              ModuleCallingContext const* mcc);
     template<typename D>
-    void callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal& rp,
+    void callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal const& rp,
                                EventSetup const& c,
                                ModuleCallingContext const* mcc);
     template<typename D>
-    void callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal& rp,
+    void callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal const& rp,
                              EventSetup const& c,
                              ModuleCallingContext const* mcc);
     
@@ -77,26 +77,26 @@ namespace edm {
     T const& module() const {return *module_;}
 
   private:
-    virtual bool implDo(EventPrincipal& ep, EventSetup const& c,
+    virtual bool implDo(EventPrincipal const& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
     virtual bool implDoPrePrefetchSelection(StreamID id,
-                                            EventPrincipal& ep,
+                                            EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) override;
-    virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoBegin(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) override;
-    virtual bool implDoEnd(RunPrincipal& rp, EventSetup const& c,
+    virtual bool implDoEnd(RunPrincipal const& rp, EventSetup const& c,
                            ModuleCallingContext const* mcc) override;
-    virtual bool implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                              ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) override;
-    virtual bool implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                            ModuleCallingContext const* mcc) override;
     virtual void implBeginJob() override;
     virtual void implEndJob() override;

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -51,7 +51,7 @@ namespace edm {
     }
     
     bool
-    EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -77,7 +77,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                                ModuleCallingContext const* mcc) {
       
       Run r(rp, moduleDescription_, mcc);
@@ -88,7 +88,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -98,7 +98,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -108,7 +108,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -127,7 +127,7 @@ namespace edm {
     }
     void
     EDAnalyzerBase::doStreamBeginRun(StreamID id,
-                                     RunPrincipal& rp,
+                                     RunPrincipal const& rp,
                                      EventSetup const& c,
                                      ModuleCallingContext const* mcc)
     {
@@ -137,7 +137,7 @@ namespace edm {
     }
     void
     EDAnalyzerBase::doStreamEndRun(StreamID id,
-                                   RunPrincipal& rp,
+                                   RunPrincipal const& rp,
                                    EventSetup const& c,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
@@ -147,7 +147,7 @@ namespace edm {
     }
     void
     EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                 LuminosityBlockPrincipal& lbp,
+                                                 LuminosityBlockPrincipal const& lbp,
                                                  EventSetup const& c,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
@@ -157,7 +157,7 @@ namespace edm {
     
     void
     EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
-                                               LuminosityBlockPrincipal& lbp,
+                                               LuminosityBlockPrincipal const& lbp,
                                                EventSetup const& c,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -48,7 +48,7 @@ namespace edm {
     }
     
     bool
-    EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                           ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -79,7 +79,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -91,7 +91,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                            ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -103,7 +103,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -115,7 +115,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                        ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -136,7 +136,7 @@ namespace edm {
     }
     void
     EDFilterBase::doStreamBeginRun(StreamID id,
-                                     RunPrincipal& rp,
+                                     RunPrincipal const& rp,
                                      EventSetup const& c,
                                      ModuleCallingContext const* mcc)
     {
@@ -146,7 +146,7 @@ namespace edm {
     }
     void
     EDFilterBase::doStreamEndRun(StreamID id,
-                                   RunPrincipal& rp,
+                                   RunPrincipal const& rp,
                                    EventSetup const& c,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
@@ -156,7 +156,7 @@ namespace edm {
     }
     void
     EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                 LuminosityBlockPrincipal& lbp,
+                                                 LuminosityBlockPrincipal const& lbp,
                                                  EventSetup const& c,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
@@ -166,7 +166,7 @@ namespace edm {
     
     void
     EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
-                                               LuminosityBlockPrincipal& lbp,
+                                               LuminosityBlockPrincipal const& lbp,
                                                EventSetup const& c,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -48,7 +48,7 @@ namespace edm {
     }
     
     bool
-    EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -79,7 +79,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                                ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -91,7 +91,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -103,7 +103,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -115,7 +115,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -136,7 +136,7 @@ namespace edm {
     }
     void
     EDProducerBase::doStreamBeginRun(StreamID id,
-                                     RunPrincipal& rp,
+                                     RunPrincipal const& rp,
                                      EventSetup const& c,
                                      ModuleCallingContext const* mcc)
     {
@@ -146,7 +146,7 @@ namespace edm {
     }
     void
     EDProducerBase::doStreamEndRun(StreamID id,
-                                   RunPrincipal& rp,
+                                   RunPrincipal const& rp,
                                    EventSetup const& c,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
@@ -156,7 +156,7 @@ namespace edm {
     }
     void
     EDProducerBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                 LuminosityBlockPrincipal& lbp,
+                                                 LuminosityBlockPrincipal const& lbp,
                                                  EventSetup const& c,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
@@ -166,7 +166,7 @@ namespace edm {
     
     void
     EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
-                                               LuminosityBlockPrincipal& lbp,
+                                               LuminosityBlockPrincipal const& lbp,
                                                EventSetup const& c,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -52,7 +52,7 @@ namespace edm {
     }
 
     bool
-    EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -84,7 +84,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                                ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -93,7 +93,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -102,7 +102,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -111,7 +111,7 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -49,7 +49,7 @@ namespace edm {
     }
     
     bool
-    EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                           ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -85,7 +85,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -96,7 +96,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                            ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -107,7 +107,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -118,7 +118,7 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                        ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -48,7 +48,7 @@ namespace edm {
     }
     
     bool
-    EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -83,7 +83,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                                ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -94,7 +94,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
@@ -105,7 +105,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
@@ -116,7 +116,7 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -138,7 +138,7 @@ EDAnalyzerAdaptorBase::consumesInfo() const {
 }
 
 bool
-EDAnalyzerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+EDAnalyzerAdaptorBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                                ActivityRegistry* act,
                                ModuleCallingContext const* mcc) {
   assert(ep.streamID()<m_streamModules.size());
@@ -165,7 +165,7 @@ EDAnalyzerAdaptorBase::doEndStream(StreamID id) {
 
 void
 EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
-                                        RunPrincipal& rp,
+                                        RunPrincipal const& rp,
                                         EventSetup const& c,
                                         ModuleCallingContext const* mcc)
 {
@@ -180,7 +180,7 @@ EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
 
 void
 EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
-                    RunPrincipal& rp,
+                    RunPrincipal const& rp,
                     EventSetup const& c,
                     ModuleCallingContext const* mcc)
 {
@@ -193,7 +193,7 @@ EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
 
 void
 EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                    LuminosityBlockPrincipal& lbp,
+                                                    LuminosityBlockPrincipal const& lbp,
                                                     EventSetup const& c,
                                                     ModuleCallingContext const* mcc) {
   auto mod = m_streamModules[id];
@@ -205,7 +205,7 @@ EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
 }
 void
 EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
-                                LuminosityBlockPrincipal& lbp,
+                                LuminosityBlockPrincipal const& lbp,
                                 EventSetup const& c,
                                 ModuleCallingContext const* mcc)
 {

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -46,7 +46,7 @@ namespace edm {
     }
     
     bool
-    EDFilterAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDFilterAdaptorBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -46,7 +46,7 @@ namespace edm {
     }
     
     bool
-    EDProducerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+    EDProducerAdaptorBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -160,7 +160,7 @@ namespace edm {
     template< typename T>
     void
     ProducingModuleAdaptorBase<T>::doStreamBeginRun(StreamID id,
-                                                    RunPrincipal& rp,
+                                                    RunPrincipal const& rp,
                                                     EventSetup const& c,
                                                     ModuleCallingContext const* mcc)
     {
@@ -175,7 +175,7 @@ namespace edm {
     template< typename T>
     void
     ProducingModuleAdaptorBase<T>::doStreamEndRun(StreamID id,
-                                                  RunPrincipal& rp,
+                                                  RunPrincipal const& rp,
                                                   EventSetup const& c,
                                                   ModuleCallingContext const* mcc)
     {
@@ -189,7 +189,7 @@ namespace edm {
     template< typename T>
     void
     ProducingModuleAdaptorBase<T>::doStreamBeginLuminosityBlock(StreamID id,
-                                                                LuminosityBlockPrincipal& lbp,
+                                                                LuminosityBlockPrincipal const& lbp,
                                                                 EventSetup const& c,
                                                                 ModuleCallingContext const* mcc) {
       auto mod = m_streamModules[id];
@@ -203,7 +203,7 @@ namespace edm {
     template< typename T>
     void
     ProducingModuleAdaptorBase<T>::doStreamEndLuminosityBlock(StreamID id,
-                                                              LuminosityBlockPrincipal& lbp,
+                                                              LuminosityBlockPrincipal const& lbp,
                                                               EventSetup const& c,
                                                               ModuleCallingContext const* mcc)
     {

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -118,7 +118,7 @@ namespace edm {
           ++it) {
         if(*it && (*it)->singleProduct()) {
             BranchID branchID = (*it)->branchDescription().branchID();
-            idToProductHolder[branchID] = (*it);
+            idToProductHolder[branchID] = get_underlying(*it);
             if((*it)->productUnavailable()) {
                //This call seems to have a side effect of filling the 'ProductProvenance' in the ProductHolder
               OutputHandle const oh = e.getForOutput(branchID, false, mcc);

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1523,7 +1523,7 @@ namespace edm {
     runTree_.insertEntryForIndex(runPrincipal.transitionIndex());
     runPrincipal.fillRunPrincipal(*processHistoryRegistry_, runTree_.rootDelayedReader());
     // Read in all the products now.
-    runPrincipal.readImmediate();
+    runPrincipal.readAllFromSourceAndMergeImmediately();
   }
 
 
@@ -1579,7 +1579,7 @@ namespace edm {
     lumiTree_.insertEntryForIndex(lumiPrincipal.transitionIndex());
     lumiPrincipal.fillLuminosityBlockPrincipal(*processHistoryRegistry_, lumiTree_.rootDelayedReader());
     // Read in all the products now.
-    lumiPrincipal.readImmediate();
+    lumiPrincipal.readAllFromSourceAndMergeImmediately();
     ++indexIntoFileIter_;
   }
 


### PR DESCRIPTION
During the portion of the event loop where the framework is interacting with modules we now only call const methods of the Principal. Therefore to make it safe to use multiple threads per event we just need to make Principal const thread-safe.
