### PR TITLE
Bugfix to merging loop in PFEGAlgo

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1449,6 +1449,8 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
          // -- check that the front is still mergeable!
          if( !mergeTest(*roToMerge) ) {
             // back up one step and repartition(since we will increment later)
+           LOGWARN("PFEGammaAlgo::mergeROsByAnyLink") 
+             << "Merge-i-ness of ROs changed while doing the merge!";
            nomerge = std::partition(roToMerge--,ROs.end(),mergeTest);
            continue;
          }

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1447,13 +1447,15 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
        for( auto roToMerge = mergestart; roToMerge != nomerge; ++roToMerge) {
          //bugfix! L.Gray 14 Jan 2016 
          // -- check that the front is still mergeable!
-         if( !mergeTest(*roToMerge) ) {
-            // back up one step and repartition(since we will increment later)
-           LOGWARN("PFEGammaAlgo::mergeROsByAnyLink") 
-             << "Merge-i-ness of ROs changed while doing the merge!";
-           nomerge = std::partition(roToMerge--,ROs.end(),mergeTest);
-           continue;
-         }
+         if( thefront.ecalclusters.size() && roToMerge->ecalclusters.size() ) {
+           if( thefront.ecalclusters.front().first->clusterRef()->layer() !=   
+               roToMerge->ecalclusters.front().first->clusterRef()->layer() ) {
+             LOGWARN("PFEGammaAlgo::mergeROsByAnyLink") 
+               << "Tried to merge EB and EE clusters! Skipping!";
+             ROs.push_back(*roToMerge);
+             continue;
+           }
+         }         
          //end bugfix
 	 thefront.ecalclusters.insert(thefront.ecalclusters.end(),
 				      roToMerge->ecalclusters.begin(),

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1445,6 +1445,14 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
 	 << "Found objects " << std::distance(mergestart,nomerge)
 	 << " to merge by links to the front!" << std::endl;
        for( auto roToMerge = mergestart; roToMerge != nomerge; ++roToMerge) {
+         //bugfix! L.Gray 14 Jan 2016 
+         // -- check that the front is still mergeable!
+         if( !mergeTest(*roToMerge) ) {
+            // back up one step and repartition(since we will increment later)
+           nomerge = std::partition(roToMerge--,ROs.end(),mergeTest);
+           continue;
+         }
+         //end bugfix
 	 thefront.ecalclusters.insert(thefront.ecalclusters.end(),
 				      roToMerge->ecalclusters.begin(),
 				      roToMerge->ecalclusters.end());


### PR DESCRIPTION
Fixes a bug in the merging loop of PFEGAlgo where it was possible that EB and EE clusters end up in the same e/gamma candidate.

The rate of this bug appears to be one in a few billion.
