### PR TITLE
Update tracking MC validation scripts

### DIFF
--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -35,6 +35,7 @@ _sampleFileName = {
 _allTPEfficName = "All tracks (all TPs)"
 _fromPVName = "Tracks from PV"
 _fromPVAllTPName = "Tracks from PV (all TPs)"
+_conversionName = "Tracks for conversions"
 _trackQualityNameOrder = collections.OrderedDict([
     ("seeding_seeds", "Seeds"),
     ("seeding_seedsa", "Seeds A"),
@@ -64,6 +65,7 @@ _trackQualityNameOrder = collections.OrderedDict([
     ("fromPVAllTP2_highPurity", "High purity "+_lowerFirst(_fromPVAllTPName).replace("PV", "PV v2")),
     ("fromPVAllTP2_Pt", _fromPVAllTPName.replace("Tracks", "Tracks pT &gt; 0.9 GeV").replace("PV", "PV v2")),
     ("fromPVAllTP2_highPurityPt", "High purity "+_lowerFirst(_fromPVAllTPName).replace("tracks", "tracks pT &gt; 0.9 GeV").replace("PV", "PV v2")),
+    ("conversion_", _conversionName)
 ])
 
 _trackAlgoName = {
@@ -96,6 +98,10 @@ _trackAlgoOrder = [
     'muonSeededStepInOut',
     'muonSeededStepOutIn',
     'duplicateMerge',
+    'convStep',
+    'conversionStep',
+    'ckfInOutFromConversions',
+    'ckfOutInFromConversions',
     'iter0',
     'iter1',
     'iter2',
@@ -127,6 +133,7 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("fromPV_highPurity", "High purity "+_lowerFirst(_fromPVName)),
     ("fromPVAllTP", _fromPVAllTPName),
     ("fromPVAllTP_highPurity", "High purity "+_lowerFirst(_fromPVAllTPName)),
+    ("conversion", _conversionName),
     # These are for vertices
     ("offlinePrimaryVertices", "All vertices (offlinePrimaryVertices)"),
     ("selectedOfflinePrimaryVertices", "Selected vertices (selectedOfflinePrimaryVertices)"),

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -77,6 +77,7 @@ _trackAlgoName = {
     "iter4" : "Iterative Step 4",
     "iter5" : "Iterative Step 5",
     "iter6" : "Iterative Step 6",
+    "iter7" : "Iterative Step 7",
     "iter9" : "Iterative Step 9",
     "iter10": "Iterative Step 10",
 }
@@ -109,6 +110,7 @@ _trackAlgoOrder = [
     'iter4',
     'iter5',
     'iter6',
+    'iter7',
     'iter9',
     'iter10',
 ]

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -1976,8 +1976,17 @@ class PlotterFolder:
         if dqmSubFolders is None:
             self._dqmSubFolders = None
         else:
-            self._dqmSubFolders = map(lambda sf: DQMSubFolder(sf, self._plotFolder.translateSubFolder(sf)), dqmSubFolders[0])
-            self._dqmSubFolders = filter(lambda sf: sf.translated is not None, self._dqmSubFolders)
+            # Match the subfolders between files in case the lists differ
+            # equality is by the 'translated' name
+            subfolders = {}
+            for sf_list in dqmSubFolders:
+                for sf in sf_list:
+                    sf_translated = self._plotFolder.translateSubFolder(sf)
+                    if sf_translated is not None and not sf_translated in subfolders:
+                        subfolders[sf_translated] = DQMSubFolder(sf, sf_translated)
+
+            self._dqmSubFolders = subfolders.values()
+            self._dqmSubFolders.sort(key=lambda sf: sf.subfolder)
 
         self._fallbackNames = fallbackNames
         self._fallbackDqmSubFolders = fallbackDqmSubFolders

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2233,6 +2233,10 @@ class Plotter:
                 return
         raise Exception("Did not find plot folder '%s' when trying to attach a table creator to it" % attachToFolder)
 
+    def clear(self):
+        """Remove all plot folders and tables"""
+        self._plots = []
+
     def getPlotFolderNames(self):
         return [item.getName() for item in self._plots]
 

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2227,6 +2227,7 @@ class Plotter:
         ROOT.gStyle.SetStatFontSize(statSize)
 
         ROOT.TH1.AddDirectory(False)
+        ROOT.TGaxis.SetMaxDigits(4)
 
     def append(self, *args, **kwargs):
         """Append a plot folder to the plotter.

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -835,6 +835,7 @@ _appendTrackingPlots("TrackFromPVAllTP", "fromPVAllTP", _simBasedPlots+_recoBase
 _appendTrackingPlots("TrackFromPVAllTP2", "fromPVAllTP2", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackSeeding", "seeding", _seedingBuildingPlots, seeding=True)
 _appendTrackingPlots("TrackBuilding", "building", _seedingBuildingPlots)
+_appendTrackingPlots("TrackConversion", "conversion", _simBasedPlots+_recoBasedPlots, rawSummary=True)
 
 # MiniAOD
 plotter.append("packedCandidate", _trackingFolders("PackedCandidate"),

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -284,7 +284,11 @@ _resolutionsPt = PlotGroup("resolutionsPt", [
 #
 ########################################
 
-_possibleTrackingIterations = [
+_possibleTrackingNonIterationColls = [
+    'ak4PFJets',
+    'btvLike',
+]
+_possibleTrackingColls = [
     'initialStepPreSplitting',
     'initialStep',
     'highPtTripletStep', # phase1
@@ -304,11 +308,7 @@ _possibleTrackingIterations = [
     'muonSeededStepInOut',
     'muonSeededStepOutIn',
     'duplicateMerge',
-]
-_possibleTrackingColls = _possibleTrackingIterations+[
-    'ak4PFJets',
-    'btvLike',
-]
+] + _possibleTrackingNonIterationColls
 _possibleTrackingCollsOld = {
     "Zero"  : "iter0",
     "First" : "iter1",
@@ -644,7 +644,7 @@ class TrackingPlotFolder(PlotFolder):
 
     # track-specific hack
     def isAlgoIterative(self, algo):
-        return algo in _possibleTrackingIterations or algo in _possibleTrackingCollsOld.values()
+        return algo not in _possibleTrackingNonIterationColls
 
 class TrackingSummaryTable:
     def __init__(self, section, highPurity=False):

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -17,9 +17,13 @@ _maxFake = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025]
 _minMaxResol = [1e-5, 4e-5, 1e-4, 4e-4, 1e-3, 4e-3, 1e-2, 4e-2, 0.1, 0.4, 1]
 _minMaxN = [5e-1, 5, 5e1, 5e2, 5e3, 5e4, 5e5, 5e6, 5e7, 5e8, 5e9]
 
-_maxLayers = 25
+_minHits = [0, 5, 10]
+_maxHits = [5, 10, 20, 40, 60, 80]
+_minLayers = [0, 5, 10]
+_maxLayers = [5, 10, 25]
 _maxPixelLayers = 8
-_max3DLayers = 20
+_min3DLayers = [0, 5, 10]
+_max3DLayers = [5, 10, 20]
 
 _legendDy_4rows = 0.09
 _legendDy_2rows = -0.025
@@ -55,18 +59,18 @@ _effandfake2 = PlotGroup("effandfake2", [
                          legendDy=_legendDy_4rows
 )
 _effandfake3 = PlotGroup("effandfake3", [
-    Plot("effic_vs_hit", xtitle="TP hits", ytitle="efficiency vs hits", ymax=_maxEff),
+    Plot("effic_vs_hit", xtitle="TP hits", ytitle="efficiency vs hits", xmin=_minHits, xmax=_maxHits, ymax=_maxEff),
     Plot(FakeDuplicate("fakeduprate_vs_hit", assoc="num_assoc(recoToSim)_hit", dup="num_duplicate_hit", reco="num_reco_hit", title="fake+duplicates vs hit"),
-         xtitle="track hits", ytitle="fake+duplicates rate vs hits", ymax=_maxFake),
-    Plot("effic_vs_layer", xtitle="TP layers", ytitle="efficiency vs layers", xmax=_maxLayers, ymax=_maxEff),
+         xtitle="track hits", ytitle="fake+duplicates rate vs hits", xmin=_minHits, xmax=_maxHits, ymax=_maxFake),
+    Plot("effic_vs_layer", xtitle="TP layers", ytitle="efficiency vs layers", xmin=_minLayers, xmax=_maxLayers, ymax=_maxEff),
     Plot(FakeDuplicate("fakeduprate_vs_layer", assoc="num_assoc(recoToSim)_layer", dup="num_duplicate_layer", reco="num_reco_layer", title="fake+duplicates vs layer"),
-         xtitle="track layers", ytitle="fake+duplicates rate vs layers", xmax=_maxLayers, ymax=_maxFake),
+         xtitle="track layers", ytitle="fake+duplicates rate vs layers", xmin=_minLayers, xmax=_maxLayers, ymax=_maxFake),
     Plot("effic_vs_pixellayer", xtitle="TP pixel layers", ytitle="efficiency vs pixel layers", title="", xmax=_maxPixelLayers, ymax=_maxEff),
     Plot(FakeDuplicate("fakeduprate_vs_pixellayer", assoc="num_assoc(recoToSim)_pixellayer", dup="num_duplicate_pixellayer", reco="num_reco_pixellayer", title=""),
          xtitle="track pixel layers", ytitle="fake+duplicates rate vs pixel layers", xmax=_maxPixelLayers, ymax=_maxFake),
-    Plot("effic_vs_3Dlayer", xtitle="TP 3D layers", ytitle="efficiency vs 3D layers", xmax=_max3DLayers, ymax=_maxEff),
+    Plot("effic_vs_3Dlayer", xtitle="TP 3D layers", ytitle="efficiency vs 3D layers", xmin=_min3DLayers, xmax=_max3DLayers, ymax=_maxEff),
     Plot(FakeDuplicate("fakeduprate_vs_3Dlayer", assoc="num_assoc(recoToSim)_3Dlayer", dup="num_duplicate_3Dlayer", reco="num_reco_3Dlayer", title="fake+duplicates vs 3D layer"),
-         xtitle="track 3D layers", ytitle="fake+duplicates rate vs 3D layers", xmax=_max3DLayers, ymax=_maxFake),
+         xtitle="track 3D layers", ytitle="fake+duplicates rate vs 3D layers", xmin=_min3DLayers, xmax=_max3DLayers, ymax=_maxFake),
 ],
                          legendDy=_legendDy_4rows
 )
@@ -114,21 +118,21 @@ _dupandfake2 = PlotGroup("dupandfake2", [
                          ncols=3, legendDy=_legendDy_4rows
 )
 _dupandfake3 = PlotGroup("dupandfake3", [
-    Plot("fakerate_vs_hit", xtitle="track hits", ytitle="fakerate vs hits", ymax=_maxFake),
-    Plot("duplicatesRate_hit", xtitle="track hits", ytitle="duplicates rate vs hits", ymax=_maxFake),
-    Plot("pileuprate_hit", xtitle="track hits", ytitle="pileup rate vs hits", ymax=_maxFake),
+    Plot("fakerate_vs_hit", xtitle="track hits", ytitle="fakerate vs hits", ymax=_maxFake, xmin=_minHits, xmax=_maxHits),
+    Plot("duplicatesRate_hit", xtitle="track hits", ytitle="duplicates rate vs hits", ymax=_maxFake, xmin=_minHits, xmax=_maxHits),
+    Plot("pileuprate_hit", xtitle="track hits", ytitle="pileup rate vs hits", ymax=_maxFake, xmin=_minHits, xmax=_maxHits),
     #
-    Plot("fakerate_vs_layer", xtitle="track layers", ytitle="fakerate vs layer", ymax=_maxFake, xmax=_maxLayers),
-    Plot("duplicatesRate_layer", xtitle="track layers", ytitle="duplicates rate vs layers", ymax=_maxFake, xmax=_maxLayers),
-    Plot("pileuprate_layer", xtitle="track layers", ytitle="pileup rate vs layers", ymax=_maxFake, xmax=_maxLayers),
+    Plot("fakerate_vs_layer", xtitle="track layers", ytitle="fakerate vs layer", ymax=_maxFake, xmin=_minLayers, xmax=_maxLayers),
+    Plot("duplicatesRate_layer", xtitle="track layers", ytitle="duplicates rate vs layers", ymax=_maxFake, xmin=_minLayers, xmax=_maxLayers),
+    Plot("pileuprate_layer", xtitle="track layers", ytitle="pileup rate vs layers", ymax=_maxFake, xmin=_minLayers, xmax=_maxLayers),
     #
     Plot("fakerate_vs_pixellayer", xtitle="track pixel layers", ytitle="fakerate vs pixel layers", title="", ymax=_maxFake, xmax=_maxPixelLayers),
     Plot("duplicatesRate_pixellayer", xtitle="track pixel layers", ytitle="duplicates rate vs pixel layers", title="", ymax=_maxFake, xmax=_maxPixelLayers),
     Plot("pileuprate_pixellayer", xtitle="track pixel layers", ytitle="pileup rate vs pixel layers", title="", ymax=_maxFake, xmax=_maxPixelLayers),
     #
-    Plot("fakerate_vs_3Dlayer", xtitle="track 3D layers", ytitle="fakerate vs 3D layers", ymax=_maxFake, xmax=_max3DLayers),
-    Plot("duplicatesRate_3Dlayer", xtitle="track 3D layers", ytitle="duplicates rate vs 3D layers", ymax=_maxFake, xmax=_max3DLayers),
-    Plot("pileuprate_3Dlayer", xtitle="track 3D layers", ytitle="pileup rate vs 3D layers", ymax=_maxFake, xmax=_max3DLayers)
+    Plot("fakerate_vs_3Dlayer", xtitle="track 3D layers", ytitle="fakerate vs 3D layers", ymax=_maxFake, xmin=_min3DLayers, xmax=_max3DLayers),
+    Plot("duplicatesRate_3Dlayer", xtitle="track 3D layers", ytitle="duplicates rate vs 3D layers", ymax=_maxFake, xmin=_min3DLayers, xmax=_max3DLayers),
+    Plot("pileuprate_3Dlayer", xtitle="track 3D layers", ytitle="pileup rate vs 3D layers", ymax=_maxFake, xmin=_min3DLayers, xmax=_max3DLayers)
 ],
                          ncols=3, legendDy=_legendDy_4rows
 )
@@ -235,11 +239,11 @@ _chargemisid = PlotGroup("chargemisid", [
 ])
 _common = {"stat": True, "normalizeToUnitArea": True, "ylog": True, "ymin": 1e-6, "drawStyle": "hist"}
 _hitsAndPt = PlotGroup("hitsAndPt", [
-    Plot("missing_inner_layers", ymax=1, **_common),
-    Plot("missing_outer_layers", ymax=1, **_common),
-    Plot("hits_eta", stat=True, statx=0.38, xtitle="track #eta", ytitle="<hits> vs #eta", ymin=8, ymax=24, statyadjust=[0,0,-0.15],
+    Plot("missing_inner_layers", xmin=_minLayers, xmax=_maxLayers, ymax=1, **_common),
+    Plot("missing_outer_layers", xmin=_minLayers, xmax=_maxLayers, ymax=1, **_common),
+    Plot("hits_eta", stat=True, statx=0.38, xtitle="track #eta", ytitle="<hits> vs #eta", ymin=_minHits, ymax=_maxHits, statyadjust=[0,0,-0.15],
          fallback={"name": "nhits_vs_eta", "profileX": True}),
-    Plot("hits", stat=True, xtitle="track hits", xmin=0, ylog=True, ymin=[5e-1, 5, 5e1, 5e2, 5e3], drawStyle="hist"),
+    Plot("hits", stat=True, xtitle="track hits", xmin=_minHits, xmax=_maxHits, ylog=True, ymin=[5e-1, 5, 5e1, 5e2, 5e3], drawStyle="hist"),
     Plot("num_simul_pT", xtitle="TP p_{T}", xlog=True, ymax=[1e-1, 2e-1, 5e-1, 1], **_common),
     Plot("num_reco_pT", xtitle="track p_{T}", xlog=True, ymax=[1e-1, 2e-1, 5e-1, 1], **_common)
 ])
@@ -521,10 +525,13 @@ def _constructSummary(mapping=None, highPurity=False, byOriginalAlgo=False, byAl
 #
 ########################################
 
-_common = {"normalizeToUnitArea": True, "ylog": True, "ymin": [1e-6, 1e-5, 1e-4, 1e-3, 1e-2], "ymax": [1e-2, 1e-1, 1.1]}
+_common = {"normalizeToUnitArea": True, "ylog": True, "ymin": [1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2], "ymax": [1e-2, 1e-1, 1.1]}
 _commonStatus = {}
 _commonStatus.update(_common)
-_commonStatus.update({"xbinlabelsize": 10, "drawStyle": "hist", "adjustMarginRight": 0.08})
+_commonStatus.update({"xbinlabelsize": 10, "xbinlabeloption": "d", "drawStyle": "hist", "adjustMarginRight": 0.08})
+_commonLabelSize = {}
+_commonLabelSize.update(_common)
+_commonLabelSize.update({"xlabelsize": 17})
 
 _packedCandidateFlow = PlotGroup("flow", [
     Plot("selectionFlow", xbinlabelsize=10, xbinlabeloption="d", adjustMarginRight=0.1, drawStyle="hist", ylog=True, ymin=[0.9, 9, 9e1, 9e2, 9e3, 9e4, 9e5, 9e6, 9e7]),
@@ -554,56 +561,56 @@ _packedCandidateHits = PlotGroup("hits", [
 )
 
 _packedCandidateImpactParameter1 = PlotGroup("impactParameter1", [
-    Plot("diffDxyAssocPV", xtitle="dxy(assocPV)", **_common),
+    Plot("diffDxyAssocPV", xtitle="dxy(assocPV)", adjustMarginRight=0.02, **_commonLabelSize),
     Plot("diffDxyAssocPVStatus", **_commonStatus),
     Plot("diffDxyAssocPVUnderOverFlowSign", xtitle="dxy(assocPV)", **_common),
-    Plot("diffDzAssocPV", xtitle="dz(assocPV)", **_common),
+    Plot("diffDzAssocPV", xtitle="dz(assocPV)", adjustMarginRight=0.02, **_commonLabelSize),
     Plot("diffDzAssocPVStatus", **_commonStatus),
     Plot("diffDzAssocPVUnderOverFlowSign", xtitle="dz(assocPV)", **_common),
-    Plot("diffDxyError", xtitle="dxyError()", **_common),
-    Plot("diffDszError", xtitle="dszError()", **_common),
-    Plot("diffDzError", xtitle="dzError()", **_common),
+    Plot("diffDxyError", xtitle="dxyError()", adjustMarginRight=0.02, **_commonLabelSize),
+    Plot("diffDszError", xtitle="dszError()", adjustMarginRight=0.02, **_commonLabelSize),
+    Plot("diffDzError", xtitle="dzError()", adjustMarginRight=0.02, **_commonLabelSize),
 
 ],
                                              ncols=3
 )
 
 _packedCandidateImpactParameter2 = PlotGroup("impactParameter2", [
-    Plot("diffDxyPV", xtitle="dxy(PV) via PC", **_common),
-    Plot("diffDzPV", xtitle="dz(PV) via PC", **_common),
-    Plot("diffTrackDxyAssocPV", xtitle="dxy(PV) via PC::bestTrack()", **_common),
-    Plot("diffTrackDzAssocPV", xtitle="dz(PV) via PC::bestTrack()", **_common),
-    Plot("diffTrackDxyError", xtitle="dxyError() via PC::bestTrack()", **_common),
-    Plot("diffTrackDzError", xtitle="dzError() via PC::besTTrack()", **_common),
+    Plot("diffDxyPV", xtitle="dxy(PV) via PC", **_commonLabelSize),
+    Plot("diffDzPV", xtitle="dz(PV) via PC", **_commonLabelSize),
+    Plot("diffTrackDxyAssocPV", xtitle="dxy(PV) via PC::bestTrack()", **_commonLabelSize),
+    Plot("diffTrackDzAssocPV", xtitle="dz(PV) via PC::bestTrack()", **_commonLabelSize),
+    Plot("diffTrackDxyError", xtitle="dxyError() via PC::bestTrack()", adjustMarginRight=0.02, **_commonLabelSize),
+    Plot("diffTrackDzError", xtitle="dzError() via PC::bestTrack()", **_commonLabelSize),
 ])
 
 _packedCandidateCovarianceMatrix1 = PlotGroup("covarianceMatrix1", [
-    Plot("diffCovQoverpQoverp", xtitle="cov(qoverp, qoverp)", **_common),
+    Plot("diffCovQoverpQoverp", xtitle="cov(qoverp, qoverp)", **_commonLabelSize),
     Plot("diffCovQoverpQoverpStatus", **_commonStatus),
     Plot("diffCovQoverpQoverpUnderOverFlowSign", xtitle="cov(qoverp, qoverp)", **_common),
-    Plot("diffCovLambdaLambda", xtitle="cov(lambda, lambda)", **_common),
+    Plot("diffCovLambdaLambda", xtitle="cov(lambda, lambda)", **_commonLabelSize),
     Plot("diffCovLambdaLambdaStatus", **_commonStatus),
     Plot("diffCovLambdaLambdaUnderOverFlowSign", xtitle="cov(lambda, lambda)", **_common),
-    Plot("diffCovLambdaDsz", xtitle="cov(lambda, dsz)", **_common),
+    Plot("diffCovLambdaDsz", xtitle="cov(lambda, dsz)", **_commonLabelSize),
     Plot("diffCovLambdaDszStatus", **_commonStatus),
     Plot("diffCovLambdaDszUnderOverFlowSign", xtitle="cov(lambda, dsz)", **_common),
-    Plot("diffCovPhiPhi", xtitle="cov(phi, phi)", **_common),
+    Plot("diffCovPhiPhi", xtitle="cov(phi, phi)", **_commonLabelSize),
     Plot("diffCovPhiPhiStatus", **_commonStatus),
     Plot("diffCovPhiPhiUnderOverFlowSign", xtitle="cov(phi, phi)", **_common),
 ],
                                               ncols=3, legendDy=_legendDy_4rows
 )
 _packedCandidateCovarianceMatrix2 = PlotGroup("covarianceMatrix2", [
-    Plot("diffCovPhiDxy", xtitle="cov(phi, dxy)", **_common),
+    Plot("diffCovPhiDxy", xtitle="cov(phi, dxy)", **_commonLabelSize),
     Plot("diffCovPhiDxyStatus", **_commonStatus),
     Plot("diffCovPhiDxyUnderOverFlowSign", xtitle="cov(phi, dxy)", **_common),
-    Plot("diffCovDxyDxy", xtitle="cov(dxy, dxy)", **_common),
+    Plot("diffCovDxyDxy", xtitle="cov(dxy, dxy)", adjustMarginRight=0.02, **_commonLabelSize),
     Plot("diffCovDxyDxyStatus", **_commonStatus),
     Plot("diffCovDxyDxyUnderOverFlowSign", xtitle="cov(dxy, dxy)", **_common),
-    Plot("diffCovDxyDsz", xtitle="cov(dxy, dsz)", **_common),
+    Plot("diffCovDxyDsz", xtitle="cov(dxy, dsz)", adjustMarginRight=0.02, **_commonLabelSize),
     Plot("diffCovDxyDszStatus", **_commonStatus),
     Plot("diffCovDxyDszUnderOverFlowSign", xtitle="cov(dxy, dsz)", **_common),
-    Plot("diffCovDszDsz", xtitle="cov(dsz, dsz)", **_common),
+    Plot("diffCovDszDsz", xtitle="cov(dsz, dsz)", adjustMarginRight=0.02, **_commonLabelSize),
     Plot("diffCovDszDszStatus", **_commonStatus),
     Plot("diffCovDszDszUnderOverFlowSign", xtitle="cov(dsz, dsz)", **_common),
 ],
@@ -626,7 +633,6 @@ _packedCandidateKinematics = PlotGroup("kinematics", [
     Plot("diffEta", xtitle="#eta", **_common),
     Plot("diffEtaError", xtitle="#eta error", **_common),
     Plot("diffPhi", xtitle="#phi", **_common),
-    Plot("diffPhiError", xtitle="#phi error", **_common), # currently missing?
 ])
 
 class TrackingPlotFolder(PlotFolder):

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -452,7 +452,7 @@ def _summaryBinRename(binLabel, highPurity, byOriginalAlgo, byAlgoMask, seeds):
 
     return ret
 
-def _constructSummary(mapping, highPurity=False, byOriginalAlgo=False, byAlgoMask=False, seeds=False, midfix=""):
+def _constructSummary(mapping=None, highPurity=False, byOriginalAlgo=False, byAlgoMask=False, seeds=False, midfix=""):
     _common = {"drawStyle": "EP", "xbinlabelsize": 10, "xbinlabeloption": "d"}
     _commonN = {"ylog": True, "ymin": _minMaxN, "ymax": _minMaxN}
     _commonN.update(_common)
@@ -463,26 +463,50 @@ def _constructSummary(mapping, highPurity=False, byOriginalAlgo=False, byAlgoMas
     if byOriginalAlgo or byAlgoMask:
         _commonAB["minExistingBins"] = 2
     prefix = "summary"+midfix
-    summary = PlotGroup(prefix, [
-        Plot(AggregateBins("efficiency", "effic_vs_coll", **_commonAB),
-             title="Efficiency vs collection", ytitle="Efficiency", ymin=1e-3, ymax=1, ylog=True, **_common),
-        Plot(AggregateBins("efficiencyAllPt", "effic_vs_coll_allPt", **_commonAB),
-             title="Efficiency vs collection (no pT cut in denominator)", ytitle="Efficiency", ymin=1e-3, ymax=1, ylog=True, **_common),
 
-        Plot(AggregateBins("fakerate", "fakerate_vs_coll", **_commonAB), title="Fakerate vs collection", ytitle="Fake rate", ymax=_maxFake, **_common),
-        Plot(AggregateBins("duplicatesRate", "duplicatesRate_coll", **_commonAB), title="Duplicates rate vs collection", ytitle="Duplicates rate", ymax=_maxFake, **_common),
-        Plot(AggregateBins("pileuprate", "pileuprate_coll", **_commonAB), title="Pileup rate vs collection", ytitle="Pileup rate", ymax=_maxFake, **_common),
+    h_eff = "effic_vs_coll"
+    h_eff_allpt = "effic_vs_coll_allPt"
+    h_fakerate = "fakerate_vs_coll"
+    h_duplicaterate = "duplicatesRate_coll"
+    h_pileuprate = "pileuprate_coll"
+
+    h_reco = "num_reco_coll"
+    h_true = "num_assoc(recoToSim)_coll"
+    h_fake = Subtract("num_fake_coll_orig", "num_reco_coll", "num_assoc(recoToSim)_coll")
+    h_duplicate = "num_duplicate_coll"
+    h_pileup = "num_pileup_coll"
+    if mapping is not None:
+        h_eff = AggregateBins("efficiency", h_eff, **_commonAB)
+        h_eff_allpt = AggregateBins("efficiencyAllPt", h_eff_allpt, **_commonAB)
+        h_fakerate = AggregateBins("fakerate", h_fakerate, **_commonAB)
+        h_duplicaterate = AggregateBins("duplicatesRate", h_duplicaterate, **_commonAB)
+        h_pileuprate = AggregateBins("pileuprate", h_pileuprate, **_commonAB)
+
+        h_reco = AggregateBins("num_reco_coll", h_reco, **_commonAB)
+        h_true = AggregateBins("num_true_coll", h_true, **_commonAB)
+        h_fake = AggregateBins("num_fake_coll", h_fake, **_commonAB)
+        h_duplicate = AggregateBins("num_duplicate_coll", h_duplicate, **_commonAB)
+        h_pileup = AggregateBins("num_pileup_coll", h_pileup, **_commonAB)
+
+    summary = PlotGroup(prefix, [
+        Plot(h_eff, title="Efficiency vs collection", ytitle="Efficiency", ymin=1e-3, ymax=1, ylog=True, **_common),
+        Plot(h_eff_allpt, title="Efficiency vs collection (no pT cut in denominator)", ytitle="Efficiency", ymin=1e-3, ymax=1, ylog=True, **_common),
+
+        Plot(h_fakerate, title="Fakerate vs collection", ytitle="Fake rate", ymax=_maxFake, **_common),
+        Plot(h_duplicaterate, title="Duplicates rate vs collection", ytitle="Duplicates rate", ymax=_maxFake, **_common),
+        Plot(h_pileuprate, title="Pileup rate vs collection", ytitle="Pileup rate", ymax=_maxFake, **_common),
     ])
     summaryN = PlotGroup(prefix+"_ntracks", [
-        Plot(AggregateBins("num_reco_coll", "num_reco_coll", **_commonAB), ytitle="Tracks", title="Number of tracks vs collection", **_commonN),
-        Plot(AggregateBins("num_true_coll", "num_assoc(recoToSim)_coll", **_commonAB), ytitle="True tracks", title="Number of true tracks vs collection", **_commonN),
-        Plot(AggregateBins("num_fake_coll", Subtract("num_fake_coll_orig", "num_reco_coll", "num_assoc(recoToSim)_coll"), **_commonAB), ytitle="Fake tracks", title="Number of fake tracks vs collection", **_commonN),
-        Plot(AggregateBins("num_duplicate_coll", "num_duplicate_coll", **_commonAB), ytitle="Duplicate tracks", title="Number of duplicate tracks vs collection", **_commonN),
-        Plot(AggregateBins("num_pileup_coll", "num_pileup_coll", **_commonAB), ytitle="Pileup tracks", title="Number of pileup tracks vs collection", **_commonN),
+        Plot(h_reco, ytitle="Tracks", title="Number of tracks vs collection", **_commonN),
+        Plot(h_true, ytitle="True tracks", title="Number of true tracks vs collection", **_commonN),
+        Plot(h_fake, ytitle="Fake tracks", title="Number of fake tracks vs collection", **_commonN),
+        Plot(h_duplicate, ytitle="Duplicate tracks", title="Number of duplicate tracks vs collection", **_commonN),
+        Plot(h_pileup, ytitle="Pileup tracks", title="Number of pileup tracks vs collection", **_commonN),
     ])
 
     return (summary, summaryN)
 
+(_summaryRaw,              _summaryRawN)              = _constructSummary(midfix="Raw")
 (_summary,                 _summaryN)                 = _constructSummary(_collLabelMap)
 (_summaryHp,               _summaryNHp)               = _constructSummary(_collLabelMapHp, highPurity=True)
 (_summaryByOriginalAlgo,   _summaryByOriginalAlgoN)   = _constructSummary(_collLabelMapHp, byOriginalAlgo=True, midfix="ByOriginalAlgo")
@@ -777,15 +801,19 @@ _packedCandidatePlots = [
     _packedCandidateHitsHitPattern,
 ]
 plotter = Plotter()
-def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, seeding=False):
+def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, seeding=False, rawSummary=False):
     # to keep backward compatibility, this set of plots has empty name
     plotter.append(name, _trackingFolders(lastDirName), TrackingPlotFolder(*algoPlots, onlyForPileup=onlyForPileup, purpose=PlotPurpose.TrackingIteration, fallbackRefFiles=[_trackingRefFileFallbackSLHC]), fallbackDqmSubFolders=[_trackingSubFoldersFallbackSLHC])
     summaryName = ""
     if name != "":
         summaryName += name+"_"
     summaryName += "summary"
+    summaryPlots = []
+    if rawSummary:
+        summaryPlots.extend([_summaryRaw, _summaryRawN])
+    summaryPlots.extend(_summaryPlots)
     plotter.append(summaryName, _trackingFolders(lastDirName),
-                   PlotFolder(*_summaryPlots, loopSubFolders=False, onlyForPileup=onlyForPileup,
+                   PlotFolder(*summaryPlots, loopSubFolders=False, onlyForPileup=onlyForPileup,
                               purpose=PlotPurpose.TrackingSummary, page="summary", section=name))
     plotter.append(summaryName+"_highPurity", _trackingFolders(lastDirName),
                    PlotFolder(*_summaryPlotsHp, loopSubFolders=False, onlyForPileup=onlyForPileup,

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -321,6 +321,7 @@ _possibleTrackingCollsOld = {
     "Fourth": "iter4",
     "Fifth" : "iter5",
     "Sixth" : "iter6",
+    "Seventh": "iter7",
     "Ninth" : "iter9",
     "Tenth" : "iter10",
 }

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -107,16 +107,22 @@ _globalTags = {
     "CMSSW_7_6_0": {"default": "76X_mcRun2_asymptotic_v11", "fullsim_50ns": "76X_mcRun2_startup_v11"},
     "CMSSW_7_6_0_71XGENSIM": {"default": "76X_mcRun2_asymptotic_v11_gs7120p2rlBS", "fullsim_50ns": "76X_mcRun2_startup_v11_gs7120p2rlBS"},
     "CMSSW_7_6_2": {"default": "76X_mcRun2_asymptotic_v12", "fullsim_50ns": "76X_mcRun2_startup_v11"},
+    "CMSSW_7_6_3_patch2_0T": {"default": "76X_mcRun2_0T_v1_0Tv1GT"},
     "CMSSW_8_0_0_pre1": {"default": "76X_mcRun2_asymptotic_v11", "fullsim_50ns": "76X_mcRun2_startup_v11"},
     "CMSSW_8_0_0_pre2": {"default": "76X_mcRun2_asymptotic_v12", "fullsim_50ns": "76X_mcRun2_startup_v11"},
     "CMSSW_8_0_0_pre2_phase1": {"default": "76X_upgrade2017_design_v7"},
     "CMSSW_8_0_0_pre2_phase1_rereco": {"default": "76X_upgrade2017_design_v7_rereco"},
     "CMSSW_8_0_0_pre3_phase1": {"default": "76X_upgrade2017_design_v8"},
     "CMSSW_8_0_0_pre3_phase1_pythia8": {"default": "76X_upgrade2017_design_v8_pythia8"},
+    "CMSSW_8_0_0_pre4": {"default": "76X_mcRun2_asymptotic_v13", "fullsim_50ns": "76X_mcRun2_startup_v12"},
+    "CMSSW_8_0_0_pre4_phase1": {"default": "76X_upgrade2017_design_v8_UPG17"},
+    "CMSSW_8_0_0_pre4_phase1_13TeV": {"default": "76X_upgrade2017_design_v8_UPG17"},
+    "CMSSW_8_0_0_pre4_ecal15fb": {"default": "80X_mcRun2_asymptotic_2016EcalTune_15fb_v0_ecal15fbm1"},
+    "CMSSW_8_0_0_pre4_ecal30fb": {"default": "80X_mcRun2_asymptotic_2016EcalTune_30fb_v0_ecal30fbm1"},
 }
 
 _releasePostfixes = ["_AlcaCSA14", "_PHYS14", "_TEST", "_71XGENSIM_pmx", "_pmx_v2", "_pmx_v3", "_pmx", "_Fall14DR", "_71XGENSIM_FIXGT", "_71XGENSIM_PU", "_71XGENSIM_PXbest", "_71XGENSIM_PXworst", "_71XGENSIM", "_73XGENSIM", "_BS", "_GenSim_7113", "_extended",
-                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch", "_noCCC_v3", "_noCCC", "_MT", "_phase1_rereco", "_phase1_pythia8", "_phase1"]
+                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch", "_noCCC_v3", "_noCCC", "_MT", "_phase1_rereco", "_phase1_pythia8", "_phase1_13TeV", "_phase1", "_ecal15fb", "_ecal30fb"]
 def _stripRelease(release):
     for pf in _releasePostfixes:
         if pf in release:

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -815,8 +815,8 @@ class SimpleValidation:
         self._labels = labels
         self._newdir = newdir
 
-    def createHtmlReport(self, baseUrl=None, validationName=""):
-        return html.HtmlReport(validationName, self._newdir, baseUrl)
+    def createHtmlReport(self, validationName=""):
+        return html.HtmlReport(validationName, self._newdir)
 
     def doPlots(self, plotter, subdirprefix=None, sample=None, plotterDrawArgs={}, limitSubFoldersOnlyTo=None, htmlReport=html.HtmlReportDummy()):
         if subdirprefix is None and sample is None:

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -15,18 +15,17 @@ filesLabels = [
 ]
 
 outputDir = "plots"
-subdirprefix = "sample"
-
 
 # To auto-generate HTML pages, uncomment the commented lines below
 val = SimpleValidation([x[0] for x in filesLabels], [x[1] for x in filesLabels], outputDir)
-#report = val.createHtmlReport("INSERT_YOUR_BASE_URL_HERE", validationName="Short description of your comparison")
-#report.beginSample(SimpleSample("prefix", "Sample name"))
-val.doPlots(trackingPlots.plotter, subdirprefix=subdirprefix, plotterDrawArgs={"ratio": True},
+sample = SimpleSample("sample_prefix", "Sample name")
+#report = val.createHtmlReport(validationName="Short description of your comparison")
+#report.beginSample(sample)
+val.doPlots(trackingPlots.plotter, sample=sample, plotterDrawArgs={"ratio": True},
 #            htmlReport=report
 )
 ## Uncomment this to include also vertex plots
-##val.doPlots(vertexPlots.plotter, subdirprefix=subdirprefix, plotterDrawArgs={"ratio": True},
+##val.doPlots(vertexPlots.plotter, sample=sample, plotterDrawArgs={"ratio": True},
 ##            htmlReport=report
 ##)
 #report.write()


### PR DESCRIPTION
This PR updates the tracking MC validation scripts. Main changes
- Fix `makeTrackValidationPlots.py --html` (side-effect of tuning `trackingCompare.py`)
- Include plots for conversions (introduced in #12909)

Tested in 8_0_0_pre5, should have no effect on standard workflows.

@rovere @VinInn 
