### PR TITLE
Mixing module multithreading

### DIFF
--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -1,12 +1,12 @@
 #include "FastSimulation/Tracking/plugins/RecoTrackAccumulator.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
 
-RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
   signalTracksTag(conf.getParameter<edm::InputTag>("signalTracks")),
   signalMVAValuesTag(conf.getParameter<edm::InputTag>("signalMVAValues")),
   pileUpTracksTag(conf.getParameter<edm::InputTag>("pileUpTracks")),

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -26,7 +26,7 @@
 namespace edm {
   class ConsumesCollector;
   template<typename T> class Handle;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class StreamID;
@@ -36,7 +36,7 @@ namespace edm {
 class RecoTrackAccumulator : public DigiAccumulatorMixMod 
 {
  public:
-  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~RecoTrackAccumulator();
   
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c);

--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -18,18 +18,20 @@
 #include <vector>
 #include <memory>
 
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Mixing/Base/interface/PileUp.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "CondFormats/DataRecord/interface/MixingRcd.h"
 
+class PileUpConfig{};
+typedef std::vector<PileUpConfig> PileUpConfigVec;
 
 namespace edm {
-  class BMixingModule : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+  class BMixingModule : public edm::stream::EDProducer<edm::GlobalCache<PileUpConfigVec>> {
     public:
       /** standard constructor*/
-      explicit BMixingModule(const edm::ParameterSet& ps);
+      explicit BMixingModule(const edm::ParameterSet& ps, PileUpConfigVec const* t = nullptr);
 
       /**Default destructor*/
       virtual ~BMixingModule();
@@ -47,6 +49,9 @@ namespace edm {
 
       virtual void endRun(const edm::Run& r, const edm::EventSetup& setup) override;
       virtual void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& setup) override;
+
+      static std::unique_ptr<PileUpConfigVec> initializeGlobalCache(edm::ParameterSet const&);
+      static void globalEndJob(PileUpConfigVec*) {}
 
       // to be overloaded by dependent class
       virtual void reload(const edm::EventSetup & setup){};
@@ -70,8 +75,8 @@ namespace edm {
   protected:
       void setupPileUpEvent(const edm::EventSetup& setup);
       void dropUnwantedBranches(std::vector<std::string> const& wantedBranches);
-      virtual void beginJob() override;
-      virtual void endJob() override;
+      virtual void beginStream(edm::StreamID) override;
+      virtual void endStream() override;
       //      std::string type_;
       int bunchSpace_;
       int vertexOffset_;

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -26,6 +26,7 @@ namespace CLHEP {
 namespace edm {
   class SecondaryEventProvider;
   class StreamID;
+  class ProcessContext;
 
   class PileUp {
   public:
@@ -54,8 +55,8 @@ namespace edm {
     void dropUnwantedBranches(std::vector<std::string> const& wantedBranches) {
       input_->dropUnwantedBranches(wantedBranches);
     }
-    void beginJob();
-    void endJob();
+    void beginStream(edm::StreamID);
+    void endStream();
 
     void beginRun(const edm::Run& run, const edm::EventSetup& setup);
     void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup);
@@ -111,6 +112,8 @@ namespace edm {
     std::shared_ptr<ProductRegistry> productRegistry_;
     std::unique_ptr<VectorInputSource> const input_;
     std::shared_ptr<ProcessConfiguration> processConfiguration_;
+    std::shared_ptr<ProcessContext> processContext_;
+    std::shared_ptr<StreamContext> streamContext_;
     std::unique_ptr<EventPrincipal> eventPrincipal_;
     std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
     std::shared_ptr<RunPrincipal> runPrincipal_;

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -28,9 +28,18 @@ namespace edm {
   class StreamID;
   class ProcessContext;
 
+  struct PileUpConfig {
+    PileUpConfig(std::string sourcename, double averageNumber, std::unique_ptr<TH1F>& histo, const bool playback)
+                   : sourcename_(sourcename), averageNumber_(averageNumber), histo_(histo.release()), playback_(playback) {}
+    std::string sourcename_;
+    double averageNumber_;
+    std::shared_ptr<TH1F> histo_;
+    const bool playback_;
+  };
+
   class PileUp {
   public:
-    explicit PileUp(ParameterSet const& pset, std::string sourcename, double averageNumber, TH1F* const histo, const bool playback);
+    explicit PileUp(ParameterSet const& pset, const std::shared_ptr<PileUpConfig>& config);
     ~PileUp();
 
     template<typename T>
@@ -88,7 +97,7 @@ namespace edm {
     std::string Source_type_;
     double averageNumber_;
     int const intAverage_;
-    TH1F* histo_;
+    std::shared_ptr<TH1F> histo_;
     bool histoDistribution_;
     bool probFunctionDistribution_;
     bool poisson_;
@@ -118,13 +127,13 @@ namespace edm {
     std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
     std::shared_ptr<RunPrincipal> runPrincipal_;
     std::unique_ptr<SecondaryEventProvider> provider_;
-    std::vector<std::unique_ptr<CLHEP::RandPoissonQ> > vPoissonDistribution_;
-    std::vector<std::unique_ptr<CLHEP::RandPoisson> > vPoissonDistr_OOT_;
-    std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+    std::unique_ptr<CLHEP::RandPoissonQ> PoissonDistribution_;
+    std::unique_ptr<CLHEP::RandPoisson> PoissonDistr_OOT_;
+    CLHEP::HepRandomEngine* randomEngine_;
 
-    TH1F *h1f;
-    TH1F *hprobFunction;
-    TFile *probFileHisto;
+    //TH1F *h1f;
+    //TH1F *hprobFunction;
+    //TFile *probFileHisto;
     
     //playback info
     bool playback_;

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -163,7 +163,7 @@ namespace
 namespace edm {
 
   // Constructor 
-  BMixingModule::BMixingModule(const edm::ParameterSet& pset) :
+  BMixingModule::BMixingModule(const edm::ParameterSet& pset, PileUpConfigVec const*) :
     bunchSpace_(pset.getParameter<int>("bunchspace")),
     vertexOffset_(0),
     minBunch_((pset.getParameter<int>("minBunch")*25)/pset.getParameter<int>("bunchspace")),
@@ -197,6 +197,8 @@ namespace edm {
 
   // Virtual destructor needed.
   BMixingModule::~BMixingModule() {;}
+
+  std::unique_ptr<PileUpConfigVec> BMixingModule::initializeGlobalCache(edm::ParameterSet const&) { return nullptr; }
 
   // update method call at begin run/lumi to reload the mixing configuration
   void BMixingModule::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup){
@@ -271,15 +273,15 @@ namespace edm {
     }
   }
 
-  void BMixingModule::beginJob() {
+  void BMixingModule::beginStream(edm::StreamID iID) {
     for (size_t endIdx=0; endIdx<maxNbSources_; ++endIdx) {
-      if(inputSources_[endIdx]) inputSources_[endIdx]->beginJob();
+      if(inputSources_[endIdx]) inputSources_[endIdx]->beginStream(iID);
     }
   }
 
-  void BMixingModule::endJob() {
+  void BMixingModule::endStream() {
     for (size_t endIdx=0; endIdx<maxNbSources_; ++endIdx) {
-      if(inputSources_[endIdx]) inputSources_[endIdx]->endJob();
+      if(inputSources_[endIdx]) inputSources_[endIdx]->endStream();
     }
   }
 

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -178,6 +178,7 @@ namespace edm {
     streamContext_.reset(new StreamContext(iID, processContext_.get()));
     input_->doBeginJob();
     if (provider_.get() != nullptr) {
+      provider_->beginJob(*productRegistry_);
       provider_->beginStream(iID, *streamContext_);
     }
   }
@@ -185,6 +186,7 @@ namespace edm {
   void PileUp::endStream () {
     if (provider_.get() != nullptr) {
       provider_->endStream(streamContext_->streamID(), *streamContext_);
+      provider_->endJob();
     }
     input_->doEndJob();
   }

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -32,14 +32,14 @@ namespace edm {
   // to also send the stream based transitions
   void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> >(run, setup, StreamID::invalidStreamID(),
-                                                                                                  mcc->getGlobalContext(), mcc);
+                                                                                                  nullptr, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> >(run, setup, sContext.streamID(),
                                                                                                   &sContext, mcc);
   }
 
   void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> >(lumi, setup, StreamID::invalidStreamID(),
-                                                                                                              mcc->getGlobalContext(), mcc);
+                                                                                                              nullptr, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> >(lumi, setup, sContext.streamID(),
                                                                                                               &sContext, mcc);
   }
@@ -48,14 +48,14 @@ namespace edm {
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> >(run, setup, sContext.streamID(),
                                                                                                 &sContext, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> >(run, setup, StreamID::invalidStreamID(),
-                                                                                                mcc->getGlobalContext(), mcc);
+                                                                                                nullptr, mcc);
   }
 
   void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> >(lumi, setup, sContext.streamID(),
                                                                                                             &sContext, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> >(lumi, setup, StreamID::invalidStreamID(),
-                                                                                                            mcc->getGlobalContext(), mcc);
+                                                                                                            nullptr, mcc);
   }
 
   void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext) {

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -24,34 +24,49 @@ namespace edm {
                                                shouldBeUsedLabels);
     }
     if(!unscheduledLabels.empty()) {
-      workerManager_.setOnDemandProducts(preg, unscheduledLabels); 
+      workerManager_.setOnDemandProducts(preg, unscheduledLabels);
     }
   } // SecondaryEventProvider::SecondaryEventProvider
-  
+
   //NOTE: When the Stream interfaces are propagated to the modules, this code must be updated
   // to also send the stream based transitions
-  void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc) {
+  void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> >(run, setup, StreamID::invalidStreamID(),
                                                                                                   mcc->getGlobalContext(), mcc);
+    workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> >(run, setup, sContext.streamID(),
+                                                                                                  &sContext, mcc);
   }
 
-  void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc) {
+  void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> >(lumi, setup, StreamID::invalidStreamID(),
                                                                                                               mcc->getGlobalContext(), mcc);
+    workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> >(lumi, setup, sContext.streamID(),
+                                                                                                              &sContext, mcc);
   }
 
-  void SecondaryEventProvider::endRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc) {
+  void SecondaryEventProvider::endRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
+    workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> >(run, setup, sContext.streamID(),
+                                                                                                &sContext, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> >(run, setup, StreamID::invalidStreamID(),
                                                                                                 mcc->getGlobalContext(), mcc);
   }
 
-  void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc) {
+  void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
+    workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> >(lumi, setup, sContext.streamID(),
+                                                                                                            &sContext, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> >(lumi, setup, StreamID::invalidStreamID(),
                                                                                                             mcc->getGlobalContext(), mcc);
   }
 
-  void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup) {
+  void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>, StreamContext >(ep, setup, ep.streamID(),
-                                                                                                                   nullptr, nullptr);
+                                                                                                                   &sContext, &sContext);
+  }
+  void SecondaryEventProvider::beginStream(edm::StreamID iID, StreamContext& sContext) {
+    workerManager_.beginStream(iID, sContext);
+  }
+
+  void SecondaryEventProvider::endStream(edm::StreamID iID, StreamContext& sContext) {
+    workerManager_.endStream(iID, sContext);
   }
 }

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -25,8 +25,8 @@ namespace edm {
 
     void setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup);
 
-    void beginJob(ProductRegistry const& iRegistry) {workerManager_.beginJob(iRegistry);}
-    void endJob() {workerManager_.endJob();}
+    void beginStream(edm::StreamID iID, StreamContext& sContext) {workerManager_.beginStream(iID, sContext);}
+    void endStream(edm::StreamID iID, StreamContext& sContext) {workerManager_.endStream(iID, sContext);}
 
   private:
     std::unique_ptr<ExceptionToActionTable> exceptionToActionTable_;

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -17,16 +17,16 @@ namespace edm {
              ProductRegistry& pregistry,
              std::shared_ptr<ProcessConfiguration> processConfiguration);
 
-    void beginRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*);
-    void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*);
+    void beginRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
+    void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
 
-    void endRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*);
-    void endLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*);
+    void endRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
+    void endLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
 
-    void setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup);
+    void setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext);
 
-    void beginStream(edm::StreamID iID, StreamContext& sContext) {workerManager_.beginStream(iID, sContext);}
-    void endStream(edm::StreamID iID, StreamContext& sContext) {workerManager_.endStream(iID, sContext);}
+    void beginStream(edm::StreamID iID, StreamContext& sContext);
+    void endStream(edm::StreamID iID, StreamContext& sContext);
 
   private:
     std::unique_ptr<ExceptionToActionTable> exceptionToActionTable_;

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -25,6 +25,9 @@ namespace edm {
 
     void setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext);
 
+    void beginJob(ProductRegistry const& iRegistry) {workerManager_.beginJob(iRegistry);}
+    void endJob() {workerManager_.endJob();}
+
     void beginStream(edm::StreamID iID, StreamContext& sContext);
     void endStream(edm::StreamID iID, StreamContext& sContext);
 

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) 
+CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) 
 : theParameterMap(new CastorSimParameterMap(ps)),
   theCastorShape(new CastorShape()),
   theCastorIntegratedShape(new CaloShapeIntegrator(theCastorShape)),

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef CastorDigiProducer_h
 #define CastorDigiProducer_h
 
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -34,7 +34,7 @@ class PileUpEventPrincipal;
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~CastorDigiProducer();
 
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -43,7 +43,7 @@ class PileUpEventPrincipal ;
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class Event;
@@ -60,7 +60,7 @@ namespace CLHEP {
 class EcalDigiProducer : public DigiAccumulatorMixMod {
    public:
 
-      EcalDigiProducer( const edm::ParameterSet& params , edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+      EcalDigiProducer( const edm::ParameterSet& params , edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
       EcalDigiProducer( const edm::ParameterSet& params , edm::ConsumesCollector& iC);
       virtual ~EcalDigiProducer();
 

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -19,7 +19,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -54,7 +54,7 @@
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
 
-EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
    DigiAccumulatorMixMod(),
    m_APDShape         ( params.getParameter<double>( "apdShapeTstart" ) ,
 			params.getParameter<double>( "apdShapeTau"    )   )  ,

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -9,7 +9,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class Event;
@@ -23,7 +23,7 @@ class EcalTBDigiProducer : public EcalDigiProducer
 {
    public:
 
-      EcalTBDigiProducer( const edm::ParameterSet& params, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) ;
+      EcalTBDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) ;
       virtual ~EcalTBDigiProducer() ;
 
 

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -2,7 +2,7 @@
 #include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -12,7 +12,7 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
 
-EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
    EcalDigiProducer(params, mixMod, iC)
 {
    std::string const instance("simEcalUnsuppressedDigis");

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -1,14 +1,14 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
 //
-HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::one::EDProducerBase& mixMod, 
+HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, 
                                  edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod(),
   theDigitizer_(new HGCDigitizer(pset, iC) ) 

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
@@ -9,7 +9,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class ParameterSet;
@@ -22,7 +22,7 @@ namespace CLHEP {
 
 class HGCDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HGCDigiProducer(edm::ParameterSet const& pset, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  HGCDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   HGCDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
 
   virtual void initializeEvent(edm::Event const&, edm::EventSetup const&) override;

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -8,7 +8,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class ParameterSet;
@@ -21,7 +21,7 @@ namespace CLHEP {
 
 class HcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HcalDigiProducer(edm::ParameterSet const& pset, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
 
   HcalDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -1,11 +1,11 @@
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod(),
   theDigitizer_(pset, iC) {
   mixMod.produces<HBHEDigiCollection>();

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 #define SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -35,7 +35,7 @@ namespace CLHEP {
 class HcalTBDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~HcalTBDigiProducer();
 
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -17,7 +17,7 @@
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
   theParameterMap(new HcalTBSimParameterMap(ps)), 
   theHcalShape(new HcalShape()),
   theHcalIntegratedShape(new CaloShapeIntegrator(theHcalShape)),

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -36,7 +36,7 @@ namespace edm
 {
 
   // Constructor 
-  DataMixingModule::DataMixingModule(const edm::ParameterSet& ps) : BMixingModule(ps),
+  DataMixingModule::DataMixingModule(const edm::ParameterSet& ps, PileUpConfigVec const*) : BMixingModule(ps),
     EBPileInputTag_(ps.getParameter<edm::InputTag>("EBPileInputTag")),
     EEPileInputTag_(ps.getParameter<edm::InputTag>("EEPileInputTag")),
     ESPileInputTag_(ps.getParameter<edm::InputTag>("ESPileInputTag")),

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -36,7 +36,8 @@ namespace edm
 {
 
   // Constructor 
-  DataMixingModule::DataMixingModule(const edm::ParameterSet& ps, PileUpConfigVec const*) : BMixingModule(ps),
+  DataMixingModule::DataMixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf) :
+    BMixingModule(ps, globalConf),
     EBPileInputTag_(ps.getParameter<edm::InputTag>("EBPileInputTag")),
     EEPileInputTag_(ps.getParameter<edm::InputTag>("EEPileInputTag")),
     ESPileInputTag_(ps.getParameter<edm::InputTag>("ESPileInputTag")),

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -53,7 +53,7 @@ namespace edm {
     public:
 
       /** standard constructor*/
-      explicit DataMixingModule(const edm::ParameterSet& ps, PileUpConfigVec const* t = nullptr);
+      explicit DataMixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf);
 
       /**Default destructor*/
       virtual ~DataMixingModule();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -53,7 +53,7 @@ namespace edm {
     public:
 
       /** standard constructor*/
-      explicit DataMixingModule(const edm::ParameterSet& ps);
+      explicit DataMixingModule(const edm::ParameterSet& ps, PileUpConfigVec const* t = nullptr);
 
       /**Default destructor*/
       virtual ~DataMixingModule();

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 namespace edm {
   class ConsumesCollector;
@@ -11,7 +12,7 @@ namespace edm {
     class EDProducerBase;
   }
 
-  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, one::EDProducerBase&, ConsumesCollector&);
+  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, stream::EDProducerBase&, ConsumesCollector&);
   typedef edmplugin::PluginFactory<DAFunc> DigiAccumulatorMixModPluginFactory;
 
   class DigiAccumulatorMixModFactory {
@@ -21,7 +22,7 @@ namespace edm {
     static DigiAccumulatorMixModFactory const* get();
 
     std::auto_ptr<DigiAccumulatorMixMod>
-      makeDigiAccumulator(ParameterSet const&, one::EDProducerBase&, ConsumesCollector&) const;
+      makeDigiAccumulator(ParameterSet const&, stream::EDProducerBase&, ConsumesCollector&) const;
 
   private:
     DigiAccumulatorMixModFactory();

--- a/SimGeneral/MixingModule/plugins/CFWriter.h
+++ b/SimGeneral/MixingModule/plugins/CFWriter.h
@@ -14,7 +14,7 @@
  *
  ************************************************************/
  
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
  
@@ -28,7 +28,7 @@
 
 namespace edm
 {
-class CFWriter : public edm::EDProducer
+class CFWriter : public edm::stream::EDProducer<>
 {
  public:
  
@@ -36,7 +36,7 @@ class CFWriter : public edm::EDProducer
   
   virtual ~CFWriter();
   
-  void beginJob() {}
+  //void beginJob() {}
   void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
   virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
   virtual void put(edm::Event &e) {;}

--- a/SimGeneral/MixingModule/plugins/HiMixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/HiMixingModule.cc
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -150,15 +150,15 @@ void HiMixingWorker<HepMCProduct>::addSignals(edm::Event &e){
    }
 }
 
-class HiMixingModule : public edm::EDProducer {
+class HiMixingModule : public edm::stream::EDProducer<> {
    public:
       explicit HiMixingModule(const edm::ParameterSet&);
       ~HiMixingModule();
 
    private:
-  virtual void beginJob() override ;
+      //virtual void beginJob() override {}
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      //virtual void endJob() override {}
       bool verifyRegistry(std::string object, std::string subdet, InputTag &tag,std::string &label);      
       // ----------member data ---------------------------
 
@@ -264,17 +264,6 @@ HiMixingModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    std::auto_ptr< PileupMixingContent > PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent());
    iEvent.put(PileupMixing_);
 
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-HiMixingModule::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HiMixingModule::endJob() {
 }
 
 bool HiMixingModule::verifyRegistry(std::string object, std::string subdet, InputTag &tag,std::string &label) {

--- a/SimGeneral/MixingModule/plugins/MixEvtVtxGenerator.cc
+++ b/SimGeneral/MixingModule/plugins/MixEvtVtxGenerator.cc
@@ -5,7 +5,7 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -32,7 +32,7 @@ namespace HepMC {
 }
 
 
-class MixEvtVtxGenerator : public edm::EDProducer
+class MixEvtVtxGenerator : public edm::stream::EDProducer<>
 {
    public:
   

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -38,8 +38,8 @@
 namespace edm {
 
   // Constructor
-  MixingModule::MixingModule(const edm::ParameterSet& ps_mix, PileUpConfigVec const*) :
-  BMixingModule(ps_mix),
+  MixingModule::MixingModule(const edm::ParameterSet& ps_mix, MixingCache::Config const* globalConf) :
+  BMixingModule(ps_mix, globalConf),
   inputTagPlayback_(),
   mixProdStep2_(ps_mix.getParameter<bool>("mixProdStep2")),
   mixProdStep1_(ps_mix.getParameter<bool>("mixProdStep1")),

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -38,7 +38,7 @@
 namespace edm {
 
   // Constructor
-  MixingModule::MixingModule(const edm::ParameterSet& ps_mix) :
+  MixingModule::MixingModule(const edm::ParameterSet& ps_mix, PileUpConfigVec const*) :
   BMixingModule(ps_mix),
   inputTagPlayback_(),
   mixProdStep2_(ps_mix.getParameter<bool>("mixProdStep2")),

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -51,7 +51,7 @@ namespace edm {
       typedef std::vector<DigiAccumulatorMixMod*> Accumulators;
 
       /** standard constructor*/
-      explicit MixingModule(const edm::ParameterSet& ps, PileUpConfigVec const* t = nullptr);
+      explicit MixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf);
 
       /**Default destructor*/
       virtual ~MixingModule();

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -51,7 +51,7 @@ namespace edm {
       typedef std::vector<DigiAccumulatorMixMod*> Accumulators;
 
       /** standard constructor*/
-      explicit MixingModule(const edm::ParameterSet& ps);
+      explicit MixingModule(const edm::ParameterSet& ps, PileUpConfigVec const* t = nullptr);
 
       /**Default destructor*/
       virtual ~MixingModule();

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -180,7 +180,7 @@ SecSourceAnalyzer::beginJob()
 // ------------ method called once each job just after ending the event loop  ------------
 void 
 SecSourceAnalyzer::endJob() {
-  if (input_) input_->endJob();
+  if (input_) input_->endStream();
 }
 
 }//edm

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -61,11 +61,11 @@ SecSourceAnalyzer::SecSourceAnalyzer(const edm::ParameterSet& iConfig)
 //    int maxb = maxBunch_;
    int averageNumber = 1;
    std::string histoFileName = " ";
-   TH1F * histoName = new TH1F("h","",10,0,10); 
+   std::unique_ptr<TH1F> histoName(new TH1F("h","",10,0,10));
    bool playback = false;
    
-   input_.reset(new edm::PileUp(iConfig.getParameter<edm::ParameterSet>("input"),"input",
-                                averageNumber,histoName,playback));
+   std::shared_ptr<PileUpConfig> conf(new PileUpConfig("input",averageNumber,histoName,playback));
+   input_.reset(new edm::PileUp(iConfig.getParameter<edm::ParameterSet>("input"),conf));
       
    dataStep2_ = iConfig.getParameter<bool>("dataStep2");
    

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -30,7 +30,7 @@ namespace edm {
   }
 
   std::auto_ptr<DigiAccumulatorMixMod>
-  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, one::EDProducerBase& mixMod, ConsumesCollector& iC) const {
+  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, stream::EDProducerBase& mixMod, ConsumesCollector& iC) const {
     std::string accumulatorType = conf.getParameter<std::string>("accumulatorType");
     FDEBUG(1) << "DigiAccumulatorMixModFactory: digi_accumulator_type = " << accumulatorType << std::endl;
     std::auto_ptr<DigiAccumulatorMixMod> wm;

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -67,7 +67,7 @@
 
 namespace cms
 {
-  PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC)
+  PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC)
   {
     edm::LogInfo ("PixelDigitizer ") <<"Enter the Pixel Digitizer";
     

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -40,7 +41,7 @@ namespace cms {
   class PileupVertexAccumulator : public DigiAccumulatorMixMod {
   public:
 
-    explicit PileupVertexAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+    explicit PileupVertexAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
 
     virtual ~PileupVertexAccumulator();
 

--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -2,7 +2,7 @@
 #define SimGeneral_TrackingAnalysis_SimHitTPAssociationProducer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
@@ -12,7 +12,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class SimHitTPAssociationProducer : public edm::EDProducer 
+class SimHitTPAssociationProducer : public edm::stream::EDProducer<>
 {
 public:
 

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -37,7 +37,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
@@ -217,7 +217,7 @@ namespace
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
 		messageCategory_("TrackingTruthAccumulator"),
 		volumeRadius_( config.getParameter<double>("volumeRadius") ),
 		volumeZ_( config.getParameter<double>("volumeZ") ),

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -13,7 +13,7 @@ namespace edm
 {
 	class ParameterSet;
         class ConsumesCollector;
-  namespace one {
+  namespace stream {
 	class EDProducerBase;
   }
 	class Event;
@@ -75,7 +75,7 @@ class PSimHit;
 class TrackingTruthAccumulator : public DigiAccumulatorMixMod
 {
 public:
-	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
 private:
 	virtual void initializeEvent( const edm::Event& event, const edm::EventSetup& setup );
 	virtual void accumulate( const edm::Event& event, const edm::EventSetup& setup );

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -29,7 +29,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -91,7 +91,7 @@ namespace CLHEP {
 
 namespace cms
 {
-  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC):
+  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC):
     firstInitializeEvent_(true),
     firstFinalizeEvent_(true),
     _pixeldigialgo(),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -24,7 +24,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class Event;
@@ -49,7 +49,7 @@ namespace cms {
   class SiPixelDigitizer : public DigiAccumulatorMixMod {
   public:
 
-    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
 
     virtual ~SiPixelDigitizer();
 

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkProducer.h
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkProducer.h
@@ -9,7 +9,7 @@
 
 #include "boost/shared_ptr.hpp"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -27,7 +27,7 @@
 #include <vector>
 #include <map>
 
-class DigiSimLinkProducer : public edm::EDProducer
+class DigiSimLinkProducer : public edm::stream::EDProducer<>
 {
 public:
   

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -55,7 +55,7 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) : 
+SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) : 
   gainLabel(conf.getParameter<std::string>("Gain")),
   hitsProducer(conf.getParameter<std::string>("hitsProducer")),
   trackerContainers(conf.getParameter<std::vector<std::string> >("ROUList")),

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -17,7 +17,7 @@ namespace CLHEP {
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
+  namespace stream {
     class EDProducerBase;
   }
   class Event;
@@ -44,7 +44,7 @@ class TrackerGeometry;
  */
 class SiStripDigitizer : public DigiAccumulatorMixMod {
 public:
-  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   
   virtual ~SiStripDigitizer();
   


### PR DESCRIPTION
Change MixingModule base class from edm::one::EDProducer to edm::stream::EDProducer.  This includes making the MixingModule base class and derived classes thread safe, adds stream interfaces to the PileUp and SecondaryEventProvider, plus mechanical changes to the interfaces of many of the associated producers.  Most of the changes outside of Mixing/Base are simple type changes.
