### PR TITLE
Make lockTracks passed by reference

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -45,7 +45,7 @@ class PFEGammaFilters {
   bool isElectronSafeForJetMET(const reco::GsfElectron &, 
 			       const reco::PFCandidate &,
 			       const reco::Vertex &,
-			       bool lockTracks);
+			       bool& lockTracks);
 
   bool isPhotonSafeForJetMET(const reco::Photon &, 
 			     const reco::PFCandidate &);

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -129,7 +129,7 @@ bool PFEGammaFilters::isElectron(const reco::GsfElectron & electron) {
 bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron, 
 					      const reco::PFCandidate & pfcand,
 					      const reco::Vertex & primaryVertex,
-					      bool lockTracks) {
+					      bool& lockTracks) {
 
   bool debugSafeForJetMET = false;
   bool isSafeForJetMET = true;


### PR DESCRIPTION
Fix PFEGammaFilter JetMET checks to ensure that tracks are locked when they should be.

This may cause fluctuations in JetMET tails.
