### PR TITLE
Implimenting HLTConfigData::globalTag() function

### DIFF
--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -341,6 +341,10 @@ const std::string& HLTConfigData::processName() const {
   return processName_;
 }
 
+const std::string& HLTConfigData::globalTag() const {
+  return globalTag_;
+}
+
 unsigned int HLTConfigData::size() const {
   return triggerNames_.size();
 }


### PR DESCRIPTION
HLTConfigData::globalTag() was not actually implemented. This is a fairly minor issue but also straightforward to fix
