### PR TITLE
Updated b-tag candidate kinematics

### DIFF
--- a/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
@@ -28,7 +28,6 @@ class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
     void calcNsubjettiness(const reco::JetBaseRef & jet, float & tau1, float & tau2, std::vector<fastjet::PseudoJet> & currentAxes) const;
     void setTracksPVBase(const reco::TrackRef & trackRef, const reco::VertexRef & vertexRef, float & PVweight) const;
     void setTracksPV(const reco::CandidatePtr & trackRef, const reco::VertexRef & vertexRef, float & PVweight) const;
-    void vertexKinematics(const reco::VertexCompositePtrCandidate & vertex, reco::TrackKinematics & vertexKinematics) const;
     void etaRelToTauAxis(const reco::VertexCompositePtrCandidate & vertex, fastjet::PseudoJet & tauAxis, std::vector<float> & tau_trackEtaRel) const;
 
     const double beta_;

--- a/RecoBTag/SecondaryVertex/interface/TrackKinematics.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackKinematics.h
@@ -30,6 +30,10 @@ class TrackKinematics {
 	void add(const reco::Track &track, double weight = 1.0);
 	void add(const reco::CandidatePtr &track);
 
+	inline
+	void add(const reco::TrackRef &track, double weight = 1.0)
+	{return add(*track, weight); }
+
 	TrackKinematics &operator += (const TrackKinematics &other);
 	inline TrackKinematics operator + (const TrackKinematics &other)
 	{ TrackKinematics copy = *this; copy += other; return copy; }

--- a/RecoBTag/SecondaryVertex/interface/TrackKinematics.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackKinematics.h
@@ -5,6 +5,8 @@
 
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
@@ -16,6 +18,8 @@ class TrackKinematics {
 	TrackKinematics();
 	TrackKinematics(const std::vector<reco::Track> &tracks);
 	TrackKinematics(const reco::TrackRefVector &tracks);
+	TrackKinematics(const std::vector<reco::CandidatePtr> &tracks);
+	TrackKinematics(const reco::CandidatePtrVector &tracks);
 	TrackKinematics(const reco::Vertex &vertex);
 	TrackKinematics(const reco::VertexCompositePtrCandidate &vertex):
  	       n(vertex.numberOfSourceCandidatePtrs()), sumWeights(vertex.numberOfSourceCandidatePtrs()),
@@ -24,6 +28,7 @@ class TrackKinematics {
 	~TrackKinematics() {}
 
 	void add(const reco::Track &track, double weight = 1.0);
+	void add(const reco::CandidatePtr &track);
 
 	TrackKinematics &operator += (const TrackKinematics &other);
 	inline TrackKinematics operator + (const TrackKinematics &other)

--- a/RecoBTag/SecondaryVertex/interface/TrackSelector.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackSelector.h
@@ -6,6 +6,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/BTauReco/interface/IPTagInfo.h"
 
 namespace reco {
@@ -20,7 +21,24 @@ class TrackSelector {
 	                 const reco::Jet &jet,
 	                 const GlobalPoint &pv) const;
 
+	bool operator() (const reco::CandidatePtr &track,
+	                 const reco::btag::TrackIPData &ipData,
+	                 const reco::Jet &jet,
+	                 const GlobalPoint &pv) const;
+
+	inline
+	bool operator() (const reco::TrackRef &track,
+	                 const reco::btag::TrackIPData &ipData,
+	                 const reco::Jet &jet,
+	                 const GlobalPoint &pv) const
+	{ return (*this)(*track, ipData, jet, pv); }
+
     private:
+	bool trackSelection(const reco::Track &track,
+	                    const reco::btag::TrackIPData &ipData,
+	                    const reco::Jet &jet,
+	                    const GlobalPoint &pv) const;
+
 	bool				selectQuality;
 	reco::TrackBase::TrackQuality	quality;
 	unsigned int			minPixelHits;

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -570,7 +570,25 @@ void CandidateBoostedDoubleSecondaryVertexComputer::calcNsubjettiness(const reco
   for(const reco::CandidatePtr & daughter : jet->daughterPtrVector())
   {
     if ( daughter.isNonnull() && daughter.isAvailable() )
-      fjParticles.push_back( fastjet::PseudoJet( daughter->px(), daughter->py(), daughter->pz(), daughter->energy() ) );
+    {
+      const reco::Jet * subjet = dynamic_cast<const reco::Jet *>(daughter.get());
+      // if the daughter is actually a subjet
+      if( subjet && daughter->numberOfDaughters() > 1 )
+      {
+        // loop over subjet constituents and push them in the vector of FastJet constituents
+        for(size_t i=0; i<daughter->numberOfDaughters(); ++i)
+        {
+          const reco::Candidate * constit = daughter->daughter(i);
+
+          if ( constit )
+            fjParticles.push_back( fastjet::PseudoJet( constit->px(), constit->py(), constit->pz(), constit->energy() ) );
+          else
+            edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
+        }
+      }
+      else
+        fjParticles.push_back( fastjet::PseudoJet( daughter->px(), daughter->py(), daughter->pz(), daughter->energy() ) );
+    }
     else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
   }

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -113,23 +113,21 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
   // loop over tracks associated to the jet
   for (size_t itt=0; itt < trackSize; ++itt)
   {
-    const reco::CandidatePtr ptrackRef = selectedTracks[itt];
-    const reco::Track * ptrackPtr = reco::btag::toTrack(ptrackRef);
-    const reco::Track & ptrack = *ptrackPtr;
+    const reco::CandidatePtr trackRef = selectedTracks[itt];
 
     float track_PVweight = 0.;
-    setTracksPV(ptrackRef, vertexRef, track_PVweight);
-    if (track_PVweight>0.5) allKinematics.add(ptrack, track_PVweight);
+    setTracksPV(trackRef, vertexRef, track_PVweight);
+    if (track_PVweight>0.5) allKinematics.add(trackRef);
 
     const reco::btag::TrackIPData &data = ipData[itt];
     bool isSelected = false;
-    if (trackSelector(ptrack, data, *jet, pv)) isSelected = true;
+    if (trackSelector(trackRef, data, *jet, pv)) isSelected = true;
 
     // check if the track is from V0
     bool isfromV0 = false, isfromV0Tight = false;
-    const reco::Track * trackPairV0Test[2];
+    std::vector<reco::CandidatePtr> trackPairV0Test(2);
 
-    trackPairV0Test[0] = ptrackPtr;
+    trackPairV0Test[0] = trackRef;
 
     for (size_t jtt=0; jtt < trackSize; ++jtt)
     {
@@ -137,16 +135,14 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
 
       const reco::btag::TrackIPData & pairTrackData = ipData[jtt];
       const reco::CandidatePtr pairTrackRef = selectedTracks[jtt];
-      const reco::Track * pairTrackPtr = reco::btag::toTrack(pairTrackRef);
-      const reco::Track & pairTrack = *pairTrackPtr;
 
-      trackPairV0Test[1] = pairTrackPtr;
+      trackPairV0Test[1] = pairTrackRef;
 
-      if (!trackPairV0Filter(trackPairV0Test, 2))
+      if (!trackPairV0Filter(trackPairV0Test))
       {
         isfromV0 = true;
 
-        if ( trackSelector(pairTrack, pairTrackData, *jet, pv) )
+        if ( trackSelector(pairTrackRef, pairTrackData, *jet, pv) )
           isfromV0Tight = true;
       }
 
@@ -156,11 +152,11 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
 
     if( isSelected && !isfromV0Tight ) jetNTracks += 1.;
 
-    reco::TransientTrack transientTrack = trackBuilder->build(ptrack);
+    reco::TransientTrack transientTrack = trackBuilder->build(trackRef);
     GlobalVector direction(jet->px(), jet->py(), jet->pz());
 
     int index = 0;
-    if (currentAxes.size() > 1 && reco::deltaR2(ptrack,currentAxes[1]) < reco::deltaR2(ptrack,currentAxes[0]))
+    if (currentAxes.size() > 1 && reco::deltaR2(trackRef->momentum(),currentAxes[1]) < reco::deltaR2(trackRef->momentum(),currentAxes[0]))
         index = 1;
     direction = GlobalVector(currentAxes[index].px(), currentAxes[index].py(), currentAxes[index].pz());
 
@@ -182,7 +178,7 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
       ++contTrk;
       if (currentAxes.size() > 1)
       {
-        if (reco::deltaR2(ptrack,currentAxes[0]) < reco::deltaR2(ptrack,currentAxes[1]))
+        if (reco::deltaR2(trackRef->momentum(),currentAxes[0]) < reco::deltaR2(trackRef->momentum(),currentAxes[1]))
           IP3Ds_1.push_back( IP3Dsig<-50. ? -50. : IP3Dsig );
         else
           IP3Ds_2.push_back( IP3Dsig<-50. ? -50. : IP3Dsig );
@@ -200,11 +196,9 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
   {
     size_t idx = indices[i];
     const reco::btag::TrackIPData & data = ipData[idx];
-    const reco::CandidatePtr ptrackRef = selectedTracks[idx];
-    const reco::Track * ptrackPtr = reco::btag::toTrack(ptrackRef);
-    const reco::Track & track = (*ptrackPtr);
+    const reco::CandidatePtr trackRef = selectedTracks[idx];
 
-    kin.add(track);
+    kin.add(trackRef);
 
     if ( kin.vectorSum().M() > charmThreshold // charm cut
          && !charmThreshSet )
@@ -328,11 +322,9 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
   std::map<double, size_t> VTXmap;
   for (size_t vtx = 0; vtx < svTagInfo.nVertices(); ++vtx)
   {
-    reco::TrackKinematics vertexKinematic;
-
-    // get the vertex kinematics
     const reco::VertexCompositePtrCandidate vertex = svTagInfo.secondaryVertex(vtx);
-    vertexKinematics(vertex, vertexKinematic);
+    // get the vertex kinematics
+    reco::TrackKinematics vertexKinematic(vertex);
 
     if (currentAxes.size() > 1)
     {
@@ -634,17 +626,6 @@ void CandidateBoostedDoubleSecondaryVertexComputer::setTracksPV(const reco::Cand
     const reco::PFCandidate * pfcand = dynamic_cast<const reco::PFCandidate *>(trackRef.get());
 
     setTracksPVBase(pfcand->trackRef(), vertexRef, PVweight);
-  }
-}
-
-
-void CandidateBoostedDoubleSecondaryVertexComputer::vertexKinematics(const reco::VertexCompositePtrCandidate & vertex, reco::TrackKinematics & vtxKinematics) const
-{
-  const std::vector<reco::CandidatePtr> & tracks = vertex.daughterPtrVector();
-
-  for(std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
-    const reco::Track& mytrack = *(*track)->bestTrack();
-    vtxKinematics.add(mytrack, 1.0);
   }
 }
 

--- a/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
@@ -68,7 +68,7 @@ CombinedSVComputer::threshTrack(const CandIPTagInfo &trackIPTagInfo,
         range_for(i, range) {
                 std::size_t idx = indices[i];
                 const btag::TrackIPData &data = ipData[idx];
-                const Track &track = *tracks[idx]->bestTrack();
+                const CandidatePtr &track = tracks[idx];
 
                 if (!trackNoDeltaRSelector(track, data, jet, pv))
                         continue;
@@ -221,7 +221,7 @@ CombinedSVComputer::operator () (const CandIPTagInfo &ipInfo,
 		const reco::VertexCompositePtrCandidate &vertex = svInfo.secondaryVertex(i);
 		const std::vector<CandidatePtr> & tracks = vertex.daughterPtrVector();
 		for(std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
-			vertexKinematics.add(*(*track)->bestTrack(), 1.0);
+			vertexKinematics.add(*track);
 			vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,(*track)->momentum()), true);
 			if(vtx < 0) // calculate this only for the first vertex
 			{

--- a/RecoBTag/SecondaryVertex/src/TrackKinematics.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackKinematics.cc
@@ -34,6 +34,22 @@ TrackKinematics::TrackKinematics(const TrackRefVector &tracks) :
 		add(**iter);
 }
 
+TrackKinematics::TrackKinematics(const std::vector<CandidatePtr> &tracks) :
+	n(0), sumWeights(0)
+{
+	for(std::vector<CandidatePtr>::const_iterator iter = tracks.begin();
+	    iter != tracks.end(); iter++)
+		add(*iter);
+}
+
+TrackKinematics::TrackKinematics(const CandidatePtrVector &tracks) :
+	n(0), sumWeights(0)
+{
+	for(CandidatePtrVector::const_iterator iter = tracks.begin();
+	    iter != tracks.end(); iter++)
+		add(*iter);
+}
+
 TrackKinematics::TrackKinematics(const Vertex &vertex) :
 	n(0), sumWeights(0)
 {
@@ -71,4 +87,14 @@ void TrackKinematics::add(const Track &track, double weight)
 	sumWeights += weight;
 	sum += vec;
 	weightedSum += weight * vec;
+}
+
+void TrackKinematics::add(const CandidatePtr &track)
+{
+	double weight = 1.0;
+
+	n++;
+	sumWeights += weight;
+	sum += track->p4();
+	weightedSum += weight * track->p4();
 }

--- a/RecoBTag/SecondaryVertex/src/TrackSelector.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackSelector.cc
@@ -2,9 +2,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "DataFormats/JetReco/interface/Jet.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/BTauReco/interface/TrackIPTagInfo.h"
 
@@ -71,16 +69,49 @@ TrackSelector::operator () (const Track &track,
   }
   else  jtaPassed = true;
 
+  return track.pt() >= minPt &&
+    VectorUtil::DeltaR(jet.momentum(),
+		       track.momentum()) < maxJetDeltaR &&
+    jtaPassed &&
+    trackSelection(track, ipData, jet, pv);
+}
+
+bool
+TrackSelector::operator () (const CandidatePtr &track,
+                            const btag::TrackIPData &ipData,
+                            const Jet &jet,
+                            const GlobalPoint &pv) const
+{
+
+ 
+  bool jtaPassed = false;
+  if (useVariableJTA_) {
+    jtaPassed = TrackIPTagInfo::passVariableJTA( varJTApars,
+					jet.pt(),track->pt(),
+					VectorUtil::DeltaR(jet.momentum(),track->momentum()));
+  }
+  else  jtaPassed = true;
+
+  return track->pt() >= minPt &&
+    VectorUtil::DeltaR(jet.momentum(),
+		       track->momentum()) < maxJetDeltaR &&
+    jtaPassed &&
+    trackSelection(*reco::btag::toTrack(track), ipData, jet, pv);
+}
+
+bool
+TrackSelector::trackSelection(const Track &track,
+                              const btag::TrackIPData &ipData,
+                              const Jet &jet,
+                              const GlobalPoint &pv) const
+{
+
   return (!selectQuality || track.quality(quality)) &&
     (minPixelHits <= 0 ||
      track.hitPattern().numberOfValidPixelHits() >= (int)minPixelHits) &&
     (minTotalHits <= 0 ||
      track.hitPattern().numberOfValidHits() >= (int)minTotalHits) &&
-    track.pt() >= minPt &&
     track.normalizedChi2() < maxNormChi2 &&
-    VectorUtil::DeltaR(jet.momentum(),
-		       track.momentum()) < maxJetDeltaR &&
-    jtaPassed &&
     std::abs(ipData.distanceToJetAxis.value()) <= maxDistToAxis &&
     (ipData.closestToJetAxis - pv).mag() <= maxDecayLen &&
     ipData.ip2d.value()        >= sip2dValMin &&

--- a/RecoBTag/SecondaryVertex/src/TrackSelector.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackSelector.cc
@@ -1,5 +1,3 @@
-#include <Math/GenVector/VectorUtil.h>
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -9,7 +7,6 @@
 #include "RecoBTag/SecondaryVertex/interface/TrackSelector.h"
 
 using namespace reco; 
-using namespace ROOT::Math;
 
 TrackSelector::TrackSelector(const edm::ParameterSet &params) :
 	minPixelHits(params.getParameter<unsigned int>("pixelHitsMin")),
@@ -65,13 +62,13 @@ TrackSelector::operator () (const Track &track,
   if (useVariableJTA_) {
     jtaPassed = TrackIPTagInfo::passVariableJTA( varJTApars,
 					jet.pt(),track.pt(),
-					VectorUtil::DeltaR(jet.momentum(),track.momentum()));
+					reco::deltaR(jet.momentum(),track.momentum()));
   }
   else  jtaPassed = true;
 
   return track.pt() >= minPt &&
-    VectorUtil::DeltaR(jet.momentum(),
-		       track.momentum()) < maxJetDeltaR &&
+    reco::deltaR2(jet.momentum(),
+		       track.momentum()) < maxJetDeltaR*maxJetDeltaR &&
     jtaPassed &&
     trackSelection(track, ipData, jet, pv);
 }
@@ -88,13 +85,13 @@ TrackSelector::operator () (const CandidatePtr &track,
   if (useVariableJTA_) {
     jtaPassed = TrackIPTagInfo::passVariableJTA( varJTApars,
 					jet.pt(),track->pt(),
-					VectorUtil::DeltaR(jet.momentum(),track->momentum()));
+					reco::deltaR(jet.momentum(),track->momentum()));
   }
   else  jtaPassed = true;
 
   return track->pt() >= minPt &&
-    VectorUtil::DeltaR(jet.momentum(),
-		       track->momentum()) < maxJetDeltaR &&
+    reco::deltaR2(jet.momentum(),
+		       track->momentum()) < maxJetDeltaR*maxJetDeltaR &&
     jtaPassed &&
     trackSelection(*reco::btag::toTrack(track), ipData, jet, pv);
 }

--- a/RecoBTag/SecondaryVertex/src/V0Filter.cc
+++ b/RecoBTag/SecondaryVertex/src/V0Filter.cc
@@ -62,12 +62,19 @@ V0Filter::operator () (const reco::TrackRef *tracks, unsigned int n) const
 bool
 V0Filter::operator () (const std::vector<reco::CandidatePtr> & tracks) const
 {
-	std::vector<const reco::Track*> trackPtrs(tracks.size());
-	for(unsigned int i = 0; i < tracks.size(); i++)
-		trackPtrs[i] = tracks[i]->bestTrack();
+	if (tracks.size() != 2)
+		return true;
 
-	return (*this)(&trackPtrs[0], tracks.size());
+	if (tracks[0]->charge() * tracks[1]->charge() > 0)
+		return true;
+	
+	double invariantMass = (tracks[0]->p4()+tracks[1]->p4()).M();
+	if (std::abs(invariantMass - ParticleMasses::k0) < k0sMassWindow)
+		return false;
+
+	return true;
 }
+
 bool
 V0Filter::operator () (const std::vector<const reco::Track *> & tracks) const
 {


### PR DESCRIPTION
This PR introduces updated handling of candidate kinematics in the b-tagging code with the goal of improving the agreement between discriminators computed from AOD and MiniAOD (problem reported, for example, in https://hypernews.cern.ch/HyperNews/CMS/get/btag/1232.html).

In AOD PF candidates and tracks linked to them have their own separate momenta defined while in MiniAOD PackedCandidates store track info with the track momentum set to the candidate momentum in order to save some space.  The main change introduced by this PR is the use of the PF candidate momentum instead of the track momentum where possible. This change results in a better agreement between the b-tag discriminators computed from AOD and those computed from MiniAOD. The improved agreement can be seen in the plots attached below.

**MiniAOD vs AOD CVSv2IVF discriminator before the fix:**
![miniaod_vs_aod_beforefix](https://cloud.githubusercontent.com/assets/4885289/12398854/83e36946-be16-11e5-83f6-c7533cb03cad.png)

**MiniAOD vs AOD CVSv2IVF discriminator after the fix:**
![miniaod_vs_aod_afterfix](https://cloud.githubusercontent.com/assets/4885289/12398872/a80eef2a-be16-11e5-9abf-23dcf17dbf40.png)

The introduced changes leave the overall b-tagging performance essentially unchanged, as can be seen from the plots attached below (before: red circles, after: blue triangles).

**CVSv2IVF performance against light jets:**
![flaveffvsbeff_dusg_pfcsvv2ivf](https://cloud.githubusercontent.com/assets/4885289/12398972/68355b18-be17-11e5-8233-e577d5a77061.png)

**CVSv2IVF performance against c jets:**
![flaveffvsbeff_c_pfcsvv2ivf](https://cloud.githubusercontent.com/assets/4885289/12398973/6e91a016-be17-11e5-892e-31b98b3a53a1.png)
