### PR TITLE
Update to MVA MET: Fullfills "consumes" call requirement, Bugfix for the calculation of the covariance matrix, updated path to weight files. Same changes as in PR for CMSSW76X

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -16,12 +16,12 @@ PFMETProducerMVA::PFMETProducerMVA(const edm::ParameterSet& cfg)
   srcPFCandidatesView_ = consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
   srcVertices_     = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
   vInputTag srcLeptonsTags = cfg.getParameter<vInputTag>("srcLeptons");
+  consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"));
   for(vInputTag::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
     srcLeptons_.push_back( consumes<reco::CandidateView >( *it ) );
   }
 
   minNumLeptons_   = cfg.getParameter<int>("minNumLeptons");
-  srcRho_          = consumes<edm::Handle<double> >(cfg.getParameter<edm::InputTag>("srcRho"));
 
   globalThreshold_ = cfg.getParameter<double>("globalThreshold");
 

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -16,7 +16,8 @@ PFMETProducerMVA::PFMETProducerMVA(const edm::ParameterSet& cfg)
   srcPFCandidatesView_ = consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
   srcVertices_     = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
   vInputTag srcLeptonsTags = cfg.getParameter<vInputTag>("srcLeptons");
-  consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"));
+  edm::InputTag srcRho = ( cfg.exists("srcRho") ) ? cfg.getParameter<edm::InputTag>("srcRho") : (edm::InputTag("fixedGridRhoFastjetAll"));
+  consumes<double>(srcRho);
   for(vInputTag::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
     srcLeptons_.push_back( consumes<reco::CandidateView >( *it ) );
   }

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -16,19 +16,16 @@ PFMETProducerMVA::PFMETProducerMVA(const edm::ParameterSet& cfg)
   srcPFCandidatesView_ = consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
   srcVertices_     = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
   vInputTag srcLeptonsTags = cfg.getParameter<vInputTag>("srcLeptons");
-  edm::InputTag srcRho = ( cfg.exists("srcRho") ) ? cfg.getParameter<edm::InputTag>("srcRho") : (edm::InputTag("fixedGridRhoFastjetAll"));
-  consumes<double>(srcRho);
   for(vInputTag::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
     srcLeptons_.push_back( consumes<reco::CandidateView >( *it ) );
   }
-
+  mJetCorrector_  = consumes<reco::JetCorrector>(cfg.getParameter<edm::InputTag>("corrector"));
   minNumLeptons_   = cfg.getParameter<int>("minNumLeptons");
 
   globalThreshold_ = cfg.getParameter<double>("globalThreshold");
 
   minCorrJetPt_    = cfg.getParameter<double>     ("minCorrJetPt");
   useType1_        = cfg.getParameter<bool>       ("useType1");
-  correctorLabel_  = cfg.getParameter<std::string>("corrector");
    
   verbosity_ = ( cfg.exists("verbosity") ) ?
     cfg.getParameter<int>("verbosity") : 0;
@@ -74,8 +71,11 @@ void PFMETProducerMVA::produce(edm::Event& evt, const edm::EventSetup& es)
   edm::Handle<reco::PFJetCollection> uncorrJets;
   evt.getByToken(srcUncorrJets_, uncorrJets);
 
-  const JetCorrector* corrector = nullptr;
-  if( useType1_ ) corrector = JetCorrector::getJetCorrector(correctorLabel_, es);
+  edm::Handle<reco::JetCorrector> corrector;
+  if( useType1_ )
+  {
+    evt.getByToken(mJetCorrector_, corrector); 
+  }
   
   edm::Handle<reco::CandidateView> pfCandidates_view;
   evt.getByToken(srcPFCandidatesView_, pfCandidates_view);
@@ -193,10 +193,9 @@ PFMETProducerMVA::computeJetInfo(const reco::PFJetCollection& uncorrJets,
 				 const edm::ValueMap<float>& jetIds,
 				 const reco::VertexCollection& vertices,
 				 const reco::Vertex* hardScatterVertex,
-				 const JetCorrector &iCorrector,edm::Event &iEvent,const edm::EventSetup &iSetup,
+				 const reco::JetCorrector &iCorrector,edm::Event &iEvent,const edm::EventSetup &iSetup,
 				 std::vector<reco::PUSubMETCandInfo> &iLeptons,std::vector<reco::PUSubMETCandInfo> &iCands)
 {
-  const L1FastjetCorrector* lCorrector = dynamic_cast<const L1FastjetCorrector*>(&iCorrector);
   std::vector<reco::PUSubMETCandInfo> retVal;
   for ( reco::PFJetCollection::const_iterator uncorrJet = uncorrJets.begin();
 	uncorrJet != uncorrJets.end(); ++uncorrJet ) {
@@ -222,7 +221,7 @@ PFMETProducerMVA::computeJetInfo(const reco::PFJetCollection& uncorrJets,
       jetInfo.setP4( corrJet->p4() );
       double lType1Corr = 0;
       if(useType1_) { //Compute the type 1 correction ===> This code is crap 
-	double pCorr = lCorrector->correction(*uncorrJet,iEvent,iSetup);
+	double pCorr = iCorrector.correction(*uncorrJet);
 	lType1Corr = std::abs(corrJet->pt()-pCorr*uncorrJet->pt());
 	TLorentzVector pVec; pVec.SetPtEtaPhiM(lType1Corr,0,corrJet->phi(),0); 
 	reco::Candidate::LorentzVector pType1Corr; pType1Corr.SetCoordinates(pVec.Px(),pVec.Py(),pVec.Pz(),pVec.E());

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.h
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.h
@@ -14,38 +14,23 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/Exception.h"
 
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/METReco/interface/CommonMETData.h"
 #include "DataFormats/METReco/interface/PFMET.h"
 #include "DataFormats/METReco/interface/PFMETCollection.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
-#include "DataFormats/TauReco/interface/PFTau.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "JetMETCorrections/Algorithms/interface/L1FastjetCorrector.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 
 #include "RecoMET/METAlgorithms/interface/METAlgo.h"
 #include "RecoMET/METAlgorithms/interface/PFSpecificAlgo.h"
@@ -53,11 +38,6 @@
 #include "RecoMET/METPUSubtraction/interface/MvaMEtUtilities.h"
 
 #include "RecoJets/JetProducers/interface/PileupJetIdAlgo.h"
-
-#include <algorithm>
-#include <vector>
-
-#include "TLorentzVector.h"
 
 namespace reco
 {
@@ -103,7 +83,6 @@ namespace reco
     typedef std::vector<edm::InputTag> vInputTag;
     std::vector<edm::EDGetTokenT<reco::CandidateView > > srcLeptons_;
     int minNumLeptons_; // CV: option to skip MVA MET computation in case there are less than specified number of leptons in the event
-    edm::EDGetTokenT<edm::Handle<double> > srcRho_;
 
     std::string correctorLabel_;
     bool useType1_;

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.h
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.h
@@ -30,7 +30,7 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-#include "JetMETCorrections/Algorithms/interface/L1FastjetCorrector.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 
 #include "RecoMET/METAlgorithms/interface/METAlgo.h"
 #include "RecoMET/METAlgorithms/interface/PFSpecificAlgo.h"
@@ -38,6 +38,7 @@
 #include "RecoMET/METPUSubtraction/interface/MvaMEtUtilities.h"
 
 #include "RecoJets/JetProducers/interface/PileupJetIdAlgo.h"
+#include <TLorentzVector.h>
 
 namespace reco
 {
@@ -60,7 +61,7 @@ namespace reco
 
     std::vector<reco::PUSubMETCandInfo> computeJetInfo(const reco::PFJetCollection&, const edm::Handle<reco::PFJetCollection>&,
 							  const edm::ValueMap<float>&, const reco::VertexCollection&, 
-							  const reco::Vertex*, const JetCorrector &iCorr,
+							  const reco::Vertex*, const reco::JetCorrector &iCorr,
 							  edm::Event & iEvent,const edm::EventSetup &iSetup,
 							  std::vector<reco::PUSubMETCandInfo> &iLeptons,
 							  std::vector<reco::PUSubMETCandInfo> &iCands);
@@ -80,11 +81,11 @@ namespace reco
     //edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidates_;
     edm::EDGetTokenT<edm::View<reco::Candidate> > srcPFCandidatesView_;
     edm::EDGetTokenT<reco::VertexCollection> srcVertices_;
+    edm::EDGetTokenT<reco::JetCorrector> mJetCorrector_;
     typedef std::vector<edm::InputTag> vInputTag;
     std::vector<edm::EDGetTokenT<reco::CandidateView > > srcLeptons_;
     int minNumLeptons_; // CV: option to skip MVA MET computation in case there are less than specified number of leptons in the event
 
-    std::string correctorLabel_;
     bool useType1_;
     
     double globalThreshold_;

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #from RecoMET.METProducers.PFMET_cfi import pfMet
-from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
-from JetMETCorrections.Configuration.DefaultJEC_cff import *
+from JetMETCorrections.Configuration.JetCorrectors_cff import *
 ##from RecoMET.METPUSubtraction.mvaPFMET_leptons_cfi import *
 ## CV: importing mvaPFMET_leptons_cfi breaks produceAndDiscriminateHPSPFTaus sequence
 ##    (hpsPFTauDiscriminationByDecayModeFinding module gets overwritten by None,
@@ -10,11 +9,11 @@ from JetMETCorrections.Configuration.DefaultJEC_cff import *
 ##     by top-level cfg.py file before RecoMET/METPUSubtraction/python/mvaPFMET_cff.py gets loaded)
 ##from RecoJets.JetProducers.PileupJetIDCutParams_cfi import full_53x_wp
 
-calibratedAK4PFJetsForPFMVAMEt = cms.EDProducer('PFJetCorrectionProducer',
+calibratedAK4PFJetsForPFMVAMEt = cms.EDProducer('CorrectedPFJetProducer',
     src = cms.InputTag('ak4PFJets'),
-    correctors = cms.vstring("ak4PFL1FastL2L3") # NOTE: use "ak5PFL1FastL2L3" for MC / "ak5PFL1FastL2L3Residual" for Data
+    correctors = cms.VInputTag("ak4PFL1FastL2L3Corrector") # NOTE: use "ak5PFL1FastL2L3" for MC / "ak5PFL1FastL2L3Residual" for Data
 )
-
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak4PFL1Fastjet
 from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdEvaluator
 from RecoJets.JetProducers.PileupJetIDParams_cfi import JetIdParams
 puJetIdForPFMVAMEt = pileupJetIdEvaluator.clone(
@@ -69,15 +68,13 @@ pfMVAMEt = cms.EDProducer("PFMETProducerMVA",
     srcLeptons = cms.VInputTag(),#"isomuons","isoelectrons","isotaus") # NOTE: you need to set this to collections of electrons, muons and tau-jets
                                  #                                             passing the lepton reconstruction & identification criteria applied in your analysis
     minNumLeptons = cms.int32(0),                     
-    srcRho = cms.InputTag('fixedGridRhoFastjetAll'),
     globalThreshold = cms.double(-1.),#pfMet.globalThreshold,
     minCorrJetPt = cms.double(-1.),
     inputFileNames = cms.PSet(
-        U     = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrmet_7_2_X_MINIAOD_BX25PU20_Mar2015.root'),
-        DPhi  = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrphi_7_2_X_MINIAOD_BX25PU20_Mar2015.root'),
-        CovU1 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru1cov_7_2_X_MINIAOD_BX25PU20_Mar2015.root'),
-        CovU2 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru2cov_7_2_X_MINIAOD_BX25PU20_Mar2015.root')
-    ),
+        U     = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru_7_4_X_miniAOD_25NS_July2015.root'),
+        DPhi  = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrphi_7_4_X_miniAOD_25NS_July2015.root'),
+        CovU1 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru1cov_7_4_X_miniAOD_25NS_July2015.root'),
+        CovU2 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru2cov_7_4_X_miniAOD_25NS_July2015.root') ),
     inputRecords = cms.PSet(
         U     = cms.string("RecoilCor"),
         DPhi  = cms.string("PhiCor"), 

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
@@ -11,7 +11,7 @@ from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
 calibratedAK4PFJetsForPFMVAMEt = cms.EDProducer('CorrectedPFJetProducer',
     src = cms.InputTag('ak4PFJets'),
-    correctors = cms.VInputTag("ak4PFL1FastL2L3Corrector") # NOTE: use "ak5PFL1FastL2L3" for MC / "ak5PFL1FastL2L3Residual" for Data
+    correctors = cms.VInputTag("ak4PFL1FastL2L3Corrector") # NOTE: use "ak4PFL1FastL2L3Corrector" for MC / "ak4PFL1FastL2L3ResidualCorrector" for Data
 )
 from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak4PFL1Fastjet
 from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdEvaluator

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
@@ -83,7 +83,7 @@ pfMVAMEt = cms.EDProducer("PFMETProducerMVA",
     ),
     loadMVAfromDB = cms.bool(False),                             
 
-    corrector = cms.string("ak4PFL1Fastjet"),
+    corrector = cms.InputTag("ak4PFL1FastjetCorrector"),
     useType1  = cms.bool(True), 
     dZcut     = cms.double(0.1),
        

--- a/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
+++ b/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
@@ -224,8 +224,8 @@ void PFMETAlgorithmMVA::evaluateMVA()
   mvaOutputU_     = GetResponse(mvaReaderU_, varForU_);
   var_["RecoilCor_U"] = var_["particleFlow_U"] * mvaOutputU_;
   var_["RecoilCor_UPhi"] = var_["PhiCor_UPhi"];
-  mvaOutputCovU1_ = GetResponse(mvaReaderCovU1_, varForCovU1_)* mvaOutputU_ * var_["particleFlow_U"];
-  mvaOutputCovU2_ = GetResponse(mvaReaderCovU2_, varForCovU2_)* mvaOutputU_ * var_["particleFlow_U"];
+  mvaOutputCovU1_ = std::pow(GetResponse(mvaReaderCovU1_, varForCovU1_)* mvaOutputU_ * var_["particleFlow_U"], 2);
+  mvaOutputCovU2_ = std::pow(GetResponse(mvaReaderCovU2_, varForCovU2_)* mvaOutputU_ * var_["particleFlow_U"], 2);
 
 
   // compute MET(Photon check)

--- a/RecoMET/METPUSubtraction/test/mvaMETOnMiniAOD_cfg.py
+++ b/RecoMET/METPUSubtraction/test/mvaMETOnMiniAOD_cfg.py
@@ -23,7 +23,7 @@ process.maxEvents = cms.untracked.PSet(
 # Input source
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
-    fileNames = cms.untracked.vstring('root://eoscms//eos/cms/store/relval/CMSSW_7_5_0_pre4/RelValZMM_13/MINIAODSIM/PU50ns_MCRUN2_75_V0-v1/00000/66CB72C0-70F8-E411-81DC-002590596468.root'),
+    fileNames = cms.untracked.vstring('/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/DC327D28-D3B8-E511-9FB7-008CFA0A59C0.root '),
                             skipEvents = cms.untracked.uint32(0)         
 )
 


### PR DESCRIPTION
Same commit as this one:
https://github.com/cms-sw/cmssw/pull/13086
