### PR TITLE
Updated IVF vertex arbitration

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -45,6 +45,9 @@
 
 //#define VTXDEBUG
 
+const unsigned int nTracks(const reco::Vertex & sv) {return sv.nTracks();}
+const unsigned int nTracks(const reco::VertexCompositePtrCandidate & sv) {return sv.numberOfSourceCandidatePtrs();}
+
 template <class InputContainer, class VTX>
 class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
     public:
@@ -114,6 +117,7 @@ void TemplatedVertexArbitrator<InputContainer,VTX>::produce(edm::Event &event, c
 				theSecVertexColl);
 
 		for(unsigned int ivtx=0; ivtx < theRecoVertices.size(); ivtx++){
+			if ( !(nTracks(theRecoVertices[ivtx]) > 1) ) continue;
 			recoVertices->push_back(theRecoVertices[ivtx]);
 		}
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -61,7 +61,7 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
 	edm::EDGetTokenT<Product> token_secondaryVertex;
 	edm::EDGetTokenT<InputContainer>	 token_tracks; 
 	edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 
-	TrackVertexArbitration<VTX> * theArbitrator;
+	std::unique_ptr<TrackVertexArbitration<VTX> > theArbitrator;
 };
 
 
@@ -73,7 +73,7 @@ TemplatedVertexArbitrator<InputContainer,VTX>::TemplatedVertexArbitrator(const e
 	token_beamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"));
 	token_tracks = consumes<InputContainer>(params.getParameter<edm::InputTag>("tracks"));
 	produces<Product>();
-	theArbitrator = new TrackVertexArbitration<VTX>(params);
+	theArbitrator.reset( new TrackVertexArbitration<VTX>(params) );
 }
 
 template <class InputContainer, class VTX>


### PR DESCRIPTION
This PR updates the arbitration step in the IVF secondary vertex reconstruction by requiring all vertices to have at least two tracks with weight>0.5. This change ensures we do not end up with any single-candidate vertices (when vertices are candidate-based, i.e. stored as `reco::VertexCompositePtrCandidate`, only vertex tracks with weight>0.5 are kept. Hence, for vertices consisting of two tracks where one track has weight<0.5 a single-track vertex is produced).

This PR also affects secondary vertices stored as `reco::Vertex`. The difference here is that, in contrast to `reco::VertexCompositePtrCandidate`, `reco::Vertex` actually stores the track weights so vertices consisting of two tracks where one track has weight<0.5 are still kept as two-track vertices. However, since in track counting and computing the vertex kinematics only tracks with w>0.5 are taken into account, it is better to apply the same requirement also to secondary vertices stored as `reco::Vertex`. In this way both types of secondary vertices are treated in the same way.

This PR is expected to produce small changes in the size of the IVF secondary vertex collection. However, the IVF-based b-tag discriminators are expected to remain unchanged since they already require secondary vertices with at least two tracks with weight>0.5.

@arizzi
