### PR TITLE
put back the by lumi saving for the EventInfo folder

### DIFF
--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -116,6 +116,7 @@ def harvestingMode(process, datasetName, args,rANDl=True):
     if rANDl and (not args.get('newDQMIO', False)):
         process.source.processingMode = cms.untracked.string('RunsAndLumis')
     process.dqmSaver.workflow = datasetName
+    process.dqmSaver.saveByLumiSection = 1
     if 'referenceFile' in args and args.get('referenceFile', ''):
         process.DQMStore.referenceFileName = cms.untracked.string(args['referenceFile'])
 


### PR DESCRIPTION
this reverts the changes done in #12397
the saveByLumiSection flag is needed at the T0 as well in addition to Online to save the EventInfo folder and enable the by lumi certification in the offline GUI.

the crash mentioned in the original PR is cured in:
https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/DQMServices/Core/src/DQMStore.cc#L2094
