### PR TITLE
Link cmsShowSendReport to zlib from CMSDIST

### DIFF
--- a/Fireworks/Core/bin/BuildFile.xml
+++ b/Fireworks/Core/bin/BuildFile.xml
@@ -5,5 +5,5 @@
  <lib name="Eve"/>
 </bin>
 <bin name="cmsShowSendReport" file="cmsShowSendReport.cc">
- <lib name="z"/>
+ <use name="zlib"/>
 </bin>


### PR DESCRIPTION
Currently cmsShowSendReport is linking to zlib from standard system
location which is not what we want. zlib-devel pacakge is not required
by the bootstrap and if it's not installed -- compilation will fail.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
