### PR TITLE
Iso-filter RBX Cluster Cut Retuning

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/HBHEIsolatedNoiseReflagger_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEIsolatedNoiseReflagger_cfi.py
@@ -41,6 +41,8 @@ hbhereco = cms.EDProducer(
     LooseMonoHitEne = cms.double(35.0),
     TightMonoHitEne = cms.double(15.0),
 
+    RBXEneThreshold = cms.double(500.0),
+
     # used by the object validator
     HBThreshold = cms.double(0.7),
     HESThreshold = cms.double(0.8),

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
@@ -161,13 +161,13 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
     // RBX mistag reduction
     bool isLooseIso=false;
     bool isTightIso=false;
-    if( ene>RBXEneThreshold_ ){// New absolute iso-cut for high energy RBX clusters
+    if( ene>RBXEneThreshold_ && ene>0 ){// New absolute iso-cut for high energy RBX clusters
       if( isolhcale<LooseHcalIsol_*RBXEneThreshold_ && isolecale<LooseEcalIsol_*RBXEneThreshold_ && isoltrke<LooseTrackIsol_*RBXEneThreshold_ )
 	isLooseIso=true; 
       if( isolhcale<TightHcalIsol_*RBXEneThreshold_ && isolecale<TightEcalIsol_*RBXEneThreshold_ && isoltrke<TightTrackIsol_*RBXEneThreshold_ )
 	isTightIso=true;
     }
-    if( ene<=RBXEneThreshold_ ){// Old relative iso-cut for low energy RBX clusters
+    if( ene<=RBXEneThreshold_ && ene>0 ){// Old relative iso-cut for low energy RBX clusters
       if( isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ )
 	isLooseIso=true;
       if( isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ )
@@ -189,8 +189,8 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
     double isolhcale=hpds[i].hcalEnergySameTowers()+hpds[i].hcalEnergyNeighborTowers();
     double isolecale=hpds[i].ecalEnergySameTowers();
     double isoltrke=hpds[i].trackEnergySameTowers()+hpds[i].trackEnergyNeighborTowers();
-    if((isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && ((trkfide>LooseHPDEne1_ && nhits>=LooseHPDHits1_) || (trkfide>LooseHPDEne2_ && nhits>=LooseHPDHits2_))) ||
-       (isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ((trkfide>TightHPDEne1_ && nhits>=TightHPDHits1_) || (trkfide>TightHPDEne2_ && nhits>=TightHPDHits2_)))) {
+    if((ene>0 && isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && ((trkfide>LooseHPDEne1_ && nhits>=LooseHPDHits1_) || (trkfide>LooseHPDEne2_ && nhits>=LooseHPDHits2_))) ||
+       (ene>0 && isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ((trkfide>TightHPDEne1_ && nhits>=TightHPDHits1_) || (trkfide>TightHPDEne2_ && nhits>=TightHPDHits2_)))) {
       for(HBHEHitMap::hitmap_const_iterator it=hpds[i].beginHits(); it!=hpds[i].endHits(); ++it)
 	noisehits.insert(it->first);
       //      result=false;
@@ -203,8 +203,8 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
     double isolhcale=dihits[i].hcalEnergySameTowers()+dihits[i].hcalEnergyNeighborTowers();
     double isolecale=dihits[i].ecalEnergySameTowers();
     double isoltrke=dihits[i].trackEnergySameTowers()+dihits[i].trackEnergyNeighborTowers();
-    if((isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && trkfide>0.99*ene && trkfide>LooseDiHitEne_) ||
-       (isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ene>TightDiHitEne_)) {
+    if((ene>0 && isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && trkfide>0.99*ene && trkfide>LooseDiHitEne_) ||
+       (ene>0 && isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ene>TightDiHitEne_)) {
       for(HBHEHitMap::hitmap_const_iterator it=dihits[i].beginHits(); it!=dihits[i].endHits(); ++it)
 	noisehits.insert(it->first);
       //      result=false;
@@ -217,8 +217,8 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
     double isolhcale=monohits[i].hcalEnergySameTowers()+monohits[i].hcalEnergyNeighborTowers();
     double isolecale=monohits[i].ecalEnergySameTowers();
     double isoltrke=monohits[i].trackEnergySameTowers()+monohits[i].trackEnergyNeighborTowers();
-    if((isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && trkfide>0.99*ene && trkfide>LooseMonoHitEne_) ||
-       (isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ene>TightMonoHitEne_)) {
+    if((ene>0 && isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && trkfide>0.99*ene && trkfide>LooseMonoHitEne_) ||
+       (ene>0 && isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ene>TightMonoHitEne_)) {
       for(HBHEHitMap::hitmap_const_iterator it=monohits[i].beginHits(); it!=monohits[i].endHits(); ++it)
 	noisehits.insert(it->first);
       //      result=false;

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
@@ -52,6 +52,8 @@ HBHEIsolatedNoiseReflagger::HBHEIsolatedNoiseReflagger(const edm::ParameterSet& 
   TightDiHitEne_(iConfig.getParameter<double>("TightDiHitEne")),
   LooseMonoHitEne_(iConfig.getParameter<double>("LooseMonoHitEne")),
   TightMonoHitEne_(iConfig.getParameter<double>("TightMonoHitEne")),
+
+  RBXEneThreshold_(iConfig.getParameter<double>("RBXEneThreshold")),
   
   debug_(iConfig.getUntrackedParameter<bool>("debug",true)),
   objvalidator_(iConfig)
@@ -155,8 +157,25 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
     double isolhcale=rbxs[i].hcalEnergySameTowers()+rbxs[i].hcalEnergyNeighborTowers();
     double isolecale=rbxs[i].ecalEnergySameTowers();
     double isoltrke=rbxs[i].trackEnergySameTowers()+rbxs[i].trackEnergyNeighborTowers();
-    if((isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ && ((trkfide>LooseRBXEne1_ && nhits>=LooseRBXHits1_) || (trkfide>LooseRBXEne2_ && nhits>=LooseRBXHits2_))) ||
-       (isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ && ((trkfide>TightRBXEne1_ && nhits>=TightRBXHits1_) || (trkfide>TightRBXEne2_ && nhits>=TightRBXHits2_)))) {
+    // 
+    // RBX mistag reduction
+    bool isLooseIso=false;
+    bool isTightIso=false;
+    if( ene>RBXEneThreshold_ ){// New absolute iso-cut for high energy RBX clusters
+      if( isolhcale<LooseHcalIsol_*RBXEneThreshold_ && isolecale<LooseEcalIsol_*RBXEneThreshold_ && isoltrke<LooseTrackIsol_*RBXEneThreshold_ )
+	isLooseIso=true; 
+      if( isolhcale<TightHcalIsol_*RBXEneThreshold_ && isolecale<TightEcalIsol_*RBXEneThreshold_ && isoltrke<TightTrackIsol_*RBXEneThreshold_ )
+	isTightIso=true;
+    }
+    if( ene<=RBXEneThreshold_ ){// Old relative iso-cut for low energy RBX clusters
+      if( isolhcale/ene<LooseHcalIsol_ && isolecale/ene<LooseEcalIsol_ && isoltrke/ene<LooseTrackIsol_ )
+	isLooseIso=true;
+      if( isolhcale/ene<TightHcalIsol_ && isolecale/ene<TightEcalIsol_ && isoltrke/ene<TightTrackIsol_ )
+	isTightIso=true;
+    }
+    //
+    if((isLooseIso && ((trkfide>LooseRBXEne1_ && nhits>=LooseRBXHits1_) || (trkfide>LooseRBXEne2_ && nhits>=LooseRBXHits2_))) ||
+       (isTightIso && ((trkfide>TightRBXEne1_ && nhits>=TightRBXHits1_) || (trkfide>TightRBXEne2_ && nhits>=TightRBXHits2_)))) {
       for(HBHEHitMap::hitmap_const_iterator it=rbxs[i].beginHits(); it!=rbxs[i].endHits(); ++it)
 	noisehits.insert(it->first);
       //      result=false;

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.h
@@ -52,6 +52,8 @@ class HBHEIsolatedNoiseReflagger : public edm::stream::EDProducer<> {
   double TightDiHitEne_;
   double LooseMonoHitEne_;
   double TightMonoHitEne_;
+
+  double RBXEneThreshold_;
   
   bool debug_;
 


### PR DESCRIPTION
This is a PR to reduce anomalous misID rate of the iso-filter in very energetic (􏰀 ~1 TeV), late showering, neutral jets which could occasionally produce HCAL clusters that are misidentified as “noisy isolated RBX clusters”  due to small corresponding energy deposits in ECAL and very few tracks.
The set of "relative isolation cuts" on the RBX clusters has been turned into a set of "absolute isolation cuts" for clusters with energies greater than 500 GeV. 
This is expected to minimally affect the filter performance, whereas it has been verified to reduce the misID rate by an order of magnitude in 13 TeV QCD events (see tail of attached plot, >~ 1 TeV ).

![dn-15-028_plots___qcd_pt-15to7000_13tev_runiispring15dr74_v14d_dnplotsmaker_filtermetperformance_](https://cloud.githubusercontent.com/assets/1124123/12541189/354335c4-c30b-11e5-9ba7-5d218b22feb2.png)
