### PR TITLE
Remove Duplicated Sections in PCon Shapes

### DIFF
--- a/Geometry/CMSCommonData/data/PhaseI/beampipe.xml
+++ b/Geometry/CMSCommonData/data/PhaseI/beampipe.xml
@@ -155,7 +155,6 @@
  <Polycone name="BEAM1" startPhi="0*deg" deltaPhi="360*deg" >
   <ZSection z="[cms:MuonBeamZ0]"  rMin="[cms:Rmin]" rMax="[cms:MuonBeamR0]" />
   <ZSection z="[cms:MuonBeamZ1]"  rMin="[cms:Rmin]" rMax="[cms:MuonBeamR1]" />
-  <ZSection z="[cms:MuonBeamZ1]"  rMin="[cms:Rmin]" rMax="[cms:TotemBeamR1]"/>
   <ZSection z="[cms:TotemBeamZ1]" rMin="[cms:Rmin]" rMax="[cms:TotemBeamR2]"/>
   <ZSection z="[cms:TotemBeamZ1]" rMin="[cms:Rmin]" rMax="[cms:TotemBeamR3]"/>
   <ZSection z="[cms:ForwdBeamZ1]" rMin="[cms:Rmin]" rMax="[cms:ForwdBeamR0]"/>

--- a/Geometry/CMSCommonData/data/cms.xml
+++ b/Geometry/CMSCommonData/data/cms.xml
@@ -40,7 +40,7 @@
 		<Constant name="TotemBeamZ2" value="13.381*m"/>
 		<Constant name="TotemBeamZ3" value="13.439*m"/>
 		<Constant name="TotemBeamZ4" value="13.465*m"/>
-		<Constant name="TotemBeamR1" value="11.785*cm"/>
+		<Constant name="TotemBeamR1" value="[MuonBeamR1]"/>
 		<Constant name="TotemBeamR2" value="12.15*cm"/>
 		<Constant name="TotemBeamR3" value="12.20*cm"/>
 		<Constant name="TotemBeamR4" value="3.675*cm"/>

--- a/Geometry/ForwardCommonData/data/ionpump.xml
+++ b/Geometry/ForwardCommonData/data/ionpump.xml
@@ -14,8 +14,6 @@
 		<Polycone name="VTUB" startPhi="0*deg" deltaPhi="360*deg">
 			<ZSection z="0*fm" rMin="0*fm" rMax="1.8*cm"/>
 			<ZSection z="40*mm" rMin="0*fm" rMax="1.8*cm"/>
-			<ZSection z="40*mm" rMin="0*fm" rMax="1.8*cm"/>
-			<ZSection z="65.4*mm" rMin="0*fm" rMax="1.8*cm"/>
 			<ZSection z="65.4*mm" rMin="0*fm" rMax="1.8*cm"/>
 			<ZSection z="80.*mm" rMin="0*fm" rMax="1.8*cm"/>
 		</Polycone>

--- a/Geometry/TrackerCommonData/data/tibtidservices.xml
+++ b/Geometry/TrackerCommonData/data/tibtidservices.xml
@@ -156,7 +156,6 @@
 			<ZSection z="[OpticalPanelZ1]" rMin="[tid:SupportRin]" rMax="[MargheritaRb]"/>
 			<ZSection z="[OpticalPanelZ2]" rMin="[tid:SupportRin]" rMax="[MargheritaRb]"/>
 			<ZSection z="[OpticalPanelZ2]" rMin="[tid:SupportRin]" rMax="[PowerConnectorsRin]"/>
-			<ZSection z="[OpticalPanelZ2]" rMin="[tid:SupportRin]" rMax="[PowerConnectorsRin]"/>
 			<ZSection z="[OpticalPanelZb]" rMin="[tid:SupportRin]" rMax="[PowerConnectorsRin]"/>
 		</Polycone>
 		<!-- "Margherita" Panel  -->

--- a/Geometry/TrackerCommonData/data/tob.xml
+++ b/Geometry/TrackerCommonData/data/tob.xml
@@ -5,8 +5,7 @@
 		<Constant name="Rin1" value="54.0*cm"/>
 		<Constant name="Rin2" value="58.0*cm"/>
 		<Constant name="Rin3" value="1.160*m"/>
-		<Constant name="Rout1" value="1.169*m"/>
-		<Constant name="Rout2" value="1.169*m"/>
+		<Constant name="Rout" value="1.169*m"/>
 		<Constant name="Zv0" value="1.100*m"/>
 		<Constant name="Zv1" value="1.160*m"/>
 		<Constant name="Zv2" value="1.180*m"/>
@@ -154,7 +153,7 @@
 		<Constant name="SideDiskZ" value="114.05*cm"/>
 		<Constant name="DetectorTilt" value="0*deg"/>
 		<Constant name="AxCableRin" value="[Rin3]"/>
-		<Constant name="AxCableRout" value="[Rout1]"/>
+		<Constant name="AxCableRout" value="[Rout]"/>
 		<Constant name="AxCableT" value="0.210*cm"/>
 		<Constant name="AxCableDz" value="([Zv3]-[Zv1])/2"/>
 		<Constant name="AxCableW" value="22.5*deg"/>
@@ -216,20 +215,18 @@
 	</ConstantsSection>
 	<SolidSection label="tob.xml">
 		<Polycone name="TOB" startPhi="0*deg" deltaPhi="360*deg">
-			<ZSection z="-[Zv3]" rMin="[Rin3]" rMax="[Rout1]"/>
-			<ZSection z="-[Zv2]" rMin="[Rin3]" rMax="[Rout1]"/>
-			<ZSection z="-[Zv2]" rMin="[Rin2]" rMax="[Rout1]"/>
-			<ZSection z="-[Zv1]" rMin="[Rin2]" rMax="[Rout1]"/>
-			<ZSection z="-[Zv1]" rMin="[Rin2]" rMax="[Rout2]"/>
-			<ZSection z="-[Zv0]" rMin="[Rin2]" rMax="[Rout2]"/>
-			<ZSection z="-[Zv0]" rMin="[Rin1]" rMax="[Rout2]"/>
-			<ZSection z="[Zv0]" rMin="[Rin1]" rMax="[Rout2]"/>
-			<ZSection z="[Zv0]" rMin="[Rin2]" rMax="[Rout2]"/>
-			<ZSection z="[Zv1]" rMin="[Rin2]" rMax="[Rout2]"/>
-			<ZSection z="[Zv1]" rMin="[Rin2]" rMax="[Rout1]"/>
-			<ZSection z="[Zv2]" rMin="[Rin2]" rMax="[Rout1]"/>
-			<ZSection z="[Zv2]" rMin="[Rin3]" rMax="[Rout1]"/>
-			<ZSection z="[Zv3]" rMin="[Rin3]" rMax="[Rout1]"/>
+			<ZSection z="-[Zv3]" rMin="[Rin3]" rMax="[Rout]"/>
+			<ZSection z="-[Zv2]" rMin="[Rin3]" rMax="[Rout]"/>
+			<ZSection z="-[Zv2]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="-[Zv1]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="-[Zv0]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="-[Zv0]" rMin="[Rin1]" rMax="[Rout]"/>
+			<ZSection z="[Zv0]" rMin="[Rin1]" rMax="[Rout]"/>
+			<ZSection z="[Zv0]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="[Zv1]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="[Zv2]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="[Zv2]" rMin="[Rin3]" rMax="[Rout]"/>
+			<ZSection z="[Zv3]" rMin="[Rin3]" rMax="[Rout]"/>
 		</Polycone>
 		<Tubs name="TIBStiffener" rMin="[zero]" rMax="[StiffenerR]" dz="[StiffenerL]" startPhi="0*deg" deltaPhi="360*deg"/>
 		<Box name="TIBRailTop" dx="[RailDx]" dy="[RailTopDy]" dz="[RailL]"/>


### PR DESCRIPTION
Geometry is not changed. Duplicated section in a PCon shape is reported as error by root.

```
TotemBeamR1 == MuonBeamR1
Rout1 == Rout2
```
