### PR TITLE
Fastsim: fix muon HLT: reintroduce hitless seeds in TrackProducer

### DIFF
--- a/FastSimulation/Muons/python/TrackCandidateFromL2_cfi.py
+++ b/FastSimulation/Muons/python/TrackCandidateFromL2_cfi.py
@@ -8,7 +8,7 @@ hltL3TrackCandidateFromL2 = FastSimulation.Tracking.TrackCandidateProducer_cfi.t
     SeedCleaning = cms.bool(True),
     SplitHits = cms.bool(False),
     SimTracks = cms.InputTag('famosSimHits'),
-    EstimatorCut = cms.double(200)
+    maxSeedMatchEstimator = cms.untracked.double(200)
 )
 
 

--- a/FastSimulation/Tracking/BuildFile.xml
+++ b/FastSimulation/Tracking/BuildFile.xml
@@ -1,3 +1,7 @@
+<use   name="DataFormats/TrajectoryState"/>
+<use   name="TrackingTools/GeomPropagators"/>
+<use   name="TrackingTools/TrajectoryParametrization"/>
+<use   name="SimDataFormats/Track"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="DataFormats/SiStripDetId"/>

--- a/FastSimulation/Tracking/interface/FastTrackerRecHitSplitter.h
+++ b/FastSimulation/Tracking/interface/FastTrackerRecHitSplitter.h
@@ -16,7 +16,7 @@ class FastTrackerRecHitSplitter {
     FastTrackerRecHitSplitter(){;}
     ~FastTrackerRecHitSplitter(){;}
     
-    inline void split(const FastTrackerRecHit & hitIn,edm::OwnVector<TrackingRecHit> & hitsOut) const {
+    inline void split(const FastTrackerRecHit & hitIn,edm::OwnVector<TrackingRecHit> & hitsOut,bool reverseHits) const {
 	
 	if(hitIn.dimension()==1 || hitIn.isPixel())
 	    hitsOut.push_back( hitIn.clone() );
@@ -25,8 +25,10 @@ class FastTrackerRecHitSplitter {
 	    hitsOut.push_back(buildSplitStripHit(static_cast<const FastProjectedTrackerRecHit &>(hitIn).originalHit()));
 	
 	else if(hitIn.isMatched()){
-	    hitsOut.push_back(buildSplitStripHit(static_cast<const FastMatchedTrackerRecHit &>(hitIn).firstHit()));
-	    hitsOut.push_back(buildSplitStripHit(static_cast<const FastMatchedTrackerRecHit &>(hitIn).secondHit()));
+	    const FastSingleTrackerRecHit & firstHit = (static_cast<const FastMatchedTrackerRecHit &>(hitIn)).firstHit();
+	    const FastSingleTrackerRecHit & secondHit = (static_cast<const FastMatchedTrackerRecHit &>(hitIn)).secondHit();
+	    hitsOut.push_back(buildSplitStripHit(reverseHits ? secondHit : firstHit));
+	    hitsOut.push_back(buildSplitStripHit(reverseHits ? firstHit : secondHit));
 	}
 	
 	else{

--- a/FastSimulation/Tracking/interface/SeedMatcher.h
+++ b/FastSimulation/Tracking/interface/SeedMatcher.h
@@ -1,0 +1,33 @@
+#ifndef SEEDMATCHER_H
+#define SEEDMATCHER_H
+
+#include "vector"
+#include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHitCollection.h"
+
+class TrajectorySeed;
+class Propagator;
+class MagneticField;
+class TrajectoryStateOnSurface;
+class SimTrack;
+class TrackerGeometry;
+
+class SeedMatcher
+{
+public:
+    static std::vector<int> matchRecHitCombinations(
+	const TrajectorySeed & seed,
+	const FastTrackerRecHitCombinationCollection & recHitCombinationCollection,
+	const std::vector<SimTrack> & simTrackCollection,
+	double maxMatchEstimator,
+	const Propagator & propagator,
+	const MagneticField & magneticField,
+	const TrackerGeometry & trackerGeometry) ;
+
+    static double matchSimTrack(
+	const TrajectoryStateOnSurface & seedState,
+	const SimTrack & simTrack,
+	const Propagator & propagator,
+	const MagneticField & magneticField);
+};
+
+#endif

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -37,6 +37,9 @@
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
+#include "iostream"
+#include "FastSimulation/Tracking/interface/SeedMatcher.h"
+
 //Propagator withMaterial
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 
@@ -61,13 +64,16 @@ TrackCandidateProducer::TrackCandidateProducer(const edm::ParameterSet& conf)
   simVertexToken = consumes<edm::SimVertexContainer>(simTrackLabel);
   simTrackToken = consumes<edm::SimTrackContainer>(simTrackLabel);
 
-  edm::InputTag seedLabel = conf.getParameter<edm::InputTag>("src");
+  //edm::InputTag seedLabel = conf.getParameter<edm::InputTag>("src");
+  seedLabel = conf.getParameter<edm::InputTag>("src");
   seedToken = consumes<edm::View<TrajectorySeed> >(seedLabel);
 
   edm::InputTag recHitCombinationsLabel = conf.getParameter<edm::InputTag>("recHitCombinations");
   recHitCombinationsToken = consumes<FastTrackerRecHitCombinationCollection>(recHitCombinationsLabel);
   
   propagatorLabel = conf.getParameter<std::string>("propagator");
+
+  maxSeedMatchEstimator = conf.getUntrackedParameter<double>("maxSeedMatchEstimator",0);
 }
   
 void 
@@ -116,16 +122,35 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
     
       const TrajectorySeed seed = (*seeds)[seednr];
+      std::vector<int32_t> recHitCombinationIndices;
     if(seed.nHits()==0){
-      edm::LogError("TrackCandidateProducer") << "empty trajectory seed in TrajectorySeedCollection: skip" << std::endl;
-      continue;
+	recHitCombinationIndices = SeedMatcher::matchRecHitCombinations(
+	    seed,
+	    *recHitCombinations,
+	    *simTracks,
+	    maxSeedMatchEstimator,
+	    *propagator,
+	    *magneticField,
+	    *trackerGeometry);
     }
+    else
+    {
 
     // Get the combination of hits that produced the seed
     int32_t icomb = fastTrackingHelper::getRecHitCombinationIndex(seed);
+    recHitCombinationIndices.push_back(icomb);
+    }
+
+
+
+    for(auto icomb : recHitCombinationIndices)
+    {
     if(icomb < 0 || unsigned(icomb) >= recHitCombinations->size()){
 	throw cms::Exception("TrackCandidateProducer") << " found seed with recHitCombination out or range: " << icomb << std::endl;
     }
+    
+
+
     const FastTrackerRecHitCombination & recHitCombination = (*recHitCombinations)[icomb];
 
     // select hits, temporarily store as TrajectorySeedHitCandidates
@@ -174,22 +199,25 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       continue;
     }
 
+
+    // order hits along the seed direction
+    bool oiSeed = seed.direction()==oppositeToMomentum;
+    if (oiSeed)
+    {
+	std::reverse(recHitCandidates.begin(),recHitCandidates.end());
+    }
+
     // Convert TrajectorySeedHitCandidate to TrackingRecHit and split hits
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
 	if(splitHits){
-	    hitSplitter.split(*recHitCandidates[index].hit(),trackRecHits);
+	    hitSplitter.split(*recHitCandidates[index].hit(),trackRecHits,oiSeed);
 	}
 	else {
 	    trackRecHits.push_back(recHitCandidates[index].hit()->clone());
 	}
     }
 
-    // order hits along the seed direction
-    if (seed.direction()==oppositeToMomentum){
-      LogDebug("FastTracking")<<"reversing the order of the hits";
-      std::reverse(recHitCandidates.begin(),recHitCandidates.end());
-    }
 
     // set the recHitCombinationIndex
     fastTrackingHelper::setRecHitCombinationIndex(trackRecHits,icomb);
@@ -205,9 +233,10 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     //   - check validity and transform
     if (!initialTSOS.isValid()) continue; 
     PTrajectoryStateOnDet PTSOD = trajectoryStateTransform::persistentState(initialTSOS,trackRecHits.front().geographicalId().rawId()); 
-
     // add track candidate to output collection
     output->push_back(TrackCandidate(trackRecHits,seed,PTSOD,edm::RefToBase<TrajectorySeed>(seeds,seednr)));
+
+  }
   }
   
   // Save the track candidates

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -22,6 +22,7 @@
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
 #include "FastSimulation/Tracking/interface/HitMaskHelper.h"
 #include "FastSimulation/Tracking/interface/FastTrackingHelper.h"
+#include "FastSimulation/Tracking/interface/SeedMatcher.h"
 
 #include <vector>
 #include <map>
@@ -36,9 +37,6 @@
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-
-#include "iostream"
-#include "FastSimulation/Tracking/interface/SeedMatcher.h"
 
 //Propagator withMaterial
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
@@ -64,8 +62,7 @@ TrackCandidateProducer::TrackCandidateProducer(const edm::ParameterSet& conf)
   simVertexToken = consumes<edm::SimVertexContainer>(simTrackLabel);
   simTrackToken = consumes<edm::SimTrackContainer>(simTrackLabel);
 
-  //edm::InputTag seedLabel = conf.getParameter<edm::InputTag>("src");
-  seedLabel = conf.getParameter<edm::InputTag>("src");
+  edm::InputTag seedLabel = conf.getParameter<edm::InputTag>("src");
   seedToken = consumes<edm::View<TrajectorySeed> >(seedLabel);
 
   edm::InputTag recHitCombinationsLabel = conf.getParameter<edm::InputTag>("recHitCombinations");
@@ -140,17 +137,11 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     int32_t icomb = fastTrackingHelper::getRecHitCombinationIndex(seed);
     recHitCombinationIndices.push_back(icomb);
     }
-
-
-
     for(auto icomb : recHitCombinationIndices)
     {
     if(icomb < 0 || unsigned(icomb) >= recHitCombinations->size()){
 	throw cms::Exception("TrackCandidateProducer") << " found seed with recHitCombination out or range: " << icomb << std::endl;
     }
-    
-
-
     const FastTrackerRecHitCombination & recHitCombination = (*recHitCombinations)[icomb];
 
     // select hits, temporarily store as TrajectorySeedHitCandidates

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
@@ -27,6 +27,7 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   
  private:
 
+    edm::InputTag seedLabel;
   unsigned int minNumberOfCrossedLayers;
   unsigned int maxNumberOfCrossedLayers;
 
@@ -43,7 +44,7 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
   edm::EDGetTokenT<std::vector<bool> > hitMasksToken;
   std::string propagatorLabel;
-  
+  double maxSeedMatchEstimator;
 };
 
 #endif

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
@@ -27,7 +27,6 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   
  private:
 
-    edm::InputTag seedLabel;
   unsigned int minNumberOfCrossedLayers;
   unsigned int maxNumberOfCrossedLayers;
 

--- a/FastSimulation/Tracking/src/SeedMatcher.cc
+++ b/FastSimulation/Tracking/src/SeedMatcher.cc
@@ -31,9 +31,15 @@ std::vector<int32_t> SeedMatcher::matchRecHitCombinations(const TrajectorySeed &
     TrajectoryStateOnSurface seedState(trajectoryStateTransform::transientState(ptod,seedState_surface,&magneticField));
     
     // find matches
+    int nSimTracks = simTrackCollection.size();
     for(unsigned recHitCombinationIndex = 0;recHitCombinationIndex < recHitCombinationCollection.size(); recHitCombinationIndex++)
     {
 	const auto & recHitCombination = recHitCombinationCollection[recHitCombinationIndex];
+	int simTrackIndex = recHitCombination.back()->simTrackId(0);
+	if(simTrackIndex < 0 || simTrackIndex >= nSimTracks)
+	{
+	    throw cms::Exception("SeedMatcher") << "SimTrack index out of range: " << simTrackIndex << std::endl;
+	}
 	const auto & simTrack = simTrackCollection[recHitCombination.back()->simTrackId(0)];
 	double matchEstimator = matchSimTrack(seedState,simTrack,propagator,magneticField);
 	if(matchEstimator < maxMatchEstimator)

--- a/FastSimulation/Tracking/src/SeedMatcher.cc
+++ b/FastSimulation/Tracking/src/SeedMatcher.cc
@@ -1,0 +1,98 @@
+#include "FastSimulation/Tracking/interface/SeedMatcher.h"
+
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "iostream"
+
+std::vector<int32_t> SeedMatcher::matchRecHitCombinations(const TrajectorySeed & seed,
+							  const FastTrackerRecHitCombinationCollection & recHitCombinationCollection,
+							  const edm::SimTrackContainer & simTrackCollection,
+							  double maxMatchEstimator,
+							  const Propagator & propagator,
+							  const MagneticField & magneticField,
+							  const TrackerGeometry & trackerGeometry)
+{
+
+    // container for result
+    std::vector<int32_t> result;
+    
+    // seed state
+    PTrajectoryStateOnDet ptod =seed.startingState();
+    DetId seedState_detId(ptod.detId());
+    const GeomDet * seedState_det = trackerGeometry.idToDet(seedState_detId);
+    const Surface * seedState_surface=&seedState_det->surface();
+    TrajectoryStateOnSurface seedState(trajectoryStateTransform::transientState(ptod,seedState_surface,&magneticField));
+    
+    // find matches
+    for(unsigned recHitCombinationIndex = 0;recHitCombinationIndex < recHitCombinationCollection.size(); recHitCombinationIndex++)
+    {
+	const auto & recHitCombination = recHitCombinationCollection[recHitCombinationIndex];
+	const auto & simTrack = simTrackCollection[recHitCombination.back()->simTrackId(0)];
+	double matchEstimator = matchSimTrack(seedState,simTrack,propagator,magneticField);
+	if(matchEstimator < maxMatchEstimator)
+	{
+	    result.push_back(recHitCombinationIndex);
+	}
+    }
+    return result;
+}
+
+double SeedMatcher::matchSimTrack(const TrajectoryStateOnSurface & seedState,
+				  const SimTrack & simTrack,
+				  const Propagator & propagator,
+				  const MagneticField & magneticField)
+{
+    
+    // simtrack and simvertex at tracker surface
+    GlobalPoint simTrack_atTrackerSurface_position(simTrack.trackerSurfacePosition().x(),
+						   simTrack.trackerSurfacePosition().y(),
+						   simTrack.trackerSurfacePosition().z());    
+    GlobalVector simTrack_atTrackerSurface_momentum(simTrack.trackerSurfaceMomentum().x(),
+						    simTrack.trackerSurfaceMomentum().y(),
+						    simTrack.trackerSurfaceMomentum().z());
+    
+    // no match if seedstate and simtrack in oposite direction
+    if ( simTrack_atTrackerSurface_position.basicVector().dot(simTrack_atTrackerSurface_momentum.basicVector() ) 
+	 * seedState.globalPosition().basicVector().dot(seedState.globalMomentum().basicVector()) <0. )
+    {
+	return 9999.;
+    }
+    
+    // find simtrack state on surface of seed state
+    GlobalTrajectoryParameters simTrack_atTrackerSurface_parameters(simTrack_atTrackerSurface_position,
+								    simTrack_atTrackerSurface_momentum,
+								    simTrack.charge(),
+								    &magneticField);
+    FreeTrajectoryState simtrack_atTrackerSurface_state(simTrack_atTrackerSurface_parameters);
+    TrajectoryStateOnSurface simtrack_atSeedStateSurface_state = propagator.propagate(simtrack_atTrackerSurface_state,seedState.surface());
+    
+    // simtrack does not propagate to surface of seed state
+    if (!simtrack_atSeedStateSurface_state.isValid())
+    {
+	return 9999.;
+    }
+    
+    // simtrack and seed state have opposite direction
+    if ( simtrack_atSeedStateSurface_state.globalPosition().basicVector().dot(simtrack_atSeedStateSurface_state.globalMomentum().basicVector()) 
+	 * seedState.globalPosition().basicVector().dot(seedState.globalMomentum().basicVector()) <0. )
+    {
+	return 9999.;
+    }
+
+    AlgebraicVector5 difference(seedState.localParameters().vector() - simtrack_atSeedStateSurface_state.localParameters().vector());
+    AlgebraicSymMatrix55 error(seedState.localError().matrix());
+    if(!error.Invert())
+    {
+	edm::LogWarning("FastSim SeedToSimTrackMatcher") <<"Cannot invert seed state error matrix => no match...";
+	return 9999.;
+    }
+
+    return ROOT::Math::Similarity(difference,error);
+}


### PR DESCRIPTION
Treatment of hitless seeds in the FastSim TrackProducer,
 as used by the muon HLT in FastSim were disabled since CMSSW_7_5_0_pre6,
#9595. This feature is now re-implemented in a clean way.
