### PR TITLE
FastSim BugFix : PreMix : fix segfault, fix L1 reco, fix digisim link for muons, fix track validation

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -619,7 +619,7 @@ FS_PREMIXUP15_PU25_OVERLAY = merge([
         {"-s" : "GEN,SIM,RECOBEFMIX,DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,L1Reco,RECO,HLT:@relval25ns,VALIDATION",
          "--datamix" : "PreMix",
          "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW"%(baseDataSetRelease[8],),
-         "--customise":"SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1"
+         "--customise":"SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput"
          },
         Kby(100,500),step1FastUpg2015Defaults])
 

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -68,4 +68,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -68,4 +68,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,6 +41,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
-
-
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,6 +41,6 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
 

--- a/Configuration/StandardSequences/python/SimL1Emulator_cff.py
+++ b/Configuration/StandardSequences/python/SimL1Emulator_cff.py
@@ -9,5 +9,5 @@ if eras.fastSim.isChosen():
     # consider moving these mods to the HLT configuration
     from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
     loadTriggerDigiAliases()
-    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis
+    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis
     

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -9,14 +9,15 @@ hcalDigis = None
 muonDTDigis = None
 muonCSCDigis = None
 muonRPCDigis = None
-gtDigisAliasInfo = None
-gmtDigisAliasInfo = None
+caloStage1LegacyFormatDigis = None
+gtDigis = None
+gmtDigis = None
 
 def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -95,6 +96,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("DTLayerIdDTDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
                     )
                 )
            }
@@ -105,6 +109,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("RPCDetIdRPCDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("RPCDigiSimLinkedmDetSetVector")
                     )
                 )
            }
@@ -115,14 +122,35 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCWireDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM")),
+                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM"),
+                    toProductInstance = cms.string("MuonCSCWireDigi")),
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCStripDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM")
-                    )
+                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM"),
+                    toProductInstance = cms.string("MuonCSCStripDigi")),
+                cms.PSet(
+                    type = cms.string('StripDigiSimLinkedmDetSetVector')
+                    ),
                 )
            }
           )
+    
+    # also sim in case of premixing?
+    caloStage1LegacyFormatDigis = cms.EDAlias(
+        **{ "simCaloStage1LegacyFormatDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
+
 
 def loadTriggerDigiAliases():
 

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -17,7 +17,7 @@ def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -135,7 +135,10 @@ def loadDigiAliases(premix=False):
            }
           )
     
-    # also sim in case of premixing?
+def loadTriggerDigiAliases():
+
+    global gctDigis,gtDigis,gmtDigis,caloStage1LegacyFormatDigis
+
     caloStage1LegacyFormatDigis = cms.EDAlias(
         **{ "simCaloStage1LegacyFormatDigis" :
                 cms.VPSet(
@@ -151,25 +154,34 @@ def loadDigiAliases(premix=False):
                 cms.PSet(type = cms.string("L1GctInternJetDatas")),
                 cms.PSet(type = cms.string("L1GctJetCands")))})
 
-
-def loadTriggerDigiAliases():
-
-    global gtDigis,gmtDigis
+    gctDigis = cms.EDAlias(
+        **{ "simGctDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
 
     gtDigis = cms.EDAlias(
-        simGtDigis=
-        cms.VPSet(
-            cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")),
-            cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord"))
-            )
-        )
+        **{ "simGtDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GlobalTriggerEvmReadoutRecord")),
+                cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord")),
+                cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")))})
     
 
     gmtDigis = cms.EDAlias (
         simGmtDigis = 
         cms.VPSet(
-            cms.PSet(type = cms.string("L1MuGMTReadoutCollection"))
+            cms.PSet(type = cms.string("L1MuGMTReadoutCollection")),
+            cms.PSet(type = cms.string("L1MuGMTCands"))
             )
         )
     
-

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -265,6 +265,7 @@ for _entry in [FEVTDEBUGEventContent,FEVTSIMEventContent,GENRAWEventContent,FEVT
     _entry.outputCommands.append('drop *_hltIter*_*_*')
     _entry.outputCommands.append('drop *_hlt*Digis_*_*')
     _entry.outputCommands.append('drop *_gmtDigis_*_*')
+    _entry.outputCommands.append('drop *_gctDigis_*_*')
 
 #####################################################################
 #

--- a/FastSimulation/Configuration/python/L1Reco_cff.py
+++ b/FastSimulation/Configuration/python/L1Reco_cff.py
@@ -9,35 +9,6 @@ from L1Trigger.Configuration.L1Reco_cff import l1extraParticles
 # imported into this namespace, i.e. "from <module> import *".
 from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
 
-# some collections have different labels
-def _changeLabelForFastSim( object ) :
-    """
-    Takes an InputTag, changes the first letter of the module label to a capital
-    and adds "sim" in front, e.g. "gctDigid" -> "simGctDigis".
-    This works for both Run 1 and Run 2 collections.
-    """
-    object.moduleLabel="sim"+object.moduleLabel[0].upper()+object.moduleLabel[1:]
-
-_changeLabelForFastSim( l1extraParticles.isolatedEmSource )
-_changeLabelForFastSim( l1extraParticles.nonIsolatedEmSource )
-
-_changeLabelForFastSim( l1extraParticles.centralJetSource )
-_changeLabelForFastSim( l1extraParticles.tauJetSource )
-_changeLabelForFastSim( l1extraParticles.isoTauJetSource )
-_changeLabelForFastSim( l1extraParticles.forwardJetSource )
-
-_changeLabelForFastSim( l1extraParticles.etTotalSource )
-_changeLabelForFastSim( l1extraParticles.etHadSource )
-_changeLabelForFastSim( l1extraParticles.htMissSource )
-_changeLabelForFastSim( l1extraParticles.etMissSource )
-
-_changeLabelForFastSim( l1extraParticles.hfRingEtSumsSource )
-_changeLabelForFastSim( l1extraParticles.hfRingBitCountsSource )
-
-# This one is subtly different, but is the same for Run 1 and Run 2 FastSim
-l1extraParticles.muonSource = cms.InputTag('simGmtDigis')
-
-
 # must be set to true when used in HLT, as is the case for FastSim
 l1extraParticles.centralBxOnly = True
 

--- a/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
+++ b/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
@@ -4,14 +4,10 @@ def customiseForPreMixingInput(process):
     from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
 
     # Replace TrackingParticles and TrackingVertices globally
-    for s in process.paths_().keys():
-        massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True) 
-
-    for s in process.endpaths_().keys():
-        massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True)
-
-    
-
+    # only apply on validation and dqm: we don't want to apply this in the mixing and digitization sequences
+    for s in process.paths_().keys() + process.endpaths_().keys():
+        if s.lower().find("validation")>= 0 or s.lower().find("dqm") >= 0:
+            massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True) 
 
     # Replace Pixel/StripDigiSimLinks only for the known modules
     def replaceInputTag(tag, old, new):
@@ -64,7 +60,6 @@ def customiseForPreMixingInput(process):
         if analyzer.type_() == "SiStripRecHitsValid":
             replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
             replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-
 
 
 


### PR DESCRIPTION
replaces #13071 

Lots of fixes in one pr, but they are all entangled
### Fix L1 reco, fix seg fault in premix relvals

FastSim no longer runs
SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1
because it overwrites modification defined in the fastsim era and the run2 eras

New EDAlias for caloStage1LegacyFormatDigis to make the l1extraParticles function properly.

Note: FullSim still runs SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1 in the DIGI step.
At some point also FullSim should move away from this.
### Fix digi-sim links for muons

FastSim now runs
SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput
This customisation function should not affect anything but validation and dqm,
and the customisation function was modified accordingly.
Note: FullSim had never trouble with this because there the customisation function is only applied on the RECO,VALIDATION,DQM jobs.
### Fix track validation

Thanks to SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput, the tracking particle collection should now include PU tracks
