### PR TITLE
Fixing HGCal Hexagonal Geometry Round 1

### DIFF
--- a/Geometry/HGCalCommonData/data/v7/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/v7/hgcalCons.xml
@@ -2,14 +2,25 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
 
 <SpecParSection label="hgcalReco.xml" eval="true">
-  <SpecPar name="HGCalWafer">
-    <PartSelector path="//HGCalWafer.*"/>
-    <Parameter name="Volume" value="HGCalWafer" eval="false"/>
+  <SpecPar name="HGCalEEWafer">
+    <PartSelector path="//HGCalEEWafer.*"/>
+    <Parameter name="Volume" value="HGCalEEWafer" eval="false"/>
     <Parameter name="WaferSize"      value="[hgcal:WaferW]"/>
   </SpecPar>
-  <SpecPar name="HGCalCell">
-    <PartSelector path="//HGCalCell.*"/>
-    <Parameter name="Volume" value="HGCalCell" eval="false"/>
+  <SpecPar name="HGCalHEWafer">
+    <PartSelector path="//HGCalHEWafer.*"/>
+    <Parameter name="Volume" value="HGCalHEWafer" eval="false"/>
+    <Parameter name="WaferSize"      value="[hgcal:WaferW]"/>
+  </SpecPar>
+  <SpecPar name="HGCalEECell">
+    <PartSelector path="//HGCalEECell.*"/>
+    <Parameter name="Volume" value="HGCalEECell" eval="false"/>
+    <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
+    <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
+  </SpecPar>
+  <SpecPar name="HGCalHECell">
+    <PartSelector path="//HGCalHECell.*"/>
+    <Parameter name="Volume" value="HGCalHECell" eval="false"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>

--- a/Geometry/HGCalCommonData/data/v7/hgcalEE.xml
+++ b/Geometry/HGCalCommonData/data/v7/hgcalEE.xml
@@ -12,7 +12,7 @@
   <Algorithm name="hgcal:DDHGCalModuleAlgo">
     <rParent name="hgcal:HGCalEE"/>
     <Vector name="WaferName" type="string" nEntries="2">
-      hgcalwafer:HGCalWaferFine, hgcalwafer:HGCalWaferCoarse</Vector>
+      hgcalwafer:HGCalEEWaferFine, hgcalwafer:HGCalEEWaferCoarse</Vector>
     <Vector name="MaterialNames" type="string" nEntries="15">
       materials:Carbon_fibre_str_Upgrade2, materials:Tungsten,
       materials:Tungsten, materials:Tungsten, hgcal:WCu, hgcal:WCu,
@@ -86,7 +86,7 @@
 
 <SpecParSection label="hgcalEE.xml" eval="true">
   <SpecPar name="HGCalEE">
-    <PartSelector path="//HGCalEESensitive.*"/>
+    <PartSelector path="//HGCalEESensitive.*"/>    
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon" eval="false"/>
     <Parameter name="RadiusBound"  value="[rMinFine]"/>

--- a/Geometry/HGCalCommonData/data/v7/hgcalHEsil.xml
+++ b/Geometry/HGCalCommonData/data/v7/hgcalHEsil.xml
@@ -12,7 +12,7 @@
   <Algorithm name="hgcal:DDHGCalModuleAlgo">
     <rParent name="hgcal:HGCalHE"/>
     <Vector name="WaferName" type="string" nEntries="2">
-      hgcalwafer:HGCalWaferFine, hgcalwafer:HGCalWaferCoarse</Vector>
+      hgcalwafer:HGCalHEWaferFine, hgcalwafer:HGCalHEWaferCoarse</Vector>
     <Vector name="MaterialNames" type="string" nEntries="11">
       materials:H_Brass, materials:Carbon_fibre_str_Upgrade2, materials:Copper,
       materials:Copper, materials:Air, materials:M_NEMA FR4 plate, 

--- a/Geometry/HGCalCommonData/data/v7/hgcalwafer.xml
+++ b/Geometry/HGCalCommonData/data/v7/hgcalwafer.xml
@@ -13,68 +13,127 @@
 </ConstantsSection>
 
 <SolidSection label="hgcalwafer.xml">
-  <Polyhedra name="HGCalWafer" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
+
+  <Polyhedra name="HGCalEEWafer" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
     <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[WaferW]/2"/>
     <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[WaferW]/2"/>
   </Polyhedra>
-  <Polyhedra name="HGCalCellCoarse" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
+  <Polyhedra name="HGCalEECellCoarse" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
     <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[CellWC]/2"/>
     <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[CellWC]/2"/>
   </Polyhedra>
+  <Polyhedra name="HGCalEECellFine" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
+    <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[CellWF]/2"/>
+    <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[CellWF]/2"/>
+  </Polyhedra>  
+  <Polyhedra name="HGCalHEWafer" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
+    <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[WaferW]/2"/>
+    <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[WaferW]/2"/>
+  </Polyhedra>
+  <Polyhedra name="HGCalHECellCoarse" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
+    <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[CellWC]/2"/>
+    <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[CellWC]/2"/>
+  </Polyhedra>
+  <Polyhedra name="HGCalHECellFine" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
+    <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[CellWF]/2"/>
+    <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[CellWF]/2"/>
+  </Polyhedra>  
+
   <Box name="HGCalCellCoarseMask" dx="[CellWC]/2" dy="[CellWC]" dz="[WaferT]/2"/>
-  <SubtractionSolid name="HGCalCellCoarseHalf">
-   <rSolid name="HGCalCellCoarse"/>
+  <Box name="HGCalCellFineMask" dx="[CellWF]/2" dy="[CellWF]" dz="[WaferT]/2"/>
+
+  <SubtractionSolid name="HGCalEECellCoarseHalf">
+   <rSolid name="HGCalEECellCoarse"/>
    <rSolid name="HGCalCellCoarseMask"/>
    <rRotation name="rotations:000D"/>
    <Translation x="[CellWC]/2" y="0.0*fm" z="0.0*fm"/>
   </SubtractionSolid>
-  <Polyhedra name="HGCalCellFine" numSide="6" startPhi="330*deg" deltaPhi="360*deg">
-    <ZSection z="-[WaferT]/2" rMin="0*fm" rMax="[CellWF]/2"/>
-    <ZSection z= "[WaferT]/2" rMin="0*fm" rMax="[CellWF]/2"/>
-  </Polyhedra>
-  <Box name="HGCalCellFineMask" dx="[CellWF]/2" dy="[CellWF]" dz="[WaferT]/2"/>
-  <SubtractionSolid name="HGCalCellFineHalf">
-   <rSolid name="HGCalCellFine"/>
+  <SubtractionSolid name="HGCalHECellCoarseHalf">
+   <rSolid name="HGCalHECellCoarse"/>
+   <rSolid name="HGCalCellCoarseMask"/>
+   <rRotation name="rotations:000D"/>
+   <Translation x="[CellWC]/2" y="0.0*fm" z="0.0*fm"/>
+  </SubtractionSolid>
+
+  <SubtractionSolid name="HGCalEECellFineHalf">
+   <rSolid name="HGCalEECellFine"/>
    <rSolid name="HGCalCellFineMask"/>
    <rRotation name="rotations:000D"/>
    <Translation x="[CellWF]/2" y="0.0*fm" z="0.0*fm"/>
   </SubtractionSolid>
+  <SubtractionSolid name="HGCalHECellFineHalf">
+   <rSolid name="HGCalHECellFine"/>
+   <rSolid name="HGCalCellFineMask"/>
+   <rRotation name="rotations:000D"/>
+   <Translation x="[CellWF]/2" y="0.0*fm" z="0.0*fm"/>
+  </SubtractionSolid>
+  
+
 </SolidSection> 
 
 <LogicalPartSection label="hgcalwafer.xml">
-  <LogicalPart name="HGCalWaferCoarse" category="unspecified">
-    <rSolid name="HGCalWafer"/>
+  <LogicalPart name="HGCalEEWaferCoarse" category="unspecified">
+    <rSolid name="HGCalEEWafer"/>
     <rMaterial name="materials:Air"/>
   </LogicalPart>
-  <LogicalPart name="HGCalWaferFine" category="unspecified">
-    <rSolid name="HGCalWafer"/>
+  <LogicalPart name="HGCalHEWaferCoarse" category="unspecified">
+    <rSolid name="HGCalHEWafer"/>
     <rMaterial name="materials:Air"/>
   </LogicalPart>
-  <LogicalPart name="HGCalCellCoarse" category="unspecified">
-    <rSolid name="HGCalCellCoarse"/>
+
+  <LogicalPart name="HGCalEEWaferFine" category="unspecified">
+    <rSolid name="HGCalEEWafer"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEWaferFine" category="unspecified">
+    <rSolid name="HGCalHEWafer"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+
+  <LogicalPart name="HGCalEECellCoarse" category="unspecified">
+    <rSolid name="HGCalEECellCoarse"/>
     <rMaterial name="materials:Silicon"/>
   </LogicalPart>
-  <LogicalPart name="HGCalCellCoarseHalf" category="unspecified">
-    <rSolid name="HGCalCellCoarseHalf"/>
+  <LogicalPart name="HGCalHECellCoarse" category="unspecified">
+    <rSolid name="HGCalHECellCoarse"/>
     <rMaterial name="materials:Silicon"/>
   </LogicalPart>
-  <LogicalPart name="HGCalCellFine" category="unspecified">
-    <rSolid name="HGCalCellFine"/>
+
+  <LogicalPart name="HGCalEECellCoarseHalf" category="unspecified">
+    <rSolid name="HGCalEECellCoarseHalf"/>
     <rMaterial name="materials:Silicon"/>
   </LogicalPart>
-  <LogicalPart name="HGCalCellFineHalf" category="unspecified">
-    <rSolid name="HGCalCellFineHalf"/>
+  <LogicalPart name="HGCalHECellCoarseHalf" category="unspecified">
+    <rSolid name="HGCalHECellCoarseHalf"/>
+    <rMaterial name="materials:Silicon"/>
+  </LogicalPart>
+
+  <LogicalPart name="HGCalEECellFine" category="unspecified">
+    <rSolid name="HGCalEECellFine"/>
+    <rMaterial name="materials:Silicon"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHECellFine" category="unspecified">
+    <rSolid name="HGCalHECellFine"/>
+    <rMaterial name="materials:Silicon"/>
+  </LogicalPart>
+  
+  <LogicalPart name="HGCalEECellFineHalf" category="unspecified">
+    <rSolid name="HGCalEECellFineHalf"/>
+    <rMaterial name="materials:Silicon"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHECellFineHalf" category="unspecified">
+    <rSolid name="HGCalHECellFineHalf"/>
     <rMaterial name="materials:Silicon"/>
   </LogicalPart>
 </LogicalPartSection>
 
 <PosPartSection label="hgcalwafer.xml">
   <Algorithm name="hgcal:DDHGCalWaferAlgo">
-    <rParent name="hgcalwafer:HGCalWaferCoarse"/>
+    <rParent name="hgcalwafer:HGCalEEWaferCoarse"/>
     <Numeric name="CellSize" value="[CellWC]"/>
     <Numeric name="CellType" value="[TypeWC]"/>
     <Vector name="ChildNames" type="string" nEntries="2">
-      HGCalCellCoarse, HGCalCellCoarseHalf</Vector>
+      HGCalEECellCoarse, HGCalEECellCoarseHalf</Vector>
     <Vector name="PositionX" type="numeric" nEntries="133">
       -1,1,-4,-2,0,2,4,
       -7,-5,-3,-1,1,3,5,7,
@@ -124,11 +183,135 @@
     <String name="RotNameSpace" value="hgcalwafer"/>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalWaferAlgo">
-    <rParent name="hgcalwafer:HGCalWaferFine"/>
+    <rParent name="hgcalwafer:HGCalEEWaferFine"/>
     <Numeric name="CellSize" value="[CellWF]"/>
     <Numeric name="CellType" value="[TypeWF]"/>
     <Vector name="ChildNames" type="string" nEntries="2">
-      HGCalCellFine, HGCalCellFineHalf</Vector>
+      HGCalEECellFine, HGCalEECellFineHalf</Vector>
+    <Vector name="PositionX" type="numeric" nEntries="240">
+      -2,0,2,-5,-3,-1,1,3,5,
+      -8,-6,-4,-2,0,2,4,6,8,
+      -11,-9,-7,-5,-3,-1,1,3,5,7,9,11,
+      -14,-12,-10,-8,-6,-4,-2,0,2,4,6,8,10,12,14,
+      -15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15,
+      -14,-12,-10,-8,-6,-4,-2,0,2,4,6,8,10,12,14,
+      -15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15,
+      -14,-12,-10,-8,-6,-4,-2,0,2,4,6,8,10,12,14,
+      -15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15,
+      -14,-12,-10,-8,-6,-4,-2,0,2,4,6,8,10,12,14,
+      -15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15,
+      -14,-12,-10,-8,-6,-4,-2,0,2,4,6,8,10,12,14,
+      -15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15,
+      -14,-12,-10,-8,-6,-4,-2,0,2,4,6,8,10,12,14,
+      -13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,
+      -10,-8,-6,-4,-2,0,2,4,6,8,10,
+      -7,-5,-3,-1,1,3,5,7,
+      -4,-2,0,2,4,-1,1
+    </Vector>
+    <Vector name="PositionY" type="numeric" nEntries="240">
+      -56,-56,-56,-50,-50,-50,-50,-50,-50,
+      -44,-44,-44,-44,-44,-44,-44,-44,-44,
+      -38,-38,-38,-38,-38,-38,-38,-38,-38,-38,-38,-38,
+      -32,-32,-32,-32,-32,-32,-32,-32,-32,-32,-32,-32,-32,-32,-32,
+      -26,-26,-26,-26,-26,-26,-26,-26,-26,-26,-26,-26,-26,-26,-26,-26,
+      -20,-20,-20,-20,-20,-20,-20,-20,-20,-20,-20,-20,-20,-20,-20,
+      -14,-14,-14,-14,-14,-14,-14,-14,-14,-14,-14,-14,-14,-14,-14,-14,
+      -8,-8,-8,-8,-8,-8,-8,-8,-8,-8,-8,-8,-8,-8,-8,
+      -2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,
+       4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+       10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,
+       16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,
+       22,22,22,22,22,22,22,22,22,22,22,22,22,22,22,22,
+       28,28,28,28,28,28,28,28,28,28,28,28,28,28,28,
+       34,34,34,34,34,34,34,34,34,34,34,34,34,34,
+       40,40,40,40,40,40,40,40,40,40,40,
+       46,46,46,46,46,46,46,46,
+       52,52,52,52,52,58,58
+    </Vector>
+    <Vector name="Angles" type="numeric" nEntries="240">
+      240,0,300,240,0,0,0,0,300,240,0,0,0,0,0,0,0,300,
+      240,0,0,0,0,0,0,0,0,0,0,300,240,0,0,0,0,0,0,0,0,0,0,0,0,0,300,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      120,0,0,0,0,0,0,0,0,0,0,0,0,60,120,0,0,0,0,0,0,0,0,0,60,
+      120,0,0,0,0,0,0,60,120,0,0,0,60,120,60
+    </Vector>
+    <Vector name="DetectorType" type="numeric" nEntries="240">
+     1,0,1,1,0,0,0,0,1,1,0,0,0,0,0,0,0,1,
+     1,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,
+     1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,1,
+     1,0,0,0,0,0,0,1,1,0,0,0,1,1,1
+    </Vector>
+    <String name="RotNameSpace" value="hgcalwafer"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferAlgo">
+    <rParent name="hgcalwafer:HGCalHEWaferCoarse"/>
+    <Numeric name="CellSize" value="[CellWC]"/>
+    <Numeric name="CellType" value="[TypeWC]"/>
+    <Vector name="ChildNames" type="string" nEntries="2">
+      HGCalHECellCoarse, HGCalHECellCoarseHalf</Vector>
+    <Vector name="PositionX" type="numeric" nEntries="133">
+      -1,1,-4,-2,0,2,4,
+      -7,-5,-3,-1,1,3,5,7,
+      -10,-8,-6,-4,-2,0,2,4,6,8,10,
+      -11,-9,-7,-5,-3,-1,1,3,5,7,9,11,
+      -10,-8,-6,-4,-2,0,2,4,6,8,10,
+      -11,-9,-7,-5,-3,-1,1,3,5,7,9,11,
+      -10,-8,-6,-4,-2,0,2,4,6,8,10,
+      -11,-9,-7,-5,-3,-1,1,3,5,7,9,11,
+      -10,-8,-6,-4,-2,0,2,4,6,8,10,
+      -11,-9,-7,-5,-3,-1,1,3,5,7,9,11,
+      -10,-8,-6,-4,-2,0,2,4,6,8,10,
+      -7,-5,-3,-1,1,3,5,7,
+      -4,-2,0,2,4,-1,1
+    </Vector>
+    <Vector name="PositionY" type="numeric" nEntries="133">
+      -42,-42,-36,-36,-36,-36,-36,
+      -30,-30,-30,-30,-30,-30,-30,-30,
+      -24,-24,-24,-24,-24,-24,-24,-24,-24,-24,-24,
+      -18,-18,-18,-18,-18,-18,-18,-18,-18,-18,-18,-18,
+      -12,-12,-12,-12,-12,-12,-12,-12,-12,-12,-12,
+      -6,-6,-6,-6,-6,-6,-6,-6,-6,-6,-6,-6,
+       0,0,0,0,0,0,0,0,0,0,0,
+       6,6,6,6,6,6,6,6,6,6,6,6,
+       12,12,12,12,12,12,12,12,12,12,12,
+       18,18,18,18,18,18,18,18,18,18,18,18,
+       24,24,24,24,24,24,24,24,24,24,24,
+       30,30,30,30,30,30,30,30,
+       36,36,36,36,36,42,42
+    </Vector>
+    <Vector name="Angles" type="numeric" nEntries="133">
+      240,300,240,0,0,0,300,240,0,0,0,0,0,0,300,240,0,0,0,0,0,0,0,0,0,300,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      180,0,0,0,0,0,0,0,0,0,0,0,120,0,0,0,0,0,0,0,0,0,60,
+      120,0,0,0,0,0,0,60,120,0,0,0,60,120,60
+    </Vector>
+    <Vector name="DetectorType" type="numeric" nEntries="133">
+     1,1,1,0,0,0,1,1,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,1,
+     1,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,
+     1,0,0,0,0,0,0,0,0,0,0,1,
+     1,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,1,1,0,0,0,1,1,1
+    </Vector>
+    <String name="RotNameSpace" value="hgcalwafer"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferAlgo">
+    <rParent name="hgcalwafer:HGCalHEWaferFine"/>
+    <Numeric name="CellSize" value="[CellWF]"/>
+    <Numeric name="CellType" value="[TypeWF]"/>
+    <Vector name="ChildNames" type="string" nEntries="2">
+      HGCalHECellFine, HGCalHECellFineHalf</Vector>
     <Vector name="PositionX" type="numeric" nEntries="240">
       -2,0,2,-5,-3,-1,1,3,5,
       -8,-6,-4,-2,0,2,4,6,8,

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -18,10 +18,14 @@
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
+#include <unordered_map>
+
 class HGCalDDDConstants {
 
 public:
 
+  typedef std::array<std::vector<int32_t>, 2> simrecovecs;
+  
   HGCalDDDConstants(const HGCalParameters* hp, const std::string name);
   ~HGCalDDDConstants();
 
@@ -38,6 +42,7 @@ public:
   HGCalGeometryMode   geomMode() const {return mode_;}
   bool                isValid(int lay, int mod, int cell, bool reco) const;
   unsigned int        layers(bool reco) const;
+  unsigned int        layersInit(bool reco) const;
   std::pair<float,float> locateCell(int cell, int lay, int type, 
 				    bool reco) const;
   std::pair<float,float> locateCellHex(int cell, int wafer, bool reco) const;
@@ -47,6 +52,7 @@ public:
 				     float cellSize) const;
   int                 maxRows(int lay, bool reco) const;
   int                 modules(int lay, bool reco) const;
+  int                 modulesInit(int lay, bool reco) const;
   std::pair<int,int>  newCell(int cell, int layer, int sector, int subsector,
 			      int incrx, int incry, bool half) const;
   std::pair<int,int>  newCell(int cell, int layer, int subsector, int incrz,
@@ -74,11 +80,12 @@ public:
   HGCalParameters::hgtrform getTrForm(unsigned int k) const {return hgpar_->getTrForm(k);}
   std::vector<HGCalParameters::hgtrform> getTrForms() const ;
   
+  std::pair<int,float> getIndex(int lay, bool reco) const;
+
 private:
   int cellHex(double xx, double yy, const double& cellR, 
 	      const std::vector<double>& posX,
-	      const std::vector<double>& posY) const;
-  std::pair<int,float> getIndex(int lay, bool reco) const;
+	      const std::vector<double>& posY) const;  
   void getParameterSquare(int lay, int subSec, bool reco, float& h, float& bl,
 			  float& tl, float& alpha) const;
   bool waferInLayer(int wafer, int lay) const;
@@ -87,6 +94,9 @@ private:
   constexpr static double tan30deg_ = 0.5773502693;
   double                 rmax_;
   HGCalGeometryMode      mode_;
+  int32_t tot_wafers_;
+  std::array<uint32_t,2> tot_layers_;
+  simrecovecs max_modules_layer_; 
 };
 
 #endif

--- a/Geometry/HGCalCommonData/python/hgcalV6ParametersInitialization_cfi.py
+++ b/Geometry/HGCalCommonData/python/hgcalV6ParametersInitialization_cfi.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 hgcalEEParametersInitialize = cms.ESProducer("HGCalParametersESModule",
                                              Name = cms.untracked.string("HGCalEESensitive"),
-                                             NameW = cms.untracked.string("HGCalWafer"),
-                                             NameC = cms.untracked.string("HGCalCell")
+                                             NameW = cms.untracked.string("HGCalEEWafer"),
+                                             NameC = cms.untracked.string("HGCalEECell")
 )
 
 hgcalHESiParametersInitialize = cms.ESProducer("HGCalParametersESModule",
                                                Name = cms.untracked.string("HGCalHESiliconSensitive"),
-                                             NameW = cms.untracked.string("HGCalWafer"),
-                                             NameC = cms.untracked.string("HGCalCell")
+                                               NameW = cms.untracked.string("HGCalHEWafer"),
+                                               NameC = cms.untracked.string("HGCalHECell")
 )
 

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -22,6 +22,11 @@ HGCalDDDConstants::HGCalDDDConstants(const HGCalParameters* hp,
   mode_ = HGCalGeometryMode( hgpar_->mode_ );
   if (mode_ == HGCalGeometryMode::Square) {
     rmax_ = 0;
+    
+    for( int simreco = 0; simreco < 2; ++simreco ) {
+      tot_layers_[simreco] = layersInit((bool)simreco);
+    }
+
     edm::LogInfo("HGCalGeom") << "HGCalDDDConstants initialized for " << name
 			      << " with " << layers(false) << ":" <<layers(true)
 			      << " layers, " << sectors() << " sectors and "

--- a/Geometry/HGCalGeometry/src/HGCalGeometryLoader.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometryLoader.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 
-//#define DebugLog
+//#define DebugLog 1
 
 typedef CaloCellGeometry::CCGFloat CCGFloat;
 typedef std::vector<float> ParmVec;

--- a/Geometry/HGCalSimData/data/hgcsensv6.xml
+++ b/Geometry/HGCalSimData/data/hgcsensv6.xml
@@ -3,12 +3,12 @@
 
 <SpecParSection label="hgcsens.xml" eval="true">
   <SpecPar name="hgcee">
-    <PartSelector path="//.*EESensitive.*"/>
+    <PartSelector path="//.*HGCalEECell.*"/>  
     <Parameter name="SensitiveDetector" value="HGCSensitiveDetector" eval="false"/>
     <Parameter name="ReadOutName" value="HGCHitsEE" eval="false"/>
   </SpecPar>
   <SpecPar name="hgchesil">
-    <PartSelector path="//.*HESiliconSensitive.*"/>
+    <PartSelector path="//.*HGCalHECell.*"/> 
     <Parameter name="SensitiveDetector" value="HGCSensitiveDetector" eval="false"/>
     <Parameter name="ReadOutName" value="HGCHitsHEfront" eval="false"/>
   </SpecPar>

--- a/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
+++ b/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
@@ -26,12 +26,12 @@ public:
   static const int kHGCalCellTypHOffset   = 8;
   static const int kHGCalCellTypHMask     = 0x1;
   static const int kHGCalWaferHOffset     = 9;
-  static const int kHGCalWaferHMask       = 0x1FF;
-  static const int kHGCalLayerHOffset     = 18;
+  static const int kHGCalWaferHMask       = 0x3FF;
+  static const int kHGCalLayerHOffset     = 19;
   static const int kHGCalLayerHMask       = 0x7F;
-  static const int kHGCalZsideHOffset     = 25;
+  static const int kHGCalZsideHOffset     = 26;
   static const int kHGCalZsideHMask       = 0x1;
-  static const int kHGCalSubdetHOffset    = 30;
+  static const int kHGCalSubdetHOffset    = 27;
   static const int kHGCalSubdetHMask      = 0x7;
   HGCalTestNumbering() {}
   virtual ~HGCalTestNumbering() {}

--- a/SimDataFormats/CaloTest/src/HGCalTestNumbering.cc
+++ b/SimDataFormats/CaloTest/src/HGCalTestNumbering.cc
@@ -27,7 +27,7 @@ uint32_t HGCalTestNumbering::packHexagonIndex(int subdet, int zp, int lay,
   if (!HGCalTestNumbering::isValidHexagon(subdet,zp,lay,wafer,celltyp,cell)) {
     subdet = zp = lay = wafer = celltyp = cell = 0;
   }
-
+  
   uint32_t rawid=0;
   rawid |= ((cell   & kHGCalCellHMask)        << kHGCalCellHOffset);
   rawid |= ((celltyp& kHGCalCellTypHMask)     << kHGCalCellTypHOffset);

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -45,7 +45,7 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer,
       index = 0;
     }
   } else {    
-    wafer =  hgcons->waferFromCopy(module);
+    wafer =  hgcons_.waferFromCopy(module);
     celltyp = cell/1000;
     icell   = cell%1000;
     if (celltyp != 1) celltyp = 0;    
@@ -55,17 +55,16 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer,
     //check if it fits
     if (!hgcons_.isValid(layer,wafer,icell,false)) {
       index = 0;
-      if (check_) {
-        std::pair<int,int> temp = hgcons->assignCell(pos.x(),pos.y(),layer,0,false);
-        std::cout << "wafer from copy: " << wafer << ", from assign: " << temp.first << std::endl;
-        std::cout << "cell from copy:  " << icell << ", from assign: " << temp.second << std::endl;
 
-	edm::LogError("HGCSim") << "[HGCNumberingScheme] ID out of bounds :"
-				<< " Subdet= " << subdet << " Zside= " << iz
-				<< " Layer= " << layer << " Wafer= " << wafer
-				<< " CellType= " << celltyp << " Cell= "
-				<< icell;
-      }    
+      std::pair<int,int> temp = hgcons_.assignCell(pos.x(),pos.y(),layer,0,false);
+      edm::LogError("HGCSim") << "wafer from copy: " << wafer << ", from assign: " << temp.first << std::endl;
+      edm::LogError("HGCSim") << "cell from copy:  " << icell << ", from assign: " << temp.second << std::endl;
+      
+      edm::LogError("HGCSim") << "[HGCNumberingScheme] ID out of bounds :"
+                              << " Subdet= " << subdet << " Zside= " << iz
+                              << " Layer= " << layer << " Wafer= " << wafer
+                              << " CellType= " << celltyp << " Cell= "
+                              << icell;
     }
   }
 #ifdef DebugLog

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -8,6 +8,8 @@
 #include "DataFormats/Math/interface/FastMath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include <iostream>
 
@@ -42,16 +44,28 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer,
     if (!hgcons_.isValid(layer,module,icell,false)) {
       index = 0;
     }
-  } else {
+  } else {    
+    wafer =  hgcons->waferFromCopy(module);
     celltyp = cell/1000;
     icell   = cell%1000;
-    if (celltyp != 1) celltyp = 0;
-    wafer   = hgcons_.waferFromCopy(module);
+    if (celltyp != 1) celltyp = 0;    
+    
     index   = HGCalTestNumbering::packHexagonIndex((int)subdet,iz,layer,wafer, 
-						   celltyp,icell);
+						   celltyp,icell);    
     //check if it fits
     if (!hgcons_.isValid(layer,wafer,icell,false)) {
       index = 0;
+      if (check_) {
+        std::pair<int,int> temp = hgcons->assignCell(pos.x(),pos.y(),layer,0,false);
+        std::cout << "wafer from copy: " << wafer << ", from assign: " << temp.first << std::endl;
+        std::cout << "cell from copy:  " << icell << ", from assign: " << temp.second << std::endl;
+
+	edm::LogError("HGCSim") << "[HGCNumberingScheme] ID out of bounds :"
+				<< " Subdet= " << subdet << " Zside= " << iz
+				<< " Layer= " << layer << " Wafer= " << wafer
+				<< " CellType= " << celltyp << " Cell= "
+				<< icell;
+      }    
     }
   }
 #ifdef DebugLog


### PR DESCRIPTION
This PR fixes a number of bugs in the HGCal geometry.
Previous to this PR the HGCal Hex geometry did not produce simhits.
- Set the silicon as the sensitive detector to read out.
- Logically factorize EE and HE cells and wafers so they can be read out separately.
- Fix packing of hexagon indices to be compatible with the ranges of wafers/cells/layers encountered
- Speed ups to the DDD constants class

Event display for RECO geometry of pT = 35 GeV electron seems to be OK.
<img width="696" alt="screen shot 2016-01-22 at 18 30 39" src="https://cloud.githubusercontent.com/assets/1068089/12518530/7ea24148-c139-11e5-962d-09d2e2fc5599.png">
Likewise, energy distributions look good now.
<img width="819" alt="screen shot 2016-01-22 at 16 24 57" src="https://cloud.githubusercontent.com/assets/1068089/12518532/820699ce-c139-11e5-9f10-71edafc448e1.png">

While simulating, there are still invalid detids encountered in the sensitive detector, so I do not think we are done yet.

@bsunanda 
