### PR TITLE
Default-initialize SubTurbineCrossings fields

### DIFF
--- a/RecoTracker/TkDetLayers/src/PixelForwardLayer.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayer.h
@@ -37,7 +37,7 @@ class PixelForwardLayer final : public ForwardDetLayer {
   static int computeHelicity(const GeometricSearchDet* firstBlade,const GeometricSearchDet* secondBlade);
 
   struct SubTurbineCrossings {
-    SubTurbineCrossings(): isValid(false){}
+    SubTurbineCrossings(): isValid(false), closestIndex(0), nextIndex(0), nextDistance(0.0f) {}
     SubTurbineCrossings( int ci, int ni, float nd) : 
       isValid(true),closestIndex(ci), nextIndex(ni), nextDistance(nd) {}
     

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.h
@@ -38,7 +38,7 @@ class PixelForwardLayerPhase1 final : public ForwardDetLayer {
   static int computeHelicity(const GeometricSearchDet* firstBlade,const GeometricSearchDet* secondBlade);
 
   struct SubTurbineCrossings {
-    SubTurbineCrossings(): isValid(false){}
+    SubTurbineCrossings(): isValid(false), closestIndex(0), nextIndex(0), nextDistance(0.0f) {}
     SubTurbineCrossings( int ci, int ni, float nd) :
       isValid(true),closestIndex(ci), nextIndex(ni), nextDistance(nd) {}
 


### PR DESCRIPTION
Add default values for closestIndex (0), nextIndex (0), nextDistance (0.0f).

Should resolve the following compiler errors:

```
src/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.cc: In member function 'virtual void PixelForwardLayerPhase1::groupedCompatibleDetsV(const TrajectoryStateOnSurface&, const Propagator&, const MeasurementEstim
ator&, std::vector<DetGroup>&) const':
src/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.cc:232:70: error: 'crossings_inner.PixelForwardLayerPhase1::SubTurbineCrossings::nextIndex' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  int negStart = min( crossings.closestIndex, crossings.nextIndex) - 1;
                                                                     ^
src/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.cc:124:24: note: 'crossings_inner.PixelForwardLayerPhase1::SubTurbineCrossings::nextIndex' was declared here
  SubTurbineCrossings  crossings_inner;
                       ^
src/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.cc:232:70: error: 'crossings_inner.PixelForwardLayerPhase1::SubTurbineCrossings::closestIndex' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  int negStart = min( crossings.closestIndex, crossings.nextIndex) - 1;
                                                                     ^
src/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.cc:124:24: note: 'crossings_inner.PixelForwardLayerPhase1::SubTurbineCrossings::closestIndex' was declared here
  SubTurbineCrossings  crossings_inner;
                       ^
```

Signed-off-by: David Abdurachmanov davidlt@cern.ch
