### PR TITLE
Removes subsequent unused return statement in createIfNeeded

### DIFF
--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -61,7 +61,6 @@ namespace edm {
 
     static std::unique_ptr<edm::OutputModuleCommunicator> createIfNeeded(T* iMod) {
       return std::move(impl::createCommunicatorIfNeeded(iMod));
-      return std::move(std::unique_ptr<edm::OutputModuleCommunicator>{});
     }
 
   private:


### PR DESCRIPTION
Removes subsequent unused return statement and resolves 3742 warnings
from Clang (3.7.1).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
