### PR TITLE
Make JobReport::inputFileOpened sufficiently thread-safe

### DIFF
--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -405,9 +405,9 @@ namespace edm {
 
     if (inputType == "mixingFiles") {
       theInputType = InputType::SecondarySource;
-      impl_->inputFilesSecSource_.push_back(InputFile());
-      newFile = &impl_->inputFilesSecSource_.back();
-      newToken = impl_->inputFilesSecSource_.size() - 1;
+      auto itr = impl_->inputFilesSecSource_.push_back(InputFile());
+      newFile = &(*itr);
+      newToken = itr - impl_->inputFilesSecSource_.begin();
     } else {
       if (inputType == "secondaryFiles") {
         theInputType = InputType::SecondaryFile;


### PR DESCRIPTION
Now that the mixing module runs multiple threads, we can get multiple threads each calling JobReport::inputFileOpened and trying to open files for the mixing. The code path which is called must be thread safe. Although the container used for this purpose was already thread safe, the way the item in the container was used was not safe.
