### PR TITLE
Fixed data race for G4 cuts

### DIFF
--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -45,6 +45,7 @@ class TrackingAction;
 class SteppingAction;
 
 class DDDWorld;
+class DDG4ProductionCuts;
 
 class G4RunManagerKernel;
 class G4Run;
@@ -143,6 +144,7 @@ private:
   std::vector<SensitiveTkDetector*> m_sensTkDets;
   std::vector<SensitiveCaloDetector*> m_sensCaloDets;
 
+  std::unique_ptr<DDG4ProductionCuts> m_prodCuts;
   SimActivityRegistry m_registry;
   std::vector<std::shared_ptr<SimWatcher> > m_watchers;
   std::vector<std::shared_ptr<SimProducer> > m_producers;

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -35,6 +35,7 @@ class RunAction;
 
 class DDCompactView;
 class DDDWorld;
+class DDG4ProductionCuts;
 class MagneticField;
 
 class G4MTRunManagerKernel;
@@ -130,6 +131,7 @@ private:
   std::vector<std::string> m_G4Commands;
 
   std::unique_ptr<DDDWorld> m_world;
+  std::unique_ptr<DDG4ProductionCuts> m_prodCuts;
   SimActivityRegistry m_registry;
   SensitiveDetectorCatalog m_catalog;
     

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -14,6 +14,7 @@
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
+#include "SimG4Core/Physics/interface/DDG4ProductionCuts.h"
 
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 
@@ -130,8 +131,7 @@ RunManager::RunManager(edm::ParameterSet const & p)
       m_p(p), m_fieldBuilder(0), m_chordFinderSetter(nullptr),
       m_theLHCTlinkTag(p.getParameter<edm::InputTag>("theLHCTlinkTag"))
 {    
-  m_kernel = G4RunManagerKernel::GetRunManagerKernel();
-  if (m_kernel==0) m_kernel = new G4RunManagerKernel();
+  m_kernel = new G4RunManagerKernel();
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");
@@ -266,6 +266,10 @@ void RunManager::initG4(const edm::EventSetup & es)
   } 
   edm::LogInfo("SimG4CoreApplication") 
     << "RunManager: start initialisation of PhysicsList";
+
+  int verb = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
+  m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
+  m_prodCuts->update();
   
   m_kernel->SetPhysics(phys);
   m_kernel->InitializePhysics();

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -268,6 +268,8 @@ void RunManager::initG4(const edm::EventSetup & es)
     << "RunManager: start initialisation of PhysicsList";
 
   int verb = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
+  m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
+  m_physicsList->SetCutsWithDefault();
   m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
   m_prodCuts->update();
   

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -8,6 +8,7 @@
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
+#include "SimG4Core/Physics/interface/DDG4ProductionCuts.h"
 
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 
@@ -72,12 +73,7 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
       m_fieldBuilder(nullptr)
 {    
   m_currentRun = nullptr;
-  G4RunManagerKernel *kernel = G4MTRunManagerKernel::GetRunManagerKernel();
-  if(!kernel) m_kernel = new G4MTRunManagerKernel();
-  else {
-    m_kernel = dynamic_cast<G4MTRunManagerKernel *>(kernel);
-    assert(m_kernel);
-  }
+  m_kernel = new G4MTRunManagerKernel();
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");
@@ -152,6 +148,10 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   }
   edm::LogInfo("SimG4CoreApplication") 
     << "RunManagerMT: start initialisation of PhysicsList for master";
+
+  int verb = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
+  m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
+  m_prodCuts->update();
   
   m_kernel->SetPhysics(phys);
   m_kernel->InitializePhysics();
@@ -188,6 +188,8 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
       G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
     }
   }
+
+  if(verb > 1) { m_physicsList->DumpCutValuesTable(); }
 
   // geometry dump
   if("" != m_WriteFile) {

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -150,6 +150,8 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
     << "RunManagerMT: start initialisation of PhysicsList for master";
 
   int verb = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
+  m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
+  m_physicsList->SetCutsWithDefault();
   m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
   m_prodCuts->update();
   

--- a/SimG4Core/Physics/interface/PhysicsList.h
+++ b/SimG4Core/Physics/interface/PhysicsList.h
@@ -21,8 +21,6 @@ public:
   virtual ~PhysicsList();
   virtual void SetCuts();
 
-private:
-  const edm::ParameterSet m_pPhysics;
 };
 
 #endif

--- a/SimG4Core/Physics/interface/PhysicsList.h
+++ b/SimG4Core/Physics/interface/PhysicsList.h
@@ -7,7 +7,6 @@
 #include "HepPDT/ParticleDataTable.hh"
 #include "G4VModularPhysicsList.hh"
 
-class DDG4ProductionCuts;
 namespace sim {
   class ChordFinderSetter;
 }
@@ -24,8 +23,6 @@ public:
 
 private:
   const edm::ParameterSet m_pPhysics;
-  DDG4ProductionCuts * prodCuts;
-  int                  m_Verbosity;
 };
 
 #endif

--- a/SimG4Core/Physics/src/PhysicsList.cc
+++ b/SimG4Core/Physics/src/PhysicsList.cc
@@ -1,21 +1,14 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4SystemOfUnits.hh"
-
-PhysicsList::PhysicsList(G4LogicalVolumeToDDLogicalPartMap & map,
-			 const HepPDT::ParticleDataTable * table_,
+PhysicsList::PhysicsList(G4LogicalVolumeToDDLogicalPartMap &,
+			 const HepPDT::ParticleDataTable *,
 			 sim::ChordFinderSetter *chordFinderSetter_,
-			 const edm::ParameterSet & p) 
-  : G4VModularPhysicsList(), m_pPhysics(p) {
+			 const edm::ParameterSet &) {
 }
  
 PhysicsList::~PhysicsList() {
 }
 
 void PhysicsList::SetCuts() { 
-
-  SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
-  SetCutsWithDefault();
 }
 

--- a/SimG4Core/Physics/src/PhysicsList.cc
+++ b/SimG4Core/Physics/src/PhysicsList.cc
@@ -1,37 +1,21 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
-#include "SimG4Core/Physics/interface/DDG4ProductionCuts.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4LossTableManager.hh"
 #include "G4SystemOfUnits.hh"
 
 PhysicsList::PhysicsList(G4LogicalVolumeToDDLogicalPartMap & map,
 			 const HepPDT::ParticleDataTable * table_,
 			 sim::ChordFinderSetter *chordFinderSetter_,
 			 const edm::ParameterSet & p) 
-  : G4VModularPhysicsList(), m_pPhysics(p),  prodCuts(0) {
-  m_Verbosity = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
-  prodCuts = new DDG4ProductionCuts(map, m_Verbosity, m_pPhysics);	
+  : G4VModularPhysicsList(), m_pPhysics(p) {
 }
  
 PhysicsList::~PhysicsList() {
-  delete prodCuts;
 }
 
 void PhysicsList::SetCuts() { 
 
-  SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*cm);
+  SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
   SetCutsWithDefault();
-
-  if ( m_pPhysics.getParameter<bool>("CutsPerRegion") ) {
-    prodCuts->update();
-  }
-
-  if ( m_Verbosity > 1) {
-    G4VUserPhysicsList::DumpCutValuesTable();
-  }
-
-  return ;
-
 }
 


### PR DESCRIPTION
Geant4 cuts should be defined once at initialisation of master thread. This is an attempt to fix helgrind report.
