### PR TITLE
Implement propagate_const in the framework

### DIFF
--- a/DataFormats/Common/interface/CloningPtr.h
+++ b/DataFormats/Common/interface/CloningPtr.h
@@ -30,7 +30,7 @@ namespace edm {
   template< class T, class P = ClonePolicy<T> >
   class CloningPtr {
 public:
-    CloningPtr(): ptr_(0) {}
+    CloningPtr(): ptr_(nullptr) {}
     CloningPtr(const T& iPtr) : ptr_(P::clone(iPtr)) {}
     CloningPtr(std::auto_ptr<T> iPtr) : ptr_(iPtr.release()) {}
     CloningPtr(const CloningPtr<T,P>& iPtr) : ptr_(P::clone(*(iPtr.ptr_))) {}
@@ -48,11 +48,11 @@ public:
     ~CloningPtr() { delete ptr_;}
     
     // ---------- const member functions ---------------------
-    T& operator*() const { return *ptr_; }
+    T& operator*() { return *ptr_; }
     
-    T* operator->() const { return ptr_; }
+    T* operator->() { return ptr_; }
     
-    T* get() const { return ptr_; }
+    T* get() { return ptr_; }
     
 private:
     T* ptr_;

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -4,7 +4,6 @@
 #include "DataFormats/Common/interface/BaseHolder.h"
 #include "DataFormats/Common/interface/RefHolderBase.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 #include <memory>
 
@@ -27,7 +26,7 @@ namespace edm {
       // It may be better to use auto_ptr<RefHolderBase> in
       // this constructor, so that the cloning can be avoided. I'm not
       // sure if use of auto_ptr here causes any troubles elsewhere.
-      IndirectHolder() : BaseHolder<T>(), helper_( 0 ) { }
+      IndirectHolder() : BaseHolder<T>(), helper_( nullptr ) { }
       IndirectHolder(std::shared_ptr<RefHolderBase> p);
       template< typename U>
       IndirectHolder(std::unique_ptr<U> p): helper_(p.release()) {}

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -4,7 +4,6 @@
 #include "DataFormats/Common/interface/BaseVectorHolder.h"
 #include "DataFormats/Common/interface/RefVectorHolderBase.h"
 #include "DataFormats/Common/interface/IndirectHolder.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <memory>
 
 namespace edm {
@@ -55,7 +54,7 @@ namespace edm {
 
     private:
       typedef typename base_type::const_iterator_imp const_iterator_imp;
-      RefVectorHolderBase * helper_;
+      RefVectorHolderBase* helper_;
 
     public:
       struct const_iterator_imp_specific : public const_iterator_imp {
@@ -100,7 +99,7 @@ namespace edm {
     };
 
     template <typename T>
-    IndirectVectorHolder<T>::IndirectVectorHolder() : BaseVectorHolder<T>(), helper_( 0 ) { }
+    IndirectVectorHolder<T>::IndirectVectorHolder() : BaseVectorHolder<T>(), helper_( nullptr ) { }
 
     template <typename T>
     IndirectVectorHolder<T>::IndirectVectorHolder(std::shared_ptr<RefVectorHolderBase> p) :

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -9,7 +9,7 @@ is the storage unit of such information.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include <memory>
 
 namespace edm {

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -9,7 +9,6 @@ is the storage unit of such information.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include <memory>
 
 namespace edm {

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -129,13 +129,13 @@ namespace edm {
   template <class T>
   inline
   RefToBase<T>::RefToBase() :
-    holder_(0)
+    holder_(nullptr)
   { }
 
   template <class T>
   inline
   RefToBase<T>::RefToBase(RefToBase const& other) :
-    holder_(other.holder_  ? other.holder_->clone() : 0)
+    holder_(other.holder_  ? other.holder_->clone() : nullptr)
   { }
 
   template <class T>
@@ -234,7 +234,7 @@ namespace edm {
   size_t
   RefToBase<T>::key() const
   {
-    if ( holder_ == 0 )
+    if ( holder_ == nullptr )
 	Exception::throwThis(errors::InvalidReference,
 	  "attempting get key from  null RefToBase;\n"
 	  "You should check for nullity before calling key().");
@@ -370,7 +370,7 @@ namespace edm {
   T const*
   RefToBase<T>::getPtrImpl() const
   {
-    return holder_ ? holder_->getPtr() : 0;
+    return holder_ ? holder_->getPtr() : nullptr;
   }
 
   template <class T>

--- a/DataFormats/Common/interface/RefToBaseVector.h
+++ b/DataFormats/Common/interface/RefToBaseVector.h
@@ -49,8 +49,8 @@ namespace edm {
 
     value_type at(size_type idx) const;
     value_type operator[](size_type idx) const;
-    bool isValid() const { return holder_ != 0; }
-    bool isInvalid() const { return holder_ == 0; }
+    bool isValid() const { return holder_ != nullptr; }
+    bool isInvalid() const { return holder_ == nullptr; }
     bool empty() const;
     size_type size() const;
     //size_type capacity() const;
@@ -72,7 +72,7 @@ namespace edm {
     CMS_CLASS_VERSION(10)
 
   private:
-    holder_type * holder_;
+    holder_type* holder_;
   };
 }
 
@@ -109,7 +109,7 @@ namespace edm {
   template <class T>
   inline
   RefToBaseVector<T>::RefToBaseVector() : 
-    holder_(0) 
+    holder_(nullptr)
   { }
 
   template <class T>
@@ -122,7 +122,7 @@ namespace edm {
   template <class T>
   inline
   RefToBaseVector<T>::RefToBaseVector(const RefToBaseVector<T>& iOther) : 
-    holder_(iOther.holder_ ? iOther.holder_->clone() : 0)
+    holder_(iOther.holder_ ? iOther.holder_->clone() : nullptr)
   { }
 
   template <class T>
@@ -159,7 +159,7 @@ namespace edm {
   typename RefToBaseVector<T>::value_type
   RefToBaseVector<T>::at(size_type idx) const 
   {
-    if ( holder_ == 0 )
+    if ( holder_ == nullptr )
       Exception::throwThis( errors::InvalidReference,
 	"Trying to dereference null RefToBaseVector<T> in method: at(",
 	idx,
@@ -196,7 +196,7 @@ namespace edm {
   void 
   RefToBaseVector<T>::clear()
   {
-    if ( holder_ != 0 )
+    if ( holder_ != nullptr )
       holder_->clear();
   }
 
@@ -213,7 +213,7 @@ namespace edm {
   EDProductGetter const * 
   RefToBaseVector<T>::productGetter() const
   {
-    return holder_ ? holder_->productGetter() : 0;
+    return holder_ ? holder_->productGetter() : nullptr;
   }
 
   template <class T>
@@ -262,7 +262,7 @@ namespace edm {
 
   template <typename T>
   void RefToBaseVector<T>::push_back( const RefToBase<T> & r ) {
-    if ( holder_ == 0 ) {
+    if ( holder_ == nullptr ) {
       std::auto_ptr<reftobase::BaseVectorHolder<T> > p = r.holder_->makeVectorHolder();
       holder_ = p.release();
     }

--- a/DataFormats/Common/test/OwnArray_t.cpp
+++ b/DataFormats/Common/test/OwnArray_t.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "DataFormats/Common/interface/OwnArray.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 
 struct Base

--- a/DataFormats/Common/test/OwnArray_t.cpp
+++ b/DataFormats/Common/test/OwnArray_t.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "DataFormats/Common/interface/OwnArray.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 
 struct Base
@@ -22,7 +23,7 @@ struct Derived : Base
   void swap(Derived& other);
   virtual Derived* clone() const;
 
-  int*  pointer;
+  edm::propagate_const<int*> pointer;
 };
 
 Derived::Derived(int n) : pointer(new int(n)) { }
@@ -48,7 +49,7 @@ void swap(Derived& a, Derived& b)
 
 Derived::~Derived()
 {
-  delete pointer;
+  delete pointer.get();
 }
 
 Derived*

--- a/DataFormats/Common/test/OwnVector_t.cpp
+++ b/DataFormats/Common/test/OwnVector_t.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "DataFormats/Common/interface/OwnVector.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 
 struct Base

--- a/DataFormats/Common/test/OwnVector_t.cpp
+++ b/DataFormats/Common/test/OwnVector_t.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "DataFormats/Common/interface/OwnVector.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 
 struct Base
@@ -22,7 +23,7 @@ struct Derived : Base
   void swap(Derived& other);
   virtual Derived* clone() const;
 
-  int*  pointer;
+  edm::propagate_const<int*> pointer;
 };
 
 Derived::Derived(int n) : pointer(new int(n)) { }
@@ -48,7 +49,7 @@ void swap(Derived& a, Derived& b)
 
 Derived::~Derived()
 {
-  delete pointer;
+  delete pointer.get();
 }
 
 Derived*

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <map>
 #include <memory>
@@ -10,7 +11,7 @@
 class SimpleEDProductGetter : public edm::EDProductGetter {
 public:
 
-  typedef std::map<edm::ProductID, std::shared_ptr<edm::WrapperBase> > map_t;
+  typedef std::map<edm::ProductID, edm::propagate_const<std::shared_ptr<edm::WrapperBase>>> map_t;
 
   template<typename T>
   void

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>

--- a/DataFormats/Common/test/testOwnArray.cc
+++ b/DataFormats/Common/test/testOwnArray.cc
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <iostream>
 #include "DataFormats/Common/interface/OwnArray.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 class testOwnArray : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testOwnArray);
@@ -26,7 +27,7 @@ namespace testOA {
       return value < o.value;
     }
   private:
-    bool * ref;
+    edm::propagate_const<bool*> ref;
   };
 
   struct DummyComp {

--- a/DataFormats/Common/test/testOwnArray.cc
+++ b/DataFormats/Common/test/testOwnArray.cc
@@ -4,7 +4,7 @@
 #include <iterator>
 #include <iostream>
 #include "DataFormats/Common/interface/OwnArray.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 class testOwnArray : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testOwnArray);

--- a/DataFormats/Common/test/testOwnVector.cc
+++ b/DataFormats/Common/test/testOwnVector.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 class testOwnVector : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testOwnVector);
@@ -27,7 +28,7 @@ namespace test {
       return value < o.value;
     }
   private:
-    bool * ref;
+    edm::propagate_const<bool*> ref;
   };
 
   struct DummyComp {

--- a/DataFormats/Common/test/testOwnVector.cc
+++ b/DataFormats/Common/test/testOwnVector.cc
@@ -5,7 +5,7 @@
 #include <iostream>
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 class testOwnVector : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testOwnVector);

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -166,7 +166,7 @@ The interface is too complex for general use.
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/value_ptr.h"
 
 #include <memory>

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -166,6 +166,7 @@ The interface is too complex for general use.
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "FWCore/Utilities/interface/value_ptr.h"
 
 #include <memory>
@@ -1020,7 +1021,7 @@ namespace edm {
         RunNumber_t currentRun_;
         LuminosityBlockNumber_t currentLumi_;
         EntryNumber_t numberOfEvents_;
-        std::shared_ptr<EventFinder> eventFinder_;
+        edm::propagate_const<std::shared_ptr<EventFinder>> eventFinder_;
         std::vector<RunOrLumiIndexes> runOrLumiIndexes_;
         std::vector<EventNumber_t> eventNumbers_;
         std::vector<EventEntry> eventEntries_;
@@ -1042,7 +1043,7 @@ namespace edm {
       void fillRunOrLumiIndexes() const;
 
       void fillUnsortedEventNumbers() const;
-      void resetEventFinder() const {transient_.eventFinder_.reset();}
+      void resetEventFinder() const {transient_.eventFinder_ = nullptr;} // propagate_const<T> has no reset() function
       std::vector<EventEntry>& eventEntries() const {return transient_.eventEntries_;}
       std::vector<EventNumber_t>& eventNumbers() const {return transient_.eventNumbers_;}
       void sortEvents() const;

--- a/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
@@ -54,6 +54,7 @@ ProductRegistry is frozen.
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <iosfwd>
 #include <memory>
@@ -334,9 +335,9 @@ namespace edm {
       ProductHolderIndex index_;
     };
 
-    std::unique_ptr<std::set<Item> > items_;
+    edm::propagate_const<std::unique_ptr<std::set<Item>>> items_;
 
-    std::unique_ptr<std::set<std::string> > processItems_;
+    edm::propagate_const<std::unique_ptr<std::set<std::string>>> processItems_;
   };
 }
 #endif

--- a/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
@@ -54,7 +54,7 @@ ProductRegistry is frozen.
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <iosfwd>
 #include <memory>

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -9,7 +9,7 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "tbb/concurrent_unordered_set.h"
 #include <memory>

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -9,7 +9,7 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "tbb/concurrent_unordered_set.h"
 #include <memory>

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -14,7 +14,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "boost/array.hpp"
 #include <memory>

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -14,6 +14,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "boost/array.hpp"
 #include <memory>
@@ -98,7 +99,8 @@ namespace edm {
 
     bool anyProducts(BranchType const brType) const;
 
-    std::shared_ptr<ProductHolderIndexHelper> const& productLookup(BranchType branchType) const;
+    std::shared_ptr<ProductHolderIndexHelper const> productLookup(BranchType branchType) const;
+    std::shared_ptr<ProductHolderIndexHelper> productLookup(BranchType branchType);
 
     // returns the appropriate ProductHolderIndex else ProductHolderIndexInvalid if no BranchID is available
     ProductHolderIndex indexFrom(BranchID const& iID) const;
@@ -127,14 +129,22 @@ namespace edm {
     struct Transients {
       Transients();
       void reset();
+
+      std::shared_ptr<ProductHolderIndexHelper const> eventProductLookup() const {return get_underlying_safe(eventProductLookup_);}
+      std::shared_ptr<ProductHolderIndexHelper>& eventProductLookup() {return get_underlying_safe(eventProductLookup_);}
+      std::shared_ptr<ProductHolderIndexHelper const> lumiProductLookup() const {return get_underlying_safe(lumiProductLookup_);}
+      std::shared_ptr<ProductHolderIndexHelper>& lumiProductLookup() {return get_underlying_safe(lumiProductLookup_);}
+      std::shared_ptr<ProductHolderIndexHelper const> runProductLookup() const {return get_underlying_safe(runProductLookup_);}
+      std::shared_ptr<ProductHolderIndexHelper>& runProductLookup() {return get_underlying_safe(runProductLookup_);}
+
       bool frozen_;
       // Is at least one (run), (lumi), (event) product produced this process?
       boost::array<bool, NumBranchTypes> productProduced_;
       bool anyProductProduced_;
 
-      std::shared_ptr<ProductHolderIndexHelper> eventProductLookup_;
-      std::shared_ptr<ProductHolderIndexHelper> lumiProductLookup_;
-      std::shared_ptr<ProductHolderIndexHelper> runProductLookup_;
+      edm::propagate_const<std::shared_ptr<ProductHolderIndexHelper>> eventProductLookup_;
+      edm::propagate_const<std::shared_ptr<ProductHolderIndexHelper>> lumiProductLookup_;
+      edm::propagate_const<std::shared_ptr<ProductHolderIndexHelper>> runProductLookup_;
 
       ProductHolderIndex eventNextIndexValue_;
       ProductHolderIndex lumiNextIndexValue_;

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -42,7 +42,7 @@ namespace edm {
     currentRun_ = invalidRun;
     currentLumi_ = invalidLumi;
     numberOfEvents_ = 0;
-    eventFinder_.reset();
+    eventFinder_ = nullptr; // propagate_const<T> has no reset() function
     runOrLumiIndexes_.clear();
     eventNumbers_.clear();
     eventEntries_.clear();

--- a/DataFormats/Provenance/src/ProductHolderIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductHolderIndexHelper.cc
@@ -403,8 +403,9 @@ namespace edm {
     sanityCheck();
 
     // Cleanup, do not need the temporary containers anymore
-    items_.reset();
-    processItems_.reset();
+    // propagate_const<T> has no reset() function
+    items_ = nullptr;
+    processItems_ = nullptr;
   }
 
   std::vector<std::string> const& ProductHolderIndexHelper::lookupProcessNames() const {

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -61,7 +61,7 @@ namespace edm {
     
     if(iFrom.nextRetriever_) {
       if(not nextRetriever_) {
-        get_underlying(nextRetriever_) = std::make_shared<ProductProvenanceRetriever>(transitionIndex_);
+        nextRetriever_ = std::make_shared<ProductProvenanceRetriever>(transitionIndex_);
       }
       nextRetriever_->deepCopy(*(iFrom.nextRetriever_));
     }

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -62,9 +62,12 @@ namespace edm {
     frozen_ = false;
     for(bool& isProduced : productProduced_) isProduced = false;
     anyProductProduced_ = false;
-    eventProductLookup_.reset(new ProductHolderIndexHelper);
-    lumiProductLookup_.reset(new ProductHolderIndexHelper);
-    runProductLookup_.reset(new ProductHolderIndexHelper);
+
+    // propagate_const<T> has no reset() function
+    eventProductLookup_ = std::make_unique<ProductHolderIndexHelper>();
+    lumiProductLookup_ = std::make_unique<ProductHolderIndexHelper>();
+    runProductLookup_ = std::make_unique<ProductHolderIndexHelper>();
+
     eventNextIndexValue_ = 0;
     lumiNextIndexValue_ = 0;
     runNextIndexValue_ = 0;
@@ -137,11 +140,18 @@ namespace edm {
     return false;
   }
 
-  std::shared_ptr<ProductHolderIndexHelper> const&
+  std::shared_ptr<ProductHolderIndexHelper const>
   ProductRegistry::productLookup(BranchType branchType) const {
-    if (branchType == InEvent) return transient_.eventProductLookup_;
-    if (branchType == InLumi) return transient_.lumiProductLookup_;
-    return transient_.runProductLookup_;
+    if (branchType == InEvent) return transient_.eventProductLookup();
+    if (branchType == InLumi) return transient_.lumiProductLookup();
+    return transient_.runProductLookup();
+  }
+
+  std::shared_ptr<ProductHolderIndexHelper>
+  ProductRegistry::productLookup(BranchType branchType) {
+    if (branchType == InEvent) return transient_.eventProductLookup();
+    if (branchType == InLumi) return transient_.lumiProductLookup();
+    return transient_.runProductLookup();
   }
 
   void

--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 #include "FWCore/Catalog/interface/FileLocator.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
   class FileCatalogItem {

--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -6,10 +6,11 @@
 //
 //////////////////////////////////////////////////////////////////////
 
+#include <memory>
 #include <string>
 #include <vector>
-#include "boost/scoped_ptr.hpp"
 #include "FWCore/Catalog/interface/FileLocator.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
   class FileCatalogItem {
@@ -46,10 +47,10 @@ namespace edm {
     std::vector<std::string> fileNames_;
     std::vector<std::string> fallbackFileNames_;
     std::vector<FileCatalogItem> fileCatalogItems_;
-    boost::scoped_ptr<FileLocator> fileLocator_;
-    boost::scoped_ptr<FileLocator> overrideFileLocator_;
-    boost::scoped_ptr<FileLocator> fallbackFileLocator_;
-    boost::scoped_ptr<FileLocator> overrideFallbackFileLocator_;
+    edm::propagate_const<std::unique_ptr<FileLocator>> fileLocator_;
+    edm::propagate_const<std::unique_ptr<FileLocator>> overrideFileLocator_;
+    edm::propagate_const<std::unique_ptr<FileLocator>> fallbackFileLocator_;
+    edm::propagate_const<std::unique_ptr<FileLocator>> overrideFallbackFileLocator_;
   };
 }
 

--- a/FWCore/Catalog/src/InputFileCatalog.cc
+++ b/FWCore/Catalog/src/InputFileCatalog.cc
@@ -59,20 +59,20 @@ namespace edm {
         lt->clear();
       } else {
         if (!fileLocator_) {
-          fileLocator_.reset(new FileLocator("", false));
+          fileLocator_ = std::make_unique<FileLocator>("", false); // propagate_const<T> has no reset() function
         }
         if (!overrideFileLocator_ && !inputOverride.empty()) {
-          overrideFileLocator_.reset(new FileLocator(inputOverride, false));
+          overrideFileLocator_ = std::make_unique<FileLocator>(inputOverride, false); // propagate_const<T> has no reset() function
         }
         if (!fallbackFileLocator_) {
           try {
-            fallbackFileLocator_.reset(new FileLocator("", true));
+            fallbackFileLocator_ = std::make_unique<FileLocator>("", true); // propagate_const<T> has no reset() function
           } catch (cms::Exception const& e) {
             // No valid fallback locator is OK too.
           }
         }
         if (!overrideFallbackFileLocator_ && !inputOverrideFallback.empty()) {
-          overrideFallbackFileLocator_.reset(new FileLocator(inputOverrideFallback, true));
+          overrideFallbackFileLocator_ = std::make_unique<FileLocator>(inputOverrideFallback, true); // propagate_const<T> has no reset() function
         }
         boost::trim(*lt);
         findFile(*it, *ft, *lt, useLFNasPFNifLFNnotFound);

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -22,6 +22,7 @@
 #include <vector>
 // user include files
 #include "FWCore/Framework/interface/produce_helpers.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -109,7 +110,7 @@ namespace edm {
          const Callback& operator=(const Callback&); // stop default
 
          std::vector<void*> proxyData_;
-         T* producer_;
+         edm::propagate_const<T*> producer_;
          method_type method_;
          bool wasCalledForThisRecord_;
          TDecorator decorator_;

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -22,7 +22,7 @@
 #include <vector>
 // user include files
 #include "FWCore/Framework/interface/produce_helpers.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 
 #include "FWCore/Framework/interface/produce_helpers.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -73,7 +74,7 @@ namespace edm {
          
          // ---------- member data --------------------------------
          DataT data_;
-         boost::shared_ptr<CallbackT> callback_;
+         edm::propagate_const<boost::shared_ptr<CallbackT>> callback_;
       };
       
    }

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -28,7 +28,7 @@
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 
 #include "FWCore/Framework/interface/produce_helpers.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/ConstProductRegistry.h
+++ b/FWCore/Framework/interface/ConstProductRegistry.h
@@ -25,6 +25,7 @@ Usage:
 // user include files
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "FWCore/ServiceRegistry/interface/connect_but_block_self.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -74,7 +75,7 @@ namespace edm {
   private:
 
     // ---------- member data --------------------------------
-    SignallingProductRegistry* reg_;
+    edm::propagate_const<SignallingProductRegistry*> reg_;
   };
 }
 

--- a/FWCore/Framework/interface/ConstProductRegistry.h
+++ b/FWCore/Framework/interface/ConstProductRegistry.h
@@ -25,7 +25,7 @@ Usage:
 // user include files
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "FWCore/ServiceRegistry/interface/connect_but_block_self.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -30,7 +30,7 @@ a functor passed to the Framework with a call to callWhenNewProductsRegistered.
 
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -30,6 +30,7 @@ a functor passed to the Framework with a call to callWhenNewProductsRegistered.
 
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -100,7 +101,7 @@ namespace edm {
     m_consumer(iConsumer) {}
 
     // ---------- member data --------------------------------
-    EDConsumerBase* m_consumer;
+    edm::propagate_const<EDConsumerBase*> m_consumer;
     
   };
 }

--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -29,6 +29,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/DataKey.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -44,8 +45,7 @@ class DataProxyProvider
 
    public:   
       typedef std::vector< EventSetupRecordKey> Keys;
-      typedef std::vector<std::pair<DataKey, 
-                                    boost::shared_ptr<DataProxy> > > KeyedProxies ;
+      typedef std::vector<std::pair<DataKey, edm::propagate_const<boost::shared_ptr<DataProxy>>>> KeyedProxies;
       typedef std::map<EventSetupRecordKey, KeyedProxies> RecordProxies;
       
       DataProxyProvider();

--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -29,7 +29,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/DataKey.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -31,7 +31,7 @@ namespace edm {
     
     
   private:
-    virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) const = 0;
+    virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) = 0;
     virtual void mergeReaders_(DelayedReader*) = 0;
     virtual void reset_() = 0;
     virtual SharedResourcesAcquirer* sharedResources_() const;

--- a/FWCore/Framework/interface/DependentRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/DependentRecordIntervalFinder.h
@@ -26,6 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -61,10 +62,10 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
       const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&); // stop default
 
       // ---------- member data --------------------------------
-      typedef std::vector< boost::shared_ptr<EventSetupRecordProvider> > Providers;
+      typedef std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordProvider>>> Providers;
       Providers providers_;
       
-      boost::shared_ptr<EventSetupRecordIntervalFinder> alternate_;
+      edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>> alternate_;
       std::vector<ValidityInterval> previousIOVs_;
 };
 

--- a/FWCore/Framework/interface/DependentRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/DependentRecordIntervalFinder.h
@@ -26,7 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -56,6 +56,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <set>
 #include <memory>
@@ -106,11 +107,11 @@ namespace edm {
       virtual std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const;
 
       void copyInfo(ScheduleInfo const&);
-      void setModuleChanger(ModuleChanger const*);
+      void setModuleChanger(ModuleChanger*);
 
     protected:
       ///This only returns a non-zero value during the call to endOfLoop
-      ModuleChanger const* moduleChanger() const;
+      ModuleChanger* moduleChanger();
       ///This returns a non-zero value after the constructor has been called
       ScheduleInfo const* scheduleInfo() const;
     private:
@@ -147,8 +148,8 @@ namespace edm {
       unsigned int iCounter_;
       ExceptionToActionTable const* act_table_;
 
-      std::auto_ptr<ScheduleInfo> scheduleInfo_;
-      ModuleChanger const* moduleChanger_;
+      edm::propagate_const<std::unique_ptr<ScheduleInfo>> scheduleInfo_;
+      edm::propagate_const<ModuleChanger*> moduleChanger_;
 
       ModuleDescription moduleDescription_;
       ModuleCallingContext moduleCallingContext_;

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -56,7 +56,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <set>
 #include <memory>

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -60,7 +60,7 @@ BarProd::BarProd(const edm::ParameterSet& iPS) {
 
 // forward declarations
 #include "FWCore/Framework/interface/DataProxyProvider.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
    namespace eventsetup {

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -60,6 +60,7 @@ BarProd::BarProd(const edm::ParameterSet& iPS) {
 
 // forward declarations
 #include "FWCore/Framework/interface/DataProxyProvider.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
    namespace eventsetup {
@@ -72,7 +73,7 @@ namespace edm {
          : key_(iKey), 
          factory_(iFactory) {} 
          DataKey key_;
-         boost::shared_ptr<ProxyFactoryBase> factory_;
+         edm::propagate_const<boost::shared_ptr<ProxyFactoryBase>> factory_;
       };
    }      
    

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -37,7 +37,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 #include <string>

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -37,6 +37,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <string>
@@ -225,7 +226,7 @@ namespace edm {
 
     void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
 
-    typedef std::vector<std::pair<std::unique_ptr<WrapperBase>, BranchDescription const*> > ProductPtrVec;
+    typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*> > ProductPtrVec;
 
     EDProductGetter const&
     productGetter() const;
@@ -404,7 +405,7 @@ namespace edm {
   template<typename PROD>
   RefProd<PROD>
   Event::getRefBeforePut(std::string const& productInstanceName) {
-    PROD* p = 0;
+    PROD* p = nullptr;
     BranchDescription const& desc =
       provRecorder_.getBranchDescription(TypeID(*p), productInstanceName);
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -19,6 +19,7 @@ is the DataBlock.
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Framework/interface/Principal.h"
 
 #include <map>

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -167,8 +167,8 @@ namespace edm {
 
     ProductID branchIDToProductID(BranchID const& bid) const;
 
-    void mergeProvenanceRetrievers(EventPrincipal const& other) {
-      provRetrieverPtr_->mergeProvenanceRetrievers(get_underlying(other.provRetrieverPtr_));
+    void mergeProvenanceRetrievers(EventPrincipal& other) {
+      provRetrieverPtr_->mergeProvenanceRetrievers(other.provRetrieverPtr());
     }
 
     using Base::getProvenance;
@@ -191,6 +191,9 @@ namespace edm {
 
     virtual unsigned int transitionIndex_() const override;
     
+    std::shared_ptr<ProductProvenanceRetriever const> provRetrieverPtr() const {return get_underlying_safe(provRetrieverPtr_);}
+    std::shared_ptr<ProductProvenanceRetriever>& provRetrieverPtr() {return get_underlying_safe(provRetrieverPtr_);}
+
   private:
 
     EventAuxiliary aux_;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -27,7 +27,7 @@ configured in the user's main() function, and is set running.
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "boost/shared_ptr.hpp"
 #include "boost/thread/condition.hpp"
@@ -267,7 +267,7 @@ namespace edm {
     // only during construction, and never again. If they aren't
     // really needed, we should remove them.
 
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<std::shared_ptr<ProductRegistry>> preg_;
     edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -27,6 +27,8 @@ configured in the user's main() function, and is set running.
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 #include "boost/shared_ptr.hpp"
 #include "boost/thread/condition.hpp"
 
@@ -249,6 +251,15 @@ namespace edm {
 
     //returns true if an asynchronous stop was requested
     bool checkForAsyncStopRequest(StatusCode&);
+
+    std::shared_ptr<ProductRegistry const> preg() const {return get_underlying_safe(preg_);}
+    std::shared_ptr<ProductRegistry>& preg() {return get_underlying_safe(preg_);}
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
+    boost::shared_ptr<EDLooperBase const> looper() const {return get_underlying_safe(looper_);}
+    boost::shared_ptr<EDLooperBase>& looper() {return get_underlying_safe(looper_);}
     //------------------------------------------------------------------
     //
     // Data members below.
@@ -256,24 +267,24 @@ namespace edm {
     // only during construction, and never again. If they aren't
     // really needed, we should remove them.
 
-    std::shared_ptr<ActivityRegistry>           actReg_;
-    std::shared_ptr<ProductRegistry>            preg_;
-    std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
-    std::shared_ptr<ThinnedAssociationsHelper>  thinnedAssociationsHelper_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    edm::propagate_const<std::shared_ptr<ProductRegistry>> preg_;
+    edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
+    edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     ServiceToken                                  serviceToken_;
-    std::unique_ptr<InputSource>                  input_;
-    std::unique_ptr<eventsetup::EventSetupsController> espController_;
-    boost::shared_ptr<eventsetup::EventSetupProvider> esp_;
+    edm::propagate_const<std::unique_ptr<InputSource>> input_;
+    edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
+    edm::propagate_const<boost::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     std::unique_ptr<ExceptionToActionTable const>          act_table_;
     std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
     ProcessContext                                processContext_;
     PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
-    std::auto_ptr<Schedule>                       schedule_;
-    std::unique_ptr<std::vector<SubProcess> >     subProcesses_;
-    std::unique_ptr<HistoryAppender>            historyAppender_;
+    edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
+    edm::propagate_const<std::unique_ptr<std::vector<SubProcess>>> subProcesses_;
+    edm::propagate_const<std::unique_ptr<HistoryAppender>> historyAppender_;
 
-    std::unique_ptr<FileBlock>                    fb_;
-    boost::shared_ptr<EDLooperBase>               looper_;
+    edm::propagate_const<std::unique_ptr<FileBlock>> fb_;
+    edm::propagate_const<boost::shared_ptr<EDLooperBase>> looper_;
 
     //The atomic protects concurrent access of deferredExceptionPtr_
     std::atomic<bool>                             deferredExceptionPtrIsSet_;

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -21,7 +21,7 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 // system include files
 #include "boost/shared_ptr.hpp"

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -21,6 +21,7 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // system include files
 #include "boost/shared_ptr.hpp"
@@ -64,10 +65,10 @@ class EventSetupRecordProvider {
       std::set<ComponentDescription> proxyProviderDescriptions() const;
       
       ///returns the first matching DataProxyProvider or a 'null' if not found
-      boost::shared_ptr<DataProxyProvider> proxyProvider(ComponentDescription const&) const;
+      boost::shared_ptr<DataProxyProvider> proxyProvider(ComponentDescription const&);
 
       ///returns the first matching DataProxyProvider or a 'null' if not found
-      boost::shared_ptr<DataProxyProvider> proxyProvider(ParameterSetIDHolder const&) const;
+      boost::shared_ptr<DataProxyProvider> proxyProvider(ParameterSetIDHolder const&);
 
 
       // ---------- static member functions --------------------
@@ -97,7 +98,8 @@ class EventSetupRecordProvider {
       ///This will clear the cache's of all the Proxies so that next time they are called they will run
       void resetProxies();
       
-      boost::shared_ptr<EventSetupRecordIntervalFinder> finder() const { return finder_; }
+      boost::shared_ptr<EventSetupRecordIntervalFinder const> finder() const {return get_underlying_safe(finder_);}
+      boost::shared_ptr<EventSetupRecordIntervalFinder>& finder() {return get_underlying_safe(finder_);}
 
       void getReferencedESProducers(std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers);
 
@@ -106,6 +108,8 @@ class EventSetupRecordProvider {
       void resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap);
 
    protected:
+      void addProxiesToRecordHelper(edm::propagate_const<boost::shared_ptr<DataProxyProvider>>& dpp,
+                              DataToPreferredProviderMap const& mp) {addProxiesToRecord(get_underlying_safe(dpp), mp);}
       void addProxiesToRecord(boost::shared_ptr<DataProxyProvider>,
                               DataToPreferredProviderMap const&);
       void cacheReset();
@@ -113,7 +117,7 @@ class EventSetupRecordProvider {
       virtual EventSetupRecord& record() = 0;
       
       boost::shared_ptr<EventSetupRecordIntervalFinder> swapFinder(boost::shared_ptr<EventSetupRecordIntervalFinder> iNew) {
-        std::swap(iNew, finder_);
+        std::swap(iNew, finder());
         return iNew;
       }
 
@@ -127,9 +131,9 @@ class EventSetupRecordProvider {
       // ---------- member data --------------------------------
       EventSetupRecordKey const key_;
       ValidityInterval validityInterval_;
-      boost::shared_ptr<EventSetupRecordIntervalFinder> finder_;
-      std::vector<boost::shared_ptr<DataProxyProvider> > providers_;
-      std::auto_ptr<std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> > > multipleFinders_;
+      edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>> finder_;
+      std::vector<edm::propagate_const<boost::shared_ptr<DataProxyProvider>>> providers_;
+      std::unique_ptr<std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>> multipleFinders_;
       bool lastSyncWasBeginOfRun_;
 };
    }

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -111,7 +111,7 @@ namespace edm {
       whyNotFastClonable_ |= why;
     }
     BranchChildren const& branchChildren() const { return *branchChildren_; }
-    void close () {runMetaTree_ = lumiMetaTree_ = metaTree_ = runTree_ = lumiTree_ = tree_ = 0;}
+    void close () {runMetaTree_ = lumiMetaTree_ = metaTree_ = runTree_ = lumiTree_ = tree_ = nullptr;}
 
   private:
     FileFormatVersion fileFormatVersion_;

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -76,7 +76,7 @@ namespace edm {
               std::string const& fileName,
               bool branchListIndexesUnchanged,
               bool modifiedIDs,
-              std::shared_ptr<BranchChildren> branchChildren) :
+              std::shared_ptr<BranchChildren const> branchChildren) :
       fileFormatVersion_(version),
       tree_(const_cast<TTree*>(ev)),
       metaTree_(const_cast<TTree*>(meta)),
@@ -127,7 +127,7 @@ namespace edm {
     std::string fileName_;
     bool branchListIndexesUnchanged_;
     bool modifiedIDs_;
-    std::shared_ptr<BranchChildren> branchChildren_;
+    std::shared_ptr<BranchChildren const> branchChildren_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -51,6 +51,7 @@ Some examples of InputSource subclasses may be:
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
 
 #include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <string>
@@ -165,17 +166,21 @@ namespace edm {
     /// Register any produced products
     void registerProducts();
 
-    /// Accessor for product registry.
-    std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
+    /// Accessors for product registry
+    std::shared_ptr<ProductRegistry const> productRegistry() const {return get_underlying_safe(productRegistry_);}
+    std::shared_ptr<ProductRegistry>& productRegistry() {return get_underlying_safe(productRegistry_);}
 
-    /// Const accessor for process history registry.
+    /// Accessors for process history registry.
     ProcessHistoryRegistry const& processHistoryRegistry() const {return *processHistoryRegistry_;}
+    ProcessHistoryRegistry& processHistoryRegistry() {return *processHistoryRegistry_;}
 
-    /// Accessor for branchIDListHelper
-    std::shared_ptr<BranchIDListHelper> branchIDListHelper() const {return branchIDListHelper_;}
+    /// Accessors for branchIDListHelper
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
 
-    /// Accessor for thinnedAssociationsHelper
-    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() const {return thinnedAssociationsHelper_;}
+    /// Accessors for thinnedAssociationsHelper
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
 
     /// Reset the remaining number of events/lumis to the maximum number.
     void repeat() {
@@ -184,7 +189,7 @@ namespace edm {
     }
     
     /// Returns nullptr if no resource shared between the Source and a DelayedReader
-    SharedResourcesAcquirer* resourceSharedWithDelayedReader() const;
+    SharedResourcesAcquirer* resourceSharedWithDelayedReader();
 
     /// Accessor for maximum number of events to be read.
     /// -1 is used for unlimited.
@@ -342,8 +347,8 @@ namespace edm {
     /// To set the current time, as seen by the input source
     void setTimestamp(Timestamp const& theTime) {time_ = theTime;}
 
-    ProductRegistry& productRegistryUpdate() const {return *productRegistry_;}
-    ProcessHistoryRegistry& processHistoryRegistryForUpdate() const {return *processHistoryRegistry_;}
+    ProductRegistry& productRegistryUpdate() {return *productRegistry_;}
+    ProcessHistoryRegistry& processHistoryRegistryForUpdate() {return *processHistoryRegistry_;}
     ItemType state() const{return state_;}
     void setRunAuxiliary(RunAuxiliary* rp) {
       runAuxiliary_.reset(rp);
@@ -366,8 +371,6 @@ namespace edm {
       resetRunAuxiliary();
       state_ = IsInvalid;
     }
-    std::shared_ptr<LuminosityBlockPrincipal> const luminosityBlockPrincipal() const;
-    std::shared_ptr<RunPrincipal> const runPrincipal() const;
     bool newRun() const {return newRun_;}
     void setNewRun() {newRun_ = true;}
     void resetNewRun() {newRun_ = false;}
@@ -414,7 +417,7 @@ namespace edm {
     virtual void endRun(Run&);
     virtual void beginJob();
     virtual void endJob();
-    virtual SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const;
+    virtual SharedResourcesAcquirer* resourceSharedWithDelayedReader_();
 
     virtual void preForkReleaseResources();
     virtual void postForkReacquireResources(std::shared_ptr<multicore::MessageReceiverForSource>);
@@ -424,7 +427,7 @@ namespace edm {
 
   private:
 
-    std::shared_ptr<ActivityRegistry> actReg_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
     int maxEvents_;
     int remainingEvents_;
     int maxLumis_;
@@ -434,10 +437,10 @@ namespace edm {
     std::chrono::time_point<std::chrono::steady_clock> processingStart_;
     ProcessingMode processingMode_;
     ModuleDescription const moduleDescription_;
-    std::shared_ptr<ProductRegistry> productRegistry_;
-    std::unique_ptr<ProcessHistoryRegistry> processHistoryRegistry_;
-    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
-    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+    edm::propagate_const<std::shared_ptr<ProductRegistry>> productRegistry_;
+    edm::propagate_const<std::unique_ptr<ProcessHistoryRegistry>> processHistoryRegistry_;
+    edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
+    edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     std::string processGUID_;
     Timestamp time_;
     mutable bool newRun_;
@@ -449,7 +452,7 @@ namespace edm {
     std::string statusFileName_;
 
     //used when process has been forked
-    std::shared_ptr<edm::multicore::MessageReceiverForSource> receiver_;
+    edm::propagate_const<std::shared_ptr<edm::multicore::MessageReceiverForSource>> receiver_;
     unsigned int numberOfEventsBeforeBigSkip_;
   };
 }

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -51,7 +51,7 @@ Some examples of InputSource subclasses may be:
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
 
 #include "FWCore/Utilities/interface/Signal.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 #include <string>
@@ -427,7 +427,7 @@ namespace edm {
 
   private:
 
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
     int maxEvents_;
     int remainingEvents_;
     int maxLumis_;

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -51,7 +51,7 @@ namespace edm {
     std::shared_ptr<ProductRegistry> productRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
-    std::shared_ptr<ActivityRegistry> actReg_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
     int maxEvents_;
     int maxLumis_;
     int maxSecondsUntilRampdown_;

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -51,7 +51,7 @@ namespace edm {
     std::shared_ptr<ProductRegistry> productRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
     int maxEvents_;
     int maxLumis_;
     int maxSecondsUntilRampdown_;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -25,6 +25,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <set>
@@ -143,7 +144,7 @@ namespace edm {
     // Override version from LuminosityBlockBase class
     virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;
 
-    typedef std::vector<std::pair<std::unique_ptr<WrapperBase>, BranchDescription const*> > ProductPtrVec;
+    typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*>> ProductPtrVec;
     ProductPtrVec& putProducts() {return putProducts_;}
     ProductPtrVec const& putProducts() const {return putProducts_;}
 

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -25,7 +25,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 #include <set>

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -17,7 +17,7 @@ is the DataBlock.
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Framework/interface/Principal.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -17,7 +17,7 @@ is the DataBlock.
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Framework/interface/Principal.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 

--- a/FWCore/Framework/interface/ModuleChanger.h
+++ b/FWCore/Framework/interface/ModuleChanger.h
@@ -23,7 +23,7 @@
 #include <string>
 
 // user include files
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 

--- a/FWCore/Framework/interface/ModuleChanger.h
+++ b/FWCore/Framework/interface/ModuleChanger.h
@@ -23,6 +23,7 @@
 #include <string>
 
 // user include files
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 
@@ -38,12 +39,12 @@ namespace edm {
       virtual ~ModuleChanger();
 
       // ---------- const member functions ---------------------
-      bool changeModule(const std::string& iLabel,
-                        const ParameterSet& iPSet) const;
 
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
+      bool changeModule(const std::string& iLabel,
+                        const ParameterSet& iPSet);
 
    private:
       ModuleChanger(const ModuleChanger&) = delete; // stop default
@@ -51,7 +52,7 @@ namespace edm {
       const ModuleChanger& operator=(const ModuleChanger&) = delete; // stop default
 
       // ---------- member data --------------------------------
-      Schedule* schedule_;
+      edm::propagate_const<Schedule*> schedule_;
       ProductRegistry const* registry_;
    };
 }

--- a/FWCore/Framework/interface/ModuleContextSentry.h
+++ b/FWCore/Framework/interface/ModuleContextSentry.h
@@ -4,6 +4,7 @@
 #include "FWCore/ServiceRegistry/interface/CurrentModuleOnThread.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
 
@@ -21,7 +22,7 @@ namespace edm {
       moduleCallingContext_->setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
     }
   private:
-    ModuleCallingContext* moduleCallingContext_;
+    edm::propagate_const<ModuleCallingContext*> moduleCallingContext_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/ModuleContextSentry.h
+++ b/FWCore/Framework/interface/ModuleContextSentry.h
@@ -4,7 +4,7 @@
 #include "FWCore/ServiceRegistry/interface/CurrentModuleOnThread.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
 

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -24,6 +24,7 @@ output stream.
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <array>
 #include <memory>
@@ -163,10 +164,10 @@ namespace edm {
     // needed because of possible EDAliases.
     // filled in only if key and value are different.
     std::map<BranchID::value_type, BranchID::value_type> droppedBranchIDToKeptBranchID_;
-    std::unique_ptr<BranchIDLists> branchIDLists_;
+    edm::propagate_const<std::unique_ptr<BranchIDLists>> branchIDLists_;
     BranchIDLists const* origBranchIDLists_;
 
-    std::unique_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+    edm::propagate_const<std::unique_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     std::map<BranchID, bool> keepAssociation_;
 
     SharedResourcesAcquirer resourceAcquirer_;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -24,7 +24,7 @@ output stream.
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <array>
 #include <memory>

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -29,7 +29,7 @@ pointer to a ProductHolder, when queried.
 #include "FWCore/Framework/interface/ProductHolder.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "boost/iterator/filter_iterator.hpp"
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -29,7 +29,7 @@ pointer to a ProductHolder, when queried.
 #include "FWCore/Framework/interface/ProductHolder.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "boost/iterator/filter_iterator.hpp"
 

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -106,7 +106,7 @@ edm::Ref<AppleCollection> ref(refApples, index);
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/ProductLabels.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 
 namespace edm {
@@ -236,7 +236,7 @@ namespace edm {
     ModuleDescription const& md_;
     
     EDConsumerBase const* consumer_;
-    mutable SharedResourcesAcquirer* resourcesAcquirer_;
+    SharedResourcesAcquirer* resourcesAcquirer_; // We do not use propagate_const because the acquirer is itself mutable.
   };
 
   template <typename PROD>

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -106,6 +106,7 @@ edm::Ref<AppleCollection> ref(refApples, index);
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/ProductLabels.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 
 namespace edm {
@@ -235,7 +236,7 @@ namespace edm {
     ModuleDescription const& md_;
     
     EDConsumerBase const* consumer_;
-    SharedResourcesAcquirer* resourcesAcquirer_;
+    mutable SharedResourcesAcquirer* resourcesAcquirer_;
   };
 
   template <typename PROD>

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -178,7 +178,7 @@ namespace edm {
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
     ModuleCallingContext const* moduleCallingContext_;
-    edm::propagate_const<SharedResourcesAcquirer*> sharedResourcesAcquirer_;
+    SharedResourcesAcquirer* sharedResourcesAcquirer_; // We do not use propagate_const because the acquirer is itself mutable.
 
     static const std::string emptyString_;
   };

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -156,7 +156,7 @@ namespace edm {
     // Override version from RunBase class
     virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;
 
-    typedef std::vector<std::pair<std::unique_ptr<WrapperBase>, BranchDescription const*> > ProductPtrVec;
+    typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*>> ProductPtrVec;
     ProductPtrVec& putProducts() {return putProducts_;}
     ProductPtrVec const& putProducts() const {return putProducts_;}
 
@@ -178,7 +178,7 @@ namespace edm {
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
     ModuleCallingContext const* moduleCallingContext_;
-    SharedResourcesAcquirer* sharedResourcesAcquirer_;
+    edm::propagate_const<SharedResourcesAcquirer*> sharedResourcesAcquirer_;
 
     static const std::string emptyString_;
   };

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -79,6 +79,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "boost/shared_ptr.hpp"
 
@@ -113,9 +114,8 @@ namespace edm {
   class Schedule {
   public:
     typedef std::vector<std::string> vstring;
-    typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
-    typedef std::vector<std::shared_ptr<OutputModuleCommunicator> > AllOutputModuleCommunicators;
+    typedef std::vector<edm::propagate_const<std::shared_ptr<OutputModuleCommunicator>>> AllOutputModuleCommunicators;
 
     typedef std::vector<Worker*> Workers;
 
@@ -248,7 +248,7 @@ namespace edm {
     
     /// Return the trigger timing report information on paths,
     /// modules-in-path, modules-in-endpath, and modules.
-    void getTriggerTimingReport(TriggerTimingReport& rep) const;
+    void getTriggerTimingReport(TriggerTimingReport& rep);
 
     /// Return whether each output module has reached its maximum count.
     bool terminate() const;
@@ -270,16 +270,21 @@ namespace edm {
     
     void limitOutput(ParameterSet const& proc_pset, BranchIDLists const& branchIDLists);
 
-    std::shared_ptr<TriggerResultInserter> resultsInserter_;
-    std::shared_ptr<ModuleRegistry> moduleRegistry_;
-    std::vector<std::shared_ptr<StreamSchedule>> streamSchedules_;
+    std::shared_ptr<TriggerResultInserter const> resultsInserter() const {return get_underlying_safe(resultsInserter_);}
+    std::shared_ptr<TriggerResultInserter>& resultsInserter() {return get_underlying_safe(resultsInserter_);}
+    std::shared_ptr<ModuleRegistry const> moduleRegistry() const {return get_underlying_safe(moduleRegistry_);}
+    std::shared_ptr<ModuleRegistry>& moduleRegistry() {return get_underlying_safe(moduleRegistry_);}
+
+    edm::propagate_const<std::shared_ptr<TriggerResultInserter>> resultsInserter_;
+    edm::propagate_const<std::shared_ptr<ModuleRegistry>> moduleRegistry_;
+    std::vector<edm::propagate_const<std::shared_ptr<StreamSchedule>>> streamSchedules_;
     //In the future, we will have one GlobalSchedule per simultaneous transition
-    std::unique_ptr<GlobalSchedule> globalSchedule_;
+    edm::propagate_const<std::unique_ptr<GlobalSchedule>> globalSchedule_;
 
     AllOutputModuleCommunicators         all_output_communicators_;
     PreallocationConfiguration           preallocConfig_;
 
-    std::unique_ptr<SystemTimeKeeper> summaryTimeKeeper_;
+    edm::propagate_const<std::unique_ptr<SystemTimeKeeper>> summaryTimeKeeper_;
 
     bool                           wantSummary_;
     bool                           printDependencies_;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -79,7 +79,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "boost/shared_ptr.hpp"
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -248,7 +248,7 @@ namespace edm {
     
     /// Return the trigger timing report information on paths,
     /// modules-in-path, modules-in-endpath, and modules.
-    void getTriggerTimingReport(TriggerTimingReport& rep);
+    void getTriggerTimingReport(TriggerTimingReport& rep) const;
 
     /// Return whether each output module has reached its maximum count.
     bool terminate() const;

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 #include <vector>
@@ -63,7 +63,7 @@ namespace edm {
     std::shared_ptr<ProcessConfiguration const> processConfiguration() const {return get_underlying_safe(processConfiguration_);}
     std::shared_ptr<ProcessConfiguration>& processConfiguration() {return get_underlying_safe(processConfiguration_);}
 
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<std::shared_ptr<SignallingProductRegistry>> preg_;
     edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <vector>
@@ -53,12 +54,21 @@ namespace edm {
     void
     clear();
 
-    std::shared_ptr<ActivityRegistry> actReg_;
-    std::shared_ptr<SignallingProductRegistry> preg_;
-    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
-    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+    std::shared_ptr<SignallingProductRegistry const> preg() const {return get_underlying_safe(preg_);}
+    std::shared_ptr<SignallingProductRegistry>& preg() {return get_underlying_safe(preg_);}
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<ProcessConfiguration const> processConfiguration() const {return get_underlying_safe(processConfiguration_);}
+    std::shared_ptr<ProcessConfiguration>& processConfiguration() {return get_underlying_safe(processConfiguration_);}
+
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    edm::propagate_const<std::shared_ptr<SignallingProductRegistry>> preg_;
+    edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
+    edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;
-    std::shared_ptr<ProcessConfiguration> processConfiguration_;
+    edm::propagate_const<std::shared_ptr<ProcessConfiguration>> processConfiguration_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -14,6 +14,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 
@@ -287,13 +288,18 @@ namespace edm {
     bool hasSubProcesses() const {
       return subProcesses_.get() != nullptr && !subProcesses_->empty();
     }
+
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
     
-    std::shared_ptr<ActivityRegistry>             actReg_;
+    mutable std::shared_ptr<ActivityRegistry>     actReg_;
     ServiceToken                                  serviceToken_;
     std::shared_ptr<ProductRegistry const>        parentPreg_;
     std::shared_ptr<ProductRegistry const>        preg_;
-    std::shared_ptr<BranchIDListHelper>           branchIDListHelper_;
-    std::shared_ptr<ThinnedAssociationsHelper>    thinnedAssociationsHelper_;
+    edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
+    edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;
     std::shared_ptr<ProcessConfiguration const>   processConfiguration_;
     ProcessContext                                processContext_;
@@ -305,11 +311,11 @@ namespace edm {
     std::vector<ProcessHistoryRegistry>           processHistoryRegistries_;
     std::vector<HistoryAppender>                  historyAppenders_;
     PrincipalCache                                principalCache_;
-    boost::shared_ptr<eventsetup::EventSetupProvider> esp_;
-    std::unique_ptr<Schedule>                     schedule_;
+    edm::propagate_const<boost::shared_ptr<eventsetup::EventSetupProvider>> esp_;
+    edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
     std::map<ProcessHistoryID, ProcessHistoryID>  parentToChildPhID_;
-    std::unique_ptr<std::vector<SubProcess> >     subProcesses_;
-    std::unique_ptr<ParameterSet>                 processParameterSet_;
+    edm::propagate_const<std::unique_ptr<std::vector<SubProcess>>> subProcesses_;
+    edm::propagate_const<std::unique_ptr<ParameterSet>> processParameterSet_;
 
     // keptProducts_ are pointers to the BranchDescription objects describing
     // the branches we are to write.

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -14,7 +14,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/BranchType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 
@@ -294,7 +294,7 @@ namespace edm {
     std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
     
-    mutable std::shared_ptr<ActivityRegistry>     actReg_;
+    std::shared_ptr<ActivityRegistry>             actReg_; // We do not use propagate_const because the registry itself is mutable.
     ServiceToken                                  serviceToken_;
     std::shared_ptr<ProductRegistry const>        parentPreg_;
     std::shared_ptr<ProductRegistry const>        preg_;

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/src/WorkerRegistry.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/src/WorkerRegistry.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -78,12 +79,15 @@ namespace edm {
 
     void setupOnDemandSystem(EventPrincipal& principal, EventSetup const& es);
 
+    std::shared_ptr<UnscheduledCallProducer const> unscheduled() const {return get_underlying_safe(unscheduled_);}
+    std::shared_ptr<UnscheduledCallProducer>& unscheduled() {return get_underlying_safe(unscheduled_);}
+
     WorkerRegistry      workerReg_;
     ExceptionToActionTable const*  actionTable_;
 
     AllWorkers          allWorkers_;
 
-    std::shared_ptr<UnscheduledCallProducer> unscheduled_;
+    edm::propagate_const<std::shared_ptr<UnscheduledCallProducer>> unscheduled_;
   };
 
   template <typename T, typename U>

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -38,7 +38,7 @@
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -38,6 +38,7 @@
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -187,10 +188,10 @@ namespace edm {
       // needed because of possible EDAliases.
       // filled in only if key and value are different.
       std::map<BranchID::value_type, BranchID::value_type> droppedBranchIDToKeptBranchID_;
-      std::unique_ptr<BranchIDLists> branchIDLists_;
+      edm::propagate_const<std::unique_ptr<BranchIDLists>> branchIDLists_;
       BranchIDLists const* origBranchIDLists_;
 
-      std::unique_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+      edm::propagate_const<std::unique_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
       std::map<BranchID, bool> keepAssociation_;
 
       //------------------------------------------------------------------

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -26,7 +26,7 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -26,6 +26,7 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -98,13 +99,13 @@ namespace edm {
         }
         void doEndRun_(Run const& rp, EventSetup const& c) override final {
           globalEndRun(rp,c);
-          cache_.reset();
+          cache_ = nullptr; // propagate_const<T> has no reset() function
         }
         
         virtual std::shared_ptr<C> globalBeginRun(edm::Run const&, edm::EventSetup const&) const = 0;
         virtual void globalEndRun(edm::Run const&, edm::EventSetup const&) const = 0;
         //When threaded we will have a container for N items whre N is # of simultaneous runs
-        std::shared_ptr<C> cache_;
+        edm::propagate_const<std::shared_ptr<C>> cache_;
       };
       
       template <typename T, typename C>

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -41,7 +41,7 @@
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -41,6 +41,7 @@
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -170,10 +171,11 @@ namespace edm {
       // needed because of possible EDAliases.
       // filled in only if key and value are different.
       std::map<BranchID::value_type, BranchID::value_type> droppedBranchIDToKeptBranchID_;
-      std::unique_ptr<BranchIDLists> branchIDLists_;
+      edm::propagate_const<std::unique_ptr<BranchIDLists>> branchIDLists_;
       BranchIDLists const* origBranchIDLists_;
 
-      std::unique_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+
+      edm::propagate_const<std::unique_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
       std::map<BranchID, bool> keepAssociation_;
 
       SharedResourcesAcquirer resourcesAcquirer_;

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -16,7 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -16,6 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -38,7 +39,7 @@ namespace edm {
     virtual void registerThinnedAssociations(ProductRegistry const& productRegistry,
                                              ThinnedAssociationsHelper& thinnedAssociationsHelper) override;
   private:
-    std::unique_ptr<Selector> selector_;
+    edm::propagate_const<std::unique_ptr<Selector>> selector_;
     edm::EDGetTokenT<Collection> inputToken_;
     edm::InputTag inputTag_;
   };

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -158,11 +158,11 @@ namespace edm {
     scheduleInfo_ = std::auto_ptr<ScheduleInfo>(new ScheduleInfo(iInfo));
   }
   void 
-  EDLooperBase::setModuleChanger(const ModuleChanger* iChanger) {
+  EDLooperBase::setModuleChanger(ModuleChanger* iChanger) {
     moduleChanger_ = iChanger;
   }
 
-  const ModuleChanger* EDLooperBase::moduleChanger() const {
+  ModuleChanger* EDLooperBase::moduleChanger() {
     return moduleChanger_;
   }
   const ScheduleInfo* EDLooperBase::scheduleInfo() const {

--- a/FWCore/Framework/src/EPStates.cc
+++ b/FWCore/Framework/src/EPStates.cc
@@ -30,7 +30,8 @@ namespace statemachine {
     emptyRunLumiMode_(emptyRunLumiMode) {
   }
 
-  edm::IEventProcessor& Machine::ep() const { return *ep_; }
+  edm::IEventProcessor const& Machine::ep() const { return *ep_; }
+  edm::IEventProcessor& Machine::ep() { return *ep_; }
   FileMode Machine::fileMode() const { return fileMode_; }
   EmptyRunLumiMode Machine::emptyRunLumiMode() const { return emptyRunLumiMode_; }
 

--- a/FWCore/Framework/src/EPStates.h
+++ b/FWCore/Framework/src/EPStates.h
@@ -14,6 +14,7 @@ Original Authors: W. David Dagenhart, Marc Paterno
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "boost/statechart/event.hpp"
 #include "boost/statechart/state_machine.hpp"
@@ -96,7 +97,8 @@ namespace statemachine {
             FileMode fileMode,
             EmptyRunLumiMode emptyRunLumiMode);
 
-    edm::IEventProcessor& ep() const;
+    edm::IEventProcessor const& ep() const;
+    edm::IEventProcessor& ep();
     FileMode fileMode() const;
     EmptyRunLumiMode emptyRunLumiMode() const;
 
@@ -106,7 +108,7 @@ namespace statemachine {
 
   private:
 
-    edm::IEventProcessor* ep_;
+    edm::propagate_const<edm::IEventProcessor*> ep_;
     FileMode fileMode_;
     EmptyRunLumiMode emptyRunLumiMode_;
   };

--- a/FWCore/Framework/src/EPStates.h
+++ b/FWCore/Framework/src/EPStates.h
@@ -14,7 +14,7 @@ Original Authors: W. David Dagenhart, Marc Paterno
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "boost/statechart/event.hpp"
 #include "boost/statechart/state_machine.hpp"

--- a/FWCore/Framework/src/ESProxyFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProxyFactoryProducer.cc
@@ -72,7 +72,7 @@ ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord,
    for(Iterator it = range.first; it != range.second; ++it) {
       
       boost::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy().release());
-      if(0 != proxy.get()) {
+      if(nullptr != proxy.get()) {
          iProxies.push_back(KeyedProxies::value_type((*it).second.key_,
                                          proxy));
       }
@@ -84,7 +84,7 @@ ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecor
                                              std::auto_ptr<ProxyFactoryBase>& iFactory,
                                              const std::string& iLabel )
 {
-   if(0 == iFactory.get()) {
+   if(nullptr == iFactory.get()) {
       assert(false && "Factor pointer was null");
       ::exit(1);
    }
@@ -110,7 +110,7 @@ ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecor
    }
                                                
    record2Factories_.insert(Record2Factories::value_type(iRecord,
-                                                         info));
+                                                         std::move(info)));
 }
 
 void 

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -165,11 +165,11 @@ namespace edm {
       if(!sameAsPrevious) {
         ProductProvenance prov(pit->second->branchID(), std::move(gotBranchIDVector));
         *previousParentageId = prov.parentageID();
-        ep.put(*pit->second, std::move(pit->first), prov);
+        ep.put(*pit->second, std::move(get_underlying_safe(pit->first)), prov);
         sameAsPrevious = true;
       } else {
         ProductProvenance prov(pit->second->branchID(), *previousParentageId);
-        ep.put(*pit->second, std::move(pit->first), prov);
+        ep.put(*pit->second, std::move(get_underlying_safe(pit->first)), prov);
       }
       ++pit;
     }

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -53,7 +53,7 @@ namespace edm {
   EventPrincipal::clearEventPrincipal() {
     clearPrincipal();
     aux_ = EventAuxiliary();
-    get_underlying(luminosityBlockPrincipal_).reset();
+    luminosityBlockPrincipal_ = nullptr; // propagate_const<T> has no reset() function
     provRetrieverPtr_->reset();
     unscheduledHandler_.reset();
     branchListIndexToProcessIndex_.clear();

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -56,6 +56,7 @@
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RootHandlers.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "MessageForSource.h"
 #include "MessageForParent.h"
@@ -104,7 +105,7 @@ namespace {
       reg_ = nullptr;
     }
   private:
-    edm::ActivityRegistry* reg_;
+    edm::propagate_const<edm::ActivityRegistry*> reg_;
     
   };
 }
@@ -513,7 +514,14 @@ namespace edm {
     preallocations_ = PreallocationConfiguration{nThreads,nStreams,nConcurrentLumis,nConcurrentRuns};
 
     // initialize the input source
-    input_ = makeInput(*parameterSet, *common, items.preg_, items.branchIDListHelper_, items.thinnedAssociationsHelper_, items.actReg_, items.processConfiguration_, preallocations_);
+    input_ = makeInput(*parameterSet,
+                       *common,
+                       items.preg(),
+                       items.branchIDListHelper(),
+                       items.thinnedAssociationsHelper(),
+                       items.actReg_,
+                       items.processConfiguration(),
+                       preallocations_);
 
     // intialize the Schedule
     schedule_ = items.initSchedule(*parameterSet,hasSubProcesses,preallocations_,&processContext_);
@@ -521,10 +529,10 @@ namespace edm {
     // set the data members
     act_table_ = std::move(items.act_table_);
     actReg_ = items.actReg_;
-    preg_ = items.preg_;
-    branchIDListHelper_ = items.branchIDListHelper_;
-    thinnedAssociationsHelper_ = items.thinnedAssociationsHelper_;
-    processConfiguration_ = items.processConfiguration_;
+    preg_ = items.preg();
+    branchIDListHelper_ = items.branchIDListHelper();
+    thinnedAssociationsHelper_ = items.thinnedAssociationsHelper();
+    processConfiguration_ = items.processConfiguration();
     processContext_.setProcessConfiguration(processConfiguration_.get());
     principalCache_.setProcessHistoryRegistry(input_->processHistoryRegistry());
 
@@ -533,7 +541,8 @@ namespace edm {
     principalCache_.setNumberOfConcurrentPrincipals(preallocations_);
     for(unsigned int index = 0; index<preallocations_.numberOfStreams(); ++index ) {
       // Reusable event principal
-      auto ep = std::make_shared<EventPrincipal>(preg_, branchIDListHelper_, thinnedAssociationsHelper_, *processConfiguration_, historyAppender_.get(), index);
+      auto ep = std::make_shared<EventPrincipal>(preg(), branchIDListHelper(),
+           thinnedAssociationsHelper(), *processConfiguration_, historyAppender_.get(), index);
       ep->preModuleDelayedGetSignal_.connect(std::cref(actReg_->preModuleEventDelayedGetSignal_));
       ep->postModuleDelayedGetSignal_.connect(std::cref(actReg_->postModuleEventDelayedGetSignal_));
       principalCache_.insert(ep);
@@ -547,8 +556,8 @@ namespace edm {
       for(auto& subProcessPSet : *subProcessVParameterSet) { 
         subProcesses_->emplace_back(subProcessPSet,
                                     *parameterSet,
-                                    preg_,
-                                    branchIDListHelper_,
+                                    preg(),
+                                    branchIDListHelper(),
                                     *thinnedAssociationsHelper_,
                                     *espController_,
                                     *actReg_,
@@ -566,13 +575,14 @@ namespace edm {
     ServiceRegistry::Operate op(token);
 
     // manually destroy all these thing that may need the services around
-    espController_.reset();
-    subProcesses_.reset();
-    esp_.reset();
-    schedule_.reset();
-    input_.reset();
-    looper_.reset();
-    actReg_.reset();
+    // propagate_const<T> has no reset() function
+    espController_ = nullptr;
+    subProcesses_ = nullptr;
+    esp_ = nullptr;
+    schedule_ = nullptr;
+    input_ = nullptr;
+    looper_ = nullptr;
+    actReg_ = nullptr;
 
     pset::Registry::instance()->clear();
     ParentageRegistry::instance()->clear();
@@ -593,7 +603,7 @@ namespace edm {
                                  preallocations_.numberOfRuns(),
                                  preallocations_.numberOfThreads());
     actReg_->preallocateSignal_(bounds);
-    pathsAndConsumesOfModules_.initialize(schedule_.get(), preg_);
+    pathsAndConsumesOfModules_.initialize(schedule_.get(), preg());
     actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
 
     //NOTE:  This implementation assumes 'Job' means one call
@@ -665,7 +675,7 @@ namespace edm {
     }
     c.call(std::bind(&InputSource::doEndJob, input_.get()));
     if(looper_) {
-      c.call(std::bind(&EDLooperBase::endOfJob, looper_));
+      c.call(std::bind(&EDLooperBase::endOfJob, looper()));
     }
     c.call([actReg](){actReg->postEndJobSignal_();});
     if(c.hasThrown()) {
@@ -1325,7 +1335,7 @@ namespace edm {
                 if(size < preg_->size()) {
                   principalCache_.adjustIndexesAfterProductRegistryAddition();
                 }
-                principalCache_.adjustEventsToNewProductRegistry(preg_);
+                principalCache_.adjustEventsToNewProductRegistry(preg());
               }
             }
             {
@@ -1486,7 +1496,7 @@ namespace edm {
     if(size < preg_->size()) {
       principalCache_.adjustIndexesAfterProductRegistryAddition();
     }
-    principalCache_.adjustEventsToNewProductRegistry(preg_);
+    principalCache_.adjustEventsToNewProductRegistry(preg());
     if((numberOfForkedChildren_ > 0) or
        (preallocations_.numberOfStreams()>1 and
         preallocations_.numberOfThreads()>1)) {
@@ -1827,7 +1837,7 @@ namespace edm {
         << "Illegal attempt to insert run into cache\n"
         << "Contact a Framework Developer\n";
     }
-    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg_, *processConfiguration_, historyAppender_.get(), 0);
+    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg(), *processConfiguration_, historyAppender_.get(), 0);
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readRun(*rp, *historyAppender_);
@@ -1839,7 +1849,7 @@ namespace edm {
   }
 
   statemachine::Run EventProcessor::readAndMergeRun() {
-    principalCache_.merge(input_->runAuxiliary(), preg_);
+    principalCache_.merge(input_->runAuxiliary(), preg());
     auto runPrincipal =principalCache_.runPrincipalPtr();
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
@@ -1864,7 +1874,7 @@ namespace edm {
         << "Run is invalid\n"
         << "Contact a Framework Developer\n";
     }
-    auto lbp = std::make_shared<LuminosityBlockPrincipal>(input_->luminosityBlockAuxiliary(), preg_, *processConfiguration_, historyAppender_.get(), 0);
+    auto lbp = std::make_shared<LuminosityBlockPrincipal>(input_->luminosityBlockAuxiliary(), preg(), *processConfiguration_, historyAppender_.get(), 0);
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readLuminosityBlock(*lbp, *historyAppender_);
@@ -1876,7 +1886,7 @@ namespace edm {
   }
 
   int EventProcessor::readAndMergeLumi() {
-    principalCache_.merge(input_->luminosityBlockAuxiliary(), preg_);
+    principalCache_.merge(input_->luminosityBlockAuxiliary(), preg());
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readAndMergeLumi(*principalCache_.lumiPrincipalPtr());
@@ -1942,10 +1952,10 @@ namespace edm {
       return nullptr;
     }
   private:
-    EventProcessor* m_proc;
+    edm::propagate_const<EventProcessor*> m_proc;
     unsigned int m_streamID;
-    std::atomic<bool>* m_finishedProcessingEvents;
-    tbb::task* m_waitTask;
+    edm::propagate_const<std::atomic<bool>*> m_finishedProcessingEvents;
+    edm::propagate_const<tbb::task*> m_waitTask;
   };
   
   void EventProcessor::processEventsForStreamAsync(unsigned int iStreamIndex,

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -56,7 +56,7 @@
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RootHandlers.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "MessageForSource.h"
 #include "MessageForParent.h"
@@ -105,7 +105,8 @@ namespace {
       reg_ = nullptr;
     }
   private:
-    edm::propagate_const<edm::ActivityRegistry*> reg_;
+    edm::ActivityRegistry* reg_; // We do not use propagate_const because the registry itself is mutable.
+
     
   };
 }

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -44,7 +44,7 @@ namespace edm {
 //
 EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordKey& iKey) : key_(iKey),
     validityInterval_(), finder_(), providers_(),
-    multipleFinders_(new std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> >()),
+    multipleFinders_(new std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>()),
     lastSyncWasBeginOfRun_(true)
 {
 }
@@ -77,21 +77,22 @@ void
 EventSetupRecordProvider::add(boost::shared_ptr<DataProxyProvider> iProvider)
 {
    assert(iProvider->isUsingRecord(key_));
-   assert(!search_all(providers_, iProvider));
-   providers_.push_back(iProvider);
+   edm::propagate_const<boost::shared_ptr<DataProxyProvider>> pProvider(iProvider);
+   assert(!search_all(providers_, pProvider));
+   providers_.emplace_back(iProvider);
 }
 
 void 
 EventSetupRecordProvider::addFinder(boost::shared_ptr<EventSetupRecordIntervalFinder> iFinder)
 {
-   boost::shared_ptr<EventSetupRecordIntervalFinder> oldFinder = finder_;  
+   auto oldFinder = finder();
    finder_ = iFinder;
-   if (0 != multipleFinders_.get()) {
-     multipleFinders_->push_back(iFinder);
+   if (nullptr != multipleFinders_.get()) {
+     multipleFinders_->emplace_back(iFinder);
    } else {
      //dependent records set there finders after the multipleFinders_ has been released
      // but they also have never had a finder set
-     if(0 != oldFinder.get()) {
+     if(nullptr != oldFinder.get()) {
        cms::Exception("EventSetupMultipleSources")<<"An additional source has been added to the Record "
        <<key_.name()<<"'\n"
        <<"after all the other sources have been dealt with.  This is a logic error, please send email to the framework group.";
@@ -115,7 +116,7 @@ EventSetupRecordProvider::setDependentProviders(const std::vector< boost::shared
    for_all(iProviders, std::bind(std::mem_fun(&DependentRecordIntervalFinder::addProviderWeAreDependentOn), &(*newFinder), _1));
    //if a finder was already set, add it as a depedency.  This is done to ensure that the IOVs properly change even if the
    // old finder does not update each time a dependent record does change
-   if(old.get() != 0) {
+   if(old.get() != nullptr) {
       newFinder->setAlternateFinder(old);
    }
 }
@@ -123,7 +124,7 @@ void
 EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap)
 {
   using std::placeholders::_1;
-  for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecord,this,_1,iMap));
+  for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper,this,_1,iMap));
   if (1 < multipleFinders_->size()) {
      
      boost::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder(new IntersectingIOVRecordIntervalFinder(key_));
@@ -204,7 +205,7 @@ EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime)
    }
    bool returnValue = false;
    //need to see if we get a new interval
-   if(0 != finder_.get()) {
+   if(nullptr != finder_.get()) {
       IOVSyncValue oldFirst(validityInterval_.first());
       
       validityInterval_ = finder_->findIntervalFor(key_, iTime);
@@ -214,11 +215,8 @@ EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime)
          //did we actually change?
          if(oldFirst != validityInterval_.first()) {
             //tell all Providers to update
-            for(std::vector<boost::shared_ptr<DataProxyProvider> >::iterator itProvider = providers_.begin(),
-	        itProviderEnd = providers_.end();
-                itProvider != itProviderEnd;
-                ++itProvider) {
-               (*itProvider)->newInterval(key_, validityInterval_);
+            for(auto& provider : providers_) {
+               provider->newInterval(key_, validityInterval_);
             }
             cacheReset();
          }
@@ -254,7 +252,7 @@ void
 EventSetupRecordProvider::resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap) {
    using std::placeholders::_1;
    record().clearProxies();
-   for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecord, this, _1, iMap));
+   for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
 }
 
 void 
@@ -288,24 +286,24 @@ EventSetupRecordProvider::proxyProviderDescriptions() const
 }
 
 boost::shared_ptr<DataProxyProvider> 
-EventSetupRecordProvider::proxyProvider(const ComponentDescription& iDesc) const {
+EventSetupRecordProvider::proxyProvider(ComponentDescription const& iDesc) {
    using std::placeholders::_1;
-   std::vector<boost::shared_ptr<DataProxyProvider> >::const_iterator itFound =
-   std::find_if(providers_.begin(),providers_.end(),
+   //std::vector<boost::shared_ptr<DataProxyProvider> >::const_iterator itFound =
+   auto itFound = std::find_if(providers_.begin(),providers_.end(),
                 std::bind(std::equal_to<ComponentDescription>(), 
                             iDesc, 
                             std::bind(&DataProxyProvider::description,_1)));
    if(itFound == providers_.end()){
       return boost::shared_ptr<DataProxyProvider>();
    }
-   return *itFound;
+   return get_underlying_safe(*itFound);
 }
 
 boost::shared_ptr<DataProxyProvider> 
-EventSetupRecordProvider::proxyProvider(ParameterSetIDHolder const& psetID) const {
-   for (auto const& dataProxyProvider : providers_) {
+EventSetupRecordProvider::proxyProvider(ParameterSetIDHolder const& psetID) {
+   for (auto& dataProxyProvider : providers_) {
       if (dataProxyProvider->description().pid_ == psetID.psetID()) {
-         return dataProxyProvider;
+         return get_underlying_safe(dataProxyProvider);
       }
    }
    return boost::shared_ptr<DataProxyProvider>();

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -288,7 +288,6 @@ EventSetupRecordProvider::proxyProviderDescriptions() const
 boost::shared_ptr<DataProxyProvider> 
 EventSetupRecordProvider::proxyProvider(ComponentDescription const& iDesc) {
    using std::placeholders::_1;
-   //std::vector<boost::shared_ptr<DataProxyProvider> >::const_iterator itFound =
    auto itFound = std::find_if(providers_.begin(),providers_.end(),
                 std::bind(std::equal_to<ComponentDescription>(), 
                             iDesc, 

--- a/FWCore/Framework/src/EventSignalsSentry.h
+++ b/FWCore/Framework/src/EventSignalsSentry.h
@@ -21,7 +21,6 @@
 // system include files
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // user include files
 
@@ -42,7 +41,7 @@ namespace edm {
     
   private:
     // ---------- member data --------------------------------
-    edm::propagate_const<ActivityRegistry*> m_reg;
+    ActivityRegistry* m_reg; // We do not use propagate_const because the registry itself is mutable.
     ModuleCallingContext const* m_context;
   };
 }

--- a/FWCore/Framework/src/EventSignalsSentry.h
+++ b/FWCore/Framework/src/EventSignalsSentry.h
@@ -21,6 +21,7 @@
 // system include files
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // user include files
 
@@ -41,7 +42,7 @@ namespace edm {
     
   private:
     // ---------- member data --------------------------------
-    ActivityRegistry* m_reg;
+    edm::propagate_const<ActivityRegistry*> m_reg;
     ModuleCallingContext const* m_context;
   };
 }

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -11,7 +11,7 @@ namespace edm {
 
   static void cleanup(const Factory::MakerMap::value_type& v)
   {
-    delete v.second;
+    delete v.second.get();
   }
 
   Factory const Factory::singleInstance_;

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <memory>
 #include "FWCore/Utilities/interface/Signal.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
   typedef edmplugin::PluginFactory<Maker* ()> MakerPluginFactory;

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <memory>
 #include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
   typedef edmplugin::PluginFactory<Maker* ()> MakerPluginFactory;
@@ -17,7 +18,7 @@ namespace edm {
   class Factory  
   {
   public:
-    typedef std::map<std::string, Maker*> MakerMap;
+    typedef std::map<std::string, edm::propagate_const<Maker*>> MakerMap;
 
     ~Factory();
 

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -45,7 +45,7 @@ namespace edm {
 
     }
     if(inserter) {
-      results_inserter_.reset(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
+      results_inserter_ = WorkerPtr(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions)); // propagate_const<T> has no reset() function
       inserter->doPreallocate(prealloc);
       results_inserter_->setActivityRegistry(actReg_);
       addToAllWorkers(results_inserter_.get());

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -19,6 +19,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <map>
 #include <memory>
@@ -52,7 +53,7 @@ namespace edm {
 
     private:
       // We own none of these resources.
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       typename T::Context const* context_;
       bool allowThrow_;
     };
@@ -135,7 +136,7 @@ namespace edm {
         reg_ = nullptr;
       }
     private:
-      edm::ActivityRegistry* reg_;
+      edm::propagate_const<edm::ActivityRegistry*> reg_;
       GlobalContext const* context_;
     };
 
@@ -152,8 +153,8 @@ namespace edm {
     void addToAllWorkers(Worker* w);
     
     WorkerManager                         workerManager_;
-    std::shared_ptr<ActivityRegistry>   actReg_;
-    WorkerPtr                             results_inserter_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    edm::propagate_const<WorkerPtr>       results_inserter_;
 
 
     ProcessContext const*                 processContext_;

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -19,7 +19,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>
@@ -53,7 +53,7 @@ namespace edm {
 
     private:
       // We own none of these resources.
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       typename T::Context const* context_;
       bool allowThrow_;
     };
@@ -136,7 +136,7 @@ namespace edm {
         reg_ = nullptr;
       }
     private:
-      edm::propagate_const<edm::ActivityRegistry*> reg_;
+      edm::ActivityRegistry* reg_; // We do not use propagate_const because the registry itself is mutable.
       GlobalContext const* context_;
     };
 
@@ -153,7 +153,7 @@ namespace edm {
     void addToAllWorkers(Worker* w);
     
     WorkerManager                         workerManager_;
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry>     actReg_; // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<WorkerPtr>       results_inserter_;
 
 

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -246,12 +246,12 @@ namespace edm {
   }
 
   SharedResourcesAcquirer*
-  InputSource::resourceSharedWithDelayedReader() const {
+  InputSource::resourceSharedWithDelayedReader() {
     return resourceSharedWithDelayedReader_();
   }
 
   SharedResourcesAcquirer*
-  InputSource::resourceSharedWithDelayedReader_() const {
+  InputSource::resourceSharedWithDelayedReader_() {
     return nullptr;
   }
 

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
@@ -58,7 +58,7 @@ IntersectingIOVRecordIntervalFinder::~IntersectingIOVRecordIntervalFinder()
 // member functions
 //
 void 
-IntersectingIOVRecordIntervalFinder::swapFinders(std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> >& iFinders)
+IntersectingIOVRecordIntervalFinder::swapFinders(std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>& iFinders)
 {
    finders_.swap(iFinders);
 }
@@ -77,9 +77,8 @@ IntersectingIOVRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& i
    bool haveUnknownEnding = false;
    ValidityInterval newInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
 
-   for(std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> >::iterator it = finders_.begin(),
-       itEnd = finders_.end(); it != itEnd; ++it) {
-      ValidityInterval test = (*it)->findIntervalFor(iKey, iTime);
+   for(auto& finder : finders_) {
+      ValidityInterval test = finder->findIntervalFor(iKey, iTime);
       if ( test != ValidityInterval::invalidInterval() ) {
          haveAValidRecord =true;
          if(newInterval.first() < test.first()) {

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
@@ -24,6 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -40,7 +41,7 @@ namespace edm {
          // ---------- static member functions --------------------
          
          // ---------- member functions ---------------------------
-         void swapFinders(std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> >&);
+         void swapFinders(std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>&);
       protected:
          virtual void setIntervalFor(const EventSetupRecordKey&,
                                      const IOVSyncValue& , 
@@ -52,7 +53,7 @@ namespace edm {
          const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&); // stop default
          
          // ---------- member data --------------------------------
-         std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> > finders_;
+         std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;
       };
    }
 }

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
 

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -65,7 +65,7 @@ namespace edm {
     ProductPtrVec::iterator pie(putProducts().end());
 
     while(pit != pie) {
-        lbp.put(*pit->second, std::move(pit->first));
+        lbp.put(*pit->second, std::move(get_underlying_safe(pit->first)));
         ++pit;
     }
 

--- a/FWCore/Framework/src/ModuleChanger.cc
+++ b/FWCore/Framework/src/ModuleChanger.cc
@@ -59,15 +59,16 @@ ModuleChanger::~ModuleChanger()
 // member functions
 //
 
-//
-// const member functions
-//
 bool 
 ModuleChanger::changeModule(const std::string& iLabel,
-                            const ParameterSet& iPSet) const
+                            const ParameterSet& iPSet)
 {
    return schedule_->changeModule(iLabel,iPSet, *registry_);
 }
+
+//
+// const member functions
+//
 
 //
 // static member functions

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -30,9 +30,9 @@ namespace edm {
       
       // Transfer ownership of worker to the registry
       labelToModule_[moduleLabel] = modPtr;
-      return labelToModule_[moduleLabel];
+      return modPtr;
     }
-    return (modItr->second);
+    return get_underlying_safe(modItr->second);
   }
   
   maker::ModuleHolder*

--- a/FWCore/Framework/src/ModuleRegistry.h
+++ b/FWCore/Framework/src/ModuleRegistry.h
@@ -25,6 +25,7 @@
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -50,13 +51,13 @@ namespace edm {
     
     template <typename F>
     void forAllModuleHolders(F iFunc) {
-      for(auto const& labelMod: labelToModule_) {
+      for(auto& labelMod: labelToModule_) {
         maker::ModuleHolder* t = labelMod.second.get();
         iFunc(t);
       }
     }
   private:
-    std::map<std::string,std::shared_ptr<maker::ModuleHolder>> labelToModule_;
+    std::map<std::string, edm::propagate_const<std::shared_ptr<maker::ModuleHolder>>> labelToModule_;
   };
 }
 

--- a/FWCore/Framework/src/ModuleRegistry.h
+++ b/FWCore/Framework/src/ModuleRegistry.h
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -19,7 +19,6 @@
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -96,7 +95,7 @@ namespace edm {
 
     int bitpos_;
     TrigResPtr trptr_;
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
     ExceptionToActionTable const* act_table_;
 
     WorkersInPath workers_;
@@ -144,7 +143,7 @@ namespace edm {
         if(a_) T::postPathSignal(a_, status, pathContext_);
       }
     private:
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       int const& nwrwue_;
       hlt::HLTState const& state_;
       PathContext const* pathContext_;

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -19,6 +19,7 @@
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -95,7 +96,7 @@ namespace edm {
 
     int bitpos_;
     TrigResPtr trptr_;
-    std::shared_ptr<ActivityRegistry> actReg_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
     ExceptionToActionTable const* act_table_;
 
     WorkersInPath workers_;
@@ -143,7 +144,7 @@ namespace edm {
         if(a_) T::postPathSignal(a_, status, pathContext_);
       }
     private:
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       int const& nwrwue_;
       hlt::HLTState const& state_;
       PathContext const* pathContext_;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -813,7 +813,7 @@ namespace edm {
       assert(index!=ProductHolderIndexInvalid);
       ProductHolderIndex indexO = other.preg_->indexFrom(prod);
       assert(indexO!=ProductHolderIndexInvalid);
-      get_underlying(productHolders_[index]).swap(get_underlying(other.productHolders_[indexO]));
+      get_underlying_safe(productHolders_[index]).swap(get_underlying_safe(other.productHolders_[indexO]));
     }
     reader_->mergeReaders(other.reader());
   }

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
 

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -81,7 +81,7 @@ namespace edm {
     ProductPtrVec::iterator pie(putProducts().end());
 
     while(pit != pie) {
-        rp.put(*pit->second, std::move(pit->first));
+        rp.put(*pit->second, std::move(get_underlying_safe(pit->first)));
         ++pit;
     }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1065,7 +1065,7 @@ namespace edm {
   }
                           
   void
-  Schedule::getTriggerTimingReport(TriggerTimingReport& rep) {
+  Schedule::getTriggerTimingReport(TriggerTimingReport& rep) const {
     rep.eventSummary.totalEvents = 0;
     rep.eventSummary.cpuTime = 0.;
     rep.eventSummary.realTime = 0.;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -941,7 +941,7 @@ namespace edm {
     globalSchedule_->replaceModule(newMod,iLabel);
 
     for(auto& s: streamSchedules_) {
-      get_underlying_safe(s)->replaceModule(newMod,iLabel);
+      s->replaceModule(newMod,iLabel);
     }
     
     {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -383,7 +383,15 @@ namespace edm {
     assert(0<prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
     for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
-      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(resultsInserter_,moduleRegistry_,proc_pset,tns,prealloc,preg,branchIDListHelper,actions,areg,processConfiguration,!hasSubprocesses,StreamID{i},processContext));
+      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(
+        resultsInserter(),
+        moduleRegistry(),
+        proc_pset,tns,prealloc,preg,
+        branchIDListHelper,actions,
+        areg,processConfiguration,
+        !hasSubprocesses,
+        StreamID{i},
+        processContext));
     }
     
     //TriggerResults are injected automatically by StreamSchedules and are
@@ -407,16 +415,19 @@ namespace edm {
       std::copy(modulesToUse.begin(),itBeginUnscheduled,std::back_inserter(temp));
       temp.swap(modulesToUse);
     }
-    globalSchedule_.reset(new GlobalSchedule{ resultsInserter_,
-      moduleRegistry_,
+
+    // propagate_const<T> has no reset() function
+    globalSchedule_ = std::make_unique<GlobalSchedule>(
+      resultsInserter(),
+      moduleRegistry(),
       modulesToUse,
       proc_pset, preg, prealloc,
-      actions,areg,processConfiguration,processContext });
+      actions,areg,processConfiguration,processContext);
     
     //TriggerResults is not in the top level ParameterSet so the call to
     // reduceParameterSet would fail to find it. Just remove it up front.
     std::set<std::string> usedModuleLabels;
-    for(auto const worker: allWorkers()) {
+    for(auto const& worker: allWorkers()) {
       if(worker->description().moduleLabel() != kTriggerResults) {
         usedModuleLabels.insert(worker->description().moduleLabel());
       }
@@ -458,7 +469,7 @@ namespace edm {
     }
     thinnedAssociationsHelper.sort();
 
-    for (auto c : all_output_communicators_) {
+    for (auto& c : all_output_communicators_) {
       c->setEventSelectionInfo(outputModulePathPositions, preg.anyProductProduced());
       c->selectProducts(preg, thinnedAssociationsHelper);
     }
@@ -474,9 +485,11 @@ namespace edm {
                        return iWorker->descPtr();
                      });
       
-      summaryTimeKeeper_.reset(new SystemTimeKeeper(prealloc.numberOfStreams(),
+      // propagate_const<T> has no reset() function
+      summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(
+                                                    prealloc.numberOfStreams(),
                                                     modDesc,
-                                                    tns));
+                                                    tns);
       auto timeKeeperPtr = summaryTimeKeeper_.get();
       
       areg->watchPreModuleEvent(timeKeeperPtr, &SystemTimeKeeper::startModuleEvent);
@@ -525,7 +538,7 @@ namespace edm {
         "\nAt most, one form of 'output' may appear in the 'maxEvents' parameter set";
     }
 
-    for (auto c : all_output_communicators_) {
+    for (auto& c : all_output_communicators_) {
       OutputModuleDescription desc(branchIDLists, maxEventsOut);
       if (vMaxEventsOut != 0 && !vMaxEventsOut->empty()) {
         std::string const& moduleLabel = c->description().moduleLabel();
@@ -544,7 +557,7 @@ namespace edm {
     if (all_output_communicators_.empty()) {
       return false;
     }
-    for (auto c : all_output_communicators_) {
+    for (auto& c : all_output_communicators_) {
       if (!c->limitReached()) {
         // Found an output module that has not reached output event count.
         return false;
@@ -927,8 +940,8 @@ namespace edm {
     
     globalSchedule_->replaceModule(newMod,iLabel);
 
-    for(auto s: streamSchedules_) {
-      s->replaceModule(newMod,iLabel);
+    for(auto& s: streamSchedules_) {
+      get_underlying_safe(s)->replaceModule(newMod,iLabel);
     }
     
     {
@@ -1031,7 +1044,7 @@ namespace edm {
   void
   Schedule::enableEndPaths(bool active) {
     endpathsAreActive_ = active;
-    for(auto const &  s : streamSchedules_) {
+    for(auto& s : streamSchedules_) {
       s->enableEndPaths(active);
     }
   }
@@ -1052,7 +1065,7 @@ namespace edm {
   }
                           
   void
-  Schedule::getTriggerTimingReport(TriggerTimingReport& rep) const {
+  Schedule::getTriggerTimingReport(TriggerTimingReport& rep) {
     rep.eventSummary.totalEvents = 0;
     rep.eventSummary.cpuTime = 0.;
     rep.eventSummary.realTime = 0.;
@@ -1089,7 +1102,7 @@ namespace edm {
   
   void
   Schedule::clearCounters() {
-    for(auto const& s: streamSchedules_) {
+    for(auto& s: streamSchedules_) {
       s->clearCounters();
     }
   }

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -116,7 +116,7 @@ namespace edm {
   ScheduleItems::initMisc(ParameterSet& parameterSet) {
     act_table_.reset(new ExceptionToActionTable(parameterSet));
     std::string processName = parameterSet.getParameter<std::string>("@process_name");
-    processConfiguration_.reset(new ProcessConfiguration(processName, getReleaseVersion(), getPassID()));
+    processConfiguration_ = std::make_shared<ProcessConfiguration>(processName, getReleaseVersion(), getPassID()); // propagate_const<T> has no reset() function
     auto common = std::make_shared<CommonParams>(
                                 parameterSet.getUntrackedParameterSet(
                                    "maxEvents", ParameterSet()).getUntrackedParameter<int>("input", -1),
@@ -140,7 +140,7 @@ namespace edm {
                      *thinnedAssociationsHelper_,
                      *act_table_,
                      actReg_,
-                     processConfiguration_,
+                     processConfiguration(),
                      hasSubprocesses,
                      config,
                      processContext));
@@ -149,10 +149,11 @@ namespace edm {
 
   void
   ScheduleItems::clear() {
-    actReg_.reset();
-    preg_.reset();
-    branchIDListHelper_.reset();
-    thinnedAssociationsHelper_.reset();
-    processConfiguration_.reset();
+    // propagate_const<T> has no reset() function
+    actReg_ = nullptr;
+    preg_ = nullptr;
+    branchIDListHelper_ = nullptr;
+    thinnedAssociationsHelper_ = nullptr;
+    processConfiguration_ = nullptr;
   }
 }

--- a/FWCore/Framework/src/SharedResourcesRegistry.cc
+++ b/FWCore/Framework/src/SharedResourcesRegistry.cc
@@ -67,7 +67,7 @@ namespace edm {
   SharedResourcesAcquirer
   SharedResourcesRegistry::createAcquirerForSourceDelayedReader() {
     if(not resourceForDelayedReader_) {
-      resourceForDelayedReader_.reset(new std::recursive_mutex{});
+      resourceForDelayedReader_ = std::make_shared<std::recursive_mutex>(); // propagate_const<T> has no reset() function
     }
     std::vector<std::recursive_mutex*> mutexes = {resourceForDelayedReader_.get()};
 

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -25,6 +25,8 @@
 #include <mutex>
 #include <memory>
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 // user include files
 
 // forward declarations
@@ -70,7 +72,7 @@ namespace edm {
     // ---------- member data --------------------------------
     std::map<std::string, std::pair<std::shared_ptr<std::recursive_mutex>,unsigned int>> resourceMap_;
     
-    std::shared_ptr<std::recursive_mutex> resourceForDelayedReader_;
+    edm::propagate_const<std::shared_ptr<std::recursive_mutex>> resourceForDelayedReader_;
 
     unsigned int nLegacy_;
   };

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <memory>
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // user include files
 

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -165,14 +165,14 @@ namespace edm {
     trig_paths_.reserve(trig_name_list_.size());
     vstring labelsOnTriggerPaths;
       for (auto const& trig_name : trig_name_list_) {
-      fillTrigPath(proc_pset, preg, &prealloc, processConfiguration, trig_bitpos, trig_name, results_, &labelsOnTriggerPaths);
+      fillTrigPath(proc_pset, preg, &prealloc, processConfiguration, trig_bitpos, trig_name, results(), &labelsOnTriggerPaths);
       ++trig_bitpos;
       hasPath = true;
     }
 
     if (hasPath) {
       // the results inserter stands alone
-      inserter->setTrigResultForStream(streamID.value(),results_);
+      inserter->setTrigResultForStream(streamID.value(), results());
 
       results_inserter_ = makeInserter(actions, actReg_, inserter);
       addToAllWorkers(results_inserter_.get());

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -81,6 +81,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <map>
 #include <memory>
@@ -129,7 +130,7 @@ namespace edm {
 
     private:
       // We own none of these resources.
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       typename T::Context const* context_;
       bool allowThrow_;
     };
@@ -141,9 +142,9 @@ namespace edm {
     typedef std::vector<Path> TrigPaths;
     typedef std::vector<Path> NonTrigPaths;
     typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
+    typedef std::shared_ptr<HLTGlobalStatus const> TrigResConstPtr;
     typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
-    typedef std::vector<std::shared_ptr<OutputModuleCommunicator> > AllOutputModuleCommunicators;
 
     typedef std::vector<Worker*> Workers;
 
@@ -276,7 +277,7 @@ namespace edm {
         reg_ = nullptr;
       }
     private:
-      edm::ActivityRegistry* reg_;
+      edm::propagate_const<edm::ActivityRegistry*> reg_;
       StreamContext const* context_;
     };
 
@@ -322,15 +323,18 @@ namespace edm {
                                edm::ProductRegistry const& preg, 
                                bool allowEarlyDelete);
 
+    TrigResConstPtr results() const {return get_underlying_safe(results_);}
+    TrigResPtr& results() {return get_underlying_safe(results_);}
+
     WorkerManager            workerManager_;
-    std::shared_ptr<ActivityRegistry>           actReg_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
 
     vstring                  trig_name_list_;
     vstring                  end_path_name_list_;
 
-    TrigResPtr               results_;
+    edm::propagate_const<TrigResPtr> results_;
 
-    WorkerPtr                results_inserter_;
+    edm::propagate_const<WorkerPtr> results_inserter_;
     TrigPaths                trig_paths_;
     TrigPaths                end_paths_;
     std::vector<int>         empty_trig_paths_;

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -81,7 +81,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <map>
 #include <memory>
@@ -130,7 +130,7 @@ namespace edm {
 
     private:
       // We own none of these resources.
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       typename T::Context const* context_;
       bool allowThrow_;
     };
@@ -277,7 +277,7 @@ namespace edm {
         reg_ = nullptr;
       }
     private:
-      edm::propagate_const<edm::ActivityRegistry*> reg_;
+      edm::ActivityRegistry* reg_; // We do not use propagate_const because the registry itself is mutable.
       StreamContext const* context_;
     };
 
@@ -327,7 +327,7 @@ namespace edm {
     TrigResPtr& results() {return get_underlying_safe(results_);}
 
     WorkerManager            workerManager_;
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
 
     vstring                  trig_name_list_;
     vstring                  end_path_name_list_;

--- a/FWCore/Framework/src/SystemTimeKeeper.cc
+++ b/FWCore/Framework/src/SystemTimeKeeper.cc
@@ -245,7 +245,7 @@ fillPathSummary(unsigned int iStartIndex,
 }
 
 void
-SystemTimeKeeper::fillTriggerTimingReport( TriggerTimingReport& rep) {
+SystemTimeKeeper::fillTriggerTimingReport(TriggerTimingReport& rep) const {
   {
     rep.eventSummary.totalEvents = m_numberOfEvents;
     double sumEventTime = 0.;

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -83,7 +83,7 @@ namespace edm {
       unsigned int m_timesRun =0;
     };
 
-    void fillTriggerTimingReport( TriggerTimingReport& rep) ;
+    void fillTriggerTimingReport(TriggerTimingReport& rep) const;
   private:
     SystemTimeKeeper(const SystemTimeKeeper&) = delete; // stop default
     

--- a/FWCore/Framework/src/TriggerResultInserter.h
+++ b/FWCore/Framework/src/TriggerResultInserter.h
@@ -16,6 +16,7 @@
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -43,7 +44,7 @@ namespace edm
     void produce(StreamID id, edm::Event& e, edm::EventSetup const& c) const override final;
 
   private:
-    std::vector<TrigResPtr> resultsPerStream_;
+    std::vector<edm::propagate_const<TrigResPtr>> resultsPerStream_;
 
     ParameterSetID pset_id_;
   };

--- a/FWCore/Framework/src/TriggerResultInserter.h
+++ b/FWCore/Framework/src/TriggerResultInserter.h
@@ -16,7 +16,7 @@
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -5,7 +5,6 @@
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/EarlyDeleteHelper.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
   namespace {
@@ -18,7 +17,7 @@ public:
         if(a_) a_->postModuleBeginJobSignal_(*md_);
       }
 private:
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       ModuleDescription const* md_;
     };
 
@@ -31,7 +30,7 @@ public:
         if(a_) a_->postModuleEndJobSignal_(*md_);
       }
 private:
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       ModuleDescription const* md_;
     };
 
@@ -46,7 +45,7 @@ private:
         if(a_) a_->postModuleBeginStreamSignal_(sc_, mcc_);
       }
     private:
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       StreamContext const& sc_;
       ModuleCallingContext const& mcc_;
     };
@@ -62,7 +61,7 @@ private:
         if(a_) a_->postModuleEndStreamSignal_(sc_, mcc_);
       }
     private:
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       StreamContext const& sc_;
       ModuleCallingContext const& mcc_;
     };

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/EarlyDeleteHelper.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
   namespace {
@@ -17,7 +18,7 @@ public:
         if(a_) a_->postModuleBeginJobSignal_(*md_);
       }
 private:
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       ModuleDescription const* md_;
     };
 
@@ -30,7 +31,7 @@ public:
         if(a_) a_->postModuleEndJobSignal_(*md_);
       }
 private:
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       ModuleDescription const* md_;
     };
 
@@ -45,7 +46,7 @@ private:
         if(a_) a_->postModuleBeginStreamSignal_(sc_, mcc_);
       }
     private:
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       StreamContext const& sc_;
       ModuleCallingContext const& mcc_;
     };
@@ -61,7 +62,7 @@ private:
         if(a_) a_->postModuleEndStreamSignal_(sc_, mcc_);
       }
     private:
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       StreamContext const& sc_;
       ModuleCallingContext const& mcc_;
     };

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -41,6 +41,7 @@ the worker is reset().
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
@@ -189,11 +190,11 @@ namespace edm {
     ModuleCallingContext moduleCallingContext_;
 
     ExceptionToActionTable const* actions_; // memory assumed to be managed elsewhere
-    std::shared_ptr<cms::Exception> cached_exception_; // if state is 'exception'
+    edm::propagate_const<std::shared_ptr<cms::Exception>> cached_exception_; // if state is 'exception'
 
-    std::shared_ptr<ActivityRegistry> actReg_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
 
-    EarlyDeleteHelper* earlyDeleteHelper_;
+    edm::propagate_const<EarlyDeleteHelper*> earlyDeleteHelper_;
   };
 
   namespace {
@@ -213,7 +214,7 @@ namespace edm {
       }
 
     private:
-      ActivityRegistry* a_;
+      edm::propagate_const<ActivityRegistry*> a_;
       typename T::Context const* context_;
       ModuleCallingContext const* moduleCallingContext_;
     };
@@ -537,7 +538,7 @@ namespace edm {
         default:
           if (T::isEvent_) ++timesExcept_;
 	  state_ = Exception;
-          cached_exception_.reset(ex.clone());
+          cached_exception_ = std::shared_ptr<cms::Exception>(ex.clone()); // propagate_const<T> has no reset() function
 	  cached_exception_->raise();
       }
     }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -41,7 +41,7 @@ the worker is reset().
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
@@ -192,7 +192,7 @@ namespace edm {
     ExceptionToActionTable const* actions_; // memory assumed to be managed elsewhere
     edm::propagate_const<std::shared_ptr<cms::Exception>> cached_exception_; // if state is 'exception'
 
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
 
     edm::propagate_const<EarlyDeleteHelper*> earlyDeleteHelper_;
   };
@@ -214,7 +214,7 @@ namespace edm {
       }
 
     private:
-      edm::propagate_const<ActivityRegistry*> a_;
+      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
       typename T::Context const* context_;
       ModuleCallingContext const* moduleCallingContext_;
     };

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -135,7 +135,7 @@ namespace edm {
   WorkerManager::setupOnDemandSystem(EventPrincipal& ep, EventSetup const& es) {
     // NOTE: who owns the productdescrption?  Just copied by value
     unscheduled_->setEventSetup(es);
-    ep.setUnscheduledHandler(unscheduled_);
+    ep.setUnscheduledHandler(unscheduled());
   }
   
 }

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -52,7 +52,7 @@ namespace edm {
       workerPtr->setActivityRegistry(actReg_);
 
       // Transfer ownership of worker to the registry
-      m_workerMap[moduleLabel].reset(workerPtr.release());
+      m_workerMap[moduleLabel] = std::shared_ptr<Worker>(workerPtr.release()); // propagate_const<T> has no reset() function
       return m_workerMap[moduleLabel].get(); 
     } 
     return (workerIt->second.get());

--- a/FWCore/Framework/src/WorkerRegistry.h
+++ b/FWCore/Framework/src/WorkerRegistry.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <string>
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace edm {
 
@@ -55,13 +56,13 @@ namespace edm {
     
   private:
     /// the container of workers
-    typedef std::map<std::string, std::shared_ptr<Worker> > WorkerMap;
+    typedef std::map<std::string, edm::propagate_const<std::shared_ptr<Worker>>> WorkerMap;
 
-    std::shared_ptr<ModuleRegistry> modRegistry_;
+    edm::propagate_const<std::shared_ptr<ModuleRegistry>> modRegistry_;
     
     /// internal map of registered workers (owned).
     WorkerMap m_workerMap;
-    std::shared_ptr<ActivityRegistry> actReg_;
+    mutable std::shared_ptr<ActivityRegistry> actReg_;
      
   }; // WorkerRegistry
 

--- a/FWCore/Framework/src/WorkerRegistry.h
+++ b/FWCore/Framework/src/WorkerRegistry.h
@@ -14,7 +14,7 @@
 #include <map>
 #include <string>
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
 
@@ -62,7 +62,7 @@ namespace edm {
     
     /// internal map of registered workers (owned).
     WorkerMap m_workerMap;
-    mutable std::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
      
   }; // WorkerRegistry
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -12,7 +12,7 @@ WorkerT: Code common to all workers.
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerParams.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -12,7 +12,7 @@ WorkerT: Code common to all workers.
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerParams.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <map>
 #include <memory>

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -17,6 +17,7 @@ Test of the EventProcessor class.
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Presence.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "cppunit/extensions/HelperMacros.h"
 
@@ -46,11 +47,11 @@ class testeventprocessor: public CppUnit::TestFixture {
   void setUp() {
     //std::cout << "setting up testeventprocessor" << std::endl;
     doInit();
-    m_handler = std::auto_ptr<edm::AssertHandler>(new edm::AssertHandler());
+    m_handler = std::make_unique<edm::AssertHandler>(); // propagate_const<T> has no reset() function
     sleep_secs_ = 0;
   }
 
-  void tearDown() { m_handler.reset();}
+  void tearDown() { m_handler = nullptr; }
   void parseTest();
   void beginEndTest();
   void cleanupJobTest();
@@ -60,7 +61,7 @@ class testeventprocessor: public CppUnit::TestFixture {
   void serviceConfigSaveTest();
 
  private:
-  std::auto_ptr<edm::AssertHandler> m_handler;
+  edm::propagate_const<std::unique_ptr<edm::AssertHandler>> m_handler;
   void work() {
     //std::cout << "work in testeventprocessor" << std::endl;
     std::string configuration(

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -17,7 +17,7 @@ Test of the EventProcessor class.
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Presence.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "cppunit/extensions/HelperMacros.h"
 

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -98,7 +98,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -98,7 +98,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -79,7 +79,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -79,7 +79,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;

--- a/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
+++ b/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
@@ -86,7 +86,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
    const EventSetupRecordKey dummyRecordKey = DummyRecord::keyForClass();
 
    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-   std::vector<boost::shared_ptr<edm::EventSetupRecordIntervalFinder> > finders;
+   std::vector<edm::propagate_const<boost::shared_ptr<edm::EventSetupRecordIntervalFinder>>> finders;
    boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
    {
       const edm::EventID eID_1(1, 1, 1);

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -87,7 +87,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -87,7 +87,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;

--- a/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
@@ -80,7 +80,7 @@ void testProxyfactor::registerProxyfactorytemplateTest()
       testProd.keyedProxies(dummyRecordKey);
 
    CPPUNIT_ASSERT(keyedProxies.size() == 1);
-   CPPUNIT_ASSERT(0 != dynamic_cast<DummyProxy*>(&(*(keyedProxies.front().second))));
+   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
 }
 
 void testProxyfactor::labelTest()
@@ -93,7 +93,7 @@ void testProxyfactor::labelTest()
       testProd.keyedProxies(dummyRecordKey);
    
    CPPUNIT_ASSERT(keyedProxies.size() == 1);
-   CPPUNIT_ASSERT(0 != dynamic_cast<DummyProxy*>(&(*(keyedProxies.front().second))));
+   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
    const std::string kFred("fred");
    CPPUNIT_ASSERT(kFred == keyedProxies.front().first.name().value());
 }
@@ -115,7 +115,7 @@ void testProxyfactor::appendLabelTest()
       testProd.keyedProxies(dummyRecordKey);
     
     CPPUNIT_ASSERT(keyedProxies.size() == 1);
-    CPPUNIT_ASSERT(0 != dynamic_cast<DummyProxy*>(&(*(keyedProxies.front().second))));
+    CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
     const std::string kFredBarney("fredBarney");
     CPPUNIT_ASSERT(kFredBarney == keyedProxies.front().first.name().value());
   }
@@ -129,7 +129,7 @@ void testProxyfactor::appendLabelTest()
     testProd.keyedProxies(dummyRecordKey);
   
   CPPUNIT_ASSERT(keyedProxies.size() == 1);
-  CPPUNIT_ASSERT(0 != dynamic_cast<DummyProxy*>(&(*(keyedProxies.front().second))));
+  CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
   const std::string kBarney("Barney");
   CPPUNIT_ASSERT(kBarney == keyedProxies.front().first.name().value());
   

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -97,7 +97,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -97,7 +97,7 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  mutable std::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   

--- a/FWCore/Framework/test/stubs/DummyLooper.cc
+++ b/FWCore/Framework/test/stubs/DummyLooper.cc
@@ -27,9 +27,7 @@
 
 #include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyRecord.h"
-
-
-
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 //
 // class decleration
@@ -42,6 +40,7 @@ class DummyLooper : public edm::ESProducerLooper {
       ~DummyLooper();
 
       typedef boost::shared_ptr<DummyData> ReturnType;
+      typedef boost::shared_ptr<DummyData const> ConstReturnType;
 
       ReturnType produce(const DummyRecord&);
       
@@ -58,7 +57,10 @@ class DummyLooper : public edm::ESProducerLooper {
       }
    private:
       // ----------member data ---------------------------
-      ReturnType data_;
+      ConstReturnType data() const {return get_underlying_safe(data_);}
+      ReturnType& data() {return get_underlying_safe(data_);}
+
+      edm::propagate_const<ReturnType> data_;
       int counter_;
       bool issueStop_;
 };
@@ -103,7 +105,7 @@ DummyLooper::~DummyLooper()
 DummyLooper::ReturnType
 DummyLooper::produce(const DummyRecord&)
 {
-   return data_ ;
+   return data();
 }
 
 //define this as a plug-in

--- a/FWCore/Framework/test/stubs/DummyLooper.cc
+++ b/FWCore/Framework/test/stubs/DummyLooper.cc
@@ -27,7 +27,7 @@
 
 #include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyRecord.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 //
 // class decleration

--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.h
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <vector>
 
@@ -32,7 +33,7 @@ namespace edmtest {
 
     std::vector<unsigned long long> expectedRunLumisEvents0_;
     std::vector<unsigned long long> expectedRunLumisEvents1_;
-    std::vector<unsigned long long> *expectedRunLumisEvents_;
+    edm::propagate_const<std::vector<unsigned long long>*> expectedRunLumisEvents_;
     int index_;
     bool verbose_;
     bool dumpTriggerResults_;

--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.h
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.h
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <vector>
 

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -46,6 +46,10 @@ struct UnsafeCache {
    unsigned int strm;
    unsigned int work;
 };
+
+struct Dummy {
+};
+
 } //end anonymous namespace
 
 
@@ -428,7 +432,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginRunFilter : public edm::global::EDFilter<edm::RunCache<void>,edm::BeginRunProducer> {
+  class TestBeginRunFilter : public edm::global::EDFilter<edm::RunCache<Dummy>,edm::BeginRunProducer> {
   public:
     explicit TestBeginRunFilter(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {
@@ -439,9 +443,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> brp{false}; 
 
-    std::shared_ptr<void> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       brp = false;
-      return std::shared_ptr<void>();
+      return std::shared_ptr<Dummy>();
     }
  
     void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
@@ -469,7 +473,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestEndRunFilter : public edm::global::EDFilter<edm::RunCache<void>,edm::EndRunProducer> {
+  class TestEndRunFilter : public edm::global::EDFilter<edm::RunCache<Dummy>,edm::EndRunProducer> {
   public:
     explicit TestEndRunFilter(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {
@@ -479,9 +483,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> p{false}; 
 
-    std::shared_ptr<void> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       p = false;
-      return std::shared_ptr<void>();
+      return std::shared_ptr<Dummy>();
     }
 
 
@@ -510,7 +514,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginLumiBlockFilter : public edm::global::EDFilter<edm::LuminosityBlockCache<void>,edm::BeginLuminosityBlockProducer> {
+  class TestBeginLumiBlockFilter : public edm::global::EDFilter<edm::LuminosityBlockCache<Dummy>,edm::BeginLuminosityBlockProducer> {
   public:
     explicit TestBeginLumiBlockFilter(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {
@@ -520,9 +524,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> gblp{false}; 
 
-    std::shared_ptr<void> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    std::shared_ptr<Dummy> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       gblp = false;
-      return std::shared_ptr<void>();
+      return std::shared_ptr<Dummy>();
     }
 
 
@@ -551,7 +555,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestEndLumiBlockFilter : public edm::global::EDFilter<edm::LuminosityBlockCache<void>,edm::EndLuminosityBlockProducer> {
+  class TestEndLumiBlockFilter : public edm::global::EDFilter<edm::LuminosityBlockCache<Dummy>,edm::EndLuminosityBlockProducer> {
   public:
     explicit TestEndLumiBlockFilter(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {
@@ -561,9 +565,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> p{false}; 
 
-    std::shared_ptr<void> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    std::shared_ptr<Dummy> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       p = false;
-      return std::shared_ptr<void>();
+      return std::shared_ptr<Dummy>();
     }
 
 

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -46,6 +46,10 @@ struct UnsafeCache {
    unsigned int strm;
    unsigned int work;
 };
+
+struct Dummy {
+};
+
 } //end anonymous namespace
 
   class StreamIntProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>> {
@@ -406,7 +410,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginRunProducer : public edm::global::EDProducer<edm::RunCache<void>,edm::BeginRunProducer> {
+  class TestBeginRunProducer : public edm::global::EDProducer<edm::RunCache<Dummy>,edm::BeginRunProducer> {
   public:
     explicit TestBeginRunProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {	
@@ -417,9 +421,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> brp{false}; 
  
-    std::shared_ptr<void> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       brp = false;
-      return std::shared_ptr<void>();
+      return std::shared_ptr<Dummy>();
     }
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
@@ -446,7 +450,7 @@ struct UnsafeCache {
 
   };
 
-  class TestEndRunProducer : public edm::global::EDProducer<edm::RunCache<void>,edm::EndRunProducer> {
+  class TestEndRunProducer : public edm::global::EDProducer<edm::RunCache<Dummy>,edm::EndRunProducer> {
   public:
     explicit TestEndRunProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {	
@@ -456,9 +460,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> p{false}; 
 
-    std::shared_ptr<void> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       p = false;
-      return std::shared_ptr<void>();
+      return std::shared_ptr<Dummy>();
     }
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {

--- a/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
@@ -32,7 +32,7 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 //
 // class decleration

--- a/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
@@ -32,6 +32,8 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 //
 // class decleration
 //
@@ -75,8 +77,8 @@ namespace {
       }
    private:
       unsigned int m_usecondsToSleep;
-      std::atomic<unsigned int>* m_count;
-      std::atomic<unsigned int>* m_maxCount;
+      edm::propagate_const<std::atomic<unsigned int>*> m_count;
+      edm::propagate_const<std::atomic<unsigned int>*> m_maxCount;
    };
 
    unsigned int startTasks(unsigned int iNTasks, unsigned int iSleepTime) {

--- a/FWCore/Integration/test/standalone_t.cppunit.cc
+++ b/FWCore/Integration/test/standalone_t.cppunit.cc
@@ -11,6 +11,7 @@ if the MessageLogger is not runnning.
 
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/Framework/interface/EventProcessor.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 // #include "FWCore/Utilities/interface/Presence.h"
 // #include "FWCore/PluginManager/interface/PresenceFactory.h"
 
@@ -30,18 +31,18 @@ class testStandalone: public CppUnit::TestFixture
 
   void setUp()
   {
-    m_handler = std::auto_ptr<edm::AssertHandler>(new edm::AssertHandler());
+    m_handler = std::unique_ptr<edm::AssertHandler>(new edm::AssertHandler());
   }
 
   void tearDown(){
-    m_handler.reset();
+    m_handler = nullptr; // propagate_const<T> has no reset() function
   }
 
   void writeAndReadFile();
 
  private:
 
-  std::auto_ptr<edm::AssertHandler> m_handler;
+  edm::propagate_const<std::unique_ptr<edm::AssertHandler>> m_handler;
 };
 
 ///registration of the test so that the runner can find it

--- a/FWCore/Integration/test/standalone_t.cppunit.cc
+++ b/FWCore/Integration/test/standalone_t.cppunit.cc
@@ -11,7 +11,7 @@ if the MessageLogger is not runnning.
 
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/Framework/interface/EventProcessor.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 // #include "FWCore/Utilities/interface/Presence.h"
 // #include "FWCore/PluginManager/interface/PresenceFactory.h"
 

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -83,17 +83,18 @@ Changes Log 1: 2009/01/14 10:29:00, Natalia Garcia Nebot
 
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Utilities/interface/InputType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <atomic>
 #include <cstddef>
 #include <iosfwd>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <set>
 #include <string>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
 #include "tbb/concurrent_unordered_map.h"
 #include "tbb/concurrent_vector.h"
 
@@ -244,6 +245,9 @@ namespace edm {
 
         JobReportImpl(std::ostream* iOst): printedReadBranches_(false), ost_(iOst) {}
 
+        std::ostream const* ost() const {return get_underlying_safe(ost_);}
+        std::ostream*& ost() {return get_underlying_safe(ost_);}
+
         std::vector<InputFile> inputFiles_;
         tbb::concurrent_vector<InputFile> inputFilesSecSource_;
         std::vector<OutputFile> outputFiles_;
@@ -252,7 +256,7 @@ namespace edm {
         tbb::concurrent_unordered_map<std::string, AtomicLongLong> readBranchesSecSource_;
         bool printedReadBranches_;
         std::vector<InputFile>::size_type lastOpenedPrimaryInputFile_;
-        std::ostream* ost_;
+        edm::propagate_const<std::ostream*> ost_;
       };
 
       JobReport();
@@ -431,10 +435,10 @@ namespace edm {
       std::string dumpFiles(void);
 
    protected:
-      boost::scoped_ptr<JobReportImpl>& impl() {return impl_;}
+      edm::propagate_const<std::unique_ptr<JobReportImpl>>& impl() {return impl_;}
 
    private:
-      boost::scoped_ptr<JobReportImpl> impl_;
+      edm::propagate_const<std::unique_ptr<JobReportImpl>> impl_;
       std::mutex write_mutex;
    };
 

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -83,7 +83,7 @@ Changes Log 1: 2009/01/14 10:29:00, Natalia Garcia Nebot
 
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <atomic>
 #include <cstddef>

--- a/FWCore/MessageLogger/interface/MessageDrop.h
+++ b/FWCore/MessageLogger/interface/MessageDrop.h
@@ -24,6 +24,7 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"	// change log 4
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // system include files
 
@@ -112,9 +113,9 @@ public:
   CMS_THREAD_SAFE static bool infoAlwaysSuppressed;			// change log 9
   CMS_THREAD_SAFE static bool warningAlwaysSuppressed;			// change log 9
 private:
-  messagedrop::StringProducerWithPhase * spWithPhase;
-  messagedrop::StringProducerPath      * spPath;
-  messagedrop::StringProducerSinglet   * spSinglet;
+  edm::propagate_const<messagedrop::StringProducerWithPhase*> spWithPhase;
+  edm::propagate_const<messagedrop::StringProducerPath*> spPath;
+  edm::propagate_const<messagedrop::StringProducerSinglet*> spSinglet;
   messagedrop::StringProducer const    * moduleNameProducer;
 };
 

--- a/FWCore/MessageLogger/interface/MessageDrop.h
+++ b/FWCore/MessageLogger/interface/MessageDrop.h
@@ -24,7 +24,7 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"	// change log 4
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // system include files
 

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -4,7 +4,6 @@
 #include "FWCore/MessageLogger/interface/ELstring.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -4,6 +4,7 @@
 #include "FWCore/MessageLogger/interface/ELstring.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -368,7 +368,7 @@ namespace edm {
       }
       *(impl_->ost_) << "</ChildProcessFiles>\n";
       *(impl_->ost_) << "</FrameworkJobReport>\n";
-      std::ofstream* p = dynamic_cast<std::ofstream *>(impl_->ost_);
+      std::ofstream* p = dynamic_cast<std::ofstream *>(impl_->ost());
       if(p) {
         p->close();
       }
@@ -381,7 +381,7 @@ namespace edm {
 
   void
   JobReport::childAfterFork(std::string const& jobReportFile, unsigned int childIndex, unsigned int numberOfChildren) {
-    std::ofstream* p = dynamic_cast<std::ofstream*>(impl_->ost_);
+    std::ofstream* p = dynamic_cast<std::ofstream*>(impl_->ost());
     if(!p) return;
     std::ostringstream ofilename;
     toFileName(jobReportFile, childIndex, numberOfChildren, ofilename);

--- a/FWCore/MessageLogger/src/MessageDrop.cc
+++ b/FWCore/MessageLogger/src/MessageDrop.cc
@@ -183,9 +183,9 @@ MessageDrop::MessageDrop()
 
 MessageDrop::~MessageDrop()
 {
-  delete spSinglet;
-  delete spPath;
-  delete spWithPhase;
+  delete spSinglet.get();
+  delete spPath.get();
+  delete spWithPhase.get();
 }
 
 void MessageDrop::setModuleWithPhase(std::string const & name,

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -87,7 +87,7 @@ namespace  {
 MessageSender::MessageSender( ELseverityLevel const & sev, 
 			      ELstring const & id,
 			      bool verbatim, bool suppressed )
-: errorobj_p( suppressed ? 0 : new ErrorObj(sev,id,verbatim), ErrorObjDeleter())
+: errorobj_p( suppressed ? nullptr : new ErrorObj(sev,id,verbatim), ErrorObjDeleter())
 {
   //std::cout << "MessageSender ctor; new ErrorObj at: " << errorobj_p << '\n';
 }

--- a/FWCore/MessageService/interface/ELadministrator.h
+++ b/FWCore/MessageService/interface/ELadministrator.h
@@ -55,7 +55,7 @@
 #include "FWCore/MessageLogger/interface/ELlist.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 

--- a/FWCore/MessageService/interface/ELadministrator.h
+++ b/FWCore/MessageService/interface/ELadministrator.h
@@ -55,6 +55,7 @@
 #include "FWCore/MessageLogger/interface/ELlist.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -124,7 +125,6 @@ protected:
   //
   const ELseverityLevel       & abortThreshold() const;
   const ELseverityLevel       &  exitThreshold() const;
-  std::list<std::shared_ptr<ELdestination> >  & sinks();
   const ELseverityLevel       & highSeverity() const;
   int                           severityCounts( int lev ) const;
 
@@ -137,11 +137,11 @@ private:
 
   // ---  traditional member data:
   //
-  std::list<std::shared_ptr<ELdestination> > sinks_;		
+  std::list<edm::propagate_const<std::shared_ptr<ELdestination>>> sinks_;		
   ELseverityLevel            highSeverity_;
   int                        severityCounts_[ ELseverityLevel::nLevels ];
 
-  std::map < ELstring, std::shared_ptr<ELdestination> > attachedDestinations_;
+  std::map<ELstring, edm::propagate_const<std::shared_ptr<ELdestination>>> attachedDestinations_;
 
 };  // ELadministrator
 

--- a/FWCore/MessageService/interface/MainThreadMLscribe.h
+++ b/FWCore/MessageService/interface/MainThreadMLscribe.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/MessageLogger/interface/AbstractMLscribe.h"
 #include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // I believe the below are not needed:
 
@@ -49,7 +50,7 @@ public:
 
 private:
 
-   std::shared_ptr<ThreadQueue>   m_queue;
+   edm::propagate_const<std::shared_ptr<ThreadQueue>> m_queue;
 };  // MainThreadMLscribe
 
 

--- a/FWCore/MessageService/interface/MainThreadMLscribe.h
+++ b/FWCore/MessageService/interface/MainThreadMLscribe.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/MessageLogger/interface/AbstractMLscribe.h"
 #include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // I believe the below are not needed:
 

--- a/FWCore/MessageService/interface/MessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/MessageLoggerScribe.h
@@ -2,7 +2,7 @@
 #define FWCore_MessageService_MessageLoggerScribe_h
 
 #include "FWCore/Utilities/interface/value_ptr.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "FWCore/MessageService/interface/ELdestControl.h"
 #include "FWCore/MessageService/interface/MessageLoggerDefaults.h"

--- a/FWCore/MessageService/interface/MessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/MessageLoggerScribe.h
@@ -2,6 +2,7 @@
 #define FWCore_MessageService_MessageLoggerScribe_h
 
 #include "FWCore/Utilities/interface/value_ptr.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "FWCore/MessageService/interface/ELdestControl.h"
 #include "FWCore/MessageService/interface/MessageLoggerDefaults.h"
@@ -217,12 +218,12 @@ private:
   void parseCategories (std::string const & s, std::vector<std::string> & cats);
   
   // --- data:
-  std::shared_ptr<ELadministrator>  admin_p;
+  edm::propagate_const<std::shared_ptr<ELadministrator>> admin_p;
   ELdestControl                       early_dest;
-  std::vector<std::shared_ptr<std::ofstream> > file_ps;
-  std::shared_ptr<PSet>             job_pset_p;
+  std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> file_ps;
+  edm::propagate_const<std::shared_ptr<PSet>> job_pset_p;
   std::vector<NamedDestination     *> extern_dests;
-  std::map<String,std::ostream     *> stream_ps;
+  std::map<String,edm::propagate_const<std::ostream*>> stream_ps;
   std::vector<String> 	  	      ordinary_destination_filenames;
   std::vector<ELdestControl>          statisticsDestControls;
   std::vector<bool>                   statisticsResets;
@@ -233,7 +234,7 @@ private:
   bool 				      done;			// changeLog 9
   bool 				      purge_mode;		// changeLog 9
   int				      count;			// changeLog 9
-  std::shared_ptr<ThreadQueue>      m_queue;			// changeLog 12
+  edm::propagate_const<std::shared_ptr<ThreadQueue>> m_queue;	// changeLog 12
       
 };  // MessageLoggerScribe
 

--- a/FWCore/MessageService/interface/MessageServicePresence.h
+++ b/FWCore/MessageService/interface/MessageServicePresence.h
@@ -2,7 +2,7 @@
 #define FWCore_MessageService_MessageServicePresence_h
 
 #include "FWCore/Utilities/interface/Presence.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "boost/thread/thread.hpp"
 

--- a/FWCore/MessageService/interface/MessageServicePresence.h
+++ b/FWCore/MessageService/interface/MessageServicePresence.h
@@ -2,6 +2,7 @@
 #define FWCore_MessageService_MessageServicePresence_h
 
 #include "FWCore/Utilities/interface/Presence.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "boost/thread/thread.hpp"
 
@@ -22,11 +23,14 @@ public:
 
 private:
   // --- no copying:
-  MessageServicePresence(MessageServicePresence const &);
-  void  operator = (MessageServicePresence const &);
+  MessageServicePresence(MessageServicePresence const&) = delete; // Disallow copying
+  void operator=(MessageServicePresence const &) = delete; // Disallow copying
+
+  std::shared_ptr<ThreadQueue const> queue() const {return get_underlying_safe(m_queue);}
+  std::shared_ptr<ThreadQueue>& queue() {return get_underlying_safe(m_queue);}
 
   // --- data:
-  std::shared_ptr<ThreadQueue> m_queue;
+  edm::propagate_const<std::shared_ptr<ThreadQueue>> m_queue;
   boost::thread  m_scribeThread;
 
 };  // MessageServicePresence

--- a/FWCore/MessageService/interface/NamedDestination.h
+++ b/FWCore/MessageService/interface/NamedDestination.h
@@ -2,6 +2,7 @@
 #define FWCore_MessageService_NamedDestination_h 1
 
 #include "FWCore/MessageService/interface/ELdestination.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <string>
 #include <memory>
@@ -18,10 +19,10 @@ namespace service {
       , dest_p_(dp)
       {}
     std::string const & name() const {return name_;}
-    std::auto_ptr<ELdestination> & dest_p() {return dest_p_;}
+    edm::propagate_const<std::unique_ptr<ELdestination>>& dest_p() {return dest_p_;}
   private:
     std::string name_;
-    std::auto_ptr<ELdestination> dest_p_;
+    edm::propagate_const<std::unique_ptr<ELdestination>> dest_p_;
   };
 }        // end of namespace service
 }       // end of namespace edm

--- a/FWCore/MessageService/interface/NamedDestination.h
+++ b/FWCore/MessageService/interface/NamedDestination.h
@@ -2,7 +2,7 @@
 #define FWCore_MessageService_NamedDestination_h 1
 
 #include "FWCore/MessageService/interface/ELdestination.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <string>
 #include <memory>

--- a/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
@@ -2,7 +2,7 @@
 #define FWCore_MessageService_ThreadSafeLogMessageLoggerScribe_h
 
 #include "FWCore/Utilities/interface/value_ptr.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "FWCore/MessageService/interface/ELdestControl.h"
 #include "FWCore/MessageService/interface/MessageLoggerDefaults.h"

--- a/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
@@ -2,6 +2,7 @@
 #define FWCore_MessageService_ThreadSafeLogMessageLoggerScribe_h
 
 #include "FWCore/Utilities/interface/value_ptr.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "FWCore/MessageService/interface/ELdestControl.h"
 #include "FWCore/MessageService/interface/MessageLoggerDefaults.h"
@@ -94,12 +95,12 @@ private:
   void parseCategories (std::string const & s, std::vector<std::string> & cats);
   
   // --- data:
-  std::shared_ptr<ELadministrator>  admin_p;
+  edm::propagate_const<std::shared_ptr<ELadministrator>>  admin_p;
   ELdestControl                       early_dest;
-  std::vector<std::shared_ptr<std::ofstream> > file_ps;
-  std::shared_ptr<PSet>             job_pset_p;
+  std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> file_ps;
+  edm::propagate_const<std::shared_ptr<PSet>> job_pset_p;
   std::vector<NamedDestination     *> extern_dests;
-  std::map<String,std::ostream     *> stream_ps;
+  std::map<String, edm::propagate_const<std::ostream*>> stream_ps;
   std::vector<String> 	  	      ordinary_destination_filenames;
   std::vector<ELdestControl>          statisticsDestControls;
   std::vector<bool>                   statisticsResets;

--- a/FWCore/MessageService/src/ELadministrator.cc
+++ b/FWCore/MessageService/src/ELadministrator.cc
@@ -63,7 +63,7 @@
 // ELadministrator::context() const
 // ELadministrator::abortThreshold() const
 // ELadministrator::exitThreshold() const
-// ELadministrator::sinks()
+// ELadministrator::sinks_
 // ELadministrator::highSeverity() const
 // ELadministrator::severityCounts( const int lev ) const
 // ELadministrator::finishMsg()
@@ -105,15 +105,14 @@ void ELadministrator::log(edm::ErrorObj & msg) {
   
   // -----  send the message to each destination:
   //
-  if (sinks().begin() == sinks().end())  {
+  if (sinks_.begin() == sinks_.end())  {
     std::cerr << "\nERROR LOGGED WITHOUT DESTINATION!\n";
     std::cerr << "Attaching destination \"cerr\" to ELadministrator by default\n"
     << std::endl;
     attach(ELoutput(std::cerr));
   }
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    if (  (*d)->log( msg )  )
+  for (auto& sink : sinks_)
+    if ( sink->log( msg )  )
       msg.setReactedTo ( true );
   
   return;
@@ -128,7 +127,7 @@ void ELadministrator::log(edm::ErrorObj & msg) {
 ELdestControl ELadministrator::attach( const ELdestination & sink )  {
 
   std::shared_ptr<ELdestination> dest(sink.clone());
-  sinks().push_back( dest );
+  sinks_.push_back( dest );
   return ELdestControl( dest );
 
 }  // attach()
@@ -137,7 +136,7 @@ ELdestControl ELadministrator::attach(  const ELdestination & sink,
                                         const ELstring & name )     {
   std::shared_ptr<ELdestination> dest(sink.clone());
   attachedDestinations_[name] = dest;
-  sinks().push_back( dest );
+  sinks_.push_back( dest );
   return ELdestControl( dest );
 } // attach()
 
@@ -201,9 +200,6 @@ void ELadministrator::resetSeverityCount()  {
 // Accessors:
 // ----------------------------------------------------------------------
 
-std::list<std::shared_ptr<ELdestination> > & ELadministrator::sinks()  { return sinks_; }
-
-
 const ELseverityLevel & ELadministrator::highSeverity() const  {
   return highSeverity_;
 }
@@ -225,18 +221,16 @@ int ELadministrator::severityCounts( const int lev ) const  {
 
 void ELadministrator::setThresholds( const ELseverityLevel & sev )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->threshold = sev;
+  for (auto& sink : sinks_)
+    sink->threshold = sev;
 
 }  // setThresholds()
 
 
 void ELadministrator::setLimits( const ELstring & id, int limit )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.setLimit( id, limit );
+  for (auto& sink : sinks_)
+    sink->limits.setLimit( id, limit );
 
 }  // setLimits()
 
@@ -244,61 +238,54 @@ void ELadministrator::setLimits( const ELstring & id, int limit )  {
 void ELadministrator::setIntervals
 			( const ELseverityLevel & sev, int interval )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.setInterval( sev, interval );
+  for (auto& sink : sinks_)
+    sink->limits.setInterval( sev, interval );
 
 }  // setIntervals()
 
 void ELadministrator::setIntervals( const ELstring & id, int interval )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.setInterval( id, interval );
+  for (auto& sink : sinks_)
+    sink->limits.setInterval( id, interval );
 
 }  // setIntervals()
 
 
 void ELadministrator::setLimits( const ELseverityLevel & sev, int limit )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.setLimit( sev, limit );
+  for (auto& sink : sinks_)
+    sink->limits.setLimit( sev, limit );
 
 }  // setLimits()
 
 
 void ELadministrator::setTimespans( const ELstring & id, int seconds )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.setTimespan( id, seconds );
+  for (auto& sink : sinks_)
+    sink->limits.setTimespan( id, seconds );
 
 }  // setTimespans()
 
 
 void ELadministrator::setTimespans( const ELseverityLevel & sev, int seconds )  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.setTimespan( sev, seconds );
+  for (auto& sink : sinks_)
+    sink->limits.setTimespan( sev, seconds );
 
 }  // setTimespans()
 
 
 void ELadministrator::wipe()  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->limits.wipe();
+  for (auto& sink : sinks_)
+    sink->limits.wipe();
 
 }  // wipe()
 
 void ELadministrator::finish()  {
 
-  std::list<std::shared_ptr<ELdestination> >::iterator d;
-  for ( d = sinks().begin();  d != sinks().end();  ++d )
-    (*d)->finish();
+  for (auto& sink : sinks_)
+    sink->finish();
 
 }  // wipe()
 
@@ -326,7 +313,7 @@ ELadministrator::~ELadministrator()  {
     std::cerr << "ELadministrator Destructor\n";
   #endif
 
-  sinks().clear();
+  sinks_.clear();
 
 }  // ~ELadministrator()
 

--- a/FWCore/MessageService/src/MessageServicePresence.cc
+++ b/FWCore/MessageService/src/MessageServicePresence.cc
@@ -52,7 +52,7 @@ MessageServicePresence::MessageServicePresence()
   , m_queue (new ThreadQueue)
   , m_scribeThread
          ( ( (void) MessageLoggerQ::instance() // ensure Q's static data init'd
-            , std::bind(&runMessageLoggerScribe, m_queue)
+            , std::bind(&runMessageLoggerScribe, queue())
 	    			// start a new thread, run rMLS(m_queue)
 				// ChangeLog 2
           ) ) 
@@ -65,7 +65,7 @@ MessageServicePresence::MessageServicePresence()
 	  // first executing the before-the-comma statement. 
 {
   MessageLoggerQ::setMLscribe_ptr(
-    std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<MainThreadMLscribe>(m_queue)));
+    std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<MainThreadMLscribe>(queue())));
     								// change log 3
   //std::cout << "MessageServicePresence ctor\n";
 }

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -116,7 +116,7 @@ namespace edm {
           break;
         }
         case MessageLoggerQ::CONFIGURE:  {			// changelog 17
-          job_pset_p.reset(static_cast<ParameterSet *>(operand));
+          job_pset_p = std::shared_ptr<PSet>(static_cast<PSet*>(operand)); // propagate_const<T> has no reset() function
           configure_errorlog();
           break;
         }
@@ -787,17 +787,14 @@ namespace edm {
         return;
       }
       
-      for( std::vector<NamedDestination*>::const_iterator it = extern_dests.begin()
-          ; it != extern_dests.end()
-          ;  ++it
-          )
+      for( auto& dest : extern_dests)
       {
-        ELdestination *  dest_p = (*it)->dest_p().get();
+        ELdestination *  dest_p = dest->dest_p().get();
         ELdestControl  dest_ctrl = admin_p->attach( *dest_p );
         
         // configure the newly-attached destination:
-        configure_dest( dest_ctrl, (*it)->name() );
-        delete *it;  // dispose of our (copy of the) NamedDestination
+        configure_dest( dest_ctrl, dest->name() );
+        delete dest;  // dispose of our (copy of the) NamedDestination
       }
       extern_dests.clear();
       

--- a/FWCore/MessageService/test/MemoryTestClient_A.cc
+++ b/FWCore/MessageService/test/MemoryTestClient_A.cc
@@ -12,7 +12,7 @@ namespace edmtest
 int  MemoryTestClient_A::nevent = 0;
 
 MemoryTestClient_A::MemoryTestClient_A( edm::ParameterSet const & ps)
-  : memoryPattern(), vsize(0), last_allocation(0) 
+  : memoryPattern(), vsize(0), last_allocation(nullptr) 
 {
   int pattern = ps.getUntrackedParameter<int>("pattern",1);
   edm::LogWarning("memoryPattern") << "Memory Pattern selected: " << pattern;

--- a/FWCore/MessageService/test/MemoryTestClient_A.h
+++ b/FWCore/MessageService/test/MemoryTestClient_A.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <vector>
 
@@ -38,7 +39,7 @@ private:
   std::vector<double> memoryPattern;
   void initializeMemoryPattern(int pattern);
   double vsize;
-  char* last_allocation;
+  edm::propagate_const<char*> last_allocation;
 };
 
 

--- a/FWCore/MessageService/test/MemoryTestClient_A.h
+++ b/FWCore/MessageService/test/MemoryTestClient_A.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <vector>
 

--- a/FWCore/MessageService/test/MemoryTestClient_B.h
+++ b/FWCore/MessageService/test/MemoryTestClient_B.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <vector>
 
@@ -38,7 +39,7 @@ private:
   std::vector<double> memoryPattern;
   void initializeMemoryPattern(int pattern);
   double vsize;
-  char* last_Allocation;
+  edm::propagate_const<char*> last_Allocation;
 };
 
 

--- a/FWCore/MessageService/test/MemoryTestClient_B.h
+++ b/FWCore/MessageService/test/MemoryTestClient_B.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <vector>
 

--- a/FWCore/Modules/src/MulticoreRunLumiEventChecker.cc
+++ b/FWCore/Modules/src/MulticoreRunLumiEventChecker.cc
@@ -27,6 +27,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // system include files
 #include <algorithm>
@@ -78,7 +79,7 @@ private:
    unsigned int numberOfEventsLeftBeforeSearch_;
    bool mustSearch_;
    
-   std::shared_ptr<boost::thread> listenerThread_;
+   edm::propagate_const<std::shared_ptr<boost::thread>> listenerThread_;
    int messageQueue_;
 };
 

--- a/FWCore/Modules/src/MulticoreRunLumiEventChecker.cc
+++ b/FWCore/Modules/src/MulticoreRunLumiEventChecker.cc
@@ -27,7 +27,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // system include files
 #include <algorithm>

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -112,19 +112,17 @@ namespace edm {
       std::set<BranchID> missingFromMapper;
       std::set<BranchID> missingProductProvenance;
 
-      std::map<BranchID, std::shared_ptr<ProductHolderBase> > idToProductHolder;
-      for(EventPrincipal::const_iterator it = e.begin(), itEnd = e.end();
-          it != itEnd;
-          ++it) {
-        if(*it && (*it)->singleProduct()) {
-            BranchID branchID = (*it)->branchDescription().branchID();
-            idToProductHolder[branchID] = get_underlying(*it);
-            if((*it)->productUnavailable()) {
+      std::map<BranchID, std::shared_ptr<ProductHolderBase const>> idToProductHolder;
+      for(auto const& product : e) {
+        if(product && product->singleProduct()) {
+            BranchID branchID = product->branchDescription().branchID();
+            idToProductHolder[branchID] = get_underlying_safe(product);
+            if(product->productUnavailable()) {
                //This call seems to have a side effect of filling the 'ProductProvenance' in the ProductHolder
               OutputHandle const oh = e.getForOutput(branchID, false, mcc);
 
                bool cannotFindProductProvenance=false;
-               if(!(*it)->productProvenancePtr()) {
+               if(!product->productProvenancePtr()) {
                   missingProductProvenance.insert(branchID);
                   cannotFindProductProvenance=true;
                }
@@ -136,7 +134,7 @@ namespace edm {
                if(cannotFindProductProvenance) {
                   continue;
                }
-               markAncestors(*((*it)->productProvenancePtr()), *mapperPtr, seenParentInPrincipal, missingFromMapper);
+               markAncestors(*(product->productProvenancePtr()), *mapperPtr, seenParentInPrincipal, missingFromMapper);
             }
             seenParentInPrincipal[branchID] = true;
          }

--- a/FWCore/ParameterSet/interface/ProcessDesc.h
+++ b/FWCore/ParameterSet/interface/ProcessDesc.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
 

--- a/FWCore/ParameterSet/interface/ProcessDesc.h
+++ b/FWCore/ParameterSet/interface/ProcessDesc.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 namespace edm {
 
   class ParameterSet;
@@ -20,10 +22,12 @@ namespace edm {
     ~ProcessDesc();
 
     /// get the parameter set
-    std::shared_ptr<ParameterSet> getProcessPSet() const;
+    std::shared_ptr<ParameterSet const> getProcessPSet() const {return get_underlying_safe(pset_);}
+    std::shared_ptr<ParameterSet>& getProcessPSet() {return get_underlying_safe(pset_);}
 
     /// get the descriptions of the services
-    std::shared_ptr<std::vector<ParameterSet> > getServicesPSets() const;
+    std::shared_ptr<std::vector<ParameterSet> const> getServicesPSets() const {return get_underlying_safe(services_);}
+    std::shared_ptr<std::vector<ParameterSet>>& getServicesPSets() {return get_underlying_safe(services_);}
 
     void addService(ParameterSet& pset);
     /// add a service as an empty pset
@@ -38,8 +42,8 @@ namespace edm {
 
     std::string dump() const;
   private:
-    std::shared_ptr<ParameterSet> pset_;
-    std::shared_ptr<std::vector<ParameterSet> > services_;
+    edm::propagate_const<std::shared_ptr<ParameterSet>> pset_;
+    edm::propagate_const<std::shared_ptr<std::vector<ParameterSet>>> services_;
   };
 }
 

--- a/FWCore/ParameterSet/src/ProcessDesc.cc
+++ b/FWCore/ParameterSet/src/ProcessDesc.cc
@@ -18,16 +18,6 @@ namespace edm {
   ProcessDesc::~ProcessDesc() {
   }
 
-  std::shared_ptr<ParameterSet>
-  ProcessDesc::getProcessPSet() const {
-    return pset_;
-  }
-
-  std::shared_ptr<std::vector<ParameterSet> >
-  ProcessDesc::getServicesPSets() const {
-    return services_;
-  }
-
   void ProcessDesc::addService(ParameterSet& pset) {
     // The standard services should be initialized first.
     services_->insert(services_->begin(), pset);

--- a/FWCore/ServiceRegistry/interface/RandomEngineSentry.h
+++ b/FWCore/ServiceRegistry/interface/RandomEngineSentry.h
@@ -13,7 +13,7 @@ Description:
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace CLHEP {
   class HepRandomEngine;

--- a/FWCore/ServiceRegistry/interface/RandomEngineSentry.h
+++ b/FWCore/ServiceRegistry/interface/RandomEngineSentry.h
@@ -13,6 +13,7 @@ Description:
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -60,11 +61,12 @@ namespace edm {
 
     ~RandomEngineSentry() { if(t_) t_->setRandomEngine(nullptr); }
 
-    CLHEP::HepRandomEngine* randomEngine() const { return engine_; }
+    CLHEP::HepRandomEngine const* randomEngine() const {return get_underlying_safe(engine_);}
+    CLHEP::HepRandomEngine*& randomEngine() {return get_underlying_safe(engine_);}
 
   private:
-    T* t_;
-    CLHEP::HepRandomEngine* engine_;
+    edm::propagate_const<T*> t_;
+    edm::propagate_const<CLHEP::HepRandomEngine*> engine_;
   };
 }
 #endif

--- a/FWCore/ServiceRegistry/interface/ServiceWrapper.h
+++ b/FWCore/ServiceRegistry/interface/ServiceWrapper.h
@@ -23,6 +23,7 @@
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/ServiceWrapperBase.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // forward declarations
 namespace edm {
@@ -41,11 +42,12 @@ public:
          //virtual ~ServiceWrapper();
          
          // ---------- const member functions ---------------------
-         T& get() const { return *service_; }
+         T const& get() const { return *service_; }
          
          // ---------- static member functions --------------------
          
          // ---------- member functions ---------------------------
+         T& get() { return *service_; }
 
 private:
          ServiceWrapper(const ServiceWrapper&); // stop default
@@ -53,7 +55,7 @@ private:
          const ServiceWrapper& operator=(const ServiceWrapper&); // stop default
          
          // ---------- member data --------------------------------
-         std::auto_ptr<T> service_;
+         edm::propagate_const<std::auto_ptr<T>> service_;
          
       };
    }

--- a/FWCore/ServiceRegistry/interface/ServiceWrapper.h
+++ b/FWCore/ServiceRegistry/interface/ServiceWrapper.h
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/ServiceWrapperBase.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -25,6 +25,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceWrapper.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeIDBase.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 // system include files
 #include <memory>
@@ -47,9 +48,9 @@ public:
                         ActivityRegistry&) ;
             bool add(ServicesManager&) const;
 
-            std::shared_ptr<ServiceMakerBase> maker_;
+            edm::propagate_const<std::shared_ptr<ServiceMakerBase>> maker_;
             ParameterSet* pset_;
-            ActivityRegistry* registry_;
+            mutable ActivityRegistry* registry_;
             mutable bool wasAdded_;
          };
          typedef std::map<TypeIDBase, std::shared_ptr<ServiceWrapperBase> > Type2Service;
@@ -155,11 +156,11 @@ private:
          // the ActivityRegistry of that Manager does not go out of scope
          // This must be first to get the Service destructors called in
          // the correct order.
-         std::shared_ptr<ServicesManager> associatedManager_;
+         edm::propagate_const<std::shared_ptr<ServicesManager>> associatedManager_;
 
          ActivityRegistry registry_;
          Type2Service type2Service_;
-         std::auto_ptr<Type2Maker> type2Maker_;
+         edm::propagate_const<std::unique_ptr<Type2Maker>> type2Maker_;
          std::vector<TypeIDBase> requestedCreationOrder_;
          std::vector<TypeIDBase> actualCreationOrder_;
       };

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -25,7 +25,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceWrapper.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeIDBase.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // system include files
 #include <memory>
@@ -50,7 +50,7 @@ public:
 
             edm::propagate_const<std::shared_ptr<ServiceMakerBase>> maker_;
             ParameterSet* pset_;
-            mutable ActivityRegistry* registry_;
+            ActivityRegistry* registry_; // We do not use propagate_const because the registry itself is mutable
             mutable bool wasAdded_;
          };
          typedef std::map<TypeIDBase, std::shared_ptr<ServiceWrapperBase> > Type2Service;

--- a/FWCore/ServiceRegistry/src/ServicesManager.cc
+++ b/FWCore/ServiceRegistry/src/ServicesManager.cc
@@ -324,7 +324,7 @@ namespace edm {
            }
          }
          //No longer need the makers
-         type2Maker_.reset();
+         type2Maker_ = nullptr; // propagate_const<T> has no reset() function
       }
       //
       // const member functions

--- a/FWCore/Services/plugins/ProcInfoFetcher.cc
+++ b/FWCore/Services/plugins/ProcInfoFetcher.cc
@@ -30,6 +30,7 @@
 
 #include "FWCore/Services/plugins/ProcInfoFetcher.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 
@@ -92,7 +93,7 @@ namespace {
     
     explicit Fetcher(char* buffer) : 
     buffer_(buffer),
-    save_(0),
+    save_(nullptr),
     delims_(" \t\n\f\v\r") {
     }
   private:
@@ -128,13 +129,17 @@ namespace {
       return std::string(getItem());
     }
     char* getItem() {
-      char* item = strtok_r(buffer_, delims_, &save_); 
+      char* item = strtok_r(buffer_, delims_, &save());
       assert(item);
-      buffer_ = 0; // Null for subsequent strtok_r calls.
+      buffer_ = nullptr; // Null for subsequent strtok_r calls.
       return item;
     }
-    char* buffer_;
-    char* save_;
+
+    char const* save() const {return get_underlying_safe(save_);}
+    char*& save() {return get_underlying_safe(save_);}
+
+    edm::propagate_const<char*> buffer_;
+    edm::propagate_const<char*> save_;
     char const* const delims_; 
   };
   

--- a/FWCore/Services/plugins/ProcInfoFetcher.cc
+++ b/FWCore/Services/plugins/ProcInfoFetcher.cc
@@ -30,7 +30,7 @@
 
 #include "FWCore/Services/plugins/ProcInfoFetcher.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -41,6 +41,7 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/MallocOpts.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <cstring>
 #include <iostream>
@@ -116,12 +117,15 @@ namespace edm {
       void updateAndPrint(const std::string& type,
                           const std::string& mdlabel, const std::string& mdname);
       void openFiles();
+
+      char const* smapsLineBuffer() const {return get_underlying_safe(smapsLineBuffer_);}
+      char*& smapsLineBuffer() {return get_underlying_safe(smapsLineBuffer_);}
       
       ProcInfo a_;
       ProcInfo b_;
       ProcInfo max_;
-      ProcInfo* current_;
-      ProcInfo* previous_;
+      edm::propagate_const<ProcInfo*> current_;
+      edm::propagate_const<ProcInfo*> previous_;
       
       smapsInfo currentSmaps_;
       
@@ -136,8 +140,8 @@ namespace edm {
       std::atomic<int> count_;
       
       //smaps
-      FILE* smapsFile_;
-      char* smapsLineBuffer_;
+      edm::propagate_const<FILE*> smapsFile_;
+      edm::propagate_const<char*> smapsLineBuffer_;
       size_t smapsLineBufferLen_;
       
       
@@ -318,7 +322,7 @@ namespace edm {
        Pss:                 72 kB
        */
       
-      while ((read = getline(&smapsLineBuffer_, &smapsLineBufferLen_, smapsFile_)) != -1) {
+      while ((read = getline(&smapsLineBuffer(), &smapsLineBufferLen_, smapsFile_)) != -1) {
         if(read > 14) {
           //Private
           if(0==strncmp("Private_",smapsLineBuffer_,8)) {
@@ -353,8 +357,8 @@ namespace edm {
     , jobReportOutputOnly_(iPS.getUntrackedParameter<bool>("jobReportOutputOnly"))
     , monitorPssAndPrivate_(iPS.getUntrackedParameter<bool>("monitorPssAndPrivate"))
     , count_()
-    , smapsFile_(0)
-    , smapsLineBuffer_(NULL)
+    , smapsFile_(nullptr)
+    , smapsLineBuffer_(nullptr)
     , smapsLineBufferLen_(0)
     , growthRateVsize_()
     , growthRateRss_()
@@ -661,10 +665,10 @@ namespace edm {
         size_t value;
 
         while(fgets(buf, sizeof(buf), fmeminfo)) {
-          char* token = NULL;
+          char* token = nullptr;
           token = strtok(buf, space);
-          if(token != NULL) {
-            value = atol(strtok(NULL, space));
+          if(token != nullptr) {
+            value = atol(strtok(nullptr, space));
             std::string category = token;
             reportMemoryProperties.insert(std::make_pair(category.substr(0, strlen(token)-1), i2str(value)));
           }

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -41,7 +41,7 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/MallocOpts.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <cstring>
 #include <iostream>

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <vector>
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 //<<<<<< PUBLIC DEFINES                                                 >>>>>>
 //<<<<<< PUBLIC CONSTANTS                                               >>>>>>
 //<<<<<< PUBLIC TYPES                                                   >>>>>>
@@ -79,7 +80,7 @@ namespace edm {
             std::vector<std::string> m_nativeProtocols;
             std::vector<std::string> const* m_nativeProtocolsPtr;
             std::string         m_statisticsDestination;
-            struct addrinfo   * m_statisticsAddrInfo;
+            edm::propagate_const<struct addrinfo*> m_statisticsAddrInfo;
             static const std::string m_statisticsDefaultPort;
             std::set<std::string> m_statisticsInfo;
             bool m_statisticsInfoAvail;

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -6,7 +6,7 @@
 #include <list>
 #include <vector>
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 //<<<<<< PUBLIC DEFINES                                                 >>>>>>
 //<<<<<< PUBLIC CONSTANTS                                               >>>>>>
 //<<<<<< PUBLIC TYPES                                                   >>>>>>

--- a/FWCore/Sources/interface/VectorInputSource.h
+++ b/FWCore/Sources/interface/VectorInputSource.h
@@ -9,7 +9,7 @@ VectorInputSource: Abstract interface for vector input sources.
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 #include <string>

--- a/FWCore/Sources/interface/VectorInputSource.h
+++ b/FWCore/Sources/interface/VectorInputSource.h
@@ -9,6 +9,7 @@ VectorInputSource: Abstract interface for vector input sources.
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <string>
@@ -42,8 +43,9 @@ namespace edm {
     /// Called at end of job
     void doEndJob();
 
-    std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
-    ProductRegistry& productRegistryUpdate() const {return *productRegistry_;}
+    std::shared_ptr<ProductRegistry const> productRegistry() const {return get_underlying_safe(productRegistry_);}
+    std::shared_ptr<ProductRegistry>& productRegistry() {return get_underlying_safe(productRegistry_);}
+    ProductRegistry& productRegistryUpdate() {return *productRegistry_;}
     ProcessHistoryRegistry const& processHistoryRegistry() const {return *processHistoryRegistry_;}
     ProcessHistoryRegistry& processHistoryRegistryForUpdate() {return *processHistoryRegistry_;}
 
@@ -63,8 +65,8 @@ namespace edm {
     virtual void beginJob() = 0;
     virtual void endJob() = 0;
 
-    std::shared_ptr<ProductRegistry> productRegistry_;
-    std::unique_ptr<ProcessHistoryRegistry> processHistoryRegistry_;
+    edm::propagate_const<std::shared_ptr<ProductRegistry>> productRegistry_;
+    edm::propagate_const<std::unique_ptr<ProcessHistoryRegistry>> processHistoryRegistry_;
   };
 
   template<typename T>

--- a/FWCore/Sources/interface/VectorInputSourceDescription.h
+++ b/FWCore/Sources/interface/VectorInputSourceDescription.h
@@ -8,7 +8,6 @@ a VectorinputSource that does not come in through the ParameterSet
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 

--- a/FWCore/Sources/interface/VectorInputSourceDescription.h
+++ b/FWCore/Sources/interface/VectorInputSourceDescription.h
@@ -8,6 +8,7 @@ a VectorinputSource that does not come in through the ParameterSet
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -67,7 +67,7 @@ namespace edm {
       void set(std::shared_ptr<ProductRegistry const> iReg) { reg_ = iReg;}
      private:
       std::unique_ptr<WrapperBase> getTheProduct(BranchKey const& k) const;
-      virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) const override;
+      virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
       virtual std::auto_ptr<EventEntryDescription> getProvenance_(BranchKey const&) const {
         return std::auto_ptr<EventEntryDescription>();
       }
@@ -79,7 +79,7 @@ namespace edm {
     };
 
     std::unique_ptr<WrapperBase>
-    FWLiteDelayedReader::getProduct_(BranchKey const& k, EDProductGetter const* /*ep*/) const {
+    FWLiteDelayedReader::getProduct_(BranchKey const& k, EDProductGetter const* /*ep*/) {
       return getTheProduct(k);
     }
 

--- a/FWCore/Utilities/interface/ConstRespectingPtr.h
+++ b/FWCore/Utilities/interface/ConstRespectingPtr.h
@@ -19,7 +19,7 @@ the classes_def.xml file if it is a member of a persistent class!
 
 #include <memory>
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
 

--- a/FWCore/Utilities/interface/ConstRespectingPtr.h
+++ b/FWCore/Utilities/interface/ConstRespectingPtr.h
@@ -19,6 +19,8 @@ the classes_def.xml file if it is a member of a persistent class!
 
 #include <memory>
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 namespace edm {
 
   template <typename T>
@@ -50,7 +52,7 @@ namespace edm {
     ConstRespectingPtr(ConstRespectingPtr<T> const&);
     ConstRespectingPtr& operator=(ConstRespectingPtr<T> const&);
 
-    T* m_data;
+    edm::propagate_const<T*> m_data;
   };
 
   template<typename T>
@@ -61,7 +63,7 @@ namespace edm {
 
   template<typename T>
   ConstRespectingPtr<T>::~ConstRespectingPtr() {
-    delete m_data;
+    delete m_data.get();
   }
 
   template<typename T>

--- a/FWCore/Utilities/interface/RandomNumberGenerator.h
+++ b/FWCore/Utilities/interface/RandomNumberGenerator.h
@@ -153,10 +153,10 @@ namespace edm {
     /// These are the only functions most modules should call.
 
     /// Use this engine in event methods
-    virtual CLHEP::HepRandomEngine& getEngine(StreamID const&) const = 0;
+    virtual CLHEP::HepRandomEngine& getEngine(StreamID const&) = 0;
 
     /// Use this engine in the global begin luminosity block method
-    virtual CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const&) const = 0;
+    virtual CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const&) = 0;
 
     /// This returns the seed from the configuration. In the unusual case where an
     /// an engine type takes multiple seeds to initialize a sequence, this function

--- a/FWCore/Utilities/interface/RootHandlers.h
+++ b/FWCore/Utilities/interface/RootHandlers.h
@@ -1,7 +1,7 @@
 #ifndef FWCore_Utilities_RootHandlers_h
 #define FWCore_Utilities_RootHandlers_h
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 namespace edm {
   class EventProcessor;
   class RootHandlers {

--- a/FWCore/Utilities/interface/RootHandlers.h
+++ b/FWCore/Utilities/interface/RootHandlers.h
@@ -1,6 +1,7 @@
 #ifndef FWCore_Utilities_RootHandlers_h
 #define FWCore_Utilities_RootHandlers_h
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 namespace edm {
   class EventProcessor;
   class RootHandlers {
@@ -12,7 +13,7 @@ namespace edm {
       ~WarningSentry() {
         m_handler->enableWarnings_();
       }
-      RootHandlers* m_handler;
+      edm::propagate_const<RootHandlers*> m_handler;
     };
     friend struct edm::RootHandlers::WarningSentry;
     friend class edm::EventProcessor;

--- a/FWCore/Utilities/interface/get_underlying_safe.h
+++ b/FWCore/Utilities/interface/get_underlying_safe.h
@@ -1,5 +1,5 @@
-#ifndef FWCore_Utilities_propagate_const_safe_h
-#define FWCore_Utilities_propagate_const_safe_h
+#ifndef FWCore_Utilities_get_underlying_safe_h
+#define FWCore_Utilities_get_underlying_safe_h
 
 /*
  Description:

--- a/FWCore/Utilities/interface/propagate_const_safe.h
+++ b/FWCore/Utilities/interface/propagate_const_safe.h
@@ -1,0 +1,59 @@
+#ifndef FWCore_Utilities_propagate_const_safe_h
+#define FWCore_Utilities_propagate_const_safe_h
+
+/*
+ Description:
+
+ The function get_underlying(), provided by propagate_const, should not be called directly
+ by users because it may cast away constness.
+ This header  provides helper function(s) get_underlying_safe() to users of propagate_const<T>.
+ The get_underlying_safe() functions avoid this issue.
+
+ If called with a non-const ref argument, get_underlying_safe() simply calls get_underlying().
+ If called with a const ref argument, get_underlying_safe() returns a pointer to const,
+ which preserves constness, but requires copying the pointer.
+
+ For non-copyable pointers, such as std::unique_ptr, it is not possible to preserve constness.
+ so get_underlying_safe() will fail to compile if called with a const ref to a unique_ptr.
+ This is intentional.
+
+ This header can be expanded to support other smart pointers as needed.
+*/
+
+//
+// Original Author:  Bill Tanenbaum
+//
+
+// system include files
+#include <memory>
+
+// user include files
+
+#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Utilities/interface/propagate_const.h"
+
+// forward declarations
+
+namespace edm {
+
+  // for std::shared_ptr
+  template<typename T> std::shared_ptr<T>& get_underlying_safe(propagate_const<std::shared_ptr<T>>& iP) {return get_underlying(iP);}
+  template<typename T> std::shared_ptr<T const> get_underlying_safe(propagate_const<std::shared_ptr<T>> const& iP ) {std::shared_ptr<T const> copy = get_underlying(iP); return copy;}
+
+  // for bare pointer
+  template<typename T> T*& get_underlying_safe(propagate_const<T*>& iP) {return get_underlying(iP);}
+  template<typename T> T const* get_underlying_safe(propagate_const<T*> const& iP) {T const* copy = get_underlying(iP); return copy;}
+
+  // for boost::shared_ptr
+  template<typename T> boost::shared_ptr<T>& get_underlying_safe(propagate_const<boost::shared_ptr<T>>& iP) {return get_underlying(iP);}
+  template<typename T> boost::shared_ptr<T const> get_underlying_safe(propagate_const<boost::shared_ptr<T>> const& iP) {boost::shared_ptr<T const> copy = get_underlying(iP); return copy;}
+
+  // for std::unique_ptr
+  template<typename T> std::unique_ptr<T>& get_underlying_safe(propagate_const<std::unique_ptr<T>>& iP) {return get_underlying(iP);}
+  // This template below will deliberately not compile.
+  template<typename T> std::unique_ptr<T const> get_underlying_safe(propagate_const<std::unique_ptr<T>> const& iP) {std::unique_ptr<T const> copy = get_underlying(iP); return copy;}
+
+}
+
+#endif

--- a/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
+++ b/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
@@ -6,7 +6,7 @@ Test program for edm::propagate_const class.
 
 #include <cppunit/extensions/HelperMacros.h>
 #include <memory>
-#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 class test_propagate_const: public CppUnit::TestFixture
 {
@@ -45,12 +45,14 @@ void test_propagate_const::test()
       CPPUNIT_ASSERT(0 == pChecker.get()->value());
       CPPUNIT_ASSERT( pChecker.get()->value() == pChecker->value());
       CPPUNIT_ASSERT( pChecker.get()->value() == (*pChecker).value());
+      CPPUNIT_ASSERT(0 == get_underlying_safe(pChecker)->value());
 
       const edm::propagate_const<ConstChecker*> pConstChecker(&checker);
 
       CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
       CPPUNIT_ASSERT( pConstChecker.get()->value() == pConstChecker->value());
       CPPUNIT_ASSERT( pConstChecker.get()->value() == (*pConstChecker).value());
+      CPPUNIT_ASSERT(1 == get_underlying_safe(pConstChecker)->value());
    }
    
    {
@@ -60,13 +62,14 @@ void test_propagate_const::test()
       CPPUNIT_ASSERT(0 == pChecker.get()->value());
       CPPUNIT_ASSERT( pChecker.get()->value() == pChecker->value());
       CPPUNIT_ASSERT( pChecker.get()->value() == (*pChecker).value());
-      
+      CPPUNIT_ASSERT(0 == get_underlying_safe(pChecker)->value());
+
       const edm::propagate_const<std::shared_ptr<ConstChecker>> pConstChecker(checker);
       
       CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
       CPPUNIT_ASSERT( pConstChecker.get()->value() == pConstChecker->value());
       CPPUNIT_ASSERT( pConstChecker.get()->value() == (*pConstChecker).value());
-      
+      CPPUNIT_ASSERT(1 == get_underlying_safe(pConstChecker)->value());
    }
    
    {
@@ -76,13 +79,13 @@ void test_propagate_const::test()
       CPPUNIT_ASSERT(0 == pChecker.get()->value());
       CPPUNIT_ASSERT( pChecker.get()->value() == pChecker->value());
       CPPUNIT_ASSERT( pChecker.get()->value() == (*pChecker).value());
-      
+      CPPUNIT_ASSERT(0 == get_underlying_safe(pChecker)->value());
+
       const edm::propagate_const<std::unique_ptr<ConstChecker>> pConstChecker(std::make_unique<ConstChecker>());
       
       CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
       CPPUNIT_ASSERT( pConstChecker.get()->value() == pConstChecker->value());
       CPPUNIT_ASSERT( pConstChecker.get()->value() == (*pConstChecker).value());
-      
    }
 
 }

--- a/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
+++ b/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
@@ -6,7 +6,7 @@ Test program for edm::propagate_const class.
 
 #include <cppunit/extensions/HelperMacros.h>
 #include <memory>
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 class test_propagate_const: public CppUnit::TestFixture
 {

--- a/IOMC/Input/interface/HepMCFileReader.h
+++ b/IOMC/Input/interface/HepMCFileReader.h
@@ -17,7 +17,7 @@
 #include <vector>
 #include <map>
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace HepMC {
   class IO_BaseClass;

--- a/IOMC/Input/interface/HepMCFileReader.h
+++ b/IOMC/Input/interface/HepMCFileReader.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <map>
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 namespace HepMC {
   class IO_BaseClass;
@@ -53,9 +54,12 @@ class HepMCFileReader {
   static HepMCFileReader *instance();
 
   private:
+  HepMC::IO_BaseClass const* input() const {return get_underlying_safe(input_);}
+  HepMC::IO_BaseClass*& input() {return get_underlying_safe(input_);}
+
   // current  HepMC evt
-  HepMC::GenEvent *evt_;
-  HepMC::IO_BaseClass *input_;
+  edm::propagate_const<HepMC::GenEvent*> evt_;
+  edm::propagate_const<HepMC::IO_BaseClass*> input_;
 
   static HepMCFileReader *instance_;
 

--- a/IOMC/Input/interface/MCFileSource.h
+++ b/IOMC/Input/interface/MCFileSource.h
@@ -8,7 +8,7 @@
  ***************************************/
 
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 class HepMCFileReader;
 

--- a/IOMC/Input/interface/MCFileSource.h
+++ b/IOMC/Input/interface/MCFileSource.h
@@ -8,6 +8,7 @@
  ***************************************/
 
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 class HepMCFileReader;
 
@@ -32,8 +33,8 @@ namespace edm {
     virtual void produce(Event &e);
     void clear();
     
-    HepMCFileReader *reader_;
-    HepMC::GenEvent *evt_;
+    edm::propagate_const<HepMCFileReader*> reader_;
+    edm::propagate_const<HepMC::GenEvent*> evt_;
     bool useExtendedAscii_;
   };
 } 

--- a/IOMC/Input/plugins/HepMCEventWriter.cc
+++ b/IOMC/Input/plugins/HepMCEventWriter.cc
@@ -12,6 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "HepMC/IO_GenEvent.h"
@@ -28,7 +29,7 @@ protected:
   virtual void analyze(const edm::Event &event, const edm::EventSetup &es) override;
   
 private:
-  HepMC::IO_GenEvent* _output;
+  edm::propagate_const<HepMC::IO_GenEvent*> _output;
   edm::InputTag hepMCProduct_;
 };
 
@@ -51,7 +52,7 @@ void HepMCEventWriter::beginRun(const edm::Run &run, const edm::EventSetup &es)
 
 void HepMCEventWriter::endRun(const edm::Run &run, const edm::EventSetup &es)
 {
-  if (_output) delete _output;
+  if (_output) delete _output.get();
 }
 
 void HepMCEventWriter::analyze(const edm::Event &event, const edm::EventSetup &es)

--- a/IOMC/Input/plugins/HepMCEventWriter.cc
+++ b/IOMC/Input/plugins/HepMCEventWriter.cc
@@ -12,7 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "HepMC/IO_GenEvent.h"

--- a/IOMC/Input/src/HepMCFileReader.cc
+++ b/IOMC/Input/src/HepMCFileReader.cc
@@ -23,7 +23,7 @@
 using namespace std;
 
 
-HepMCFileReader *HepMCFileReader::instance_=0;
+HepMCFileReader *HepMCFileReader::instance_=nullptr;
 
 
 //-------------------------------------------------------------------------
@@ -31,7 +31,7 @@ HepMCFileReader *HepMCFileReader::instance()
 {
   // Implement a HepMCFileReader singleton.
 
-  if (instance_== 0) {
+  if (instance_== nullptr) {
     instance_ = new HepMCFileReader();
   }
   return instance_;
@@ -40,10 +40,10 @@ HepMCFileReader *HepMCFileReader::instance()
 
 //-------------------------------------------------------------------------
 HepMCFileReader::HepMCFileReader() :
-  evt_(0), input_(0)
+  evt_(nullptr), input_(nullptr)
 { 
   // Default constructor.
-  if (instance_ == 0) {
+  if (instance_ == nullptr) {
     instance_ = this;  
   } else {
     edm::LogError("HepMCFileReader") << "Constructing a new instance";
@@ -56,8 +56,8 @@ HepMCFileReader::~HepMCFileReader()
 {
   edm::LogInfo("HepMCFileReader") << "Destructing HepMCFileReader";
   
-  instance_=0;    
-  delete input_;
+  instance_=nullptr;    
+  delete input_.get();
 }
 
 
@@ -66,7 +66,7 @@ void HepMCFileReader::initialize(const string &filename)
 {
   if (isInitialized()) {
     edm::LogError("HepMCFileReader") << "Was already initialized... reinitializing";
-    delete input_;
+    delete input_.get();
   }
 
   edm::LogInfo("HepMCFileReader") << "Opening file" << filename << "using HepMC::IO_GenEvent";
@@ -84,7 +84,7 @@ int HepMCFileReader::rdstate() const
 {
   // work around a HepMC IO_ inheritence shortfall
 
-  HepMC::IO_GenEvent *p = dynamic_cast<HepMC::IO_GenEvent*>(input_);
+  HepMC::IO_GenEvent const* p = dynamic_cast<HepMC::IO_GenEvent const*>(input());
   if (p) return p->rdstate();
 
   return std::ios::failbit;
@@ -105,7 +105,7 @@ bool HepMCFileReader::readCurrentEvent()
     edm::LogInfo("HepMCFileReader") << "Got no event" <<endl;
   }
 
-  return evt_ != 0;
+  return evt_ != nullptr;
 }
 
 
@@ -119,7 +119,7 @@ bool HepMCFileReader::setEvent(int event)
 //-------------------------------------------------------------------------
 bool HepMCFileReader::printHepMcEvent() const
 {
-  if (evt_ != 0) evt_->print(); 
+  if (evt_ != nullptr) evt_->print(); 
   return true;
 }
 
@@ -136,7 +136,7 @@ HepMC::GenEvent * HepMCFileReader::fillCurrentEventData()
 // Print out in old CMKIN style for comparisons
 void HepMCFileReader::printEvent() const {
   int mo1=0,mo2=0,da1=0,da2=0,status=0,pid=0;   
-  if (evt_ != 0) {   
+  if (evt_ != nullptr) {   
     cout << "---#-------pid--st---Mo1---Mo2---Da1---Da2------px------py------pz-------E-";
     cout << "------m---------x---------y---------z---------t-";
     cout << endl;
@@ -159,7 +159,7 @@ void HepMCFileReader::printEvent() const {
       cout << setw(8) << setprecision(2) << g->momentum().t();
       cout << setw(8) << setprecision(2) << g->generatedMass();       
       // tau=L/(gamma*beta*c) 
-      if (g->production_vertex() != 0 && g->end_vertex() != 0 && status == 2) {
+      if (g->production_vertex() != nullptr && g->end_vertex() != nullptr && status == 2) {
         cout << setw(10) << setprecision(2) <<g->production_vertex()->position().x();
         cout << setw(10) << setprecision(2) <<g->production_vertex()->position().y();
         cout << setw(10) << setprecision(2) <<g->production_vertex()->position().z();
@@ -196,7 +196,7 @@ void HepMCFileReader::ReadStats()
 {
   unsigned int particle_counter=0;
   index_to_particle.reserve(evt_->particles_size()+1); 
-  index_to_particle[0] = 0; 
+  index_to_particle[0] = nullptr;
   for (HepMC::GenEvent::vertex_const_iterator v = evt_->vertices_begin();
        v != evt_->vertices_end(); ++v ) {
     // making a list of incoming particles of the vertices

--- a/IOMC/Input/src/MCFileSource.cc
+++ b/IOMC/Input/src/MCFileSource.cc
@@ -22,7 +22,7 @@ namespace edm {
 //-------------------------------------------------------------------------
 MCFileSource::MCFileSource(const ParameterSet & pset, InputSourceDescription const& desc) :
   ProducerSourceFromFiles(pset, desc, false),
-  reader_(HepMCFileReader::instance()), evt_(0)
+  reader_(HepMCFileReader::instance()), evt_(nullptr)
 {
   LogInfo("MCFileSource") << "Reading HepMC file:" << fileNames()[0];
   std::string fileName = fileNames()[0];

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -13,6 +13,7 @@
 
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <atomic>
 #include <cstdint>
@@ -58,10 +59,10 @@ namespace edm {
       /// These are the only functions most modules should call.
 
       /// Use this engine in event methods
-      virtual CLHEP::HepRandomEngine& getEngine(StreamID const& streamID) const override;
+      virtual CLHEP::HepRandomEngine& getEngine(StreamID const& streamID) override;
 
       /// Use this engine in the global begin luminosity block method
-      virtual CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const& luminosityBlockIndex) const override;
+      virtual CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const& luminosityBlockIndex) override;
 
       // This returns the seed from the configuration. In the unusual case where an
       // an engine type takes multiple seeds to initialize a sequence, this function
@@ -122,12 +123,13 @@ namespace edm {
           label_(theLabel), seeds_(theSeeds), engine_(theEngine) { }
         std::string const& label() const { return label_; }
         VUint32 const& seeds() const { return seeds_; }
-        std::shared_ptr<CLHEP::HepRandomEngine> const& engine() const { return engine_; }
+        std::shared_ptr<CLHEP::HepRandomEngine const> engine() const { return get_underlying_safe(engine_); }
+        std::shared_ptr<CLHEP::HepRandomEngine>& engine() { return get_underlying_safe(engine_); }
         void setSeed(std::uint32_t v, unsigned int index) { seeds_.at(index) = v; }
       private:
         std::string label_;
         VUint32 seeds_;
-        std::shared_ptr<CLHEP::HepRandomEngine> engine_;
+        edm::propagate_const<std::shared_ptr<CLHEP::HepRandomEngine>> engine_;
       };
 
       // This class exists because it is faster to lookup a module using
@@ -139,14 +141,15 @@ namespace edm {
           engineState_(), labelAndEngine_(theLabelAndEngine), moduleID_(theModuleID) { }
 
         std::vector<unsigned long> const& engineState() const { return engineState_; }
-        LabelAndEngine* labelAndEngine() const { return labelAndEngine_; }
+        LabelAndEngine const* labelAndEngine() const { return get_underlying_safe(labelAndEngine_); }
+        LabelAndEngine*& labelAndEngine() { return get_underlying_safe(labelAndEngine_); }
         unsigned int moduleID() const { return moduleID_; }
         void setEngineState(std::vector<unsigned long> const& v) { engineState_ = v; }
         // Used to sort so binary lookup can be used on a container of these.
         bool operator<(ModuleIDToEngine const& r) const { return moduleID() < r.moduleID(); }
       private:
         std::vector<unsigned long> engineState_; // Used only for check in stream transitions
-        LabelAndEngine* labelAndEngine_;
+        edm::propagate_const<LabelAndEngine*> labelAndEngine_;
         unsigned int moduleID_;
       };
 
@@ -248,7 +251,7 @@ namespace edm {
       // the save file name has been recorded in the job report.
       std::string saveFileName_;
       std::atomic<bool> saveFileNameRecorded_;
-      std::vector<std::shared_ptr<std::ofstream> > outFiles_; // streamID
+      std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> outFiles_; // streamID
 
       // Keep the name of the file from which we restore the state
       // of all declared engines at the beginning of a run. A

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -13,7 +13,7 @@
 
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <atomic>
 #include <cstdint>

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -64,7 +64,7 @@ the text file containing the states.
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "IOMC/RandomEngine/src/TRandomAdaptor.h"
 
 #include "CLHEP/Random/RandExponential.h"

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -64,6 +64,7 @@ the text file containing the states.
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "IOMC/RandomEngine/src/TRandomAdaptor.h"
 
 #include "CLHEP/Random/RandExponential.h"
@@ -89,19 +90,19 @@ public:
   TestRandomNumberServiceStreamCache() :
     serviceEngine_(nullptr),
     countEvents_(0) { }
-  CLHEP::HepRandomEngine* serviceEngine_;
+  edm::propagate_const<CLHEP::HepRandomEngine*> serviceEngine_;
   unsigned int countEvents_;
   std::ofstream outFile_;
   std::string lastEventRandomNumbers_;
 
-  std::shared_ptr<CLHEP::HepRandomEngine> referenceEngine_;
+  edm::propagate_const<std::shared_ptr<CLHEP::HepRandomEngine>> referenceEngine_;
   std::vector<double> referenceRandomNumbers_;
 };
 
 class TestRandomNumberServiceLumiCache {
 public:
   TestRandomNumberServiceLumiCache() { }
-  std::shared_ptr<CLHEP::HepRandomEngine> referenceEngine_;
+  edm::propagate_const<std::shared_ptr<CLHEP::HepRandomEngine>> referenceEngine_;
   std::vector<double> referenceRandomNumbers_;
 };
 
@@ -336,7 +337,7 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
   }
 
   if(engineName_ == "RanecuEngine") {
-    lumiCache->referenceEngine_.reset(new CLHEP::RanecuEngine());
+    lumiCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new CLHEP::RanecuEngine()); // propagate_const<T> has no reset() function
     long int seedL[2];
     seedL[0] = static_cast<long int>(seed0);
     seedL[1] = static_cast<long int>(seeds_.at(1));
@@ -345,9 +346,9 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
   else {
     long int seedL = static_cast<long int>(seed0);
     if(engineName_ == "HepJamesRandom") {
-      lumiCache->referenceEngine_.reset(new CLHEP::HepJamesRandom(seedL));
+      lumiCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new CLHEP::HepJamesRandom(seedL)); // propagate_const<T> has no reset() function
     } else {
-      lumiCache->referenceEngine_.reset(new edm::TRandomAdaptor(seedL));
+      lumiCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new edm::TRandomAdaptor(seedL)); // propagate_const<T> has no reset() function
     }
   }
 
@@ -388,7 +389,7 @@ TestRandomNumberServiceGlobal::beginStream(edm::StreamID streamID) const {
   streamCache->outFile_.open(outFileName.c_str(), std::ofstream::out);
 
   if(engineName_ == "RanecuEngine") {
-    streamCache->referenceEngine_.reset(new CLHEP::RanecuEngine());
+    streamCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new CLHEP::RanecuEngine()); // propagate_const<T> has no reset() function
     long int seedL[2];
     seedL[0] = static_cast<long int>(seeds_.at(0) + streamID.value() + offset_);
     seedL[1] = static_cast<long int>(seeds_.at(1));
@@ -397,9 +398,9 @@ TestRandomNumberServiceGlobal::beginStream(edm::StreamID streamID) const {
   else {
     long int seedL = static_cast<long int>(seeds_.at(0) + streamID.value() + offset_);
     if(engineName_ == "HepJamesRandom") {
-      streamCache->referenceEngine_.reset(new CLHEP::HepJamesRandom(seedL));
+      streamCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new CLHEP::HepJamesRandom(seedL)); // propagate_const<T> has no reset() function
     } else {
-      streamCache->referenceEngine_.reset(new edm::TRandomAdaptor(seedL));
+      streamCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new edm::TRandomAdaptor(seedL)); // propagate_const<T> has no reset() function
     }
   }
 

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -17,7 +17,7 @@
 
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "TError.h"
 #include "TFile.h"

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -17,6 +17,7 @@
 
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "TError.h"
 #include "TFile.h"
@@ -502,7 +503,7 @@ private:
                       std::map<edm::BranchID, std::set<edm::BranchID> >& parentToChildren) const;
 
   std::string              filename_;
-  std::unique_ptr<TFile>   inputFile_;
+  edm::propagate_const<std::unique_ptr<TFile>>   inputFile_;
   int                      exitCode_;
   std::stringstream        errorLog_;
   int                      errorCount_;

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -11,7 +11,7 @@ EmbeddedRootSource: This is an InputSource
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
 #include <array>

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -11,6 +11,7 @@ EmbeddedRootSource: This is an InputSource
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
 #include <array>
@@ -65,7 +66,7 @@ namespace edm {
     std::unique_ptr<RunHelperBase> runHelper_;
 
     InputFileCatalog catalog_;
-    std::unique_ptr<RootEmbeddedFileSequence> fileSequence_;
+    edm::propagate_const<std::unique_ptr<RootEmbeddedFileSequence>> fileSequence_;
     
   }; // class EmbeddedRootSource
 }

--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -19,7 +19,7 @@ namespace edm {
     file_(), fileName_(fileName), reportToken_(0), inputType_(inputType) {
 
     logFileAction(msg, fileName);
-    file_.reset(TFile::Open(fileName));
+    file_ = std::unique_ptr<TFile>(TFile::Open(fileName)); // propagate_const<T> has no reset() function
     std::exception_ptr e = edm::threadLocalException::getException();
     if(e != std::exception_ptr()) {
       edm::threadLocalException::setException(std::exception_ptr());
@@ -29,7 +29,7 @@ namespace edm {
       return;
     }
     if(file_->IsZombie()) {
-      file_.reset();
+      file_ = nullptr; // propagate_const<T> has no reset() function
       return;
     }
     

--- a/IOPool/Input/src/InputFile.h
+++ b/IOPool/Input/src/InputFile.h
@@ -7,6 +7,7 @@ Holder for an input TFile.
 ----------------------------------------------------------------------*/
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/Utilities/interface/InputType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "TFile.h"
 
@@ -47,7 +48,7 @@ namespace edm {
     void SetCacheRead(TFileCacheRead* tfcr) {file_->SetCacheRead(tfcr, NULL, TFile::kDoNotDisconnect);}
     void logFileAction(char const* msg, char const* fileName) const;
   private:
-    std::unique_ptr<TFile> file_;
+    edm::propagate_const<std::unique_ptr<TFile>> file_;
     std::string fileName_;
     JobReport::Token reportToken_;
     InputType inputType_;

--- a/IOPool/Input/src/InputFile.h
+++ b/IOPool/Input/src/InputFile.h
@@ -7,7 +7,7 @@ Holder for an input TFile.
 ----------------------------------------------------------------------*/
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "TFile.h"
 

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -128,7 +128,7 @@ namespace edm {
         }
       }
       if(idsToReplace[InEvent].empty() && idsToReplace[InLumi].empty() && idsToReplace[InRun].empty()) {
-        secondaryFileSequence_.reset();
+        secondaryFileSequence_ = nullptr; // propagate_const<T> has no reset() function
       } else {
         for(int i = InEvent; i < NumBranchTypes; ++i) {
           branchIDsToReplace_[i].reserve(idsToReplace[i].size());
@@ -275,7 +275,7 @@ namespace edm {
   }
 
   SharedResourcesAcquirer*
-  PoolSource::resourceSharedWithDelayedReader_() const {
+  PoolSource::resourceSharedWithDelayedReader_() {
     return resourceSharedWithDelayedReaderPtr_.get();
   }
 

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -13,7 +13,7 @@ PoolSource: This is an InputSource
 #include "FWCore/Framework/interface/ProcessingController.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/InputSource.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
 #include <array>
@@ -86,7 +86,7 @@ namespace edm {
     bool labelRawDataLikeMC_;
     
     edm::propagate_const<std::unique_ptr<RunHelperBase>> runHelper_;
-    edm::propagate_const<std::unique_ptr<SharedResourcesAcquirer>> resourceSharedWithDelayedReaderPtr_;
+    std::unique_ptr<SharedResourcesAcquirer> resourceSharedWithDelayedReaderPtr_; // We do not use propagate_const because the acquirer is itself mutable.
     edm::propagate_const<std::unique_ptr<RootPrimaryFileSequence>> primaryFileSequence_;
     edm::propagate_const<std::unique_ptr<RootSecondaryFileSequence>> secondaryFileSequence_;
   }; // class PoolSource

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -13,6 +13,7 @@ PoolSource: This is an InputSource
 #include "FWCore/Framework/interface/ProcessingController.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
 #include <array>
@@ -66,14 +67,14 @@ namespace edm {
     virtual ProcessingController::ForwardState forwardState_() const override;
     virtual ProcessingController::ReverseState reverseState_() const override;
 
-    SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const override;
+    SharedResourcesAcquirer* resourceSharedWithDelayedReader_() override;
     
     RootServiceChecker rootServiceChecker_;
     InputFileCatalog catalog_;
     InputFileCatalog secondaryCatalog_;
-    std::shared_ptr<RunPrincipal> secondaryRunPrincipal_;
-    std::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
-    std::vector<std::unique_ptr<EventPrincipal>> secondaryEventPrincipals_;
+    edm::propagate_const<std::shared_ptr<RunPrincipal>> secondaryRunPrincipal_;
+    edm::propagate_const<std::shared_ptr<LuminosityBlockPrincipal>> secondaryLumiPrincipal_;
+    std::vector<edm::propagate_const<std::unique_ptr<EventPrincipal>>> secondaryEventPrincipals_;
     std::array<std::vector<BranchID>, NumBranchTypes>  branchIDsToReplace_;
 
     unsigned int nStreams_;
@@ -84,10 +85,10 @@ namespace edm {
     bool dropDescendants_;
     bool labelRawDataLikeMC_;
     
-    std::unique_ptr<RunHelperBase> runHelper_;
-    std::unique_ptr<SharedResourcesAcquirer> resourceSharedWithDelayedReaderPtr_;
-    std::unique_ptr<RootPrimaryFileSequence> primaryFileSequence_;
-    std::unique_ptr<RootSecondaryFileSequence> secondaryFileSequence_;
+    edm::propagate_const<std::unique_ptr<RunHelperBase>> runHelper_;
+    edm::propagate_const<std::unique_ptr<SharedResourcesAcquirer>> resourceSharedWithDelayedReaderPtr_;
+    edm::propagate_const<std::unique_ptr<RootPrimaryFileSequence>> primaryFileSequence_;
+    edm::propagate_const<std::unique_ptr<RootSecondaryFileSequence>> secondaryFileSequence_;
   }; // class PoolSource
 }
 #endif

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -41,7 +41,7 @@ namespace edm {
   }
 
   std::unique_ptr<WrapperBase>
-  RootDelayedReader::getProduct_(BranchKey const& k, EDProductGetter const* ep) const {
+  RootDelayedReader::getProduct_(BranchKey const& k, EDProductGetter const* ep) {
     if (lastException_) {
       throw *lastException_;
     }

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -10,6 +10,7 @@ RootDelayedReader.h // used by ROOT input sources
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Utilities/interface/InputType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "RootTree.h"
 
 #include <map>
@@ -44,7 +45,7 @@ namespace edm {
     RootDelayedReader& operator=(RootDelayedReader const&) = delete; // Disallow copying and moving
 
   private:
-    virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) const override;
+    virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
     virtual void mergeReaders_(DelayedReader* other) override {nextReader_ = other;}
     virtual void reset_() override {nextReader_ = nullptr;}
     SharedResourcesAcquirer* sharedResources_() const override;
@@ -56,11 +57,11 @@ namespace edm {
     // NOTE: filePtr_ appears to be unused, but is needed to prevent
     // the file containing the branch from being reclaimed.
     RootTree const& tree_;
-    std::shared_ptr<InputFile> filePtr_;
-    DelayedReader* nextReader_;
-    std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_;
+    edm::propagate_const<std::shared_ptr<InputFile>> filePtr_;
+    edm::propagate_const<DelayedReader*> nextReader_;
+    mutable std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_;
     InputType inputType_;
-    TClass* wrapperBaseTClass_;
+    edm::propagate_const<TClass*> wrapperBaseTClass_;
     //If a fatal exception happens we need to make a copy so we can
     // rethrow that exception on other threads. This avoids TTree
     // non-exception safety problems on later calls to TTree.

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -10,7 +10,7 @@ RootDelayedReader.h // used by ROOT input sources
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "RootTree.h"
 
 #include <map>
@@ -59,7 +59,7 @@ namespace edm {
     RootTree const& tree_;
     edm::propagate_const<std::shared_ptr<InputFile>> filePtr_;
     edm::propagate_const<DelayedReader*> nextReader_;
-    mutable std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_;
+    std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_; // We do not use propagate_const because the acquirer is itself mutable.
     InputType inputType_;
     edm::propagate_const<TClass*> wrapperBaseTClass_;
     //If a fatal exception happens we need to make a copy so we can

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -69,7 +69,7 @@ namespace edm {
     MakeOldProvenanceReader(std::unique_ptr<EntryDescriptionMap>&& entryDescriptionMap) : MakeProvenanceReader(), entryDescriptionMap_(std::move(entryDescriptionMap)) {}
     virtual std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
   private:
-    std::unique_ptr<EntryDescriptionMap> entryDescriptionMap_;
+    edm::propagate_const<std::unique_ptr<EntryDescriptionMap>> entryDescriptionMap_;
   };
   class MakeFullProvenanceReader : public MakeProvenanceReader {
   public:
@@ -174,9 +174,9 @@ namespace edm {
       hasNewlyDroppedBranch_(),
       branchListIndexesUnchanged_(false),
       eventAux_(),
-      eventTree_(filePtr_, InEvent, nStreams, treeMaxVirtualSize, treeCacheSize, roottree::defaultLearningEntries, enablePrefetching, inputType),
-      lumiTree_(filePtr_, InLumi, 1, treeMaxVirtualSize, roottree::defaultNonEventCacheSize, roottree::defaultNonEventLearningEntries, enablePrefetching, inputType),
-      runTree_(filePtr_, InRun, 1, treeMaxVirtualSize, roottree::defaultNonEventCacheSize, roottree::defaultNonEventLearningEntries, enablePrefetching, inputType),
+      eventTree_(filePtr, InEvent, nStreams, treeMaxVirtualSize, treeCacheSize, roottree::defaultLearningEntries, enablePrefetching, inputType),
+      lumiTree_(filePtr, InLumi, 1, treeMaxVirtualSize, roottree::defaultNonEventCacheSize, roottree::defaultNonEventLearningEntries, enablePrefetching, inputType),
+      runTree_(filePtr, InRun, 1, treeMaxVirtualSize, roottree::defaultNonEventCacheSize, roottree::defaultNonEventLearningEntries, enablePrefetching, inputType),
       treePointers_(),
       lastEventEntryNumberRead_(IndexIntoFile::invalidEntry),
       productRegistry_(),
@@ -299,7 +299,7 @@ namespace edm {
     }
 
     if(inputType != InputType::SecondarySource) {
-      fileThinnedAssociationsHelper_.reset(new ThinnedAssociationsHelper);
+      fileThinnedAssociationsHelper_ = std::make_unique<ThinnedAssociationsHelper>(); // propagate_const<T> has no reset() function
       ThinnedAssociationsHelper* thinnedAssociationsHelperPtr = fileThinnedAssociationsHelper_.get();
       if(metaDataTree->FindBranch(poolNames::thinnedAssociationsHelperBranchName().c_str()) != nullptr) {
         metaDataTree->SetBranchAddress(poolNames::thinnedAssociationsHelperBranchName().c_str(), &thinnedAssociationsHelperPtr);
@@ -350,15 +350,17 @@ namespace edm {
     }
     if(!fileFormatVersion().splitProductIDs()) {
       // Old provenance format input file.  Create a provenance adaptor.
-      provenanceAdaptor_.reset(new ProvenanceAdaptor(
-            inputProdDescReg, pHistMap, pHistVector, processConfigurations, psetIdConverter, true));
+      // propagate_const<T> has no reset() function
+      provenanceAdaptor_ = std::make_unique<ProvenanceAdaptor>(
+            inputProdDescReg, pHistMap, pHistVector, processConfigurations, psetIdConverter, true);
       // Fill in the branchIDLists branch from the provenance adaptor
       branchIDLists_ = provenanceAdaptor_->branchIDLists();
     } else {
       if(!fileFormatVersion().triggerPathsTracked()) {
         // New provenance format, but change in ParameterSet Format. Create a provenance adaptor.
-        provenanceAdaptor_.reset(new ProvenanceAdaptor(
-            inputProdDescReg, pHistMap, pHistVector, processConfigurations, psetIdConverter, false));
+        // propagate_const<T> has no reset() function
+        provenanceAdaptor_ = std::make_unique<ProvenanceAdaptor>(
+            inputProdDescReg, pHistMap, pHistVector, processConfigurations, psetIdConverter, false);
       }
       // New provenance format input file. The branchIDLists branch was read directly from the input file.
       if(metaDataTree->FindBranch(poolNames::branchIDListBranchName().c_str()) == nullptr) {
@@ -390,7 +392,8 @@ namespace edm {
         // We need to change the module label and process name.
         // Create helper.
         it->second.init();
-        daqProvenanceHelper_.reset(new DaqProvenanceHelper(it->second.unwrappedTypeID()));
+        // propagate_const<T> has no reset() function
+        daqProvenanceHelper_ = std::make_unique<DaqProvenanceHelper>(it->second.unwrappedTypeID());
         // Create the new branch description
         BranchDescription const& newBD = daqProvenanceHelper_->branchDescription();
         // Save info from the old and new branch descriptions
@@ -427,7 +430,8 @@ namespace edm {
 
     // Here, we make the class that will make the ProvenanceReader
     // It reads whatever trees it needs.
-    provenanceReaderMaker_.reset(makeProvenanceReaderMaker(inputType).release());
+    // propagate_const<T> has no reset() function
+    provenanceReaderMaker_ = std::unique_ptr<MakeProvenanceReader>(makeProvenanceReaderMaker(inputType).release());
 
     // Merge into the hashed registries.
     if(eventSkipperByID_ && eventSkipperByID_->somethingToSkip()) {
@@ -638,7 +642,7 @@ namespace edm {
   }
 
   std::unique_ptr<FileBlock>
-  RootFile::createFileBlock() const {
+  RootFile::createFileBlock() {
     return std::unique_ptr<FileBlock>(new FileBlock(fileFormatVersion(),
                                                      eventTree_.tree(),
                                                      eventTree_.metaTree(),
@@ -651,7 +655,7 @@ namespace edm {
                                                      file_,
                                                      branchListIndexesUnchanged(),
                                                      modifiedIDs(),
-                                                     branchChildren_));
+                                                     branchChildren()));
   }
 
   std::string const&
@@ -1149,7 +1153,7 @@ namespace edm {
       treePointer = nullptr;
     }
     filePtr_->Close();
-    filePtr_.reset();
+    filePtr_ = nullptr; // propagate_const<T> has no reset() function
   }
 
   void
@@ -1446,7 +1450,7 @@ namespace edm {
   RootFile::readRunAuxiliary_() {
     if(runHelper_->fakeNewRun()) {
       runHelper_->overrideRunNumber(savedRunAuxiliary_->id());
-      return savedRunAuxiliary_;
+      return savedRunAuxiliary();
     }
     assert(indexIntoFileIter_ != indexIntoFileEnd_);
     assert(indexIntoFileIter_.getEntryType() == IndexIntoFile::kRun);
@@ -1464,7 +1468,7 @@ namespace edm {
       RunID run = RunID(indexIntoFileIter_.run());
       runHelper_->overrideRunNumber(run);
       savedRunAuxiliary_ = std::make_shared<RunAuxiliary>(run.run(), eventAux().time(), Timestamp::invalidTimestamp());
-      return savedRunAuxiliary_;
+      return savedRunAuxiliary();
     }
     // End code for backward compatibility before the existence of run trees.
     runTree_.setEntryNumber(indexIntoFileIter_.entry());
@@ -1624,7 +1628,7 @@ namespace edm {
   RootFile::readEventHistoryTree() {
     // Read in the event history tree, if we have one...
     if(fileFormatVersion().eventHistoryTree()) {
-      history_.reset(new History);
+      history_ = std::make_unique<History>(); // propagate_const<T> has no reset() function
       eventHistoryTree_ = dynamic_cast<TTree*>(filePtr_->Get(poolNames::eventHistoryTreeName().c_str()));
       if(!eventHistoryTree_) {
         throw Exception(errors::EventCorruption)
@@ -1723,7 +1727,8 @@ namespace edm {
           temp->addAssociation(associationBranches);
         }
       }
-      fileThinnedAssociationsHelper_.reset(temp.release());
+      // propagate_const<T> has no reset() function
+      fileThinnedAssociationsHelper_ = std::unique_ptr<ThinnedAssociationsHelper>(temp.release());
     }
 
     // On this pass, actually drop the branches.
@@ -1795,10 +1800,11 @@ namespace edm {
       eventProductProvenanceRetrievers_.resize(iStreamID+1);
     }
     if(!eventProductProvenanceRetrievers_[iStreamID]) {
-      eventProductProvenanceRetrievers_[iStreamID].reset(new ProductProvenanceRetriever(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
+      // propagate_const<T> has no reset() function
+      eventProductProvenanceRetrievers_[iStreamID] = std::make_shared<ProductProvenanceRetriever>(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get()));
     }
     eventProductProvenanceRetrievers_[iStreamID]->reset();
-    return eventProductProvenanceRetrievers_[iStreamID];
+    return eventProductProvenanceRetriever(iStreamID);
   }
 
   class ReducedProvenanceReader : public ProvenanceReaderBase {
@@ -1806,10 +1812,10 @@ namespace edm {
     ReducedProvenanceReader(RootTree* iRootTree, std::vector<ParentageID> const& iParentageIDLookup, DaqProvenanceHelper const* daqProvenanceHelper);
   private:
     virtual std::set<ProductProvenance> readProvenance(unsigned int) const override;
-    RootTree* rootTree_;
-    TBranch* provBranch_;
+    edm::propagate_const<RootTree*> rootTree_;
+    edm::propagate_const<TBranch*> provBranch_;
     StoredProductProvenanceVector provVector_;
-    StoredProductProvenanceVector* pProvVector_;
+    StoredProductProvenanceVector const* pProvVector_;
     std::vector<ParentageID> const& parentageIDLookup_;
     DaqProvenanceHelper const* daqProvenanceHelper_;
     mutable SharedResourcesAcquirer resourceAcquirer_;
@@ -1908,7 +1914,7 @@ namespace edm {
     virtual ~OldProvenanceReader() {}
   private:
     virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
-    RootTree* rootTree_;
+    edm::propagate_const<RootTree*> rootTree_;
     std::vector<EventEntryInfo> infoVector_;
     mutable std::vector<EventEntryInfo> *pInfoVector_;
     EntryDescriptionMap const& entryDescriptionMap_;

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -642,7 +642,7 @@ namespace edm {
   }
 
   std::unique_ptr<FileBlock>
-  RootFile::createFileBlock() {
+  RootFile::createFileBlock() const {
     return std::unique_ptr<FileBlock>(new FileBlock(fileFormatVersion(),
                                                      eventTree_.tree(),
                                                      eventTree_.metaTree(),

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -23,7 +23,7 @@ RootFile.h // used by ROOT input sources
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/InputSource.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <array>
 #include <map>
@@ -176,7 +176,7 @@ namespace edm {
     std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const {return hasNewlyDroppedBranch_;}
     bool branchListIndexesUnchanged() const {return branchListIndexesUnchanged_;}
     bool modifiedIDs() const {return daqProvenanceHelper_.get() != 0;}
-    std::unique_ptr<FileBlock> createFileBlock();
+    std::unique_ptr<FileBlock> createFileBlock() const;
     bool setEntryAtItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
       return (event != 0) ? setEntryAtEvent(run, lumi, event) : (lumi ? setEntryAtLumi(run, lumi) : setEntryAtRun(run));
     }

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -23,6 +23,7 @@ RootFile.h // used by ROOT input sources
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/InputSource.h"
 #include "FWCore/Utilities/interface/InputType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <array>
 #include <map>
@@ -162,7 +163,6 @@ namespace edm {
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     std::string const& file() const {return file_;}
     std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
-    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return branchIDListHelper_;}
     EventAuxiliary const& eventAux() const {return eventAux_;}
     // IndexIntoFile::EntryNumber_t const& entryNumber() const {return indexIntoFileIter().entry();}
     // LuminosityBlockNumber_t const& luminosityBlockNumber() const {return indexIntoFileIter().lumi();}
@@ -176,7 +176,7 @@ namespace edm {
     std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const {return hasNewlyDroppedBranch_;}
     bool branchListIndexesUnchanged() const {return branchListIndexesUnchanged_;}
     bool modifiedIDs() const {return daqProvenanceHelper_.get() != 0;}
-    std::unique_ptr<FileBlock> createFileBlock() const;
+    std::unique_ptr<FileBlock> createFileBlock();
     bool setEntryAtItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
       return (event != 0) ? setEntryAtEvent(run, lumi, event) : (lumi ? setEntryAtLumi(run, lumi) : setEntryAtRun(run));
     }
@@ -202,9 +202,10 @@ namespace edm {
     bool goToEvent(EventID const& eventID);
     bool nextEventEntry() {return eventTree_.next();}
     IndexIntoFile::EntryType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
-    std::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr() const {
-      return indexIntoFileSharedPtr_;
-    }
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<IndexIntoFile const> indexIntoFileSharedPtr() const {return get_underlying_safe(indexIntoFileSharedPtr_);}
+    std::shared_ptr<IndexIntoFile>& indexIntoFileSharedPtr() {return get_underlying_safe(indexIntoFileSharedPtr_);}
     bool wasLastEventJustRead() const;
     bool wasFirstEventJustRead() const;
     IndexIntoFile::IndexIntoFileItr indexIntoFileIter() const;
@@ -236,15 +237,24 @@ namespace edm {
     std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker(InputType inputType);
     std::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever(unsigned int iStreamIndex);
 
+    std::shared_ptr<RunAuxiliary const> savedRunAuxiliary() const {return get_underlying_safe(savedRunAuxiliary_);}
+    std::shared_ptr<RunAuxiliary>& savedRunAuxiliary() {return get_underlying_safe(savedRunAuxiliary_);}
+
+    std::shared_ptr<BranchChildren const> branchChildren() const {return get_underlying_safe(branchChildren_);}
+    std::shared_ptr<BranchChildren>& branchChildren() {return get_underlying_safe(branchChildren_);}
+
+    std::shared_ptr<ProductProvenanceRetriever const> eventProductProvenanceRetriever(size_t index) const {return get_underlying_safe(eventProductProvenanceRetrievers_[index]);}
+    std::shared_ptr<ProductProvenanceRetriever>& eventProductProvenanceRetriever(size_t index) {return get_underlying_safe(eventProductProvenanceRetrievers_[index]);}
+
     std::string const file_;
     std::string const logicalFile_;
     ProcessConfiguration const& processConfiguration_;
-    ProcessHistoryRegistry* processHistoryRegistry_;  // We don't own this
-    std::shared_ptr<InputFile> filePtr_;
-    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    edm::propagate_const<ProcessHistoryRegistry*> processHistoryRegistry_;  // We don't own this
+    edm::propagate_const<std::shared_ptr<InputFile>> filePtr_;
+    edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
     FileFormatVersion fileFormatVersion_;
     FileID fid_;
-    std::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr_;
+    edm::propagate_const<std::shared_ptr<IndexIntoFile>> indexIntoFileSharedPtr_;
     IndexIntoFile& indexIntoFile_;
     std::vector<ProcessHistoryID>& orderedProcessHistoryIDs_;
     IndexIntoFile::IndexIntoFileItr indexIntoFileBegin_;
@@ -252,7 +262,7 @@ namespace edm {
     IndexIntoFile::IndexIntoFileItr indexIntoFileIter_;
     std::vector<EventProcessHistoryID> eventProcessHistoryIDs_;  // backward compatibility
     std::vector<EventProcessHistoryID>::const_iterator eventProcessHistoryIter_; // backward compatibility
-    std::shared_ptr<RunAuxiliary> savedRunAuxiliary_;
+    edm::propagate_const<std::shared_ptr<RunAuxiliary>> savedRunAuxiliary_;
     bool skipAnyEvents_;
     bool noEventSort_;
     int whyNotFastClonable_;
@@ -266,24 +276,24 @@ namespace edm {
     IndexIntoFile::EntryNumber_t lastEventEntryNumberRead_;
     std::shared_ptr<ProductRegistry const> productRegistry_;
     std::shared_ptr<BranchIDLists const> branchIDLists_;
-    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
-    std::unique_ptr<ThinnedAssociationsHelper> fileThinnedAssociationsHelper_;
-    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+    edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
+    edm::propagate_const<std::unique_ptr<ThinnedAssociationsHelper>> fileThinnedAssociationsHelper_;
+    edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     InputSource::ProcessingMode processingMode_;
-    RunHelperBase* runHelper_;
+    edm::propagate_const<RunHelperBase*> runHelper_;
     std::map<std::string, std::string> newBranchToOldBranch_;
-    TTree* eventHistoryTree_;			// backward compatibility
+    edm::propagate_const<TTree*> eventHistoryTree_; // backward compatibility
     EventSelectionIDVector eventSelectionIDs_;
     BranchListIndexes branchListIndexes_;
-    std::unique_ptr<History> history_; // backward compatibility
-    std::shared_ptr<BranchChildren> branchChildren_;
-    std::shared_ptr<DuplicateChecker> duplicateChecker_;
-    std::unique_ptr<ProvenanceAdaptor> provenanceAdaptor_; // backward comatibility
-    std::unique_ptr<MakeProvenanceReader> provenanceReaderMaker_;
-    mutable std::vector<std::shared_ptr<ProductProvenanceRetriever>> eventProductProvenanceRetrievers_;
+    edm::propagate_const<std::unique_ptr<History>> history_; // backward compatibility
+    edm::propagate_const<std::shared_ptr<BranchChildren>> branchChildren_;
+    edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;
+    edm::propagate_const<std::unique_ptr<ProvenanceAdaptor>> provenanceAdaptor_; // backward comatibility
+    edm::propagate_const<std::unique_ptr<MakeProvenanceReader>> provenanceReaderMaker_;
+    std::vector<edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>>> eventProductProvenanceRetrievers_;
     std::vector<ParentageID> parentageIDLookup_;
-    std::unique_ptr<DaqProvenanceHelper> daqProvenanceHelper_;
-    TClass* edProductClass_;
+    edm::propagate_const<std::unique_ptr<DaqProvenanceHelper>> daqProvenanceHelper_;
+    edm::propagate_const<TClass*> edProductClass_;
   }; // class RootFile
 
 }

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -112,7 +112,7 @@ namespace edm {
     if(!findFileForSpecifiedID_) {
       // We use a multimap because there may be hash collisions (Two different LFNs could have the same hash).
       // We map the hash of the LFN to the index into the list of files.
-      findFileForSpecifiedID_.reset(new std::unordered_multimap<size_t, size_t>);
+      findFileForSpecifiedID_ =  std::make_unique<std::unordered_multimap<size_t, size_t>>(); // propagate_const<T> has no reset() function
       auto hasher = std::hash<std::string>();
       for(auto fileIter = fileIterBegin_; fileIter != fileIterEnd_; ++fileIter) {
         findFileForSpecifiedID_->insert(std::make_pair(hasher(fileIter->logicalFileName()), fileIter - fileIterBegin_));
@@ -139,8 +139,7 @@ namespace edm {
   bool
   RootInputFileSequence::skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
     // Look for item in files not yet opened.  We do not have a valid hash of the logical file name.
-    typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
-    for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
+    for(auto it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
       if(!*it) {
         // File not yet opened.
         setAtFileSequenceNumber(it - indexesIntoFiles_.begin());
@@ -166,8 +165,7 @@ namespace edm {
         return false;
       }
       // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
-      typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
-      for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
+      for(auto it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
         if(*it && (*it)->containsItem(run, lumi, event)) {
           // We found it. Close the currently open file, and open the correct one.
           std::vector<FileCatalogItem>::const_iterator currentIter = fileIter_;

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -11,6 +11,7 @@ RootInputFileSequence: This is an InputSource
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Utilities/interface/InputType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <string>
@@ -74,19 +75,19 @@ namespace edm {
     size_t lfnHash() const {return lfnHash_;}
     bool usedFallback() const {return usedFallback_;}
 
-    RootFileSharedPtr const& rootFile() const {return rootFile_;}
-    RootFileSharedPtr& rootFile() {return rootFile_;}
+    std::shared_ptr<RootFile const> rootFile() const {return get_underlying_safe(rootFile_);}
+    std::shared_ptr<RootFile>& rootFile() {return get_underlying_safe(rootFile_);}
   private:
     InputFileCatalog const& catalog_;
     std::string lfn_;
     size_t lfnHash_;
     bool usedFallback_;
-    std::unique_ptr<std::unordered_multimap<size_t, size_t> > findFileForSpecifiedID_;
+    edm::propagate_const<std::unique_ptr<std::unordered_multimap<size_t, size_t>>> findFileForSpecifiedID_;
     std::vector<FileCatalogItem>::const_iterator const fileIterBegin_;
     std::vector<FileCatalogItem>::const_iterator const fileIterEnd_;
     std::vector<FileCatalogItem>::const_iterator fileIter_;
     std::vector<FileCatalogItem>::const_iterator fileIterLastOpened_;
-    RootFileSharedPtr rootFile_;
+    edm::propagate_const<RootFileSharedPtr> rootFile_;
     std::vector<std::shared_ptr<IndexIntoFile> > indexesIntoFiles_;
 
   private:

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -11,7 +11,7 @@ RootInputFileSequence: This is an InputSource
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 #include <string>

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -120,7 +120,7 @@ namespace edm {
           input_.processConfiguration(),
           logicalFileName(),
           filePtr,
-          eventSkipperByID_,
+          eventSkipperByID(),
           initialNumberOfEventsToSkip_ != 0,
           remainingEvents(),
           remainingLuminosityBlocks(),
@@ -135,7 +135,7 @@ namespace edm {
           input_.branchIDListHelper(),
           input_.thinnedAssociationsHelper(),
           nullptr, // associationsFromSecondary
-          duplicateChecker_,
+          duplicateChecker(),
           input_.dropDescendants(),
           input_.processHistoryRegistryForUpdate(),
           indexesIntoFiles(),
@@ -273,8 +273,7 @@ namespace edm {
       IndexIntoFile::IndexIntoFileItr originalPosition = rootFile()->indexIntoFileIter();
 
       // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
-      typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
-      for(Iter it = indexesIntoFiles().begin(), itEnd = indexesIntoFiles().end(); it != itEnd; ++it) {
+      for(auto it = indexesIntoFiles().begin(), itEnd = indexesIntoFiles().end(); it != itEnd; ++it) {
         if(*it && (*it)->containsItem(eventID.run(), eventID.luminosityBlock(), eventID.event())) {
           // We found it. Close the currently open file, and open the correct one.
           setAtFileSequenceNumber(it - indexesIntoFiles().begin());
@@ -287,7 +286,7 @@ namespace edm {
         }
       }
       // Look for item in files not yet opened.
-      for(Iter it = indexesIntoFiles().begin(), itEnd = indexesIntoFiles().end(); it != itEnd; ++it) {
+      for(auto it = indexesIntoFiles().begin(), itEnd = indexesIntoFiles().end(); it != itEnd; ++it) {
         if(!*it) {
           setAtFileSequenceNumber(it - indexesIntoFiles().begin());
           initFile(false);

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -13,7 +13,7 @@ RootPrimaryFileSequence: This is an InputSource
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
 #include "FWCore/Sources/interface/EventSkipperByID.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -13,6 +13,7 @@ RootPrimaryFileSequence: This is an InputSource
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
 #include "FWCore/Sources/interface/EventSkipperByID.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
@@ -65,11 +66,16 @@ namespace edm {
     BranchDescription::MatchMode branchesMustMatch_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
-    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    std::shared_ptr<EventSkipperByID const> eventSkipperByID() const {return get_underlying_safe(eventSkipperByID_);}
+    std::shared_ptr<EventSkipperByID>& eventSkipperByID() {return get_underlying_safe(eventSkipperByID_);}
+    std::shared_ptr<DuplicateChecker const> duplicateChecker() const {return get_underlying_safe(duplicateChecker_);}
+    std::shared_ptr<DuplicateChecker>& duplicateChecker() {return get_underlying_safe(duplicateChecker_);}
+
+    edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
     int initialNumberOfEventsToSkip_;
     bool noEventSort_;
     unsigned int treeCacheSize_;
-    std::shared_ptr<DuplicateChecker> duplicateChecker_;
+    edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;
     bool usingGoToEvent_;
     bool enablePrefetching_;
   }; // class RootPrimaryFileSequence

--- a/IOPool/Input/test/IOExerciser.cc
+++ b/IOPool/Input/test/IOExerciser.cc
@@ -30,7 +30,7 @@ to use this plugin.
 #include "FWCore/Framework/interface/GenericHandle.h"
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"

--- a/IOPool/Input/test/IOExerciser.cc
+++ b/IOPool/Input/test/IOExerciser.cc
@@ -30,6 +30,7 @@ to use this plugin.
 #include "FWCore/Framework/interface/GenericHandle.h"
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -67,7 +68,7 @@ class IOExerciser : public edm::OutputModule {
 
       // ----------member data ------------------------------------------------
       bool m_fetchedProducts;
-      TTree *m_eventsTree;
+      edm::propagate_const<TTree*> m_eventsTree;
       ProductInfos m_products;
       ProductInfos m_all_products;
       unsigned int m_percentBranches;
@@ -84,7 +85,7 @@ class IOExerciser : public edm::OutputModule {
 IOExerciser::IOExerciser(const edm::ParameterSet& pset) :
    OutputModule(pset),
    m_fetchedProducts(false),
-   m_eventsTree(NULL),
+   m_eventsTree(nullptr),
    m_percentBranches(pset.getUntrackedParameter<unsigned int>("percentBranches")),
    m_currentUsage(0),
    m_triggerFactor(pset.getUntrackedParameter<unsigned int>("triggerFactor")),

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -17,6 +17,7 @@
 #include "IOPool/Common/interface/RootServiceChecker.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 
@@ -167,7 +168,7 @@ namespace edm {
     BranchParents branchParents_;
     BranchChildren branchChildren_;
     bool overrideInputFileSplitLevels_;
-    std::unique_ptr<RootOutputFile> rootOutputFile_;
+    edm::propagate_const<std::unique_ptr<RootOutputFile>> rootOutputFile_;
     std::string statusFileName_;
   };
 }

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -17,7 +17,7 @@
 #include "IOPool/Common/interface/RootServiceChecker.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -119,7 +119,7 @@ namespace edm {
 
   PoolOutputModule::OutputItem::Sorter::Sorter(TTree* tree) : treeMap_(new std::map<std::string, int>) {
     // Fill a map mapping branch names to an index specifying the order in the tree.
-    if(tree != 0) {
+    if(tree != nullptr) {
       TObjArray* branches = tree->GetListOfBranches();
       for(int i = 0; i < branches->GetEntries(); ++i) {
         TBranchElement* br = (TBranchElement*)branches->At(i);
@@ -156,7 +156,7 @@ namespace edm {
     AuxItem&   auxItem = auxItems_[branchType];
 
     // Fill AuxItem
-    if (theInputTree != 0 && !overrideInputFileSplitLevels_) {
+    if (theInputTree != nullptr && !overrideInputFileSplitLevels_) {
       TBranch* auxBranch = theInputTree->GetBranch(BranchTypeToAuxiliaryBranchName(branchType).c_str());
       if (auxBranch) {
         auxItem.basketSize_ = auxBranch->GetBasketSize();
@@ -173,9 +173,9 @@ namespace edm {
       int basketSize = BranchDescription::invalidBasketSize;
 
       BranchDescription const& prod = **it;
-      TBranch* theBranch = ((!prod.produced() && theInputTree != 0 && !overrideInputFileSplitLevels_) ? theInputTree->GetBranch(prod.branchName().c_str()) : 0);
+      TBranch* theBranch = ((!prod.produced() && theInputTree != nullptr && !overrideInputFileSplitLevels_) ? theInputTree->GetBranch(prod.branchName().c_str()) : 0);
 
-      if(theBranch != 0) {
+      if(theBranch != nullptr) {
         splitLevel = theBranch->GetSplitLevel();
         basketSize = theBranch->GetBasketSize();
       } else {
@@ -288,9 +288,9 @@ namespace edm {
   void PoolOutputModule::writeBranchIDListRegistry() { rootOutputFile_->writeBranchIDListRegistry(); }
   void PoolOutputModule::writeThinnedAssociationsHelper() { rootOutputFile_->writeThinnedAssociationsHelper(); }
   void PoolOutputModule::writeProductDependencies() { rootOutputFile_->writeProductDependencies(); }
-  void PoolOutputModule::finishEndFile() { rootOutputFile_->finishEndFile(); rootOutputFile_.reset(); }
+  void PoolOutputModule::finishEndFile() { rootOutputFile_->finishEndFile(); rootOutputFile_ = nullptr; } // propagate_const<T> has no reset() function
   void PoolOutputModule::doExtrasAfterCloseFile() {}
-  bool PoolOutputModule::isFileOpen() const { return rootOutputFile_.get() != 0; }
+  bool PoolOutputModule::isFileOpen() const { return rootOutputFile_.get() != nullptr; }
   bool PoolOutputModule::shouldWeCloseFile() const { return rootOutputFile_->shouldWeCloseFile(); }
 
   std::pair<std::string, std::string>
@@ -329,13 +329,13 @@ namespace edm {
 
   void PoolOutputModule::reallyOpenFile() {
     auto names = physicalAndLogicalNameForNewFile();
-    rootOutputFile_.reset( new RootOutputFile(this, names.first, names.second));
+    rootOutputFile_ = std::make_unique<RootOutputFile>(this, names.first, names.second); // propagate_const<T> has no reset() function
   }
 
   void
   PoolOutputModule::updateBranchParents(EventPrincipal const& ep) {
     for(EventPrincipal::const_iterator i = ep.begin(), iEnd = ep.end(); i != iEnd; ++i) {
-      if((*i) && (*i)->productProvenancePtr() != 0) {
+      if((*i) && (*i)->productProvenancePtr() != nullptr) {
         BranchID const& bid = (*i)->branchDescription().branchID();
         BranchParents::iterator it = branchParents_.find(bid);
         if(it == branchParents_.end()) {

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -99,9 +99,9 @@ namespace edm {
       pEventEntryInfoVector_(&eventEntryInfoVector_),
       pBranchListIndexes_(nullptr),
       pEventSelectionIDs_(nullptr),
-      eventTree_(filePtr_, InEvent, om_->splitLevel(), om_->treeMaxVirtualSize()),
-      lumiTree_(filePtr_, InLumi, om_->splitLevel(), om_->treeMaxVirtualSize()),
-      runTree_(filePtr_, InRun, om_->splitLevel(), om_->treeMaxVirtualSize()),
+      eventTree_(filePtr(), InEvent, om_->splitLevel(), om_->treeMaxVirtualSize()),
+      lumiTree_(filePtr(), InLumi, om_->splitLevel(), om_->treeMaxVirtualSize()),
+      runTree_(filePtr(), InRun, om_->splitLevel(), om_->treeMaxVirtualSize()),
       treePointers_(),
       dataTypeReported_(false),
       processHistoryRegistry_(),
@@ -122,7 +122,7 @@ namespace edm {
     eventTree_.addAuxiliary<EventAuxiliary>(BranchTypeToAuxiliaryBranchName(InEvent),
                                             pEventAux_, om_->auxItems()[InEvent].basketSize_);
     eventTree_.addAuxiliary<StoredProductProvenanceVector>(BranchTypeToProductProvenanceBranchName(InEvent),
-                                                     pEventEntryInfoVector_, om_->auxItems()[InEvent].basketSize_);
+                                                     pEventEntryInfoVector(), om_->auxItems()[InEvent].basketSize_);
     eventTree_.addAuxiliary<EventSelectionIDVector>(poolNames::eventSelectionsBranchName(),
                                                     pEventSelectionIDs_, om_->auxItems()[InEvent].basketSize_,false);
     eventTree_.addAuxiliary<BranchListIndexes>(poolNames::branchListIndexesBranchName(),
@@ -629,7 +629,7 @@ namespace edm {
       treePointer = nullptr;
     }
     filePtr_->Close();
-    filePtr_.reset();
+    filePtr_ = nullptr; // propagate_const<T> has no reset() function
 
     // report that file has been closed
     Service<JobReport> reportSvc;

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -18,6 +18,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/FileID.h"
@@ -45,7 +46,7 @@ namespace edm {
   public:
     typedef PoolOutputModule::OutputItem OutputItem;
     typedef PoolOutputModule::OutputItemList OutputItemList;
-    typedef std::array<RootOutputTree*, NumBranchTypes> RootOutputTreePtrArray;
+    typedef std::array<edm::propagate_const<RootOutputTree*>, NumBranchTypes> RootOutputTreePtrArray;
     explicit RootOutputFile(PoolOutputModule* om, std::string const& fileName,
                             std::string const& logicalFileName);
     ~RootOutputFile() {}
@@ -95,31 +96,37 @@ namespace edm {
 
     bool insertProductProvenance(const ProductProvenance&,
                                  std::set<StoredProductProvenance>& oToInsert);
+
+    std::shared_ptr<TFile const> filePtr() const {return get_underlying_safe(filePtr_);}
+    std::shared_ptr<TFile>& filePtr() {return get_underlying_safe(filePtr_);}
+    StoredProductProvenanceVector const* pEventEntryInfoVector() const {return get_underlying_safe(pEventEntryInfoVector_);}
+    StoredProductProvenanceVector*& pEventEntryInfoVector() {return get_underlying_safe(pEventEntryInfoVector_);}
+
     //-------------------------------
     // Member data
 
     std::string file_;
     std::string logicalFile_;
     JobReport::Token reportToken_;
-    PoolOutputModule* om_;
+    edm::propagate_const<PoolOutputModule*> om_;
     int whyNotFastClonable_;
     bool canFastCloneAux_;
-    std::shared_ptr<TFile> filePtr_;
+    edm::propagate_const<std::shared_ptr<TFile>> filePtr_;
     FileID fid_;
     IndexIntoFile::EntryNumber_t eventEntryNumber_;
     IndexIntoFile::EntryNumber_t lumiEntryNumber_;
     IndexIntoFile::EntryNumber_t runEntryNumber_;
     IndexIntoFile indexIntoFile_;
-    TTree* metaDataTree_;
-    TTree* parameterSetsTree_;
-    TTree* parentageTree_;
+    edm::propagate_const<TTree*> metaDataTree_;
+    edm::propagate_const<TTree*> parameterSetsTree_;
+    edm::propagate_const<TTree*> parentageTree_;
     LuminosityBlockAuxiliary  lumiAux_;
     RunAuxiliary              runAux_;
     EventAuxiliary const*           pEventAux_;
     LuminosityBlockAuxiliary const* pLumiAux_;
     RunAuxiliary const*             pRunAux_;
     StoredProductProvenanceVector eventEntryInfoVector_;
-    StoredProductProvenanceVector*        pEventEntryInfoVector_;
+    edm::propagate_const<StoredProductProvenanceVector*> pEventEntryInfoVector_;
     BranchListIndexes const*        pBranchListIndexes_;
     EventSelectionIDVector const*   pEventSelectionIDs_;
     RootOutputTree eventTree_;
@@ -130,7 +137,7 @@ namespace edm {
     ProcessHistoryRegistry processHistoryRegistry_;
     std::map<ParentageID,unsigned int> parentageIDs_;
     std::set<BranchID> branchesWithStoredHistory_;
-    TClass* wrapperBaseTClass_;
+    edm::propagate_const<TClass*> wrapperBaseTClass_;
   };
 
 }

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -18,7 +18,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/FileID.h"

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -129,10 +129,7 @@ namespace edm {
     assert(inputTree != nullptr);
 
     // Do the split level and basket size match in the input and output?
-    for(std::vector<TBranch*>::const_iterator it = readBranches_.begin(), itEnd = readBranches_.end();
-      it != itEnd; ++it) {
-
-      TBranch* outputBranch = *it;
+    for(auto const& outputBranch : readBranches_) {
       if(outputBranch != nullptr) {
         TBranch* inputBranch = inputTree->GetBranch(outputBranch->GetName());
 
@@ -181,8 +178,8 @@ namespace edm {
     if(inputTree == nullptr) return false;
 
     // Do the sub-branches match in the input and output. Extra sub-branches in the input are OK for fast cloning, but not in the output.
-    for(std::vector<TBranch*>::const_iterator it = readBranches_.begin(), itEnd = readBranches_.end(); it != itEnd; ++it) {
-      TBranchElement* outputBranch = dynamic_cast<TBranchElement*>(*it);
+    for(auto const& outputBr : readBranches_) {
+      TBranchElement* outputBranch = dynamic_cast<TBranchElement*>(outputBr);
       if(outputBranch != nullptr) {
         TBranchElement* inputBranch = dynamic_cast<TBranchElement*>(inputTree->GetBranch(outputBranch->GetName()));
         if(inputBranch != nullptr) {
@@ -199,8 +196,8 @@ namespace edm {
   }
 
   bool RootOutputTree::checkEntriesInReadBranches(Long64_t expectedNumberOfEntries) const {
-    for(std::vector<TBranch*>::const_iterator it = readBranches_.begin(), itEnd = readBranches_.end(); it != itEnd; ++it) {
-      if((*it)->GetEntries() != expectedNumberOfEntries) {
+    for(auto const& readBranch : readBranches_) {
+      if(readBranch->GetEntries() != expectedNumberOfEntries) {
         return false;
       }
     }
@@ -216,23 +213,20 @@ namespace edm {
       std::map<Int_t, TBranch *> auxIndexes;
       bool mustRemoveSomeAuxs = false;
       if(!fastCloneAuxBranches_) {
-        for(std::vector<TBranch *>::const_iterator it = auxBranches_.begin(), itEnd = auxBranches_.end();
-             it != itEnd; ++it) {
-          int auxIndex = branches->IndexOf(*it);
+        for(auto const& auxBranch : auxBranches_) {
+          int auxIndex = branches->IndexOf(auxBranch);
           assert (auxIndex >= 0);
-          auxIndexes.insert(std::make_pair(auxIndex, *it));
+          auxIndexes.insert(std::make_pair(auxIndex, auxBranch));
           branches->RemoveAt(auxIndex);
         }
         mustRemoveSomeAuxs = true;
       }
 
       //Deal with any aux branches which can never be cloned
-      for(std::vector<TBranch *>::const_iterator it = unclonedAuxBranches_.begin(),
-           itEnd = unclonedAuxBranches_.end();
-           it != itEnd; ++it) {
-        int auxIndex = branches->IndexOf(*it);
+      for(auto const& auxBranch : unclonedAuxBranches_) {
+        int auxIndex = branches->IndexOf(auxBranch);
         assert (auxIndex >= 0);
-        auxIndexes.insert(std::make_pair(auxIndex, *it));
+        auxIndexes.insert(std::make_pair(auxIndex, auxBranch));
         branches->RemoveAt(auxIndex);
         mustRemoveSomeAuxs = true;
       }
@@ -259,18 +253,17 @@ namespace edm {
       rootHandler->ignoreWarningsWhileDoing([&cloner] { cloner.Exec(); });
 
       if(mustRemoveSomeAuxs) {
-        for(std::map<Int_t, TBranch *>::const_iterator it = auxIndexes.begin(), itEnd = auxIndexes.end();
-             it != itEnd; ++it) {
+        for(auto const& auxIndex : auxIndexes) {
           // Add the auxiliary branches back after fast copying the rest of the tree.
           Int_t last = branches->GetLast();
           if(last >= 0) {
             branches->AddAtAndExpand(branches->At(last), last+1);
-            for(Int_t ind = last-1; ind >= it->first; --ind) {
+            for(Int_t ind = last-1; ind >= auxIndex.first; --ind) {
               branches->AddAt(branches->At(ind), ind+1);
             };
-            branches->AddAt(it->second, it->first);
+            branches->AddAt(auxIndex.second, auxIndex.first);
           } else {
-            branches->Add(it->second);
+            branches->Add(auxIndex.second);
           }
         }
       }
@@ -292,8 +285,8 @@ namespace edm {
   }
 
   void
-  RootOutputTree::writeTree() const {
-    writeTTree(tree_);
+  RootOutputTree::writeTree() {
+    writeTTree(tree());
   }
 
   void
@@ -304,12 +297,11 @@ namespace edm {
     if(currentlyFastCloning_) {
       fastCloneAuxBranches_ = canFastCloneAux;
       fastCloneTTree(tree, option);
-      for(std::vector<TBranch*>::const_iterator it = readBranches_.begin(), itEnd = readBranches_.end();
-          it != itEnd; ++it) {
-        if((*it)->GetEntries() == tree_->GetEntries()) {
-          clonedReadBranchNames_.insert(std::string((*it)->GetName()));
+      for(auto const& branch : readBranches_) {
+        if(branch->GetEntries() == tree_->GetEntries()) {
+          clonedReadBranchNames_.insert(std::string(branch->GetName()));
         } else {
-          unclonedReadBranches_.push_back(*it);
+          unclonedReadBranches_.push_back(branch);
         }
       }
       Service<JobReport> reportSvc;
@@ -318,7 +310,7 @@ namespace edm {
   }
 
   void
-  RootOutputTree::fillTree() const {
+  RootOutputTree::fillTree() {
     if(currentlyFastCloning_) {
       if(!fastCloneAuxBranches_)fillTTree(auxBranches_);
       fillTTree(unclonedAuxBranches_);
@@ -368,7 +360,7 @@ namespace edm {
     producedBranches_.clear();
     readBranches_.clear();
     unclonedReadBranches_.clear();
-    tree_ = nullptr;
-    filePtr_.reset();
+    tree_ = nullptr; // propagate_const<T> has no reset() function
+    filePtr_ = nullptr; // propagate_const<T> has no reset() function
   }
 }

--- a/IOPool/Output/src/RootOutputTree.h
+++ b/IOPool/Output/src/RootOutputTree.h
@@ -14,6 +14,7 @@ RootOutputTree.h // used by ROOT output modules
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "TTree.h"
 
@@ -78,12 +79,16 @@ namespace edm {
 
     void maybeFastCloneTree(bool canFastClone, bool canFastCloneAux, TTree* tree, std::string const& option);
 
-    void fillTree() const;
+    void fillTree();
 
-    void writeTree() const;
+    void writeTree();
 
-    TTree* tree() const {
-      return tree_;
+    TTree const* tree() const {
+      return tree_.get();
+    }
+
+    TTree* tree() {
+      return tree_.get();
     }
 
     void setEntries() {
@@ -109,13 +114,15 @@ namespace edm {
 // We use bare pointers for pointers to some ROOT entities.
 // Root owns them and uses bare pointers internally.
 // Therefore, using smart pointers here will do no good.
-    std::shared_ptr<TFile> filePtr_;
-    TTree* tree_;
+    edm::propagate_const<std::shared_ptr<TFile>> filePtr_;
+    edm::propagate_const<TTree*> tree_;
+
     std::vector<TBranch*> producedBranches_; // does not include cloned branches
     std::vector<TBranch*> readBranches_;
     std::vector<TBranch*> auxBranches_;
     std::vector<TBranch*> unclonedAuxBranches_;
     std::vector<TBranch*> unclonedReadBranches_;
+
     std::set<std::string> clonedReadBranchNames_;
     bool currentlyFastCloning_;
     bool fastCloneAuxBranches_;

--- a/IOPool/Output/src/RootOutputTree.h
+++ b/IOPool/Output/src/RootOutputTree.h
@@ -14,7 +14,7 @@ RootOutputTree.h // used by ROOT output modules
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Utilities/interface/BranchType.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "TTree.h"
 

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -68,11 +68,13 @@ namespace edm {
   }
 
   void SecondaryProducer::beginJob() {
-    eventPrincipal_.reset(new EventPrincipal(secInput_->productRegistry(),
+    // propagate_const<T> has no reset() function
+    eventPrincipal_ = std::make_unique<EventPrincipal>(
+                                             secInput_->productRegistry(),
                                              std::make_shared<BranchIDListHelper>(),
                                              std::make_shared<ThinnedAssociationsHelper>(),
                                              *processConfiguration_,
-                                             nullptr));
+                                             nullptr);
 
   }
 
@@ -161,7 +163,7 @@ namespace edm {
   std::shared_ptr<VectorInputSource> SecondaryProducer::makeSecInput(ParameterSet const& ps) {
     ParameterSet const& sec_input = ps.getParameterSet("input");
     PreallocationConfiguration dummy;
-    VectorInputSourceDescription desc(productRegistry_, dummy);
+    VectorInputSourceDescription desc(productRegistry(), dummy);
     std::shared_ptr<VectorInputSource> input_(static_cast<VectorInputSource *>
       (VectorInputSourceFactory::get()->makeVectorInputSource(sec_input, desc).release()));
     return input_;

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -10,7 +10,7 @@
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -10,6 +10,7 @@
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -33,33 +34,23 @@ namespace edm {
     void processOneEvent(EventPrincipal const& eventPrincipal, Event& e);
 
   private:
-
     virtual void put(Event &) {}
-
     virtual void beginJob();
-
     virtual void endJob();
-
     std::shared_ptr<VectorInputSource> makeSecInput(ParameterSet const& ps);
 
-    std::shared_ptr<ProductRegistry> productRegistry_;
+    std::shared_ptr<ProductRegistry const> productRegistry() const {return get_underlying_safe(productRegistry_);}
+    std::shared_ptr<ProductRegistry>& productRegistry() {return get_underlying_safe(productRegistry_);}
 
-    std::shared_ptr<VectorInputSource> const secInput_;
-
-    std::unique_ptr<ProcessConfiguration> processConfiguration_;
-
-    std::unique_ptr<EventPrincipal> eventPrincipal_;
-
+    edm::propagate_const<std::shared_ptr<ProductRegistry>> productRegistry_;
+    edm::propagate_const<std::shared_ptr<VectorInputSource> const> secInput_;
+    edm::propagate_const<std::unique_ptr<ProcessConfiguration>> processConfiguration_;
+    edm::propagate_const<std::unique_ptr<EventPrincipal>> eventPrincipal_;
     bool sequential_;
-
     bool specified_;
-
     bool sameLumiBlock_;
-
     bool firstEvent_;
-
     bool firstLoop_;
-
     EventNumber_t expectedEventNumber_;
   };
 }//edm

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -16,7 +16,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 const int init_size = 1024*1024;
 

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -16,6 +16,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 const int init_size = 1024*1024;
 
@@ -39,7 +40,8 @@ struct SerializeDataBuffer
   // serialization operation.  You get access to the data using the
   // following member functions.
 
-  unsigned char* bufferPointer() const { return ptr_; }
+  unsigned char const* bufferPointer() const { return get_underlying_safe(ptr_); }
+  unsigned char*& bufferPointer() { return get_underlying_safe(ptr_); }
   unsigned int currentSpaceUsed() const { return curr_space_used_; }
   unsigned int currentEventSize() const { return curr_event_size_; }
   uint32_t adler32_chksum() const { return adler32_chksum_; }
@@ -48,7 +50,7 @@ struct SerializeDataBuffer
   unsigned int curr_event_size_;
   unsigned int curr_space_used_; // less than curr_event_size_ if compressed
   TBufferFile rootbuf_;
-  unsigned char* ptr_; // set to the place where the last event stored
+  edm::propagate_const<unsigned char*> ptr_; // set to the place where the last event stored
   SBuffer header_buf_; // place for INIT message creation
   SBuffer bufs_;       // place for EVENT message creation
   uint32_t  adler32_chksum_; // adler32 check sum for the (compressed) data
@@ -93,7 +95,7 @@ namespace edm
   private:
 
     SelectedProducts const* selections_;
-    TClass* tc_;
+    edm::propagate_const<TClass*> tc_;
   };
 
 }

--- a/IOPool/Streamer/interface/StreamerFileIO.h
+++ b/IOPool/Streamer/interface/StreamerFileIO.h
@@ -7,7 +7,7 @@ Class representing Output (Streamer) file.
 */
 
 #include "IOPool/Streamer/interface/MsgTools.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include <memory>
 #include <iosfwd>
 #include <string>

--- a/IOPool/Streamer/interface/StreamerFileIO.h
+++ b/IOPool/Streamer/interface/StreamerFileIO.h
@@ -7,6 +7,7 @@ Class representing Output (Streamer) file.
 */
 
 #include "IOPool/Streamer/interface/MsgTools.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include <memory>
 #include <iosfwd>
 #include <string>
@@ -41,7 +42,7 @@ class OutputFile
      uint32 adlera_;
      uint32 adlerb_;
 
-     std::shared_ptr<std::ofstream> ost_;
+     edm::propagate_const<std::shared_ptr<std::ofstream>> ost_;
      std::string filename_; 
   };
 

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -6,7 +6,7 @@
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "Utilities/StorageFactory/interface/IOTypes.h"
 #include "Utilities/StorageFactory/interface/Storage.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -6,6 +6,7 @@
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "Utilities/StorageFactory/interface/IOTypes.h"
 #include "Utilities/StorageFactory/interface/Storage.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 
@@ -56,8 +57,8 @@ namespace edm {
 
     void logFileAction(char const* msg);
 
-    std::shared_ptr<InitMsgView> startMsg_;
-    std::shared_ptr<EventMsgView> currentEvMsg_;
+    edm::propagate_const<std::shared_ptr<InitMsgView>> startMsg_;
+    edm::propagate_const<std::shared_ptr<EventMsgView>> currentEvMsg_;
 
     std::vector<char> headerBuf_; /** Buffer to store file Header */
     std::vector<char> eventBuf_;  /** Buffer to store Event Data */
@@ -68,14 +69,14 @@ namespace edm {
     std::string currentFileName_;
     bool currentFileOpen_;
 
-    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
 
     uint32 currRun_;
     uint32 currProto_;
 
     bool newHeader_;
 
-    std::unique_ptr<Storage> storage_;
+    edm::propagate_const<std::unique_ptr<Storage>> storage_;
 
     bool endOfFile_;
   };

--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -4,6 +4,7 @@
 #include "IOPool/Streamer/interface/StreamerInputSource.h"
 
 #include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <string>
@@ -35,7 +36,7 @@ namespace edm
     virtual bool checkNextEvent();
 
     //ProductRegistry const* prod_reg_;
-    std::auto_ptr<Producer> pr_; 
+    edm::propagate_const<std::unique_ptr<Producer>> pr_;
   }; //end-of-class-def
 
   template <typename Producer>

--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -4,7 +4,7 @@
 #include "IOPool/Streamer/interface/StreamerInputSource.h"
 
 #include "FWCore/Utilities/interface/DebugMacros.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <memory>
 #include <string>

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -13,7 +13,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Sources/interface/RawInputSource.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "DataFormats/Common/interface/EDProductGetter.h"

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -13,6 +13,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Sources/interface/RawInputSource.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "DataFormats/Common/interface/EDProductGetter.h"
@@ -35,7 +36,7 @@ namespace edm {
     virtual ~StreamerInputSource();
     static void fillDescription(ParameterSetDescription& description);
 
-    std::auto_ptr<SendJobHeader> deserializeRegistry(InitMsgView const& initView);
+    std::unique_ptr<SendJobHeader> deserializeRegistry(InitMsgView const& initView);
 
     void deserializeAndMergeWithRegistry(InitMsgView const& initView, bool subsequent = false);
 
@@ -94,12 +95,12 @@ namespace edm {
 
     virtual std::unique_ptr<FileBlock> readFile_();
 
-    TClass* tc_;
+    edm::propagate_const<TClass*> tc_;
     std::vector<unsigned char> dest_;
     TBufferFile xbuf_;
-    std::unique_ptr<SendEvent> sendEvent_;
-    std::unique_ptr<EventPrincipalHolder> eventPrincipalHolder_;
-    std::vector<std::unique_ptr<EventPrincipalHolder>> streamToEventPrincipalHolders_;
+    edm::propagate_const<std::unique_ptr<SendEvent>> sendEvent_;
+    edm::propagate_const<std::unique_ptr<EventPrincipalHolder>> eventPrincipalHolder_;
+    std::vector<edm::propagate_const<std::unique_ptr<EventPrincipalHolder>>> streamToEventPrincipalHolders_;
     bool adjustEventToNewProductRegistry_;
 
     std::string processName_;

--- a/IOPool/Streamer/interface/StreamerOutputFile.h
+++ b/IOPool/Streamer/interface/StreamerOutputFile.h
@@ -3,7 +3,7 @@
 
 /** StreamerOutputFile: Class for doing Streamer Write operations */
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "IOPool/Streamer/interface/MsgTools.h"
 

--- a/IOPool/Streamer/interface/StreamerOutputFile.h
+++ b/IOPool/Streamer/interface/StreamerOutputFile.h
@@ -3,6 +3,8 @@
 
 /** StreamerOutputFile: Class for doing Streamer Write operations */
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 #include "IOPool/Streamer/interface/MsgTools.h"
 
 #include "IOPool/Streamer/interface/InitMsgBuilder.h"
@@ -59,7 +61,7 @@ class StreamerOutputFile
      void writeStart(const InitMsgView& inview);
 
   private:
-     std::shared_ptr<OutputFile> streamerfile_;
+     edm::propagate_const<std::shared_ptr<OutputFile>> streamerfile_;
 };
 
 #endif

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -101,7 +101,7 @@ namespace edm {
    data_buffer.curr_space_used_ = data_buffer.curr_event_size_;
    data_buffer.ptr_ = (unsigned char*)data_buffer.rootbuf_.Buffer();
    // calculate the adler32 checksum and fill it into the struct
-   data_buffer.adler32_chksum_ = cms::Adler32((char*)data_buffer.ptr_, data_buffer.curr_space_used_);
+   data_buffer.adler32_chksum_ = cms::Adler32((char*)data_buffer.bufferPointer(), data_buffer.curr_space_used_);
    //std::cout << "Adler32 checksum of init message = " << data_buffer.adler32_chksum_ << std::endl;
    return data_buffer.curr_space_used_;
   }
@@ -216,7 +216,7 @@ namespace edm {
       }
     }
     // calculate the adler32 checksum and fill it into the struct
-    data_buffer.adler32_chksum_ = cms::Adler32((char*)data_buffer.ptr_, data_buffer.curr_space_used_);
+    data_buffer.adler32_chksum_ = cms::Adler32((char*)data_buffer.bufferPointer(), data_buffer.curr_space_used_);
     //std::cout << "Adler32 checksum of event = " << data_buffer.adler32_chksum_ << std::endl;
 
     return data_buffer.curr_space_used_;

--- a/IOPool/Streamer/src/StreamerFileReader.cc
+++ b/IOPool/Streamer/src/StreamerFileReader.cc
@@ -29,9 +29,9 @@ namespace edm {
   void
   StreamerFileReader::reset_() {
     if (streamerNames_.size() > 1) {
-      streamReader_ = std::unique_ptr<StreamerInputFile>(new StreamerInputFile(streamerNames_, eventSkipperByID_));
+      streamReader_ = std::unique_ptr<StreamerInputFile>(new StreamerInputFile(streamerNames_, eventSkipperByID()));
     } else if (streamerNames_.size() == 1) {
-      streamReader_ = std::unique_ptr<StreamerInputFile>(new StreamerInputFile(streamerNames_.at(0), eventSkipperByID_));
+      streamReader_ = std::unique_ptr<StreamerInputFile>(new StreamerInputFile(streamerNames_.at(0), eventSkipperByID()));
     } else {
       throw Exception(errors::FileReadError, "StreamerFileReader::StreamerFileReader")
          << "No fileNames were specified\n";

--- a/IOPool/Streamer/src/StreamerFileReader.h
+++ b/IOPool/Streamer/src/StreamerFileReader.h
@@ -2,6 +2,7 @@
 #define IOPool_Streamer_StreamerFileReader_h
 
 #include "IOPool/Streamer/interface/StreamerInputSource.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <memory>
 #include <string>
@@ -33,9 +34,12 @@ namespace edm {
     virtual void genuineCloseFile() override;
     virtual void reset_();
 
+    std::shared_ptr<EventSkipperByID const> eventSkipperByID() const {return get_underlying_safe(eventSkipperByID_);}
+    std::shared_ptr<EventSkipperByID>& eventSkipperByID() {return get_underlying_safe(eventSkipperByID_);}
+
     std::vector<std::string> streamerNames_; // names of Streamer files
-    std::unique_ptr<StreamerInputFile> streamReader_;
-    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    edm::propagate_const<std::unique_ptr<StreamerInputFile>> streamReader_;
+    edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
     int initialNumberOfEventsToSkip_;
   };
 } //end-of-namespace-def

--- a/IOPool/Streamer/src/StreamerFileReader.h
+++ b/IOPool/Streamer/src/StreamerFileReader.h
@@ -2,7 +2,7 @@
 #define IOPool_Streamer_StreamerFileReader_h
 
 #include "IOPool/Streamer/interface/StreamerInputSource.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 #include <string>

--- a/IOPool/Streamer/src/StreamerFileWriter.h
+++ b/IOPool/Streamer/src/StreamerFileWriter.h
@@ -6,7 +6,7 @@
 #include "IOPool/Streamer/interface/StreamerOutputFile.h"
 #include "IOPool/Streamer/interface/InitMsgBuilder.h"
 #include "IOPool/Streamer/interface/EventMsgBuilder.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "IOPool/Streamer/interface/InitMessage.h"
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/MsgTools.h"

--- a/IOPool/Streamer/src/StreamerFileWriter.h
+++ b/IOPool/Streamer/src/StreamerFileWriter.h
@@ -6,6 +6,7 @@
 #include "IOPool/Streamer/interface/StreamerOutputFile.h"
 #include "IOPool/Streamer/interface/InitMsgBuilder.h"
 #include "IOPool/Streamer/interface/EventMsgBuilder.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 #include "IOPool/Streamer/interface/InitMessage.h"
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
@@ -41,7 +42,7 @@ namespace edm
 
   private:
 
-    std::auto_ptr<StreamerOutputFile> stream_writer_;
+    edm::propagate_const<std::unique_ptr<StreamerOutputFile>> stream_writer_;
 
   };
 }

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -162,7 +162,7 @@ namespace edm {
         << "Failed reading streamer file, init header size from data too small\n";
     }
 
-    startMsg_.reset(new InitMsgView(&headerBuf_[0]));
+    startMsg_ = std::make_shared<InitMsgView>(&headerBuf_[0]); // propagate_const<T> has no reset() function
   }
 
   bool StreamerInputFile::next() {
@@ -278,7 +278,7 @@ namespace edm {
         }
       }
     }
-    currentEvMsg_.reset(new EventMsgView((void*)&eventBuf_[0]));
+    currentEvMsg_ = std::make_shared<EventMsgView>((void*)&eventBuf_[0]); // propagate_const<T> has no reset() function
     return 1;
   }
 

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -118,7 +118,7 @@ namespace edm {
    * Deserializes the specified init message into a SendJobHeader object
    * (which is related to the product registry).
    */
-  std::auto_ptr<SendJobHeader>
+  std::unique_ptr<SendJobHeader>
   StreamerInputSource::deserializeRegistry(InitMsgView const& initView) {
     if(initView.code() != Header::INIT)
       throw cms::Exception("StreamTranslation","Registry deserialization error")
@@ -152,7 +152,7 @@ namespace edm {
     TBufferFile xbuf(TBuffer::kRead, initView.descLength(),
                  const_cast<char*>((char const*)initView.descData()),kFALSE);
     RootDebug tracer(10,10);
-    std::auto_ptr<SendJobHeader> sd((SendJobHeader*)xbuf.ReadObjectAny(desc));
+    std::unique_ptr<SendJobHeader> sd((SendJobHeader*)xbuf.ReadObjectAny(desc));
 
     if(sd.get() == nullptr) {
         throw cms::Exception("StreamTranslation","Registry deserialization error")
@@ -169,7 +169,7 @@ namespace edm {
    */
   void
   StreamerInputSource::deserializeAndMergeWithRegistry(InitMsgView const& initView, bool subsequent) {
-     std::auto_ptr<SendJobHeader> sd = deserializeRegistry(initView);
+     std::unique_ptr<SendJobHeader> sd = deserializeRegistry(initView);
      mergeIntoRegistry(*sd, productRegistryUpdate(), *branchIDListHelper(), *thinnedAssociationsHelper(), subsequent);
      if (subsequent) {
        adjustEventToNewProductRegistry_ = true;
@@ -241,7 +241,7 @@ namespace edm {
     // make a new one instead of reusing the same one becuase when running
     // multi-threaded there will be multiple EventPrincipals being used
     // simultaneously.
-    eventPrincipalHolder_.reset( new EventPrincipalHolder() );
+    eventPrincipalHolder_ = std::make_unique<EventPrincipalHolder>(); // propagate_const<T> has no reset() function
     setRefCoreStreamer(eventPrincipalHolder_.get());
     sendEvent_ = std::unique_ptr<SendEvent>((SendEvent*)xbuf_.ReadObjectAny(tc_));
     setRefCoreStreamer();

--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -7,7 +7,7 @@
 # include "TFile.h"
 
 # include "Utilities/StorageFactory/interface/IOPosBuffer.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 
 class Storage;

--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -7,6 +7,7 @@
 # include "TFile.h"
 
 # include "Utilities/StorageFactory/interface/IOPosBuffer.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 
 class Storage;
@@ -52,9 +53,11 @@ private:
 
   Bool_t                ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf);
 
+  void                  releaseStorage() {get_underlying_safe(storage_).release();}
+
   TStorageFactoryFile(void);
 
-  std::unique_ptr<Storage>	storage_;		//< Real underlying storage
+  edm::propagate_const<std::unique_ptr<Storage>> storage_; //< Real underlying storage
 };
 
 #endif // TFILE_ADAPTOR_TSTORAGE_FACTORY_FILE_H

--- a/IOPool/TFileAdaptor/src/ReadRepacker.h
+++ b/IOPool/TFileAdaptor/src/ReadRepacker.h
@@ -28,7 +28,7 @@
 #include <vector>
 
 # include "Utilities/StorageFactory/interface/IOPosBuffer.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 class ReadRepacker {
 

--- a/IOPool/TFileAdaptor/src/ReadRepacker.h
+++ b/IOPool/TFileAdaptor/src/ReadRepacker.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 # include "Utilities/StorageFactory/interface/IOPosBuffer.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 class ReadRepacker {
 
@@ -71,7 +72,7 @@ void reset(unsigned int nbuf); // Reset all the internal counters and arrays.  R
 std::vector<int>         m_idx_to_iopb;        // Mapping from idx in the input array to the iopb in the IO vector
 std::vector<int>         m_idx_to_iopb_offset; // Mapping from idx in the input array to the data offset in the results of the iopb.
 std::vector<IOPosBuffer> m_iov;                // Vector of IO for the storage system to perform.
-int                     *m_len;                // Pointed to the array of read sizes.
+edm::propagate_const<int*> m_len;              // Pointed to the array of read sizes.
 IOSize                   m_buffer_used;        // Bytes in the temporary buffer used.
 IOSize                   m_extra_bytes;        // Number of bytes read from storage that will be discarded.
 std::vector<char>        m_spare_buffer;       // The spare buffer; allocated if we cannot fit the I/O results into the ROOT buffer.

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -263,7 +263,7 @@
 TFileAdaptorUI::TFileAdaptorUI() {
   edm::ActivityRegistry ar;
   const edm::ParameterSet param;
-  me.reset(new TFileAdaptor(param, ar));
+  me = std::make_shared<TFileAdaptor>(param, ar); // propagate_const<T> has no reset() function
 }
 
 TFileAdaptorUI::~TFileAdaptorUI() {}

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.h
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.h
@@ -1,7 +1,7 @@
 #ifndef IOPool_TFileAdaptor_TFileAdaptor_h
 #define IOPool_TFileAdaptor_TFileAdaptor_h
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.h
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.h
@@ -1,9 +1,10 @@
 #ifndef IOPool_TFileAdaptor_TFileAdaptor_h
 #define IOPool_TFileAdaptor_TFileAdaptor_h
 
-#include "boost/shared_ptr.hpp"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -74,7 +75,7 @@ public:
   void stats() const;
 
 private:
-  boost::shared_ptr<TFileAdaptor> me;
+  edm::propagate_const<std::shared_ptr<TFileAdaptor>> me;
 };
 
 #endif

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -578,7 +578,7 @@ TStorageFactoryFile::SysClose(Int_t /* fd */)
   if (storage_)
   {
     storage_->close();
-    storage_.release();
+    releaseStorage();
   }
 
   stats.tick();

--- a/IOPool/TFileAdaptor/src/classes_def.xml
+++ b/IOPool/TFileAdaptor/src/classes_def.xml
@@ -1,7 +1,8 @@
 <lcgdict>
  <class name="TStorageFactoryFile" ClassVersion="0"/>
  <class name="TStorageFactorySystem" ClassVersion="0"/>
- <class name="TFileAdaptorUI" ClassVersion="3">
+ <class name="TFileAdaptorUI" ClassVersion="4">
+   <version ClassVersion="4" checksum="2616425535"/>
    <version ClassVersion="3" checksum="818216219"/>
  </class>
 </lcgdict>

--- a/Utilities/StorageFactory/interface/LocalCacheFile.h
+++ b/Utilities/StorageFactory/interface/LocalCacheFile.h
@@ -3,6 +3,7 @@
 
 # include "Utilities/StorageFactory/interface/Storage.h"
 # include "Utilities/StorageFactory/interface/File.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 # include <vector>
 # include <string>
 # include <memory>
@@ -37,8 +38,8 @@ private:
 
   IOOffset		image_;
   std::vector<char>	present_;
-  std::unique_ptr<File>	file_;
-  std::unique_ptr<Storage>	storage_;
+  edm::propagate_const<std::unique_ptr<File>>    file_;
+  edm::propagate_const<std::unique_ptr<Storage>> storage_;
   bool                  closedFile_;
   unsigned int          cacheCount_;
   unsigned int          cacheTotal_;

--- a/Utilities/StorageFactory/interface/LocalCacheFile.h
+++ b/Utilities/StorageFactory/interface/LocalCacheFile.h
@@ -3,7 +3,7 @@
 
 # include "Utilities/StorageFactory/interface/Storage.h"
 # include "Utilities/StorageFactory/interface/File.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 # include <vector>
 # include <string>
 # include <memory>

--- a/Utilities/StorageFactory/interface/StorageAccountProxy.h
+++ b/Utilities/StorageFactory/interface/StorageAccountProxy.h
@@ -3,6 +3,7 @@
 
 # include "Utilities/StorageFactory/interface/StorageAccount.h"
 # include "Utilities/StorageFactory/interface/Storage.h"
+# include "FWCore/Utilities/interface/propagate_const_safe.h"
 # include <string>
 #include <memory>
 
@@ -39,7 +40,9 @@ public:
   virtual void		close (void);
 
 protected:
-  std::unique_ptr<Storage> m_baseStorage;
+  void releaseStorage() {get_underlying_safe(m_baseStorage).release();}
+
+  edm::propagate_const<std::unique_ptr<Storage>> m_baseStorage;
 
   StorageAccount::StorageClassToken m_token;
   StorageAccount::Counter &m_statsRead;

--- a/Utilities/StorageFactory/interface/StorageAccountProxy.h
+++ b/Utilities/StorageFactory/interface/StorageAccountProxy.h
@@ -3,7 +3,7 @@
 
 # include "Utilities/StorageFactory/interface/StorageAccount.h"
 # include "Utilities/StorageFactory/interface/Storage.h"
-# include "FWCore/Utilities/interface/propagate_const_safe.h"
+# include "FWCore/Utilities/interface/get_underlying_safe.h"
 # include <string>
 #include <memory>
 

--- a/Utilities/StorageFactory/src/StorageAccountProxy.cc
+++ b/Utilities/StorageFactory/src/StorageAccountProxy.cc
@@ -18,7 +18,7 @@ StorageAccountProxy::StorageAccountProxy (const std::string &storageClass,
 StorageAccountProxy::~StorageAccountProxy (void)
 {
   StorageAccount::Stamp stats (StorageAccount::counter (m_token, StorageAccount::Operation::destruct));
-  m_baseStorage.release();
+  releaseStorage();
   stats.tick ();
 }
 

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -9,7 +9,7 @@
 
 #include <boost/utility.hpp>
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace XrdAdaptor {
 

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -9,6 +9,8 @@
 
 #include <boost/utility.hpp>
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 namespace XrdAdaptor {
 
 class QualityMetric;
@@ -28,8 +30,8 @@ public:
 private:
     QualityMetricWatch(QualityMetric *parent1, QualityMetric *parent2);
     timespec m_start;
-    QualityMetric *m_parent1;
-    QualityMetric *m_parent2;
+    edm::propagate_const<QualityMetric*> m_parent1;
+    edm::propagate_const<QualityMetric*> m_parent2;
 };
 
 class QualityMetric : boost::noncopyable {

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -202,7 +202,7 @@ XrdFile::close (void)
     return;
   }
 
-  m_requestmanager.reset();
+  m_requestmanager = nullptr; // propagate_const<T> has no reset() function
 
   m_close = false;
   m_offset = 0;
@@ -213,7 +213,7 @@ XrdFile::close (void)
 void
 XrdFile::abort (void)
 {
-  m_requestmanager.reset();
+  m_requestmanager = nullptr; // propagate_const<T> has no reset() function
   m_close = false;
   m_offset = 0;
   m_size = -1;

--- a/Utilities/XrdAdaptor/src/XrdFile.h
+++ b/Utilities/XrdAdaptor/src/XrdFile.h
@@ -4,6 +4,7 @@
 # include "Utilities/StorageFactory/interface/Storage.h"
 # include "Utilities/StorageFactory/interface/IOFlags.h"
 # include "FWCore/Utilities/interface/Exception.h"
+# include "FWCore/Utilities/interface/propagate_const_safe.h"
 # include "XrdCl/XrdClFile.hh"
 # include <string>
 # include <memory>
@@ -64,7 +65,7 @@ private:
    */
   std::shared_ptr<XrdCl::File>   getActiveFile();
 
-  std::shared_ptr<XrdAdaptor::RequestManager> m_requestmanager;
+  edm::propagate_const<std::shared_ptr<XrdAdaptor::RequestManager>> m_requestmanager;
   IOOffset	 	         m_offset;
   IOOffset                       m_size;
   bool			         m_close;

--- a/Utilities/XrdAdaptor/src/XrdFile.h
+++ b/Utilities/XrdAdaptor/src/XrdFile.h
@@ -4,7 +4,7 @@
 # include "Utilities/StorageFactory/interface/Storage.h"
 # include "Utilities/StorageFactory/interface/IOFlags.h"
 # include "FWCore/Utilities/interface/Exception.h"
-# include "FWCore/Utilities/interface/propagate_const_safe.h"
+# include "FWCore/Utilities/interface/propagate_const.h"
 # include "XrdCl/XrdClFile.hh"
 # include <string>
 # include <memory>

--- a/Utilities/XrdAdaptor/src/XrdHostHandler.hh
+++ b/Utilities/XrdAdaptor/src/XrdHostHandler.hh
@@ -2,6 +2,7 @@
 #define __XRDADAPTOR_HOSTHANDLER_H_
 
 #include "XrdCl/XrdClXRootDResponses.hh"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #if defined(__linux__)
   #define HAVE_ATOMICS 1
@@ -32,8 +33,9 @@ public:
   virtual void HandleResponse(XrdCl::XRootDStatus *status,
                               XrdCl::AnyObject    *response) override
   {
-    pStatus.reset(status);
-    pResponse.reset(response);
+    // propagate_const<T> has no reset() function
+    pStatus_ = std::unique_ptr<XrdCl::XRootDStatus>(status);
+    pResponse_ = std::unique_ptr<XrdCl::AnyObject>(response);
     sem.Post();
   }
 
@@ -41,25 +43,26 @@ public:
                                        XrdCl::AnyObject    *response,
                                        XrdCl::HostList     *hostList) override
   {
-    pStatus.reset(status);
-    pResponse.reset(response);
-    pHostList.reset(hostList);
+    // propagate_const<T> has no reset() function
+    pStatus_ = std::unique_ptr<XrdCl::XRootDStatus>(status);
+    pResponse_ = std::unique_ptr<XrdCl::AnyObject>(response);
+    pHostList_ = std::unique_ptr<XrdCl::HostList>(hostList);
     sem.Post();
   }
 
   std::unique_ptr<XrdCl::XRootDStatus> GetStatus()
   {
-        return std::move(pStatus);
+        return std::move(get_underlying_safe(pStatus_));
   }
 
   std::unique_ptr<XrdCl::AnyObject> GetResponse()
   {
-    return std::move(pResponse);
+    return std::move(get_underlying_safe(pResponse_));
   }
 
   std::unique_ptr<XrdCl::HostList> GetHosts()
   {
-    return std::move(pHostList);
+    return std::move(get_underlying_safe(pHostList_));
   }
 
   void WaitForResponse()
@@ -69,9 +72,9 @@ public:
 
 private:
 
-  std::unique_ptr<XrdCl::XRootDStatus> pStatus;
-  std::unique_ptr<XrdCl::AnyObject>    pResponse;
-  std::unique_ptr<XrdCl::HostList>     pHostList;
+  edm::propagate_const<std::unique_ptr<XrdCl::XRootDStatus>> pStatus_;
+  edm::propagate_const<std::unique_ptr<XrdCl::AnyObject>>    pResponse_;
+  edm::propagate_const<std::unique_ptr<XrdCl::HostList>>     pHostList_;
   Semaphore                            sem;
 };
 

--- a/Utilities/XrdAdaptor/src/XrdHostHandler.hh
+++ b/Utilities/XrdAdaptor/src/XrdHostHandler.hh
@@ -2,7 +2,7 @@
 #define __XRDADAPTOR_HOSTHANDLER_H_
 
 #include "XrdCl/XrdClXRootDResponses.hh"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #if defined(__linux__)
   #define HAVE_ATOMICS 1

--- a/Utilities/XrdAdaptor/src/XrdRequest.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequest.cc
@@ -24,13 +24,13 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
 {
     std::unique_ptr<XrdCl::AnyObject> response(resp);
     std::unique_ptr<XrdCl::XRootDStatus> status(stat);
-    std::shared_ptr<ClientRequest> self_ref = m_self_reference;
-    m_self_reference.reset();
+    std::shared_ptr<ClientRequest> self_ref = self_reference();
+    m_self_reference = nullptr; // propagate_const<T> has no reset() function
     {
         QualityMetricWatch qmw;
         m_qmw.swap(qmw);
     }
-    m_stats.reset();
+    m_stats = nullptr; // propagate_const<T> has no reset() function
 
     if ((!FAKE_ERROR_COUNTER || ((++g_fakeError % FAKE_ERROR_COUNTER) != 0)) && (status->IsOK() && resp))
     {

--- a/Utilities/XrdAdaptor/src/XrdRequest.h
+++ b/Utilities/XrdAdaptor/src/XrdRequest.h
@@ -8,7 +8,7 @@
 #include <XrdCl/XrdClXRootDResponses.hh>
 
 #include "Utilities/StorageFactory/interface/Storage.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "QualityMetric.h"
 

--- a/Utilities/XrdAdaptor/src/XrdRequest.h
+++ b/Utilities/XrdAdaptor/src/XrdRequest.h
@@ -8,6 +8,7 @@
 #include <XrdCl/XrdClXRootDResponses.hh>
 
 #include "Utilities/StorageFactory/interface/Storage.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
 #include "QualityMetric.h"
 
@@ -77,24 +78,28 @@ public:
      * Returns a pointer to the current source; may be nullptr
      * if there is no outstanding IO
      */
-    std::shared_ptr<Source> getCurrentSource() const {return m_source;}
+    std::shared_ptr<Source const> getCurrentSource() const {return get_underlying_safe(m_source);}
+    std::shared_ptr<Source>& getCurrentSource() {return get_underlying_safe(m_source);}
 
 private:
+    std::shared_ptr<ClientRequest const> self_reference() const {return get_underlying_safe(m_self_reference);}
+    std::shared_ptr<ClientRequest>& self_reference() {return get_underlying_safe(m_self_reference);}
+
     unsigned m_failure_count;
     void *m_into;
     IOSize m_size;
     IOOffset m_off;
-    std::shared_ptr<std::vector<IOPosBuffer> > m_iolist;
+    edm::propagate_const<std::shared_ptr<std::vector<IOPosBuffer>>> m_iolist;
     RequestManager &m_manager;
-    std::shared_ptr<Source> m_source;
-    std::shared_ptr<XrdReadStatistics> m_stats;
+    edm::propagate_const<std::shared_ptr<Source>> m_source;
+    edm::propagate_const<std::shared_ptr<XrdReadStatistics>> m_stats;
 
     // Some explanation is due here.  When an IO is outstanding,
     // Xrootd takes a raw pointer to this object.  Hence we cannot
     // allow it to go out of scope until some indeterminate time in the
     // future.  So, while the IO is outstanding, we take a reference to
     // ourself to prevent the object from being unexpectedly deleted.
-    std::shared_ptr<ClientRequest> m_self_reference;
+    edm::propagate_const<std::shared_ptr<ClientRequest>> m_self_reference;
 
     std::promise<IOSize> m_promise;
 

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -71,7 +71,7 @@ public:
 
 
 private:
-    std::shared_ptr<XrdCl::File> m_fh;
+    edm::propagate_const<std::shared_ptr<XrdCl::File>> m_fh;
     std::string m_id;
     std::string m_site;
 };
@@ -282,13 +282,13 @@ Source::setXrootdSite()
 
 Source::~Source()
 {
-  new DelayedClose(m_fh, m_id, m_site);
+  new DelayedClose(fh(), m_id, m_site);
 }
 
 std::shared_ptr<XrdCl::File>
 Source::getFileHandle()
 {
-    return m_fh;
+    return fh();
 }
 
 static void
@@ -315,7 +315,7 @@ Source::handle(std::shared_ptr<ClientRequest> c)
     m_qm->startWatch(c->m_qmw);
     if (m_stats)
     {
-        std::shared_ptr<XrdReadStatistics> readStats = XrdSiteStatistics::startRead(m_stats, c);
+        std::shared_ptr<XrdReadStatistics> readStats = XrdSiteStatistics::startRead(stats(), c);
         c->setStatistics(readStats);
     }
 #ifdef XRD_FAKE_SLOW

--- a/Utilities/XrdAdaptor/src/XrdSource.h
+++ b/Utilities/XrdAdaptor/src/XrdSource.h
@@ -1,6 +1,8 @@
 #ifndef Utilities_XrdAdaptor_XrdSource_h
 #define Utilities_XrdAdaptor_XrdSource_h
 
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
+
 #include <memory>
 #include <vector>
 
@@ -63,15 +65,20 @@ private:
 
     void setXrootdSite();
 
+    std::shared_ptr<XrdCl::File const> fh() const {return get_underlying_safe(m_fh);}
+    std::shared_ptr<XrdCl::File>& fh() {return get_underlying_safe(m_fh);}
+    std::shared_ptr<XrdSiteStatistics const> stats() const {return get_underlying_safe(m_stats);}
+    std::shared_ptr<XrdSiteStatistics>& stats() {return get_underlying_safe(m_stats);}
+
     struct timespec m_lastDowngrade;
     std::string m_id;
     std::string m_prettyid;
     std::string m_site;
     std::string m_exclude;
-    std::shared_ptr<XrdCl::File> m_fh;
+    edm::propagate_const<std::shared_ptr<XrdCl::File>> m_fh;
 
-    std::unique_ptr<QualityMetricSource> m_qm;
-    std::shared_ptr<XrdSiteStatistics> m_stats;
+    edm::propagate_const<std::unique_ptr<QualityMetricSource>> m_qm;
+    edm::propagate_const<std::shared_ptr<XrdSiteStatistics>> m_stats;
 
 #ifdef XRD_FAKE_SLOW
     bool m_slow;

--- a/Utilities/XrdAdaptor/src/XrdSource.h
+++ b/Utilities/XrdAdaptor/src/XrdSource.h
@@ -1,7 +1,7 @@
 #ifndef Utilities_XrdAdaptor_XrdSource_h
 #define Utilities_XrdAdaptor_XrdSource_h
 
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
 #include <vector>

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -37,7 +37,7 @@ void XrdStatisticsService::postEndJob()
     if (!instance) {return;}
 
     std::map<std::string, std::string> props;
-    for (std::shared_ptr<XrdSiteStatistics> const &stats : instance->m_sites)
+    for (auto& stats : instance->m_sites)
     {
         stats->recomputeProperties(props);
         reportSvc->reportPerformanceForModule(stats->site(), "XrdSiteStatistics", props);
@@ -49,12 +49,12 @@ std::shared_ptr<XrdSiteStatistics>
 XrdSiteStatisticsInformation::getStatisticsForSite(std::string const &site)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    for (std::shared_ptr<XrdSiteStatistics> &stats : m_sites)
+    for (auto& stats : m_sites)
     {
-        if (stats->site() == site) {return stats;}
+        if (stats->site() == site) {return get_underlying_safe(stats);}
     }
     m_sites.emplace_back(new XrdSiteStatistics(site));
-    return m_sites.back();
+    return get_underlying_safe(m_sites.back());
 }
 
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -2,7 +2,7 @@
 #define __XRD_STATISTICS_SERVICE_H_
 
 #include "Utilities/StorageFactory/interface/IOTypes.h"
-#include "FWCore/Utilities/interface/propagate_const_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <atomic>
 #include <chrono>

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -2,10 +2,14 @@
 #define __XRD_STATISTICS_SERVICE_H_
 
 #include "Utilities/StorageFactory/interface/IOTypes.h"
+#include "FWCore/Utilities/interface/propagate_const_safe.h"
 
-#include <chrono>
-#include <mutex>
 #include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
 
 namespace edm
 {
@@ -55,7 +59,7 @@ private:
 
     static std::atomic<XrdSiteStatisticsInformation*> m_instance;
     std::mutex m_mutex;
-    std::vector<std::shared_ptr<XrdSiteStatistics>> m_sites;
+    std::vector<edm::propagate_const<std::shared_ptr<XrdSiteStatistics>>> m_sites;
 };
 
 class XrdSiteStatistics
@@ -107,7 +111,7 @@ private:
 
     size_t m_size;
     IOSize m_count;
-    std::shared_ptr<XrdSiteStatistics> m_parent;
+    edm::propagate_const<std::shared_ptr<XrdSiteStatistics>> m_parent;
     std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
 };
 


### PR DESCRIPTION
This PR supersedes PR #13015.
This PR uses the propagate_const template for most pointers in the framework that are data members of classes or structs, and makes the knock on changes caused by this. This means that a const member function of the class will no longer be able to modify the data to which the pointer points. This PR is therefore a partial implementation of issue #12840. The member pointers in the framework that are not modified by this PR are:
1) Those in FWLite (will be done in a separate PR).
2) Pointers to const or pointers already declared mutable (no need to modify).
3) Those pointers whose modifications require changes that were too extensive or complex to be done in this PR. These will be dealt within a case by case basis.
Other minor changes made in a very few places in affected code:
a) a few boost::scoped_ptr changed to std::unique_ptr
b) a few std::auto_ptr changed to std::unique_ptr
c) iterator loops replaced by range based for loops
d) nullptr replaces 0 for pointers

This PR does not change any instances of boost::shared_ptr to std::shared_ptr, because most of these have already been changed in previous PR's, and the ones remaining are not trivial to change. These will be changed in subsequent PR's where feasible.
