### PR TITLE
Add QIETypes to es_hardcode for phase 1 upgrade customization

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -31,6 +31,7 @@ def customise_HcalPhase1(process):
                 'RecoParams',
                 'RespCorrs',
                 'QIEData',
+                'QIETypes',
                 'Gains',
                 'Pedestals',
                 'PedestalWidths',


### PR DESCRIPTION
This fixes an HGCal unit test in RecoLocalCalo/HGCalRecProducers.
