### PR TITLE
Updating e/gamma Mustache SuperCluster regressions for 80X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,19 +10,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v2',
+    'run2_design'       :   '80X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v1',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v3',
+    'run1_data'         :   '80X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v3',
+    'run2_data'         :   '80X_dataRun2_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -30,7 +30,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v2',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '80X_mcRun1_design_v3',
+    'run1_design'       :   '80X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '80X_mcRun1_realistic_v3',
+    'run1_mc'           :   '80X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '80X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '80X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '80X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunI simulation
- **RunI Ideal scenario** : [80X_mcRun1_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_design_v4) as [80X_mcRun1_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_design_v4/80X_mcRun1_design_v3): 
  - Updated Mustache SuperCluster Regressions for 80X
- **RunI Heavy Ions scenario** : [80X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_HeavyIon_v4) as [80X_mcRun1_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_HeavyIon_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_HeavyIon_v4/80X_mcRun1_HeavyIon_v3): 
  - Updated Mustache SuperCluster Regressions for 80X
- **RunI Realistic scenario** : [80X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_realistic_v4) as [80X_mcRun1_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_realistic_v4/80X_mcRun1_realistic_v3): 
  - Updated Mustache SuperCluster Regressions for 80X
- **RunI Proton-Lead scenario** : [80X_mcRun1_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_pA_v4) as [80X_mcRun1_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun1_pA_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun1_pA_v4/80X_mcRun1_pA_v3): 
  - Updated Mustache SuperCluster Regressions for 80X
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v4) as [80X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v4/80X_mcRun2_design_v2): 
  - Updated Mustache SuperCluster Regressions for 80X
  - additions of 8 labels for `JetResolutionRcd` and 4 labels for `JetResolutionScaleFactorRcd`
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v2) as [80X_mcRun2cosmics_startup_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v2/80X_mcRun2cosmics_startup_peak_v1): 
  - Updated Mustache SuperCluster Regressions for 80X
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v4) as [80X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v4/80X_mcRun2_asymptotic_v2): 
  - Updated Mustache SuperCluster Regressions for 80X
  - additions of 8 labels for `JetResolutionRcd` and 4 labels for `JetResolutionScaleFactorRcd`
- **RunII Startup scenario** : [80X_mcRun2_startup_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v4) as [80X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v4/80X_mcRun2_startup_v2): 
  - Updated Mustache SuperCluster Regressions for 80X
  - additions of 8 labels for `JetResolutionRcd` and 4 labels for `JetResolutionScaleFactorRcd`
- **RunII Heavy Ions scenario** : [80X_mcRun2_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v3) as [80X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_HeavyIon_v3/80X_mcRun2_HeavyIon_v2): 
  - Updated Mustache SuperCluster Regressions for 80X
  - Updated L1T Calo Parameters configuration changing the thresholds for the stage-1 MB bits. 
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v4) as [80X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v4/80X_dataRun2_v3): 
  - Updated Mustache SuperCluster Regressions for 80X
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v3) as [80X_upgrade2017_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v3/80X_upgrade2017_design_v2): 
  - Updated Mustache SuperCluster Regressions for 80X
# 

This combines the needs in terms of conditions of #13000 and #13115
