### PR TITLE
bug fix: don't run conversion track validation for fastsim

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -444,3 +444,7 @@ tracksValidationTrackingOnly = cms.Sequence(
     tracksValidationSeedSelectorsTrackingOnly +
     trackValidatorsTrackingOnly
 )
+
+if eras.fastSim.isChosen():
+    trackValidatorsStandalone.remove(trackValidatorConversionStandalone)
+    trackValidatorsTrackingOnly.remove(trackValidatorConversionTrackingOnly)


### PR DESCRIPTION
conversion track validation is currently not compatible with fastsim
=> don't run it in the fastsim era
