### PR TITLE
[RFC] Utilities/XrdAdaptor: fix -Wunused-result errors

### DIFF
--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -1,6 +1,7 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Utilities/StorageFactory/interface/StorageMaker.h"
 #include "Utilities/StorageFactory/interface/StorageMakerFactory.h"
@@ -83,7 +84,12 @@ public:
     XrdCl::URL url(fullpath);
     XrdCl::FileSystem fs(url);
     std::vector<std::string> fileList; fileList.push_back(url.GetPath());
-    fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, &m_null_handler);
+    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, &m_null_handler);
+    if (!status.IsOK())
+    {
+        edm::LogWarning("StageInError") << "XrdCl::FileSystem::Prepare failed with error '"
+                                        << status.ToStr() << "' (errNo = " << status.errNo << ")";
+    }
   }
 
   virtual bool check (const std::string &proto,

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -99,7 +99,10 @@ SendMonitoringInfo(XrdCl::File &file)
     {
         XrdCl::URL url(lastUrl);
         XrdCl::FileSystem fs(url);
-        fs.SendInfo(jobId, &nullHandler, 30);
+        if (!(fs.SendInfo(jobId, &nullHandler, 30).IsOK()))
+        {
+            edm::LogWarning("XrdAdaptorInternal") << "Failed to send the monitoring information, monitoring ID is " << jobId << ".";
+        }
         edm::LogInfo("XrdAdaptorInternal") << "Set monitoring ID to " << jobId << ".";
     }
 }

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -9,6 +9,7 @@
 
 #include "XrdCl/XrdClFile.hh"
 
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "XrdSource.h"
@@ -321,10 +322,12 @@ Source::handle(std::shared_ptr<ClientRequest> c)
 #ifdef XRD_FAKE_SLOW
     if (m_slow) std::this_thread::sleep_for(std::chrono::milliseconds(XRD_DELAY));
 #endif
+
+    XrdCl::XRootDStatus status;
     if (c->m_into)
     {
         // See notes in ClientRequest definition to understand this voodoo.
-        m_fh->Read(c->m_off, c->m_size, c->m_into, c.get());
+        status = m_fh->Read(c->m_off, c->m_size, c->m_into, c.get());
     }
     else
     {
@@ -335,7 +338,16 @@ Source::handle(std::shared_ptr<ClientRequest> c)
             cl.emplace_back(it.offset(), it.size(), it.data());
         }
         validateList(cl);
-        m_fh->VectorRead(cl, nullptr, c.get());
+        status = m_fh->VectorRead(cl, nullptr, c.get());
+    }
+
+    if (!status.IsOK())
+    {
+        edm::Exception ex(edm::errors::FileReadError);
+        ex << "XrdFile::Read or XrdFile::VectorRead failed with error: '"
+           << status.ToStr() << "' (errNo = " << status.errNo << ")";
+        ex.addContext("Calling Source::handle");
+        throw ex;
     }
 }
 


### PR DESCRIPTION
Some xrootd methods are marked with `XRD_WARN_UNUSED_RESULT`
(`__attribute__((warn_unused_result))`) and `-Wunused-result` forces us
to not ignore return values.

```
src/Utilities/XrdAdaptor/src/XrdSource.cc:327:9: error: ignoring return value of function declared with warn_unused_result attribute [-Werror,-Wunused-result]
src/Utilities/XrdAdaptor/src/XrdSource.cc:338:9: error: ignoring return value of function declared with warn_unused_result attribute [-Werror,-Wunused-result]
src/Utilities/XrdAdaptor/src/XrdRequestManager.cc:102:9: error: ignoring return value of function declared with warn_unused_result attribute [-Werror,-Wunused-result]
src/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc:86:5: error: ignoring return value of function declared with warn_unused_result attribute [-Werror,-Wunused-result]
```

Feel free to take it and modify as needed as I might not have picked a correct way of handling issues (warnings/error/exception/cleanups before exception/etc).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
