### PR TITLE
Fixing HGCal Hexagonal Geometry Round 2

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -24,7 +24,7 @@ class HGCalDDDConstants {
 
 public:
 
-  typedef std::array<std::vector<int32_t>, 2> simrecovecs;
+  typedef std::array<std::vector<int32_t>, 2> simrecovecs;  
   
   HGCalDDDConstants(const HGCalParameters* hp, const std::string name);
   ~HGCalDDDConstants();

--- a/Geometry/HGCalCommonData/interface/HGCalGeomParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomParameters.h
@@ -8,6 +8,7 @@
  *  
  *  $Date: 2015/06/25 00:06:50 $
  * \author Sunanda Banerjee, Fermilab <sunanda.banerjee@cern.ch>
+ * \author Lindsey Gray, Fermilab <lagray@fnal.gov> (for fixes)
  *
  */
 
@@ -41,8 +42,8 @@ public:
 private:
   std::vector<double> getDDDArray(const std::string&, const DDsvalues_type&,
 				  int&);
-  std::pair<double,double> cellPosition(const std::map<int,GlobalPoint>& wafers,
-					std::map<int,GlobalPoint>::const_iterator& itrf,
+  std::pair<double,double> cellPosition(const std::vector<GlobalPoint>& wafers,
+					std::vector<GlobalPoint>::const_iterator& itrf,
 					unsigned int num, double rmax,
 					double ymax, double xx, double yy, 
 					unsigned int ncells);

--- a/Geometry/HGCalCommonData/interface/HGCalParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalParameters.h
@@ -9,9 +9,14 @@
 #include <iostream>
 #include <stdint.h>
 
+#include<vector>
+#include<unordered_map>
+
 class HGCalParameters {
 
 public:
+
+  typedef std::vector<std::unordered_map<int32_t,int32_t> > layer_map;
 
   struct hgtrap {
     int           lay;
@@ -97,6 +102,7 @@ public:
   std::vector<double>      boundR_;
   double                   waferR_;
   int                      mode_;
+  layer_map                copiesInLayers_;
 
   COND_SERIALIZABLE;
 };

--- a/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.cc
@@ -255,8 +255,8 @@ void DDHGCalModuleAlgo::positionSensitive(DDLogicalPart& glog, double rin,
 	  if (inc > incm) incm = inc;
 	  if (inr > inrm) inrm = inr;
 	  kount++;
-	  if (std::find(copies.begin(),copies.end(),copy) == copies.end())
-	    copies.push_back(copy);
+	  if ( copies.count(copy) == 0 )
+	    copies.insert(copy);
 #ifdef DebugLog
 	  edm::LogInfo("HGCalGeom") << "DDHGCalModuleAlgo: " 
 				    << name << " number " << copy

--- a/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include "DetectorDescription/Base/interface/DDTypes.h"
 #include "DetectorDescription/Algorithm/interface/DDAlgorithm.h"
+#include <unordered_set>
 
 class DDHGCalModuleAlgo : public DDAlgorithm {
  
@@ -49,7 +50,7 @@ private:
   std::vector<double>      rMaxFront;     //Corresponding rMax's
   std::string              idName;        //Name of the "parent" volume.  
   std::string              idNameSpace;   //Namespace of this and ALL sub-parts
-  std::vector<int>         copies;        //List of copy #'s
+  std::unordered_set<int>  copies;        //List of copy #'s
 };
 
 #endif

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -46,16 +46,17 @@ HGCalDDDConstants::HGCalDDDConstants(const HGCalParameters* hp,
       tot_layers_[simreco] = layersInit((bool)simreco);
       max_modules_layer_[simreco].resize(tot_layers_[simreco]+1);
       for( unsigned int layer = 1; layer <= tot_layers_[simreco]; ++layer ) {
-        max_modules_layer_[simreco][layer] = modulesInit(layer,(bool)simreco);
+        max_modules_layer_[simreco][layer] = modulesInit(layer,(bool)simreco);        
       }
     }
     tot_wafers_ = wafers();
-
+    
     edm::LogInfo("HGCalGeom") << "HGCalDDDConstants initialized for " << name
 			      << " with " << layers(false) << ":" <<layers(true)
 			      << " layers, " << wafers() << " wafers and "
 			      << "maximum of " << maxCells(false) << ":" 
 			      << maxCells(true) << " cells";
+    
 #ifdef DebugLog
     std::cout << "HGCalDDDConstants initialized for " << name << " with " 
 	      << layers(false) << ":" << layers(true) << " layers, " 
@@ -249,7 +250,7 @@ bool HGCalDDDConstants::isValid(int lay, int mod, int cell, bool reco) const {
   } else {
     modmax = modules(lay,reco);
     ok = ((lay > 0 && lay <= (int)(layers(reco))) && 
-	  (mod > 0 && mod <= modmax));
+	  (mod >= 0 && mod <= modmax));
     if (ok) {
       cellmax = (hgpar_->waferTypeT_[mod]==1) ? 
  	(int)(hgpar_->cellFineX_.size()) : (int)(hgpar_->cellCoarseX_.size());
@@ -550,8 +551,9 @@ std::pair<int,int> HGCalDDDConstants::simToReco(int cell, int lay, int mod,
 }
 
 int HGCalDDDConstants::waferFromCopy(int copy) const {
-  int wafer = tot_wafers_;
-  for (int k=0; k<tot_wafers_; ++k) {
+  const int ncopies = hgpar_->waferCopy_.size();
+  int wafer = ncopies;
+  for (int k=0; k<ncopies; ++k) {
     if (copy == hgpar_->waferCopy_[k]) {
       wafer = k;
       break;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -248,13 +248,20 @@ bool HGCalDDDConstants::isValid(int lay, int mod, int cell, bool reco) const {
 	       (mod > 0 && mod <= modmax) &&
 	       (cell >=0 && cell <= cellmax));
   } else {
-    modmax = modules(lay,reco);
-    ok = ((lay > 0 && lay <= (int)(layers(reco))) && 
-	  (mod >= 0 && mod <= modmax));
-    if (ok) {
-      cellmax = (hgpar_->waferTypeT_[mod]==1) ? 
- 	(int)(hgpar_->cellFineX_.size()) : (int)(hgpar_->cellCoarseX_.size());
-      ok = (cell >=0 && cell <=  cellmax);
+    int32_t copyNumber = hgpar_->waferCopy_[mod];
+    
+    
+    ok = ((lay > 0 && lay <= (int)(layers(reco))));
+    if( ok ) {
+      const int32_t lay_idx = reco ? (lay-1)*3 + 1 : lay;
+      const auto& the_modules = hgpar_->copiesInLayers_[lay_idx];
+      auto moditr = the_modules.find(copyNumber);
+      ok = (moditr != the_modules.end());
+      if (ok) {
+        cellmax = (hgpar_->waferTypeT_[mod]==1) ? 
+          (int)(hgpar_->cellFineX_.size()) : (int)(hgpar_->cellCoarseX_.size());
+        ok = (cell >=0 && cell <=  cellmax);
+      }
     }
   }
     
@@ -597,7 +604,8 @@ int HGCalDDDConstants::wafers() const {
   return wafer;
 }
 
-int HGCalDDDConstants::cellHex(double xx, double yy, const double& cellR, 
+int HGCalDDDConstants::cellHex(double xx, double yy, 
+                               const double& cellR, 
 			       const std::vector<double>& posX,
 			       const std::vector<double>& posY) const {
   int num(0);

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -14,6 +14,7 @@
 #include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <unordered_set>
 
 //#define DebugLog
 
@@ -272,7 +273,12 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
   }
 
   // Then wafers
-  std::map<int,GlobalPoint> wafers;
+  // This assumes layers are build starting from 1 (which on 25 Jan 2016, they were)
+  // to ensure that new copy numbers are always added
+  // to the end of the list.
+  std::unordered_set<int>  copies;
+  std::vector<int>         wafer2copy;
+  std::vector<GlobalPoint> wafers;  
   std::string attribute = "Volume";
   DDValue val1(attribute, sdTag2, 0.0);
   DDSpecificsFilter filter1;
@@ -288,7 +294,7 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
 					<< " not found but needed.";
   } else {
     dodet = true;
-    std::vector<std::string> names;
+    std::unordered_set<std::string> names;
     while (dodet) {
       const DDSolid & sol  = fv1.logicalPart().solid();
       std::string name = fv1.logicalPart().name();
@@ -296,21 +302,22 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
       if (isd) {
 	std::vector<int> copy = fv1.copyNumbers();
 	int nsiz = (int)(copy.size());
-	int wafer= (nsiz > 0) ? copy[nsiz-1] : -1;
-	if (wafer == 0) {
+	int wafer= (nsiz > 0) ? copy[nsiz-1] : 0;
+	if (wafer == 0 ) {
 	  edm::LogError("HGCalGeom") << "Funny wafer # " << wafer << " in "
 				     << nsiz << " components";
 	  throw cms::Exception("DDException") << "Funny wafer # " << wafer;
-	} else {
-	  std::map<int,GlobalPoint>::iterator itr = wafers.find(wafer);
-	  if (itr == wafers.end()) { 
+	} else {          
+	  std::unordered_set<int>::iterator itr = copies.find(wafer);
+	  if (itr == copies.end()) {            
+            copies.insert(wafer);            
 	    double xx = k_ScaleFromDDD*fv1.translation().X();
 	    if (std::abs(xx) < 0.001) xx = 0;
 	    double yy = k_ScaleFromDDD*fv1.translation().Y();
 	    if (std::abs(yy) < 0.001) yy = 0;
-	    wafers[wafer] = GlobalPoint(xx,yy,k_ScaleFromDDD*fv1.translation().Z());
-	    std::vector<std::string>::iterator its = std::find(names.begin(),names.end(),name);
-	    if (its == names.end()) {
+            wafer2copy.emplace_back(wafer);
+	    wafers.emplace_back(xx,yy,k_ScaleFromDDD*fv1.translation().Z());
+	    if ( names.count(name) == 0 ) {
 	      const DDPolyhedra & polyhedra = static_cast<DDPolyhedra>(sol);
 	      std::vector<double> zv = polyhedra.zVec();
 	      std::vector<double> rv = polyhedra.rMaxVec();
@@ -323,7 +330,7 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
 	      mytr.dz = dz;           mytr.alpha = 0.0;
 	      mytr.cellSize = waferSize_;
 	      php.fillModule(mytr,false);
-	      names.push_back(name);
+	      names.insert(name);
 	    }
 	  }
 	}
@@ -331,7 +338,7 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
       dodet = fv1.next();
     }
   }
-
+  
   // Finally the cells
   std::map<int,int>         wafertype;
   std::map<int,HGCalGeomParameters::cellParameters> cellsf, cellsc;
@@ -442,15 +449,14 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
   }
 
   double rmin = k_ScaleFromDDD*php.waferR_;
-  for (std::map<int,GlobalPoint>::iterator itr = wafers.begin();
-       itr != wafers.end(); ++itr) {
-    php.waferCopy_.push_back(itr->first);
-    php.waferPosX_.push_back(itr->second.x());
-    php.waferPosY_.push_back(itr->second.y());
-    std::map<int,int>::iterator ktr = wafertype.find(itr->first);
+  for (unsigned i = 0; i < wafer2copy.size(); ++i ) {
+    php.waferCopy_.push_back(wafer2copy[i]);
+    php.waferPosX_.push_back(wafers[i].x());
+    php.waferPosY_.push_back(wafers[i].y());
+    std::map<int,int>::iterator ktr = wafertype.find(wafer2copy[i]);
     int typet = (ktr == wafertype.end()) ? 0 : (ktr->second);
     php.waferTypeT_.push_back(typet);
-    double r = (itr->second).perp();
+    double r = wafers[i].perp();
     int    type(3);
     for (int k=1; k<4; ++k) {
       if ((r+rmin)<=php.boundR_[k]) {
@@ -461,7 +467,7 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
   }
   php.nSectors_ = (int)(php.waferCopy_.size());
 
-  std::map<int,GlobalPoint>::const_iterator itrf = wafers.end();
+  std::vector<GlobalPoint>::const_iterator itrf = wafers.end();
   for (unsigned int i=0; i<cellsf.size(); ++i) {
     std::map<int,HGCalGeomParameters::cellParameters>::iterator itr = cellsf.find(i);
     if (itr == cellsf.end()) {
@@ -738,19 +744,19 @@ std::vector<double> HGCalGeomParameters::getDDDArray(const std::string & str,
 }
 
 std::pair<double,double>
-HGCalGeomParameters::cellPosition(const std::map<int,GlobalPoint>& wafers, 
-				  std::map<int,GlobalPoint>::const_iterator& itrf,
+HGCalGeomParameters::cellPosition(const std::vector<GlobalPoint>& wafers, 
+				  std::vector<GlobalPoint>::const_iterator& itrf,
 				  unsigned int num, double rmax, double ymax, 
 				  double xx, double yy, unsigned int ncells) {
 
   if (itrf == wafers.end()) {
-    for (std::map<int,GlobalPoint>::const_iterator itr = wafers.begin();
+    for (std::vector<GlobalPoint>::const_iterator itr = wafers.begin();
 	 itr != wafers.end(); ++itr) {
-      double dx = std::abs(xx - itr->second.x());
-      double dy = std::abs(yy - itr->second.y());
+      double dx = std::abs(xx - itr->x());
+      double dy = std::abs(yy - itr->y());
       if (dx <= (rmax+0.0001) && dy <= ymax) {
 	double xmax = (dy <= 0.5*ymax) ? rmax : (rmax-(dy-0.5*ymax)/tan(30.0*CLHEP::deg));
-	if ((dx <= (xmax+0.0001)) && ((yy-itr->second.y()>0) || (num<=ncells/2+8))) {
+	if ((dx <= (xmax+0.0001)) && ((yy-itr->y()>0) || (num<=ncells/2+8))) {
 	  itrf = itr;
 	  break;
 	}
@@ -759,9 +765,9 @@ HGCalGeomParameters::cellPosition(const std::map<int,GlobalPoint>& wafers,
   }
   double dx(0), dy(0);
   if (itrf != wafers.end()) {
-    dx = (xx - itrf->second.x());
+    dx = (xx - itrf->x());
     if (std::abs(dx) < 0.001) dx = 0;
-    dy = (yy - itrf->second.y());
+    dy = (yy - itrf->y());
     if (std::abs(dy) < 0.001) dy = 0;
   }
   return std::pair<double,double>(dx,dy);

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -55,11 +55,6 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer,
     //check if it fits
     if (!hgcons_.isValid(layer,wafer,icell,false)) {
       index = 0;
-
-      std::pair<int,int> temp = hgcons_.assignCell(pos.x(),pos.y(),layer,0,false);
-      edm::LogError("HGCSim") << "wafer from copy: " << wafer << ", from assign: " << temp.first << std::endl;
-      edm::LogError("HGCSim") << "cell from copy:  " << icell << ", from assign: " << temp.second << std::endl;
-      
       edm::LogError("HGCSim") << "[HGCNumberingScheme] ID out of bounds :"
                               << " Subdet= " << subdet << " Zside= " << iz
                               << " Layer= " << layer << " Wafer= " << wafer


### PR DESCRIPTION
Continuation of #13038.

This PR fixes a hex wafer numbering bug arising from having used a map to store a list of wafer copy numbers. This meant that wafer indices did not contiguously span a given layer, and that property was assumed elsewhere in the code. This led to numerous out-of-bounds det ids in certain regions of the HGCal.

Part two of the fix was then to realize that "contiguous set of det ids" is not well defined in this geometry since the inner and outer radii are changing in the layers. The valid det ids in each layer are now indexed by a hash map.

The out-of-bounds detids no longer appear even in large samples, but there are a few cases where the sim and reco geometries do not map to each other correctly. That will come in another round of fixes.

@bsunanda
