### PR TITLE
C++11 modernization for FWLite

### DIFF
--- a/DataFormats/FWLite/interface/ESHandle.h
+++ b/DataFormats/FWLite/interface/ESHandle.h
@@ -38,20 +38,20 @@ class ESHandle
    friend class fwlite::Record;
    
    public:
-      ESHandle(): m_data(0), m_exception(eshandle_not_set_exception()) {}
+      ESHandle(): m_data(nullptr), m_exception(eshandle_not_set_exception()) {}
 
       // ---------- const member functions ---------------------
-      bool isValid() const { return 0!=m_data;}
+      bool isValid() const { return nullptr != m_data;}
 
       const T& operator*() const {
-         if(0!=m_exception.get()) {
+         if(nullptr != m_exception.get()) {
             throw *m_exception;
          }
          return *m_data;
       }
       
       const T* operator->() const {
-         if(0!=m_exception.get()) {
+         if(nullptr != m_exception.get()) {
             throw *m_exception;
          }
          return m_data;
@@ -70,7 +70,7 @@ class ESHandle
          m_data(static_cast<const T*>(iData)),
          m_exception() {}
       ESHandle(cms::Exception* iException) :
-         m_data(0), m_exception(iException) {}
+         m_data(nullptr), m_exception(iException) {}
       //ESHandle(const ESHandle&); // stop default
 
       //const ESHandle& operator=(const ESHandle&); // stop default

--- a/DataFormats/FWLite/interface/Handle.h
+++ b/DataFormats/FWLite/interface/Handle.h
@@ -45,11 +45,11 @@ class Handle
       // of reco::JetTracksAssociation::Container
       typedef edm::Wrapper<T> TempWrapT;
 
-      Handle() : data_(0), errorThrower_(ErrorThrower::unsetErrorThrower()) {}
+      Handle() : data_(nullptr), errorThrower_(ErrorThrower::unsetErrorThrower()) {}
       ~Handle() { delete errorThrower_;}
 
       Handle(const Handle<T>& iOther) : data_(iOther.data_),
-      errorThrower_( iOther.errorThrower_? iOther.errorThrower_->clone(): 0) {}
+      errorThrower_( iOther.errorThrower_? iOther.errorThrower_->clone(): nullptr) {}
 
       const Handle<T>& operator=(const Handle<T>& iOther) {
          Handle<T> temp(iOther);
@@ -58,10 +58,10 @@ class Handle
       }
 
       // ---------- const member functions ---------------------
-      bool isValid() const { return data_ != 0; }
+      bool isValid() const { return data_ != nullptr; }
 
       ///Returns true only if Handle was used in a 'get' call and the data could not be found
-      bool failedToGet() const {return errorThrower_ != 0; }
+      bool failedToGet() const {return errorThrower_ != nullptr; }
 
       T const* product() const { check(); return data_;}
 
@@ -90,8 +90,8 @@ class Handle
 
       template <class P> void getByLabel(const P& iP,
                       const char* iModuleLabel,
-                      const char* iProductInstanceLabel = 0,
-                      const char* iProcessLabel = 0) {
+                      const char* iProductInstanceLabel = nullptr,
+                      const char* iProcessLabel = nullptr) {
         TempWrapT* temp;
         void* pTemp = &temp;
         iP.getByLabel(TempWrapT::typeInfo(),
@@ -100,8 +100,8 @@ class Handle
                           iProcessLabel,
                           pTemp);
         delete errorThrower_;
-        errorThrower_ = 0;
-        if(0==temp) {
+        errorThrower_ = nullptr;
+        if(nullptr == temp) {
            errorThrower_=ErrorThrower::errorThrowerBranchNotFoundException(TempWrapT::typeInfo(),
                                                                            iModuleLabel,
                                                                            iProductInstanceLabel,
@@ -109,7 +109,7 @@ class Handle
 	   return;
         }
         data_ = temp->product();
-        if(data_==0) {
+        if(data_== nullptr) {
            errorThrower_=ErrorThrower::errorThrowerProductNotFoundException(TempWrapT::typeInfo(),
                                                                             iModuleLabel,
                                                                             iProductInstanceLabel,
@@ -120,8 +120,8 @@ class Handle
 
       // void getByLabel(const fwlite::Event& iEvent,
       //                 const char* iModuleLabel,
-      //                 const char* iProductInstanceLabel = 0,
-      //                 const char* iProcessLabel = 0) {
+      //                 const char* iProductInstanceLabel = nullptr,
+      //                 const char* iProcessLabel = nullptr) {
       //   TempWrapT* temp;
       //   void* pTemp = &temp;
       //   iEvent.getByLabel(TempWrapT::typeInfo(),
@@ -130,8 +130,8 @@ class Handle
       //                     iProcessLabel,
       //                     pTemp);
       //   delete errorThrower_;
-      //   errorThrower_ = 0;
-      //   if(0==temp) {
+      //   errorThrower_ = nullptr;
+      //   if(nullptr == temp) {
       //      errorThrower_=ErrorThrower::errorThrowerBranchNotFoundException(TempWrapT::typeInfo(),
       //                                                                      iModuleLabel,
       //                                                                      iProductInstanceLabel,
@@ -139,7 +139,7 @@ class Handle
 	  //  return;
       //   }
       //   data_ = temp->product();
-      //   if(data_==0) {
+      //   if(data_ == nullptr) {
       //      errorThrower_=ErrorThrower::errorThrowerProductNotFoundException(TempWrapT::typeInfo(),
       //                                                                       iModuleLabel,
       //                                                                       iProductInstanceLabel,
@@ -149,8 +149,8 @@ class Handle
       //
       // void getByLabel(const fwlite::ChainEvent& iEvent,
       //                 const char* iModuleLabel,
-      //                 const char* iProductInstanceLabel = 0,
-      //                 const char* iProcessLabel = 0) {
+      //                 const char* iProductInstanceLabel = nullptr,
+      //                 const char* iProcessLabel = nullptr) {
       // TempWrapT* temp;
       // void* pTemp = &temp;
       // iEvent.getByLabel(TempWrapT::typeInfo(),
@@ -159,8 +159,8 @@ class Handle
       //                   iProcessLabel,
       //                   pTemp);
       //    delete errorThrower_;
-      //    errorThrower_ = 0;
-      //    if(0==temp) {
+      //    errorThrower_ = nullptr;
+      //    if(nullptr == temp) {
       //       errorThrower_=ErrorThrower::errorThrowerBranchNotFoundException(TempWrapT::typeInfo(),
       //                                                                       iModuleLabel,
       //                                                                       iProductInstanceLabel,
@@ -168,7 +168,7 @@ class Handle
 	  //   return;
       //    }
       //    data_ = temp->product();
-      //    if(data_==0) {
+      //    if(data_ == nullptr) {
       //       errorThrower_=ErrorThrower::errorThrowerProductNotFoundException(TempWrapT::typeInfo(),
       //                                                                        iModuleLabel,
       //                                                                        iProductInstanceLabel,
@@ -179,8 +179,8 @@ class Handle
       //
       // void getByLabel(const fwlite::MultiChainEvent& iEvent,
       //                 const char* iModuleLabel,
-      //                 const char* iProductInstanceLabel = 0,
-      //                 const char* iProcessLabel = 0) {
+      //                 const char* iProductInstanceLabel = nullptr,
+      //                 const char* iProcessLabel = nullptr) {
       // TempWrapT* temp;
       // void* pTemp = &temp;
       // iEvent.getByLabel(TempWrapT::typeInfo(),
@@ -188,9 +188,9 @@ class Handle
       //                   iProductInstanceLabel,
       //                   iProcessLabel,
       //                   pTemp);
-      //    if ( 0 != errorThrower_ ) delete errorThrower_;
-      //    errorThrower_ = 0;
-      //    if(0==temp) {
+      //    if ( nullptr != errorThrower_ ) delete errorThrower_;
+      //    errorThrower_ = nullptr;
+      //    if(nullptr == temp) {
       //       errorThrower_=ErrorThrower::errorThrowerBranchNotFoundException(TempWrapT::typeInfo(),
       //                                                                       iModuleLabel,
       //                                                                       iProductInstanceLabel,
@@ -198,7 +198,7 @@ class Handle
 	  //   return;
       //    }
       //    data_ = temp->product();
-      //    if(data_==0) {
+      //    if(data_ == nullptr) {
       //       errorThrower_=ErrorThrower::errorThrowerProductNotFoundException(TempWrapT::typeInfo(),
       //                                                                        iModuleLabel,
       //                                                                        iProductInstanceLabel,
@@ -208,8 +208,8 @@ class Handle
 
       const std::string getBranchNameFor(const fwlite::EventBase& iEvent,
                                          const char* iModuleLabel,
-                                         const char* iProductInstanceLabel = 0,
-                                         const char* iProcessLabel = 0)
+                                         const char* iProductInstanceLabel = nullptr,
+                                         const char* iProcessLabel = nullptr)
       {
          return iEvent.getBranchNameFor(TempWrapT::typeInfo(),
                                         iModuleLabel,
@@ -219,8 +219,8 @@ class Handle
 
       // const std::string getBranchNameFor(const fwlite::Event& iEvent,
       //                                    const char* iModuleLabel,
-      //                                    const char* iProductInstanceLabel = 0,
-      //                                    const char* iProcessLabel = 0) {
+      //                                    const char* iProductInstanceLabel = nullptr,
+      //                                    const char* iProcessLabel = nullptr) {
       //    return iEvent.getBranchNameFor(TempWrapT::typeInfo(),
       //                                   iModuleLabel,
       //                                   iProductInstanceLabel,
@@ -229,8 +229,8 @@ class Handle
       //
       // const std::string getBranchNameFor(const fwlite::ChainEvent& iEvent,
       //                                    const char* iModuleLabel,
-      //                                    const char* iProductInstanceLabel = 0,
-      //                                    const char* iProcessLabel = 0) {
+      //                                    const char* iProductInstanceLabel = nullptr,
+      //                                    const char* iProcessLabel = nullptr) {
       //    return iEvent.getBranchNameFor(TempWrapT::typeInfo(),
       //                                   iModuleLabel,
       //                                   iProductInstanceLabel,
@@ -241,8 +241,8 @@ class Handle
       //
       // const std::string getBranchNameFor(const fwlite::MultiChainEvent& iEvent,
       //                                    const char* iModuleLabel,
-      //                                    const char* iProductInstanceLabel = 0,
-      //                                    const char* iProcessLabel = 0) {
+      //                                    const char* iProductInstanceLabel = nullptr,
+      //                                    const char* iProcessLabel = nullptr) {
       //    return iEvent.getBranchNameFor(TempWrapT::typeInfo(),
       //                                   iModuleLabel,
       //                                   iProductInstanceLabel,

--- a/DataFormats/FWLite/interface/InternalDataKey.h
+++ b/DataFormats/FWLite/interface/InternalDataKey.h
@@ -39,9 +39,9 @@ namespace fwlite {
                     char const* iProduct,
                     char const* iProcess) :
                type_(iType),
-               module_(iModule!=0? iModule:kEmpty()),
-               product_(iProduct!=0?iProduct:kEmpty()),
-               process_(iProcess!=0?iProcess:kEmpty()) {}
+               module_(iModule != nullptr ? iModule : kEmpty()),
+               product_(iProduct != nullptr ? iProduct : kEmpty()),
+               process_(iProcess != nullptr ? iProcess : kEmpty()) {}
 
             ~DataKey() {
             }

--- a/DataFormats/FWLite/interface/Record.h
+++ b/DataFormats/FWLite/interface/Record.h
@@ -86,14 +86,14 @@ namespace fwlite
    bool
    Record::get(HANDLE& iHandle, const char* iLabel) const
    {
-      const void* value = 0;
+      const void* value = nullptr;
       cms::Exception* e = get(edm::TypeID(iHandle.typeInfo()),iLabel,value);
-      if(0==e){
+      if(nullptr == e){
          iHandle = HANDLE(value);
       } else {
          iHandle = HANDLE(e);
       }
-      return 0==e;
+      return nullptr == e;
    }
 
 } /* fwlite */

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -43,19 +43,17 @@ ChainEvent::ChainEvent(std::vector<std::string> const& iFileNames):
   accumulatedSize_.reserve(iFileNames.size()+1);
   fileNames_.reserve(iFileNames.size());
     
-  for (std::vector<std::string>::const_iterator it= iFileNames.begin(), itEnd = iFileNames.end();
-      it!=itEnd;
-      ++it) {
-    TFile *tfilePtr = TFile::Open(it->c_str());
+  for (auto const& fileName : iFileNames) {
+    TFile *tfilePtr = TFile::Open(fileName.c_str());
     file_ = std::shared_ptr<TFile>(tfilePtr);
     gROOT->GetListOfFiles()->Remove(tfilePtr);
     TTree* tree = dynamic_cast<TTree*>(file_->Get(edm::poolNames::eventTreeName().c_str()));
-    if (0 == tree) {
-      throw cms::Exception("NotEdmFile")<<"The file "<<*it<<" has no 'Events' TTree and therefore is not an EDM ROOT file";
+    if (nullptr == tree) {
+      throw cms::Exception("NotEdmFile")<<"The file "<<fileName<<" has no 'Events' TTree and therefore is not an EDM ROOT file";
     }
     Long64_t nEvents = tree->GetEntries();
     if (nEvents > 0) { // skip empty files
-      fileNames_.push_back(*it);
+      fileNames_.push_back(fileName);
       // accumulatedSize_ is the entry # at the beginning of this file
       accumulatedSize_.push_back(summedSize);
       summedSize += nEvents;
@@ -215,7 +213,7 @@ ChainEvent::switchToFile(Long64_t iIndex)
   TFile *tfilePtr = TFile::Open(fileNames_[iIndex].c_str());
   file_ = std::shared_ptr<TFile>(tfilePtr);
   gROOT->GetListOfFiles()->Remove(tfilePtr);
-  event_ = std::shared_ptr<Event>(new Event(file_.get()));
+  event_ = std::make_shared<Event>(file_.get());
 }
 
 //

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -58,7 +58,7 @@ namespace fwlite {
         getter_(getter),
         tcTrained_(false)
     {
-        if(0==tree) {
+        if(nullptr == tree) {
             throw cms::Exception("NoTree")<<"The TTree pointer passed to the constructor was null";
         }
         tree_ = tree;
@@ -125,7 +125,7 @@ namespace fwlite {
         //iData.pObj_ = iData.obj_.address();
         //iData.branch_->SetAddress(&(iData.pObj_));
         ////If a REF to this was requested in the past, we might as well do the work now
-        //if(0!=iData.pProd_) {
+        //if(nullptr != iData.pProd_) {
         //    iData.pProd_ = iData.obj_.address();
         //}
         //obj.destruct();
@@ -133,7 +133,7 @@ namespace fwlite {
 
         TTreeCache* tcache = dynamic_cast<TTreeCache*> (branchMap_->getFile()->GetCacheRead());
 
-        if (0 == tcache) {
+        if (nullptr == tcache) {
             iData.branch_->GetEntry(eventEntry);
         } else {
             if (!tcTrained_) {
@@ -167,12 +167,12 @@ namespace fwlite {
 
             //if we have to lookup the process label, remember it and register the product again
             std::string foundProcessLabel;
-            TBranch* branch = 0;
+            TBranch* branch = nullptr;
             std::shared_ptr<internal::Data> theData;
 
-            if (0==iProcessLabel || iProcessLabel==key.kEmpty() ||
+            if (nullptr == iProcessLabel || iProcessLabel == key.kEmpty() ||
                 strlen(iProcessLabel)==0) {
-                std::string const* lastLabel=0;
+                std::string const* lastLabel = nullptr;
                 //have to search in reverse order since newest are on the bottom
                 const edm::ProcessHistory& h = DataGetterHelper::history();
                 for (edm::ProcessHistory::const_reverse_iterator iproc = h.rbegin(), eproc = h.rend();
@@ -181,15 +181,15 @@ namespace fwlite {
 
                     lastLabel = &(iproc->processName());
                     branch=findBranch(tree_,name,iproc->processName());
-                    if(0!=branch) {
+                    if(nullptr != branch) {
                     break;
                     }
                 }
-                if(0==branch) {
+                if(nullptr == branch) {
                     return branchNotFound;
                 }
                 //do we already have this one?
-                if(0!=lastLabel) {
+                if(nullptr != lastLabel) {
                     internal::DataKey fullKey(type,iModuleLabel,iProductInstanceLabel,lastLabel->c_str());
                     itFind = data_.find(fullKey);
                     if(itFind != data_.end()) {
@@ -203,7 +203,7 @@ namespace fwlite {
             } else {
                 //we have all the pieces
                 branch = findBranch(tree_,name,key.process());
-                if(0==branch){
+                if(nullptr == branch){
                     return branchNotFound;
                 }
             }
@@ -230,7 +230,7 @@ namespace fwlite {
             }
             internal::DataKey newKey(edm::TypeID(iInfo),newModule,newProduct,newProcess);
 
-            if(0 == theData.get()) {
+            if(nullptr == theData.get()) {
                 //We do not already have this data as another key
 
                 //create an instance of the object to be used as a buffer
@@ -277,7 +277,7 @@ namespace fwlite {
         internal::Data& theData =
             DataGetterHelper::getBranchDataFor(iInfo, iModuleLabel, iProductInstanceLabel, iProcessLabel);
 
-        if (0 != theData.branch_) {
+        if (nullptr != theData.branch_) {
             return std::string(theData.branch_->GetName());
         }
         return std::string("");
@@ -297,7 +297,7 @@ namespace fwlite {
         internal::Data& theData =
             DataGetterHelper::getBranchDataFor(iInfo, iModuleLabel, iProductInstanceLabel, iProcessLabel);
 
-        if (0 != theData.branch_) {
+        if (nullptr != theData.branch_) {
             if(eventEntry != theData.lastProduct_) {
                 //haven't gotten the data for this event
                 getBranchData(getter_.get(), eventEntry, theData);
@@ -325,7 +325,7 @@ namespace fwlite {
       //Only the product instance label may be empty
       char const* pIL = bDesc.productInstanceName().c_str();
       if(pIL[0] == 0) {
-        pIL = 0;
+        pIL = nullptr;
       }
       internal::DataKey k(type,
                           bDesc.moduleLabel().c_str(),

--- a/DataFormats/FWLite/src/EntryFinder.cc
+++ b/DataFormats/FWLite/src/EntryFinder.cc
@@ -108,7 +108,7 @@ namespace fwlite {
    EntryFinder::fillIndex(BranchMapReader const& branchMap) {
     if (empty()) {
       TTree* meta = dynamic_cast<TTree*>(branchMap.getFile()->Get(edm::poolNames::metaDataTreeName().c_str()));
-      if (0 == meta) {
+      if (nullptr == meta) {
         throw cms::Exception("NoMetaTree") << "The TFile does not contain a TTree named "
           << edm::poolNames::metaDataTreeName();
       }
@@ -119,7 +119,7 @@ namespace fwlite {
         b->GetEntry(0);
         TTree* eventTree = branchMap.getEventTree();
         TBranch* auxBranch = eventTree->GetBranch(edm::BranchTypeToAuxiliaryBranchName(edm::InEvent).c_str());
-        if(0 == auxBranch) {
+        if(nullptr == auxBranch) {
           throw cms::Exception("NoEventAuxilliary") << "The TTree "
           << edm::poolNames::eventTreeName()
           << " does not contain a branch named 'EventAuxiliary'";

--- a/DataFormats/FWLite/src/ErrorThrower.cc
+++ b/DataFormats/FWLite/src/ErrorThrower.cc
@@ -32,7 +32,7 @@ namespace {
 
          edm::TypeID type(*type_);
          throw edm::Exception(edm::errors::ProductNotFound)<<"A branch was found for \n  type ='"<<type.className()<<"'\n  module='"<<module_
-         <<"'\n  productInstance='"<<((0!=instance_)?instance_:"")<<"'\n  process='"<<((0!=process_)?process_:"")<<"'\n"
+         <<"'\n  productInstance='"<<((nullptr != instance_)?instance_:"")<<"'\n  process='"<<((nullptr != process_)?process_:"")<<"'\n"
          "but no data is available for this Event";
       }
       virtual ErrorThrower* clone() const override {
@@ -55,7 +55,7 @@ namespace {
          
          edm::TypeID type(*type_);
          throw edm::Exception(edm::errors::ProductNotFound)<<"No branch was found for \n  type ='"<<type.className()<<"'\n  module='"<<module_
-         <<"'\n  productInstance='"<<((0!=instance_)?instance_:"")<<"'\n  process='"<<((0!=process_)?process_:"")<<"'";
+         <<"'\n  productInstance='"<<((nullptr != instance_)?instance_:"")<<"'\n  process='"<<((nullptr != process_)?process_:"")<<"'";
       }
       
       virtual ErrorThrower* clone() const override {

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -110,12 +110,12 @@ namespace fwlite {
 //
   Event::Event(TFile* iFile):
   file_(iFile),
-//  eventTree_(0),
-  eventHistoryTree_(0),
+//  eventTree_(nullptr),
+  eventHistoryTree_(nullptr),
 //  eventIndex_(-1),
   branchMap_(iFile),
   pAux_(&aux_),
-  pOldAux_(0),
+  pOldAux_(nullptr),
   fileVersion_(-1),
   parameterSetRegistryFilled_(false),
   dataHelper_(branchMap_.getEventTree(),
@@ -123,11 +123,11 @@ namespace fwlite {
               std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
               std::shared_ptr<edm::EDProductGetter>(new internal::ProductGetter(this)),
               true) {
-    if(0 == iFile) {
+    if(nullptr == iFile) {
       throw cms::Exception("NoFile") << "The TFile pointer passed to the constructor was null";
     }
 
-    if(0 == branchMap_.getEventTree()) {
+    if(nullptr == branchMap_.getEventTree()) {
       throw cms::Exception("NoEventTree") << "The TFile contains no TTree named " << edm::poolNames::eventTreeName();
     }
     //need to know file version in order to determine how to read the basic event info
@@ -138,7 +138,7 @@ namespace fwlite {
     TTree* eventTree = branchMap_.getEventTree();
     if(fileVersion_ >= 3) {
       auxBranch_ = eventTree->GetBranch(edm::BranchTypeToAuxiliaryBranchName(edm::InEvent).c_str());
-      if(0 == auxBranch_) {
+      if(nullptr == auxBranch_) {
         throw cms::Exception("NoEventAuxilliary") << "The TTree "
         << edm::poolNames::eventTreeName()
         << " does not contain a branch named 'EventAuxiliary'";
@@ -147,7 +147,7 @@ namespace fwlite {
     } else {
       pOldAux_ = new edm::EventAux();
       auxBranch_ = eventTree->GetBranch(edm::BranchTypeToAuxBranchName(edm::InEvent).c_str());
-      if(0 == auxBranch_) {
+      if(nullptr == auxBranch_) {
         throw cms::Exception("NoEventAux") << "The TTree "
           << edm::poolNames::eventTreeName()
           << " does not contain a branch named 'EventAux'";
@@ -169,10 +169,8 @@ namespace fwlite {
 // }
 
 Event::~Event() {
-  for(std::vector<char const*>::iterator it = labels_.begin(), itEnd = labels_.end();
-      it != itEnd;
-      ++it) {
-    delete [] *it;
+  for(auto const& label : labels_) {
+    delete [] label;
   }
   delete pOldAux_;
 }
@@ -291,10 +289,8 @@ Event::atEnd() const {
 std::vector<std::string> const&
 Event::getProcessHistory() const {
   if (procHistoryNames_.empty()) {
-    const edm::ProcessHistory& h = history();
-    for (edm::ProcessHistory::const_iterator iproc = h.begin(), eproc = h.end();
-         iproc != eproc; ++iproc) {
-      procHistoryNames_.push_back(iproc->processName());
+    for (auto const& proc : history()) {
+      procHistoryNames_.push_back(proc.processName());
     }
   }
   return procHistoryNames_;
@@ -335,7 +331,7 @@ Event::updateAux(Long_t eventIndex) const {
   if(auxBranch_->GetEntryNumber() != eventIndex) {
     auxBranch_->GetEntry(eventIndex);
     //handling dealing with old version
-    if(0 != pOldAux_) {
+    if(nullptr != pOldAux_) {
       conversion(*pOldAux_,aux_);
     }
   }
@@ -355,7 +351,7 @@ Event::history() const {
   if(historyMap_.empty() || newFormat) {
     procHistoryNames_.clear();
     TTree *meta = dynamic_cast<TTree*>(branchMap_.getFile()->Get(edm::poolNames::metaDataTreeName().c_str()));
-    if(0 == meta) {
+    if(nullptr == meta) {
       throw cms::Exception("NoMetaTree") << "The TFile does not appear to contain a TTree named "
       << edm::poolNames::metaDataTreeName();
     }
@@ -428,13 +424,13 @@ Event::getThinnedProducts(edm::ProductID const& pid,
 edm::TriggerNames const&
 Event::triggerNames(edm::TriggerResults const& triggerResults) const {
   edm::TriggerNames const* names = triggerNames_(triggerResults);
-  if (names != 0) return *names;
+  if (names != nullptr) return *names;
 
   if (!parameterSetRegistryFilled_) {
     fillParameterSetRegistry();
     names = triggerNames_(triggerResults);
   }
-  if (names != 0) return *names;
+  if (names != nullptr) return *names;
 
   throw cms::Exception("TriggerNamesNotFound")
     << "TriggerNames not found in ParameterSet registry";
@@ -447,7 +443,7 @@ Event::fillParameterSetRegistry() const {
   parameterSetRegistryFilled_ = true;
 
   TTree* meta = dynamic_cast<TTree*>(branchMap_.getFile()->Get(edm::poolNames::metaDataTreeName().c_str()));
-  if (0 == meta) {
+  if (nullptr == meta) {
     throw cms::Exception("NoMetaTree") << "The TFile does not contain a TTree named "
       << edm::poolNames::metaDataTreeName();
   }
@@ -462,13 +458,13 @@ Event::fillParameterSetRegistry() const {
 
   typedef std::map<edm::ParameterSetID, edm::ParameterSetBlob> PsetMap;
   PsetMap psetMap;
-  TTree* psetTree(0);
+  TTree* psetTree(nullptr);
   if (meta->FindBranch(edm::poolNames::parameterSetMapBranchName().c_str()) != 0) {
     PsetMap *psetMapPtr = &psetMap;
     TBranch* b = meta->GetBranch(edm::poolNames::parameterSetMapBranchName().c_str());
     b->SetAddress(&psetMapPtr);
     b->GetEntry(0);
-  } else if(0 == (psetTree = dynamic_cast<TTree *>(branchMap_.getFile()->Get(edm::poolNames::parameterSetsTreeName().c_str())))) {
+  } else if(nullptr == (psetTree = dynamic_cast<TTree *>(branchMap_.getFile()->Get(edm::poolNames::parameterSetsTreeName().c_str())))) {
     throw cms::Exception("NoParameterSetMapTree")
     << "The TTree "
     << edm::poolNames::parameterSetsTreeName() << " could not be found in the file.";
@@ -488,10 +484,9 @@ Event::fillParameterSetRegistry() const {
   } else {
     // Merge into the parameter set registry.
     edm::pset::Registry& psetRegistry = *edm::pset::Registry::instance();
-    for(PsetMap::const_iterator i = psetMap.begin(), iEnd = psetMap.end();
-        i != iEnd; ++i) {
-      edm::ParameterSet pset(i->second.pset());
-      pset.setID(i->first);
+    for(auto const&  item : psetMap) {
+      edm::ParameterSet pset(item.second.pset());
+      pset.setID(item.first);
       psetRegistry.insertMapped(pset);
     }
   }
@@ -507,7 +502,7 @@ Event::triggerResultsByName(std::string const& process) const {
   }
 
   edm::TriggerNames const* names = triggerNames_(*hTriggerResults);
-  if (names == 0 && !parameterSetRegistryFilled_) {
+  if (names == nullptr && !parameterSetRegistryFilled_) {
     fillParameterSetRegistry();
     names = triggerNames_(*hTriggerResults);
   }
@@ -521,7 +516,7 @@ void
 Event::throwProductNotFoundException(std::type_info const& iType, char const* iModule, char const* iProduct, char const* iProcess) {
     edm::TypeID type(iType);
   throw edm::Exception(edm::errors::ProductNotFound) << "A branch was found for \n  type ='" << type.className() << "'\n  module='" << iModule
-    << "'\n  productInstance='" << ((0!=iProduct)?iProduct:"") << "'\n  process='" << ((0 != iProcess) ? iProcess : "") << "'\n"
+    << "'\n  productInstance='" << ((nullptr != iProduct)?iProduct:"") << "'\n  process='" << ((nullptr != iProcess) ? iProcess : "") << "'\n"
     "but no data is available for this Event";
 }
 

--- a/DataFormats/FWLite/src/EventBase.cc
+++ b/DataFormats/FWLite/src/EventBase.cc
@@ -44,8 +44,8 @@ namespace fwlite
       void* prodPtr = &prod;
       getByLabel(iWrapperInfo,
                  iTag.label().c_str(),
-                 iTag.instance().empty()?static_cast<char const*>(0):iTag.instance().c_str(),
-                 iTag.process().empty()?static_cast<char const*> (0):iTag.process().c_str(),
+                 iTag.instance().empty() ? static_cast<char const*>(nullptr) : iTag.instance().c_str(),
+                 iTag.process().empty() ? static_cast<char const*> (nullptr) : iTag.process().c_str(),
                  prodPtr);
       if(prod == nullptr || !prod->isPresent()) {
         edm::TypeID productType(iWrapperInfo);

--- a/DataFormats/FWLite/src/EventSetup.cc
+++ b/DataFormats/FWLite/src/EventSetup.cc
@@ -47,9 +47,8 @@ m_file(iFile)
 
 EventSetup::~EventSetup()
 {
-   for(std::vector<Record*>::iterator it = m_records.begin(), itEnd=m_records.end();
-    it !=itEnd; ++it) {
-       delete *it;
+   for(auto const& record : m_records) {
+       delete record;
    }
 }
 
@@ -84,14 +83,14 @@ EventSetup::exists(const char* iRecordName) const
 {
    std::string realName = unformat_mangled_to_type(iRecordName);
    TObject* obj = m_file->Get(realName.c_str());
-   if(0==obj) {
+   if(nullptr == obj) {
       return false;
    }
    TTree* tree = dynamic_cast<TTree*>(obj);
-   if(0==tree) {
+   if(nullptr == tree) {
       return false;
    }
-   return 0 != tree->FindBranch(kRecordAuxiliaryBranchName);
+   return nullptr != tree->FindBranch(kRecordAuxiliaryBranchName);
 }
 
 RecordID 
@@ -99,19 +98,19 @@ EventSetup::recordID(const char* iRecordName) const
 {
    std::string treeName = format_type_to_mangled(iRecordName);
    TObject* obj = m_file->Get(treeName.c_str());
-   if(0==obj) {
+   if(nullptr == obj) {
       throw cms::Exception("UnknownRecord")<<"The TTree for the record "<<iRecordName<<" does not exist "<<m_file->GetName();
    }
    TTree* tree = dynamic_cast<TTree*>(obj);
-   if(0==tree) {
+   if(nullptr == tree) {
       throw cms::Exception("UnknownRecord")<<"The object corresponding to "<<iRecordName<<" in file "<<m_file->GetName()<<" is not a TTree and therefore is not a Record";   
    }
-   if(0 == tree->FindBranch(kRecordAuxiliaryBranchName)) {
+   if(nullptr == tree->FindBranch(kRecordAuxiliaryBranchName)) {
       throw cms::Exception("UnknownRecord")<<"The TTree corresponding to "<<iRecordName<<" in file "<<m_file->GetName()<<" does not have the proper structure to be a Record";
    }
    //do we already have this Record?
    std::string name(iRecordName);
-   for(std::vector<Record*>::iterator it = m_records.begin(), itEnd=m_records.end(); it!=itEnd;++it){
+   for(std::vector<Record*>::const_iterator it = m_records.begin(), itEnd=m_records.end(); it!=itEnd;++it){
       if((*it)->name()==name) {
          return it - m_records.begin();
       }

--- a/DataFormats/FWLite/src/LuminosityBlockBase.cc
+++ b/DataFormats/FWLite/src/LuminosityBlockBase.cc
@@ -46,8 +46,8 @@ namespace fwlite
       void* prodPtr = &prod;
       getByLabel(iWrapperInfo,
                  iTag.label().c_str(),
-                 iTag.instance().empty()?static_cast<char const*>(0):iTag.instance().c_str(),
-                 iTag.process().empty()?static_cast<char const*> (0):iTag.process().c_str(),
+                 iTag.instance().empty() ? static_cast<char const*>(nullptr) : iTag.instance().c_str(),
+                 iTag.process().empty() ? static_cast<char const*>(nullptr) : iTag.process().c_str(),
                  prodPtr);
       if(prod == nullptr || !prod->isPresent()) {
         edm::TypeID productType(iWrapperInfo);

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -72,10 +72,10 @@ private:
 				   std::vector<std::string> const& iFileNames2,
 				   bool useSecFileMapSorted)
 {
-  event1_ = std::shared_ptr<ChainEvent> (new ChainEvent(iFileNames1));
-  event2_ = std::shared_ptr<ChainEvent> (new ChainEvent(iFileNames2));
+  event1_ = std::make_shared<ChainEvent>(iFileNames1);
+  event2_ = std::make_shared<ChainEvent>(iFileNames2);
 
-  getter_ = std::shared_ptr<internal::MultiProductGetter>(new internal::MultiProductGetter(this));
+  getter_ = std::make_shared<internal::MultiProductGetter>(this);
 
   if (event1_->size() == 0) {
     std::cout << "------------------------------------------------------------------------" << std::endl;
@@ -116,7 +116,7 @@ private:
 
     // Loop over events, when a new file is encountered, store the first run number from this file,
     // and the last run number from the last file.
-    TFile * lastFile = 0;
+    TFile * lastFile = nullptr;
     std::pair<event_id_range,Long64_t> eventRange;
     bool firstFile = true;
 
@@ -440,18 +440,18 @@ edm::TriggerNames const&
 MultiChainEvent::triggerNames(edm::TriggerResults const& triggerResults) const
 {
   edm::TriggerNames const* names = triggerNames_(triggerResults);
-  if (names != 0) return *names;
+  if (names != nullptr) return *names;
 
   event1_->fillParameterSetRegistry();
   names = triggerNames_(triggerResults);
-  if (names != 0) return *names;
+  if (names != nullptr) return *names;
 
   // If we cannot find it in the primary file, this probably will
   // not help but try anyway
   event2_->to(event1_->id());
   event2_->fillParameterSetRegistry();
   names = triggerNames_(triggerResults);
-  if (names != 0) return *names;
+  if (names != nullptr) return *names;
 
   throw cms::Exception("TriggerNamesNotFound")
     << "TriggerNames not found in ParameterSet registry";
@@ -469,12 +469,12 @@ MultiChainEvent::triggerResultsByName(std::string const& process) const {
 
   edm::TriggerNames const* names = triggerNames_(*hTriggerResults);
 
-  if (names == 0) {
+  if (names == nullptr) {
     event1_->fillParameterSetRegistry();
     names = triggerNames_(*hTriggerResults);
   }
 
-  if (names == 0) {
+  if (names == nullptr) {
     event2_->to(event1_->id());
     event2_->fillParameterSetRegistry();
     names = triggerNames_(*hTriggerResults);

--- a/DataFormats/FWLite/src/Record.cc
+++ b/DataFormats/FWLite/src/Record.cc
@@ -139,17 +139,17 @@ void
 Record::resetCaches()
 {
   for(auto&b : m_branches){
-    TClass* cls=0;
+    TClass* cls = nullptr;
     EDataType dt;
-    if(0==b.second.first or 0==b.second.second) continue;
+    if(nullptr == b.second.first or nullptr == b.second.second) continue;
     if(0==b.second.first->GetExpectedType(cls,dt)) {
       cls->Destructor(b.second.second);
-      b.second.second=0;
+      b.second.second = nullptr;
     }
   }
   for(auto&b : m_branches){
-    if(0==b.second.first) continue;
-    assert(b.second.second==0);
+    if(nullptr == b.second.first) continue;
+    assert(b.second.second == nullptr);
   }
 }
 
@@ -181,8 +181,8 @@ Record::get(const edm::TypeID& iType,
    cms::Exception* returnValue = nullptr;
    
    std::pair<TBranch*,void*>& branch = m_branches[std::make_pair(iType,iLabel)];
-   if(0==branch.first){
-      branch.second=0;
+   if(nullptr == branch.first){
+      branch.second = nullptr;
       if(!edm::hasDictionary(iType.typeInfo())){
          returnValue = new cms::Exception("UnknownType");
          (*returnValue)<<"The type "
@@ -194,7 +194,7 @@ Record::get(const edm::TypeID& iType,
       std::string branchName = fwlite::format_type_to_mangled(iType.className())+"__"+iLabel;
       branch.first = m_tree->FindBranch(branchName.c_str());
       
-      if(0==branch.first){
+      if(nullptr == branch.first){
          returnValue = new cms::Exception("NoDataAvailable");
          (*returnValue)<<"The data of type "
                        <<iType.className()
@@ -220,12 +220,12 @@ Record::get(const edm::TypeID& iType,
          <<name()<<" was asked to get data for a 'time' for which it has no data";
       return returnValue;
    }
-   if(0!=branch.second) {
+   if(nullptr != branch.second) {
      iData=branch.second;
      return nullptr;
    }
 
-   assert(0==branch.second);
+   assert(nullptr == branch.second);
    branch.first->SetAddress(&branch.second);
    iData = branch.second;
    branch.first->GetEntry(m_entry);

--- a/DataFormats/FWLite/src/Run.cc
+++ b/DataFormats/FWLite/src/Run.cc
@@ -44,17 +44,17 @@ namespace fwlite {
   Run::Run(TFile* iFile):
     branchMap_(new BranchMapReader(iFile)),
     pAux_(&aux_),
-    pOldAux_(0),
+    pOldAux_(nullptr),
     fileVersion_(-1),
     dataHelper_(branchMap_->getRunTree(),
                 std::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
                 branchMap_)
   {
-    if(0==iFile) {
+    if(nullptr == iFile) {
       throw cms::Exception("NoFile")<<"The TFile pointer passed to the constructor was null";
     }
 
-    if(0==branchMap_->getRunTree()) {
+    if(nullptr == branchMap_->getRunTree()) {
       throw cms::Exception("NoRunTree")<<"The TFile contains no TTree named " <<edm::poolNames::runTreeName();
     }
     //need to know file version in order to determine how to read the basic product info
@@ -65,7 +65,7 @@ namespace fwlite {
     TTree* runTree = branchMap_->getRunTree();
     if(fileVersion_ >= 3) {
       auxBranch_ = runTree->GetBranch(edm::BranchTypeToAuxiliaryBranchName(edm::InRun).c_str());
-      if(0==auxBranch_) {
+      if(nullptr == auxBranch_) {
         throw cms::Exception("NoRunAuxilliary")<<"The TTree "
         <<edm::poolNames::runTreeName()
         <<" does not contain a branch named 'RunAuxiliary'";
@@ -76,7 +76,7 @@ namespace fwlite {
 //       This code commented from fwlite::Event. May be portable if needed.
 //       pOldAux_ = new edm::EventAux();
 //       auxBranch_ = runTree->GetBranch(edm::BranchTypeToAuxBranchName(edm::InRun).c_str());
-//       if(0==auxBranch_) {
+//       if(nullptr == auxBranch_) {
 //         throw cms::Exception("NoRunAux")<<"The TTree "
 //           <<edm::poolNames::runTreeName()
 //           <<" does not contain a branch named 'RunAux'";
@@ -90,13 +90,13 @@ namespace fwlite {
   Run::Run(std::shared_ptr<BranchMapReader> branchMap):
     branchMap_(branchMap),
     pAux_(&aux_),
-    pOldAux_(0),
+    pOldAux_(nullptr),
     fileVersion_(-1),
     dataHelper_(branchMap_->getRunTree(),
                 std::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
                 branchMap_)
   {
-    if(0==branchMap_->getRunTree()) {
+    if(nullptr == branchMap_->getRunTree()) {
       throw cms::Exception("NoRunTree")<<"The TFile contains no TTree named " <<edm::poolNames::runTreeName();
     }
     //need to know file version in order to determine how to read the basic event info
@@ -106,7 +106,7 @@ namespace fwlite {
     TTree* runTree = branchMap_->getRunTree();
     if(fileVersion_ >= 3) {
       auxBranch_ = runTree->GetBranch(edm::BranchTypeToAuxiliaryBranchName(edm::InRun).c_str());
-      if(0==auxBranch_) {
+      if(nullptr == auxBranch_) {
         throw cms::Exception("NoRunAuxilliary")<<"The TTree "
         <<edm::poolNames::runTreeName()
         <<" does not contain a branch named 'RunAuxiliary'";
@@ -116,7 +116,7 @@ namespace fwlite {
       throw cms::Exception("OldFileVersion")<<"The FWLite Run code des not support old file versions";
 /*      pOldAux_ = new edm::EventAux();
       auxBranch_ = runTree->GetBranch(edm::BranchTypeToAuxBranchName(edm::InRun).c_str());
-      if(0==auxBranch_) {
+      if(nullptr == auxBranch_) {
         throw cms::Exception("NoRunAux")<<"The TTree "
           <<edm::poolNames::runTreeName()
           <<" does not contain a branch named 'RunAux'";
@@ -134,10 +134,8 @@ namespace fwlite {
 
 Run::~Run()
 {
-  for(std::vector<char const*>::iterator it = labels_.begin(), itEnd=labels_.end();
-      it != itEnd;
-      ++it) {
-    delete [] *it;
+  for(auto const& label  : labels_) {
+    delete [] label;
   }
   delete pOldAux_;
 }
@@ -244,7 +242,7 @@ Run::updateAux(Long_t runIndex) const
   if(auxBranch_->GetEntryNumber() != runIndex) {
     auxBranch_->GetEntry(runIndex);
     //handling dealing with old version
-    if(0 != pOldAux_) {
+    if(nullptr != pOldAux_) {
       conversion(*pOldAux_,aux_);
     }
   }
@@ -266,7 +264,7 @@ Run::history() const
   if(historyMap_.empty() || newFormat) {
     procHistoryNames_.clear();
     TTree *meta = dynamic_cast<TTree*>(branchMap_->getFile()->Get(edm::poolNames::metaDataTreeName().c_str()));
-    if(0==meta) {
+    if(nullptr == meta) {
       throw cms::Exception("NoMetaTree")<<"The TFile does not appear to contain a TTree named "
       <<edm::poolNames::metaDataTreeName();
     }
@@ -329,7 +327,7 @@ Run::throwProductNotFoundException(std::type_info const& iType, char const* iMod
 {
     edm::TypeID type(iType);
   throw edm::Exception(edm::errors::ProductNotFound)<<"A branch was found for \n  type ='"<<type.className()<<"'\n  module='"<<iModule
-    <<"'\n  productInstance='"<<((0!=iProduct)?iProduct:"")<<"'\n  process='"<<((0!=iProcess)?iProcess:"")<<"'\n"
+    <<"'\n  productInstance='"<<((nullptr != iProduct)?iProduct:"")<<"'\n  process='"<<((nullptr != iProcess)?iProcess:"")<<"'\n"
     "but no data is available for this Run";
 }
 }

--- a/DataFormats/FWLite/src/RunBase.cc
+++ b/DataFormats/FWLite/src/RunBase.cc
@@ -46,8 +46,8 @@ namespace fwlite
       void* prodPtr = &prod;
       getByLabel(iWrapperInfo,
                  iTag.label().c_str(),
-                 iTag.instance().empty()?static_cast<char const*>(0):iTag.instance().c_str(),
-                 iTag.process().empty()?static_cast<char const*> (0):iTag.process().c_str(),
+                 iTag.instance().empty() ? static_cast<char const*>(nullptr) : iTag.instance().c_str(),
+                 iTag.process().empty() ? static_cast<char const*>(nullptr) : iTag.process().c_str(),
                  prodPtr);
       if(prod == nullptr || !prod->isPresent()) {
         edm::TypeID productType(iWrapperInfo);

--- a/DataFormats/FWLite/src/RunFactory.cc
+++ b/DataFormats/FWLite/src/RunFactory.cc
@@ -25,7 +25,7 @@ namespace fwlite {
 
     std::shared_ptr<fwlite::Run> RunFactory::makeRun(std::shared_ptr<BranchMapReader> branchMap) const {
         if (not run_) {
-            run_ = std::shared_ptr<fwlite::Run>(new fwlite::Run(branchMap));
+            run_ = std::make_shared<fwlite::Run>(branchMap);
         }
         return run_;
     }

--- a/DataFormats/FWLite/test/format_type_name.cppunit.cpp
+++ b/DataFormats/FWLite/test/format_type_name.cppunit.cpp
@@ -47,19 +47,16 @@ void testFormatTypeName::test()
   classToFriendly.push_back( Values("Aa<Bb<Cc,Dd>, Ee<Ff> >","Aa_9Bb_9Cc_3Dd_0_3_4Ee_9Ff_0_4_0"));
   classToFriendly.push_back( Values("Aa<Bb<Cc,Dd>, Ee<Ff,Gg> >","Aa_9Bb_9Cc_3Dd_0_3_4Ee_9Ff_3Gg_0_4_0"));
                                  
-  for(std::vector<Values>::iterator itInfo = classToFriendly.begin(),
-      itInfoEnd = classToFriendly.end();
-      itInfo != itInfoEnd;
-      ++itInfo) {
-    //std::cout <<itInfo->first<<std::endl;
-    if( itInfo->second != fwlite::format_type_to_mangled(itInfo->first) ) {
-      std::cout <<"class name: '"<<itInfo->first<<"' has wrong mangled name \n"
-      <<"expect: '"<<itInfo->second<<"' got: '"<<fwlite::format_type_to_mangled(itInfo->first)<<"'"<<std::endl;
+  for(auto const& item : classToFriendly) {
+    //std::cout << item.first << std::endl;
+    if(item.second != fwlite::format_type_to_mangled(item.first)) {
+      std::cout  << "class name: '" << item.first << "' has wrong mangled name \n"
+       << "expect: '" << item.second << "' got: '" << fwlite::format_type_to_mangled(item.first) << "'" << std::endl;
       CPPUNIT_ASSERT(0 && "expected mangled name does not match actual mangled name");
     }
-    if( itInfo->first != fwlite::unformat_mangled_to_type(itInfo->second) ) {
-      std::cout <<"mangled name: '"<<itInfo->second<<"' has wrong type name \n"
-      <<"expect: '"<<itInfo->first<<"' got: '"<<fwlite::unformat_mangled_to_type(itInfo->second)<<"'"<<std::endl;
+    if(item.first != fwlite::unformat_mangled_to_type(item.second)) {
+      std::cout  << "mangled name: '" << item.second << "' has wrong type name \n"
+       << "expect: '" << item.first << "' got: '" << fwlite::unformat_mangled_to_type(item.second) << "'" << std::endl;
       CPPUNIT_ASSERT(0 && "expected type name does not match actual type name");
     }
     

--- a/DataFormats/FWLite/test/record.cppunit.cpp
+++ b/DataFormats/FWLite/test/record.cppunit.cpp
@@ -88,18 +88,15 @@ void testRecord::testGood()
       
       CPPUNIT_ASSERT(dataIds.size() == 2);
       unsigned int matches =0;
-      for(std::vector<std::pair<std::string,std::string> >::const_iterator it = dataIds.begin(),
-          itEnd = dataIds.end();
-          it != itEnd;
-          ++it) {
-         std::cout <<it->first<< " '"<<it->second<<"'"<<std::endl;
-         if( (it->first == "std::vector<int>") &&
-            (it->second =="") ) {
+      for(auto const& dataId : dataIds) {
+         std::cout << dataId.first << " '" << dataId.second << "'" << std::endl;
+         if((dataId.first == "std::vector<int>") &&
+            (dataId.second == "")) {
             ++matches;
             continue;
          }
-         if( (it->first == "edmtest::Simple") &&
-            (it->second =="") ) {
+         if((dataId.first == "edmtest::Simple") &&
+            (dataId.second == "")) {
             ++matches;
          }
       }

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -23,7 +23,7 @@ Test program for edm::Ref use in ROOT.
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 
-static char* gArgV = 0;
+static char* gArgV = nullptr;
 
 extern "C" char** environ;
 
@@ -94,8 +94,8 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testRefInROOT);
 static void checkMatch(const edmtest::OtherThingCollection* pOthers,
                        const edmtest::ThingCollection* pThings)
 {
-  CPPUNIT_ASSERT(pOthers != 0);
-  CPPUNIT_ASSERT(pThings != 0);
+  CPPUNIT_ASSERT(pOthers != nullptr);
+  CPPUNIT_ASSERT(pThings != nullptr);
   CPPUNIT_ASSERT(pOthers->size() == pThings->size());
 
   //This test requires at least one entry
@@ -248,11 +248,10 @@ void testRefInROOT::testRefFirst()
     pOthers.getByLabel(events,"OtherThing","testUserTag");
 
     //std::cout <<"got OtherThing"<<std::endl;
-    for(edmtest::OtherThingCollection::const_iterator itOther=pOthers->begin(), itEnd=pOthers->end() ;
-        itOther != itEnd; ++itOther) {
+    for(auto const& other : *pOthers) {
       //std::cout <<"getting ref"<<std::endl;
       int arbitraryBigNumber = 1000000; 
-      CPPUNIT_ASSERT(itOther->ref.get()->a < arbitraryBigNumber);
+      CPPUNIT_ASSERT(other.ref.get()->a < arbitraryBigNumber);
     }
     //std::cout <<"get all Refs"<<std::endl;
     
@@ -281,11 +280,10 @@ void testRefInROOT::testMissingRef()
       
       fwlite::Handle<edmtest::OtherThingCollection> pOthers;
       pOthers.getByLabel(events,"OtherThing","testUserTag");
-      for(edmtest::OtherThingCollection::const_iterator itOther=pOthers->begin(), itEnd=pOthers->end() ;
-          itOther != itEnd; ++itOther) {
+      for(auto const& other : *pOthers) {
          //std::cout <<"getting ref"<<std::endl;
-         CPPUNIT_ASSERT(not itOther->ref.isAvailable());
-         CPPUNIT_ASSERT_THROW(itOther->ref.get(), cms::Exception);
+         CPPUNIT_ASSERT(not other.ref.isAvailable());
+         CPPUNIT_ASSERT_THROW(other.ref.get(), cms::Exception);
       }
    }
 }
@@ -378,18 +376,18 @@ void testRefInROOT::testGoodChain()
   eventChain.Add((tmpdir + "goodDataFormatsFWLite.root").c_str());
   eventChain.Add((tmpdir + "good2DataFormatsFWLite.root").c_str());
 
-  edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
+  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
   eventChain.SetBranchAddress("edmtestOtherThings_OtherThing_testUserTag_TEST.",&pOthers);
   
-  edm::Wrapper<edmtest::ThingCollection>* pThings = 0;
+  edm::Wrapper<edmtest::ThingCollection>* pThings = nullptr;
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.",&pThings);
   
   int nev = eventChain.GetEntries();
   for( int ev=0; ev<nev; ++ev) {
     std::cout <<"event #" <<ev<<std::endl;
     eventChain.GetEntry(ev);
-    CPPUNIT_ASSERT(pOthers != 0);
-    CPPUNIT_ASSERT(pThings != 0);
+    CPPUNIT_ASSERT(pOthers != nullptr);
+    CPPUNIT_ASSERT(pThings != nullptr);
     checkMatch(pOthers->product(),pThings->product());
   }
   */
@@ -401,18 +399,18 @@ void testRefInROOT::failChainWithMissingFile()
   eventChain.Add((tmpdir + "goodDataFormatsFWLite.root").c_str());
   eventChain.Add("thisFileDoesNotExist.root");
   
-  edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
+  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
   eventChain.SetBranchAddress("edmtestOtherThings_OtherThing_testUserTag_TEST.",&pOthers);
   
-  edm::Wrapper<edmtest::ThingCollection>* pThings = 0;
+  edm::Wrapper<edmtest::ThingCollection>* pThings = nullptr;
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.",&pThings);
   
   int nev = eventChain.GetEntries();
   for( int ev=0; ev<nev; ++ev) {
     std::cout <<"event #" <<ev<<std::endl;    
     eventChain.GetEntry(ev);
-    CPPUNIT_ASSERT(pOthers != 0);
-    CPPUNIT_ASSERT(pThings != 0);
+    CPPUNIT_ASSERT(pOthers != nullptr);
+    CPPUNIT_ASSERT(pThings != nullptr);
     checkMatch(pOthers->product(),pThings->product());
   }
   

--- a/FWCore/FWLite/bin/storageSize.cc
+++ b/FWCore/FWLite/bin/storageSize.cc
@@ -69,13 +69,13 @@ int main(int argc, char* argv[]) try
    FWLiteEnabler::enable();
 
    TClass* cls = TClass::GetClass(className.c_str());
-   if(0==cls) {
+   if(nullptr == cls) {
       std::cerr <<"class '"<<className<<"' is unknown by ROOT\n";
       return 1;
    }
    
    void* objInstance = cls->New();
-   if(0==objInstance) {
+   if(nullptr == objInstance) {
       std::cerr <<"unable to create a default instance of the class "<<className;
       return 1;
    }

--- a/FWCore/FWLite/bin/storageSizeForBranch.cc
+++ b/FWCore/FWLite/bin/storageSizeForBranch.cc
@@ -88,21 +88,21 @@ int main(int argc, char* argv[]) try
    std::string fileName(vm[kFileNameOpt].as<std::string>());
    
    TFile* file = TFile::Open(fileName.c_str());
-   if (0 == file) {
+   if (nullptr == file) {
       std::cerr <<"failed to open '"<<fileName<<"'";
       return 1;
    }
    
    TTree* eventTree = dynamic_cast<TTree*> (file->Get("Events"));
    
-   if(0 == eventTree) {
+   if(nullptr == eventTree) {
       std::cerr <<"The file '"<<fileName<<"' does not contain an 'Events' TTree";
       return 1;
    }
    
    TBranch* branch = eventTree->GetBranch(branchName.c_str());
    
-   if(0==branch) {
+   if(nullptr == branch) {
       std::cerr <<"The Events TTree does not contain the branch "<<branchName;
       return 1;
    }
@@ -111,13 +111,13 @@ int main(int argc, char* argv[]) try
    FWLiteEnabler::enable();
 
    TClass* cls = TClass::GetClass(branch->GetClassName());
-   if(0==cls) {
+   if(nullptr == cls) {
       std::cerr <<"class '"<<branch->GetClassName()<<"' is unknown by ROOT\n";
       return 1;
    }
    
    void* objInstance = cls->New();
-   if(0==objInstance) {
+   if(nullptr == objInstance) {
       std::cerr <<"unable to create a default instance of the class "<<branch->GetClassName();
       return 1;
    }

--- a/FWCore/FWLite/interface/BranchMapReader.h
+++ b/FWCore/FWLite/interface/BranchMapReader.h
@@ -69,7 +69,7 @@ namespace fwlite {
   class BranchMapReader {
   public:
     BranchMapReader(TFile* file);
-    BranchMapReader() : strategy_(0),fileVersion_(0) {}
+    BranchMapReader() : strategy_(nullptr),fileVersion_(0) {}
 
       // ---------- const member functions ---------------------
 
@@ -100,8 +100,8 @@ namespace fwlite {
 
       // ---------- member data --------------------------------
   private:
-    std::auto_ptr<internal::BMRStrategy> newStrategy(TFile* file, int fileVersion);
-    std::auto_ptr<internal::BMRStrategy> strategy_;
+    std::unique_ptr<internal::BMRStrategy> newStrategy(TFile* file, int fileVersion);
+    std::unique_ptr<internal::BMRStrategy> strategy_;
     int fileVersion_;
   };
 }

--- a/FWCore/FWLite/interface/setRefStreamer.h
+++ b/FWCore/FWLite/interface/setRefStreamer.h
@@ -32,7 +32,7 @@ namespace fwlite {
   
   class GetterOperate {
 public:
-    GetterOperate( edm::EDProductGetter const* iEP): old_(0) {
+    GetterOperate(edm::EDProductGetter const* iEP): old_(nullptr) {
       old_ = setRefStreamer(iEP);
     }
     ~GetterOperate() {

--- a/FWCore/FWLite/src/BareRootProductGetter.cc
+++ b/FWCore/FWLite/src/BareRootProductGetter.cc
@@ -73,7 +73,7 @@ edm::WrapperBase const*
 BareRootProductGetter::getIt(edm::ProductID const& pid) const  {
   // std::cout << "getIt called " << pid << std::endl;
   TFile* currentFile = dynamic_cast<TFile*>(gROOT->GetListOfFiles()->Last());
-  if(0 == currentFile) {
+  if(nullptr == currentFile) {
      throw cms::Exception("FileNotFound")
         << "unable to find the TFile '" << gROOT->GetListOfFiles()->Last() << "'\n"
         << "retrieved by calling 'gROOT->GetListOfFiles()->Last()'\n"
@@ -84,7 +84,7 @@ BareRootProductGetter::getIt(edm::ProductID const& pid) const  {
   }
   TTree* eventTree = branchMap_.getEventTree();
   // std::cout << "eventTree " << eventTree << std::endl;
-  if(0 == eventTree) {
+  if(nullptr == eventTree) {
      throw cms::Exception("NoEventsTree")
         << "unable to find the TTree '" << edm::poolNames::eventTreeName() << "' in the last open file, \n"
         << "file: '" << branchMap_.getFile()->GetName()

--- a/FWCore/FWLite/src/BranchMapReader.cc
+++ b/FWCore/FWLite/src/BranchMapReader.cc
@@ -39,7 +39,7 @@ namespace fwlite {
     static const edm::BranchDescription kDefaultBranchDescription;
 
     BMRStrategy::BMRStrategy(TFile* file, int fileVersion)
-      : currentFile_(file), eventTree_(0), luminosityBlockTree_(0), runTree_(0),
+      : currentFile_(file), eventTree_(nullptr), luminosityBlockTree_(nullptr), runTree_(nullptr),
         eventEntry_(-1), luminosityBlockEntry_(-1), runEntry_(-1), fileVersion_(fileVersion) {
       // do in derived obects
       // updateFile(file);
@@ -97,14 +97,14 @@ namespace fwlite {
       fileUUID_ = currentFile_->GetUUID();
       branchDescriptionMap_.clear();
       bDesc_.clear();
-      return 0 != eventTree_;
+      return nullptr != eventTree_;
     }
 
     TBranch* Strategy::getBranchRegistry(edm::ProductRegistry** ppReg) {
-      TBranch* bReg(0);
+      TBranch* bReg(nullptr);
 
       TTree* metaDataTree = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::metaDataTreeName().c_str()));
-      if(0 != metaDataTree) {
+      if(nullptr != metaDataTree) {
         bReg = metaDataTree->GetBranch(edm::poolNames::productDescriptionBranchName().c_str());
         bReg->SetAddress(ppReg);
         bReg->GetEntry(0);
@@ -115,8 +115,8 @@ namespace fwlite {
     std::vector<edm::BranchDescription> const&
     Strategy::getBranchDescriptions() {
       if(bDesc_.empty()) {
-        for(bidToDesc::const_iterator i = branchDescriptionMap_.begin(); i != branchDescriptionMap_.end(); ++i) {
-          bDesc_.push_back(i->second);
+        for(auto const& item : branchDescriptionMap_) {
+          bDesc_.push_back(item.second);
         }
       }
       return bDesc_;
@@ -181,7 +181,7 @@ namespace fwlite {
       edm::ProductRegistry* pReg = &reg;
       TBranch* br = getBranchRegistry(&pReg);
 
-      if(0 != br) {
+      if(nullptr != br) {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for(auto& item : prodList) {
@@ -195,7 +195,7 @@ namespace fwlite {
         mapperFilled_ = true;
       }
       reg.setFrozen(false);
-      return 0 != br;
+      return nullptr != br;
     }
 
     // v7 has differences in product status that are not implemented in BranchMapReader yet
@@ -262,9 +262,9 @@ namespace fwlite {
     bool BranchMapReaderStrategyV8::updateFile(TFile* file) {
       Strategy::updateFile(file);
       mapperFilled_ = false;
-      entryInfoBranch_ = 0;
+      entryInfoBranch_ = nullptr;
       TTree* metaDataTree = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::eventMetaDataTreeName().c_str()));
-      if(0 != metaDataTree) {
+      if(nullptr != metaDataTree) {
         entryInfoBranch_ = metaDataTree->GetBranch(BranchTypeToBranchEntryInfoBranchName(edm::InEvent).c_str());
 //         std::cout << "entryInfoBranch for " << BranchTypeToBranchEntryInfoBranchName(edm::InEvent) << " " << entryInfoBranch_ << std::endl;
       } else {
@@ -280,7 +280,7 @@ namespace fwlite {
       edm::ProductRegistry* pReg = &reg;
       TBranch *br = getBranchRegistry(&pReg);
 
-      if(0 != br) {
+      if(nullptr != br) {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for(auto& item : prodList) {
@@ -293,7 +293,7 @@ namespace fwlite {
         }
       }
       reg.setFrozen(false);
-      return 0 != br;
+      return nullptr != br;
     }
 
     bool BranchMapReaderStrategyV8::updateMap() {
@@ -305,11 +305,9 @@ namespace fwlite {
 
       entryInfoBranch_->GetEntry(eventEntry_);
 
-      for(std::vector<edm::EventEntryInfo>::const_iterator it = pEventEntryInfoVector_->begin(),
-           itEnd = pEventEntryInfoVector_->end();
-           it != itEnd; ++it) {
-//         eventInfoMap_.insert(*it);
-      }
+//      for(auto const& item : *pEventEntryInfoVector_) {
+//         eventInfoMap_.insert(item);
+//      }
       mapperFilled_ = true;
       return true;
     }
@@ -325,14 +323,14 @@ namespace fwlite {
       virtual edm::BranchID productToBranchID(edm::ProductID const& pid) override;
       virtual edm::BranchListIndexes const& branchListIndexes() const override {return history_.branchListIndexes();}
     private:
-      std::auto_ptr<edm::BranchIDLists> branchIDLists_;
+      std::unique_ptr<edm::BranchIDLists> branchIDLists_;
       TTree* eventHistoryTree_;
       edm::History history_;
       edm::History* pHistory_;
     };
 
     BranchMapReaderStrategyV11::BranchMapReaderStrategyV11(TFile* file, int fileVersion)
-    : Strategy(file, fileVersion), eventHistoryTree_(0), pHistory_(&history_) {
+    : Strategy(file, fileVersion), eventHistoryTree_(nullptr), pHistory_(&history_) {
       updateFile(file);
     }
 
@@ -366,7 +364,7 @@ namespace fwlite {
       mapperFilled_ = false;
       TTree* metaDataTree = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::metaDataTreeName().c_str()));
 
-      if(0 == metaDataTree) {
+      if(nullptr == metaDataTree) {
          throw edm::Exception(edm::errors::EventCorruption)
            <<"No "<<edm::poolNames::metaDataTreeName()<<" TTree in file";
       }
@@ -392,7 +390,7 @@ namespace fwlite {
       edm::ProductRegistry* pReg = &reg;
       TBranch *br = getBranchRegistry(&pReg);
 
-      if(0 != br) {
+      if(nullptr != br) {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for(auto& item : prodList) {
@@ -406,7 +404,7 @@ namespace fwlite {
               }
       }
       reg.setFrozen(false);
-      return 0 != br;
+      return nullptr != br;
     }
 
     bool BranchMapReaderStrategyV11::updateMap() {
@@ -442,14 +440,14 @@ namespace fwlite {
       virtual edm::BranchID productToBranchID(edm::ProductID const& pid) override;
       virtual edm::BranchListIndexes const& branchListIndexes() const override {return branchListIndexes_;}
     private:
-      std::auto_ptr<edm::BranchIDLists> branchIDLists_;
+      std::unique_ptr<edm::BranchIDLists> branchIDLists_;
       TTree* eventsTree_;
       edm::BranchListIndexes branchListIndexes_;
       edm::BranchListIndexes* pBranchListIndexes_;
     };
 
     BranchMapReaderStrategyV17::BranchMapReaderStrategyV17(TFile* file, int fileVersion)
-    : Strategy(file, fileVersion), eventsTree_(0), pBranchListIndexes_(&branchListIndexes_) {
+    : Strategy(file, fileVersion), eventsTree_(nullptr), pBranchListIndexes_(&branchListIndexes_) {
       updateFile(file);
     }
 
@@ -482,7 +480,7 @@ namespace fwlite {
       Strategy::updateFile(file);
       mapperFilled_ = false;
       TTree* metaDataTree = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::metaDataTreeName().c_str()));
-      if(0==metaDataTree) {
+      if(nullptr == metaDataTree) {
          throw edm::Exception(edm::errors::EventCorruption) <<"No "<<edm::poolNames::metaDataTreeName()<<" TTree in file";
       }
 
@@ -516,7 +514,7 @@ namespace fwlite {
       edm::ProductRegistry* pReg = &reg;
       TBranch *br = getBranchRegistry(&pReg);
 
-      if(0 != br) {
+      if(nullptr != br) {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for(auto& item : prodList) {
@@ -530,7 +528,7 @@ namespace fwlite {
               }
       }
       reg.setFrozen(false);
-      return 0 != br;
+      return nullptr != br;
     }
 
     bool BranchMapReaderStrategyV17::updateMap() {
@@ -570,7 +568,7 @@ namespace fwlite {
 
 BranchMapReader::BranchMapReader(TFile* file) :
     fileVersion_(-1) {
-  if(0==file) {
+  if(nullptr == file) {
      throw cms::Exception("NoFile")<<"The TFile pointer is null";
   }
   strategy_ = newStrategy(file, getFileVersion(file));
@@ -582,7 +580,7 @@ BranchMapReader::BranchMapReader(TFile* file) :
 
 int BranchMapReader::getFileVersion(TFile* file) {
   TTree* metaDataTree = dynamic_cast<TTree*>(file->Get(edm::poolNames::metaDataTreeName().c_str()));
-  if(0==metaDataTree) {
+  if(nullptr == metaDataTree) {
     return 0;
   }
 
@@ -608,7 +606,7 @@ bool BranchMapReader::updateRun(Long_t newRun) {
 }
 
 bool BranchMapReader::updateFile(TFile* file) {
-  if(0 == strategy_.get()) {
+  if(nullptr == strategy_.get()) {
     strategy_ = newStrategy(file, getFileVersion(file));
     return true;
   }
@@ -645,20 +643,20 @@ BranchMapReader::getBranchDescriptions() {
 }
 
 
-std::auto_ptr<internal::BMRStrategy>
+std::unique_ptr<internal::BMRStrategy>
 BranchMapReader::newStrategy(TFile* file, int fileVersion) {
-  std::auto_ptr<internal::BMRStrategy> s;
+  std::unique_ptr<internal::BMRStrategy> s;
 
   if(fileVersion >= 17) {
-    s = std::auto_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV17(file, fileVersion));
+    s = std::unique_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV17(file, fileVersion));
   } else if(fileVersion >= 11) {
-    s = std::auto_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV11(file, fileVersion));
+    s = std::unique_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV11(file, fileVersion));
   } else if(fileVersion >= 8) {
-    s = std::auto_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV8(file, fileVersion));
+    s = std::unique_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV8(file, fileVersion));
   } else if(fileVersion >= 7) {
-    s = std::auto_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV7(file, fileVersion));
+    s = std::unique_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV7(file, fileVersion));
   } else {
-    s = std::auto_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV1(file, fileVersion));
+    s = std::unique_ptr<internal::BMRStrategy>(new internal::BranchMapReaderStrategyV1(file, fileVersion));
   }
   return s;
 }

--- a/FWCore/FWLite/src/FWLiteEnabler.cc
+++ b/FWCore/FWLite/src/FWLiteEnabler.cc
@@ -60,7 +60,7 @@
    //Make it easy to load our headers
    TInterpreter* intrp= gROOT->GetInterpreter();
    char const* env = getenv("CMSSW_FWLITE_INCLUDE_PATH");
-   if(0 != env) {
+   if(nullptr != env) {
      //this is a comma separated list
      char const* start = env;
      char const* end;
@@ -75,7 +75,7 @@
 
    bool foundCMSIncludes = false;
    env = getenv("CMSSW_BASE");
-   if(0 != env) {
+   if(nullptr != env) {
      foundCMSIncludes = true;
      std::string dir(env);
      dir += "/src";
@@ -83,7 +83,7 @@
    }
 
    env = getenv("CMSSW_RELEASE_BASE");
-   if(0 != env) {
+   if(nullptr != env) {
      foundCMSIncludes = true;
      std::string dir(env);
      dir += "/src";
@@ -95,7 +95,7 @@
      <<"  CMSSW_RELEASE_BASE\n"
      <<" therefore attempting to '#include' any CMS headers will not work"<<std::endl;
    }
-   if (0 != gApplication) {
+   if (nullptr != gApplication) {
      gApplication->InitializeGraphics();
    }
   }

--- a/FWCore/FWLite/src/RefStreamer.cc
+++ b/FWCore/FWLite/src/RefStreamer.cc
@@ -11,14 +11,14 @@ namespace fwlite {
     {
       TClass* cl = TClass::GetClass("edm::RefCore");
       TClassStreamer* st = cl->GetStreamer();
-      if (st == 0) {
+      if (st == nullptr) {
         cl->AdoptStreamer(new edm::RefCoreStreamer());
       }
     }
     {
       TClass* cl = TClass::GetClass("edm::RefCoreWithIndex");
       TClassStreamer* st = cl->GetStreamer();
-      if (st == 0) {
+      if (st == nullptr) {
         cl->AdoptStreamer(new edm::RefCoreWithIndexStreamer());
       }
     }

--- a/FWCore/FWLite/src/branchToClass.cc
+++ b/FWCore/FWLite/src/branchToClass.cc
@@ -33,9 +33,9 @@ private:
 TClass*
 BranchToClass::doit( const TBranch* iBranch )
 {
-  TClass* contained = 0;
+  TClass* contained = nullptr;
   TClass* type = TVirtualBranchBrowsable::GetCollectionContainedType(iBranch,0,contained);
-  if( type == 0) {
+  if( type == nullptr) {
     type = contained;
   }
   return type;  

--- a/FWCore/FWLite/test/ref_t.cppunit.cpp
+++ b/FWCore/FWLite/test/ref_t.cppunit.cpp
@@ -64,7 +64,7 @@ using ROOT's "Draw" interface.
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/TestHelper.h"
 
-static char* gArgV = 0;
+static char* gArgV = nullptr;
 
 extern "C" char** environ;
 
@@ -131,8 +131,8 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testRefInROOT);
 static void checkMatch(const edmtest::OtherThingCollection* pOthers,
                        const edmtest::ThingCollection* pThings)
 {
-  CPPUNIT_ASSERT(pOthers != 0);
-  CPPUNIT_ASSERT(pThings != 0);
+  CPPUNIT_ASSERT(pOthers != nullptr);
+  CPPUNIT_ASSERT(pThings != nullptr);
   CPPUNIT_ASSERT(pOthers->size() == pThings->size());
   
   //This test requires at least one entry
@@ -178,20 +178,20 @@ static void testTree(TTree* events) {
   CPPUNIT_ASSERT(events !=0);
   
   /*
-   edmtest::OtherThingCollection* pOthers = 0;
+   edmtest::OtherThingCollection* pOthers = nullptr;
    TBranch* otherBranch = events->GetBranch("edmtestOtherThings_OtherThing_testUserTag_TEST.obj");
    this does NOT work, must get the wrapper
    */
-  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = 0;
+  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
   TBranch* otherBranch = events->GetBranch("edmtestOtherThings_OtherThing_testUserTag_TEST.");
   
-  CPPUNIT_ASSERT( otherBranch != 0);
+  CPPUNIT_ASSERT(otherBranch != nullptr);
   
   //edmtest::ThingCollection things;
-  edm::Wrapper<edmtest::ThingCollection>* pThings = 0;
+  edm::Wrapper<edmtest::ThingCollection>* pThings = nullptr;
   //NOTE: the period at the end is needed
   TBranch* thingBranch = events->GetBranch("edmtestThings_Thing__TEST.");
-  CPPUNIT_ASSERT( thingBranch != 0);
+  CPPUNIT_ASSERT( thingBranch != nullptr);
 
   int nev = events->GetEntries();
   for( int ev=0; ev<nev; ++ev) {
@@ -244,12 +244,12 @@ void testRefInROOT::testGoodChain()
   eventChain.Add("good.root");
   eventChain.Add("good_delta5.root");
 
-  edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
-  TBranch* othersBranch = 0;
+  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
+  TBranch* othersBranch = nullptr;
   eventChain.SetBranchAddress("edmtestOtherThings_OtherThing_testUserTag_TEST.",&pOthers,&othersBranch);
   
-  edm::Wrapper<edmtest::ThingCollection>* pThings = 0;
-  TBranch* thingsBranch = 0;
+  edm::Wrapper<edmtest::ThingCollection>* pThings = nullptr;
+  TBranch* thingsBranch = nullptr;
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.",&pThings,&thingsBranch);
   
   int nev = eventChain.GetEntries();
@@ -260,8 +260,8 @@ void testRefInROOT::testGoodChain()
     othersBranch->GetEntry(ev);
     thingsBranch->GetEntry(ev);
     eventChain.GetEntry(ev,0);
-    CPPUNIT_ASSERT(pOthers != 0);
-    CPPUNIT_ASSERT(pThings != 0);
+    CPPUNIT_ASSERT(pOthers != nullptr);
+    CPPUNIT_ASSERT(pThings != nullptr);
     checkMatch(pOthers->product(),pThings->product());
   }
   
@@ -271,13 +271,13 @@ void testRefInROOT::testMissingRef()
 {
    TFile file("other_only.root");
    TTree* events = dynamic_cast<TTree*>(file.Get(edm::poolNames::eventTreeName().c_str()));
-   CPPUNIT_ASSERT( events != 0);
-   if(events==0) return; // To silence Coverity
+   CPPUNIT_ASSERT(events != nullptr);
+   if(events == nullptr) return; // To silence Coverity
    
-   edm::Wrapper<edmtest::OtherThingCollection> *pOthers = 0;
+   edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
    TBranch* otherBranch = events->GetBranch("edmtestOtherThings_OtherThing_testUserTag_TEST.");
    
-   CPPUNIT_ASSERT( otherBranch != 0);
+   CPPUNIT_ASSERT(otherBranch != nullptr);
    
    int nev = events->GetEntries();
    for( int ev=0; ev<nev; ++ev) {
@@ -286,11 +286,9 @@ void testRefInROOT::testMissingRef()
       otherBranch->SetAddress(&pOthers);
       otherBranch->GetEntry(ev);
       
-      for(edmtest::OtherThingCollection::const_iterator itOther = pOthers->product()->begin(), 
-          itEnd=pOthers->product()->end();
-          itOther != itEnd; ++itOther) {
-         CPPUNIT_ASSERT(not itOther->ref.isAvailable());
-         CPPUNIT_ASSERT_THROW(itOther->ref.get(), cms::Exception);
+      for(auto const& prod : *pOthers->product()) {
+         CPPUNIT_ASSERT(not prod.ref.isAvailable());
+         CPPUNIT_ASSERT_THROW(prod.ref.get(), cms::Exception);
       }
       
    }   
@@ -303,18 +301,18 @@ void testRefInROOT::failChainWithMissingFile()
   eventChain.Add("good.root");
   eventChain.Add("thisFileDoesNotExist.root");
   
-  edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
+  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
   eventChain.SetBranchAddress("edmtestOtherThings_OtherThing_testUserTag_TEST.",&pOthers);
   
-  edm::Wrapper<edmtest::ThingCollection>* pThings = 0;
+  edm::Wrapper<edmtest::ThingCollection>* pThings = nullptr;
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.",&pThings);
   
   int nev = eventChain.GetEntries();
   for( int ev=0; ev<nev; ++ev) {
     std::cout <<"event #" <<ev<<std::endl;    
     eventChain.GetEntry(ev);
-    CPPUNIT_ASSERT(pOthers != 0);
-    CPPUNIT_ASSERT(pThings != 0);
+    CPPUNIT_ASSERT(pOthers != nullptr);
+    CPPUNIT_ASSERT(pThings != nullptr);
     checkMatch(pOthers->product(),pThings->product());
   }
   
@@ -324,23 +322,23 @@ void testRefInROOT::failDidNotCallGetEntryForEvents()
 {
   TFile file("good.root");
   TTree* events = dynamic_cast<TTree*>(file.Get(edm::poolNames::eventTreeName().c_str()));
-  CPPUNIT_ASSERT(events !=0);
-  if(events==0) return; // To silence Coverity
+  CPPUNIT_ASSERT(events != nullptr);
+  if(events == nullptr) return; // To silence Coverity
   
   /*
-   edmtest::OtherThingCollection* pOthers = 0;
+   edmtest::OtherThingCollection* pOthers = nullptr;
    TBranch* otherBranch = events->GetBranch("edmtestOtherThings_OtherThing_testUserTag_TEST.obj");
    this does NOT work, must get the wrapper
    */
-  edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
+  edm::Wrapper<edmtest::OtherThingCollection> *pOthers = nullptr;
   TBranch* otherBranch = events->GetBranch("edmtestOtherThings_OtherThing_testUserTag_TEST.");
   
-  CPPUNIT_ASSERT( otherBranch != 0);
+  CPPUNIT_ASSERT( otherBranch != nullptr);
   otherBranch->SetAddress(&pOthers);
   
   otherBranch->GetEntry(0);
   
-  CPPUNIT_ASSERT(pOthers->product() != 0);
+  CPPUNIT_ASSERT(pOthers->product() != nullptr);
 
   pOthers->product()->at(0).ref.get();
 }
@@ -348,15 +346,15 @@ void testRefInROOT::failDidNotCallGetEntryForEvents()
 void testRefInROOT::testThinning() {
   TFile file("good.root");
   TTree* events = dynamic_cast<TTree*>(file.Get(edm::poolNames::eventTreeName().c_str()));
-  CPPUNIT_ASSERT(events !=0);
-  if(events==0) return; // To silence Coverity
-  edm::Wrapper<std::vector<edmtest::TrackOfThings> > *pTracks =0;
+  CPPUNIT_ASSERT(events != nullptr);
+  if(events == nullptr) return; // To silence Coverity
+  edm::Wrapper<std::vector<edmtest::TrackOfThings> > *pTracks = nullptr;
   TBranch* tracksBranchD = events->GetBranch("edmtestTrackOfThingss_trackOfThingsProducerDPlus__TEST.");
   TBranch* tracksBranchG = events->GetBranch("edmtestTrackOfThingss_trackOfThingsProducerG__TEST.");
   TBranch* tracksBranchM = events->GetBranch("edmtestTrackOfThingss_trackOfThingsProducerM__TEST.");
-  CPPUNIT_ASSERT( tracksBranchD!= 0 &&
-                  tracksBranchG!= 0 &&
-                  tracksBranchM!= 0);
+  CPPUNIT_ASSERT( tracksBranchD != nullptr &&
+                  tracksBranchG != nullptr &&
+                  tracksBranchM != nullptr);
 
   std::vector<edmtest::TrackOfThings> const* vTracks = nullptr;
 
@@ -377,7 +375,7 @@ void testRefInROOT::testThinning() {
     tracksBranchD->SetAddress(&pTracks);
     tracksBranchD->GetEntry(ev);
     vTracks = pTracks->product();
-    CPPUNIT_ASSERT(vTracks != 0);
+    CPPUNIT_ASSERT(vTracks != nullptr);
     edmtest::TrackOfThings const& trackD = vTracks->at(0);
     CPPUNIT_ASSERT(trackD.ref1.isAvailable());
     CPPUNIT_ASSERT(trackD.ref1->a == 10 + offset);
@@ -419,7 +417,7 @@ void testRefInROOT::testThinning() {
     tracksBranchG->SetAddress(&pTracks);
     tracksBranchG->GetEntry(ev);
     vTracks = pTracks->product();
-    CPPUNIT_ASSERT(vTracks != 0);
+    CPPUNIT_ASSERT(vTracks != nullptr);
     edmtest::TrackOfThings const& trackG = vTracks->at(0);
     CPPUNIT_ASSERT(trackG.ref1.isAvailable());
     CPPUNIT_ASSERT(trackG.ref1->a == 20 + offset);
@@ -458,7 +456,7 @@ void testRefInROOT::testThinning() {
     tracksBranchM->SetAddress(&pTracks);
     tracksBranchM->GetEntry(ev);
     vTracks = pTracks->product();
-    CPPUNIT_ASSERT(vTracks != 0);
+    CPPUNIT_ASSERT(vTracks != nullptr);
 
     edmtest::TrackOfThings const& trackM0 = vTracks->at(0);
     CPPUNIT_ASSERT(!trackM0.ref1.isAvailable());

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
@@ -32,7 +32,7 @@
       your workers, you can create a new TList and assign it to 'itemsForProcessing' and then add the objects you 
       want passed into that list. 
       NOTE: you are responsible for deleting the created TList and for deleting all items held by the TList. The easiest
-      way to do this is to add a 'std::auto_ptr<TList>' member data to your Selector and then call 'SetOwner()' on the TList.
+      way to do this is to add a 'std::unique_ptr<TList>' member data to your Selector and then call 'SetOwner()' on the TList.
     2) 'terminate(TList&)'
        this is called after all processing has finished.  The TList& contains all the accumulated information
        from all the workers.

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -68,8 +68,8 @@ namespace edm {
      private:
       std::unique_ptr<WrapperBase> getTheProduct(BranchKey const& k) const;
       virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
-      virtual std::auto_ptr<EventEntryDescription> getProvenance_(BranchKey const&) const {
-        return std::auto_ptr<EventEntryDescription>();
+      virtual std::unique_ptr<EventEntryDescription> getProvenance_(BranchKey const&) const {
+        return std::unique_ptr<EventEntryDescription>();
       }
       virtual void mergeReaders_(DelayedReader*) override {}
       virtual void reset_() override {}
@@ -270,7 +270,7 @@ Bool_t
 TFWLiteSelectorBasic::Process(Long64_t iEntry) {
    //std::cout << "Process start" << std::endl;
    if(everythingOK_) {
-      std::auto_ptr<edm::EventAuxiliary> eaux(new edm::EventAuxiliary());
+      std::unique_ptr<edm::EventAuxiliary> eaux = std::make_unique<edm::EventAuxiliary>();
       edm::EventAuxiliary& aux = *eaux;
       edm::EventAuxiliary* pAux= eaux.get();
       TBranch* branch = m_->tree_->GetBranch(edm::BranchTypeToAuxiliaryBranchName(edm::InEvent).c_str());
@@ -429,7 +429,7 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
   m_->pointerToBranchBuffer_.erase(m_->pointerToBranchBuffer_.begin(),
                                    m_->pointerToBranchBuffer_.end());
 
-  std::auto_ptr<edm::ProductRegistry> newReg(new edm::ProductRegistry());
+  std::unique_ptr<edm::ProductRegistry> newReg = std::make_unique<edm::ProductRegistry>();
 
   edm::ProductRegistry::ProductList& prodList = m_->reg_->productListUpdator();
   {

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.cc
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.cc
@@ -16,18 +16,18 @@ void ThingsTSelector::begin(TList*&)
 }
 
 void ThingsTSelector::preProcessing(const TList*, TList& out ) {
-  if(0!=h_a) {
+  if(nullptr != h_a) {
      out.Remove(h_a);
      delete h_a;
-     h_a=0;
+     h_a = nullptr;
   }
   h_a  = new TH1F( kA , "a"  , 100,  0, 20 );
   out.Add(h_a);
 
-  if(0!=h_refA) {
+  if(nullptr != h_refA) {
      out.Remove(h_refA);
      delete h_refA;
-     h_refA=0;
+     h_refA = nullptr;
   }
   h_refA  = new TH1F( kRefA , "refA"  , 100,  0, 20 );
   out.Add(h_refA);
@@ -82,7 +82,7 @@ void ThingsTSelector::terminate(TList& out) {
   TCanvas * canvas = new TCanvas( );
   {
      TObject* hist = out.FindObject(kA);
-     if(0 != hist) {
+     if(nullptr != hist) {
 	hist->Draw();
 	canvas->SaveAs( "a.jpg" );
      } else {
@@ -91,7 +91,7 @@ void ThingsTSelector::terminate(TList& out) {
   }
   {
      TObject* hist = out.FindObject(kRefA);
-     if(0 != hist) {
+     if(nullptr != hist) {
 	hist->Draw();
 	canvas->SaveAs( "refA.jpg" );
      } else {

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h
@@ -14,7 +14,7 @@
 namespace tfwliteselectortest {
 class ThingsTSelector : public TFWLiteSelectorBasic {
 public :
-      ThingsTSelector() : h_a(0), h_refA(0) {}
+      ThingsTSelector() : h_a(nullptr), h_refA(nullptr) {}
       void begin(TList*&);
       void preProcessing(const TList*, TList&);
       void process(const edm::Event&);

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.cc
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.cc
@@ -81,7 +81,7 @@ void ThingsTSelector2::terminate(TList& out) {
   TCanvas * canvas = new TCanvas( );
   {
      TObject* hist = out.FindObject(kA);
-     if(0!=hist) {
+     if(nullptr != hist) {
 	hist->Draw();
 	canvas->SaveAs( "a.jpg" );
      } else {
@@ -91,7 +91,7 @@ void ThingsTSelector2::terminate(TList& out) {
   std::cout <<"refA"<< std::endl;
   {
      TObject* hist = out.FindObject(kRefA);
-     if( 0 != hist ) {
+     if(nullptr != hist) {
 	hist->Draw();
 	canvas->SaveAs( "refA.jpg" );
      } else {


### PR DESCRIPTION
This PR upgrades the FWLite code to C++11/C++14 standards.
This includes:
1) replacing auto_ptr with unique_ptr
2) using make_shared and make_unique where appropriate
3) Replacing 0 with nullptr where applicable
4) changing iterator loops to range based for loops where appropriate.
5) using the auto keyword in for loops.
Also, the const qualifier was added to some for loops where it was missing.
Some of these changes are prerequisites for implementing propagate_const in FWLite code,
which will be done in subsequent PR's.
