### PR TITLE
Process.extend now applies ProcessModifiers last

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -516,6 +516,7 @@ class Process(object):
         self.__dict__['_Process__InExtendCall'] = True
 
         seqs = dict()
+        mods = []
         for name in dir(other):
             #'from XX import *' ignores these, and so should we.
             if name.startswith('_'):
@@ -536,7 +537,7 @@ class Process(object):
             elif isinstance(item,_Unlabelable):
                 self.add_(item)
             elif isinstance(item,ProcessModifier):
-                item.apply(self)
+                mods.append(item)
             elif isinstance(item,ProcessFragment):
                 self.extend(item)
 
@@ -553,6 +554,11 @@ class Process(object):
                 self.__setObjectLabel(newSeq, name)
                 #now put in proper bucket
                 newSeq._place(name,self)
+
+        #apply modifiers now that all names have been added
+        for item in mods:
+            item.apply(self)
+
         self.__dict__['_Process__InExtendCall'] = False
 
     def _dumpConfigNamedList(self,items,typeName,options):

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -164,12 +164,16 @@ SimL1Emulator = cms.Sequence(
 ##
 ## Make changes for Run 2
 ##
-if eras.stage1L1Trigger.isChosen() :
-    from L1Trigger.L1TCalorimeter.L1TCaloStage1_cff import L1TCaloStage1
-    SimL1Emulator.replace( simGctDigis, L1TCaloStage1 )
+def _modifyStage1L1Trigger(process):
+    import L1Trigger.L1TCalorimeter.L1TCaloStage1_cff
+    if not hasattr(process, "L1TCaloStage1"):
+        process.L1TCaloStage1 = L1Trigger.L1TCalorimeter.L1TCaloStage1_cff.L1TCaloStage1
+    process.SimL1Emulator.replace( process.simGctDigis, process.L1TCaloStage1 )
+modifyStage1L1Trigger = eras.stage1L1Trigger.makeProcessModifier(_modifyStage1L1Trigger)
 
 # fastsim doesn't have the technical triggers
-if eras.fastSim.isChosen():
-    for _entry in [SimL1TechnicalTriggers]:
-        SimL1Emulator.remove(_entry)
+def _modifyFastSim(process):
+    for _entry in [process.SimL1TechnicalTriggers]:
+        process.SimL1Emulator.remove(_entry)
+modifyFastSim_SimL1Emulator = eras.fastSim.makeProcessModifier(_modifyFastSim)
 


### PR DESCRIPTION
During an extend call we need to apply all ProcesModifiers at the end of the call. That way if the modifier references an item from the Process we will be sure it has already been attached to the Process.
