### PR TITLE
FastSim BugFix : PreMix : fix segfault, fix L1 reco, fix digisim link for muons, fix track validation

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1091,7 +1091,6 @@ class ConfigBuilder(object):
 	if self._options.fast:
 		self.SIMDefaultCFF = 'FastSimulation.Configuration.SimIdeal_cff'
 		self.RECODefaultCFF= 'FastSimulation.Configuration.Reconstruction_AftMix_cff'
-                self.EVTCONTDefaultCFF = "FastSimulation.Configuration.EventContent_cff"
                 self.VALIDATIONDefaultCFF = "FastSimulation.Configuration.Validation_cff"
 		self.RECOBEFMIXDefaultCFF = 'FastSimulation.Configuration.Reconstruction_BefMix_cff'
 		self.RECOBEFMIXDefaultSeq = 'reconstruction_befmix'

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -92,6 +92,17 @@ from HLTrigger.Configuration.HLTrigger_EventContent_cff import *
 from DQMOffline.Configuration.DQMOffline_EventContent_cff import *
 #
 #
+# FastSim
+#
+#
+from FastSimulation.Configuration.EventContent_cff import FASTPUEventContent
+import FastSimulation.Configuration.EventContent_cff as fastSimEC
+from Configuration.StandardSequences.Eras import eras
+if eras.fastSim.isChosen():
+    RecoLocalTrackerRECO.outputCommands = fastSimEC.RecoLocalTracker.outputCommands
+    RecoLocalTrackerFEVT.outputCommands = fastSimEC.RecoLocalTracker.outputCommands
+    SimG4CoreRAW = fastSimEC.SimRAW
+    SimG4CoreRECO = fastSimEC.SimRECO
 
 #
 #
@@ -514,6 +525,8 @@ PREMIXEventContent.outputCommands.append('keep PixelDigiSimLinkedmDetSetVector_s
 PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simMuonCSCDigis_*_*')
 PREMIXEventContent.outputCommands.append('keep RPCDigiSimLinkedmDetSetVector_*_*_*')
 PREMIXEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
+if eras.fastSim.isChosen():
+    PREMIXEventContent.outputCommands.extend(fastSimEC.extraPremixContent)
 
 PREMIXRAWEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
 PREMIXRAWEventContent.outputCommands.append('keep CrossingFramePlaybackInfoNew_*_*_*')
@@ -525,7 +538,8 @@ PREMIXRAWEventContent.outputCommands.append('keep *_*_MuonCSCStripDigiSimLinks_*
 PREMIXRAWEventContent.outputCommands.append('keep *_*_MuonCSCWireDigiSimLinks_*')
 PREMIXRAWEventContent.outputCommands.append('keep *_*_RPCDigiSimLink_*')
 PREMIXRAWEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
-
+if eras.fastSim.isChosen():
+    PREMIXEventContent.outputCommands.extend(fastSimEC.extraPremixContent)
 
 REPACKRAWSIMEventContent.outputCommands.extend(REPACKRAWEventContent.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend(SimG4CoreRAW.outputCommands)
@@ -753,3 +767,10 @@ from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroE
 
 MINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
+
+if eras.fastSim.isChosen():
+    fastSimEC.replaceDigisWithSimDigis(FEVTDEBUGHLTEventContent.outputCommands)
+    fastSimEC.replaceDigisWithSimDigis(FEVTDEBUGEventContent.outputCommands)
+    fastSimEC.replaceDigisWithSimDigis(RECOSIMEventContent.outputCommands)
+    fastSimEC.replaceDigisWithSimDigis(AODSIMEventContent.outputCommands)
+    fastSimEC.replaceDigisWithSimDigis(MINIAODSIMEventContent.outputCommands)

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -768,9 +768,9 @@ from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroE
 MINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
 
+# in fastsim, normal digis are edaliases of simdigis
+# drop the simdigis to avoid complaints from the outputmodule related to duplicated branches
 if eras.fastSim.isChosen():
-    fastSimEC.replaceDigisWithSimDigis(FEVTDEBUGHLTEventContent.outputCommands)
-    fastSimEC.replaceDigisWithSimDigis(FEVTDEBUGEventContent.outputCommands)
-    fastSimEC.replaceDigisWithSimDigis(RECOSIMEventContent.outputCommands)
-    fastSimEC.replaceDigisWithSimDigis(AODSIMEventContent.outputCommands)
-    fastSimEC.replaceDigisWithSimDigis(MINIAODSIMEventContent.outputCommands)
+    for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent]:
+        fastSimEC.dropSimDigis(_entry.outputCommands)
+    

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -619,7 +619,7 @@ FS_PREMIXUP15_PU25_OVERLAY = merge([
         {"-s" : "GEN,SIM,RECOBEFMIX,DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,L1Reco,RECO,HLT:@relval25ns,VALIDATION",
          "--datamix" : "PreMix",
          "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW"%(baseDataSetRelease[8],),
-         "--customise":"SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1"
+         "--customise":"SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput"
          },
         Kby(100,500),step1FastUpg2015Defaults])
 

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -68,4 +68,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -68,4 +68,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,6 +41,4 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
-
-
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,6 +41,6 @@ if eras.fastSim.isChosen():
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
     loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
 

--- a/Configuration/StandardSequences/python/SimL1Emulator_cff.py
+++ b/Configuration/StandardSequences/python/SimL1Emulator_cff.py
@@ -9,5 +9,5 @@ if eras.fastSim.isChosen():
     # consider moving these mods to the HLT configuration
     from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
     loadTriggerDigiAliases()
-    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis
+    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis,caloStage1LegacyFormatDigis
     

--- a/Configuration/StandardSequences/python/SimL1Emulator_cff.py
+++ b/Configuration/StandardSequences/python/SimL1Emulator_cff.py
@@ -9,5 +9,5 @@ if eras.fastSim.isChosen():
     # consider moving these mods to the HLT configuration
     from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
     loadTriggerDigiAliases()
-    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis
+    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis
     

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -9,14 +9,15 @@ hcalDigis = None
 muonDTDigis = None
 muonCSCDigis = None
 muonRPCDigis = None
-gtDigisAliasInfo = None
-gmtDigisAliasInfo = None
+caloStage1LegacyFormatDigis = None
+gtDigis = None
+gmtDigis = None
 
 def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -95,6 +96,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("DTLayerIdDTDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
                     )
                 )
            }
@@ -105,6 +109,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("RPCDetIdRPCDigiMuonDigiCollection")
+                    ),
+                cms.PSet(
+                    type = cms.string("RPCDigiSimLinkedmDetSetVector")
                     )
                 )
            }
@@ -115,14 +122,35 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCWireDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM")),
+                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM"),
+                    toProductInstance = cms.string("MuonCSCWireDigi")),
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCStripDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM")
-                    )
+                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM"),
+                    toProductInstance = cms.string("MuonCSCStripDigi")),
+                cms.PSet(
+                    type = cms.string('StripDigiSimLinkedmDetSetVector')
+                    ),
                 )
            }
           )
+    
+    # also sim in case of premixing?
+    caloStage1LegacyFormatDigis = cms.EDAlias(
+        **{ "simCaloStage1LegacyFormatDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
+
 
 def loadTriggerDigiAliases():
 

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -17,7 +17,7 @@ def loadDigiAliases(premix=False):
 
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,caloStage1LegacyFormatDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
 
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
@@ -135,7 +135,10 @@ def loadDigiAliases(premix=False):
            }
           )
     
-    # also sim in case of premixing?
+def loadTriggerDigiAliases():
+
+    global gctDigis,gtDigis,gmtDigis,caloStage1LegacyFormatDigis
+
     caloStage1LegacyFormatDigis = cms.EDAlias(
         **{ "simCaloStage1LegacyFormatDigis" :
                 cms.VPSet(
@@ -151,25 +154,34 @@ def loadDigiAliases(premix=False):
                 cms.PSet(type = cms.string("L1GctInternJetDatas")),
                 cms.PSet(type = cms.string("L1GctJetCands")))})
 
-
-def loadTriggerDigiAliases():
-
-    global gtDigis,gmtDigis
+    gctDigis = cms.EDAlias(
+        **{ "simGctDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GctEmCands")),
+                cms.PSet(type = cms.string("L1GctEtHads")),
+                cms.PSet(type = cms.string("L1GctEtMisss")),
+                cms.PSet(type = cms.string("L1GctEtTotals")),
+                cms.PSet(type = cms.string("L1GctHFBitCountss")),
+                cms.PSet(type = cms.string("L1GctHFRingEtSumss")),
+                cms.PSet(type = cms.string("L1GctHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternEtSums")),
+                cms.PSet(type = cms.string("L1GctInternHtMisss")),
+                cms.PSet(type = cms.string("L1GctInternJetDatas")),
+                cms.PSet(type = cms.string("L1GctJetCands")))})
 
     gtDigis = cms.EDAlias(
-        simGtDigis=
-        cms.VPSet(
-            cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")),
-            cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord"))
-            )
-        )
+        **{ "simGtDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1GlobalTriggerEvmReadoutRecord")),
+                cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord")),
+                cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")))})
     
 
     gmtDigis = cms.EDAlias (
         simGmtDigis = 
         cms.VPSet(
-            cms.PSet(type = cms.string("L1MuGMTReadoutCollection"))
+            cms.PSet(type = cms.string("L1MuGMTReadoutCollection")),
+            cms.PSet(type = cms.string("L1MuGMTCands"))
             )
         )
     
-

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -97,9 +97,9 @@ def loadDigiAliases(premix=False):
                 cms.PSet(
                     type = cms.string("DTLayerIdDTDigiMuonDigiCollection")
                     ),
-                cms.PSet(
-                    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
-                    )
+                #cms.PSet(
+                #    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
+                #    )
                 )
            }
           )
@@ -110,9 +110,9 @@ def loadDigiAliases(premix=False):
                 cms.PSet(
                     type = cms.string("RPCDetIdRPCDigiMuonDigiCollection")
                     ),
-                cms.PSet(
-                    type = cms.string("RPCDigiSimLinkedmDetSetVector")
-                    )
+                #cms.PSet(
+                #    type = cms.string("RPCDigiSimLinkedmDetSetVector")
+                #    )
                 )
            }
           )
@@ -128,9 +128,9 @@ def loadDigiAliases(premix=False):
                     type = cms.string("CSCDetIdCSCStripDigiMuonDigiCollection"),
                     fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM"),
                     toProductInstance = cms.string("MuonCSCStripDigi")),
-                cms.PSet(
-                    type = cms.string('StripDigiSimLinkedmDetSetVector')
-                    ),
+                #cms.PSet(
+                #    type = cms.string('StripDigiSimLinkedmDetSetVector')
+                #    ),
                 )
            }
           )

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -1,288 +1,53 @@
 import FWCore.ParameterSet.Config as cms
-#####################################################################
-#
-# Event Content definition
-#
-#####################################################################
-from Configuration.EventContent.EventContent_cff import *
 
-#####################################################################
-# The simHits part is definitely different in FastSim
-#####################################################################
+# this method replaces outputcommands that apply to normal digis to simdigis
+# whenever using this, make sure that this is what you actually want to accomplish
+def replaceDigisWithSimDigis(outputCommands):
+    for e in range(0,len(outputCommands)):
+        pieces = outputCommands[e].split("_")
+        if len(pieces) != 4:
+            continue
+        label = pieces[1]
+        pos = label.rfind("Digis")
+        if  pos <= 0 or pos != (len(label) - 5):
+            continue
+        if label.find("sim") == 0:
+            continue
+        label = "sim"+label[0].upper()+label[1:]
+        pieces[1] = label
+        outputCommands[e] = "_".join(pieces)
+    
+extraPremixContent = ['keep *_mix_generalTracks_*']
 
-
-
-FastSimCoreFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_famosPileUp_*_*', 
-        'keep *_famosSimHits_*_*',
-        'drop *_g4SimHits_*_*', # if an EDAlias creates this, it must be dropped to avoid a clash
-        'keep *_MuonSimHits_*_*')
-)
-
-FastSimCoreFEVT.outputCommands.extend(GeneratorInterfaceRAW.outputCommands)
-
-
-#RECO content
-FastSimCoreRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep SimTracks_famosSimHits_*_*', 
-        'keep SimVertexs_famosSimHits_*_*')
-)
-FastSimCoreRECO.outputCommands.extend(GeneratorInterfaceRECO.outputCommands)
-
-#AOD content
-FastSimCoreAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-FastSimCoreAOD.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
-
-#####################################################################
-# The Tracker RecHits are also different
-#####################################################################
-
-#Full Event content 
-FastSimRecoLocalTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_siTrackerGaussianSmearingRecHits_*_*')
-)
-#RECO content
-FastSimRecoLocalTrackerRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-#AOD content
-FastSimRecoLocalTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-
-
-#####################################################################
-# CaloJet+Tracks are apparently saved nowhere
-# Let's save them in the fast simulation (AOD only)
-#####################################################################
-FastSimCJPT = cms.PSet(
+RecoLocalTracker = cms.PSet(
     outputCommands = cms.untracked.vstring(
-         'keep *_JetPlusTrackZSPCorJetIcone5_*_*',
-         'keep *_ZSPJetCorJetIcone5_*_*'
-    )
-)
+        'keep *_siTrackerGaussianSmearingRecHits_*_*'
+        ))
 
-#####################################################################
-# The Calo RecHits are also different
-#####################################################################
+SimRAW = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep edmHepMCProduct_source_*_*',
+        'keep *_famosSimHits_*_*',
+        'keep *_MuonSimHits_*_*',
+        ))
 
-#Full Event content 
-FastSimRecoLocalCaloFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_caloRecHits_*_*', 
-        'keep *_hcalRecHits_*_*',
-        'keep EBDigiCollection_ecalRecHit_*_*',
-        'keep EEDigiCollection_ecalRecHit_*_*')
-#        'keep *_particleFlowRecHit_*_*')
-)
-
-#RECO content
-FastSimRecoLocalCaloRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_caloRecHits_*_*', 
-        'keep *_hcalRecHits_*_*',
-        'keep EBDigiCollection_ecalRecHit_*_*',
-        'keep EEDigiCollection_ecalRecHit_*_*')
-#        'keep *_particleFlowRecHit_*_*')
-)
-
-#AOD content
-FastSimRecoLocalCaloAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-
-#####################################################################
-# The Tracker Tracks are also different
-#####################################################################
-
-#Full Event content 
-FastSimRecoTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_iterativeGSWithMaterialTracks_*_*',
-                                           'keep *_generalTracksBeforeMixing_*_*')
-    )
-
-#RECO content
-FastSimRecoTrackerRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_iterativeGSWithMaterialTracks_*_*',
-                                           'keep *_generalTracksBeforeMixing_*_*')
-)
-
-#AOD content
-FastSimRecoTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_iterativeGSWithMaterialTracks_*_*',
-                                           #'keep *_generalTracksBeforeMixing_*_*'
-                                           )
-)
-
-
-#####################################################################
-# new Particle Flow Collection with "Fake" Neutral Hadrons
-#####################################################################
-
-#Full Event content 
-FastSimParticleFlowFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoPFCandidates_FSparticleFlow_*_*',
-                                           #stuff added for two-step processing (simWithSomeReco followed by reconstructionHighLevel):
-                                           'keep *_muon*_*_*',
-                                           'keep *_towerMaker*_*_*',
-                                           'keep *_particleFlow*_*_*',
-                                           'keep *_pf*_*_*',
-                                           'keep *_*DetId*_*_*')
-)
-
-#RECO content 
-FastSimParticleFlowRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoPFCandidates_FSparticleFlow_*_*')
-)
-
-#AOD content 
-FastSimParticleFlowAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoPFCandidates_FSparticleFlow_*_*')
-)
-
-
-
-
-# Addition to the event content
-# We don't need to remove anything, as the corresponding products are
-# not produced anyway in a FastSimulation job.
-
-#####################################################################
-#
-# AOD Data Tier definition
-#
-#####################################################################
-
-AODEventContent.outputCommands.extend(FastSimRecoLocalTrackerAOD.outputCommands)
-AODEventContent.outputCommands.extend(FastSimRecoLocalCaloAOD.outputCommands)
-AODEventContent.outputCommands.extend(FastSimRecoTrackerAOD.outputCommands)
-AODEventContent.outputCommands.extend(FastSimParticleFlowAOD.outputCommands)
-
-#####################################################################
-#
-# AODSIM Data Tier definition
-#
-#####################################################################
-
-AODSIMEventContent.outputCommands.extend(FastSimCoreAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(FastSimRecoLocalTrackerAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(FastSimRecoLocalCaloAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(FastSimRecoTrackerAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(FastSimParticleFlowAOD.outputCommands)
-
-#####################################################################
-#
-# RECO Data Tier definition
-#
-#####################################################################
-
-RECOEventContent.outputCommands.extend(FastSimRecoLocalTrackerRECO.outputCommands)
-RECOEventContent.outputCommands.extend(FastSimRecoLocalCaloRECO.outputCommands)
-RECOEventContent.outputCommands.extend(FastSimRecoTrackerRECO.outputCommands)
-RECOEventContent.outputCommands.extend(FastSimParticleFlowRECO.outputCommands)
-
-#####################################################################
-#
-# RECOSIM Data Tier definition
-#
-#####################################################################
-
-RECOSIMEventContent.outputCommands.extend(FastSimCoreRECO.outputCommands)
-RECOSIMEventContent.outputCommands.extend(FastSimRecoLocalTrackerRECO.outputCommands)
-RECOSIMEventContent.outputCommands.extend(FastSimRecoLocalCaloRECO.outputCommands)
-RECOSIMEventContent.outputCommands.extend(FastSimRecoTrackerRECO.outputCommands)
-RECOSIMEventContent.outputCommands.extend(FastSimParticleFlowRECO.outputCommands)
-
-#####################################################################
-#
-# RECODEBUG Data Tier definition
-#
-#####################################################################
-
-RECODEBUGEventContent.outputCommands.extend(FastSimCoreRECO.outputCommands)
-RECODEBUGEventContent.outputCommands.extend(FastSimRecoLocalTrackerRECO.outputCommands)
-RECODEBUGEventContent.outputCommands.extend(FastSimRecoLocalCaloRECO.outputCommands)
-RECODEBUGEventContent.outputCommands.extend(FastSimRecoTrackerRECO.outputCommands)
-RECODEBUGEventContent.outputCommands.extend(FastSimParticleFlowRECO.outputCommands)
-
-####################################################################
-#
-# FEVT Data Tier re-definition
-#
-#####################################################################
-
-FEVTEventContent.outputCommands.extend(FastSimRecoLocalTrackerFEVT.outputCommands)
-FEVTEventContent.outputCommands.extend(FastSimRecoLocalCaloFEVT.outputCommands)
-FEVTEventContent.outputCommands.extend(FastSimRecoTrackerFEVT.outputCommands)
-FEVTEventContent.outputCommands.extend(FastSimParticleFlowFEVT.outputCommands) 
-
-####################################################################
-#
-# FEVTSIM Data Tier re-definition
-#
-#####################################################################
-
-FEVTSIMEventContent.outputCommands.extend(FastSimCoreFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(FastSimRecoLocalTrackerFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(FastSimRecoLocalCaloFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(FastSimRecoTrackerFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(FastSimParticleFlowFEVT.outputCommands) 
-
-#####################################################################
-#
-# FEVTDEBUG Data Tier re-definition
-#
-#####################################################################
-
-FEVTDEBUGEventContent.outputCommands.extend(FastSimCoreFEVT.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(FastSimRecoLocalTrackerFEVT.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(FastSimRecoLocalCaloFEVT.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(FastSimRecoTrackerFEVT.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(FastSimParticleFlowFEVT.outputCommands) 
-
-#####################################################################
-#
-# FEVTDEBUGHLT  Data Tier re-definition
-#
-#####################################################################
-FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimCoreFEVT.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimRecoLocalTrackerFEVT.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimRecoLocalCaloFEVT.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimRecoTrackerFEVT.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimParticleFlowFEVT.outputCommands) 
-
-##################
-# get rid of some edaliases in the output
-##################
-for _entry in [FEVTDEBUGEventContent,FEVTSIMEventContent,GENRAWEventContent,FEVTDEBUGHLTEventContent,HLTDEBUGEventContent,HLTDebugFEVT,HLTDebugRAW,RAWDEBUGHLTEventContent,RAWRECODEBUGHLTEventContent,RAWRECOSIMHLTEventContent,RAWSIMHLTEventContent,]:
-    _entry.outputCommands.append('drop *_ecalPreshowerDigis_*_*')
-    _entry.outputCommands.append('drop *_ecalDigis_*_*')
-    _entry.outputCommands.append('drop *_hcalDigis_*_*')
-    _entry.outputCommands.append('drop *_muonDTDigis_*_*')
-    _entry.outputCommands.append('drop *_muonCSCDigis_*_*')
-    _entry.outputCommands.append('drop *_muonRPCDigis_*_*')
-    _entry.outputCommands.append('drop *_gtDigis_*_*')
-    _entry.outputCommands.append('drop *_hltIter*_*_*')
-    _entry.outputCommands.append('drop *_hlt*Digis_*_*')
-    _entry.outputCommands.append('drop *_gmtDigis_*_*')
-
-#####################################################################
-#
-# To be used only to create the MinBias sample for "new mixing" (--eventcontent=FASTPU)
-#
-#####################################################################
+SimRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep edmHepMCProduct_source_*_*',
+        'keep SimTracks_famosSimHits_*_*',
+        'keep SimVertexs_famosSimHits_*_*',
+        ))
 
 FASTPUEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *', 
-                                           'keep *_famosSimHits_*_*',
-                                           'keep *_MuonSimHits_*_*',
-                                           'drop *_famosSimHits_VertexTypes_*',    
-                                           'keep *_generalTracksBeforeMixing_*_*',
-                                           'drop *_generalTracksBeforeMixing_MVAValues_*',
-                                           'drop *_generalTracksBeforeMixing_QualityMasks_*',
-                                           'keep edmHepMCProduct_generatorSmeared_*_*'
-                                           )
-    )
+    outputCommands = cms.untracked.vstring(
+        'drop *', 
+        'keep *_famosSimHits_*_*',
+        'keep *_MuonSimHits_*_*',
+        'drop *_famosSimHits_VertexTypes_*',    
+        'keep *_generalTracksBeforeMixing_*_*',
+        'drop *_generalTracksBeforeMixing_MVAValues_*',
+        'drop *_generalTracksBeforeMixing_QualityMasks_*',
+        'keep edmHepMCProduct_generatorSmeared_*_*'
+        ))
 
 
-PREMIXEventContent.outputCommands.extend(['keep *_mix_generalTracks_*'])

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -1,22 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-# this method replaces outputcommands that apply to normal digis to simdigis
-# whenever using this, make sure that this is what you actually want to accomplish
-def replaceDigisWithSimDigis(outputCommands):
-    for e in range(0,len(outputCommands)):
-        pieces = outputCommands[e].split("_")
-        if len(pieces) != 4:
-            continue
-        label = pieces[1]
-        pos = label.rfind("Digis")
-        if  pos <= 0 or pos != (len(label) - 5):
-            continue
-        if label.find("sim") == 0:
-            continue
-        label = "sim"+label[0].upper()+label[1:]
-        pieces[1] = label
-        outputCommands[e] = "_".join(pieces)
-    
+def dropSimDigis(outputCommands):
+    outputCommands.append("drop *_sim*Digis*_*_*")
+ 
 extraPremixContent = ['keep *_mix_generalTracks_*']
 
 RecoLocalTracker = cms.PSet(
@@ -49,5 +35,3 @@ FASTPUEventContent = cms.PSet(
         'drop *_generalTracksBeforeMixing_QualityMasks_*',
         'keep edmHepMCProduct_generatorSmeared_*_*'
         ))
-
-

--- a/FastSimulation/Configuration/python/L1Reco_cff.py
+++ b/FastSimulation/Configuration/python/L1Reco_cff.py
@@ -9,35 +9,6 @@ from L1Trigger.Configuration.L1Reco_cff import l1extraParticles
 # imported into this namespace, i.e. "from <module> import *".
 from L1Trigger.Configuration.ConditionalStage1Configuration_cff import *
 
-# some collections have different labels
-def _changeLabelForFastSim( object ) :
-    """
-    Takes an InputTag, changes the first letter of the module label to a capital
-    and adds "sim" in front, e.g. "gctDigid" -> "simGctDigis".
-    This works for both Run 1 and Run 2 collections.
-    """
-    object.moduleLabel="sim"+object.moduleLabel[0].upper()+object.moduleLabel[1:]
-
-_changeLabelForFastSim( l1extraParticles.isolatedEmSource )
-_changeLabelForFastSim( l1extraParticles.nonIsolatedEmSource )
-
-_changeLabelForFastSim( l1extraParticles.centralJetSource )
-_changeLabelForFastSim( l1extraParticles.tauJetSource )
-_changeLabelForFastSim( l1extraParticles.isoTauJetSource )
-_changeLabelForFastSim( l1extraParticles.forwardJetSource )
-
-_changeLabelForFastSim( l1extraParticles.etTotalSource )
-_changeLabelForFastSim( l1extraParticles.etHadSource )
-_changeLabelForFastSim( l1extraParticles.htMissSource )
-_changeLabelForFastSim( l1extraParticles.etMissSource )
-
-_changeLabelForFastSim( l1extraParticles.hfRingEtSumsSource )
-_changeLabelForFastSim( l1extraParticles.hfRingBitCountsSource )
-
-# This one is subtly different, but is the same for Run 1 and Run 2 FastSim
-l1extraParticles.muonSource = cms.InputTag('simGmtDigis')
-
-
 # must be set to true when used in HLT, as is the case for FastSim
 l1extraParticles.centralBxOnly = True
 

--- a/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
+++ b/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
@@ -4,14 +4,10 @@ def customiseForPreMixingInput(process):
     from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
 
     # Replace TrackingParticles and TrackingVertices globally
-    for s in process.paths_().keys():
-        massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True) 
-
-    for s in process.endpaths_().keys():
-        massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True)
-
-    
-
+    # only apply on validation and dqm: we don't want to apply this in the mixing and digitization sequences
+    for s in process.paths_().keys() + process.endpaths_().keys():
+        if s.lower().find("validation")>= 0 or s.lower().find("dqm") >= 0:
+            massSearchReplaceAnyInputTag(getattr(process, s), cms.InputTag("mix", "MergedTrackTruth"), cms.InputTag("mixData", "MergedTrackTruth"), skipLabelTest=True) 
 
     # Replace Pixel/StripDigiSimLinks only for the known modules
     def replaceInputTag(tag, old, new):
@@ -64,7 +60,6 @@ def customiseForPreMixingInput(process):
         if analyzer.type_() == "SiStripRecHitsValid":
             replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
             replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-
 
 
 


### PR DESCRIPTION
replaces #13071, #13110 

Lots of fixes in one pr, but they are all entangled
### Fix L1 reco, fix seg fault in premix relvals

FastSim no longer runs
SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1
because it overwrites modification defined in the fastsim era and the run2 eras

New EDAlias for caloStage1LegacyFormatDigis to make the l1extraParticles function properly.

Note: FullSim still runs SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1 in the DIGI step.
At some point also FullSim should move away from this.
### Fix digi-sim links for muons

FastSim now runs
SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput
This customisation function should not affect anything but validation and dqm,
and the customisation function was modified accordingly.
Note: FullSim had never trouble with this because there the customisation function is only applied on the RECO,VALIDATION,DQM jobs.
### Fix track validation

Thanks to SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput, the tracking particle collection should now include PU tracks
