### PR TITLE
Remove use of Reflex, replace with TClass calls that work with ROOT6

### DIFF
--- a/Validation/Tools/scripts/edmOneToOneComparison.py
+++ b/Validation/Tools/scripts/edmOneToOneComparison.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     random.seed( os.getpid() )
     GenObject.loadConfigFile (options.config)
     ROOT.gSystem.Load("libFWCoreFWLite.so")
-    ROOT.FWLiteEnabler::enable()
+    ROOT.FWLiteEnabler.enable()
     # Let's parse any args
     doubleColonRE = re.compile (r'(.+):(.+):(.+)')
     if options.alias:

--- a/Validation/Tools/scripts/simpleEdmComparison.py
+++ b/Validation/Tools/scripts/simpleEdmComparison.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
 
     ROOT.gSystem.Load("libFWCoreFWLite.so")
     ROOT.gSystem.Load("libDataFormatsFWLite.so")
-    ROOT.FWLiteEnabler::enable()
+    ROOT.FWLiteEnabler.enable()
 
     chain1 = Events ([options.file1], forceEvent=True)
     chain2 = Events ([options.file2], forceEvent=True)


### PR DESCRIPTION
Remove the use of calls to Reflex in Validation/Tools, replace with TClass calls that work with ROOT6.  Correctly handle the case of functions hidden by a function with a different signature in a derived class,  corrects a couple of bad search/replace errors where Bill used "::" instead of ".".  Old version was broken, so no conceivable impact to these fixes.  Still no tests.
