### PR TITLE
CalibCalorimetry/CaloTPG: definite static const float members

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -15,6 +15,8 @@
 
 using namespace std;
 
+constexpr float CaloTPGTranscoderULUT::LSB_HF;
+constexpr float CaloTPGTranscoderULUT::LSB_HBHE;
 
 CaloTPGTranscoderULUT::CaloTPGTranscoderULUT(const std::string& compressionFile,
                                              const std::string& decompressionFile)


### PR DESCRIPTION
The patch resolves issue with Clang compiler.
N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.

```
src/CalibCalorimetryCaloTPG/CaloTPGTranscoderULUT.o: In function aloTPGTranscoderULUT::setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&)':
src/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc:(.text+0x168b): undefined reference to aloTPGTranscoderULUT::LSB_HBHE'
src/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc:(.text+0x16b6): undefined reference to aloTPGTranscoderULUT::LSB_HF'
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
