### PR TITLE
Propagate constness for streamer output module

### DIFF
--- a/DQMServices/StreamerIO/test/DQMStreamerOutputModule.cc
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputModule.cc
@@ -27,13 +27,17 @@ class DQMStreamerOutputModule : public edm::StreamerOutputModuleBase {
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:
-  virtual void start() const;
-  virtual void stop() const;
+  virtual void start() override;
+  virtual void stop() override;
 
   // no clue why the hell these are const in the parent class
   // so these can't be used - I will do some very bad mutable magic
-  virtual void doOutputHeader(InitMsgBuilder const& init_message) const;
-  virtual void doOutputEvent(EventMsgBuilder const& msg) const;
+  //
+  // NOTE: these are no longer const in the parent class, (or here).
+  // So perhaps they can be used now?
+  //
+  virtual void doOutputHeader(InitMsgBuilder const& init_message) override;
+  virtual void doOutputEvent(EventMsgBuilder const& msg) override;
 
   virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&,
                                     edm::ModuleCallingContext const*) override;
@@ -76,12 +80,12 @@ DQMStreamerOutputModule::DQMStreamerOutputModule(edm::ParameterSet const& ps)
 
 DQMStreamerOutputModule::~DQMStreamerOutputModule() {}
 
-void DQMStreamerOutputModule::doOutputHeader(InitMsgBuilder const& i) const {
+void DQMStreamerOutputModule::doOutputHeader(InitMsgBuilder const& i) {
 
   init_message_cache_.reset(new InitMsgView(i.startAddress()));
 }
 
-void DQMStreamerOutputModule::doOutputEvent(EventMsgBuilder const& msg) const {
+void DQMStreamerOutputModule::doOutputEvent(EventMsgBuilder const& msg) {
 
   ++processed_;
 
@@ -160,9 +164,9 @@ void DQMStreamerOutputModule::endLuminosityBlock(
   file.close();
 }
 
-void DQMStreamerOutputModule::start() const {}
+void DQMStreamerOutputModule::start() {}
 
-void DQMStreamerOutputModule::stop() const {
+void DQMStreamerOutputModule::stop() {
   std::cout << "DQMStreamerOutputModule : end run" << std::endl;
   stream_writer_events_.reset();
 

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -38,10 +38,10 @@ namespace evf {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     
   private:
-    virtual void start() const;
-    virtual void stop() const;
-    virtual void doOutputHeader(InitMsgBuilder const& init_message) const;
-    virtual void doOutputEvent(EventMsgBuilder const& msg) const;
+    virtual void start() override;
+    virtual void stop() override;
+    virtual void doOutputHeader(InitMsgBuilder const& init_message) override;
+    virtual void doOutputEvent(EventMsgBuilder const& msg) override;
     //virtual void beginRun(edm::RunPrincipal const&, edm::ModuleCallingContext const*);
     virtual void beginJob() override;
     virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
@@ -175,7 +175,7 @@ namespace evf {
 
   template<typename Consumer>
   void
-  RecoEventOutputModuleForFU<Consumer>::start() const
+  RecoEventOutputModuleForFU<Consumer>::start()
   {
     const std::string openInitFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(stream_label_);
     edm::LogInfo("RecoEventOutputModuleForFU") << "start() method, initializing streams. init stream -: "  
@@ -187,14 +187,14 @@ namespace evf {
   
   template<typename Consumer>
   void
-  RecoEventOutputModuleForFU<Consumer>::stop() const
+  RecoEventOutputModuleForFU<Consumer>::stop()
   {
     c_->stop();
   }
 
   template<typename Consumer>
   void
-  RecoEventOutputModuleForFU<Consumer>::doOutputHeader(InitMsgBuilder const& init_message) const
+  RecoEventOutputModuleForFU<Consumer>::doOutputHeader(InitMsgBuilder const& init_message)
   {
     c_->doOutputHeader(init_message);
 
@@ -226,7 +226,7 @@ namespace evf {
    
   template<typename Consumer>
   void
-  RecoEventOutputModuleForFU<Consumer>::doOutputEvent(EventMsgBuilder const& msg) const {
+  RecoEventOutputModuleForFU<Consumer>::doOutputEvent(EventMsgBuilder const& msg) {
 	accepted_.value()++;
     c_->doOutputEvent(msg); // You can't use msg in RecoEventOutputModuleForFU after this point
   }

--- a/IOPool/Streamer/interface/StreamerOutputModule.h
+++ b/IOPool/Streamer/interface/StreamerOutputModule.h
@@ -2,6 +2,7 @@
 #define IOPool_Streamer_StreamerOutputModule_h
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "IOPool/Streamer/interface/StreamerOutputModuleBase.h"
 
 namespace edm {
@@ -22,15 +23,15 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void start() const;
-    virtual void stop() const;
-    virtual void doOutputHeader(InitMsgBuilder const& init_message) const;
-    virtual void doOutputEvent(EventMsgBuilder const& msg) const;
+    virtual void start() override;
+    virtual void stop() override;
+    virtual void doOutputHeader(InitMsgBuilder const& init_message) override;
+    virtual void doOutputEvent(EventMsgBuilder const& msg) override;
     virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
     virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
 
   private:
-    std::auto_ptr<Consumer> c_;
+    edm::propagate_const<std::unique_ptr<Consumer>> c_;
   }; //end-of-class-def
 
   template<typename Consumer>
@@ -46,26 +47,26 @@ namespace edm {
 
   template<typename Consumer>
   void
-  StreamerOutputModule<Consumer>::start() const {
+  StreamerOutputModule<Consumer>::start() {
     c_->start();
   }
   
   template<typename Consumer>
   void
-  StreamerOutputModule<Consumer>::stop() const {
+  StreamerOutputModule<Consumer>::stop() {
     c_->stop();
   }
 
   template<typename Consumer>
   void
-  StreamerOutputModule<Consumer>::doOutputHeader(InitMsgBuilder const& init_message) const {
+  StreamerOutputModule<Consumer>::doOutputHeader(InitMsgBuilder const& init_message) {
     c_->doOutputHeader(init_message);
   }
    
 //______________________________________________________________________________
   template<typename Consumer>
   void
-  StreamerOutputModule<Consumer>::doOutputEvent(EventMsgBuilder const& msg) const {
+  StreamerOutputModule<Consumer>::doOutputEvent(EventMsgBuilder const& msg) {
     c_->doOutputEvent(msg); // You can't use msg in StreamerOutputModule after this point
   }
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -31,10 +31,10 @@ namespace edm {
     virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) override;
     virtual void write(EventPrincipal const& e, ModuleCallingContext const*) override;
 
-    virtual void start() const = 0;
-    virtual void stop() const = 0;
-    virtual void doOutputHeader(InitMsgBuilder const& init_message) const = 0;
-    virtual void doOutputEvent(EventMsgBuilder const& msg) const = 0;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+    virtual void doOutputHeader(InitMsgBuilder const& init_message) = 0;
+    virtual void doOutputEvent(EventMsgBuilder const& msg) = 0;
 
     std::auto_ptr<InitMsgBuilder> serializeRegistry();
     std::auto_ptr<EventMsgBuilder> serializeEvent(EventPrincipal const& e, ModuleCallingContext const* mcc); 


### PR DESCRIPTION
This PR implements propagate_const for pointer(s) in the streamer output module.
See issue #12840 .
It is being done in a separate PR because it touches packages outside the framework.
The propagate_const template prevents a const member function of the class from modifying the data
pointed to by a pointer that is a data member of the class.
