### PR TITLE
Add geometry scenarios for Castor

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -29,11 +29,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pPb'       :   'STARTHI71_V16::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_71_V1::All',
+    'run2_design'       :   'DESRUN2_71_V2::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_71_V2::All',
+    'run2_mc_50ns'      :   'MCRUN2_71_V4::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_71_V3::All',
+    'run2_mc'           :   'MCRUN2_71_V5::All',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_71_V7::All',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Changes in GT
## RunII simulation
- **RunII Ideal scenario** : [DESRUN2_71_V2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/DESRUN2_71_V2) as [DESRUN2_71_V1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/DESRUN2_71_V2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/DESRUN2_71_V2/DESRUN2_71_V1): 
  - Adding the `Extended2015CastorSystPlus`, `Extended2015CastorSystMinus` and `Extended2015CastorMeasured` labels for the `GeometryFileRcd` 
- **RunII Startup scenario** : [MCRUN2_71_V4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/MCRUN2_71_V4) as [MCRUN2_71_V2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/MCRUN2_71_V2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/MCRUN2_71_V4/MCRUN2_71_V2): 
  - Adding the `Extended2015CastorSystPlus`, `Extended2015CastorSystMinus` and `Extended2015CastorMeasured` labels for the `GeometryFileRcd` 
- **RunII Asymptotic scenario** : [MCRUN2_71_V5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/MCRUN2_71_V5) as [MCRUN2_71_V3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/MCRUN2_71_V3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/MCRUN2_71_V5/MCRUN2_71_V3): 
  - Adding the `Extended2015CastorSystPlus`, `Extended2015CastorSystMinus` and `Extended2015CastorMeasured` labels for the `GeometryFileRcd`
