### PR TITLE
Update hcal strip 80 x

### DIFF
--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -7,6 +7,7 @@
   [date]: October 15, 2009
 */
 #include <vector>
+#include <map>
 #include "DataFormats/METReco/interface/PhiWedge.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
@@ -14,13 +15,19 @@
 struct HaloTowerStrip {
     std::vector<std::pair<uint8_t, CaloTowerDetId> > cellTowerIds;
     float hadEt;
+    float energyRatio;
+    float emEt;
     HaloTowerStrip() {
         hadEt = 0.0;
+        energyRatio = -1.0;
+        emEt = 0.0;
         cellTowerIds.clear();
     }
     HaloTowerStrip(const HaloTowerStrip& strip) {
         cellTowerIds = strip.cellTowerIds;
         hadEt = strip.hadEt;
+        energyRatio = strip.energyRatio;
+        emEt = strip.emEt;
     }
 };
 

--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -7,7 +7,6 @@
   [date]: October 15, 2009
 */
 #include <vector>
-#include <map>
 #include "DataFormats/METReco/interface/PhiWedge.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -172,7 +172,8 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
-  <class name="HaloTowerStrip" ClassVersion="2">
+  <class name="HaloTowerStrip" ClassVersion="3">
+   <version ClassVersion="3" checksum="3149281836"/>
    <version ClassVersion="2" checksum="665188928"/>
   </class>
   <class name="std::vector<HaloTowerStrip>"/>

--- a/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
@@ -196,6 +196,8 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
         float energyRatio = 0.0;
         if(iPhiHadEtMap.count(iPhiLower)) energyRatio += iPhiHadEtMap[iPhiLower];
         if(iPhiHadEtMap.count(iPhiUpper)) energyRatio += iPhiHadEtMap[iPhiUpper];
+        iPhiHadEtMap[iPhi] = max(iPhiHadEtMap[iPhi], 0.001F);
+
         energyRatio /= iPhiHadEtMap[iPhi];
         strip.energyRatio = energyRatio;
 

--- a/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
@@ -128,13 +128,24 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
 	}
     }
 
+
   // Don't use HF.
   int maxAbsIEta = 29;
+
+
+  std::map<int, float> iPhiHadEtMap;
   std::vector<const CaloTower*> sortedCaloTowers;
   for(CaloTowerCollection::const_iterator tower = TheCaloTowers->begin(); tower != TheCaloTowers->end(); tower++) {
-    if(abs(tower->ieta()) <= maxAbsIEta && tower->numProblematicHcalCells() > 0)
-      sortedCaloTowers.push_back(&(*tower));
+    if(abs(tower->ieta()) > maxAbsIEta) continue;
+
+    int iPhi = tower->iphi();
+    if(!iPhiHadEtMap.count(iPhi)) iPhiHadEtMap[iPhi] = 0.0;
+    iPhiHadEtMap[iPhi] += tower->hadEt();
+
+    if(tower->numProblematicHcalCells() > 0) sortedCaloTowers.push_back(&(*tower));
+
   }
+
 
   // Sort towers such that lowest iphi and ieta are first, highest last, and towers
   // with same iphi value are consecutive. Then we can do everything else in one loop.
@@ -142,10 +153,13 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
 
   HaloTowerStrip strip;
 
+
   int prevIEta = -99, prevIPhi = -99;
   float prevHadEt = 0.;
+  float prevEmEt = 0.;
   std::pair<uint8_t, CaloTowerDetId> prevPair, towerPair;
   bool wasContiguous = true;
+
   // Loop through and store a vector of pairs (problematicCells, DetId) for each contiguous strip we find
   for(unsigned int i = 0; i < sortedCaloTowers.size(); i++) {
     const CaloTower* tower = sortedCaloTowers[i];
@@ -162,22 +176,38 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
       strip.cellTowerIds.push_back(prevPair);
       strip.cellTowerIds.push_back(towerPair);
       strip.hadEt += prevHadEt + tower->hadEt();
+      strip.emEt += prevEmEt + tower->emEt();
     }
 
     if(wasContiguous && isContiguous) {
       strip.cellTowerIds.push_back(towerPair);
       strip.hadEt += tower->hadEt();
+      strip.emEt += tower->emEt();
     }
 
     if((wasContiguous && !isContiguous) || i == sortedCaloTowers.size()-1) { //ended the strip, so flush it
-      if(strip.cellTowerIds.size() > 2) {
+
+      if(strip.cellTowerIds.size() > 3) {
+
+        int iPhi = strip.cellTowerIds.at(0).second.iphi();
+        int iPhiLower = (iPhi == 1) ? 72 : iPhi - 1;
+        int iPhiUpper = (iPhi == 72) ? 1 : iPhi + 1;
+
+        float energyRatio = 0.0;
+        if(iPhiHadEtMap.count(iPhiLower)) energyRatio += iPhiHadEtMap[iPhiLower];
+        if(iPhiHadEtMap.count(iPhiUpper)) energyRatio += iPhiHadEtMap[iPhiUpper];
+        energyRatio /= iPhiHadEtMap[iPhi];
+        strip.energyRatio = energyRatio;
+
         TheHcalHaloData.getProblematicStrips().push_back( strip );
+
       }
       strip = HaloTowerStrip();
     }
 
     wasContiguous = isContiguous;
     prevPair = towerPair;
+    prevEmEt = tower->emEt();
     prevIPhi = tower->iphi();
     prevIEta = tower->ieta();
     prevHadEt = tower->hadEt();

--- a/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
@@ -1,4 +1,5 @@
 #include "RecoMET/METAlgorithms/interface/HcalHaloAlgo.h"
+#include <map>
 
 /*
   [class]:  HcalHaloAlgo

--- a/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
@@ -18,12 +18,16 @@ class HcalStripHaloFilter : public edm::global::EDFilter<> {
 
     const bool taggingMode_;
     const int maxWeightedStripLength_;
+    const double maxEnergyRatio_;
+    const double minHadEt_;
     edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
 };
 
 HcalStripHaloFilter::HcalStripHaloFilter(const edm::ParameterSet & iConfig)
   : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
   , maxWeightedStripLength_   (iConfig.getParameter<int>("maxWeightedStripLength"))
+  , maxEnergyRatio_   (iConfig.getParameter<int>("maxEnergyRatio"))
+  , minHadEt_   (iConfig.getParameter<int>("minHadEt"))
   , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
 {
   produces<bool>();
@@ -42,7 +46,9 @@ bool HcalStripHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const e
     for (unsigned int iTower = 0; iTower < problematicStrip.cellTowerIds.size(); iTower++) {
       numContiguousCells += (int)problematicStrip.cellTowerIds[iTower].first;
     }
-    if(numContiguousCells > maxWeightedStripLength_) {
+    if(   numContiguousCells > maxWeightedStripLength_ 
+       && problematicStrip.energyRatio < maxEnergyRatio_ 
+       && problematicStrip.hadEt > minHadEt_ ) {
       pass = false;
       break;
     }

--- a/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
@@ -26,8 +26,8 @@ class HcalStripHaloFilter : public edm::global::EDFilter<> {
 HcalStripHaloFilter::HcalStripHaloFilter(const edm::ParameterSet & iConfig)
   : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
   , maxWeightedStripLength_   (iConfig.getParameter<int>("maxWeightedStripLength"))
-  , maxEnergyRatio_   (iConfig.getParameter<int>("maxEnergyRatio"))
-  , minHadEt_   (iConfig.getParameter<int>("minHadEt"))
+  , maxEnergyRatio_   (iConfig.getParameter<double>("maxEnergyRatio"))
+  , minHadEt_   (iConfig.getParameter<double>("minHadEt"))
   , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
 {
   produces<bool>();

--- a/RecoMET/METFilters/python/HcalStripHaloFilter_cfi.py
+++ b/RecoMET/METFilters/python/HcalStripHaloFilter_cfi.py
@@ -3,5 +3,7 @@ import FWCore.ParameterSet.Config as cms
 HcalStripHaloFilter = cms.EDFilter(
   "HcalStripHaloFilter",
   taggingMode = cms.bool(False),
-  maxWeightedStripLength = cms.int32(9) # values higher than this are rejected
+  maxWeightedStripLength = cms.int32(7),
+  maxEnergyRatio = cms.double(0.15),
+  minHadEt = cms.double(100.0)
 )


### PR DESCRIPTION
The Hcal Strip beam halo filter from https://github.com/cms-sw/cmssw/pull/10934/ has been supplemented with two extra cuts to slightly increase halo rejection efficiency while dramatically lowering fake rate (O(10^-4)) in MC signal samples with large amounts of hadronic activity.
