### PR TITLE
Changing L1T Calo Params in HI MC Global Tag

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '75X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v12',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v13',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '75X_dataRun1_v13',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Heavy Ions scenario** : [75X_mcRun2_HeavyIon_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/75X_mcRun2_HeavyIon_v13) as [75X_mcRun2_HeavyIon_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/75X_mcRun2_HeavyIon_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/75X_mcRun2_HeavyIon_v13/75X_mcRun2_HeavyIon_v12): 
  - updated L1T Calo Parameters configuration changing the thresholds for the stage-1 MB bits. 
