### PR TITLE
Muon shower fix 

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -103,7 +103,6 @@ class MuonShowerInformationFiller {
     std::vector<const GeomDet*> dtPositionToDets(const GlobalPoint&) const;
     std::vector<const GeomDet*> cscPositionToDets(const GlobalPoint&) const;
     MuonRecHitContainer findPerpCluster(MuonRecHitContainer& muonRecHits) const;
-    MuonRecHitContainer findPhiCluster(MuonRecHitContainer&, const GlobalPoint&) const;
     TransientTrackingRecHit::ConstRecHitContainer findThetaCluster(TransientTrackingRecHit::ConstRecHitContainer&, const GlobalPoint&) const;
     TransientTrackingRecHit::ConstRecHitContainer hitsFromSegments(const GeomDet*,edm::Handle<DTRecSegment4DCollection>, edm::Handle<CSCSegmentCollection>) const;
     std::vector<const GeomDet*> getCompatibleDets(const reco::Track&) const;

--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -142,7 +142,7 @@ class MuonShowerInformationFiller {
         AbsLessDTheta(const GlobalPoint& point) : thePoint(point) {}
         bool operator()(const TransientTrackingRecHit::ConstRecHitPointer& lhs,
                        const TransientTrackingRecHit::ConstRecHitPointer& rhs) const{
-           return ( fabs(lhs->globalPosition().phi() - thePoint.phi()) < fabs(rhs->globalPosition().phi() - thePoint.phi()) );
+           return ( fabs(lhs->globalPosition().bareTheta() - thePoint.bareTheta()) < fabs(rhs->globalPosition().bareTheta() - thePoint.bareTheta()) );
         }
       GlobalPoint thePoint;
     };
@@ -151,7 +151,7 @@ class MuonShowerInformationFiller {
         LessPhi() : thePoint(0,0,0) {}
         bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
                        const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return (lhs->globalPosition().phi() < rhs->globalPosition().phi());
+           return (lhs->globalPosition().barePhi() < rhs->globalPosition().barePhi());
         }
         GlobalPoint thePoint;
     };

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -3,7 +3,7 @@
  *  \class: MuonShowerInformationFiller
  *  Description: class for muon shower identification
  *
- 
+
  *
  *  \author: A. Svyatkovskiy, Purdue University
  *
@@ -112,7 +112,7 @@ MuonShowerInformationFiller::~MuonShowerInformationFiller() {
 reco::MuonShower MuonShowerInformationFiller::fillShowerInformation( const reco::Muon& muon, const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   reco::MuonShower returnShower;
-  
+
   // Update the services
   theService->update(iSetup);
   setEvent(iEvent);
@@ -123,11 +123,11 @@ reco::MuonShower MuonShowerInformationFiller::fillShowerInformation( const reco:
   std::vector<int> nStationCorrelatedHits = theCorrelatedStationHits;
   std::vector<float> stationShowerSizeT = theStationShowerTSize;
   std::vector<float> stationShowerDeltaR = theStationShowerDeltaR;
-  
-  returnShower.nStationHits = nStationHits; 
+
+  returnShower.nStationHits = nStationHits;
   returnShower.nStationCorrelatedHits = nStationCorrelatedHits;
   returnShower.stationShowerSizeT = stationShowerSizeT;
-  returnShower.stationShowerDeltaR = stationShowerDeltaR; 
+  returnShower.stationShowerDeltaR = stationShowerDeltaR;
 
   return returnShower;
 
@@ -178,8 +178,8 @@ void MuonShowerInformationFiller::setServices(const EventSetup& setup) {
 // Get hits owned by segments
 //
 TransientTrackingRecHit::ConstRecHitContainer
-MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet, 
-                            edm::Handle<DTRecSegment4DCollection> dtSegments, 
+MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
+                            edm::Handle<DTRecSegment4DCollection> dtSegments,
                             edm::Handle<CSCSegmentCollection> cscSegments) const {
 
   MuonTransientTrackingRecHit::MuonRecHitContainer segments;
@@ -190,7 +190,7 @@ MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
 
     DTChamberId chamberId(geoId.rawId());
 
-    // loop on segments 4D                 
+    // loop on segments 4D
     DTRecSegment4DCollection::id_iterator chamberIdIt;
     for (chamberIdIt = dtSegments->id_begin();
          chamberIdIt != dtSegments->id_end();
@@ -198,15 +198,15 @@ MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
 
       if (*chamberIdIt != chamberId) continue;
 
-      // Get the range for the corresponding ChamberId              
+      // Get the range for the corresponding ChamberId
       DTRecSegment4DCollection::range  range = dtSegments->get((*chamberIdIt));
-  
+
       for (DTRecSegment4DCollection::const_iterator iseg = range.first;
         iseg!=range.second;++iseg) {
         if (iseg->dimension() != 4) continue;
         segments.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*iseg));
       }
-    } 
+    }
   }
   else if (geoId.subdetId() == MuonSubdetId::CSC) {
 
@@ -217,7 +217,7 @@ MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
 
       if ((*chamberId).chamber() != did.chamber()) continue;
 
-      // Get the range for the corresponding ChamberId                                                                                                                     
+      // Get the range for the corresponding ChamberId
       CSCSegmentCollection::range  range = cscSegments->get((*chamberId));
 
       for (CSCSegmentCollection::const_iterator iseg = range.first;
@@ -233,7 +233,7 @@ MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
 
   TransientTrackingRecHit::ConstRecHitContainer allhitscorrelated;
 
-  if (segments.empty()) return allhitscorrelated;  
+  if (segments.empty()) return allhitscorrelated;
 
   TransientTrackingRecHit::ConstRecHitPointer muonRecHit(segments.front());
   allhitscorrelated = MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit,2);
@@ -249,7 +249,7 @@ MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
     for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator ihit1 = hits1.begin();
          ihit1 != hits1.end(); ++ihit1 ) {
 
-      bool usedbefore = false;       
+      bool usedbefore = false;
       //unused      DetId thisID = (*ihit1)->geographicalId();
       //LocalPoint lp1dinsegHit = (*ihit1)->localPosition();
       GlobalPoint gp1dinsegHit = (*ihit1)->globalPosition();
@@ -341,7 +341,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
 
   LogTrace(category_)  << "Consider a track " << track.p() << " eta: " << track.eta() << " phi " << track.phi() << endl;
 
-  
+
   TrajectoryStateOnSurface innerTsos = trajectoryStateTransform::innerStateOnSurface(track, *theService->trackingGeometry(), &*theService->magneticField());
   TrajectoryStateOnSurface outerTsos = trajectoryStateTransform::outerStateOnSurface(track, *theService->trackingGeometry(), &*theService->magneticField());
 
@@ -356,9 +356,9 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
 
     // crossing points of track with cylinder
     GlobalPoint xPoint = crossingPoint(innerPos, outerPos, dynamic_cast<const BarrelDetLayer*>(*iLayer));
-      
+
     // check if point is inside the detector
-    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500 ) && 
+    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500 ) &&
              (!(xPoint.y() == 0 && xPoint.x() == 0 && xPoint.z() == 0))) allCrossingPoints.push_back(xPoint);
   }
 
@@ -371,10 +371,10 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
     tempDT = dtPositionToDets(*ipos);
     vector<const GeomDet*>::const_iterator begin = tempDT.begin();
     vector<const GeomDet*>::const_iterator end = tempDT.end();
-     
+
     for (; begin!=end;++begin) {
       total.push_back(*begin);
-    } 
+    }
 
   }
   allCrossingPoints.clear();
@@ -385,7 +385,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
     GlobalPoint xPoint = crossingPoint(innerPos, outerPos, dynamic_cast<const ForwardDetLayer*>(*iLayer));
 
     // check if point is inside the detector
-    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500.0) 
+    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500.0)
            && (!(xPoint.y() == 0 && xPoint.x() == 0 && xPoint.z() == 0))) allCrossingPoints.push_back(xPoint);
    }
    stable_sort(allCrossingPoints.begin(), allCrossingPoints.end(), LessMag(innerPos) );
@@ -411,7 +411,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
 //
 // Intersection point of track with barrel layer
 //
-GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1, 
+GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
                                             const GlobalPoint& p2,
                                             const BarrelDetLayer* dl) const {
 
@@ -421,7 +421,7 @@ GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
 }
 
 GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
-                                            const GlobalPoint& p2, 
+                                            const GlobalPoint& p2,
                                             const Cylinder& cyl) const {
 
   float radius = cyl.radius();
@@ -451,8 +451,8 @@ GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
 
   // there are two crossing points, return the one that is in the same quadrant as point of extrapolation
   if ((p2.x()*x1 > 0) && (y1*p2.y() > 0) && (z1*p2.z() > 0)) {
-    return GlobalPoint(x1, y1, z1); 
-  } else { 
+    return GlobalPoint(x1, y1, z1);
+  } else {
     return GlobalPoint(x2, y2, z2);
   }
 
@@ -462,17 +462,17 @@ GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
 //
 // Intersection point of track with a forward layer
 //
-GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1, 
-                                            const GlobalPoint& p2, 
+GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
+                                            const GlobalPoint& p2,
                                             const ForwardDetLayer* dl) const {
 
   const BoundDisk& bc = dl->specificSurface();
   return crossingPoint(p1, p2, bc);
-   
-}  
 
-GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1, 
-                                            const GlobalPoint& p2, 
+}
+
+GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
+                                            const GlobalPoint& p2,
                                             const BoundDisk& disk) const {
 
   float diskZ = disk.position().z();
@@ -524,7 +524,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::dtPositionToDets(const Globa
 
    float phistep = M_PI/6;
 
-   float phigp = (float)gp.phi();
+   float phigp = (float)gp.barePhi();
 
    if ( fabs(deltaPhi(phigp, 0*phistep)) < phistep ) sectors.push_back(1);
    if ( fabs(deltaPhi(phigp, phistep))   < phistep ) sectors.push_back(2);
@@ -546,7 +546,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::dtPositionToDets(const Globa
    if ( fabs(deltaPhi(phigp, 11*phistep)) < phistep ) sectors.push_back(12);
 
    LogTrace(category_) << "DT position to dets" << endl;
-   LogTrace(category_) << "number of sectors to consider: " << sectors.size() << endl;   
+   LogTrace(category_) << "number of sectors to consider: " << sectors.size() << endl;
    LogTrace(category_) << "station: " << station << " wheels: " << minwheel << " " << maxwheel << endl;
 
    vector<const GeomDet*> result;
@@ -574,7 +574,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::cscPositionToDets(const Glob
 
   // determine the endcap side
   int endcap = 0;
-  if (gp.z() > 0) {endcap = 1;} else {endcap = 2;} 
+  if (gp.z() > 0) {endcap = 1;} else {endcap = 2;}
 
   // determine the csc station and range of rings
   int station = 5;
@@ -582,7 +582,7 @@ vector<const GeomDet*> MuonShowerInformationFiller::cscPositionToDets(const Glob
   // check all rings in a station
   if ( fabs(gp.z()) > 1000. && fabs(gp.z()) < 1055.0 ) {
     station = 4;
-  }        
+  }
   else if ( fabs(gp.z()) > 910.0 && fabs(gp.z()) < 965.0) {
     station = 3;
   }
@@ -597,22 +597,22 @@ vector<const GeomDet*> MuonShowerInformationFiller::cscPositionToDets(const Glob
 
   float phistep1 = M_PI/18.; //for all the rings except first rings for stations > 1
   float phistep2 = M_PI/9.;
-  float phigp = (float)gp.phi();
+  float phigp = (float)gp.barePhi();
 
   int ring = -1;
 
   // determine the ring
   if (station == 1) {
 
-//FIX ME!!! 
+//FIX ME!!!
       if (gp.perp() >  100 && gp.perp() < 270) ring = 1;
       else if (gp.perp() > 270 && gp.perp() < 450) ring = 2;
       else if (gp.perp() > 450 && gp.perp() < 695) ring = 3;
       else if (gp.perp() > 100 && gp.perp() < 270) ring = 4;
 
-  } 
+  }
   else if (station == 2) {
-      
+
       if (gp.perp() > 140 && gp.perp() < 350) ring = 1;
       else if (gp.perp() > 350 && gp.perp() < 700) ring = 2;
 
@@ -630,10 +630,10 @@ vector<const GeomDet*> MuonShowerInformationFiller::cscPositionToDets(const Glob
 
   }
 
-  if (station > 1 && ring == 1) { 
+  if (station > 1 && ring == 1) {
 
    // we have 18 sectors in that case
-   for (int i = 0; i < 18; i++) { 
+   for (int i = 0; i < 18; i++) {
       if ( fabs(deltaPhi(phigp, i*phistep2)) < phistep2 ) sectors.push_back(i+1);
     }
 
@@ -686,7 +686,7 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
   vector<MuonRecHitContainer> muonRecHits(4);
 
   // split rechits from segs by station
-  vector<TransientTrackingRecHit::ConstRecHitContainer> muonCorrelatedHits(4);  
+  vector<TransientTrackingRecHit::ConstRecHitContainer> muonCorrelatedHits(4);
 
   // get vector of GeomDets compatible with a track
   vector<const GeomDet*> compatibleLayers = getCompatibleDets(*track);
@@ -704,7 +704,7 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
     // skip tracker hits
     if (geoId.det()!= DetId::Muon) continue;
 
-    // DT 
+    // DT
     if ( geoId.subdetId() == MuonSubdetId::DT ) {
 
       // get station
@@ -713,7 +713,7 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
       int wheel = detid.wheel();
 
       // get rechits from segments per station
-      TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp = hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);     
+      TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp = hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_begin = muonCorrelatedHitsTmp.begin();
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_end = muonCorrelatedHitsTmp.end();
 
@@ -746,7 +746,7 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
       int station = did.station();
       int ring = did.ring();
 
-      //get rechits from segments by station      
+      //get rechits from segments by station
       TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp = hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_begin = muonCorrelatedHitsTmp.begin();
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_end = muonCorrelatedHitsTmp.end();
@@ -777,7 +777,7 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
                center = temp.front()->globalPosition().perp();
              }
              temp.clear();
-             
+
              if (center > 550.) {
                 muonRecHits.at(2).insert(muonRecHits.at(2).end(),tmpCSC1.begin(),tmpCSC1.end());
               } else {
@@ -791,9 +791,9 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
      }
   }//loop over GeomDets compatible with a track
 
-  // calculate number of all and correlated hits    
+  // calculate number of all and correlated hits
   for (int stat = 0; stat < 4; stat++) {
-    theCorrelatedStationHits[stat] = muonCorrelatedHits.at(stat).size();     
+    theCorrelatedStationHits[stat] = muonCorrelatedHits.at(stat).size();
     theAllStationHits[stat] = muonRecHits[stat].size();
   }
   LogTrace(category_) << "Hits used by the segments, by station "
@@ -826,8 +826,8 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
     std::vector<size_t> clUppers;
     for ( size_t ihit = 0; ihit < nhit; ++ihit ) {
       const size_t jhit = (ihit+1)%nhit;
-      const double phi1 = muonRecHits[stat].at(ihit)->globalPosition().phi();
-      const double phi2 = muonRecHits[stat].at(jhit)->globalPosition().phi();
+      const double phi1 = muonRecHits[stat].at(ihit)->globalPosition().barePhi();
+      const double phi2 = muonRecHits[stat].at(jhit)->globalPosition().barePhi();
 
       const double dphi = std::abs(deltaPhi(phi1, phi2));
       if ( dphi >= 0.05 ) clUppers.push_back(ihit);
@@ -837,11 +837,11 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
     double dphimax = 0;
     if ( clUppers.empty() ) {
       // No gaps - there is only one cluster. Take all of them
-      const double refPhi = muonRecHits[stat].at(0)->globalPosition().phi();
+      const double refPhi = muonRecHits[stat].at(0)->globalPosition().barePhi();
       double dphilo = 0, dphihi = 0;
       for ( auto& hit : muonRecHits[stat] ) {
         muonRecHitsPhiBest.push_back(hit);
-        const double phi = hit->globalPosition().phi();
+        const double phi = hit->globalPosition().barePhi();
         dphilo = std::min(dphilo, deltaPhi(refPhi, phi));
         dphihi = std::max(dphihi, deltaPhi(refPhi, phi));
       }
@@ -860,8 +860,8 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
         // At least two hit for a cluster
         if ( upper == lower ) continue;
 
-        const double phi1 = muonRecHits[stat].at(upper)->globalPosition().phi();
-        const double phi2 = muonRecHits[stat].at(lower)->globalPosition().phi();
+        const double phi1 = muonRecHits[stat].at(upper)->globalPosition().barePhi();
+        const double phi2 = muonRecHits[stat].at(lower)->globalPosition().barePhi();
 
         const double dphi = std::abs(deltaPhi(phi1, phi2));
         if ( dphimax < dphi ) {

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -276,36 +276,7 @@ MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
 //
 // Find cluster
 //
-MuonTransientTrackingRecHit::MuonRecHitContainer 
-MuonShowerInformationFiller::findPhiCluster(MuonTransientTrackingRecHit::MuonRecHitContainer& muonRecHits, 
-                              const GlobalPoint& refpoint) const {
 
-  if ( muonRecHits.empty() ) return muonRecHits;
-
-  //clustering step by phi
-  float step = 0.05;
-  MuonTransientTrackingRecHit::MuonRecHitContainer result;
-
-  stable_sort(muonRecHits.begin(), muonRecHits.end(), AbsLessDPhi(refpoint));
-
-  for (MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator ihit = muonRecHits.begin(); ihit != muonRecHits.end() - 1; ++ihit) {
-      if (fabs(deltaPhi((*(ihit+1))->globalPosition().barePhi(), (*ihit)->globalPosition().barePhi() )) < step) {
-          result.push_back(*ihit);  
-        } else {
-           break;
-       }
-  } 
-
-  LogTrace(category_) <<  "phi front: " << muonRecHits.front()->globalPosition().phi() << endl;    
-  LogTrace(category_) <<  "phi back: " << muonRecHits.back()->globalPosition().phi() << endl;
-
-  return result;
-
-}
-
-//
-//
-//
 TransientTrackingRecHit::ConstRecHitContainer
 MuonShowerInformationFiller::findThetaCluster(TransientTrackingRecHit::ConstRecHitContainer& muonRecHits,
                               const GlobalPoint& refpoint) const {
@@ -838,28 +809,83 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
        << theAllStationHits.at(3) << endl;
 
   //station shower sizes
-  MuonTransientTrackingRecHit::MuonRecHitContainer muonRecHitsPhiTemp, muonRecHitsPhiBest;
+  MuonTransientTrackingRecHit::MuonRecHitContainer muonRecHitsPhiBest;
   TransientTrackingRecHit::ConstRecHitContainer muonRecHitsThetaTemp, muonRecHitsThetaBest;
-
   // send station hits to the clustering algorithm
   for ( int stat = 0; stat != 4; stat++ ) {
-    if (!muonRecHits[stat].empty()) {
-      stable_sort(muonRecHits[stat].begin(), muonRecHits[stat].end(), LessPhi());
+    const size_t nhit = muonRecHits[stat].size();
+    if (nhit < 2) continue; // Require at least 2 hits
+    muonRecHitsPhiBest.clear();
+    muonRecHitsPhiBest.reserve(nhit);
 
-      float dphimax = 0;
-      for (MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator iseed = muonRecHits[stat].begin(); iseed != muonRecHits[stat].end(); ++iseed) {
-          if (!(*iseed)->isValid()) continue;
-          GlobalPoint refpoint = (*iseed)->globalPosition(); //starting from the one with smallest value of phi
-          muonRecHitsPhiTemp.clear();
-          muonRecHitsPhiTemp = findPhiCluster(muonRecHits[stat], refpoint); //get clustered hits for this iseed
-      if (muonRecHitsPhiTemp.size() > 1) {
-         float dphi = fabs(deltaPhi((float)muonRecHitsPhiTemp.back()->globalPosition().barePhi(), (float)muonRecHitsPhiTemp.front()->globalPosition().barePhi()));
-         if (dphi > dphimax) {
-            dphimax = dphi;
-            muonRecHitsPhiBest = muonRecHitsPhiTemp;
-          }
-        } //at least two hits
-      }//loop over seeds 
+    // Cluster seeds by global position phi. Best cluster is chosen to give greatest dphi
+    // Sort by phi (complexity = NLogN with enough memory, or = NLog^2N for insufficient mem)
+    stable_sort(muonRecHits[stat].begin(), muonRecHits[stat].end(), LessPhi());
+
+    // Search for gaps (complexity = N)
+    std::vector<size_t> clUppers;
+    for ( size_t ihit = 0; ihit < nhit; ++ihit ) {
+      const size_t jhit = (ihit+1)%nhit;
+      const double phi1 = muonRecHits[stat].at(ihit)->globalPosition().phi();
+      const double phi2 = muonRecHits[stat].at(jhit)->globalPosition().phi();
+
+      const double dphi = std::abs(deltaPhi(phi1, phi2));
+      if ( dphi >= 0.05 ) clUppers.push_back(ihit);
+    }
+
+    //station shower sizes
+    double dphimax = 0;
+    if ( clUppers.empty() ) {
+      // No gaps - there is only one cluster. Take all of them
+      const double refPhi = muonRecHits[stat].at(0)->globalPosition().phi();
+      double dphilo = 0, dphihi = 0;
+      for ( auto& hit : muonRecHits[stat] ) {
+        muonRecHitsPhiBest.push_back(hit);
+        const double phi = hit->globalPosition().phi();
+        dphilo = std::min(dphilo, deltaPhi(refPhi, phi));
+        dphihi = std::max(dphihi, deltaPhi(refPhi, phi));
+      }
+      dphimax = std::abs(dphihi+dphilo);
+    } else {
+      // Loop over gaps to find the one with maximum dphi(begin, end)
+      // By construction, number of gap must be greater than 1.
+      size_t bestUpper = 0, bestLower = 0;
+      for ( auto icl = clUppers.begin(); icl != clUppers.end(); ++icl ) {
+        // upper bound of this cluster
+        const size_t upper = *icl;
+        // lower bound is +1 of preceeding upper bound
+        const auto prevCl = (icl == clUppers.begin()) ? clUppers.end() : icl;
+        const size_t lower = (*(prevCl-1)+1)%nhit;
+
+        // At least two hit for a cluster
+        if ( upper == lower ) continue;
+
+        const double phi1 = muonRecHits[stat].at(upper)->globalPosition().phi();
+        const double phi2 = muonRecHits[stat].at(lower)->globalPosition().phi();
+
+        const double dphi = std::abs(deltaPhi(phi1, phi2));
+        if ( dphimax < dphi ) {
+          dphimax = dphi;
+          bestUpper = upper;
+          bestLower = lower;
+        }
+      }
+
+      if ( bestUpper > bestLower ) {
+        muonRecHitsPhiBest.reserve(bestUpper-bestLower+1);
+        std::copy(muonRecHits[stat].begin()+bestLower,
+                  muonRecHits[stat].begin()+bestUpper+1,
+                  std::back_inserter(muonRecHitsPhiBest));
+      } else if ( bestUpper < bestLower ) {
+        muonRecHitsPhiBest.reserve(bestUpper+(nhit-bestLower)+1);
+        std::copy(muonRecHits[stat].begin(),
+                  muonRecHits[stat].begin()+bestUpper+1,
+                  std::back_inserter(muonRecHitsPhiBest));
+        std::copy(muonRecHits[stat].begin()+bestLower,
+                  muonRecHits[stat].end(),
+                  std::back_inserter(muonRecHitsPhiBest));
+      }
+    }
 
      //fill showerTs
       if (!muonRecHitsPhiBest.empty()) {
@@ -879,7 +905,7 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
            GlobalPoint refpoint = (*iseed)->globalPosition(); //starting from the one with smallest value of phi
            muonRecHitsThetaTemp.clear();
            muonRecHitsThetaTemp = findThetaCluster(muonCorrelatedHits.at(stat), refpoint);
-       }//loop over seeds 
+       }//loop over seeds
        if (muonRecHitsThetaTemp.size() > 1) {
          float dtheta = fabs((float)muonRecHitsThetaTemp.back()->globalPosition().theta() - (float)muonRecHitsThetaTemp.front()->globalPosition().theta());
          if (dtheta > dthetamax) {
@@ -893,7 +919,6 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
      if (muonRecHitsThetaBest.size() > 1 && muonRecHitsPhiBest.size() > 1)
        theStationShowerDeltaR.at(stat) = sqrt(pow(deltaPhi(muonRecHitsPhiBest.front()->globalPosition().barePhi(),muonRecHitsPhiBest.back()->globalPosition().barePhi()),2)+pow(muonRecHitsThetaBest.front()->globalPosition().theta()-muonRecHitsThetaBest.back()->globalPosition().theta(),2));
 
-        }//not empty container
       }//loop over station
 
        LogTrace(category_) << "deltaR around a track containing all the station hits, by station "
@@ -912,3 +937,4 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
   return;
 
 }
+


### PR DESCRIPTION
This PR re-applies #12090 which fixes issues in the muon shower variable calculation.
Some unnecessary rearranging of vectors are removed with this fix and eventually it also solves potential problem of random behavior in events with very large muon hit multiplicity.
