### PR TITLE
cMVAv2 negative/positive configuration files

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -69,6 +69,8 @@ supportedBtagDiscr = {
   , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'combinedMVAV2BJetTags'                                 : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'negativeCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexNegativeTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'positiveCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
@@ -124,6 +126,8 @@ supportedBtagDiscr = {
   , 'pfPositiveCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedMVAV2BJetTags'                               : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfNegativeCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexNegativeTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfPositiveCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedSecondaryVertexSoftLeptonBJetTags'           : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags'   : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfBoostedDoubleSecondaryVertexAK8BJetTags'             : ['pfImpactParameterTagInfosAK8', 'pfInclusiveSecondaryVertexFinderTagInfosAK8']

--- a/RecoBTag/Combined/python/candidateNegativeCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateNegativeCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+candidateNegativeCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'candidateNegativeOnlyJetProbabilityComputer',
+		'candidateNegativeOnlyJetBProbabilityComputer',
+		'candidateNegativeCombinedSecondaryVertexV2Computer',
+		'negativeSoftPFMuonComputer',
+		'negativeSoftPFElectronComputer'
+	),
+	mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+		["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+	useCondDB = cms.bool(True),
+	gbrForestLabel = cms.string("btag_CombinedMVAv2_BDT"),
+	useGBRForest = cms.bool(True),
+	useAdaBoost = cms.bool(False),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/python/candidatePositiveCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidatePositiveCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+candidatePositiveCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'candidatePositiveOnlyJetProbabilityComputer',
+		'candidatePositiveOnlyJetBProbabilityComputer',
+		'candidatePositiveCombinedSecondaryVertexV2Computer',
+		'negativeSoftPFMuonComputer',
+		'negativeSoftPFElectronComputer'
+	),
+	mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+		["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+	useCondDB = cms.bool(True),
+	gbrForestLabel = cms.string("btag_CombinedMVAv2_BDT"),
+	useGBRForest = cms.bool(True),
+	useAdaBoost = cms.bool(False),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/python/combinedMVA_EventSetup_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_EventSetup_cff.py
@@ -12,6 +12,10 @@ from RecoBTag.Combined.candidatePositiveCombinedMVAComputer_cfi import *
 # CombinedMVA V2
 from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.negativeCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.positiveCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidateNegativeCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidatePositiveCombinedMVAV2Computer_cfi import *
 
 # Charge tagger
 from RecoBTag.Combined.candidateChargeBTagComputer_cfi import *

--- a/RecoBTag/Combined/python/combinedMVA_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_cff.py
@@ -12,15 +12,9 @@ from RecoBTag.Combined.pfNegativeCombinedMVABJetTags_cfi import *
 from RecoBTag.Combined.pfPositiveCombinedMVABJetTags_cfi import *
 
 #combined MVA V2
-from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
-from RecoBTag.Combined.negativeCombinedMVAV2Computer_cfi import *
-from RecoBTag.Combined.positiveCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.combinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.negativeCombinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.positiveCombinedMVAV2BJetTags_cfi import *
-from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *
-from RecoBTag.Combined.candidateNegativeCombinedMVAV2Computer_cfi import *
-from RecoBTag.Combined.candidatePositiveCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.pfCombinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.pfNegativeCombinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.pfPositiveCombinedMVAV2BJetTags_cfi import *

--- a/RecoBTag/Combined/python/combinedMVA_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_cff.py
@@ -11,9 +11,20 @@ from RecoBTag.Combined.pfCombinedMVABJetTags_cfi import *
 from RecoBTag.Combined.pfNegativeCombinedMVABJetTags_cfi import *
 from RecoBTag.Combined.pfPositiveCombinedMVABJetTags_cfi import *
 
-# CombinedMVA V2
+#combined MVA V2
+from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.negativeCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.positiveCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.combinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.negativeCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.positiveCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidateNegativeCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidatePositiveCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.pfCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.pfNegativeCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.pfPositiveCombinedMVAV2BJetTags_cfi import *
 
 # Charge tagger
 from RecoBTag.Combined.pfChargeBJetTags_cfi import *
+

--- a/RecoBTag/Combined/python/negativeCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/negativeCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+negativeCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('negativeCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexNegativeTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderNegativeTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/negativeCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/negativeCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+negativeCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'negativeOnlyJetProbabilityComputer',
+		'negativeOnlyJetBProbabilityComputer',
+		'negativeCombinedSecondaryVertexV2Computer',
+		'negativeSoftPFMuonComputer',
+		'negativeSoftPFElectronComputer'
+	),
+    mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+        ["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+    useCondDB = cms.bool(False),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(True),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/python/pfNegativeCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfNegativeCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+pfNegativeCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('candidateNegativeCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("pfImpactParameterTagInfos"),
+		cms.InputTag("pfSecondaryVertexNegativeTagInfos"),
+		cms.InputTag("pfInclusiveSecondaryVertexFinderNegativeTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/pfPositiveCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfPositiveCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+pfPositiveCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('candidatePositiveCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("pfImpactParameterTagInfos"),
+		cms.InputTag("pfSecondaryVertexTagInfos"),
+		cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/positiveCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/positiveCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+positiveCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('positiveCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexPositiveTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderPositiveTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/positiveCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/positiveCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+positiveCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'positiveOnlyJetProbabilityComputer',
+		'positiveOnlyJetBProbabilityComputer',
+		'positiveCombinedSecondaryVertexV2Computer',
+		'positiveSoftPFMuonComputer',
+		'positiveSoftPFElectronComputer'
+	),
+    mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+        ["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+    useCondDB = cms.bool(False),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(True),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
+++ b/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
@@ -99,9 +99,6 @@ float CombinedMVAV2JetTagComputer::discriminator(const JetTagComputer::TagInfoHe
   inputs["Jet_CSVIVF"]   = (*(computers[2]))( TagInfoHelper(ivfTagInfos) );
   inputs["Jet_SoftMu"]   = (*(computers[3]))( TagInfoHelper(smTagInfos) );
   inputs["Jet_SoftEl"]   = (*(computers[4]))( TagInfoHelper(seTagInfos) );
-//  inputs["Jet_pt"]       = 0.0;
-//  inputs["Jet_eta"]      = 0.0;
-//  inputs["Jet_flavour"]  = 0.0;
   
   if (inputs["Jet_JP"] <= 0) {
       inputs["Jet_JP"] = 0;


### PR DESCRIPTION
Adds configuration files for negative and positive cMVAv2 b-tagger needed for scale factor measurements. Does not affect reco sequences or event content.

Replaces https://github.com/cms-sw/cmssw/pull/13007.
`scram b runtests` was successful. No more merge conflicts.
