### PR TITLE
Ignore rootlogon to avoid conflicts

### DIFF
--- a/FWCore/Utilities/scripts/edmCheckClassTransients
+++ b/FWCore/Utilities/scripts/edmCheckClassTransients
@@ -58,6 +58,11 @@ oparser.add_option("-f","--rootmap", dest="rmfiles", action="append", default=[]
 
 (options,args)=oparser.parse_args()
 
+#Need to not have ROOT load .rootlogon.(C|py) since it can cause interference.
+# The only way to do that is to pass -n from the command line
+import sys
+sys.argv.append("-n")
+
 import ROOT
 #Keep ROOT from trying to use X11
 ROOT.gROOT.SetBatch(True)


### PR DESCRIPTION
Fix for edmCheckClassTransients (same fix as #13113)
