### PR TITLE
Make StatisticsSenderService thread safe

### DIFF
--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -4,6 +4,8 @@
 
 #include <string>
 #include <sstream>
+#include <atomic>
+#include <mutex>
 
 namespace edm {
 
@@ -49,8 +51,9 @@ namespace edm {
         FileStatistics m_filestats;
         std::string    m_guid;
         size_t         m_counter;
-        ssize_t        m_size;
+        std::atomic<ssize_t> m_size;
         std::string    m_userdn;
+        std::mutex     m_servermutex;
     };
 
     


### PR DESCRIPTION
Two items in StatisticsSenderService could be modified at simultaneously on different threads. These items are now property protected.
