### PR TITLE
Implementing HLTConfigData::globalTag() function (80X)

### DIFF
--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -341,6 +341,10 @@ const std::string& HLTConfigData::processName() const {
   return processName_;
 }
 
+const std::string& HLTConfigData::globalTag() const {
+  return globalTag_;
+}
+
 unsigned int HLTConfigData::size() const {
   return triggerNames_.size();
 }


### PR DESCRIPTION
Implementing HLTConfigData::globalTag() function
Forward port of #13145 
