### PR TITLE
Mustache SuperCluster Regression for 800

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,19 +10,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v2',
+    'run2_design'       :   '80X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v1',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v3',
+    'run1_data'         :   '80X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v3',
+    'run2_data'         :   '80X_dataRun2_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -30,7 +30,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v2',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '80X_mcRun1_design_v3',
+    'run1_design'       :   '80X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '80X_mcRun1_realistic_v3',
+    'run1_mc'           :   '80X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '80X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '80X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2

--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -16,6 +16,7 @@
 
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 #include "RecoEgamma/EgammaTools/interface/BaselinePFSCRegression.h"
+#include "RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -149,7 +150,7 @@ class PFECALSuperClusterAlgo {
   
   // regression
   bool useRegression_;
-  std::unique_ptr<PFSCRegressionCalc> regr_;  
+  std::unique_ptr<SCEnergyCorrectorSemiParm> regr_;  
   
   double threshSuperClusterEt_;  
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -34,10 +34,10 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
     # regression setup
     useRegression = cms.bool(False), #regressions are mustache only
     regressionConfig = cms.PSet(
-       regressionKeyEB = cms.string('mustacheSC_offline_EB'),
-       uncertaintyKeyEB = cms.string('mustacheSC_offline_EB'),
-       regressionKeyEE = cms.string('mustacheSC_offline_EE'),
-       uncertaintyKeyEE = cms.string('mustacheSC_offline_EE'),
+       regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v2'),
+       uncertaintyKeyEB = cms.string('pfscecal_EBUncertainty_offline_v2'),
+       regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v2'),
+       uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
@@ -106,12 +106,12 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
     # are the seed thresholds Et or Energy?
     seedThresholdIsET = cms.bool(True),
     # regression setup
-    useRegression = cms.bool(False),
+    useRegression = cms.bool(True),
     regressionConfig = cms.PSet(
-       regressionKeyEB = cms.string('mustacheSC_offline_EB'),
-       uncertaintyKeyEB = cms.string('mustacheSC_offline_EB'),
-       regressionKeyEE = cms.string('mustacheSC_offline_EE'),
-       uncertaintyKeyEE = cms.string('mustacheSC_offline_EE'),
+       regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v2'),
+       uncertaintyKeyEB = cms.string('pfscecal_EBUncertainty_offline_v2'),
+       regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v2'),
+       uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -37,8 +37,8 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
 
     # regression setup
     useRegression = cms.bool(False), #regressions are mustache only
-    regressionKeyEB = cms.string('pfecalsc_EBCorrection'),
-    regressionKeyEE = cms.string('pfecalsc_EECorrection'),
+    regressionKey = cms.string('pfecalsc_EBCorrection'),
+    uncertaintyKey = cms.string('pfecalsc_EBUncertainty'),
     
     #threshold for final SuperCluster Et
     thresh_SCEt = cms.double(4.0),    

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -17,11 +17,7 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
     PFClusters = cms.InputTag("particleFlowClusterECAL"),
     ESAssociation = cms.InputTag("particleFlowClusterECAL"),
     BeamSpot = cms.InputTag("offlineBeamSpot"),    
-    vertexCollection = cms.InputTag("offlinePrimaryVertices"),
-    #rechit collections for lazytools
-    ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-    ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
-                                              
+                                                  
     PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterECALBarrel"),                                       
     PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterECALBarrel"),
     PFBasicClusterCollectionEndcap = cms.string("particleFlowBasicClusterECALEndcap"),                                       
@@ -37,9 +33,16 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
 
     # regression setup
     useRegression = cms.bool(False), #regressions are mustache only
-    regressionKey = cms.string('pfecalsc'),
-    uncertaintyKey = cms.string('pfecalsc'),
-    
+    regressionConfig = cms.PSet(
+       regressionKeyEB = cms.string('mustacheSC_offline_EB'),
+       uncertaintyKeyEB = cms.string('mustacheSC_offline_EB'),
+       regressionKeyEE = cms.string('mustacheSC_offline_EE'),
+       uncertaintyKeyEE = cms.string('mustacheSC_offline_EE'),
+       vertexCollection = cms.InputTag("offlinePrimaryVertices"),
+       ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ),
+
     #threshold for final SuperCluster Et
     thresh_SCEt = cms.double(4.0),    
     
@@ -105,8 +108,10 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
     # regression setup
     useRegression = cms.bool(False),
     regressionConfig = cms.PSet(
-       regressionKey = cms.string('mustacheSC_offline'),
-       uncertaintyKey = cms.string('mustacheSC_offline'),
+       regressionKeyEB = cms.string('mustacheSC_offline_EB'),
+       uncertaintyKeyEB = cms.string('mustacheSC_offline_EB'),
+       regressionKeyEE = cms.string('mustacheSC_offline_EE'),
+       uncertaintyKeyEE = cms.string('mustacheSC_offline_EE'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -37,8 +37,8 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
 
     # regression setup
     useRegression = cms.bool(False), #regressions are mustache only
-    regressionKey = cms.string('pfecalsc_EBCorrection'),
-    uncertaintyKey = cms.string('pfecalsc_EBUncertainty'),
+    regressionKey = cms.string('pfecalsc'),
+    uncertaintyKey = cms.string('pfecalsc'),
     
     #threshold for final SuperCluster Et
     thresh_SCEt = cms.double(4.0),    
@@ -103,10 +103,10 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
     # are the seed thresholds Et or Energy?
     seedThresholdIsET = cms.bool(True),
     # regression setup
-    useRegression = cms.bool(True),
+    useRegression = cms.bool(False),
     regressionConfig = cms.PSet(
-       regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v1'),
-       regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v1'),
+       regressionKey = cms.string('mustacheSC_offline'),
+       uncertaintyKey = cms.string('mustacheSC_offline'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -324,11 +324,13 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<std::string>("PFSuperClusterCollectionBarrel","particleFlowSuperClusterECALBarrel");
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("regressionKeyEE","pfscecal_EECorrection_offline_v1");
+    psd0.add<bool>("isHLT", false);
     psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
     psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
-    psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");
-    psd0.add<edm::InputTag>("vertexCollection",edm::InputTag("offlinePrimaryVertices"));
+    psd0.add<std::string>("regressionKey","pfscecal_EBCorrection_offline_v1");
+    psd0.add<std::string>("uncertaintyKey","pfscecal_EBUncertainty_offline_v1");
+    psd0.add<edm::InputTag>("vertexCollection",edm::InputTag("offlinePrimaryVertices")); 
+    psd0.add<edm::InputTag>("rhoCollection",edm::InputTag("fixedGridRhoForAll"));
     desc.add<edm::ParameterSetDescription>("regressionConfig",psd0);
   }
   desc.add<bool>("applyCrackCorrections",false);

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -332,7 +332,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
     psd0.add<std::string>("uncertaintyKeyEB","pfscecal_EBUncertainty_offline_v1");
     psd0.add<std::string>("uncertaintyKeyEE","pfscecal_EEUncertainty_offline_v1");
     psd0.add<edm::InputTag>("vertexCollection",edm::InputTag("offlinePrimaryVertices")); 
-    psd0.add<edm::InputTag>("rhoCollection",edm::InputTag("fixedGridRhoForAll"));
+    psd0.add<double>("etRecHitThreshold", 1.);
     desc.add<edm::ParameterSetDescription>("regressionConfig",psd0);
   }
   desc.add<bool>("applyCrackCorrections",false);

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -327,8 +327,10 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
     psd0.add<bool>("isHLT", false);
     psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
     psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
-    psd0.add<std::string>("regressionKey","pfscecal_EBCorrection_offline_v1");
-    psd0.add<std::string>("uncertaintyKey","pfscecal_EBUncertainty_offline_v1");
+    psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");
+    psd0.add<std::string>("regressionKeyEE","pfscecal_EECorrection_offline_v1");
+    psd0.add<std::string>("uncertaintyKeyEB","pfscecal_EBUncertainty_offline_v1");
+    psd0.add<std::string>("uncertaintyKeyEE","pfscecal_EEUncertainty_offline_v1");
     psd0.add<edm::InputTag>("vertexCollection",edm::InputTag("offlinePrimaryVertices")); 
     psd0.add<edm::InputTag>("rhoCollection",edm::InputTag("fixedGridRhoForAll"));
     desc.add<edm::ParameterSetDescription>("regressionConfig",psd0);

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -53,9 +53,7 @@ class SCEnergyCorrectorSemiParm {
   edm::EDGetTokenT<EcalRecHitCollection> tokenEBRecHits_;
   edm::EDGetTokenT<EcalRecHitCollection> tokenEERecHits_;
   edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;    
-  edm::EDGetTokenT<double> tokenRho_;    
-  
-  edm::Handle<double> rho_;
+
   edm::Handle<reco::VertexCollection> vertices_;
   edm::Handle<EcalRecHitCollection>  rechitsEB_;
   edm::Handle<EcalRecHitCollection>  rechitsEE_;
@@ -63,7 +61,6 @@ class SCEnergyCorrectorSemiParm {
   edm::InputTag ecalHitsEBInputTag_;
   edm::InputTag ecalHitsEEInputTag_;
   edm::InputTag vertexInputTag_;
-  edm::InputTag rhoInputTag_;
 
   std::string regressionKeyEB_;
   std::string uncertaintyKeyEB_;
@@ -72,6 +69,7 @@ class SCEnergyCorrectorSemiParm {
 
  private:
   bool isHLT_;
-  
+  int nHitsAboveThreshold_;
+  float etThreshold_;
 };
 #endif

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -1,0 +1,75 @@
+//--------------------------------------------------------------------------------------------------
+// $Id $
+//
+// SCEnergyCorrectorSemiParm
+//
+// Helper Class for applying regression-based energy corrections with optimized BDT implementation
+//
+// Authors: J.Bendavid
+//--------------------------------------------------------------------------------------------------
+
+#ifndef EGAMMATOOLS_SCEnergyCorrectorSemiParm_H
+#define EGAMMATOOLS_SCEnergyCorrectorSemiParm_H
+    
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h" 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class SCEnergyCorrectorSemiParm {
+ public:
+  SCEnergyCorrectorSemiParm();
+  ~SCEnergyCorrectorSemiParm(); 
+  
+  void setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc);
+  
+  void modifyObject(reco::SuperCluster &sc);
+  
+  void setEventSetup(const edm::EventSetup &es);
+  void setEvent(const edm::Event &e);
+  
+ protected:    
+  const GBRForestD *foresteb_;
+  const GBRForestD *forestee_;
+  const GBRForestD *forestsigmaeb_;
+  const GBRForestD *forestsigmaee_;
+  
+  edm::ESHandle<CaloTopology> calotopo_;
+  edm::ESHandle<CaloGeometry> calogeom_;
+  const CaloTopologyRecord* topo_record_;
+  const CaloGeometryRecord* geom_record_;    
+  
+  edm::EDGetTokenT<EcalRecHitCollection> tokenEBRecHits_;
+  edm::EDGetTokenT<EcalRecHitCollection> tokenEERecHits_;
+  edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;    
+  edm::EDGetTokenT<double> tokenRho_;    
+  
+  edm::Handle<double> rho_;
+  edm::Handle<reco::VertexCollection> vertices_;
+  edm::Handle<EcalRecHitCollection>  rechitsEB_;
+  edm::Handle<EcalRecHitCollection>  rechitsEE_;
+
+  edm::InputTag ecalHitsEBInputTag_;
+  edm::InputTag ecalHitsEEInputTag_;
+  edm::InputTag vertexInputTag_;
+  edm::InputTag rhoInputTag_;
+
+  std::string regressionKey_;
+  std::string uncertaintyKey_;
+
+ private:
+  bool isHLT_;
+  
+};
+#endif

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -65,8 +65,10 @@ class SCEnergyCorrectorSemiParm {
   edm::InputTag vertexInputTag_;
   edm::InputTag rhoInputTag_;
 
-  std::string regressionKey_;
-  std::string uncertaintyKey_;
+  std::string regressionKeyEB_;
+  std::string uncertaintyKeyEB_;
+  std::string regressionKeyEE_;
+  std::string uncertaintyKeyEE_;
 
  private:
   bool isHLT_;

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -1,11 +1,12 @@
 #include "RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h"
+
 #include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "TStreamerInfo.h"
+
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <vdt/vdtMath.h>
 

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -1,0 +1,316 @@
+//#include <TFile.h>
+#include "../interface/SCEnergyCorrectorSemiParm.h"
+#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
+#include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h" 
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "RooWorkspace.h"
+#include "RooArgList.h"
+#include "RooRealVar.h"
+#include "RooAbsReal.h"
+#include "RooAbsPdf.h"
+#include "RooConstVar.h"
+#include "TStreamerInfo.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+#include <vdt/vdtMath.h>
+
+using namespace reco;
+
+//--------------------------------------------------------------------------------------------------
+SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm() :
+foresteb_(0),
+forestee_(0),
+forestsigmaeb_(0),
+forestsigmaee_(0),
+calotopo_(0),
+calogeom_(0),
+topo_record_(0),
+geom_record_(0)
+{}
+
+//--------------------------------------------------------------------------------------------------
+SCEnergyCorrectorSemiParm::~SCEnergyCorrectorSemiParm()
+{}
+
+//--------------------------------------------------------------------------------------------------
+void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc) {
+  
+  isHLT_ = iConfig.getParameter<bool>("isHLT");
+
+  tokenEBRecHits_   = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEB"));
+  tokenEERecHits_   = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEE"));
+
+  regressionKey_  = iConfig.getParameter<std::string>("regressionKey");
+  uncertaintyKey_ = iConfig.getParameter<std::string>("uncertaintyKey");
+ 
+  if (not isHLT_)
+    tokenVertices_     = cc.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
+  else
+    tokenRho_          = cc.consumes<double>(iConfig.getParameter<edm::InputTag>("rhoCollection"));
+}
+
+//--------------------------------------------------------------------------------------------------
+void SCEnergyCorrectorSemiParm::setEventSetup(const edm::EventSetup &es) {
+  
+  const CaloTopologyRecord& topofrom_es = es.get<CaloTopologyRecord>();
+  if( !topo_record_ ||
+      topofrom_es.cacheIdentifier() != topo_record_->cacheIdentifier() ) {
+    topo_record_ = &topofrom_es;
+    topo_record_->get(calotopo_);
+  }
+  const CaloGeometryRecord& geomfrom_es = es.get<CaloGeometryRecord>();
+  if( !geom_record_ ||
+      geomfrom_es.cacheIdentifier() != geom_record_->cacheIdentifier() ) {
+    geom_record_ = &geomfrom_es;
+    geom_record_->get(calogeom_);
+  }  
+
+  edm::ESHandle<GBRForestD> readereb;
+  edm::ESHandle<GBRForestD> readerebvar;
+  edm::ESHandle<GBRForestD> readeree;
+  edm::ESHandle<GBRForestD> readereevar;
+  
+  es.get<GBRDWrapperRcd>().get(std::string(TString::Format("%s_EBCorrection",  regressionKey_.c_str())), readereb);
+  es.get<GBRDWrapperRcd>().get(std::string(TString::Format("%s_EBUncertainty", uncertaintyKey_.c_str())), readerebvar);
+  es.get<GBRDWrapperRcd>().get(std::string(TString::Format("%s_EECorrection",  regressionKey_.c_str())), readeree);
+  es.get<GBRDWrapperRcd>().get(std::string(TString::Format("%s_EEUncertainty", uncertaintyKey_.c_str())), readereevar);
+  
+  foresteb_      = readereb.product();
+  forestsigmaeb_ = readerebvar.product();
+  forestee_      = readeree.product();
+  forestsigmaee_ = readereevar.product();
+}
+
+//--------------------------------------------------------------------------------------------------
+void SCEnergyCorrectorSemiParm::setEvent(const edm::Event &e) {
+  
+  e.getByToken(tokenEBRecHits_,rechitsEB_);
+  e.getByToken(tokenEERecHits_,rechitsEE_);
+
+  if (not isHLT_)
+    e.getByToken(tokenVertices_,vertices_);
+  else
+    e.getByToken(tokenRho_, rho_);
+}
+
+//--------------------------------------------------------------------------------------------------
+void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
+  
+  const reco::CaloCluster &seedCluster = *(sc.seed());
+  const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;
+  const EcalRecHitCollection *recHits = iseb ? rechitsEB_.product() : rechitsEE_.product();
+
+  const CaloTopology *topo = calotopo_.product();
+  
+  const double raw_energy = sc.rawEnergy();   
+  const int numberOfClusters =  sc.clusters().size();
+
+  std::vector<float> localCovariances = EcalClusterTools::localCovariances(seedCluster,recHits,topo) ;
+  
+  if (not isHLT_) {
+  
+    std::array<float, 29> eval;  
+    
+    const float eLeft = EcalClusterTools::eLeft(seedCluster,recHits,topo);
+    const float eRight = EcalClusterTools::eRight(seedCluster,recHits,topo);
+    const float eTop = EcalClusterTools::eTop(seedCluster,recHits,topo);
+    const float eBottom = EcalClusterTools::eBottom(seedCluster,recHits,topo);
+    
+    float sigmaIetaIeta = sqrt(localCovariances[0]);
+    float sigmaIetaIphi = std::numeric_limits<float>::max();
+    float sigmaIphiIphi = std::numeric_limits<float>::max();
+    
+    // extra shower shapes
+    const float see_by_spp = sigmaIetaIeta*sigmaIphiIphi;
+    if(  see_by_spp > 0 ) {
+      sigmaIetaIphi = localCovariances[1] / see_by_spp;
+    } else if ( localCovariances[1] > 0 ) {
+      sigmaIetaIphi = 1.f;
+    } else {
+      sigmaIetaIphi = -1.f;
+    }
+    
+    if (!edm::isNotFinite(localCovariances[2])) sigmaIphiIphi = sqrt(localCovariances[2]) ;
+    
+    // calculate sub-cluster variables
+    std::vector<float> clusterRawEnergy;
+    clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
+    std::vector<float> clusterDEtaToSeed;
+    clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
+    std::vector<float> clusterDPhiToSeed;
+    clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
+    float clusterMaxDR     = 999.;
+    float clusterMaxDRDPhi = 999.;
+    float clusterMaxDRDEta = 999.;
+    float clusterMaxDRRawEnergy = 0.;
+    
+    size_t iclus = 0;
+    float maxDR = 0;
+    edm::Ptr<reco::CaloCluster> pclus;
+    const edm::Ptr<reco::CaloCluster>& theseed = sc.seed();
+    // loop over all clusters that aren't the seed  
+    auto clusend = sc.clustersEnd();
+    for( auto clus = sc.clustersBegin(); clus != clusend; ++clus ) {
+      pclus = *clus;
+      
+      if(theseed == pclus ) 
+	continue;
+      clusterRawEnergy[iclus]  = pclus->energy();
+      clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
+      clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
+      
+      // find cluster with max dR
+      const auto the_dr = reco::deltaR(*pclus, *theseed);
+      if(the_dr > maxDR) {
+	maxDR = the_dr;
+	clusterMaxDR = maxDR;
+	clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
+	clusterMaxDRDEta = clusterDEtaToSeed[iclus];
+	clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
+      }      
+      ++iclus;
+    }  
+    
+    // SET INPUTS
+    eval[0]  = vertices_->size(); //nVtx
+    eval[1]  = raw_energy; //scRawEnergy
+    eval[2]  = sc.etaWidth(); //scEtaWidth
+    eval[3]  = sc.phiWidth(); //scPhiWidth
+    eval[4]  = EcalClusterTools::e3x3(seedCluster,recHits,topo)/raw_energy; //scSeedR9
+    eval[5]  = seedCluster.energy()/raw_energy; //scSeedRawEnergy/scRawEnergy
+    eval[6]  = EcalClusterTools::eMax(seedCluster,recHits)/raw_energy;  //scSeedEmax/scRawEnergy
+    eval[7]  = EcalClusterTools::e2nd(seedCluster,recHits)/raw_energy; // scSeedE2nd/scRawEnergy
+    eval[8] = (eLeft + eRight != 0.f  ? (eLeft-eRight)/(eLeft+eRight) : 0.f); //scSeedLeftRightAsym
+    eval[9] = (eTop  + eBottom != 0.f ? (eTop-eBottom)/(eTop+eBottom) : 0.f); //scSeedTopBottomAsym
+    eval[10] = sigmaIetaIeta; //scSeedSigmaIetaIeta
+    eval[11] = sigmaIetaIphi; //scSeedSigmaIetaIphi
+    eval[12] = sigmaIphiIphi; //scSeedSigmaIphiIphi
+    eval[13] = std::max(0,numberOfClusters-1); //N_ECALClusters
+    eval[14] = clusterMaxDR; //clusterMaxDR
+    eval[15] = clusterMaxDRDPhi; //clusterMaxDRDPhi
+    eval[16] = clusterMaxDRDEta; //clusterMaxDRDEta
+    eval[17] = clusterMaxDRRawEnergy/raw_energy; //clusterMaxDRRawEnergy/scRawEnergy
+    eval[18] = clusterRawEnergy[0]/raw_energy; //clusterRawEnergy[0]/scRawEnergy
+    eval[19] = clusterRawEnergy[1]/raw_energy; //clusterRawEnergy[1]/scRawEnergy
+    eval[20] = clusterRawEnergy[2]/raw_energy; //clusterRawEnergy[2]/scRawEnergy
+    eval[21] = clusterDPhiToSeed[0]; //clusterDPhiToSeed[0]
+    eval[22] = clusterDPhiToSeed[1]; //clusterDPhiToSeed[1]
+    eval[23] = clusterDPhiToSeed[2]; //clusterDPhiToSeed[2]
+    eval[24] = clusterDEtaToSeed[0]; //clusterDEtaToSeed[0]
+    eval[25] = clusterDEtaToSeed[1]; //clusterDEtaToSeed[1]
+    eval[26] = clusterDEtaToSeed[2]; //clusterDEtaToSeed[2]
+    if (iseb) {
+      EBDetId ebseedid(seedCluster.seed());
+      eval[27] = ebseedid.ieta(); //scSeedCryIetaV2
+      eval[28] = ebseedid.iphi(); //scSeedCryIphiV2
+    } else {
+      EEDetId eeseedid(seedCluster.seed());
+      eval[27] = eeseedid.ix(); //scSeedCryIxV2
+      eval[28] = eeseedid.iy(); //scSeedCryIyV2
+    }  
+    
+    //magic numbers for MINUIT-like transformation of BDT output onto limited range
+    //(These should be stored inside the conditions object in the future as well)
+    constexpr double meanlimlow  = 0.2;
+    constexpr double meanlimhigh = 2.0;
+    constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
+    constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+    
+    constexpr double sigmalimlow  = 0.0002;
+    constexpr double sigmalimhigh = 0.5;
+    constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
+    constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
+    
+    const GBRForestD *forestmean = iseb ? foresteb_ : forestee_;
+    const GBRForestD *forestsigma = iseb ? forestsigmaeb_ : forestsigmaee_;
+    
+    //these are the actual BDT responses
+    double rawmean = forestmean->GetResponse(eval.data());
+    double rawsigma = forestsigma->GetResponse(eval.data());
+    
+    //apply transformation to limited output range (matching the training)
+    double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
+    double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+    
+    double ecor = mean*(eval[1]);
+    const double sigmacor = sigma*ecor;
+    
+    sc.setEnergy(ecor);
+    sc.setCorrectedEnergy(ecor);
+    sc.setCorrectedEnergyUncertainty(sigmacor);
+  } else {
+
+    std::array<float, 7> eval;  
+    
+    float clusterMaxDR     = 999.;
+    size_t iclus = 0;
+    float maxDR = 0;
+    edm::Ptr<reco::CaloCluster> pclus;
+    const edm::Ptr<reco::CaloCluster>& theseed = sc.seed();
+
+    // loop over all clusters that aren't the seed  
+    auto clusend = sc.clustersEnd();
+    for( auto clus = sc.clustersBegin(); clus != clusend; ++clus ) {
+      pclus = *clus;
+      
+      if(theseed == pclus ) 
+	continue;
+      
+      // find cluster with max dR
+      const auto the_dr = reco::deltaR(*pclus, *theseed);
+      if(the_dr > maxDR) {
+	maxDR = the_dr;
+	clusterMaxDR = maxDR;
+      }      
+      ++iclus;
+    }  
+    
+    // SET INPUTS
+    eval[0] = *(rho_.product());
+    eval[1] = sc.eta(); 
+    eval[2] = sc.phiWidth(); 
+    eval[3] = EcalClusterTools::e3x3(seedCluster,recHits,topo)/raw_energy;
+    eval[4] = std::max(0,numberOfClusters-1);
+    eval[5] = clusterMaxDR;
+    eval[6] = raw_energy;
+    
+    //magic numbers for MINUIT-like transformation of BDT output onto limited range
+    //(These should be stored inside the conditions object in the future as well)
+    constexpr double meanlimlow  = 0.2;
+    constexpr double meanlimhigh = 2.0;
+    constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
+    constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+    
+    constexpr double sigmalimlow  = 0.0002;
+    constexpr double sigmalimhigh = 0.5;
+    constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
+    constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
+    
+    const GBRForestD *forestmean = iseb ? foresteb_ : forestee_;
+    const GBRForestD *forestsigma = iseb ? forestsigmaeb_ : forestsigmaee_;
+    
+    //these are the actual BDT responses
+    double rawmean = forestmean->GetResponse(eval.data());
+    double rawsigma = forestsigma->GetResponse(eval.data());
+    
+    //apply transformation to limited output range (matching the training)
+    double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
+    double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+
+    double ecor = mean*eval[6];
+    if (!iseb)  
+      ecor = mean*(eval[6]+sc.preshowerEnergy());
+    const double sigmacor = sigma*ecor;
+   
+    sc.setEnergy(ecor);
+    sc.setCorrectedEnergy(ecor);
+    sc.setCorrectedEnergyUncertainty(sigmacor);
+  }  
+}
+

--- a/RecoEgamma/EgammaTools/test/GBRWrapperMaker.cc
+++ b/RecoEgamma/EgammaTools/test/GBRWrapperMaker.cc
@@ -30,7 +30,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TFile.h"
-#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 //#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 //#include "CondCore/DBCommon/interface/CoralServiceManager.h"
@@ -102,70 +102,34 @@ GBRWrapperMaker::~GBRWrapperMaker()
 void
 GBRWrapperMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   using namespace edm;
+  using namespace edm;
 
-
-
-// #ifdef THIS_IS_AN_EVENT_EXAMPLE
-//    Handle<ExampleData> pIn;
-//    iEvent.getByLabel("example",pIn);
-// #endif
-//    
-// #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
-//    ESHandle<SetupData> pSetup;
-//    iSetup.get<SetupRecord>().get(pSetup);
-// #endif
-//from Josh:
-  TFile *infile = new TFile("eleEnergyRegWeights_WithSubClusters_VApr15.root","READ");
-
+  //from Josh:
+  //TFile *infile = new TFile("../data/GBRLikelihood_Clustering_746_bx25_Electrons_NoPosition_standardShapes_NoPS_PFMustache_results_PROD.root","READ");
+  TFile *infile = new TFile("../data/GBRLikelihood_Clustering_746_bx25_HLT.root","READ");
   printf("load forest\n");
-
-
-  GBRForest *p4comb = (GBRForest*)infile->Get("CombinationWeight");
-  //GBRForest *gbbrebvar = (GBRForest*)infile->Get("EBUncertainty");
-  //GBRForest *gbree = (GBRForest*)infile->Get("EECorrection");
-  //GBRForest *gbreevar = (GBRForest*)infile->Get("EEUncertainty");
-
-
-
-
-//from Rishi
-  /*
-  TFile *infile_PFLC = new TFile("/afs/cern.ch/user/r/rpatel/ConvXml/TMVARegression_BDTG_PFClusterCorr.root","READ");
-  TFile *infile_PFGC = new TFile("/afs/cern.ch/user/r/rpatel/ConvXml/TMVARegression_BDTG_PFGlobalCorr.root","READ");
-  TFile *infile_PFRes = new TFile("/afs/cern.ch/user/r/rpatel/ConvXml/TMVARegression_BDTG_PFRes.root ","READ");
   
-  GBRForest *gbrLC = (GBRForest*)infile_PFLC->Get("GBRForest");
-  GBRForest *gbrGC = (GBRForest*)infile_PFGC->Get("GBRForest");
-  GBRForest *gbrRes = (GBRForest*)infile_PFRes->Get("GBRForest");
-  */
-  
-  
-  
+  //GBRForestD *p4comb = (GBRForest*)infile->Get("CombinationWeight");
+  GBRForestD *gbreb = (GBRForestD*)infile->Get("EBCorrection");
+  GBRForestD *gbrebvar = (GBRForestD*)infile->Get("EBUncertainty");
+  GBRForestD *gbree = (GBRForestD*)infile->Get("EECorrection");
+  GBRForestD *gbreevar = (GBRForestD*)infile->Get("EEUncertainty");
   
   printf("made objects\n");
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-       
- poolDbService->writeOne( p4comb, poolDbService->beginOfTime(),
-                                                "gedelectron_p4combination"  );
- //poolDbService->writeOne( gbrebvar, poolDbService->beginOfTime(),
- //"wgbrph_EBUncertainty"  );
- //poolDbService->writeOne( gbree, poolDbService->beginOfTime(),
- //"pfecalsc_EECorrection"  );
- //poolDbService->writeOne( gbreevar, poolDbService->beginOfTime(),
- //		  "wgbrph_EEUncertainty"  );
     
- //poolDbService->writeOne( gbrLC, poolDbService->beginOfTime(),
- //		     "wgbrph_PFLCCorrection"  );
- // poolDbService->writeOne( gbrGC, poolDbService->beginOfTime(),
- //		     "wgbrph_PFGlobalCorrection"  );
- // poolDbService->writeOne( gbrRes, poolDbService->beginOfTime(),
- //		     "wgbrph_PFResolution"  );
-  
+    //poolDbService->writeOne( p4comb, poolDbService->beginOfTime(),
+    //		     "gedelectron_p4combination"  );
+    poolDbService->writeOne( gbreb, poolDbService->beginOfTime(),
+			     "mustacheSC_online_EBCorrection"  );
+    poolDbService->writeOne( gbrebvar, poolDbService->beginOfTime(),
+			     "mustacheSC_online_EBUncertainty"  );
+    poolDbService->writeOne( gbree, poolDbService->beginOfTime(),
+			     "mustacheSC_online_EECorrection"  );
+    poolDbService->writeOne( gbreevar, poolDbService->beginOfTime(),
+			     "mustacheSC_online_EEUncertainty"  );
   }
-
-
 }
 
 

--- a/RecoEgamma/EgammaTools/test/gbrwrappermaker_cfg.py
+++ b/RecoEgamma/EgammaTools/test/gbrwrappermaker_cfg.py
@@ -6,41 +6,39 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
-#process.source = cms.Source("PoolSource",
-    ## replace 'myfile.root' with the source file you want to use
-    #fileNames = cms.untracked.vstring(
-        #'file:myfile.root'
-    #)
-#)
-
-process.source = cms.Source("EmptySource",
-)
+process.source = cms.Source("EmptySource",)
         
 
-process.gbrwrappermaker = cms.EDAnalyzer('GBRWrapperMaker'
-)
-
-
-    
+process.gbrwrappermaker = cms.EDAnalyzer('GBRWrapperMaker')
         
 #Database output service
-
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 # output database (in this case local sqlite file)
-process.CondDBCommon.connect = 'sqlite_file:gedelectron_p4combination_14122013.db'
-
+process.CondDBCommon.connect = 'sqlite_file:mustacheSC_online_regression_18012015.db'
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-    process.CondDBCommon,
-    timetype = cms.untracked.string('runnumber'),
-    toPut = cms.VPSet(
-      cms.PSet(
-        record = cms.string('gedelectron_p4combination'),
-        tag = cms.string('gedelectron_p4combination')
-      )
-      
-  )
-)
+                                          process.CondDBCommon,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string('mustacheSC_online_EBCorrection'),
+            tag    = cms.string('mustacheSC_online_EBCorrection')
+            ),
+        cms.PSet(
+            record = cms.string('mustacheSC_online_EBUncertainty'),
+            tag    = cms.string('mustacheSC_online_EBUncertainty')
+            ),
+        cms.PSet(
+            record = cms.string('mustacheSC_online_EECorrection'),
+            tag    = cms.string('mustacheSC_online_EECorrection')
+            ),
+        cms.PSet(
+            record = cms.string('mustacheSC_online_EEUncertainty'),
+            tag    = cms.string('mustacheSC_online_EEUncertainty')
+            ),
+        
+        )
+                                          )
             
                 
                     


### PR DESCRIPTION
The PR updates the online and offline regression for mustache SC. 
At the moment the corrections are off by default due to the useRegression flag set to false. 
Once activated:
- Offline regression impact only pixel-matching since it is the only place where the energy is taken directly from the mustache supercluster.
- Online regression represent the "highest" level energy corrections used at HLT for electrons and photons.
  We plan to switch the corrections on once the payloads will be integrated into the DB.
