### PR TITLE
use QIEType instead of old transient qieIndex

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1194,8 +1194,6 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalQIEData* fObject) {
 	    coder.setSlope (capid, range, atof (items [index++].c_str ()));
 	  }
 	}
-	if (items.size()>36)
-	  coder.setQIEIndex(atoi(items[index++].c_str()));
 
 	fObject->addCoder (coder);
 //      }
@@ -1234,8 +1232,6 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalQIEData& fObjec
 	fOutput << buffer;
       }
     }
-    sprintf (buffer, " %2d", coder->qieIndex());
-    fOutput << buffer;
     fOutput << std::endl;
   }
   return true;

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -551,10 +551,8 @@ HcalQIECoder HcalDbHardcode::makeQIECoder (HcalGenericDetId fId) {
 
   // qie8/qie10 attribution - 0/1
   if (fId.genericSubdet() == HcalGenericDetId::HcalGenOuter) {
-    result.setQIEIndex(0);
     slope = 1.0;
-  } else 
-    result.setQIEIndex(1);
+  }
     
   for (unsigned range = 0; range < 4; range++) {
     for (unsigned capid = 0; capid < 4; capid++) {

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -232,19 +232,20 @@ const HcalQIECoder* HcalDbService::getHcalCoder (const HcalGenericDetId& fId) co
 }
 
 const HcalQIEShape* HcalDbService::getHcalShape (const HcalGenericDetId& fId) const {
-  if (mQIEData) {
-    return &mQIEData->getShape (fId);
+  if (mQIEData && mQIETypes) {
+    //currently 3 types of QIEs exist: QIE8, QIE10, QIE11
+    int qieType = mQIETypes->getValues(fId)->getValue();
+    //QIE10 and QIE11 have same shape (ADC ladder)
+    if(qieType>0) qieType = 1;
+    return &mQIEData->getShape(qieType);
   }
   return 0;
 }
 
 const HcalQIEShape* HcalDbService::getHcalShape (const HcalQIECoder *coder) const {
-  if (mQIEData) {
-    return &mQIEData->getShape(coder);
-  }
-  return 0;
+  HcalGenericDetId fId(coder->rawId());
+  return getHcalShape(fId);
 }
-
 
 const HcalElectronicsMap* HcalDbService::getHcalMapping () const {
   return mElectronicsMap;

--- a/CondFormats/HcalObjects/interface/HcalQIECoder.h
+++ b/CondFormats/HcalObjects/interface/HcalQIECoder.h
@@ -20,7 +20,7 @@ class HcalQIEShape;
 
 class HcalQIECoder {
  public:
-  HcalQIECoder (unsigned long fId = 0) : mId (fId), mQIEIndex(0) {}
+  HcalQIECoder (unsigned long fId = 0) : mId (fId) {}
 
   /// ADC [0..127] + capid [0..3] -> fC conversion
   float charge (const HcalQIEShape& fShape, unsigned fAdc, unsigned fCapId) const;
@@ -35,9 +35,6 @@ class HcalQIECoder {
   void setSlope (unsigned fCapId, unsigned fRange, float fValue);
 
   uint32_t rawId () const {return mId;}
-
-  uint32_t qieIndex() const {return mQIEIndex;}
-  void setQIEIndex(uint32_t v) { mQIEIndex=v;}
 
  private:
   uint32_t mId;
@@ -73,7 +70,6 @@ class HcalQIECoder {
   float mSlope31;
   float mSlope32;
   float mSlope33;
-  unsigned int mQIEIndex COND_TRANSIENT;
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalQIEData.h
+++ b/CondFormats/HcalObjects/interface/HcalQIEData.h
@@ -34,8 +34,7 @@ class HcalQIEData: public HcalCondObjectContainer<HcalQIECoder>
   void setupShape();  
   /// get basic shape
   //   const HcalQIEShape& getShape () const {return mShape;}
-   const HcalQIEShape& getShape (DetId fId) const { return mShape[getCoder(fId)->qieIndex()];}
-   const HcalQIEShape& getShape (const HcalQIECoder* coder) const { return mShape[coder->qieIndex()];}
+   const HcalQIEShape& getShape (int qieType) const { return mShape[qieType];}
   /// get QIE parameters
   const HcalQIECoder* getCoder (DetId fId) const { return getValues(fId); }
   // check if data are sorted - remove in the next version

--- a/CondFormats/HcalObjects/interface/HcalQIEShape.h
+++ b/CondFormats/HcalObjects/interface/HcalQIEShape.h
@@ -27,6 +27,7 @@ class HcalQIEShape {
     unsigned tmp = nbins_ == 32 ? (fAdc & 0x1f) : (fAdc & 0x3f) ;
     return   tmp;
   }
+  unsigned nbins() const { return nbins_; }
 
  protected:
  private:

--- a/CondFormats/HcalObjects/src/HcalQIECoder.cc
+++ b/CondFormats/HcalObjects/src/HcalQIECoder.cc
@@ -28,7 +28,7 @@ unsigned HcalQIECoder::adc (const HcalQIEShape& fShape, float fCharge, unsigned 
   // search for the range
   for (unsigned range = 0; range < 4; range++) {
     float qieCharge = fCharge * slope (fCapId, range) + offset (fCapId, range);
-    unsigned nbin   = 32 * (mQIEIndex+1); // it's just 64 = 2*32 !
+    unsigned nbin   = fShape.nbins(); // it's just 64 = 2*32 ! (for QIE10)
     unsigned minBin = nbin * range;
     unsigned maxBin = minBin + nbin - 1;
     float qieChargeMax = fShape.highEdge (maxBin);


### PR DESCRIPTION
Following up on #12905, the QIE shape (ADC ladder) should be determined by the new QIEType database parameter.

Attn: @walterjr, @abdoulline
