### PR TITLE
fix to PV sorting when all track momenta are not well measured (B=0T case mainly)

### DIFF
--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -21,13 +21,17 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
   LorentzVector met;
   std::vector<fastjet::PseudoJet> fjInputs_;  
   fjInputs_.clear();
+  size_t countScale0 = 0;
   for (size_t i = 0 ; i < cands.size(); i++) {
     const reco::Candidate * c= cands[i];
     float scale=1.;
     if(c->bestTrack() != 0)
       {
         scale=(c->pt()-c->bestTrack()->ptError())/c->pt();
-        if(scale<0) scale=0;
+        if(scale<0){ 
+	  scale=0; 
+	  countScale0++;
+	}
       }
 
     int absId=abs(c->pdgId());
@@ -37,8 +41,10 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
       met+=c->p4()*scale;
       sumEt+=c->pt()*scale;
     } else {
-      fjInputs_.push_back(fastjet::PseudoJet(c->px()*scale,c->py()*scale,c->pz()*scale,c->p4().E()*scale));
-//      fjInputs_.back().set_user_index(i);
+      if (scale != 0){ // otherwise, what is the point to cluster zeroes
+	fjInputs_.push_back(fastjet::PseudoJet(c->px()*scale,c->py()*scale,c->pz()*scale,c->p4().E()*scale));
+	//      fjInputs_.back().set_user_index(i);
+      }
     }
   }
   fastjet::ClusterSequence sequence( fjInputs_, JetDefinition(antikt_algorithm, 0.4));
@@ -53,6 +59,7 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
   if(metAbove > 0 and useMet) {
     sumPt2+=metAbove*metAbove;
   }
+  if (countScale0 == cands.size()) sumPt2 = countScale0*0.01; //leave some epsilon value to sort vertices with unknown pt
   return sumPt2;
 }
 


### PR DESCRIPTION
Updates to vertex sorting score assignment for somewhat special cases.
- For a general case of a particle with pt less than ptError, don't use it to make a jet (instead of passing 0,0,0,0 to fastjet).
- If all input particles have pt less than ptError, use the count of input particles times 0.01. These vertices will get a very low score if other well measured vertices exist (instead of zero score now). If all vertices are like that (most often the case for pp in B=0T), the number of tracks associated to the vertex becomes the score. This is somewhat more sensible than a rather random sum of pt^2 (track pt in B=0T is not well defined).

The fixes are a follow up to the bug reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1415.html
