### PR TITLE
Remove confusing message

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -375,7 +375,7 @@ namespace {
       }
       full_cerr_write("\n\nA fatal system signal has occurred: ");
       full_cerr_write(signalname);
-      full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n");
+      full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n\n");
 
       edm::service::InitRootHandlers::stacktraceFromThread();
 

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -375,8 +375,7 @@ namespace {
       }
       full_cerr_write("\n\nA fatal system signal has occurred: ");
       full_cerr_write(signalname);
-      full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n"
-        "NOTE:The first few functions on the stack are artifacts of processing the signal and can be ignored\n\n");
+      full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n");
 
       edm::service::InitRootHandlers::stacktraceFromThread();
 


### PR DESCRIPTION
When CMSSW was single-threaded, the following message from the signal handler made sense:

```
NOTE:The first few functions on the stack are artifacts of processing the signal and can be ignored
```

This is no longer true!  You have to pick through the contents of each thread's stack.
