### PR TITLE
fixed macros to be compatible with Root 6

### DIFF
--- a/Geometry/TrackerCommonData/data/Materials/Makefile
+++ b/Geometry/TrackerCommonData/data/Materials/Makefile
@@ -2,7 +2,7 @@
 f77=g77
 cflags=-O -g -c
 link=g77
-libs=`cernlib -v pro geant pawlib graflib/X11 packlib mathlib kernlib`
+libs=`cernlib geant pawlib graflib/X11 packlib mathlib kernlib`
 linkopts=-v
 INCS = /usr/include/
 

--- a/Validation/Geometry/test/ECALMaterialBudgetCompare.C
+++ b/Validation/Geometry/test/ECALMaterialBudgetCompare.C
@@ -6,8 +6,8 @@ void ECALMaterialBudgetCompare()
 {
 
  gROOT ->Reset();
- char*  rfilename = "old_matbdg_ECAL.root";
- char*  sfilename = "new_matbdg_ECAL.root";
+ const char*  rfilename = "old_matbdg_ECAL.root";
+ const char*  sfilename = "new_matbdg_ECAL.root";
 
  int rcolor = 2;
  int scolor = 4;

--- a/Validation/Geometry/test/MaterialBudget.C
+++ b/Validation/Geometry/test/MaterialBudget.C
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <fstream>
 #include <cmath>
+#include <stdlib.h>
 
 // data dirs
 TString theDirName = "Images";
@@ -33,16 +34,25 @@ TProfile* prof_x0_str_ELE;
 TProfile* prof_x0_str_OTH;
 TProfile* prof_x0_str_AIR;
 //
+TProfile* prof_l0_det_total;
+//
 TProfile2D* prof2d_x0_det_total;
 //
 unsigned int iFirst = 1;
 unsigned int iLast  = 9;
 //
 
+//forward declaration of functions
+void createPlots(TString plot);
+void create2DPlots(TString plot);
+void createRatioPlots(TString plot);
+void drawEtaValues();
+void makeColorTable();
+
 using namespace std;
 
 // Main
-MaterialBudget(TString detector) {
+void MaterialBudget(TString detector) {
 
   //
   gROOT->SetStyle("Plain");
@@ -58,7 +68,7 @@ MaterialBudget(TString detector) {
      && theDetector!="InnerTracker"
      ){
     cerr << "MaterialBudget - ERROR detector not found " << theDetector << endl;
-    break;
+    exit(0);
   }
   //
   
@@ -156,7 +166,7 @@ void createPlots(TString plot) {
   prof_x0_det_ELE   = (TProfile*)theDetectorFile->Get(Form("%u", 500 + plotNumber));
   prof_x0_det_OTH   = (TProfile*)theDetectorFile->Get(Form("%u", 600 + plotNumber));
   prof_x0_det_AIR   = (TProfile*)theDetectorFile->Get(Form("%u", 700 + plotNumber));
-  
+
   // histos
   TH1D* hist_x0_total = (TH1D*)prof_x0_det_total->ProjectionX();
   TH1D* hist_x0_SUP   = (TH1D*)prof_x0_det_SUP->ProjectionX();
@@ -165,7 +175,7 @@ void createPlots(TString plot) {
   TH1D* hist_x0_COL   = (TH1D*)prof_x0_det_COL->ProjectionX();
   TH1D* hist_x0_ELE   = (TH1D*)prof_x0_det_ELE->ProjectionX();
   TH1D* hist_x0_OTH   = (TH1D*)prof_x0_det_OTH->ProjectionX();
-  TH1D* hist_x0_AIR   = (TH1D*)prof_x0_det_AIR->ProjectionX();
+  TH1D* hist_x0_AIR   = (TH1D*)prof_x0_det_AIR->ProjectionX();  
   //
   if(theDetector=="TrackerSum" || theDetector=="Pixel" || theDetector=="Strip" || theDetector=="InnerTracker") {
     TString subDetector = "TIB";
@@ -303,6 +313,7 @@ void create2DPlots(TString plot) {
   unsigned int plotNumber = 0;
   TString abscissaName = "dummy";
   TString ordinateName = "dummy";
+  TString quotaName = "dummy";
   Int_t zLog = 0;
   Int_t iDrawEta = 0;
   Int_t iRebin = 0; //Rebin
@@ -657,7 +668,7 @@ void createRatioPlots(TString plot) {
 void drawEtaValues(){
 
   //Add eta labels
-  Float_t etas[33] = {-3.4, -3.0, -2.8, -2.6, -2.4, -2.2, -2.0, -1.8, -1.6, -1.4., -1.2, -1., -0.8, -0.6, -0.4, -0.2, 0., 0.2, 0.4, 0.6, 0.8, 1., 1.2, 1.4, 1.6, 1.8, 2., 2.2, 2.4, 2.6, 2.8, 3.0, 3.4};
+  Float_t etas[33] = {-3.4, -3.0, -2.8, -2.6, -2.4, -2.2, -2.0, -1.8, -1.6, -1.4, -1.2, -1., -0.8, -0.6, -0.4, -0.2, 0., 0.2, 0.4, 0.6, 0.8, 1., 1.2, 1.4, 1.6, 1.8, 2., 2.2, 2.4, 2.6, 2.8, 3.0, 3.4};
   Float_t etax = 2940.;
   Float_t etay = 1240.;
   Float_t lineL = 100.;
@@ -676,16 +687,18 @@ void drawEtaValues(){
     TLine *linev = new TLine(0.,-10.,0.,10.); 
     linev->Draw();  
 
+    Float_t x1;
+    Float_t y1;
     if ( etas[ieta]>-1.6 && etas[ieta]<1.6 ){
-      Float_t x1 = etay/tan(th);
-      Float_t y1 = etay;
+      x1 = etay/tan(th);
+      y1 = etay;
     } else if ( etas[ieta]<=-1.6 ) {
-      Float_t x1 = -etax;
-      Float_t y1 = -etax*tan(th);
+      x1 = -etax;
+      y1 = -etax*tan(th);
       talign = 11;
     } else if ( etas[ieta]>=1.6 ){
-      Float_t x1 = etax;
-      Float_t y1 = etax*tan(th);
+      x1 = etax;
+      y1 = etax*tan(th);
       talign = 31;
     }
     Float_t x2 = x1+lineL*cos(th);
@@ -697,10 +710,11 @@ void drawEtaValues(){
     line1->Draw();  
     char text[20];
     int rc = sprintf(text, "%3.1f", etas[ieta]);
+    TLatex *t1;
     if ( etas[ieta] == 0 ) {
-      TLatex *t1 = new TLatex(xt,yt,"#eta = 0"); 
+      t1 = new TLatex(xt,yt,"#eta = 0"); 
     } else {
-      TLatex *t1 = new TLatex(xt,yt,text); 
+      t1 = new TLatex(xt,yt,text); 
     }
     t1->SetTextSize(0.03);
     t1->SetTextAlign(talign);

--- a/Validation/Geometry/test/MaterialBudget_TDR.C
+++ b/Validation/Geometry/test/MaterialBudget_TDR.C
@@ -160,11 +160,12 @@ float xmax;
 float ymin;
 float ymax;
 //
+void createPlots(TString plot);
 
 using namespace std;
 
 // Main
-MaterialBudget_TDR() {
+void MaterialBudget_TDR() {
 
   //TDR style
   setTDRStyle();  

--- a/Validation/Geometry/test/TrackerMaterialBudgetComparison.C
+++ b/Validation/Geometry/test/TrackerMaterialBudgetComparison.C
@@ -56,10 +56,16 @@ unsigned int iFirst = 1;
 unsigned int iLast  = 9;
 //
 
+// function declarations
+void createPlots(TString plot);
+void create2DPlots(TString plot);
+void drawEtaValues();
+void makeColorTableRB();
+
 using namespace std;
 
 // Main
-TrackerMaterialBudgetComparison(TString detector) {
+void TrackerMaterialBudgetComparison(TString detector) {
 
   gROOT->SetStyle("Plain");
 
@@ -74,7 +80,7 @@ TrackerMaterialBudgetComparison(TString detector) {
      && theDetector!="InnerTracker"
      ){
     cerr << "MaterialBudget - ERROR detector not found " << theDetector << endl;
-    break;
+    exit(0);
   }
   //
   
@@ -423,7 +429,7 @@ void createPlots(TString plot) {
     histo_ratio->SetFillColor(0);     // white
     histo_ratio->SetMarkerStyle(20);  // cyrcles
     histo_ratio->SetMarkerSize(0.2);  // 
-    histo_ratio->SetLineWidth(0.8);  // 
+    histo_ratio->SetLineWidth(1);  // 
     //
     // Draw
     histo_ratio->GetXaxis()->SetTitle(abscissaName);
@@ -455,11 +461,13 @@ void create2DPlots(TString plot) {
   unsigned int plotNumber = 0;
   TString abscissaName = "dummy";
   TString ordinateName = "dummy";
+  TString quotaName = "dummy";
   Int_t zLog = 0;
   Int_t iDrawEta = 0; //draw Eta values
   Int_t iRebin = 0; //Rebin
   Double_t histoMin = -1.;
   Double_t histoMax = -1.;
+
   if(plot.CompareTo("x_vs_eta_vs_phi") == 0) {
     plotNumber = 30;
     abscissaName = TString("#eta");
@@ -712,7 +720,7 @@ void create2DPlots(TString plot) {
 void drawEtaValues(){
 
   //Add eta labels
-  Float_t etas[33] = {-3.4, -3.0, -2.8, -2.6, -2.4, -2.2, -2.0, -1.8, -1.6, -1.4., -1.2, -1., -0.8, -0.6, -0.4, -0.2, 0., 0.2, 0.4, 0.6, 0.8, 1., 1.2, 1.4, 1.6, 1.8, 2., 2.2, 2.4, 2.6, 2.8, 3.0, 3.4};
+  Float_t etas[33] = {-3.4, -3.0, -2.8, -2.6, -2.4, -2.2, -2.0, -1.8, -1.6, -1.4, -1.2, -1., -0.8, -0.6, -0.4, -0.2, 0., 0.2, 0.4, 0.6, 0.8, 1., 1.2, 1.4, 1.6, 1.8, 2., 2.2, 2.4, 2.6, 2.8, 3.0, 3.4};
   Float_t etax = 2940.;
   Float_t etay = 1240.;
   Float_t lineL = 100.;
@@ -728,16 +736,18 @@ void drawEtaValues(){
     TLine *linev = new TLine(0.,-10.,0.,10.); 
     linev->Draw();  
 
+    Float_t x1;
+    Float_t y1;
     if ( etas[ieta]>-1.6 && etas[ieta]<1.6 ){
-      Float_t x1 = etay/tan(th);
-      Float_t y1 = etay;
+      x1 = etay/tan(th);
+      y1 = etay;
     } else if ( etas[ieta]<=-1.6 ) {
-      Float_t x1 = -etax;
-      Float_t y1 = -etax*tan(th);
+      x1 = -etax;
+      y1 = -etax*tan(th);
       talign = 11;
     } else if ( etas[ieta]>=1.6 ){
-      Float_t x1 = etax;
-      Float_t y1 = etax*tan(th);
+      x1 = etax;
+      y1 = etax*tan(th);
       talign = 31;
     }
     Float_t x2 = x1+lineL*cos(th);
@@ -749,10 +759,11 @@ void drawEtaValues(){
     line1->Draw();  
     char text[20];
     int rc = sprintf(text, "%3.1f", etas[ieta]);
+    TLatex *t1;
     if ( etas[ieta] == 0 ) {
-      TLatex *t1 = new TLatex(xt,yt,"#eta = 0"); 
+      t1 = new TLatex(xt,yt,"#eta = 0"); 
     } else {
-      TLatex *t1 = new TLatex(xt,yt,text); 
+      t1 = new TLatex(xt,yt,text); 
     }
     t1->SetTextSize(0.03);
     t1->SetTextAlign(talign);


### PR DESCRIPTION
In Validation/Geometry/test, some of the root macros for producing material budget plots could not compile, due in some cases to having a structure incompatible with Root 6, and in some cases to typos and missing or improperly placed function/object/variable declarations. These bugs have been fixed in the following macros:
- MaterialBudget.C
- MaterialBudget_TDR.C
- ECALMaterialBudgetCompare.C
- TrackerMaterialBudgetComparison.C

They can now compile in Root 6.
