### PR TITLE
Geometry comparison: Plotting of y-range improved and print options added

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -128,7 +128,7 @@ class BetterConfigParser(ConfigParser.ConfigParser):
         for section in self.sections():
             if "compare:" in section:
                 self.checkInput(section,
-                                knownSimpleOptions = ["levels", "dbOutput","moduleList","modulesToPlot","useDefaultRange",
+                                knownSimpleOptions = ["levels", "dbOutput","moduleList","modulesToPlot","useDefaultRange","plotOnlyGlobal","plotPng",
                                                       "dx_min","dx_max","dy_min","dy_max","dz_min","dz_max","dr_min","dr_max","rdphi_min","rdphi_max",
                                                       "dalpha_min","dalpha_max","dbeta_min","dbeta_max","dgamma_min","dgamma_max",
                                                       "jobmode", "3DSubdetector1", "3Dubdetector2", "3DTranslationalScaleFactor"])

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
@@ -32,6 +32,8 @@ class GeometryComparison(GenericValidation):
 	    "modulesToPlot":"all",
 	    "moduleList": "/store/caf/user/cschomak/emptyModuleList.txt",
 	    "useDefaultRange":"false",
+	    "plotOnlyGlobal":"false",
+	    "plotPng":"true",
 	    "dx_min":"-99999",
 	    "dx_max":"-99999",
 	    "dy_min":"-99999",
@@ -150,7 +152,7 @@ class GeometryComparison(GenericValidation):
                      "/scripts/GeometryComparisonPlotter.cc .\n"
                      "root -b -q 'comparisonScript.C+(\""
                      ".oO[name]Oo..Comparison_common"+name+".root\",\""
-                     "./\",\".oO[modulesToPlot]Oo.\",\".oO[alignmentName]Oo.\",\".oO[reference]Oo.\",\".oO[useDefaultRange]Oo.\""+y_ranges+")'\n"
+                     "./\",\".oO[modulesToPlot]Oo.\",\".oO[alignmentName]Oo.\",\".oO[reference]Oo.\",\".oO[useDefaultRange]Oo.\",\".oO[plotOnlyGlobal]Oo.\",\".oO[plotPng]Oo.\""+y_ranges+")'\n"
 		     "rfcp "+path+"/TkAl3DVisualization_.oO[name]Oo..C .\n"
 		     "root -l -b -q TkAl3DVisualization_.oO[name]Oo..C+\n")
                 if  self.copyImages:
@@ -168,23 +170,36 @@ class GeometryComparison(GenericValidation):
                    ### At the moment translations are images with suffix _1 and _2, rotations _3 and _4
                    ### The numeration depends on the order of the MakePlots(x, y) commands in comparisonScript.C
                    ### If comparisonScript.C is changed, check if the following lines need to be changed as well
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*_1*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*_2*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
                    
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*_3*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*_4*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
+                   if repMap["plotPng"] == "true":
+	                   repMap["runComparisonScripts"] += \
+	                       ("find . -maxdepth 1 -name \"*_1*\" "
+	                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+	                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
+	                   repMap["runComparisonScripts"] += \
+	                       ("find . -maxdepth 1 -name \"*_2*\" "
+	                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+	                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
+	                   
+	                   repMap["runComparisonScripts"] += \
+	                       ("find . -maxdepth 1 -name \"*_3*\" "
+	                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+	                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
+	                   repMap["runComparisonScripts"] += \
+	                       ("find . -maxdepth 1 -name \"*_4*\" "
+	                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+	                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
+	                        
+                   else:
+	                   repMap["runComparisonScripts"] += \
+	                       ("find . -maxdepth 1 -name \"*_1*\" "
+	                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+	                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
+	                   
+	                   repMap["runComparisonScripts"] += \
+	                       ("find . -maxdepth 1 -name \"*_2*\" "
+	                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+	                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
                    
                    repMap["runComparisonScripts"] += \
                        ("find . -maxdepth 1 -name "

--- a/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.cc
+++ b/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.cc
@@ -27,13 +27,16 @@ GeometryComparisonPlotter::GeometryComparisonPlotter (TString tree_file_name,
                                                       TString output_directory,
                                                       TString modulesToPlot,
                                                       TString alignmentName,
-                                                      TString referenceName) :
+                                                      TString referenceName,
+                                                      TString printOnlyGlobal
+                                                      ) :
     _output_directory(output_directory + TString(output_directory.EndsWith("/") ? "" : "/")),
     _output_filename("comparison.root"),
     _print_option("pdf"),
     _module_plot_option(modulesToPlot),
     _alignment_name(alignmentName),
     _reference_name(referenceName),
+    _print_only_global(printOnlyGlobal),
     _print(true),       // print the graphs in a file (e.g. pdf)
     _legend(true),      // print the graphs in a file (e.g. pdf)
     _write(true),       // write the graphs in a root file
@@ -185,7 +188,9 @@ GeometryComparisonPlotter::~GeometryComparisonPlotter ()
 
 // MAIN METHOD
 void GeometryComparisonPlotter::MakePlots (vector<TString> x, // axes to combine to plot
-                                           vector<TString> y) // every combination (except the ones such that x=y) will be perfomed
+                                           vector<TString> y, // every combination (except the ones such that x=y) will be perfomed
+                                           vector<float> dyMin, // Minimum of y-variable to enable fixed ranges of the histogram
+                                           vector<float> dyMax) // Minimum of y-variable
 {
     /// -1) check that only existing branches are called 
     // (we use a macro to avoid copy/paste)
@@ -244,28 +249,14 @@ void GeometryComparisonPlotter::MakePlots (vector<TString> x, // axes to combine
 #define NB_Z_SLICES 2
 #define NB_MODULE_QUALITY 3
  
-    // Use different ordering of Plots in Multigraph if x.size()>y.size()
-	// Otherwise the plots are very squeezed
-    int nxPlots = 0;
-    int nyPlots = 0;
-    if (y.size() >= x.size()){
-		nxPlots = x.size();
-		nyPlots = y.size();
-	}
-	else{
-		nxPlots = y.size();
-		nyPlots = x.size();
-	}
-	cout << "nxPlots: " << nxPlots << endl;
-	cout << "nyPlots: " << nyPlots << endl;
-
     TGraph * graphs[x.size()][y.size()][NB_SUBLEVELS*NB_Z_SLICES*NB_MODULE_QUALITY];
     long int ipoint[x.size()][y.size()][NB_SUBLEVELS*NB_Z_SLICES*NB_MODULE_QUALITY];
     
-    TMultiGraph * mgraphs[nxPlots][nyPlots][1+NB_SUBLEVELS]; // the 0th is for global plots, the 1..6th for sublevel plots
-    TCanvas * c[nxPlots][nyPlots][1+NB_SUBLEVELS],
+    TMultiGraph * mgraphs[x.size()][y.size()][1+NB_SUBLEVELS]; // the 0th is for global plots, the 1..6th for sublevel plots
+    TCanvas * c[x.size()][y.size()][1+NB_SUBLEVELS],
             * c_global[1+NB_SUBLEVELS];
     canvas_index++; // this static index is a safety used in case the MakePlots method is used several times to avoid overloading
+    
     
     for (unsigned int ic = 0 ; ic <= NB_SUBLEVELS ; ic++)
     {
@@ -274,71 +265,39 @@ void GeometryComparisonPlotter::MakePlots (vector<TString> x, // axes to combine
                                     TString::Format("Global overview of the %s variables", ic==0?"tracker":_sublevel_names[ic-1].Data()),
                                    _window_width,
                                    _window_height);
-        c_global[ic]->Divide(nxPlots,nyPlots);
+        c_global[ic]->Divide(x.size(),y.size());
     }
     
-    if (y.size() >= x.size()){
-	    for (unsigned int ix = 0 ; ix < x.size() ; ix++)
-	    { 
-	        for (unsigned int iy = 0 ; iy < y.size() ; iy++)
-	        {
-	            //if (x[ix] == y[iy]) continue;       // do not plot graphs like (r,r) or (phi,phi)
-	            for (unsigned int igraph = 0 ; igraph < NB_SUBLEVELS*NB_Z_SLICES*NB_MODULE_QUALITY ; igraph++)
-	            {
-	                // declaring
-	                ipoint[ix][iy][igraph] = 0; // the purpose of an index for every graph is to avoid thousands of points at the origin of each
-	                graphs[ix][iy][igraph] = new TGraph ();
+    for (unsigned int ix = 0 ; ix < x.size() ; ix++)
+    { 
+        for (unsigned int iy = 0 ; iy < y.size() ; iy++)
+        {
+            //if (x[ix] == y[iy]) continue;       // do not plot graphs like (r,r) or (phi,phi)
+            for (unsigned int igraph = 0 ; igraph < NB_SUBLEVELS*NB_Z_SLICES*NB_MODULE_QUALITY ; igraph++)
+            {
+                // declaring
+                ipoint[ix][iy][igraph] = 0; // the purpose of an index for every graph is to avoid thousands of points at the origin of each
+                graphs[ix][iy][igraph] = new TGraph ();
 #define COLOR_CODE(icolor) int(icolor/4)+icolor+1
-	                graphs[ix][iy][igraph]->SetMarkerColor(COLOR_CODE(igraph));
-	                graphs[ix][iy][igraph]->SetMarkerStyle(6);
-	                // pimping
-	                graphs[ix][iy][igraph]->SetName (x[ix]+y[iy]+_sublevel_names[igraph%NB_SUBLEVELS]
-														+TString(igraph%(NB_SUBLEVELS*NB_Z_SLICES)>=NB_SUBLEVELS ? "n"      : "p" )    // graphs for negative/positive  z 
-														+TString(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 
-																( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	"bad" : "list") : "good" ));// graphs for good, bad modules and from a list 
-	                graphs[ix][iy][igraph]->SetTitle(            _sublevel_names[igraph%NB_SUBLEVELS]
-													+TString(igraph%(NB_SUBLEVELS*NB_Z_SLICES)>=NB_SUBLEVELS ? " at z<0": " at z>=0")
+                graphs[ix][iy][igraph]->SetMarkerColor(COLOR_CODE(igraph));
+                graphs[ix][iy][igraph]->SetMarkerStyle(6);
+                // pimping
+                graphs[ix][iy][igraph]->SetName (x[ix]+y[iy]+_sublevel_names[igraph%NB_SUBLEVELS]
+													+TString(igraph%(NB_SUBLEVELS*NB_Z_SLICES)>=NB_SUBLEVELS ? "n"      : "p" )    // graphs for negative/positive  z 
 													+TString(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 
-																( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	" bad modules" : " in list") : " good modules" )
-	                                                + TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]
-	                                                + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]);
-	                graphs[ix][iy][igraph]->SetMarkerStyle(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 								
-																( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	4 : 5) :  6);  // empty circle for bad modules, X for those in list, dot for good ones
-	            }
-	        }
-	    }
-	}
-    else{
-	    for (unsigned int ix = 0 ; ix < x.size() ; ix++)
-	    { 
-	        for (unsigned int iy = 0 ; iy < y.size() ; iy++)
-	        {
-	            //if (x[ix] == y[iy]) continue;       // do not plot graphs like (r,r) or (phi,phi)
-	            for (unsigned int igraph = 0 ; igraph < NB_SUBLEVELS*NB_Z_SLICES*NB_MODULE_QUALITY ; igraph++)
-	            {
-	                // declaring
-	                ipoint[iy][ix][igraph] = 0; // the purpose of an index for every graph is to avoid thousands of points at the origin of each
-	                graphs[iy][ix][igraph] = new TGraph ();
-#define COLOR_CODE(icolor) int(icolor/4)+icolor+1
-	                graphs[iy][ix][igraph]->SetMarkerColor(COLOR_CODE(igraph));
-	                graphs[iy][ix][igraph]->SetMarkerStyle(6);
-	                // pimping
-	                graphs[iy][ix][igraph]->SetName (x[ix]+y[iy]+_sublevel_names[igraph%NB_SUBLEVELS]
-														+TString(igraph%(NB_SUBLEVELS*NB_Z_SLICES)>=NB_SUBLEVELS ? "n"      : "p" )    // graphs for negative/positive  z 
-														+TString(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 
-																( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	"bad" : "list") : "good" ));// graphs for good, bad modules and from a list 
-	                graphs[iy][ix][igraph]->SetTitle(            _sublevel_names[igraph%NB_SUBLEVELS]
-													+TString(igraph%(NB_SUBLEVELS*NB_Z_SLICES)>=NB_SUBLEVELS ? " at z<0": " at z>=0")
-													+TString(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 
-																( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	" bad modules" : " in list") : " good modules" )
-	                                                + TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]
-	                                                + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]);
-	                graphs[iy][ix][igraph]->SetMarkerStyle(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 								
-																( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	4 : 5) :  6);  // empty circle for bad modules, X for those in list, dot for good ones
-	            }
-	        }
-	    }
-	}
+															( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	"bad" : "list") : "good" ));// graphs for good, bad modules and from a list 
+                graphs[ix][iy][igraph]->SetTitle(            _sublevel_names[igraph%NB_SUBLEVELS]
+												+TString(igraph%(NB_SUBLEVELS*NB_Z_SLICES)>=NB_SUBLEVELS ? " at z<0": " at z>=0")
+												+TString(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 
+															( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	" bad modules" : " in list") : " good modules" )
+                                                + TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]
+                                                + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]);							
+                graphs[ix][iy][igraph]->SetMarkerStyle(igraph >= NB_SUBLEVELS*NB_Z_SLICES ? 								
+															( igraph >= 2*NB_SUBLEVELS*NB_Z_SLICES ? 	4 : 5) :  6);  // empty circle for bad modules, X for those in list, dot for good ones
+            }
+        }
+    }
+   
 #ifdef DEBUG
     cout << __FILE__ << ":" << __LINE__ << ":Info: Creation of the TGraph[" << x.size() << "][" << y.size() << "][" << NB_SUBLEVELS*NB_Z_SLICES*NB_MODULE_QUALITY << "] ended." << endl;
 #endif
@@ -489,334 +448,164 @@ void GeometryComparisonPlotter::MakePlots (vector<TString> x, // axes to combine
 		n_module_types = 1; 				// only plot the modules that are neither bad or in the list
 	}
     
-    if (y.size() >= x.size()){
+
 #define INDEX_IN_GLOBAL_CANVAS(i1,i2) 1 + i1 + i2*x.size()
-	    // running on the TGraphs to produce the TMultiGraph and draw/print them
-	    for (unsigned int ix = 0 ; ix < x.size() ; ix++)
-	    {
+    // running on the TGraphs to produce the TMultiGraph and draw/print them
+    for (unsigned int ix = 0 ; ix < x.size() ; ix++)
+    {
 #ifdef DEBUG
-	        cout << __FILE__ << ":" << __LINE__ << ":Info: x[" << ix << "]="<< x[ix] << endl;
-#endif
-	//        // left and right margin for drawing
-	//        double  left_margin_factor = 1.,
-	//               right_margin_factor = 1.;
-	//             if (_min[x[ix]] > 0)  left_margin_factor = 0.9;
-	//        else if (_min[x[ix]] < 0)  left_margin_factor = 1.1;
-	//             if (_max[x[ix]] > 0) right_margin_factor = 1.1;
-	//        else if (_max[x[ix]] < 0) right_margin_factor = 0.9;
-	//#ifdef DEBUG
-	//        cout << __FILE__ << ":" << __LINE__ << ":Info: left_margin_factor=" <<  left_margin_factor
-	//                                            <<  " and right_margin_factor=" << right_margin_factor << endl;
-	//#endif
-	        // looping on Y axes
-	        for (unsigned int iy = 0 ; iy < y.size() ; iy++)
-	        {
-	//            // lower and upper margin for drawing
-	//            double lower_margin_factor = 1.,
-	//                   upper_margin_factor = 1.;
-	//                 if (_min[y[iy]] > 0) lower_margin_factor = 0.9;
-	//            else if (_min[y[iy]] < 0) lower_margin_factor = 1.1;
-	//                 if (_max[y[iy]] > 0) upper_margin_factor = 1.1;
-	//            else if (_max[y[iy]] < 0) upper_margin_factor = 0.9;
-	//#ifdef DEBUG
-	//            cout << __FILE__ << ":" << __LINE__ << ":Info: lower_margin_factor=" << lower_margin_factor
-	//                                                <<   " and upper_margin_factor=" << upper_margin_factor << endl;
-	//#endif
-	
-	
-#ifdef DEBUG
-	            cout << __FILE__ << ":" << __LINE__ << ":Info: x[" << ix << "]=" << x[ix]
-	                                                <<   " and y[" << iy << "]=" << y[iy] 
-	                                                <<   "\t-> creating TMultiGraph" << endl;
-#endif
-	            mgraphs[ix][iy][0] = new TMultiGraph (TString::Format("mgr_%s_vs_%s_tracker_%d", x[ix].Data(),
-	                                                                                             y[iy].Data(),
-	                                                                                             canvas_index),        // name
-	                                                  //LateXstyle(x[ix]) + TString(" vs. ") + LateXstyle(y[iy]) + TString(" for Tracker") // graph title
-	                                                    TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]                     // x axis title
-	                                                  + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]);                   // y axis title
-	
-	            /// TRACKER
-	            // fixing ranges and filling TMultiGraph
-	            // for (unsigned short int jgraph = NB_SUBLEVELS*NB_Z_SLICES-1 ; jgraph >= 0 ; --jgraph)
-	            for (unsigned short int jgraph = 0 ; jgraph < NB_SUBLEVELS*NB_Z_SLICES*n_module_types ; jgraph++)
-	            {
-	                unsigned short int igraph = NB_SUBLEVELS*NB_Z_SLICES*n_module_types - jgraph - 1; // reverse counting for humane readability (one of the sublevel takes much more place than the others)
-	//#ifdef DEBUG
-	//                cout << __FILE__ << ":" << __LINE__ << ":Info: setting X-axis range of " << graphs[ix][iy][jgraph]->GetName() << endl;
-	//#endif
-	//                graphs[ix][iy][jgraph]->GetXaxis()->SetLimits   ( left_margin_factor*_min[x[ix]],
-	//                                                                 right_margin_factor*_max[x[ix]]); // for X axis, use SetLimits
-	//#ifdef DEBUG
-	//                cout << __FILE__ << ":" << __LINE__ << ":Info: setting Y-axis range of " << graphs[ix][iy][jgraph]->GetName() << endl;
-	//#endif
-	//                graphs[ix][iy][jgraph]->GetYaxis()->SetRangeUser(lower_margin_factor*_min[y[iy]],
-	//                                                                 upper_margin_factor*_max[y[iy]]); // for Y axis, use SetRangeUser
-	//                // moreover, for the ranges to be effective in TMultiGraph, the option AP should be given for the first graph and 
-	//                // only P for the others (assuming all stacked graphs have received the same x- and y-ranges)
-	
-#ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: writing TGraph to file" << endl;
-#endif
-	                // write into root file
-	                if (_write) graphs[ix][iy][igraph]->Write();
-	                if (graphs[ix][iy][igraph]->GetN() == 0)
-	                {
-#ifdef TALKATIVE
-	                    cout <<  __FILE__ << ":" << __LINE__ << ":Info: " << graphs[ix][iy][igraph]->GetName()  << " is empty." << endl;
-#endif
-	                    continue;
-	                }
-#ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: cloning, coloring and adding TGraph "
-	                                                    << _sublevel_names[igraph%NB_SUBLEVELS] 
-	                                                    << (igraph >= NB_SUBLEVELS ? "(z<0)" : "(z>0)")
-	                                                    << " to global TMultiGraph" << endl;
-#endif
-	                // clone to prevent any injure on the graph
-	                TGraph * gr = (TGraph *) graphs[ix][iy][igraph]->Clone();
-	                // color
-	                gr->SetMarkerColor(COLOR_CODE(igraph%NB_SUBLEVELS));
-	                mgraphs[ix][iy][0]->Add(gr, "P");//, (mgraphs[ix][iy][0]->GetListOfGraphs()==0?"AP":"P"));
-	            }
-	            
-	            /// SUBLEVELS (1..6)
-	            for (unsigned int isublevel = 1 ; isublevel <= NB_SUBLEVELS ; isublevel++)
-	            {
-#ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: cloning, coloring and adding TGraph "
-	                                                    << _sublevel_names[isublevel-1] << " to sublevel TMultiGraph" << endl;
-#endif
-	                mgraphs[ix][iy][isublevel] = new TMultiGraph (TString::Format("%s_vs_%s_%s_%d", x[ix].Data(),
-	                                                                                                y[iy].Data(),
-	                                                                                                _sublevel_names[isublevel-1].Data(),
-	                                                                                                canvas_index),             // name
-	                                                             //LateXstyle(x[ix]) + TString(" vs. ") + LateXstyle(y[iy]) + TString(" for ") +
-	                                                              _sublevel_names[isublevel-1]                                 // graph title
-	                                                              + TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]   // x axis title
-	                                                              + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]); // y axis title
-	                 graphs[ix][iy][             isublevel-1]->SetMarkerColor(kBlack);
-	                 graphs[ix][iy][NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed);
-	                 graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kGray+1);
-	                 graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed-7);
-	                 graphs[ix][iy][4*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kGray+1);
-	                 graphs[ix][iy][5*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed-7);
-	                if (graphs[ix][iy][             isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][             isublevel-1], "P"); //(mgraphs[ix][iy][isublevel-1]->GetListOfGraphs()==0?"AP":"P")); // z>0
-#ifdef TALKATIVE
-	                else    cout << __FILE__ << ":" << __LINE__ << ":Info: graphs[ix][iy][isublevel-1]=" << graphs[ix][iy][isublevel-1]->GetName() << " is empty -> not added into " << mgraphs[ix][iy][isublevel]->GetName() << endl;
-#endif
-	                if (graphs[ix][iy][NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][NB_SUBLEVELS+isublevel-1], "P"); //(mgraphs[ix][iy][isublevel-1]->GetListOfGraphs()==0?"AP":"P")); // z<0
-#ifdef TALKATIVE
-	                else    cout << __FILE__ << ":" << __LINE__ << ":Info: graphs[ix][iy][NB_SUBLEVEL+isublevel-1]=" << graphs[ix][iy][NB_Z_SLICES+isublevel-1]->GetName() << " is empty -> not added into " << mgraphs[ix][iy][isublevel]->GetName() << endl;
-#endif
-#if NB_Z_SLICES!=2
-	                cout << __FILE__ << ":" << __LINE__ << ":Error: color code incomplete for Z slices..." << endl;
-#endif
-		             if (_module_plot_option == "all"){
-						if (graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[ix][iy][4*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][4*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[ix][iy][5*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][5*NB_SUBLEVELS+isublevel-1], "P");
-						}
-					if (_module_plot_option == "list"){
-						if (graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1], "P");
-					}
-	            }
-	
-	            // fixing ranges, saving, and drawing of TMultiGraph (tracker AND sublevels, i.e. 1+NB_SUBLEVELS objects)
-	            // the individual canvases are saved, but the global are just drawn and will be saved later
-	            for (unsigned short int imgr = 0 ; imgr <= NB_SUBLEVELS ; imgr++)
-	            {
-#ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: treating individual canvases." << endl;
-#endif
-	                // drawing into individual canvas and printing it (including a legend for the tracker canvas)
-	                c[ix][iy][imgr] = new TCanvas (TString::Format("c_%s_vs_%s_%s_%d", x[ix].Data(),
-	                                                                                   y[iy].Data(),
-	                                                                                   imgr==0?"tracker":_sublevel_names[imgr-1].Data(),
-	                                                                                   canvas_index),
-	                                               TString::Format("%s vs. %s at %s level", x[ix].Data(),
-	                                                                                        y[iy].Data(),
-	                                                                                        imgr==0?"tracker":_sublevel_names[imgr-1].Data()),
-	                                               _window_width,
-	                                               _window_height);
-	                c[ix][iy][imgr]->SetGrid(_grid_x,_grid_y); // grid
-	                if (mgraphs[ix][iy][imgr]->GetListOfGraphs() != 0) mgraphs[ix][iy][imgr]->Draw("A");
-	                if (imgr == 0 && _legend) legend->Draw(); // only for the tracker
-	                if (_print) c[ix][iy][imgr]->Print(_output_directory + mgraphs[ix][iy][imgr]->GetName() + ExtensionFromPrintOption(_print_option), _print_option);
-	
-	//                // setting ranges
-	//#ifdef DEBUG
-	//                cout << __FILE__ << ":" << __LINE__ << ":Info: setting X-axis range of " << mgraphs[ix][iy][imgr]->GetName() << endl;
-	//#endif
-	//                mgraphs[ix][iy][imgr]->GetXaxis()->SetLimits   ( left_margin_factor*_min[x[ix]],
-	//                                                                right_margin_factor*_max[x[ix]]); // for X axis, use SetLimits
-	//#ifdef DEBUG
-	//                cout << __FILE__ << ":" << __LINE__ << ":Info: setting Y-axis range of " << graphs[ix][iy][imgr]->GetName() << endl;
-	//#endif
-	//                mgraphs[ix][iy][imgr]->GetYaxis()->SetRangeUser(lower_margin_factor*_min[y[iy]],
-	//                                                                upper_margin_factor*_max[y[iy]]); // for Y axis, use SetRangeUser
-	
-	                // writing into root file
-	                if (_write) mgraphs[ix][iy][imgr]->Write();
-	
-	                // drawing into global canvas
-	                c_global[imgr]->cd(INDEX_IN_GLOBAL_CANVAS(ix,iy)); 
-	                c_global[imgr]->GetPad(INDEX_IN_GLOBAL_CANVAS(ix,iy))->SetFillStyle(4000); //  make the pad transparent
-	                c_global[imgr]->GetPad(INDEX_IN_GLOBAL_CANVAS(ix,iy))->SetGrid(_grid_x,_grid_y); // grid
-	                if (mgraphs[ix][iy][imgr]->GetListOfGraphs() != 0) mgraphs[ix][iy][imgr]->Draw("A");
-	                // printing will be performed after customisation (e.g. legend or title) just after the loops on ix and iy
-	            }
-	        } // end of loop on y
-	    }     // end of loop on x
-	}
-	
-    // Use different ordering of Plots in Multigraph if x.size()>y.size()
-	// Otherwise the plots are very squeezed
-    else{
-#define INDEX_IN_GLOBAL_CANVAS_Y(i1,i2) 1 + i1 + i2*y.size()
-	    // creating TLegend
-	    TLegend * legend = MakeLegend(.1,.92,.9,1.);
-	    if (_write) legend->Write();
-	    // running on the TGraphs to produce the TMultiGraph and draw/print them
-	    for (unsigned int ix = 0 ; ix < x.size() ; ix++)
-	    {
-#ifdef DEBUG
-	        cout << __FILE__ << ":" << __LINE__ << ":Info: x[" << ix << "]="<< x[ix] << endl;
+        cout << __FILE__ << ":" << __LINE__ << ":Info: x[" << ix << "]="<< x[ix] << endl;
 #endif
 
-	        // looping on Y axes
-	        for (unsigned int iy = 0 ; iy < y.size() ; iy++)
-	        {
-	
-#ifdef TALKATIVE
-	            cout << __FILE__ << ":" << __LINE__ << ":Info: x[" << ix << "]=" << x[ix]
-	                                                <<   " and y[" << iy << "]=" << y[iy] 
-	                                                <<   "\t-> creating TMultiGraph" << endl;
-#endif
-	            mgraphs[iy][ix][0] = new TMultiGraph (TString::Format("mgr_%s_vs_%s_tracker_%d", x[ix].Data(),
-	                                                                                             y[iy].Data(),
-	                                                                                             canvas_index),        // name
-	                                                  //LateXstyle(x[ix]) + TString(" vs. ") + LateXstyle(y[iy]) + TString(" for Tracker") // graph title
-	                                                    TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]                     // x axis title
-	                                                  + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]);                   // y axis title
-	
-	            /// TRACKER
-	            // fixing ranges and filling TMultiGraph
-	            // for (unsigned short int jgraph = NB_SUBLEVELS*NB_Z_SLICES-1 ; jgraph >= 0 ; --jgraph)
-	            for (unsigned short int jgraph = 0 ; jgraph < NB_SUBLEVELS*NB_Z_SLICES*n_module_types ; jgraph++)
-	            {
-	                unsigned short int igraph = NB_SUBLEVELS*NB_Z_SLICES*n_module_types - jgraph - 1; // reverse counting for humane readability (one of the sublevel takes much more place than the others)
-	
-	
-#ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: writing TGraph to file" << endl;
-#endif
-	                // write into root file
-	                if (_write) graphs[iy][ix][igraph]->Write();
-	                if (graphs[iy][ix][igraph]->GetN() == 0)
-	                {
-#ifdef TALKATIVE
-	                    cout <<  __FILE__ << ":" << __LINE__ << ":Info: " << graphs[iy][ix][igraph]->GetName()  << " is empty." << endl;
-#endif
-	                    continue;
-	                }
-#ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: cloning, coloring and adding TGraph "
-	                                                    << _sublevel_names[igraph%NB_SUBLEVELS] 
-	                                                    << (igraph >= NB_SUBLEVELS ? "(z<0)" : "(z>0)")
-	                                                    << " to global TMultiGraph" << endl;
-#endif
-	                // clone to prevent any injure on the graph
-	                TGraph * gr = (TGraph *) graphs[iy][ix][igraph]->Clone();
-	                // color
-	                gr->SetMarkerColor(COLOR_CODE(igraph%NB_SUBLEVELS));
-	                mgraphs[iy][ix][0]->Add(gr, "P");//, (mgraphs[iy][ix][0]->GetListOfGraphs()==0?"AP":"P"));
-	            }
-	            
-	            /// SUBLEVELS (1..6)
-	            for (unsigned int isublevel = 1 ; isublevel <= NB_SUBLEVELS ; isublevel++)
-	            {
+        // looping on Y axes
+        for (unsigned int iy = 0 ; iy < y.size() ; iy++)
+        {
+
 
 #ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: cloning, coloring and adding TGraph "
-	                                                    << _sublevel_names[isublevel-1] << " to sublevel TMultiGraph" << endl;
+            cout << __FILE__ << ":" << __LINE__ << ":Info: x[" << ix << "]=" << x[ix]
+                                                <<   " and y[" << iy << "]=" << y[iy] 
+                                                <<   "\t-> creating TMultiGraph" << endl;
 #endif
-	                mgraphs[iy][ix][isublevel] = new TMultiGraph (TString::Format("%s_vs_%s_%s_%d", x[ix].Data(),
-	                                                                                                y[iy].Data(),
-	                                                                                                _sublevel_names[isublevel-1].Data(),
-	                                                                                                canvas_index),             // name
-	                                                             //LateXstyle(x[ix]) + TString(" vs. ") + LateXstyle(y[iy]) + TString(" for ") +
-	                                                              _sublevel_names[isublevel-1]                                 // graph title
-	                                                              + TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]   // x axis title
-	                                                              + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]); // y axis title
-	                 graphs[iy][ix][             isublevel-1]->SetMarkerColor(kBlack);
-	                 graphs[iy][ix][NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed);
-	                 graphs[iy][ix][2*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kGray+1);
-	                 graphs[iy][ix][3*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed-7);
-	                 graphs[iy][ix][4*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kGray+1);
-	                 graphs[iy][ix][5*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed-7);
-	                if (graphs[iy][ix][             isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][             isublevel-1], "P"); //(mgraphs[iy][ix][isublevel-1]->GetListOfGraphs()==0?"AP":"P")); // z>0
-#ifdef TALKATIVE
-	                else    cout << __FILE__ << ":" << __LINE__ << ":Info: graphs[iy][ix][isublevel-1]=" << graphs[iy][ix][isublevel-1]->GetName() << " is empty -> not added into " << mgraphs[iy][ix][isublevel]->GetName() << endl;
+            mgraphs[ix][iy][0] = new TMultiGraph (TString::Format("mgr_%s_vs_%s_tracker_%d", x[ix].Data(),
+                                                                                             y[iy].Data(),
+                                                                                             canvas_index),        // name
+                                                  //LateXstyle(x[ix]) + TString(" vs. ") + LateXstyle(y[iy]) + TString(" for Tracker") // graph title
+                                                    TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]                     // x axis title
+                                                  + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]);                   // y axis title
+
+            /// TRACKER
+            // fixing ranges and filling TMultiGraph
+            // for (unsigned short int jgraph = NB_SUBLEVELS*NB_Z_SLICES-1 ; jgraph >= 0 ; --jgraph)
+            for (unsigned short int jgraph = 0 ; jgraph < NB_SUBLEVELS*NB_Z_SLICES*n_module_types ; jgraph++)
+            {
+                unsigned short int igraph = NB_SUBLEVELS*NB_Z_SLICES*n_module_types - jgraph - 1; // reverse counting for humane readability (one of the sublevel takes much more place than the others)
+
+#ifdef DEBUG
+                cout << __FILE__ << ":" << __LINE__ << ":Info: writing TGraph to file" << endl;
 #endif
-	                if (graphs[iy][ix][NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][NB_SUBLEVELS+isublevel-1], "P"); //(mgraphs[iy][ix][isublevel-1]->GetListOfGraphs()==0?"AP":"P")); // z<0
+                // write into root file
+                if (_write) graphs[ix][iy][igraph]->Write();
+                if (graphs[ix][iy][igraph]->GetN() == 0)
+                {
 #ifdef TALKATIVE
-	                else    cout << __FILE__ << ":" << __LINE__ << ":Info: graphs[iy][ix][NB_SUBLEVEL+isublevel-1]=" << graphs[iy][ix][NB_Z_SLICES+isublevel-1]->GetName() << " is empty -> not added into " << mgraphs[iy][ix][isublevel]->GetName() << endl;
+                    cout <<  __FILE__ << ":" << __LINE__ << ":Info: " << graphs[ix][iy][igraph]->GetName()  << " is empty." << endl;
+#endif
+                    continue;
+                }
+#ifdef DEBUG
+                cout << __FILE__ << ":" << __LINE__ << ":Info: cloning, coloring and adding TGraph "
+                                                    << _sublevel_names[igraph%NB_SUBLEVELS] 
+                                                    << (igraph >= NB_SUBLEVELS ? "(z<0)" : "(z>0)")
+                                                    << " to global TMultiGraph" << endl;
+#endif
+                // clone to prevent any injure on the graph
+                TGraph * gr = (TGraph *) graphs[ix][iy][igraph]->Clone();
+                // color
+                gr->SetMarkerColor(COLOR_CODE(igraph%NB_SUBLEVELS));
+                mgraphs[ix][iy][0]->Add(gr, "P");//, (mgraphs[ix][iy][0]->GetListOfGraphs()==0?"AP":"P"));
+   
+            }
+            
+            /// SUBLEVELS (1..6)
+            for (unsigned int isublevel = 1 ; isublevel <= NB_SUBLEVELS ; isublevel++)
+            {
+#ifdef DEBUG
+                cout << __FILE__ << ":" << __LINE__ << ":Info: cloning, coloring and adding TGraph "
+                                                    << _sublevel_names[isublevel-1] << " to sublevel TMultiGraph" << endl;
+#endif
+                mgraphs[ix][iy][isublevel] = new TMultiGraph (TString::Format("%s_vs_%s_%s_%d", x[ix].Data(),
+                                                                                                y[iy].Data(),
+                                                                                                _sublevel_names[isublevel-1].Data(),
+                                                                                                canvas_index),             // name
+                                                             //LateXstyle(x[ix]) + TString(" vs. ") + LateXstyle(y[iy]) + TString(" for ") +
+                                                              _sublevel_names[isublevel-1]                                 // graph title
+                                                              + TString (";") + LateXstyle(x[ix]) + " /" + _units[x[ix]]   // x axis title
+                                                              + TString (";") + LateXstyle(y[iy]) + " /" + _units[y[iy]]); // y axis title
+                                                              
+                 graphs[ix][iy][             isublevel-1]->SetMarkerColor(kBlack);
+                 graphs[ix][iy][NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed);
+                 graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kGray+1);
+                 graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed-7);
+                 graphs[ix][iy][4*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kGray+1);
+                 graphs[ix][iy][5*NB_SUBLEVELS+isublevel-1]->SetMarkerColor(kRed-7);
+                if (graphs[ix][iy][             isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][             isublevel-1], "P"); //(mgraphs[ix][iy][isublevel-1]->GetListOfGraphs()==0?"AP":"P")); // z>0
+#ifdef TALKATIVE
+                else    cout << __FILE__ << ":" << __LINE__ << ":Info: graphs[ix][iy][isublevel-1]=" << graphs[ix][iy][isublevel-1]->GetName() << " is empty -> not added into " << mgraphs[ix][iy][isublevel]->GetName() << endl;
+#endif
+                if (graphs[ix][iy][NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][NB_SUBLEVELS+isublevel-1], "P"); //(mgraphs[ix][iy][isublevel-1]->GetListOfGraphs()==0?"AP":"P")); // z<0
+#ifdef TALKATIVE
+                else    cout << __FILE__ << ":" << __LINE__ << ":Info: graphs[ix][iy][NB_SUBLEVEL+isublevel-1]=" << graphs[ix][iy][NB_Z_SLICES+isublevel-1]->GetName() << " is empty -> not added into " << mgraphs[ix][iy][isublevel]->GetName() << endl;
 #endif
 #if NB_Z_SLICES!=2
-	                cout << __FILE__ << ":" << __LINE__ << ":Error: color code incomplete for Z slices..." << endl;
+                cout << __FILE__ << ":" << __LINE__ << ":Error: color code incomplete for Z slices..." << endl;
 #endif
-	            if (_module_plot_option == "all"){
-						if (graphs[iy][ix][2*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][2*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[iy][ix][3*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][3*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[iy][ix][4*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][4*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[iy][ix][5*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][5*NB_SUBLEVELS+isublevel-1], "P");
-						}
-					if (_module_plot_option == "list"){
-						if (graphs[iy][ix][2*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][2*NB_SUBLEVELS+isublevel-1], "P");
-						if (graphs[iy][ix][3*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[iy][ix][isublevel]->Add(graphs[iy][ix][3*NB_SUBLEVELS+isublevel-1], "P");
+	             if (_module_plot_option == "all"){
+					if (graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1], "P");
+					if (graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1], "P");
+					if (graphs[ix][iy][4*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][4*NB_SUBLEVELS+isublevel-1], "P");
+					if (graphs[ix][iy][5*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][5*NB_SUBLEVELS+isublevel-1], "P");
 					}
+				if (_module_plot_option == "list"){
+					if (graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][2*NB_SUBLEVELS+isublevel-1], "P");
+					if (graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1]->GetN() > 0) mgraphs[ix][iy][isublevel]->Add(graphs[ix][iy][3*NB_SUBLEVELS+isublevel-1], "P");
 				}
-	
-	            // fixing ranges, saving, and drawing of TMultiGraph (tracker AND sublevels, i.e. 1+NB_SUBLEVELS objects)
-	            // the individual canvases are saved, but the global are just drawn and will be saved later
-	            for (unsigned short int imgr = 0 ; imgr <= NB_SUBLEVELS ; imgr++)
-	            {
+            }
+            
+
+            // fixing ranges, saving, and drawing of TMultiGraph (tracker AND sublevels, i.e. 1+NB_SUBLEVELS objects)
+            // the individual canvases are saved, but the global are just drawn and will be saved later
+            for (unsigned short int imgr = 0 ; imgr <= NB_SUBLEVELS ; imgr++)
+            {
 #ifdef DEBUG
-	                cout << __FILE__ << ":" << __LINE__ << ":Info: treating individual canvases." << endl;
+                cout << __FILE__ << ":" << __LINE__ << ":Info: treating individual canvases." << endl;
 #endif
-	                // drawing into individual canvas and printing it (including a legend for the tracker canvas)
-	                c[iy][ix][imgr] = new TCanvas (TString::Format("c_%s_vs_%s_%s_%d", x[ix].Data(),
-	                                                                                   y[iy].Data(),
-	                                                                                   imgr==0?"tracker":_sublevel_names[imgr-1].Data(),
-	                                                                                   canvas_index),
-	                                               TString::Format("%s vs. %s at %s level", x[ix].Data(),
-	                                                                                        y[iy].Data(),
-	                                                                                        imgr==0?"tracker":_sublevel_names[imgr-1].Data()),
-	                                               _window_width,
-	                                               _window_height);
-	                c[iy][ix][imgr]->SetGrid(_grid_y,_grid_x); // grid
-	                if (mgraphs[iy][ix][imgr]->GetListOfGraphs() != 0) mgraphs[iy][ix][imgr]->Draw("A");
-	                if (imgr == 0 && _legend) legend->Draw(); // only for the tracker
-	                if (_print) c[iy][ix][imgr]->Print(_output_directory + mgraphs[iy][ix][imgr]->GetName() + ExtensionFromPrintOption(_print_option), _print_option);
+                // drawing into individual canvas and printing it (including a legend for the tracker canvas)
+                c[ix][iy][imgr] = new TCanvas (TString::Format("c_%s_vs_%s_%s_%d", x[ix].Data(),
+                                                                                   y[iy].Data(),
+                                                                                   imgr==0?"tracker":_sublevel_names[imgr-1].Data(),
+                                                                                   canvas_index),
+                                               TString::Format("%s vs. %s at %s level", x[ix].Data(),
+                                                                                        y[iy].Data(),
+                                                                                        imgr==0?"tracker":_sublevel_names[imgr-1].Data()),
+                                               _window_width,
+                                               _window_height);
+                c[ix][iy][imgr]->SetGrid(_grid_x,_grid_y); // grid
+                
+                
+                if (mgraphs[ix][iy][imgr]->GetListOfGraphs() != 0) {
+	                if (dyMin[iy] != -99999) {
+						mgraphs[ix][iy][imgr]->SetMinimum(dyMin[iy]);						
+					}
+	                if (dyMax[iy] != -99999) {
+						mgraphs[ix][iy][imgr]->SetMaximum(dyMax[iy]);
+					}				
+					mgraphs[ix][iy][imgr]->Draw("A");
+				}
+                if (imgr == 0 && _legend) legend->Draw(); // only for the tracker
+                if (_print && _print_only_global != "true") c[ix][iy][imgr]->Print(_output_directory + mgraphs[ix][iy][imgr]->GetName() + ExtensionFromPrintOption(_print_option), _print_option);
+
+                // writing into root file
+                if (_write) mgraphs[ix][iy][imgr]->Write();
+
+                // drawing into global canvas
+                c_global[imgr]->cd(INDEX_IN_GLOBAL_CANVAS(ix,iy)); 
+                c_global[imgr]->GetPad(INDEX_IN_GLOBAL_CANVAS(ix,iy))->SetFillStyle(4000); //  make the pad transparent
+                c_global[imgr]->GetPad(INDEX_IN_GLOBAL_CANVAS(ix,iy))->SetGrid(_grid_x,_grid_y); // grid
+                if (mgraphs[ix][iy][imgr]->GetListOfGraphs() != 0) {
+	                if (dyMin[iy] != -99999) {
+						mgraphs[ix][iy][imgr]->SetMinimum(dyMin[iy]);						
+					}
+	                if (dyMax[iy] != -99999) {
+						mgraphs[ix][iy][imgr]->SetMaximum(dyMax[iy]);
+					}
+					mgraphs[ix][iy][imgr]->Draw("A");
+				}
+                // printing will be performed after customisation (e.g. legend or title) just after the loops on ix and iy
+            }
+        } // end of loop on y
+    }     // end of loop on x
 	
-	
-	
-	                // writing into root file
-	                if (_write) mgraphs[iy][ix][imgr]->Write();
-	
-	                // drawing into global canvas
-	                c_global[imgr]->cd(INDEX_IN_GLOBAL_CANVAS_Y(iy,ix)); 
-	                c_global[imgr]->GetPad(INDEX_IN_GLOBAL_CANVAS_Y(iy,ix))->SetFillStyle(4000); //  make the pad transparent
-	                c_global[imgr]->GetPad(INDEX_IN_GLOBAL_CANVAS_Y(iy,ix))->SetGrid(_grid_y,_grid_x); // grid
-	                if (mgraphs[iy][ix][imgr]->GetListOfGraphs() != 0) mgraphs[iy][ix][imgr]->Draw("A");
-	                // printing will be performed after customisation (e.g. legend or title) just after the loops on ix and iy
-	            }
-	        } // end of loop on y
-	    }     // end of loop on x
-	}
     
 
     // CUSTOMISATION

--- a/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.h
+++ b/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.h
@@ -6,6 +6,7 @@
 #include <TStyle.h>
 #include <TAxis.h>
 #include <TGraph.h>
+#include <TH2.h>
 #include <TMultiGraph.h>
 #include <TFile.h>
 #include <TCanvas.h>
@@ -31,7 +32,8 @@ class GeometryComparisonPlotter
             _print_option,
             _module_plot_option,
             _alignment_name,
-            _reference_name;
+            _reference_name,
+            _print_only_global;
     bool _print,
          _legend,
          _write,
@@ -73,12 +75,16 @@ public:
                               TString outputDirname = "output/",
                               TString modulesToPlot="all",
                               TString referenceName="Ideal",
-                              TString alignmentName="Alignment");
+                              TString alignmentName="Alignment",
+                              TString plotOnlyGlobal="false");
     ~GeometryComparisonPlotter ();
 
     // main methods
     void MakePlots (const vector<TString>,
-                    const vector<TString>);
+                    const vector<TString>,
+                    const vector<float>,
+                    const vector<float>
+                    );
 
     // option methods
     void SetPrint               (const bool);           // activates the printing of the individual and global pdf

--- a/Alignment/OfflineValidation/scripts/comparisonScript.C
+++ b/Alignment/OfflineValidation/scripts/comparisonScript.C
@@ -27,6 +27,8 @@ void comparisonScript (TString inFile,//="mp1510_vs_mp1509.Comparison_commonTrac
                        TString alignmentName="Alignment",
                        TString referenceName="Ideal",
                        TString useDefaultRange= "false",
+                       TString plotOnlyGlobal= "false",
+                       TString plotPng= "true",
                        float dx_min = -99999,
                        float dx_max = -99999,
                        float dy_min = -99999,
@@ -115,63 +117,71 @@ void comparisonScript (TString inFile,//="mp1510_vs_mp1509.Comparison_commonTrac
     // now the object to produce the comparison plots is created
     
     // Plot Translations
-    GeometryComparisonPlotter * trans = new GeometryComparisonPlotter (inFile, outDir,modulesToPlot,alignmentName,referenceName);
+    GeometryComparisonPlotter * trans = new GeometryComparisonPlotter (inFile, outDir,modulesToPlot,alignmentName,referenceName,plotOnlyGlobal);
     // x and y contain the couples to plot
     // -> every combination possible will be performed
     // /!\ always give units (otherwise, unexpected bug from root...)
     vector<TString> x,y;
-    x.push_back("r");                                           	trans->SetBranchUnits("r",     "cm");  
+    vector<float> dyMin,dyMax;
+    x.push_back("r");                                           	trans->SetBranchUnits("r",     "cm");
     x.push_back("phi");                                         	trans->SetBranchUnits("phi",   "rad");
     x.push_back("z");                                           	trans->SetBranchUnits("z",     "cm");      //trans->SetBranchMax("z", 100); trans->SetBranchMin("z", -100);
     y.push_back("dr");		trans->SetBranchSF("dr", 	10000);     trans->SetBranchUnits("dr",    "#mum");
+    dyMin.push_back(dr_min);
+    dyMax.push_back(dr_max);
     y.push_back("dz");		trans->SetBranchSF("dz", 	10000);     trans->SetBranchUnits("dz",    "#mum");
+    dyMin.push_back(dz_min);
+    dyMax.push_back(dz_max);
     y.push_back("rdphi");	trans->SetBranchSF("rdphi",10000);      trans->SetBranchUnits("rdphi", "#mum rad");
+    dyMin.push_back(rdphi_min);
+    dyMax.push_back(rdphi_max);
     y.push_back("dx");		trans->SetBranchSF("dx", 	10000);     trans->SetBranchUnits("dx",    "#mum");    //trans->SetBranchMax("dx", 10); trans->SetBranchMin("dx", -10);
+    dyMin.push_back(dx_min);
+    dyMax.push_back(dx_max);
     y.push_back("dy");		trans->SetBranchSF("dy", 	10000);     trans->SetBranchUnits("dy",    "#mum");    //trans->SetBranchMax("dy", 10); trans->SetBranchMin("dy", -10);
-    if (dx_min != -99999){trans->SetBranchMin("dx", 	dx_min);}
-    if (dx_max != -99999){trans->SetBranchMax("dx", 	dx_max);}
-    if (dy_min != -99999){trans->SetBranchMin("dy", 	dy_min);}
-    if (dy_max != -99999){trans->SetBranchMax("dy", 	dy_max);}
-    if (dz_min != -99999){trans->SetBranchMin("dz", 	dz_min);}
-    if (dz_max != -99999){trans->SetBranchMax("dz", 	dz_max);}
-    if (dr_min != -99999){trans->SetBranchMin("dr", 	dr_min);}
-    if (dr_max != -99999){trans->SetBranchMax("dr", 	dr_max);}
-    if (rdphi_min != -99999){trans->SetBranchMin("rdphi", 	rdphi_min);}
-    if (rdphi_max != -99999){trans->SetBranchMax("rdphi", 	rdphi_max);}
+    dyMin.push_back(dy_min);
+    dyMax.push_back(dy_max);
+    
     trans->SetGrid(1,1);
-    trans->MakePlots(x, y); // default output is pdf, but png gives a nicer result, so we use it as well
+    trans->MakePlots(x, y, dyMin, dyMax); // default output is pdf, but png gives a nicer result, so we use it as well
     // remark: what takes the more time is the creation of the output files,
     //         not the looping on the tree (because the code is perfect, of course :p)
-    trans->SetPrintOption("png");
-    trans->MakePlots(x, y);
+    if (plotPng=="true"){
+	    trans->SetPrintOption("png");
+	    trans->MakePlots(x, y, dyMin, dyMax);
+	}
 
     
     // Plot Rotations
-    GeometryComparisonPlotter * rot = new GeometryComparisonPlotter (inFile, outDir,modulesToPlot,alignmentName,referenceName);
+    GeometryComparisonPlotter * rot = new GeometryComparisonPlotter (inFile, outDir,modulesToPlot,alignmentName,referenceName,plotOnlyGlobal);
     // x and y contain the couples to plot
     // -> every combination possible will be performed
     // /!\ always give units (otherwise, unexpected bug from root...)
     vector<TString> b;
+    vector<float> dbMin,dbMax;
     //a.push_back("alpha");       									rot->SetBranchUnits("alpha",    "rad");  
     //a.push_back("beta");        									rot->SetBranchUnits("beta",   "rad");
     //a.push_back("gamma");       									rot->SetBranchUnits("gamma",   "rad");
     rot->SetBranchUnits("r",     "cm");  
     rot->SetBranchUnits("phi",   "rad");
     rot->SetBranchUnits("z",     "cm"); 
-    b.push_back("dalpha");	rot->SetBranchSF("dalpha", 	1000);      rot->SetBranchUnits("dalpha",    "mrad");      
-    b.push_back("dbeta");   rot->SetBranchSF("dbeta", 	1000);    	rot->SetBranchUnits("dbeta",    "mrad");     
+    b.push_back("dalpha");	rot->SetBranchSF("dalpha", 	1000);      rot->SetBranchUnits("dalpha",    "mrad");
+    dbMin.push_back(dalpha_min);
+    dbMax.push_back(dalpha_max);      
+    b.push_back("dbeta");   rot->SetBranchSF("dbeta", 	1000);    	rot->SetBranchUnits("dbeta",    "mrad");
+    dbMin.push_back(dbeta_min);
+    dbMax.push_back(dbeta_max);     
     b.push_back("dgamma");  rot->SetBranchSF("dgamma", 	1000);    	rot->SetBranchUnits("dgamma",    "mrad");
-    if (dalpha_min != -99999){rot->SetBranchMin("dalpha", 	dalpha_min);}
-    if (dalpha_max != -99999){rot->SetBranchMax("dalpha", 	dalpha_max);}   
-    if (dbeta_min != -99999){rot->SetBranchMin("dbeta", 	dbeta_min);}
-    if (dbeta_max != -99999){rot->SetBranchMax("dbeta", 	dbeta_max);}   
-    if (dgamma_min != -99999){rot->SetBranchMin("dgamma", 	dgamma_min);}
-    if (dgamma_max != -99999){rot->SetBranchMax("dgamma", 	dgamma_max);}
+    dbMin.push_back(dgamma_min);
+    dbMax.push_back(dgamma_max);
+ 
     rot->SetGrid(1,1);
     rot->SetPrintOption("pdf");
-    rot->MakePlots(x, b);
-    rot->SetPrintOption("png");
-    rot->MakePlots(x, b);
+    rot->MakePlots(x, b,dbMin, dbMax);
+    if (plotPng=="true"){
+	    rot->SetPrintOption("png");
+	    rot->MakePlots(x, b,dbMin, dbMax);
+	}	
     
 
     // now the same object can be reused with other specifications/cuts


### PR DESCRIPTION
The plotting of the y-range has been improved. The range given by the user is now used exactly instead of just being an upper limit

Options plotPng and plotOnlyGlobal added as possibilities to reduce the number of output plots and thus the time to run the tool.

Additionally, some obsolete code in GeometryComparisonPlotter.cc was removed
