### PR TITLE
Phase2 Outer Tracker RecHits integration in CMSSW 8

### DIFF
--- a/DataFormats/Phase2TrackerRecHit/BuildFile.xml
+++ b/DataFormats/Phase2TrackerRecHit/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="DataFormats/Common"/>
+<use name="rootrflx"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/Phase2TrackerRecHit/interface/Phase2TrackerRecHit1D.h
+++ b/DataFormats/Phase2TrackerRecHit/interface/Phase2TrackerRecHit1D.h
@@ -1,0 +1,33 @@
+#ifndef DATAFORMATS_PHASE2TRACKERRECHIT_PHASE2TRACKERRECHIT1D_H 
+#define DATAFORMATS_PHASE2TRACKERRECHIT_PHASE2TRACKERRECHIT1D_H 
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+typedef edm::Ref< edmNew::DetSetVector< Phase2TrackerCluster1D >, Phase2TrackerCluster1D > Phase2ClusterReference;
+
+class Phase2TrackerRecHit1D {
+
+    public:
+
+        Phase2TrackerRecHit1D() { }
+        Phase2TrackerRecHit1D(LocalPoint pos, LocalError err, Phase2ClusterReference cluster) : pos_(pos), err_(err), cluster_(cluster) { }
+
+        LocalPoint localPosition() const { return pos_; }
+        LocalError localPositionError() const { return err_; }
+        Phase2ClusterReference cluster() const { return cluster_; }
+
+    private:
+
+        LocalPoint pos_;
+        LocalError err_;
+        Phase2ClusterReference cluster_;
+
+};
+
+typedef edmNew::DetSetVector< Phase2TrackerRecHit1D > Phase2TrackerRecHit1DCollectionNew;
+
+#endif

--- a/DataFormats/Phase2TrackerRecHit/src/classes.h
+++ b/DataFormats/Phase2TrackerRecHit/src/classes.h
@@ -1,0 +1,18 @@
+#ifndef DATAFORMATS_PHASE2TRACKERRECHIT_CLASSES_H 
+#define DATAFORMATS_PHASE2TRACKERRECHIT_CLASSES_H 
+
+#include "DataFormats/Phase2TrackerRecHit/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/DetSetNew.h"
+
+namespace {
+    struct dictionary {
+        edm::Wrapper< Phase2TrackerRecHit1D > cl0;
+        edm::Wrapper< std::vector< Phase2TrackerRecHit1D > > cl1;
+        edm::Wrapper< edmNew::DetSet< Phase2TrackerRecHit1D > > cl2; 
+        edm::Wrapper< std::vector< edmNew::DetSet< Phase2TrackerRecHit1D > > > cl3; 
+        edm::Wrapper< Phase2TrackerRecHit1DCollectionNew > cl4;
+    };
+}
+
+#endif 

--- a/DataFormats/Phase2TrackerRecHit/src/classes_def.xml
+++ b/DataFormats/Phase2TrackerRecHit/src/classes_def.xml
@@ -1,0 +1,12 @@
+<lcgdict>
+    <class name="Phase2TrackerRecHit1D" ClassVersion="2">
+        <version ClassVersion="2" checksum="3085242308"/>
+    </class>
+    <class name="std::vector< Phase2TrackerRecHit1D >"/>
+    <class name="std::vector< edmNew::DetSet< Phase2TrackerRecHit1D > >"/>
+    <class name="edmNew::DetSet< Phase2TrackerRecHit1D >"/>
+    <class name="edmNew::DetSetVector< Phase2TrackerRecHit1D >"/>
+    <class name="edm::Wrapper< edmNew::DetSet< Phase2TrackerRecHit1D > >" splitLevel="0"/>
+    <class name="edm::Wrapper< std::vector< edmNew::DetSet< Phase2TrackerRecHit1D > > >" splitLevel="0"/>
+    <class name="edm::Wrapper< edmNew::DetSetVector< Phase2TrackerRecHit1D > >"/>
+</lcgdict>

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h
@@ -1,0 +1,46 @@
+#ifndef RecoLocalTracker_Cluster_Parameter_Estimator_H
+#define RecoLocalTracker_Cluster_Parameter_Estimator_H
+
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+
+template <class T> 
+class ClusterParameterEstimator {
+  
+ public:
+  typedef std::pair<LocalPoint,LocalError>  LocalValues;
+  typedef std::vector<LocalValues> VLocalValues;
+  virtual LocalValues localParameters( const T&,const GeomDetUnit&) const = 0; 
+  virtual LocalValues localParameters( const T& cluster, const GeomDetUnit& gd, const LocalTrajectoryParameters&) const {
+    return localParameters(cluster,gd);
+  }
+  virtual LocalValues localParameters( const T& cluster, const GeomDetUnit& gd, const TrajectoryStateOnSurface& tsos) const {
+    return localParameters(cluster,gd,tsos.localParameters());
+  }
+  virtual VLocalValues localParametersV( const T& cluster, const GeomDetUnit& gd) const {
+    VLocalValues vlp;
+    vlp.push_back(localParameters(cluster,gd));
+    return vlp;
+  }
+  virtual VLocalValues localParametersV( const T& cluster, const GeomDetUnit& gd, const TrajectoryStateOnSurface& tsos) const {
+    VLocalValues vlp;
+    vlp.push_back(localParameters(cluster,gd,tsos.localParameters()));
+    return vlp;
+  }
+  
+  virtual ~ClusterParameterEstimator(){}
+  
+  //methods needed by FastSim
+  virtual void enterLocalParameters(unsigned int id, std::pair<int,int>
+				    &row_col, LocalValues pos_err_info) const {}
+  virtual void enterLocalParameters(uint32_t id, uint16_t firstStrip,
+				    LocalValues pos_err_info) const {}
+  virtual void clearParameters() const {}
+  
+};
+
+#endif

--- a/RecoLocalTracker/Phase2TrackerRecHits/BuildFile.xml
+++ b/RecoLocalTracker/Phase2TrackerRecHits/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="RecoLocalTracker/ClusterParameterEstimator"/>
+<use name="DataFormats/Phase2TrackerCluster"/>
+<use name="DataFormats/Phase2TrackerRecHit"/>
+<export>
+    <lib name="1"/>
+</export>

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEDummy.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEDummy.h
@@ -1,0 +1,20 @@
+#ifndef RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPEDummy_H
+#define RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPEDummy_H
+
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+class Phase2StripCPEDummy : public ClusterParameterEstimator<Phase2TrackerCluster1D> {
+
+  public:
+
+    LocalValues localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const;
+
+};
+
+
+#endif

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="RecoLocalTracker/Records"/>
+<use name="RecoLocalTracker/ClusterParameterEstimator"/>
+<use name="RecoLocalTracker/Phase2TrackerRecHits"/>
+<library file="*.cc" name="RecoLocalTrackerPhase2TrackerRecHitsPlugins">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -1,0 +1,34 @@
+
+#include "RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEDummy.h"
+
+
+Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet & p) {
+  std::string name = p.getParameter<std::string>("ComponentType");
+
+  enumMap_[std::string("Phase2StripCPEDummy")] = DUMMY;
+  if (enumMap_.find(name) == enumMap_.end())
+    throw cms::Exception("Unknown StripCPE type") << name;
+
+  cpeNum_ = enumMap_[name];
+  pset_ = p;
+  setWhatProduced(this, name);
+}
+
+
+boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripCPEESProducer::produce(const TkStripCPERecord & iRecord) {
+
+  switch(cpeNum_) {
+
+    case DUMMY:
+      cpe_ = boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> >(new Phase2StripCPEDummy());
+      break;
+
+  }
+
+  return cpe_;
+}
+
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+DEFINE_FWK_EVENTSETUP_MODULE(Phase2StripCPEESProducer);

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.h
@@ -1,0 +1,36 @@
+#ifndef RecoLocaltracker_Phase2TrackerRecHits_Phase2StripCPEESProducer_h
+#define RecoLocaltracker_Phase2TrackerRecHits_Phase2StripCPEESProducer_h
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include <boost/shared_ptr.hpp>
+#include <map>
+
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEDummy.h"
+
+
+class Phase2StripCPEESProducer: public edm::ESProducer {
+
+  public:
+
+    Phase2StripCPEESProducer(const edm::ParameterSet&);
+    boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > produce(const TkStripCPERecord & iRecord);
+
+  private:
+
+    enum CPE_t { DUMMY };
+    std::map<std::string, CPE_t> enumMap_;
+
+    CPE_t cpeNum_;
+    edm::ParameterSet pset_;
+    boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe_;
+
+};
+#endif
+
+
+
+

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -1,0 +1,79 @@
+#include "RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "DataFormats/Phase2TrackerRecHit/interface/Phase2TrackerRecHit1D.h"
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include <vector>
+#include <string>
+
+
+Phase2TrackerRecHits::Phase2TrackerRecHits(edm::ParameterSet const& conf) : 
+  token_(consumes< Phase2TrackerCluster1DCollectionNew >(conf.getParameter<edm::InputTag>("src"))),
+  cpeTag_(conf.getParameter<edm::ESInputTag>("Phase2StripCPE")) {
+    produces<Phase2TrackerRecHit1DCollectionNew>();
+}
+
+
+void Phase2TrackerRecHits::produce(edm::StreamID sid, edm::Event& event, const edm::EventSetup& eventSetup) const {
+
+  // Get the Clusters
+  edm::Handle< Phase2TrackerCluster1DCollectionNew > clusters;
+  event.getByToken(token_, clusters);
+
+  // load the cpe via the eventsetup
+  edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe;
+  eventSetup.get<TkStripCPERecord>().get(cpeTag_, cpe);
+
+  // Get the geometry
+  edm::ESHandle< TrackerGeometry > geomHandle;
+  eventSetup.get< TrackerDigiGeometryRecord >().get(geomHandle);
+  const TrackerGeometry* tkGeom(&(*geomHandle));
+
+  edm::ESHandle< TrackerTopology > tTopoHandle;
+  eventSetup.get< IdealGeometryRecord >().get(tTopoHandle);
+  //const TrackerTopology* tTopo(tTopoHandle.product());
+
+  // Global container for the RecHits of each module
+  std::auto_ptr< Phase2TrackerRecHit1DCollectionNew > outputRecHits(new Phase2TrackerRecHit1DCollectionNew());
+
+  // Loop over clusters
+  for (edmNew::DetSetVector< Phase2TrackerCluster1D >::const_iterator DSViter = clusters->begin(); DSViter != clusters->end(); ++DSViter) {
+
+    DetId detId(DSViter->detId());
+
+    // Geometry
+    const GeomDetUnit * geomDetUnit(tkGeom->idToDetUnit(detId));
+
+    // Container for the clusters that will be produced for this modules
+    Phase2TrackerRecHit1DCollectionNew::FastFiller rechits(*outputRecHits, DSViter->detId());
+
+    for (edmNew::DetSet< Phase2TrackerCluster1D >::const_iterator clustIt = DSViter->begin(); clustIt != DSViter->end(); ++clustIt) {
+      ClusterParameterEstimator<Phase2TrackerCluster1D>::LocalValues lv = cpe->localParameters(*clustIt, *geomDetUnit);
+
+      // Create a persistent edm::Ref to the cluster
+      edm::Ref< edmNew::DetSetVector< Phase2TrackerCluster1D >, Phase2TrackerCluster1D > cluster = edmNew::makeRefTo(clusters, clustIt);
+
+      // Make a RecHit and add it to the DetSet
+      Phase2TrackerRecHit1D hit(lv.first, lv.second, cluster);
+
+      rechits.push_back(hit);
+    }
+  }
+
+  outputRecHits->shrink_to_fit();
+  event.put(outputRecHits);
+
+}
+
+DEFINE_FWK_MODULE(Phase2TrackerRecHits);

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.h
@@ -1,0 +1,34 @@
+#ifndef RecoLocalTracker_Phase2TrackerRecHits_Phase2TrackerRecHits_h
+#define RecoLocalTracker_Phase2TrackerRecHits_Phase2TrackerRecHits_h
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEDummy.h"
+
+
+  class Phase2TrackerRecHits : public edm::global::EDProducer<> {
+
+    public:
+
+      explicit Phase2TrackerRecHits(const edm::ParameterSet& conf);
+      virtual ~Phase2TrackerRecHits() {};
+      void produce(edm::StreamID sid, edm::Event& event, const edm::EventSetup& eventSetup) const override final;
+
+    private:
+            
+      edm::EDGetTokenT< Phase2TrackerCluster1DCollectionNew > token_;
+      edm::ESInputTag cpeTag_;
+    
+    };
+
+#endif

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2StripCPEESProducer = cms.ESProducer("Phase2StripCPEESProducer",
+  ComponentType = cms.string('Phase2StripCPEDummy'),
+  parameters    = cms.PSet()
+)

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2TrackerRecHits_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2TrackerRecHits_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+# RecHits options
+siPhase2RecHits = cms.EDProducer("Phase2TrackerRecHits",
+  src = cms.InputTag("siPhase2Clusters"),
+  Phase2StripCPE = cms.ESInputTag("phase2StripCPEESProducer", "Phase2StripCPEDummy")
+)
+
+

--- a/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPEDummy.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPEDummy.cc
@@ -1,0 +1,17 @@
+
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEDummy.h"
+
+
+Phase2StripCPEDummy::LocalValues Phase2StripCPEDummy::localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const {
+  float strippitch  = 0.0090; // hardcoded dummy, a la 2S
+  float striplength = 5.;     // hardcoded dummy, a la 2S
+  std::pair<float, float> barycenter = cluster.barycenter();
+  LocalPoint lp( barycenter.second * strippitch, striplength * (barycenter.first + 1/2), 0 );
+  LocalError le( strippitch / 12, 0, striplength / 12 );
+  return std::make_pair( lp, le );
+}
+
+
+// needed, otherwise linker misses some refs
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(ClusterParameterEstimator<Phase2TrackerCluster1D>);

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/BuildFile.xml
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/BuildFile.xml
@@ -1,0 +1,28 @@
+<use   name="boost"/>
+<use   name="root"/>
+<use   name="classlib"/>
+<use   name="clhep"/>
+<use   name="SimDataFormats/TrackingHit"/>
+<use   name="SimDataFormats/TrackerDigiSimLink"/>
+<use   name="SimDataFormats/CrossingFrame"/>
+<use   name="DataFormats/SiPixelDigi"/>
+<use   name="DataFormats/SiPixelDetId"/>
+<use   name="DataFormats/DetId"/>
+<use   name="Geometry/Records"/>
+<use   name="Geometry/CommonDetUnit"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="CommonTools/UtilAlgos"/>
+<use   name="DQMServices/Core"/>
+<use   name="DataFormats/Common"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="DataFormats/Phase2TrackerCluster"/>
+<use   name="DataFormats/Phase2TrackerRecHit"/>
+<use   name="DataFormats/ParticleFlowCandidate"/>
+<use   name="DataFormats/ParticleFlowReco"/>
+<library   file="RecHitsValidation.cc" name="Phase2TrackerRecHitsValidation">
+  <flags   EDM_PLUGIN="1"/>
+  <flags CXXFLAGS="-g3"/>
+</library>

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidation.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidation.cc
@@ -1,0 +1,276 @@
+#include <iostream>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "DataFormats/Phase2TrackerRecHit/interface/Phase2TrackerRecHit1D.h"
+
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CommonTools/Utils/interface/TFileDirectory.h"
+
+#include <TH2D.h>
+#include <TH1D.h>
+#include <THStack.h>
+
+
+struct RecHitHistos {
+    THStack* numberRecHitsMixed;
+    TH1D* numberRecHitsPixel;
+    TH1D* numberRecHitsStrip;
+
+    TH2D* globalPosXY[3];
+    TH2D* localPosXY[3];
+};
+
+class Phase2TrackerRecHitsValidation : public edm::EDAnalyzer {
+
+    public:
+
+        explicit Phase2TrackerRecHitsValidation(const edm::ParameterSet&);
+        ~Phase2TrackerRecHitsValidation();
+        void beginJob();
+        void endJob();
+        void analyze(const edm::Event&, const edm::EventSetup&);
+
+    private:
+
+        std::map< unsigned int, RecHitHistos >::iterator createLayerHistograms(unsigned int);
+        unsigned int getLayerNumber(const DetId&, const TrackerTopology*);
+
+        edm::EDGetTokenT< Phase2TrackerRecHit1DCollectionNew > tokenRecHits_;
+        
+        TH2D* trackerLayout_;
+        TH2D* trackerLayoutXY_;
+        TH2D* trackerLayoutXYBar_;
+        TH2D* trackerLayoutXYEC_;
+
+        std::map< unsigned int, RecHitHistos > histograms_;
+
+};
+
+Phase2TrackerRecHitsValidation::Phase2TrackerRecHitsValidation(const edm::ParameterSet& conf) :
+    tokenRecHits_(consumes< Phase2TrackerRecHit1DCollectionNew >(conf.getParameter<edm::InputTag>("src"))) {
+        std::cout << "RecHits Validation" << std::endl;
+    }
+
+    Phase2TrackerRecHitsValidation::~Phase2TrackerRecHitsValidation() { }
+
+    void Phase2TrackerRecHitsValidation::beginJob() {
+        edm::Service<TFileService> fs; 
+        fs->file().cd("/");
+        TFileDirectory td = fs->mkdir("Common");
+        // Create common histograms
+        trackerLayout_ = td.make< TH2D >("RVsZ", "R vs. z position", 6000, -300.0, 300.0, 1200, 0.0, 120.0);
+        trackerLayoutXY_ = td.make< TH2D >("XVsY", "x vs. y position", 2400, -120.0, 120.0, 2400, -120.0, 120.0);
+        trackerLayoutXYBar_ = td.make< TH2D >("XVsYBar", "x vs. y position", 2400, -120.0, 120.0, 2400, -120.0, 120.0);
+        trackerLayoutXYEC_ = td.make< TH2D >("XVsYEC", "x vs. y position", 2400, -120.0, 120.0, 2400, -120.0, 120.0);
+    }
+
+void Phase2TrackerRecHitsValidation::endJob() { }
+
+void Phase2TrackerRecHitsValidation::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
+
+    std::cout << "PROCESSING RECHIT EVENT" << std::endl;
+
+    /*
+     * Get the needed objects
+     */
+
+    // Get the RecHitss
+    edm::Handle< Phase2TrackerRecHit1DCollectionNew > rechits;
+    event.getByToken(tokenRecHits_, rechits);
+
+    // Get the geometry
+    edm::ESHandle< TrackerGeometry > geomHandle;
+    eventSetup.get< TrackerDigiGeometryRecord >().get(geomHandle);
+    const TrackerGeometry* tkGeom = &(*geomHandle);
+
+    edm::ESHandle< TrackerTopology > tTopoHandle;
+    eventSetup.get< IdealGeometryRecord >().get(tTopoHandle);
+    const TrackerTopology* tTopo = tTopoHandle.product();
+
+    /*
+     * Validation   
+     */
+
+    // Loop over modules
+    for (Phase2TrackerRecHit1DCollectionNew::const_iterator DSViter = rechits->begin(); DSViter != rechits->end(); ++DSViter) {
+
+        // Get the detector unit's id
+        unsigned int rawid(DSViter->detId()); 
+        DetId detId(rawid);
+        unsigned int layer(getLayerNumber(detId, tTopo));
+
+        // Get the geometry of the tracker
+        const GeomDetUnit* geomDetUnit(tkGeom->idToDetUnit(detId));
+        const PixelGeomDetUnit* theGeomDet = dynamic_cast< const PixelGeomDetUnit* >(geomDetUnit);
+        const PixelTopology& topol = theGeomDet->specificTopology();
+
+        if (!geomDetUnit) break;
+
+        // Create histograms for the layer if they do not yet exist
+        std::map< unsigned int, RecHitHistos >::iterator histogramLayer(histograms_.find(layer));
+        if (histogramLayer == histograms_.end()) histogramLayer = createLayerHistograms(layer);
+
+        // Number of clusters
+        unsigned int nRecHitsPixel(0), nRecHitsStrip(0);
+
+        // Loop over the clusters in the detector unit
+        for (edmNew::DetSet< Phase2TrackerRecHit1D >::const_iterator rechitIt = DSViter->begin(); rechitIt != DSViter->end(); ++rechitIt) {
+
+            /*
+             * Cluster related variables
+             */
+
+            //LocalPoint localPosClu = rechitIt->localPosition();
+            LocalPoint localPosClu(1, 2, 3);
+            //Global3DPoint globalPosClu = geomDetUnit->surface().toGlobal(localPosClu);
+            Global3DPoint globalPosClu(0, 0, 0); 
+
+            // Fill the position histograms
+            trackerLayout_->Fill(globalPosClu.z(), globalPosClu.perp());
+            trackerLayoutXY_->Fill(globalPosClu.x(), globalPosClu.y());
+            if (layer < 100) trackerLayoutXYBar_->Fill(globalPosClu.x(), globalPosClu.y());
+            else trackerLayoutXYEC_->Fill(globalPosClu.x(), globalPosClu.y());
+
+            histogramLayer->second.localPosXY[0]->Fill(localPosClu.x(), localPosClu.y());
+            histogramLayer->second.globalPosXY[0]->Fill(globalPosClu.z(), globalPosClu.perp());
+
+            // Pixel module
+            if (topol.ncolumns() == 32) {
+                histogramLayer->second.localPosXY[1]->Fill(localPosClu.x(), localPosClu.y());
+                histogramLayer->second.globalPosXY[1]->Fill(globalPosClu.z(), globalPosClu.perp());
+                ++nRecHitsPixel;
+            }
+            // Strip module
+            else if (topol.ncolumns() == 2) {
+                histogramLayer->second.localPosXY[2]->Fill(localPosClu.x(), localPosClu.y());
+                histogramLayer->second.globalPosXY[2]->Fill(globalPosClu.z(), globalPosClu.perp());
+                ++nRecHitsStrip;
+            }
+        }
+
+        if (nRecHitsPixel) histogramLayer->second.numberRecHitsPixel->Fill(nRecHitsPixel);
+        if (nRecHitsStrip) histogramLayer->second.numberRecHitsStrip->Fill(nRecHitsStrip);
+    }
+}
+
+// Create the histograms
+std::map< unsigned int, RecHitHistos >::iterator Phase2TrackerRecHitsValidation::createLayerHistograms(unsigned int ival) {
+    std::ostringstream fname1, fname2;
+
+    edm::Service<TFileService> fs;
+    fs->file().cd("/");
+
+    std::string tag;
+    unsigned int id;
+    if (ival < 100) {
+        id = ival;
+        fname1 << "Barrel";
+        fname2 << "Layer_" << id;
+        tag = "_layer_";
+    }
+    else {
+        int side = ival / 100;
+        id = ival - side * 100;
+        fname1 << "EndCap_Side_" << side;
+        fname2 << "Disc_" << id;
+        tag = "_disc_";
+    }
+
+    TFileDirectory td1 = fs->mkdir(fname1.str().c_str());
+    TFileDirectory td = td1.mkdir(fname2.str().c_str());
+
+    RecHitHistos local_histos;
+
+    std::ostringstream histoName;
+
+    /*
+     * Number of clusters
+     */
+
+    histoName.str(""); histoName << "Number_RecHits_Pixel" << tag.c_str() <<  id;
+    local_histos.numberRecHitsPixel = td.make< TH1D >(histoName.str().c_str(), histoName.str().c_str(), 20, 0., 20.);
+    local_histos.numberRecHitsPixel->SetFillColor(kAzure + 7);
+
+    histoName.str(""); histoName << "Number_RecHits_Strip" << tag.c_str() <<  id;
+    local_histos.numberRecHitsStrip = td.make< TH1D >(histoName.str().c_str(), histoName.str().c_str(), 20, 0., 20.);
+    local_histos.numberRecHitsStrip->SetFillColor(kOrange - 3);
+
+    histoName.str(""); histoName << "Number_RecHitss_Mixed" << tag.c_str() <<  id;
+    local_histos.numberRecHitsMixed = td.make< THStack >(histoName.str().c_str(), histoName.str().c_str());
+    local_histos.numberRecHitsMixed->Add(local_histos.numberRecHitsPixel);
+    local_histos.numberRecHitsMixed->Add(local_histos.numberRecHitsStrip);
+
+    /*
+     * Local and Global positions
+     */
+
+    histoName.str(""); histoName << "Local_Position_XY_Mixed" << tag.c_str() <<  id;
+    local_histos.localPosXY[0] = td.make< TH2D >(histoName.str().c_str(), histoName.str().c_str(), 2000, 0., 0., 2000, 0., 0.);
+
+    histoName.str(""); histoName << "Local_Position_XY_Pixel" << tag.c_str() <<  id;
+    local_histos.localPosXY[1] = td.make< TH2D >(histoName.str().c_str(), histoName.str().c_str(), 2000, 0., 0., 2000, 0., 0.);
+
+    histoName.str(""); histoName << "Local_Position_XY_Strip" << tag.c_str() <<  id;
+    local_histos.localPosXY[2] = td.make< TH2D >(histoName.str().c_str(), histoName.str().c_str(), 2000, 0., 0., 2000, 0., 0.);
+
+    histoName.str(""); histoName << "Global_Position_XY_Mixed" << tag.c_str() <<  id;
+    local_histos.globalPosXY[0] = td.make< TH2D >(histoName.str().c_str(), histoName.str().c_str(), 2400, 0., 0., 2400, 0., 0.);
+
+    histoName.str(""); histoName << "Global_Position_XY_Pixel" << tag.c_str() <<  id;
+    local_histos.globalPosXY[1] = td.make< TH2D >(histoName.str().c_str(), histoName.str().c_str(), 2400, 0., 0., 2400, 0., 0.); 
+
+    histoName.str(""); histoName << "Global_Position_XY_Strip" << tag.c_str() <<  id;
+    local_histos.globalPosXY[2] = td.make< TH2D >(histoName.str().c_str(), histoName.str().c_str(), 2400, 0., 0., 2400, 0., 0.); 
+
+    /*
+     * End
+     */
+
+    std::pair< std::map< unsigned int, RecHitHistos >::iterator, bool > insertedIt(histograms_.insert(std::make_pair(ival, local_histos)));
+    fs->file().cd("/");
+
+    return insertedIt.first;
+}
+
+unsigned int Phase2TrackerRecHitsValidation::getLayerNumber(const DetId& detid, const TrackerTopology* topo) {
+    if (detid.det() == DetId::Tracker) {
+        if (detid.subdetId() == PixelSubdetector::PixelBarrel) return (topo->pxbLayer(detid));
+        else if (detid.subdetId() == PixelSubdetector::PixelEndcap) return (100 * topo->pxfSide(detid) + topo->pxfDisk(detid));
+        else return 999;
+    }
+    return 999;
+}
+
+DEFINE_FWK_MODULE(Phase2TrackerRecHitsValidation);

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidationTest_cfg.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidationTest_cfg.py
@@ -1,0 +1,68 @@
+# Imports
+import FWCore.ParameterSet.Config as cms
+
+# Create a new CMS process
+process = cms.Process('cluTest')
+
+# Import all the necessary files
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023Dev_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('DQMOffline.Configuration.DQMOfflineMC_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Geometry.TrackerNumberingBuilder.trackerTopologyConstants_cfi')
+
+process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi')
+process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi')
+
+# Number of events (-1 = all)
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input file
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring('file:step3.root')
+)
+
+# TAG
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+# Output
+process.TFileService = cms.Service('TFileService',
+    fileName = cms.string('file:rechits_validation.root')
+)
+
+# DEBUG
+process.MessageLogger = cms.Service('MessageLogger',
+	debugModules = cms.untracked.vstring('siPhase2RecHits'),
+	destinations = cms.untracked.vstring('cout'),
+	cout = cms.untracked.PSet(
+		threshold = cms.untracked.string('ERROR')
+	)
+)
+
+
+# Analyzer
+process.analysis = cms.EDAnalyzer('Phase2TrackerRecHitsValidation',
+    src = cms.InputTag("siPhase2RecHits")
+)
+
+# Processes to run
+process.rechits_step = cms.Path(process.siPhase2RecHits)
+process.validation_step = cms.Path(process.analysis)
+
+process.schedule = cms.Schedule(process.rechits_step, process.validation_step)
+
+from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5DPixel10Ddev import customise_condOverRides
+process = customise_condOverRides(process)
+


### PR DESCRIPTION
This PR migrates the Phase2 Outer Tracker RecHits from CMSSW 6_2_SLHC to CMSSW 8. It adds the new data format for the rechits as well as the algorithm itself.

This PR depends upon PR #13087 for the clusters data format and will not compile without it. Two separated PRs were done as this concerns two different modules. 
