### PR TITLE
FastSim BugFix : PreMix : fix segfault, fix L1 reco, fix digisim link for muons, fix track validation

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1194,8 +1194,6 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalQIEData* fObject) {
 	    coder.setSlope (capid, range, atof (items [index++].c_str ()));
 	  }
 	}
-	if (items.size()>36)
-	  coder.setQIEIndex(atoi(items[index++].c_str()));
 
 	fObject->addCoder (coder);
 //      }
@@ -1234,8 +1232,6 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalQIEData& fObjec
 	fOutput << buffer;
       }
     }
-    sprintf (buffer, " %2d", coder->qieIndex());
-    fOutput << buffer;
     fOutput << std::endl;
   }
   return true;

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -551,10 +551,8 @@ HcalQIECoder HcalDbHardcode::makeQIECoder (HcalGenericDetId fId) {
 
   // qie8/qie10 attribution - 0/1
   if (fId.genericSubdet() == HcalGenericDetId::HcalGenOuter) {
-    result.setQIEIndex(0);
     slope = 1.0;
-  } else 
-    result.setQIEIndex(1);
+  }
     
   for (unsigned range = 0; range < 4; range++) {
     for (unsigned capid = 0; capid < 4; capid++) {

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -232,19 +232,20 @@ const HcalQIECoder* HcalDbService::getHcalCoder (const HcalGenericDetId& fId) co
 }
 
 const HcalQIEShape* HcalDbService::getHcalShape (const HcalGenericDetId& fId) const {
-  if (mQIEData) {
-    return &mQIEData->getShape (fId);
+  if (mQIEData && mQIETypes) {
+    //currently 3 types of QIEs exist: QIE8, QIE10, QIE11
+    int qieType = mQIETypes->getValues(fId)->getValue();
+    //QIE10 and QIE11 have same shape (ADC ladder)
+    if(qieType>0) qieType = 1;
+    return &mQIEData->getShape(qieType);
   }
   return 0;
 }
 
 const HcalQIEShape* HcalDbService::getHcalShape (const HcalQIECoder *coder) const {
-  if (mQIEData) {
-    return &mQIEData->getShape(coder);
-  }
-  return 0;
+  HcalGenericDetId fId(coder->rawId());
+  return getHcalShape(fId);
 }
-
 
 const HcalElectronicsMap* HcalDbService::getHcalMapping () const {
   return mElectronicsMap;

--- a/CondFormats/HcalObjects/interface/HcalQIECoder.h
+++ b/CondFormats/HcalObjects/interface/HcalQIECoder.h
@@ -20,7 +20,7 @@ class HcalQIEShape;
 
 class HcalQIECoder {
  public:
-  HcalQIECoder (unsigned long fId = 0) : mId (fId), mQIEIndex(0) {}
+  HcalQIECoder (unsigned long fId = 0) : mId (fId) {}
 
   /// ADC [0..127] + capid [0..3] -> fC conversion
   float charge (const HcalQIEShape& fShape, unsigned fAdc, unsigned fCapId) const;
@@ -35,9 +35,6 @@ class HcalQIECoder {
   void setSlope (unsigned fCapId, unsigned fRange, float fValue);
 
   uint32_t rawId () const {return mId;}
-
-  uint32_t qieIndex() const {return mQIEIndex;}
-  void setQIEIndex(uint32_t v) { mQIEIndex=v;}
 
  private:
   uint32_t mId;
@@ -73,7 +70,6 @@ class HcalQIECoder {
   float mSlope31;
   float mSlope32;
   float mSlope33;
-  unsigned int mQIEIndex COND_TRANSIENT;
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalQIEData.h
+++ b/CondFormats/HcalObjects/interface/HcalQIEData.h
@@ -34,8 +34,7 @@ class HcalQIEData: public HcalCondObjectContainer<HcalQIECoder>
   void setupShape();  
   /// get basic shape
   //   const HcalQIEShape& getShape () const {return mShape;}
-   const HcalQIEShape& getShape (DetId fId) const { return mShape[getCoder(fId)->qieIndex()];}
-   const HcalQIEShape& getShape (const HcalQIECoder* coder) const { return mShape[coder->qieIndex()];}
+   const HcalQIEShape& getShape (int qieType) const { return mShape[qieType];}
   /// get QIE parameters
   const HcalQIECoder* getCoder (DetId fId) const { return getValues(fId); }
   // check if data are sorted - remove in the next version

--- a/CondFormats/HcalObjects/interface/HcalQIEShape.h
+++ b/CondFormats/HcalObjects/interface/HcalQIEShape.h
@@ -27,6 +27,7 @@ class HcalQIEShape {
     unsigned tmp = nbins_ == 32 ? (fAdc & 0x1f) : (fAdc & 0x3f) ;
     return   tmp;
   }
+  unsigned nbins() const { return nbins_; }
 
  protected:
  private:

--- a/CondFormats/HcalObjects/src/HcalQIECoder.cc
+++ b/CondFormats/HcalObjects/src/HcalQIECoder.cc
@@ -28,7 +28,7 @@ unsigned HcalQIECoder::adc (const HcalQIEShape& fShape, float fCharge, unsigned 
   // search for the range
   for (unsigned range = 0; range < 4; range++) {
     float qieCharge = fCharge * slope (fCapId, range) + offset (fCapId, range);
-    unsigned nbin   = 32 * (mQIEIndex+1); // it's just 64 = 2*32 !
+    unsigned nbin   = fShape.nbins(); // it's just 64 = 2*32 ! (for QIE10)
     unsigned minBin = nbin * range;
     unsigned maxBin = minBin + nbin - 1;
     float qieChargeMax = fShape.highEdge (maxBin);

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -266,6 +266,9 @@ def OptionsFromItems(items):
         else :
             options.era="fastSim"
 
+    # options incompatible with fastsim
+    if options.fast and not options.scenario == "pp":
+        raise Exception("ERROR: the --option fast is only compatible with the default scenario (--scenario=pp)")
 
     return options
 

--- a/Configuration/Generator/python/Pythia8CUETP8M1Settings_DownVariation_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUETP8M1Settings_DownVariation_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CUETP8M1DownVariationSettingsBlock = cms.PSet(
+    pythia8CUETP8M1DownVariationSettings = cms.vstring(
+        'Tune:pp 14',
+        'Tune:ee 7',
+        'MultipartonInteractions:pT0Ref=2.60468e+00',
+        'MultipartonInteractions:ecmPow=2.5208e-01',
+        'MultipartonInteractions:expPow=1.515108e+00',
+        'ColourReconnection:range=4.200868e+00',
+    )
+)

--- a/Configuration/Generator/python/Pythia8CUETP8M1Settings_UpVariation_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUETP8M1Settings_UpVariation_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CUETP8M1UpVariationSettingsBlock = cms.PSet(
+    pythia8CUETP8M1UpVariationSettings = cms.vstring(
+        'Tune:pp 14',
+        'Tune:ee 7',
+        'MultipartonInteractions:pT0Ref=1.8238e+00',
+        'MultipartonInteractions:ecmPow=2.5208e-01',
+        'MultipartonInteractions:expPow=3.230749e+00',
+        'ColourReconnection:range=7.600778e+00',
+    )
+)

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -619,7 +619,7 @@ FS_PREMIXUP15_PU25_OVERLAY = merge([
         {"-s" : "GEN,SIM,RECOBEFMIX,DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,L1Reco,RECO,HLT:@relval25ns,VALIDATION",
          "--datamix" : "PreMix",
          "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW"%(baseDataSetRelease[8],),
-         "--customise":"SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1"
+         "--customise":"SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput"
          },
         Kby(100,500),step1FastUpg2015Defaults])
 

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -68,4 +68,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -68,4 +68,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,6 +41,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
-
-
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,6 +41,6 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
 

--- a/Configuration/StandardSequences/python/SimL1Emulator_cff.py
+++ b/Configuration/StandardSequences/python/SimL1Emulator_cff.py
@@ -9,5 +9,5 @@ if eras.fastSim.isChosen():
     # consider moving these mods to the HLT configuration
     from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
     loadTriggerDigiAliases()
-    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis
+    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis
     

--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
@@ -7,12 +7,12 @@
  */
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h" 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class RawDataCollectorByLabel: public edm::EDProducer {
+class RawDataCollectorByLabel: public edm::stream::EDProducer<> {
 public:
     
     ///Constructor

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -3,7 +3,7 @@
 #define EventFilter_SiStripRawToDigi_SiStripDigiToRawModule_H
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
@@ -25,7 +25,7 @@ namespace sistrip {
      @brief A plug-in module that takes StripDigis as input from the
      Event and creates an EDProduct comprising a FEDRawDataCollection.
   */
-  class dso_hidden DigiToRawModule final : public edm::EDProducer {
+  class dso_hidden DigiToRawModule final : public edm::stream::EDProducer<> {
   
   public:
   

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -61,7 +61,6 @@ namespace edm {
 
     static std::unique_ptr<edm::OutputModuleCommunicator> createIfNeeded(T* iMod) {
       return std::move(impl::createCommunicatorIfNeeded(iMod));
-      return std::move(std::unique_ptr<edm::OutputModuleCommunicator>{});
     }
 
   private:

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -405,9 +405,9 @@ namespace edm {
 
     if (inputType == "mixingFiles") {
       theInputType = InputType::SecondarySource;
-      impl_->inputFilesSecSource_.push_back(InputFile());
-      newFile = &impl_->inputFilesSecSource_.back();
-      newToken = impl_->inputFilesSecSource_.size() - 1;
+      auto itr = impl_->inputFilesSecSource_.push_back(InputFile());
+      newFile = &(*itr);
+      newToken = itr - impl_->inputFilesSecSource_.begin();
     } else {
       if (inputType == "secondaryFiles") {
         theInputType = InputType::SecondaryFile;

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -9,14 +9,15 @@ hcalDigis = None
 muonDTDigis = None
 muonCSCDigis = None
 muonRPCDigis = None
-gtDigisAliasInfo = None
-gmtDigisAliasInfo = None
+caloStage1LegacyFormatDigis = None
+gtDigis = None
+gmtDigis = None
 
 def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -95,6 +96,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("DTLayerIdDTDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
                     )
                 )
            }
@@ -105,6 +109,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("RPCDetIdRPCDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("RPCDigiSimLinkedmDetSetVector")
                     )
                 )
            }
@@ -115,14 +122,35 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCWireDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM")),
+                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM"),
+                    toProductInstance = cms.string("MuonCSCWireDigi")),
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCStripDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM")
-                    )
+                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM"),
+                    toProductInstance = cms.string("MuonCSCStripDigi")),
+                cms.PSet(
+                    type = cms.string('StripDigiSimLinkedmDetSetVector')
+                    ),
                 )
            }
           )
+    
+    # also sim in case of premixing?
+    caloStage1LegacyFormatDigis = cms.EDAlias(
+        **{ "simCaloStage1LegacyFormatDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
+
 
 def loadTriggerDigiAliases():
 

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -17,7 +17,7 @@ def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -135,7 +135,10 @@ def loadDigiAliases(premix=False):
            }
           )
     
-    # also sim in case of premixing?
+def loadTriggerDigiAliases():
+
+    global gctDigis,gtDigis,gmtDigis,caloStage1LegacyFormatDigis
+
     caloStage1LegacyFormatDigis = cms.EDAlias(
         **{ "simCaloStage1LegacyFormatDigis" :
                 cms.VPSet(
@@ -151,25 +154,34 @@ def loadDigiAliases(premix=False):
                 cms.PSet(type = cms.string("L1GctInternJetDatas")),
                 cms.PSet(type = cms.string("L1GctJetCands")))})
 
-
-def loadTriggerDigiAliases():
-
-    global gtDigis,gmtDigis
+    gctDigis = cms.EDAlias(
+        **{ "simGctDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
 
     gtDigis = cms.EDAlias(
-        simGtDigis=
-        cms.VPSet(
-            cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")),
-            cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord"))
-            )
-        )
+        **{ "simGtDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GlobalTriggerEvmReadoutRecord")),
+                cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord")),
+                cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")))})
     
 
     gmtDigis = cms.EDAlias (
         simGmtDigis = 
         cms.VPSet(
-            cms.PSet(type = cms.string("L1MuGMTReadoutCollection"))
+            cms.PSet(type = cms.string("L1MuGMTReadoutCollection")),
+            cms.PSet(type = cms.string("L1MuGMTCands"))
             )
         )
     
-

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -265,6 +265,7 @@ for _entry in [FEVTDEBUGEventContent,FEVTSIMEventContent,GENRAWEventContent,FEVT
     _entry.outputCommands.append('drop *_hltIter*_*_*')
     _entry.outputCommands.append('drop *_hlt*Digis_*_*')
     _entry.outputCommands.append('drop *_gmtDigis_*_*')
+    _entry.outputCommands.append('drop *_gctDigis_*_*')
 
 #####################################################################
 #

--- a/FastSimulation/Configuration/python/L1Reco_cff.py
+++ b/FastSimulation/Configuration/python/L1Reco_cff.py
@@ -9,35 +9,6 @@ from L1Trigger.Configuration.L1Reco_cff import l1extraParticles
 # imported into this namespace, i.e. "from <module> import *".
 from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
 
-# some collections have different labels
-def _changeLabelForFastSim( object ) :
-    """
-    Takes an InputTag, changes the first letter of the module label to a capital
-    and adds "sim" in front, e.g. "gctDigid" -> "simGctDigis".
-    This works for both Run 1 and Run 2 collections.
-    """
-    object.moduleLabel="sim"+object.moduleLabel[0].upper()+object.moduleLabel[1:]
-
-_changeLabelForFastSim( l1extraParticles.isolatedEmSource )
-_changeLabelForFastSim( l1extraParticles.nonIsolatedEmSource )
-
-_changeLabelForFastSim( l1extraParticles.centralJetSource )
-_changeLabelForFastSim( l1extraParticles.tauJetSource )
-_changeLabelForFastSim( l1extraParticles.isoTauJetSource )
-_changeLabelForFastSim( l1extraParticles.forwardJetSource )
-
-_changeLabelForFastSim( l1extraParticles.etTotalSource )
-_changeLabelForFastSim( l1extraParticles.etHadSource )
-_changeLabelForFastSim( l1extraParticles.htMissSource )
-_changeLabelForFastSim( l1extraParticles.etMissSource )
-
-_changeLabelForFastSim( l1extraParticles.hfRingEtSumsSource )
-_changeLabelForFastSim( l1extraParticles.hfRingBitCountsSource )
-
-# This one is subtly different, but is the same for Run 1 and Run 2 FastSim
-l1extraParticles.muonSource = cms.InputTag('simGmtDigis')
-
-
 # must be set to true when used in HLT, as is the case for FastSim
 l1extraParticles.centralBxOnly = True
 

--- a/SimG4Core/Application/test/GeometryProducer_cfg.py
+++ b/SimG4Core/Application/test/GeometryProducer_cfg.py
@@ -2,27 +2,75 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GEOM")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-
-#Geometry
-#
-process.load("Configuration.StandardSequences.Geometry_cff")
-
-#Magnetic Field
+process.load('Configuration.Geometry.GeometryExtended2015_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.Timing = cms.Service("Timing")
+process.Tracer = cms.Service("Tracer")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(0)
+    input = cms.untracked.int32(1)
 )
 process.source = cms.Source("EmptySource")
 
-process.common_heavy_suppression = cms.PSet(
+process.MessageLogger.destinations = cms.untracked.vstring("geomprod.txt")
+
+common_heavy_suppression = cms.PSet(
     NeutronThreshold = cms.double(30.0),
     ProtonThreshold = cms.double(30.0),
     IonThreshold = cms.double(30.0)
 )
+
+common_maximum_time = cms.PSet(
+    MaxTrackTime  = cms.double(500.0),
+    MaxTimeNames  = cms.vstring('ZDCRegion'),
+    MaxTrackTimes = cms.vdouble(2000.0),
+    DeadRegions   = cms.vstring('QuadRegion','InterimRegion'),
+    CriticalEnergyForVacuum = cms.double(2.0),
+    CriticalDensity         = cms.double(1e-15)
+)
+
+common_UsePMT = cms.PSet(
+    UseR7600UPMT  = cms.bool(False)
+)
+
+common_UseHF = cms.PSet(
+    Lambda1       = cms.double(280.0),
+    Lambda2       = cms.double(700.0),
+    Gain          = cms.double(0.33),
+    CheckSurvive  = cms.bool(False),
+    FibreR        = cms.untracked.double(0.3)
+)
+
+common_UseLuminosity = cms.PSet(
+    InstLuminosity  = cms.double(0.),   
+    DelivLuminosity = cms.double(5000.)
+)
+
 process.m = cms.EDProducer("GeometryProducer",
+    UseSensitiveDetectors = cms.bool(True),
+    UseMagneticField = cms.bool(True),
+    MagneticField = cms.PSet(
+        UseLocalMagFieldManager = cms.bool(False),
+        Verbosity = cms.untracked.bool(False),
+        ConfGlobalMFM = cms.PSet(
+            Volume = cms.string('OCMS'),
+            OCMS = cms.PSet(
+                Stepper = cms.string('G4ClassicalRK4'),
+                Type = cms.string('CMSIMField'),
+                StepperParam = cms.PSet(
+                    MaximumEpsilonStep = cms.untracked.double(0.01), ## in mm
+                    DeltaOneStep = cms.double(0.001), ## in mm
+                    MaximumLoopCounts = cms.untracked.double(1000.0),
+                    DeltaChord = cms.double(0.001), ## in mm
+                    MinStep = cms.double(0.1), ## in mm
+                    DeltaIntersectionAndOneStep = cms.untracked.double(-1.0),
+                    DeltaIntersection = cms.double(0.0001), ## in mm
+                    MinimumEpsilonStep = cms.untracked.double(1e-05) ## in mm
+                )
+            )
+        ),
+        delta = cms.double(1.0)
+    ),
     TrackerSD = cms.PSet(
         ZeroEnergyLoss = cms.bool(False),
         PrintHits = cms.bool(False),
@@ -31,14 +79,200 @@ process.m = cms.EDProducer("GeometryProducer",
         EnergyThresholdForPersistencyInGeV = cms.double(0.2),
         EnergyThresholdForHistoryInGeV = cms.double(0.05)
     ),
-    HcalTB06BeamSD = cms.PSet(
-        UseBirkLaw = cms.bool(False),
-        BirkC1 = cms.double(0.013),
-        BirkC3 = cms.double(1.75),
-        BirkC2 = cms.double(0.0568)
+    MuonSD = cms.PSet(
+        EnergyThresholdForPersistency = cms.double(1.0),
+        PrintHits = cms.bool(False),
+        AllMuonsPersistent = cms.bool(True)
+    ),
+    CaloSD = cms.PSet(
+        common_heavy_suppression,
+        SuppressHeavy = cms.bool(False),
+        EminTrack = cms.double(1.0),
+        TmaxHit   = cms.double(1000.0),
+        HCNames   = cms.vstring('EcalHitsEB','EcalHitsEE','EcalHitsES','HcalHits','ZDCHITS'),
+        EminHits  = cms.vdouble(0.015,0.010,0.0,0.0,0.0),
+        EminHitsDepth = cms.vdouble(0.0,0.0,0.0,0.0,0.0),
+        TmaxHits  = cms.vdouble(500.0,500.0,500.0,500.0,2000.0),
+        UseResponseTables = cms.vint32(0,0,0,0,0),
+        BeamPosition      = cms.double(0.0),
+        CorrectTOFBeam    = cms.bool(False),
+        DetailedTiming    = cms.untracked.bool(False),
+        UseMap            = cms.untracked.bool(False),
+        Verbosity         = cms.untracked.int32(0),
+        CheckHits         = cms.untracked.int32(25)
+    ),
+    CaloResponse = cms.PSet(
+        UseResponseTable  = cms.bool(True),
+        ResponseScale     = cms.double(1.0),
+        ResponseFile      = cms.FileInPath('SimG4CMS/Calo/data/responsTBpim50.dat')
+    ),
+    ECalSD = cms.PSet(
+        common_UseLuminosity,
+        UseBirkLaw      = cms.bool(True),
+        BirkL3Parametrization = cms.bool(True),
+        BirkSlope       = cms.double(0.253694),
+        BirkCut         = cms.double(0.1),
+        BirkC1          = cms.double(0.03333),
+        BirkC3          = cms.double(1.0),
+        BirkC2          = cms.double(0.0),
+        SlopeLightYield = cms.double(0.02),
+        StoreSecondary  = cms.bool(False),
+        TimeSliceUnit   = cms.double(1),
+        IgnoreTrackID   = cms.bool(False),
+        XtalMat         = cms.untracked.string('E_PbWO4'),
+        TestBeam        = cms.untracked.bool(False),
+        NullNumbering   = cms.untracked.bool(False),
+        StoreRadLength  = cms.untracked.bool(False),
+        AgeingWithSlopeLY  = cms.untracked.bool(False)
+    ),
+    HCalSD = cms.PSet(
+        common_UseLuminosity,
+        UseBirkLaw          = cms.bool(True),
+        BirkC3              = cms.double(1.75),
+        BirkC2              = cms.double(0.142),
+        BirkC1              = cms.double(0.0052),
+        UseShowerLibrary    = cms.bool(True),
+        UseParametrize      = cms.bool(False),
+        UsePMTHits          = cms.bool(False),
+        UseFibreBundleHits  = cms.bool(False),
+        TestNumberingScheme = cms.bool(False),
+        EminHitHB           = cms.double(0.0),
+        EminHitHE           = cms.double(0.0),
+        EminHitHO           = cms.double(0.0),
+        EminHitHF           = cms.double(0.0),
+        BetaThreshold       = cms.double(0.7),
+        TimeSliceUnit       = cms.double(1),
+        IgnoreTrackID       = cms.bool(False),
+        HEDarkening         = cms.bool(False),
+        HFDarkening         = cms.bool(False),
+        UseHF               = cms.untracked.bool(True),
+        ForTBH2             = cms.untracked.bool(False),
+        UseLayerWt          = cms.untracked.bool(False),
+        WtFile              = cms.untracked.string('None')
+    ),
+    CaloTrkProcessing = cms.PSet(
+        TestBeam   = cms.bool(False),
+        EminTrack  = cms.double(0.01),
+        PutHistory = cms.bool(False)
+    ),
+    HFShower = cms.PSet(
+        common_UsePMT,
+        common_UseHF,
+        ProbMax           = cms.double(1.0),
+        CFibre            = cms.double(0.5),
+        PEPerGeV          = cms.double(0.31),
+        TrackEM           = cms.bool(False),
+        UseShowerLibrary  = cms.bool(True),
+        UseHFGflash       = cms.bool(False),
+        EminLibrary       = cms.double(0.0),
+        OnlyLong          = cms.bool(True),
+        LambdaMean        = cms.double(350.0),
+        ApplyFiducialCut  = cms.bool(True),
+        RefIndex          = cms.double(1.459),
+        Aperture          = cms.double(0.33),
+        ApertureTrapped   = cms.double(0.22),
+        CosApertureTrapped= cms.double(0.5),
+        SinPsiMax         = cms.untracked.double(0.5),
+        ParametrizeLast   = cms.untracked.bool(False)
+    ),
+    HFShowerLibrary = cms.PSet(
+        FileName        = cms.FileInPath('SimG4CMS/Calo/data/HFShowerLibrary_oldpmt_noatt_eta4_16en_v3.root'),
+        BackProbability = cms.double(0.2),
+        TreeEMID        = cms.string('emParticles'),
+        TreeHadID       = cms.string('hadParticles'),
+        Verbosity       = cms.untracked.bool(False),
+        ApplyFiducialCut= cms.bool(True),
+        BranchPost      = cms.untracked.string(''),
+        BranchEvt       = cms.untracked.string(''),
+        BranchPre       = cms.untracked.string('')
+    ),
+    HFShowerPMT = cms.PSet(
+        common_UsePMT,
+        common_UseHF,
+        PEPerGeVPMT       = cms.double(1.0),
+        RefIndex          = cms.double(1.52),
+        Aperture          = cms.double(0.99),
+        ApertureTrapped   = cms.double(0.22),
+        CosApertureTrapped= cms.double(0.5),
+        SinPsiMax         = cms.untracked.double(0.5)
+    ),
+    HFShowerStraightBundle = cms.PSet(
+        common_UsePMT,
+        common_UseHF,
+        FactorBundle      = cms.double(1.0),
+        RefIndex          = cms.double(1.459),
+        Aperture          = cms.double(0.33),
+        ApertureTrapped   = cms.double(0.22),
+        CosApertureTrapped= cms.double(0.5),
+        SinPsiMax         = cms.untracked.double(0.5)
+    ),
+    HFShowerConicalBundle = cms.PSet(
+        common_UsePMT,
+        common_UseHF,
+        FactorBundle      = cms.double(1.0),
+        RefIndex          = cms.double(1.459),
+        Aperture          = cms.double(0.33),
+        ApertureTrapped   = cms.double(0.22),
+        CosApertureTrapped= cms.double(0.5),
+        SinPsiMax         = cms.untracked.double(0.5)
+    ),
+    HFGflash = cms.PSet(
+        BField          = cms.untracked.double(3.8),
+        WatcherOn       = cms.untracked.bool(True),
+        FillHisto       = cms.untracked.bool(True)
+    ),
+    CastorSD = cms.PSet(
+        useShowerLibrary               = cms.bool(True),
+        minEnergyInGeVforUsingSLibrary = cms.double(1.0),
+        nonCompensationFactor          = cms.double(0.817),
+        Verbosity                      = cms.untracked.int32(0)
+    ),
+    CastorShowerLibrary =  cms.PSet(
+        FileName  = cms.FileInPath('SimG4CMS/Forward/data/CastorShowerLibrary_CMSSW500_Standard.root'),
+        BranchEvt = cms.untracked.string('hadShowerLibInfo.'),
+        BranchEM  = cms.untracked.string('emParticles.'),
+        BranchHAD = cms.untracked.string('hadParticles.'),
+        Verbosity = cms.untracked.bool(False)
+    ),
+    BHMSD = cms.PSet(
+         Verbosity = cms.untracked.int32(0)
+    ),
+    FastTimerSD = cms.PSet(
+        Verbosity = cms.untracked.int32(0)
+    ),
+    HGCSD = cms.PSet(
+        Verbosity        = cms.untracked.int32(0),
+        TimeSliceUnit    = cms.double(1),
+        IgnoreTrackID    = cms.bool(False),
+        EminHit          = cms.double(0.0),
+        CheckID          = cms.untracked.bool(True),
+    ),
+    TotemSD = cms.PSet(
+        Verbosity = cms.untracked.int32(0)
+    ),
+    ZdcSD = cms.PSet(
+        Verbosity = cms.int32(0),
+        UseShowerLibrary = cms.bool(True),
+        UseShowerHits = cms.bool(False),
+        FiberDirection = cms.double(45.0),
+        ZdcHitEnergyCut = cms.double(10.0)
+    ),
+    ZdcShowerLibrary = cms.PSet(
+        Verbosity = cms.untracked.int32(0)
     ),
     FP420SD = cms.PSet(
         Verbosity = cms.untracked.int32(2)
+    ),
+    BscSD = cms.PSet(
+        Verbosity = cms.untracked.int32(0)
+    ),
+    PltSD = cms.PSet(
+        EnergyThresholdForPersistencyInGeV = cms.double(0.2),
+        EnergyThresholdForHistoryInGeV = cms.double(0.05)
+    ),
+    Bcm1fSD = cms.PSet(
+        EnergyThresholdForPersistencyInGeV = cms.double(0.010),
+        EnergyThresholdForHistoryInGeV = cms.double(0.005)
     ),
     HcalTB02SD = cms.PSet(
         UseBirkLaw = cms.untracked.bool(False),
@@ -46,122 +280,19 @@ process.m = cms.EDProducer("GeometryProducer",
         BirkC3 = cms.untracked.double(1.75),
         BirkC2 = cms.untracked.double(0.0568)
     ),
-    HFShower = cms.PSet(
-        ProbMax         = cms.double(0.7268),
-        CFibre          = cms.double(0.5),
-        PEPerGeV        = cms.double(0.25),
-        TrackEM         = cms.bool(False),
-        UseShowerLibrary= cms.bool(False),
-        UseR7600UPMT    = cms.bool(False),
-        EminLibrary     = cms.double(5.0),
-        RefIndex        = cms.double(1.459),
-        Lambda1         = cms.double(280.0),
-        Lambda2         = cms.double(700.0),
-        Aperture        = cms.double(0.33),
-        ApertureTrapped = cms.double(0.22),
-        Gain            = cms.double(0.33),
-        CheckSurvive    = cms.bool(False)
-    ),
-    HFShowerLibrary = cms.PSet(
-        FileName        = cms.FileInPath('SimG4CMS/Calo/data/hfshowerlibrary_lhep_140_edm.root'),
-        BackProbability = cms.double(0.2),
-        TreeEMID        = cms.string('emParticles'),
-        TreeHadID       = cms.string('hadParticles'),
-        Verbosity       = cms.untracked.bool(False),
-        BranchPost      = cms.untracked.string('_R.obj'),
-        BranchEvt       = cms.untracked.string('HFShowerLibraryEventInfos_hfshowerlib_HFShowerLibraryEventInfo'),
-        BranchPre       = cms.untracked.string('HFShowerPhotons_hfshowerlib_')
-    ),
-    HFShowerPMT = cms.PSet(
-        PEPerGeVPMT     = cms.double(1.0),
-        RefIndex        = cms.double(1.52),
-        Lambda1         = cms.double(280.0),
-        Lambda2         = cms.double(700.0),
-        Aperture        = cms.double(0.66),
-        ApertureTrapped = cms.double(0.22),
-        Gain            = cms.double(0.33),
-        CheckSurvive    = cms.bool(False)
-    ),
-    MagneticField = cms.PSet(
-        delta = cms.double(1.0)
-    ),
-    ECalSD = cms.PSet(
-        TestBeam = cms.untracked.bool(False),
-        BirkL3Parametrization = cms.bool(True),
-        BirkCut = cms.double(0.1),
-        BirkC1 = cms.double(0.03333),
-        BirkC3 = cms.double(1.0),
-        BirkC2 = cms.double(0.0),
-        SlopeLightYield = cms.double(0.02),
-        UseBirkLaw = cms.bool(True),
-        BirkSlope = cms.double(0.253694)
-    ),
-    ZdcSD = cms.PSet(
-        Verbosity = cms.int32(0),
-        FiberDirection = cms.double(0.0)
-    ),
-    UseSensitiveDetectors = cms.bool(True),
     EcalTBH4BeamSD = cms.PSet(
         UseBirkLaw = cms.bool(False),
         BirkC1 = cms.double(0.013),
         BirkC3 = cms.double(1.75),
         BirkC2 = cms.double(0.0568)
     ),
-    CastorSD = cms.PSet(
-        Verbosity = cms.untracked.int32(0)
-    ),
-    BscSD = cms.PSet(
-        Verbosity = cms.untracked.int32(0)
-    ),
-    TotemSD = cms.PSet(
-        Verbosity = cms.untracked.int32(0)
-    ),
-    MuonSD = cms.PSet(
-        EnergyThresholdForPersistency = cms.double(1.0),
-        PrintHits = cms.bool(False),
-        AllMuonsPersistent = cms.bool(False)
-    ),
-    HCalSD = cms.PSet(
-        BetaThreshold = cms.double(0.7),
-        TestNumberingScheme = cms.bool(False),
-        UsePMTHits = cms.bool(False),
-        UseParametrize = cms.bool(False),
-        ForTBH2 = cms.untracked.bool(False),
-        WtFile = cms.untracked.string('None'),
-        UseHF = cms.untracked.bool(True),
-        UseLayerWt = cms.untracked.bool(False),
-        UseShowerLibrary = cms.bool(True),
-        EminHitHB = cms.double(0.0),
-        EminHitHE = cms.double(0.0),
-        EminHitHO = cms.double(0.0),
-        EminHitHF = cms.double(0.0),
+    HcalTB06BeamSD = cms.PSet(
+        UseBirkLaw = cms.bool(False),
+        BirkC1 = cms.double(0.013),
         BirkC3 = cms.double(1.75),
-        BirkC2 = cms.double(0.142),
-        BirkC1 = cms.double(0.0052),
-        UseBirkLaw = cms.bool(True)
-    ),
-    CaloTrkProcessing = cms.PSet(
-        TestBeam = cms.bool(False),
-        EminTrack = cms.double(0.01)
-    ),
-    CaloSD = cms.PSet(
-        process.common_heavy_suppression,
-        SuppressHeavy = cms.bool(False),
-        DetailedTiming = cms.untracked.bool(False),
-        Verbosity = cms.untracked.int32(0),
-        CheckHits = cms.untracked.int32(25),
-        BeamPosition = cms.untracked.double(0.0),
-        CorrectTOFBeam = cms.untracked.bool(False),
-        UseMap = cms.untracked.bool(True),
-        EminTrack = cms.double(1.0),
-        TmaxHit   = cms.double(1000.0),
-        TmaxHits  = cms.vdouble(1000.0,1000.0,1000.0,1000.0),
-	HCNames   = cms.vstring('EcalHitsEB','EcalHitsEE','EcalHitsES','HcalHits'),
-        EminHits  = cms.vdouble(0.0,0.0,0.0,0.0)
-    ),
-    UseMagneticField = cms.bool(True)
+        BirkC2 = cms.double(0.0568)
+    )
 )
 
 process.p1 = cms.Path(process.m)
-
 

--- a/SimG4Core/CheckSecondary/interface/CheckSecondary.h
+++ b/SimG4Core/CheckSecondary/interface/CheckSecondary.h
@@ -1,7 +1,6 @@
 #ifndef SimG4Core_CheckSecondary_CheckSecondary_H
 #define SimG4Core_CheckSecondary_CheckSecondary_H
 
-#include "SimG4Core/CheckSecondary/interface/TreatSecondary.h"
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
@@ -20,6 +19,8 @@ class G4Step;
 class BeginOfEvent;
 class BeginOfTrack;
 class EndOfEvent;
+class TreatSecondary;
+class ProcessTypeEnumerator;
 
 class CheckSecondary : public SimWatcher,
 		       public Observer<const BeginOfEvent *>, 

--- a/SimG4Core/CheckSecondary/interface/StoreSecondary.h
+++ b/SimG4Core/CheckSecondary/interface/StoreSecondary.h
@@ -1,7 +1,6 @@
 #ifndef SimG4Core_CheckSecondary_StoreSecondary_H
 #define SimG4Core_CheckSecondary_StoreSecondary_H
 
-#include "SimG4Core/CheckSecondary/interface/TreatSecondary.h"
 #include "SimG4Core/Watcher/interface/SimProducer.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,6 +14,7 @@
 class G4Step;
 class BeginOfEvent;
 class BeginOfTrack;
+class TreatSecondary;
 
 class StoreSecondary : public SimProducer,
 		       public Observer<const BeginOfEvent *>, 

--- a/SimG4Core/CheckSecondary/interface/TreatSecondary.h
+++ b/SimG4Core/CheckSecondary/interface/TreatSecondary.h
@@ -1,7 +1,6 @@
 #ifndef SimG4Core_CheckSecondary_TreatSecondary_H
 #define SimG4Core_CheckSecondary_TreatSecondary_H
 
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
@@ -12,6 +11,7 @@
 
 class G4Step;
 class G4Track;
+class G4ProcessTypeEnumerator;
 
 class TreatSecondary {
 

--- a/SimG4Core/CheckSecondary/src/CheckSecondary.cc
+++ b/SimG4Core/CheckSecondary/src/CheckSecondary.cc
@@ -1,4 +1,6 @@
 #include "SimG4Core/CheckSecondary/interface/CheckSecondary.h"
+#include "SimG4Core/CheckSecondary/interface/TreatSecondary.h"
+#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimG4Core/CheckSecondary/src/StoreSecondary.cc
+++ b/SimG4Core/CheckSecondary/src/StoreSecondary.cc
@@ -1,4 +1,5 @@
 #include "SimG4Core/CheckSecondary/interface/StoreSecondary.h"
+#include "SimG4Core/CheckSecondary/interface/TreatSecondary.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -10,7 +11,6 @@
 
 #include "G4Step.hh"
 #include "G4Track.hh"
-#include "G4VProcess.hh"
 #include "G4HCofThisEvent.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
@@ -26,7 +26,6 @@ StoreSecondary::StoreSecondary(const edm::ParameterSet &p) {
 
   produces<std::vector<math::XYZTLorentzVector> >("SecondaryMomenta");
   produces<std::vector<int> >("SecondaryParticles");
-  //  produces<std::vector<std::string> >("SecondaryProcesses");
 
   edm::LogInfo("CheckSecondary") << "Instantiate StoreSecondary to store "
 				 << "secondaries after 1st hadronic inelastic"
@@ -47,17 +46,12 @@ void StoreSecondary::produce(edm::Event& e, const edm::EventSetup&) {
   *secNumber = nsecs;
   e.put(secNumber, "SecondaryParticles");
 
-  /*
-  std::auto_ptr<std::vector<std::string> > secProc(new std::vector<std::string>);
-  *secProc = procs;
-  e.put(secProc, "SecondaryProcesses");
-  */
-
   LogDebug("CheckSecondary") << "StoreSecondary:: Event " << e.id() << " with "
 			     << nsecs.size() << " hadronic collisions with "
 			     << "secondaries produced in each step";
-  for (unsigned int i= 0; i < nsecs.size(); i++) 
+  for (unsigned int i= 0; i < nsecs.size(); i++) {
     LogDebug("CheckSecondary") << " " << nsecs[i] << " from " << procs[i];
+  }
   LogDebug("CheckSecondary") << " and " << secondaries.size() << " secondaries"
 			     << " produced in the first interactions:";
   for (unsigned int i= 0; i < secondaries.size(); i++) 
@@ -94,7 +88,7 @@ void StoreSecondary::update(const G4Step * aStep) {
 								       deltaE,
 								       charge);
   if (hadrInt) {
-    nHad++;
+    ++nHad;
     if (storeIt) {
       int sec = (int)(tracks.size());
       nsecs.push_back(sec);

--- a/SimG4Core/CheckSecondary/src/TreatSecondary.cc
+++ b/SimG4Core/CheckSecondary/src/TreatSecondary.cc
@@ -1,4 +1,5 @@
 #include "SimG4Core/CheckSecondary/interface/TreatSecondary.h"
+#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -62,7 +63,7 @@ std::vector<math::XYZTLorentzVector> TreatSecondary::tracks(const G4Step*aStep,
   std::vector<math::XYZTLorentzVector> secondaries;
   charges.clear();
 
-  if (aStep != NULL) {
+  if (aStep != nullptr) {
     const G4TrackVector* tkV  = aStep->GetSecondary();
     G4Track* thTk = aStep->GetTrack();
     const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
@@ -70,93 +71,56 @@ std::vector<math::XYZTLorentzVector> TreatSecondary::tracks(const G4Step*aStep,
     double eTrackNew = thTk->GetKineticEnergy()/MeV;
     deltaE = eTrack-eTrackNew;
     eTrack = eTrackNew;
-    if (tkV != 0) {
-      int nsc  = (*tkV).size();
-      const G4VProcess*  proc = 0;
-      if (postStepPoint) proc = postStepPoint->GetProcessDefinedStep();
-      procid = typeEnumerator->processIdLong(proc);
-      G4ProcessType type   = fNotDefined;
-      if (proc) {
-	type = proc->GetProcessType();
+    if (tkV != nullptr && postStepPoint != nullptr) {
+      int nsc = (*tkV).size();
+      const G4VProcess*  proc = postStepPoint->GetProcessDefinedStep(); 
+      if (proc != nullptr) {
+	G4ProcessType type = proc->GetProcessType();
+	procid = typeEnumerator->processIdLong(proc);
 	name = proc->GetProcessName();
-      }
-      int           sec   = nsc - nsecL;
-      LogDebug("CheckSecondary") << sec << " secondaries in step " 
-				 << thTk->GetCurrentStepNumber() 
-				 << " of track "  << thTk->GetTrackID() 
-				 << " from " << name << " of type " 
-				 << type << " ID " << procid << " (" 
-				 << typeEnumerator->processG4Name(procid) 
-				 << ")"; 
+	int sec = nsc - nsecL;
+	LogDebug("CheckSecondary") << sec << " secondaries in step " 
+				   << thTk->GetCurrentStepNumber() 
+				   << " of track "  << thTk->GetTrackID() 
+				   << " from " << name << " of type " 
+				   << type << " ID " << procid << " (" 
+				   << typeEnumerator->processG4Name(procid) 
+				   << ")"; 
 
-      G4TrackStatus state = thTk->GetTrackStatus();
-      if (state == fAlive || state == fStopButAlive) sec++;
-
-      if (type == fHadronic || type == fPhotolepton_hadron || type == fDecay) {
-	if (deltaE > minDeltaE || sec > 1) {
-	  hadrInt = true;
-	  nHad++;
+	// hadronic interaction
+        if(procid >= 121 && procid <= 151) {
+	  LogDebug("CheckSecondary") << "Hadronic Interaction " << nHad
+				     << " of Type " << procid << " with "
+				     << sec << " secondaries from process "
+				     << proc->GetProcessName() << " Delta E "
+				     << deltaE << " Flag " << hadrInt;
+	  math::XYZTLorentzVector secondary;
+	  for (int i=nsecL; i<nsc; ++i) {
+	    G4Track*      tk = (*tkV)[i];
+	    G4ThreeVector pp = tk->GetMomentum();
+	    double        ee = tk->GetTotalEnergy();
+	    secondary = math::XYZTLorentzVector(pp.x(),pp.y(),pp.z(),ee);
+	    secondaries.push_back(secondary);
+	    int           charge = (int)(tk->GetDefinition()->GetPDGCharge());
+	    charges.push_back(charge);
+	  }
+	  if (verbosity > 0) {
+	    for (int i=nsecL; i<nsc; i++) {
+	      G4Track* tk = (*tkV)[i];
+	      LogDebug("CheckSecondary") << "Secondary: " << sec << " ID " 
+					 << tk->GetTrackID() << " Status " 
+					 << tk->GetTrackStatus() << " Particle " 
+					 << tk->GetDefinition()->GetParticleName()
+					 << " Position "  << tk->GetPosition()
+					 << " KE " << tk->GetKineticEnergy() 
+					 << " Time " << tk->GetGlobalTime();
+	    }
+	  }
 	}
-	LogDebug("CheckSecondary") << "Hadronic Interaction " << nHad
-				   << " of Type " << type << " with "
-				   << sec << " secondaries from process "
-				   << proc->GetProcessName() << " Delta E "
-				   << deltaE << " Flag " << hadrInt;
+	nsecL = nsc;
       }
-      if (hadrInt) {
-	math::XYZTLorentzVector secondary;
-	if (state == fAlive || state == fStopButAlive) {
-	  G4ThreeVector pp    = postStepPoint->GetMomentum();
-	  double        ee    = postStepPoint->GetTotalEnergy();
-	  secondary = math::XYZTLorentzVector(pp.x(),pp.y(),pp.z(),ee);
-	  secondaries.push_back(secondary);
-	  int           charge = (int)(postStepPoint->GetCharge());
-	  charges.push_back(charge);
-	}
-	for (int i=nsecL; i<nsc; i++) {
-	  G4Track*      tk = (*tkV)[i];
-	  G4ThreeVector pp = tk->GetMomentum();
-	  double        ee = tk->GetTotalEnergy();
-	  secondary = math::XYZTLorentzVector(pp.x(),pp.y(),pp.z(),ee);
-	  secondaries.push_back(secondary);
-	  int           charge = (int)(tk->GetDefinition()->GetPDGCharge());
-	  charges.push_back(charge);
-	}
-      }
-      
-      if (killAfter >= 0 && nHad >= killAfter)
-	thTk->SetTrackStatus(fStopAndKill);
-
-      if (verbosity > 0) {
-	sec = 0;
-	if (state == fAlive || state == fStopButAlive) {
-	  sec++;
-	  LogDebug("CheckSecondary") << "Secondary: " << sec << " ID " 
-				     << thTk->GetTrackID() << " Status " 
-				     << thTk->GetTrackStatus() << " Particle " 
-				     <<thTk->GetDefinition()->GetParticleName()
-				     << " Position "
-				     << postStepPoint->GetPosition() << " KE " 
-				     << postStepPoint->GetKineticEnergy() 
-				     << " Time " 
-				     << postStepPoint->GetGlobalTime();
-	}
-	for (int i=nsecL; i<nsc; i++) {
-	  sec++;
-	  G4Track* tk = (*tkV)[i];
-	  LogDebug("CheckSecondary") << "Secondary: " << sec << " ID " 
-				     << tk->GetTrackID() << " Status " 
-				     << tk->GetTrackStatus() << " Particle " 
-				     << tk->GetDefinition()->GetParticleName()
-				     << " Position "  << tk->GetPosition()
-				     << " KE " << tk->GetKineticEnergy() 
-				     << " Time " << tk->GetGlobalTime();
-	}
-      }
-      nsecL  = nsc;
     }
-
-    if (verbosity > 1)
+    if (verbosity > 1) {
       LogDebug("CheckSecondary") << "Track: " << thTk->GetTrackID() 
 				 << " Status " << thTk->GetTrackStatus()
 				 << " Particle " 
@@ -169,6 +133,7 @@ std::vector<math::XYZTLorentzVector> TreatSecondary::tracks(const G4Step*aStep,
 				 << aStep->GetStepLength()<< " Energy Deposit "
 				 << aStep->GetTotalEnergyDeposit()/MeV
 				 << " MeV; Interaction " << hadrInt;
+    }
   }
   return secondaries;
 }

--- a/SimG4Core/GFlash/interface/ParametrisedPhysics.h
+++ b/SimG4Core/GFlash/interface/ParametrisedPhysics.h
@@ -22,10 +22,12 @@ class ParametrisedPhysics : public G4VPhysicsConstructor
 
  private:
   edm::ParameterSet theParSet;
-  GflashEMShowerModel *theEMShowerModel;
-  GflashEMShowerModel *theHadShowerModel;
-  GflashHadronShowerModel *theHadronShowerModel;
-
+  struct ThreadPrivate {
+    GflashEMShowerModel *theEMShowerModel;
+    GflashEMShowerModel *theHadShowerModel;
+    GflashHadronShowerModel *theHadronShowerModel;
+  };
+  static G4ThreadLocal ThreadPrivate* tpdata;    
 };
 
 #endif

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -8,13 +8,12 @@
 #include "G4SystemOfUnits.hh"
 
 using namespace std;
-const vector<double> * DDG4SolidConverter::par_ = 0; 
+const vector<double> * DDG4SolidConverter::par_ = nullptr; 
 
 DDG4SolidConverter::DDG4SolidConverter()
 {
    // could also be done 'dynamically' from outside 
    // would then need to have a 'register' method ...
-  par_=0;
   convDispatch_[ddbox]            = DDG4SolidConverter::box; 
   convDispatch_[ddtubs]           = DDG4SolidConverter::tubs;
   convDispatch_[ddtrap]           = DDG4SolidConverter::trap;
@@ -46,7 +45,7 @@ G4VSolid * DDG4SolidConverter::convert(const DDSolid & s)
     edm::LogError("SimG4CoreGeometry") <<" DDG4SolidConverter::convert(..) found an undefined DDSolid " << s.toString();
     throw cms::Exception("SimG4CoreGeometry", "DDG4SolidConverter::convert(..) found an undefined DDSolid " + s.toString());
   }
-   G4VSolid * result = 0;
+   G4VSolid * result = nullptr;
    par_ = &(s.parameters());
    map<DDSolidShape,FNPTR>::iterator it = convDispatch_.find(s.shape());
    if (it != convDispatch_.end()) {

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -1,15 +1,14 @@
 #ifndef SimG4Core_GeometryProducer_H
 #define SimG4Core_GeometryProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-// #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
- 
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
@@ -19,29 +18,30 @@
 #include <memory>
 
 namespace sim { class FieldBuilder; }
+
 class SimWatcher;
 class SimProducer;
 class DDDWorld;
 class G4RunManagerKernel;
 class SimTrackManager;
 
-class GeometryProducer : public edm::EDProducer
+class GeometryProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns>
 {
 public:
     typedef std::vector<std::shared_ptr<SimProducer> > Producers;
+
     explicit GeometryProducer(edm::ParameterSet const & p);
-//    virtual ~GeometryProducer();
-//    virtual void beginJob();
-//    virtual void endJob();
-//    virtual void produce(edm::Event & e, const edm::EventSetup & c);
     virtual ~GeometryProducer() override;
-    void produce(edm::Event & e, const edm::EventSetup & c);
+    virtual void beginRun(const edm::Run & r,const edm::EventSetup& c) override;
+    virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override;
+    virtual void produce(edm::Event & e, const edm::EventSetup & c) override;
     void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
    
     std::vector<std::shared_ptr<SimProducer> > producers() const
     { return m_producers; }
     std::vector<SensitiveTkDetector*>& sensTkDetectors() { return m_sensTkDets; }
     std::vector<SensitiveCaloDetector*>& sensCaloDetectors() { return m_sensCaloDets; }
+
 private:
 
     void updateMagneticField( edm::EventSetup const& es );

--- a/SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h
@@ -57,9 +57,6 @@ class HadronPhysicsQGSPCMS_FTFP_BERT : public G4VPhysicsConstructor
 
       G4AntiBarionBuilder     *theAntiBaryon;
       G4FTFPAntiBarionBuilder *theFTFPAntiBaryon;
-
-      G4VCrossSectionDataSet * xsNeutronInelasticXS;
-      G4VCrossSectionDataSet * xsNeutronCaptureXS;
     };
     static G4ThreadLocal ThreadPrivate* tpdata;    
 };

--- a/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
@@ -236,12 +236,4 @@ void CMSEmNoDeltaRay::ConstructProcess() {
   // ApplyCuts
   //
   opt.SetApplyCuts(true);
-
-  // Physics tables
-  //
-  opt.SetMinEnergy(100.*eV);
-  opt.SetMaxEnergy(10.*TeV);
-  opt.SetDEDXBinning(77);
-  opt.SetLambdaBinning(77);
-
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -124,28 +124,19 @@ void CMSEmStandardPhysics95::ConstructParticle() {
 
 void CMSEmStandardPhysics95::ConstructProcess() 
 {
-  // Add standard EM Processes
-  /*
-  G4Region* reg = 0;
-  if (region != " ") {
-    G4RegionStore* regStore = G4RegionStore::GetInstance();
-    reg = regStore->GetRegion(region, true);
-  }
-  */
-
   // This EM builder takes default models of Geant4 10 EMV.
   // Multiple scattering by Urban for all particles
 
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
-  G4MuPairProduction* mup = new G4MuPairProduction();
-  G4hBremsstrahlung*  pib = new G4hBremsstrahlung();
-  G4hPairProduction*  pip = new G4hPairProduction();
-  G4hBremsstrahlung*  kb  = new G4hBremsstrahlung();
-  G4hPairProduction*  kp  = new G4hPairProduction();
-  G4hBremsstrahlung*  pb  = new G4hBremsstrahlung();
-  G4hPairProduction*  pp  = new G4hPairProduction();
+  G4MuBremsstrahlung* mub = nullptr;
+  G4MuPairProduction* mup = nullptr;
+  G4hBremsstrahlung* pib = nullptr;
+  G4hPairProduction* pip = nullptr;
+  G4hBremsstrahlung* kb = nullptr;
+  G4hPairProduction* kp = nullptr;
+  G4hBremsstrahlung* pb = nullptr;
+  G4hPairProduction* pp = nullptr;
 
   G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
 
@@ -194,6 +185,10 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "mu+" ||
                particleName == "mu-"    ) {
 
+      if(nullptr == mub) {
+	mub = new G4MuBremsstrahlung();
+	mup = new G4MuPairProduction();
+      }
       G4MuMultipleScattering* msc = new G4MuMultipleScattering();
       ph->RegisterProcess(msc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
@@ -214,6 +209,10 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "pi+" || 
 	       particleName == "pi-" ) {
 
+      if(nullptr == pib) {
+	pib = new G4hBremsstrahlung();
+	pip = new G4hPairProduction();
+      }
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
@@ -222,6 +221,10 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "kaon+" ||
                particleName == "kaon-" ) {
 
+      if(nullptr == kb) {
+	kb = new G4hBremsstrahlung();
+	kp = new G4hPairProduction();
+      }
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
@@ -230,6 +233,10 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "proton" || 
 	       particleName == "anti_proton") {
 
+      if(nullptr == pb) {
+	pb = new G4hBremsstrahlung();
+	pp = new G4hPairProduction();
+      }
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);
@@ -275,7 +282,6 @@ void CMSEmStandardPhysics95::ConstructProcess()
   //
   G4EmProcessOptions opt;
   opt.SetVerbose(verbose);
-  //  opt.SetPolarAngleLimit(CLHEP::pi);
   // ApplyCuts
   //
   opt.SetApplyCuts(true);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -125,16 +125,15 @@ void CMSEmStandardPhysicsLPM::ConstructParticle() {
 void CMSEmStandardPhysicsLPM::ConstructProcess() 
 {
   // Add standard EM Processes
-
   // muon & hadron bremsstrahlung and pair production
-  G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
-  G4MuPairProduction* mup = new G4MuPairProduction();
-  G4hBremsstrahlung* pib = new G4hBremsstrahlung();
-  G4hPairProduction* pip = new G4hPairProduction();
-  G4hBremsstrahlung* kb = new G4hBremsstrahlung();
-  G4hPairProduction* kp = new G4hPairProduction();
-  G4hBremsstrahlung* pb = new G4hBremsstrahlung();
-  G4hPairProduction* pp = new G4hPairProduction();
+  G4MuBremsstrahlung* mub = nullptr;
+  G4MuPairProduction* mup = nullptr;
+  G4hBremsstrahlung* pib = nullptr;
+  G4hPairProduction* pip = nullptr;
+  G4hBremsstrahlung* kb = nullptr;
+  G4hPairProduction* kp = nullptr;
+  G4hBremsstrahlung* pb = nullptr;
+  G4hPairProduction* pp = nullptr;
 
   G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
 
@@ -190,6 +189,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
     } else if (particleName == "mu+" ||
                particleName == "mu-"    ) {
 
+      if(nullptr == mub) {
+	mub = new G4MuBremsstrahlung();
+	mup = new G4MuPairProduction();
+      }
       G4MuMultipleScattering* mumsc = new G4MuMultipleScattering();
       mumsc->AddEmModel(0, new G4WentzelVIModel());
       pmanager->AddProcess(mumsc,                     -1, 1, 1);
@@ -208,6 +211,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
     } else if (particleName == "pi+" ||
 	       particleName == "pi-" ) {
 
+      if(nullptr == pib) {
+	pib = new G4hBremsstrahlung();
+	pip = new G4hPairProduction();
+      }
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
       pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
       pmanager->AddProcess(pib,   -1,-3, 3);
@@ -216,6 +223,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
     } else if (particleName == "kaon+" ||
 	       particleName == "kaon-"  ) {
 
+      if(nullptr == kb) {
+	kb = new G4hBremsstrahlung();
+	kp = new G4hPairProduction();
+      }
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
       pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
       pmanager->AddProcess(kb,   -1,-3, 3);
@@ -224,6 +235,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
     } else if (particleName == "proton" || 
 	       particleName == "anti_proton" ) {
 
+      if(nullptr == pb) {
+	pb = new G4hBremsstrahlung();
+	pp = new G4hPairProduction();
+      }
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
       pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
       pmanager->AddProcess(pb,   -1,-3, 3);
@@ -265,10 +280,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
   //
   G4EmProcessOptions opt;
   opt.SetVerbose(verbose);
-
   // muon scattering
   opt.SetPolarAngleLimit(CLHEP::pi);
-
   // ApplyCuts
   //
   opt.SetApplyCuts(true);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -138,24 +138,20 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
   // muon & hadron bremsstrahlung and pair production
-  G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
-  G4MuPairProduction* mup = new G4MuPairProduction();
-  G4hBremsstrahlung* pib = new G4hBremsstrahlung();
-  G4hPairProduction* pip = new G4hPairProduction();
-  G4hBremsstrahlung* kb = new G4hBremsstrahlung();
-  G4hPairProduction* kp = new G4hPairProduction();
-  G4hBremsstrahlung* pb = new G4hBremsstrahlung();
-  G4hPairProduction* pp = new G4hPairProduction();
+  G4MuBremsstrahlung* mub = nullptr;
+  G4MuPairProduction* mup = nullptr;
+  G4hBremsstrahlung* pib = nullptr;
+  G4hPairProduction* pip = nullptr;
+  G4hBremsstrahlung* kb = nullptr;
+  G4hPairProduction* kp = nullptr;
+  G4hBremsstrahlung* pb = nullptr;
+  G4hPairProduction* pp = nullptr;
 
   // muon & hadron multiple scattering
-  G4MuMultipleScattering* mumsc = new G4MuMultipleScattering();
-  mumsc->AddEmModel(0, new G4WentzelVIModel());
-  G4MuMultipleScattering* pimsc = new G4MuMultipleScattering();
-  pimsc->AddEmModel(0, new G4WentzelVIModel());
-  G4MuMultipleScattering* kmsc = new G4MuMultipleScattering();
-  kmsc->AddEmModel(0, new G4WentzelVIModel());
-  G4MuMultipleScattering* pmsc = new G4MuMultipleScattering();
-  pmsc->AddEmModel(0, new G4WentzelVIModel());
+  G4MuMultipleScattering* mumsc = nullptr;
+  G4MuMultipleScattering* pimsc = nullptr;
+  G4MuMultipleScattering* kmsc = nullptr;
+  G4MuMultipleScattering* pmsc = nullptr;
   G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
 
   // high energy limit for e+- scattering models and bremsstrahlung
@@ -232,6 +228,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     } else if (particleName == "mu+" ||
                particleName == "mu-" ) {
 
+      if(nullptr == mub) {
+	mub = new G4MuBremsstrahlung();
+	mup = new G4MuPairProduction();
+	mumsc = new G4MuMultipleScattering();
+	mumsc->AddEmModel(0, new G4WentzelVIModel());
+      }
       ph->RegisterProcess(mumsc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
       ph->RegisterProcess(mub, particle);
@@ -241,7 +243,6 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     } else if (particleName == "alpha" || 
 	       particleName == "He3" ) {
 
-      //ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
@@ -253,7 +254,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     } else if (particleName == "pi+" || 
 	       particleName == "pi-" ) {
 
-      //G4hMultipleScattering* pimsc = new G4hMultipleScattering();
+      if(nullptr == pib) {
+	pib = new G4hBremsstrahlung();
+	pip = new G4hPairProduction();
+	pimsc = new G4MuMultipleScattering();
+	pimsc->AddEmModel(0, new G4WentzelVIModel());
+      }
       ph->RegisterProcess(pimsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
@@ -263,18 +269,27 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     } else if (particleName == "kaon+" ||
                particleName == "kaon-" ) {
 
-      //G4hMultipleScattering* kmsc = new G4hMultipleScattering();
+      if(nullptr == kb) {
+	kb = new G4hBremsstrahlung();
+	kp = new G4hPairProduction();
+	kmsc = new G4MuMultipleScattering();
+	kmsc->AddEmModel(0, new G4WentzelVIModel());
+      }
       ph->RegisterProcess(kmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
       ph->RegisterProcess(kp, particle);
       ph->RegisterProcess(new G4CoulombScattering(), particle);
 
-      //    } else if (particleName == "proton" ) {
     } else if (particleName == "proton" ||
 	       particleName == "anti_proton") {
 
-      //G4hMultipleScattering* pmsc = new G4hMultipleScattering();
+      if(nullptr == pb) {
+	pb = new G4hBremsstrahlung();
+	pp = new G4hPairProduction();
+	pmsc = new G4MuMultipleScattering();
+	pmsc->AddEmModel(0, new G4WentzelVIModel());
+      }
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);

--- a/SimG4Core/PhysicsLists/src/HadronPhysicsQGSPCMS_FTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/src/HadronPhysicsQGSPCMS_FTFP_BERT.cc
@@ -20,7 +20,7 @@
 #include "G4SystemOfUnits.hh"
 
 G4ThreadLocal HadronPhysicsQGSPCMS_FTFP_BERT::ThreadPrivate* 
-HadronPhysicsQGSPCMS_FTFP_BERT::tpdata = 0;
+HadronPhysicsQGSPCMS_FTFP_BERT::tpdata = nullptr;
 
 HadronPhysicsQGSPCMS_FTFP_BERT::HadronPhysicsQGSPCMS_FTFP_BERT(G4int)
   :  G4VPhysicsConstructor("hInelasticQGSPCMS_FTFP_BERT")
@@ -29,8 +29,8 @@ HadronPhysicsQGSPCMS_FTFP_BERT::HadronPhysicsQGSPCMS_FTFP_BERT(G4int)
 void HadronPhysicsQGSPCMS_FTFP_BERT::CreateModels()
 {
   // First transition, between BERT and FTF/P
-  G4double minFTFP= 6.0 * GeV;     // Was 9.5 for LEP   (in FTFP_BERT 6.0 * GeV);
-  G4double maxBERT= 8.0 * GeV;     // Was 9.9 for LEP   (in FTFP_BERT 8.0 * GeV);
+  G4double minFTFP= 6.0 * GeV;  
+  G4double maxBERT= 8.0 * GeV;  
   // Second transition, between FTF/P and QGS/P
   G4double minQGSP= 12.0 * GeV;
   G4double maxFTFP= 25.0 * GeV; 
@@ -94,6 +94,7 @@ void HadronPhysicsQGSPCMS_FTFP_BERT::CreateModels()
 
 HadronPhysicsQGSPCMS_FTFP_BERT::~HadronPhysicsQGSPCMS_FTFP_BERT()
 {
+  if(nullptr != tpdata) {
    delete tpdata->theQGSPNeutron;
    delete tpdata->theFTFPNeutron;
    delete tpdata->theBertiniNeutron;
@@ -112,11 +113,10 @@ HadronPhysicsQGSPCMS_FTFP_BERT::~HadronPhysicsQGSPCMS_FTFP_BERT()
    delete tpdata->theHyperon;
    delete tpdata->theAntiBaryon;
    delete tpdata->theFTFPAntiBaryon;
-
-   delete tpdata->xsNeutronInelasticXS;
-   delete tpdata->xsNeutronCaptureXS; 
    
    delete tpdata;
+   tpdata = nullptr;
+  }
 }
 
 void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructParticle()
@@ -137,7 +137,7 @@ void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructParticle()
 #include "G4ProcessManager.hh"
 void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructProcess()
 {
-  if ( tpdata == 0 ) tpdata = new ThreadPrivate;
+  if ( tpdata == nullptr ) { tpdata = new ThreadPrivate; }
   CreateModels();
   tpdata->theNeutrons->Build();
   tpdata->thePro->Build();
@@ -146,11 +146,10 @@ void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructProcess()
   tpdata->theAntiBaryon->Build(); 
 
   // --- Neutrons ---
-  tpdata->xsNeutronInelasticXS = new G4NeutronInelasticXS();  
   G4PhysListUtil::FindInelasticProcess(G4Neutron::Neutron())
-    ->AddDataSet(tpdata->xsNeutronInelasticXS);
+    ->AddDataSet(new G4NeutronInelasticXS());
 
-  G4HadronicProcess* capture = 0;
+  G4HadronicProcess* capture = nullptr;
   G4ProcessManager* pmanager = G4Neutron::Neutron()->GetProcessManager();
   G4ProcessVector*  pv = pmanager->GetProcessList();
   for ( size_t i=0; i < static_cast<size_t>(pv->size()); ++i ) {
@@ -162,8 +161,7 @@ void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructProcess()
     capture = new G4HadronCaptureProcess("nCapture");
     pmanager->AddDiscreteProcess(capture);
   }
-  tpdata->xsNeutronCaptureXS = new G4NeutronCaptureXS();
-  capture->AddDataSet(tpdata->xsNeutronCaptureXS);
+  capture->AddDataSet(new G4NeutronCaptureXS());
   capture->RegisterMe(new G4NeutronRadCapture());
 }
 

--- a/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
+++ b/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
@@ -4,14 +4,10 @@ def customiseForPreMixingInput(process):
     from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
 
     # Replace TrackingParticles and TrackingVertices globally
-    for s in process.paths_().keys():
-        massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True) 
-
-    for s in process.endpaths_().keys():
-        massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True)
-
-    
-
+    # only apply on validation and dqm: we don't want to apply this in the mixing and digitization sequences
+    for s in process.paths_().keys() + process.endpaths_().keys():
+        if s.lower().find("validation")>= 0 or s.lower().find("dqm") >= 0:
+            massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True) 
 
     # Replace Pixel/StripDigiSimLinks only for the known modules
     def replaceInputTag(tag, old, new):
@@ -64,7 +60,6 @@ def customiseForPreMixingInput(process):
         if analyzer.type_() == "SiStripRecHitsValid":
             replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
             replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-
 
 
 

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -1,6 +1,7 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Utilities/StorageFactory/interface/StorageMaker.h"
 #include "Utilities/StorageFactory/interface/StorageMakerFactory.h"
@@ -83,7 +84,12 @@ public:
     XrdCl::URL url(fullpath);
     XrdCl::FileSystem fs(url);
     std::vector<std::string> fileList; fileList.push_back(url.GetPath());
-    fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, &m_null_handler);
+    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, &m_null_handler);
+    if (!status.IsOK())
+    {
+        edm::LogWarning("StageInError") << "XrdCl::FileSystem::Prepare failed with error '"
+                                        << status.ToStr() << "' (errNo = " << status.errNo << ")";
+    }
   }
 
   virtual bool check (const std::string &proto,

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -99,7 +99,10 @@ SendMonitoringInfo(XrdCl::File &file)
     {
         XrdCl::URL url(lastUrl);
         XrdCl::FileSystem fs(url);
-        fs.SendInfo(jobId, &nullHandler, 30);
+        if (!(fs.SendInfo(jobId, &nullHandler, 30).IsOK()))
+        {
+            edm::LogWarning("XrdAdaptorInternal") << "Failed to send the monitoring information, monitoring ID is " << jobId << ".";
+        }
         edm::LogInfo("XrdAdaptorInternal") << "Set monitoring ID to " << jobId << ".";
     }
 }

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -9,6 +9,7 @@
 
 #include "XrdCl/XrdClFile.hh"
 
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "XrdSource.h"
@@ -321,10 +322,12 @@ Source::handle(std::shared_ptr<ClientRequest> c)
 #ifdef XRD_FAKE_SLOW
     if (m_slow) std::this_thread::sleep_for(std::chrono::milliseconds(XRD_DELAY));
 #endif
+
+    XrdCl::XRootDStatus status;
     if (c->m_into)
     {
         // See notes in ClientRequest definition to understand this voodoo.
-        m_fh->Read(c->m_off, c->m_size, c->m_into, c.get());
+        status = m_fh->Read(c->m_off, c->m_size, c->m_into, c.get());
     }
     else
     {
@@ -335,7 +338,16 @@ Source::handle(std::shared_ptr<ClientRequest> c)
             cl.emplace_back(it.offset(), it.size(), it.data());
         }
         validateList(cl);
-        m_fh->VectorRead(cl, nullptr, c.get());
+        status = m_fh->VectorRead(cl, nullptr, c.get());
+    }
+
+    if (!status.IsOK())
+    {
+        edm::Exception ex(edm::errors::FileReadError);
+        ex << "XrdFile::Read or XrdFile::VectorRead failed with error: '"
+           << status.ToStr() << "' (errNo = " << status.errNo << ")";
+        ex.addContext("Calling Source::handle");
+        throw ex;
     }
 }
 

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -444,3 +444,7 @@ tracksValidationTrackingOnly = cms.Sequence(
     tracksValidationSeedSelectorsTrackingOnly +
     trackValidatorsTrackingOnly
 )
+
+if eras.fastSim.isChosen():
+    trackValidatorsStandalone.remove(trackValidatorConversionStandalone)
+    trackValidatorsTrackingOnly.remove(trackValidatorConversionTrackingOnly)


### PR DESCRIPTION
Lots of fixes in one pr, but they are all entangled
### Fix L1 reco, fix seg fault in premix relvals

FastSim no longer runs
SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1
because it overwrites modification defined in the fastsim era and the run2 eras

New EDAlias for caloStage1LegacyFormatDigis to make the l1extraParticles function properly.

Note: FullSim still runs SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1 in the DIGI step.
At some point also FullSim should move away from this.
### Fix digi-sim links for muons

FastSim now runs
SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput
This customisation function should not affect anything but validation and dqm,
and the customisation function was modified accordingly.
Note: FullSim had never trouble with this because there the customisation function is only applied on the RECO,VALIDATION,DQM jobs.
### Fix track validation

Thanks to SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput, the tracking particle collection should now include PU tracks
