### PR TITLE
The TrackerGeometry class updated to keep ModuleType information 

### DIFF
--- a/Geometry/TrackerGeometryBuilder/README.md
+++ b/Geometry/TrackerGeometryBuilder/README.md
@@ -69,3 +69,37 @@ of these methods for the three scenarios available so far are described in the t
 | 5 | `GeomDetEnumerators::P2OTB` | 6 |
 | 6 | `GeomDetEnumerators::invalidDet` | 0 |
  
+* ModuleTypes in  in `TrackerGeometry` class
+
+The `TrackerGeometry` class updated to keep module type information with the highest `DetId` of that type
+so that using `DetId` one can access the type. The `ModuleType` is contructed directly from the names defined in the
+`Geometry` xml definitions 
+
+Following types are used
+
+| `TrackerGeometry::ModuleType` | `Description` |
+|--------|-------|
+| TrackerGeometry::UNKNOWN| Undefined            |                 
+| TrackerGeometry::PXB    | Pixel Bar            |
+| TrackerGeometry::PXF    | Pixel For            |
+| TrackerGeometry::IB1    | IB1                  |
+| TrackerGeometry::IB2    | IB2                  |
+| TrackerGeometry::OB1    | OB1                  |
+| TrackerGeometry::OB2    | OB2                  |
+| TrackerGeometry::W1A    | W1A                  |
+| TrackerGeometry::W2A    | W2A                  |
+| TrackerGeometry::W3A    | W3A                  |
+| TrackerGeometry::W1B    | W1B                  |
+| TrackerGeometry::W2B    | W2B                  |
+| TrackerGeometry::W3B    | W3B                  |
+| TrackerGeometry::W4     | W4                   |
+| TrackerGeometry::W5     | W5                   |
+| TrackerGeometry::W6     | W6                   |
+| TrackerGeometry::W7     | W7                   |
+| TrackerGeometry::Ph1PXB | Phase 1 Pixel Barrel |
+| TrackerGeometry::Ph1PXF | Phase 1 Pixel Endcap |
+| TrackerGeometry::Ph2PXB | Phase 2 Pixel Barrel |
+| TrackerGeometry::Ph2PXF | Phase 2 Pixel Barrel |
+| TrackerGeometry::Ph2PSP | Phase 2 MacroPixel,PS|
+| TrackerGeometry::Ph2PSS | Phase 2 Strip, PS    |
+| TrackerGeometry::Ph2SS  | Phase2 2S            |

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -40,7 +40,8 @@ class TrackerGeometry final : public TrackingGeometry {
 
 public:
   typedef GeomDetEnumerators::SubDetector SubDetector;
-
+  enum ModuleType {UNKNOWN, PXB, PXF, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7, Ph1PXB, Ph1PXF, Ph2PXB, Ph2PXF, Ph2PSP, Ph2PSS, Ph2SS};
+ 
   virtual ~TrackerGeometry() ;
 
 
@@ -61,6 +62,9 @@ public:
   // Magic : better be called at the right moment...
   void setOffsetDU(SubDetector sid) { theOffsetDU[sid]=detUnits().size();}
   void setEndsetDU(SubDetector sid) { theEndsetDU[sid]=detUnits().size();}
+  void fillTestMap(const GeometricDet* gd);
+
+  ModuleType moduleType(std::string name) const;
 
   GeometricDet const * trackerDet() const {return  theTrackerDet;}
 
@@ -70,6 +74,10 @@ public:
   const DetContainer& detsTID() const;
   const DetContainer& detsTOB() const;
   const DetContainer& detsTEC() const;
+
+  ModuleType getDetectorType(DetId) const;
+  float getDetectorThickness(DetId) const;
+
 
 private:
 
@@ -97,7 +105,7 @@ private:
 
   GeomDetEnumerators::SubDetector theSubDetTypeMap[6];
   unsigned int theNumberOfLayers[6];
-
+  std::vector< std::tuple< DetId, TrackerGeometry::ModuleType, float> > theDetTypetList; 
 };
 
 #endif

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -40,7 +40,8 @@ class TrackerGeometry final : public TrackingGeometry {
 
 public:
   typedef GeomDetEnumerators::SubDetector SubDetector;
-  enum ModuleType {UNKNOWN, PXB, PXF, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7, Ph1PXB, Ph1PXF, Ph2PXB, Ph2PXF, Ph2PSP, Ph2PSS, Ph2SS};
+
+  enum class ModuleType;
  
   virtual ~TrackerGeometry() ;
 

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -65,7 +65,7 @@ public:
   void setEndsetDU(SubDetector sid) { theEndsetDU[sid]=detUnits().size();}
   void fillTestMap(const GeometricDet* gd);
 
-  ModuleType moduleType(std::string name) const;
+  ModuleType moduleType(const std::string& name) const;
 
   GeometricDet const * trackerDet() const {return  theTrackerDet;}
 

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -106,7 +106,7 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
    
   sort(deepcomp.begin(), deepcomp.end(), DetIdComparator());
 
-  std::cout << " Total Number of Detectors " << deepcomp.size() << std::endl;  
+  LogDebug("ThicknessAndType") << " Total Number of Detectors " << deepcomp.size() ;
   LogDebug("ThicknessAndType") << "Dump of sensors names and bounds";
   for(auto det : deepcomp) {
     fillTestMap(det); 

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -45,6 +45,33 @@ public:
 };
 }
 
+enum class TrackerGeometry::ModuleType {
+  UNKNOWN, 
+  PXB, 
+  PXF, 
+  IB1, 
+  IB2, 
+  OB1, 
+  OB2, 
+  W1A, 
+  W2A, 
+  W3A, 
+  W1B, 
+  W2B, 
+  W3B, 
+  W4, 
+  W5, 
+  W6, 
+  W7, 
+  Ph1PXB, 
+  Ph1PXF, 
+  Ph2PXB, 
+  Ph2PXF, 
+  Ph2PSP, 
+  Ph2PSS, 
+  Ph2SS
+};
+ 
 
 TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
 {

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -337,7 +337,7 @@ float TrackerGeometry::getDetectorThickness(DetId detid) const {
   return -1.0;
 }
 
-TrackerGeometry::ModuleType TrackerGeometry::moduleType(std::string name) const {
+TrackerGeometry::ModuleType TrackerGeometry::moduleType(const std::string& name) const {
   if ( name.find("PixelBarrel") != std::string::npos) return ModuleType::Ph1PXB;
   else if (name.find("PixelForward") != std::string::npos) return ModuleType::Ph1PXF;
   else if ( name.find("TIB") != std::string::npos) {

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -34,9 +34,15 @@ geometricDetToGeomDet(GeometricDet::GDEnumType gdenum) {
   if(gdenum == GeometricDet::GDEnumType::OTPhase2EndCap) return GeomDetEnumerators::SubDetector::P2OTEC;
   return GeomDetEnumerators::SubDetector::invalidDet;
 }
-                                      
-   
-
+class DetIdComparator {
+public:
+  bool operator()(GeometricDet const* gd1, GeometricDet const * gd2) const {
+    uint32_t det1 = gd1->geographicalId();
+    uint32_t det2 = gd2->geographicalId();
+    return det1 < det2;
+  }                                      
+  
+};
 }
 
 
@@ -68,7 +74,21 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
   for(unsigned int i=1;i<7;++i) {
     LogTrace("NumberOfLayers") << " detid subdet "<< i << " number of layers " << numberOfLayers(i); 
   }
-  
+  std::vector<const GeometricDet*> deepcomp;
+  gd->deepComponents(deepcomp);
+   
+  sort(deepcomp.begin(), deepcomp.end(), DetIdComparator());
+
+  std::cout << " Total Number of Detectors " << deepcomp.size() << std::endl;  
+  LogDebug("ThicknessAndType") << "Dump of sensors names and bounds";
+  for(auto det : deepcomp) {
+    fillTestMap(det); 
+    LogDebug("ThicknessAndType") << det->geographicalId() << " " << det->name().fullname() << " " << det->bounds()->thickness();
+  }
+  LogDebug("DetTypeList") << " Content of DetTypetList : size " << theDetTypetList.size();
+  for (auto iVal : theDetTypetList) {
+    LogDebug("DetTypeList") << " DetId " <<  std::get<0>(iVal) << " Type " << std::get<1>(iVal)<< " Thickness " << std::get<2>(iVal);
+  }  
 }
 
 
@@ -253,4 +273,68 @@ const TrackerGeometry::DetIdContainer&
 TrackerGeometry::detIds()   const 
 {
   return theDetIds;
+}
+void TrackerGeometry::fillTestMap(const GeometricDet* gd) {
+    
+  std::string temp = gd->name();
+  std::string name = temp.substr(temp.find(":")+1); 
+  DetId detid = gd->geographicalId();
+  float thickness = gd->bounds()->thickness();
+  std::string nameTag;  
+  TrackerGeometry::ModuleType mtype = moduleType(name);
+  if (theDetTypetList.size() == 0) {
+    theDetTypetList.push_back({std::make_tuple(detid, mtype, thickness)});
+  } else {
+    auto  & t = (*(theDetTypetList.end()-1));
+    if (std::get<1>(t) != mtype) theDetTypetList.push_back({std::make_tuple(detid, mtype, thickness)});
+    else {
+      if  ( detid > std::get<0>(t) ) std::get<0>(t) = detid;
+    }
+  }
+}
+
+TrackerGeometry::ModuleType TrackerGeometry::getDetectorType(DetId detid) const {
+  for (auto iVal : theDetTypetList) {
+    DetId detid_max = std::get<0>(iVal);
+    TrackerGeometry::ModuleType mtype =  std::get<1>(iVal);     
+    if (detid.rawId() <=  detid_max.rawId()) return mtype;
+  }
+  return TrackerGeometry::ModuleType::UNKNOWN;
+}
+float TrackerGeometry::getDetectorThickness(DetId detid) const {
+  for (auto iVal : theDetTypetList) {
+    DetId detid_max = std::get<0>(iVal);
+    if (detid.rawId() <=  detid_max.rawId()) 
+      return std::get<2>(iVal);
+  }
+  return -1.0;
+}
+
+TrackerGeometry::ModuleType TrackerGeometry::moduleType(std::string name) const {
+  if ( name.find("PixelBarrel") != std::string::npos) return ModuleType::Ph1PXB;
+  else if (name.find("PixelForward") != std::string::npos) return ModuleType::Ph1PXF;
+  else if ( name.find("TIB") != std::string::npos) {
+    if ( name.find("0") != std::string::npos) return ModuleType::IB1;
+    else return ModuleType::IB2;
+  } else if ( name.find("TOB") != std::string::npos) {
+    if ( name.find("0") != std::string::npos) return ModuleType::OB1;
+    else return ModuleType::OB2;
+  } else if ( name.find("TID") != std::string::npos) {
+    if ( name.find("0") != std::string::npos) return ModuleType::W1A; 
+    else if ( name.find("1") != std::string::npos) return ModuleType::W2A;
+    else if ( name.find("2") != std::string::npos) return ModuleType::W3A;
+  } else if ( name.find("TEC") != std::string::npos) { 
+    if ( name.find("0") != std::string::npos) return ModuleType::W1B;
+    else if ( name.find("1") != std::string::npos) return ModuleType::W2B;
+    else if ( name.find("2") != std::string::npos) return ModuleType::W3B;
+    else if ( name.find("3") != std::string::npos) return ModuleType::W4;
+    else if ( name.find("4") != std::string::npos) return ModuleType::W5;
+    else if ( name.find("5") != std::string::npos) return ModuleType::W6;
+    else if ( name.find("6") != std::string::npos) return ModuleType::W7;
+  } else if ( name.find("BModule") != std::string::npos || name.find("EModule") != std::string::npos ) { 
+    if (name.find("PSMacroPixel") != std::string::npos) return ModuleType::Ph2PSP;
+    else if (name.find("PSStrip") != std::string::npos) return ModuleType::Ph2PSS;
+    else if (name.find("2S") != std::string::npos) return ModuleType::Ph2SS;
+  }
+  return ModuleType::UNKNOWN;  
 }


### PR DESCRIPTION
Given a DetId one can access the Module Type which is  constructed directly from the names defined in Geometry xml file
