### PR TITLE
Get rid of postLS1 customisation function for premixing

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -619,7 +619,6 @@ FS_PREMIXUP15_PU25_OVERLAY = merge([
         {"-s" : "GEN,SIM,RECOBEFMIX,DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,L1Reco,RECO,HLT:@relval25ns,VALIDATION",
          "--datamix" : "PreMix",
          "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW"%(baseDataSetRelease[8],),
-         "--customise":"SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1"
          },
         Kby(100,500),step1FastUpg2015Defaults])
 
@@ -879,12 +878,12 @@ digiPremixUp2015Defaults25ns = {
     '--eventcontent' : 'FEVTDEBUGHLT',
     '--datatier'     : 'GEN-SIM-DIGI-RAW-HLTDEBUG',
     '--datamix'      : 'PreMix',
-    '--customise'    : 'SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1' 
+    '--era'          : 'Run2_25ns'
     }
 digiPremixUp2015Defaults50ns=merge([{'-s':'DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval50ns'},
                                     {'--conditions':'auto:run2_mc_'+autoHLT['relval50ns']},
                                     {'--pileup_input' : 'das:/RelValPREMIXUP15_PU50/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[6]},
-                                    {'--customise': 'SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1_50ns'},
+                                    {'--era'          : 'Run2_50ns'},
                                     digiPremixUp2015Defaults25ns])
 steps['DIGIPRMXUP15_PU25']=merge([digiPremixUp2015Defaults25ns])
 steps['DIGIPRMXUP15_PU50']=merge([digiPremixUp2015Defaults50ns])

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -9,14 +9,15 @@ hcalDigis = None
 muonDTDigis = None
 muonCSCDigis = None
 muonRPCDigis = None
-gtDigisAliasInfo = None
-gmtDigisAliasInfo = None
+caloStage1LegacyFormatDigis = None
+gtDigis = None
+gmtDigis = None
 
 def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -95,6 +96,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("DTLayerIdDTDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
                     )
                 )
            }
@@ -105,6 +109,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("RPCDetIdRPCDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("RPCDigiSimLinkedmDetSetVector")
                     )
                 )
            }
@@ -115,14 +122,35 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCWireDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM")),
+                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM"),
+                    toProductInstance = cms.string("MuonCSCWireDigi")),
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCStripDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM")
-                    )
+                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM"),
+                    toProductInstance = cms.string("MuonCSCStripDigi")),
+                cms.PSet(
+                    type = cms.string('StripDigiSimLinkedmDetSetVector')
+                    ),
                 )
            }
           )
+    
+    # also sim in case of premixing?
+    caloStage1LegacyFormatDigis = cms.EDAlias(
+        **{ "simCaloStage1LegacyFormatDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
+
 
 def loadTriggerDigiAliases():
 


### PR DESCRIPTION
The premixing digi step (step2 in matrix workflows) still depends on postLS1 customisation functions
(e.g. runTheMatrix -l 250200,50400). This pr gets rid of that dependence.

postLS1 customisation functions are no longer necessary for premixing:
Indeed, the customisation function in

```
SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
```

takes the following actions
- the deprecated customisePostLS1 function is called. 
  This is now replaced by adding the appropriate era option to the digi step in relval_steps.py
- the customisation function in Configuration/python/muonCustomsPreMixing.py is called
  This function has actually zero effect
  - line 5 is taken care of by the eras
  - line 8 and 9 are redundant (the correct settings are loaded in the premix digi step anyway)
  - line 13,14,17 and 18 have no effect on the digi step

Similar for FastSim.
FastSim premixing required some additional changes.
(part of the bugfix of #13071)

Tests: workflows 250400,250200,500200 run properly.

@mdhildreth 
