### PR TITLE
Allow FileSystem queries to occur from callback threads.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -1005,6 +1005,9 @@ XrdAdaptor::RequestManager::OpenHandler::~OpenHandler()
 void
 XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDStatus *status_ptr, XrdCl::AnyObject *, XrdCl::HostList *hostList_ptr)
 {
+  // Make sure that we set m_outstanding_open to false on exit from this function.
+  std::unique_ptr<char, std::function<void(char*)>> outstanding_guard(nullptr, [&](char*){m_outstanding_open=false;});
+
   std::shared_ptr<Source> source;
   std::unique_ptr<XrdCl::XRootDStatus> status(status_ptr);
   std::unique_ptr<XrdCl::HostList> hostList(hostList_ptr);
@@ -1105,7 +1108,7 @@ XrdAdaptor::RequestManager::OpenHandler::open()
       // and make a call into xrootd (when it invokes m_file.reset()).  Hence, our callback
       // holds our mutex and attempts to grab an Xrootd mutex; RequestManager::requestFailure holds
       // an Xrootd mutex and tries to hold m_mutex.  This is a classic deadlock.
-    if (m_file.get())
+    if (m_outstanding_open)
     {
         return m_shared_future;
     }
@@ -1118,6 +1121,11 @@ XrdAdaptor::RequestManager::OpenHandler::open()
     std::string new_name = manager.m_name + ((manager.m_name.find("?") == manager.m_name.npos) ? "?" : "&") + opaque;
     edm::LogVerbatim("XrdAdaptorInternal") << "Trying to open URL: " << new_name;
     m_file.reset(new XrdCl::File());
+    m_outstanding_open = true;
+
+    // Always make sure we release m_file and set m_outstanding_open to false on error.
+    std::unique_ptr<char, std::function<void(char*)>> exit_guard(nullptr, [&](char*){m_outstanding_open = false; m_file.reset();});
+
     XrdCl::XRootDStatus status;
     if (!(status = m_file->Open(new_name, manager.m_flags, manager.m_perms, this)).IsOK())
     {
@@ -1131,6 +1139,7 @@ XrdAdaptor::RequestManager::OpenHandler::open()
       manager.addConnections(ex);
       throw ex;
     }
+    exit_guard.release();
       // Have a strong self-reference for as long as the callback is in-progress.
     m_self = self_ptr;
     return m_shared_future;

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -257,7 +257,10 @@ private:
         OpenHandler(std::weak_ptr<RequestManager> manager);
         std::shared_future<std::shared_ptr<Source> > m_shared_future;
         std::promise<std::shared_ptr<Source> > m_promise;
-        // When this is not null, there is a file-open in process
+        // Set to true only when there is an outstanding open request; not
+        // protected by m_mutex, so the caller is required to know it is in a
+        // thread-safe context.
+        std::atomic<bool> m_outstanding_open {false};
         // Can only be touched when m_mutex is held.
         std::unique_ptr<XrdCl::File> m_file;
         std::recursive_mutex m_mutex;

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -76,6 +76,110 @@ private:
     std::string m_site;
 };
 
+
+/**
+ * A handler for querying a XrdCl::FileSystem object which is safe to be
+ * invoked from an XrdCl callback (that is, we don't need an available callback
+ * thread to timeout).
+ */
+class QueryAttrHandler : boost::noncopyable, public XrdCl::ResponseHandler
+{
+public:
+
+    virtual ~QueryAttrHandler() {}
+
+
+    static XrdCl::XRootDStatus query(XrdCl::FileSystem &fs, const std::string &attr, std::chrono::milliseconds timeout, std::string &result)
+    {
+        std::shared_ptr<QueryAttrHandler> handler(new QueryAttrHandler());
+        XrdCl::Buffer arg(attr.size());
+        arg.FromString(attr);
+
+        // On error or exception thrown, drop the reference to ourself
+        std::unique_ptr<QueryAttrHandler, std::function<void(QueryAttrHandler*)>> self_ref_guard(nullptr, [&](QueryAttrHandler*) {handler->m_self.reset();});
+        handler->m_self = handler;
+
+        XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Config, arg, handler.get());
+        if (!st.IsOK())
+        {
+            return st;
+        }
+
+        // Successfully registered the callback; keep the self-reference until the
+        // callback release it.
+        self_ref_guard.release();
+
+        std::unique_lock<std::mutex> guard(handler->m_mutex);
+        // Wait until some status is available or a timeout.
+        handler->m_condvar.wait_for(guard, timeout, [&]{return handler->m_status.get();});
+
+        if (handler->m_status)
+        {
+            if (handler->m_status->IsOK())
+            {
+                result = handler->m_response->ToString();
+            }
+            return *(handler->m_status);
+        }
+        else
+        {   // We had a timeout; construct a reasonable message.
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errSocketTimeout, 1, "Timeout when waiting for query callback.");
+        }
+    }
+
+
+private:
+
+    QueryAttrHandler() {}
+
+
+    virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response ) override
+    {
+        // NOTE: we own the status and response pointers.
+        std::unique_ptr<XrdCl::AnyObject> response_mgr;
+        response_mgr.reset(response);
+        // On exit from this function, release the self-reference.  Order matters!  m_self reset must be done after
+        // condvar is notified.
+        std::unique_ptr<char, std::function<void(char*)>> self_ref_guard(nullptr, [&](char *) {m_self.reset();});
+        // On function exit, notify any waiting threads.
+        std::unique_ptr<char, std::function<void(char*)>> notify_guard(nullptr, [&](char *) {m_condvar.notify_all();});
+
+        {
+            // m_mutex protects m_status
+            std::unique_lock<std::mutex> guard(m_mutex);
+            // On exit from the block, make sure m_status is set; it needs to be set before we notify threads.
+            std::unique_ptr<char, std::function<void(char*)>> exit_guard(nullptr, [&](char *) {m_status.reset(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInternal));});
+            if (!status) {return;}
+            m_status.reset(status);
+            if (status->IsOK())
+            {
+                if (!response) {return;}
+                XrdCl::Buffer *buf_ptr;
+                response->Get(buf_ptr);
+                // AnyObject::Set lacks specialization for nullptr
+                response->Set(static_cast<int *>(nullptr));
+                m_response.reset(buf_ptr);
+            }
+            exit_guard.release();
+        }
+    }
+
+
+    // Self-reference; if we timed out waiting for the callback, we must keep the memory alive until
+    // the Xrootd framework invokes the callback.
+    std::shared_ptr<QueryAttrHandler> m_self;
+
+    // Synchronize between the callback thread and the main thread; condvar predicate
+    // is having m_status set.  m_mutex protects m_status.
+    std::mutex m_mutex;
+    std::condition_variable m_condvar;
+
+    // Results from the server
+    std::unique_ptr<XrdCl::XRootDStatus> m_status;
+    std::unique_ptr<XrdCl::Buffer> m_response;
+};
+
+
 Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string &exclude)
     : m_lastDowngrade({0, 0}),
       m_id("(unknown)"),
@@ -238,7 +342,8 @@ Source::getXrootdSiteFromURL(std::string url, std::string &site)
     arg.FromString( attr );
 
     XrdCl::FileSystem fs(url);
-    XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Config, arg, response);
+    std::string rsite;
+    XrdCl::XRootDStatus st = QueryAttrHandler::query(fs, "sitename", std::chrono::seconds(1), rsite);
     if (!st.IsOK())
     {
         XrdCl::URL xurl(url);
@@ -246,9 +351,7 @@ Source::getXrootdSiteFromURL(std::string url, std::string &site)
         delete response;
         return false;
     }
-    std::string rsite = response->ToString();
-    delete response;
-    if (rsite.size() && (rsite[rsite.size()-1] == '\n'))
+    if (!rsite.empty() && (rsite[rsite.size()-1] == '\n'))
     {
         rsite = rsite.substr(0, rsite.size()-1);
     }

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -84,22 +84,22 @@ private:
  */
 class QueryAttrHandler : public XrdCl::ResponseHandler
 {
+    friend std::unique_ptr<QueryAttrHandler> std::make_unique<QueryAttrHandler>();
+
 public:
 
-    virtual ~QueryAttrHandler = default;
+    virtual ~QueryAttrHandler() = default;
     QueryAttrHandler(const QueryAttrHandler&) = delete;
     QueryAttrHandler& operator=(const QueryAttrHandler&) = delete;
 
 
     static XrdCl::XRootDStatus query(XrdCl::FileSystem &fs, const std::string &attr, std::chrono::milliseconds timeout, std::string &result)
     {
-        std::shared_ptr<QueryAttrHandler> handler(new QueryAttrHandler());
+        auto handler = std::make_unique<QueryAttrHandler>();
+        auto l_state = std::make_shared<QueryAttrState>();
+        handler->m_state = l_state;
         XrdCl::Buffer arg(attr.size());
         arg.FromString(attr);
-
-        // On error or exception thrown, drop the reference to ourself
-        std::unique_ptr<QueryAttrHandler, std::function<void(QueryAttrHandler*)>> self_ref_guard(nullptr, [&](QueryAttrHandler*) {handler->m_self.reset();});
-        handler->m_self = handler;
 
         XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Config, arg, handler.get());
         if (!st.IsOK())
@@ -107,21 +107,20 @@ public:
             return st;
         }
 
-        // Successfully registered the callback; keep the self-reference until the
-        // callback release it.
-        self_ref_guard.release();
+        // Successfully registered the callback; it will always delete itself, so we shouldn't.
+        handler.release();
 
-        std::unique_lock<std::mutex> guard(handler->m_mutex);
+        std::unique_lock<std::mutex> guard(l_state->m_mutex);
         // Wait until some status is available or a timeout.
-        handler->m_condvar.wait_for(guard, timeout, [&]{return handler->m_status.get();});
+        l_state->m_condvar.wait_for(guard, timeout, [&]{return l_state->m_status.get();});
 
-        if (handler->m_status)
+        if (l_state->m_status)
         {
-            if (handler->m_status->IsOK())
+            if (l_state->m_status->IsOK())
             {
-                result = handler->m_response->ToString();
+                result = l_state->m_response->ToString();
             }
-            return *(handler->m_status);
+            return *(l_state->m_status);
         }
         else
         {   // We had a timeout; construct a reasonable message.
@@ -140,19 +139,19 @@ private:
         // NOTE: we own the status and response pointers.
         std::unique_ptr<XrdCl::AnyObject> response_mgr;
         response_mgr.reset(response);
-        // On exit from this function, release the self-reference.  Order matters!  m_self reset must be done after
-        // condvar is notified.
-        std::unique_ptr<char, std::function<void(char*)>> self_ref_guard(nullptr, [&](char *) {m_self.reset();});
+
+        // Lock our state information then dispose of our object.
+        auto l_state = m_state.lock();
+        delete this;
+        if (!l_state) {return;}
+
         // On function exit, notify any waiting threads.
-        std::unique_ptr<char, std::function<void(char*)>> notify_guard(nullptr, [&](char *) {m_condvar.notify_all();});
+        std::unique_ptr<char, std::function<void(char*)>> notify_guard(nullptr, [&](char *) {l_state->m_condvar.notify_all();});
 
         {
-            // m_mutex protects m_status
-            std::unique_lock<std::mutex> guard(m_mutex);
             // On exit from the block, make sure m_status is set; it needs to be set before we notify threads.
-            std::unique_ptr<char, std::function<void(char*)>> exit_guard(nullptr, [&](char *) {m_status.reset(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInternal));});
+            std::unique_ptr<char, std::function<void(char*)>> exit_guard(nullptr, [&](char *) {if (!l_state->m_status) l_state->m_status.reset(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInternal));});
             if (!status) {return;}
-            m_status.reset(status);
             if (status->IsOK())
             {
                 if (!response) {return;}
@@ -160,25 +159,28 @@ private:
                 response->Get(buf_ptr);
                 // AnyObject::Set lacks specialization for nullptr
                 response->Set(static_cast<int *>(nullptr));
-                m_response.reset(buf_ptr);
+                l_state->m_response.reset(buf_ptr);
             }
-            exit_guard.release();
+            l_state->m_status.reset(status);
         }
     }
 
 
-    // Self-reference; if we timed out waiting for the callback, we must keep the memory alive until
-    // the Xrootd framework invokes the callback.
-    std::shared_ptr<QueryAttrHandler> m_self;
+    // Represents the current state of the callback.  The parent class only manages a weak_ptr
+    // to the state.  If the asynchronous callback cannot lock the weak_ptr, then it assumes the
+    // main thread has given up and doesn't touch any of the state variables.
+    struct QueryAttrState {
 
-    // Synchronize between the callback thread and the main thread; condvar predicate
-    // is having m_status set.  m_mutex protects m_status.
-    std::mutex m_mutex;
-    std::condition_variable m_condvar;
+        // Synchronize between the callback thread and the main thread; condvar predicate
+        // is having m_status set.  m_mutex protects m_status.
+        std::mutex m_mutex;
+        std::condition_variable m_condvar;
 
-    // Results from the server
-    std::unique_ptr<XrdCl::XRootDStatus> m_status;
-    std::unique_ptr<XrdCl::Buffer> m_response;
+        // Results from the server
+        std::unique_ptr<XrdCl::XRootDStatus> m_status;
+        std::unique_ptr<XrdCl::Buffer> m_response;
+    };
+    std::weak_ptr<QueryAttrState> m_state;
 };
 
 

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -82,11 +82,13 @@ private:
  * invoked from an XrdCl callback (that is, we don't need an available callback
  * thread to timeout).
  */
-class QueryAttrHandler : boost::noncopyable, public XrdCl::ResponseHandler
+class QueryAttrHandler : public XrdCl::ResponseHandler
 {
 public:
 
-    virtual ~QueryAttrHandler() {}
+    virtual ~QueryAttrHandler = default;
+    QueryAttrHandler(const QueryAttrHandler&) = delete;
+    QueryAttrHandler& operator=(const QueryAttrHandler&) = delete;
 
 
     static XrdCl::XRootDStatus query(XrdCl::FileSystem &fs, const std::string &attr, std::chrono::milliseconds timeout, std::string &result)


### PR DESCRIPTION
To query a filesystem property, a free callback thread is needed
with the default synchronous versions of XrdCl::FileSystem methods.

Thus, if the synchronous method is called from a _callback thread_,
then there must be an idle thread to handle the response; if there
are N threads in the pool and N simultaneous queries, then the
filesystem query would cause a deadlock.

Worse yet, the timeout mechanism for XrdCl relies on an idle callback
thread to function.

As making the synchronous query asynchronous in its currrent use case
is quite hard, I only partially solved the problem: wrote a new
response handler that can timeout without an idle thread.

Technically, any version of CMSSW 7_6 or later should be affected.  Pragmatically, do we actually open multiple files simultaneously except in the threaded mixing module?
