### PR TITLE
Ignore rootlogon to avoid conflicts

### DIFF
--- a/FWCore/Utilities/scripts/edmAddClassVersion
+++ b/FWCore/Utilities/scripts/edmAddClassVersion
@@ -223,6 +223,11 @@ if __name__ == '__main__':
 
     (options,args)=oparser.parse_args()
 
+    #Need to not have ROOT load .rootlogon.(C|py) since it can cause interference.
+    # The only way to do that is to pass -n from the command line
+    import sys
+    sys.argv.append("-n")
+
     import ROOT
     if options.library is None:
         if 0 != ROOT.gSystem.Load("libFWCoreFWLite"):

--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -161,6 +161,11 @@ oparser.add_option("-g","--generate_new",dest="generate", action="store_true",de
 
 (options,args)=oparser.parse_args()
 
+#Need to not have ROOT load .rootlogon.(C|py) since it can cause interference.
+# The only way to do that is to pass -n from the command line
+import sys
+sys.argv.append("-n")
+
 import ROOT
 #Keep ROOT from trying to use X11
 ROOT.gROOT.SetBatch(True)


### PR DESCRIPTION
If PyROOT reads .rootlogon.(py|C) files it can lead to conflicts with later library loads in the script. At the moment the only way to stop PyROOT from reading those logon files is to pass '-n' to the command line.
