### PR TITLE
pp RECO with HI photon isolation using "customise" option

### DIFF
--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -1,0 +1,77 @@
+import FWCore.ParameterSet.Config as cms
+
+# Customize process to run HI-style photon isolation in the pp RECO sequences
+def addHIIsolationProducer(process):
+
+    process.load('Configuration.EventContent.EventContent_cff')
+    
+    # extend RecoEgammaFEVT content
+    process.RecoEgammaFEVT.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
+                                                  ])
+    
+    # extend RecoEgammaRECO content
+    process.RECOEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+    
+    process.FEVTEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+    process.FEVTSIMEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+    # extend RecoEgammaRECO content
+    process.RAWRECOEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+
+    process.RECOSIMEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+
+    process.RAWRECOSIMHLTEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+    
+    process.RAWRECODEBUGHLTEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+
+    process.FEVTHLTALLEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+
+    process.FEVTDEBUGEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                  'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                  'keep recoCaloClusters_islandBasicClusters_*_*'
+                                                  ])
+
+    # extend RecoEgammaAOD content
+    process.AODEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                 'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
+                                                  ])
+
+    process.AODSIMEventContent.outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                 'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
+                                                  ])
+
+    # add HI Photon isolation sequence to pp RECO
+    process.load('RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi')
+    process.load('RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi')
+
+    process.photonIsolationHISequencePP = cms.Sequence(process.islandBasicClusters 
+                                                       * process.photonIsolationHIProducerpp 
+                                                       * process.photonIsolationHIProducerppGED)
+    
+    process.reconstruction *= process.photonIsolationHISequencePP
+    
+    return process

--- a/RecoHI/HiEgammaAlgos/python/photonIsolationHIProducer_cfi.py
+++ b/RecoHI/HiEgammaAlgos/python/photonIsolationHIProducer_cfi.py
@@ -13,3 +13,18 @@ photonIsolationHIProducer = cms.EDProducer(
     trackCollection = cms.InputTag("hiGeneralTracks"),
     trackQuality = cms.string("highPurity")
 )
+
+photonIsolationHIProducerpp = photonIsolationHIProducer.clone(
+trackCollection = cms.InputTag("generalTracks")
+)
+
+photonIsolationHIProducerppGED = photonIsolationHIProducerpp.clone(
+photonProducer=cms.InputTag("gedPhotons")
+)
+
+from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import *
+
+islandBasicClustersGED = islandBasicClusters.clone()
+photonIsolationHISequence = cms.Sequence(islandBasicClusters * photonIsolationHIProducerpp)
+photonIsolationHISequenceGED = cms.Sequence(islandBasicClustersGED * photonIsolationHIProducerppGED)
+


### PR DESCRIPTION
This PR adds the HI-style isolation to the pp photon sequences. Heavy Ions needs this information during the pp reference run in order to do proper comparisons to PbPb results, where this information will be used for photon ID.

It will add two instances of the HIPhotonIsolation ValueMap, one for "std" photons and another for GED photons to the RECO and AOD event content for pp events.

This PR was suggested by @davidlange6  in the relevant PR for 76X : #12262 
see comment : https://github.com/cms-sw/cmssw/pull/12262#issuecomment-174248822

@richard-cms 
@yenjie
