### PR TITLE
HLT DQM  for Photon+MET paths

### DIFF
--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h
@@ -1,0 +1,70 @@
+#ifndef SUSY_HLT_PhotonMET_H
+#define SUSY_HLT_PhotonMET_H
+
+//event
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+// MET
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+
+// Photon
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+
+// Trigger
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
+
+namespace reco{
+  typedef std::vector<reco::Photon> PhotonCollection;
+}
+
+class SUSY_HLT_PhotonMET: public DQMEDAnalyzer
+{
+public:
+  SUSY_HLT_PhotonMET(const edm::ParameterSet& ps);
+  virtual ~SUSY_HLT_PhotonMET();
+
+protected:
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+
+private:
+  //histos booking function
+  void bookHistos(DQMStore::IBooker &);
+
+  //variables from config file
+  edm::EDGetTokenT<reco::PFMETCollection> thePfMETCollection_;
+  edm::EDGetTokenT<reco::PhotonCollection> thePhotonCollection_;
+  edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
+
+  std::string triggerPath_;
+  std::string triggerPathBase_;
+  edm::InputTag triggerFilterPhoton_;
+  edm::InputTag triggerFilterMET_;
+  double ptThrOffline_;
+  double metThrOffline_;
+
+  // Histograms
+  MonitorElement* h_recoPhotonPt;
+  MonitorElement* h_recoMet;
+  MonitorElement* h_metTurnOn_num;
+  MonitorElement* h_metTurnOn_den;
+  MonitorElement* h_photonTurnOn_num;
+  MonitorElement* h_photonTurnOn_den;
+
+};
+
+#endif

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-SUSY_HLT_PhotonMET = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
+SUSY_HLT_PhotonMET_pt36 = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
    trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'),
    pfMETCollection = cms.InputTag("pfMet"),
    photonCollection = cms.InputTag("gedPhotons"),
@@ -12,8 +12,52 @@ SUSY_HLT_PhotonMET = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
    metThrOffline = cms.untracked.double(100),
 )
 
-SUSY_HLT_PhotonMET_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_PhotonMET_pt50 = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
+   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'),
+   pfMETCollection = cms.InputTag("pfMet"),
+   photonCollection = cms.InputTag("gedPhotons"),
+   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
+   HLTProcess = cms.string('HLT'),
+   TriggerPath = cms.string('HLT_Photon50_R9Id90_HE10_Iso40_EBOnly_PFMET40_v'),
+   TriggerPathBase = cms.string('HLT_IsoMu27_v'),
+   ptThrOffline = cms.untracked.double(75),
+   metThrOffline = cms.untracked.double(100),
+)
+
+SUSY_HLT_PhotonMET_pt75 = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
+   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'),
+   pfMETCollection = cms.InputTag("pfMet"),
+   photonCollection = cms.InputTag("gedPhotons"),
+   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
+   HLTProcess = cms.string('HLT'),
+   TriggerPath = cms.string('HLT_Photon75_R9Id90_HE10_Iso40_EBOnly_PFMET40_v'),
+   TriggerPathBase = cms.string('HLT_IsoMu27_v'),
+   ptThrOffline = cms.untracked.double(100),
+   metThrOffline = cms.untracked.double(100),
+)
+
+SUSY_HLT_PhotonMET_pt36_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon36_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
+   verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
+   resolution     = cms.vstring(""),
+   efficiency     = cms.vstring(
+      "photonPtTurnOn_eff 'Turn-on vs photon; p_{T} (GeV); #epsilon' photonTurnOn_num photonTurnOn_den",
+      "metTurnOn_eff 'Turn-on vs E_{T}^{miss}; E_{T}^{miss} (GeV); #epsilon' pfMetTurnOn_num pfMetTurnOn_den",
+   )
+)
+
+SUSY_HLT_PhotonMET_pt50_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+   subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon50_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
+   verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
+   resolution     = cms.vstring(""),
+   efficiency     = cms.vstring(
+      "photonPtTurnOn_eff 'Turn-on vs photon; p_{T} (GeV); #epsilon' photonTurnOn_num photonTurnOn_den",
+      "metTurnOn_eff 'Turn-on vs E_{T}^{miss}; E_{T}^{miss} (GeV); #epsilon' pfMetTurnOn_num pfMetTurnOn_den",
+   )
+)
+
+SUSY_HLT_PhotonMET_pt75_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+   subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon75_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),
    efficiency     = cms.vstring(

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+SUSY_HLT_PhotonMET = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
+   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'),
+   pfMETCollection = cms.InputTag("pfMet"),
+   photonCollection = cms.InputTag("gedPhotons"),
+   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
+   HLTProcess = cms.string('HLT'),
+   TriggerPath = cms.string('HLT_Photon36_R9Id90_HE10_Iso40_EBOnly_PFMET40_v'),
+   TriggerPathBase = cms.string('HLT_IsoMu27_v'),
+   ptThrOffline = cms.untracked.double(50),
+   metThrOffline = cms.untracked.double(100),
+)
+
+SUSY_HLT_PhotonMET_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+   subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon36_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
+   verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
+   resolution     = cms.vstring(""),
+   efficiency     = cms.vstring(
+      "photonPtTurnOn_eff 'Turn-on vs photon; p_{T} (GeV); #epsilon' photonTurnOn_num photonTurnOn_den",
+      "metTurnOn_eff 'Turn-on vs E_{T}^{miss}; E_{T}^{miss} (GeV); #epsilon' pfMetTurnOn_num pfMetTurnOn_den",
+   )
+)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
@@ -59,7 +59,9 @@ SusyExoPostVal = cms.Sequence(SUSY_HLT_HT_MET_POSTPROCESSING +
                               SUSY_HLT_Razor_PostVal_POSTPROCESSING + 
                               SUSY_HLT_CaloHT_POSTPROCESSING + 
                               SUSY_HLT_PhotonHT_POSTPROCESSING +                             
-                              SUSY_HLT_PhotonMET_POSTPROCESSING +
+                              SUSY_HLT_PhotonMET_pt36_POSTPROCESSING +
+                              SUSY_HLT_PhotonMET_pt50_POSTPROCESSING +
+                              SUSY_HLT_PhotonMET_pt75_POSTPROCESSING +
                               SUSY_HLT_HT_DoubleMuon_POSTPROCESSING +
                               SUSY_HLT_HT_DoubleEle_POSTPROCESSING +
                               SUSY_HLT_HT_MuEle_POSTPROCESSING +

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
@@ -26,6 +26,7 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_HT_MUON_BTAG_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_Razor_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_caloHT_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_PhotonHT_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_PhotonMET_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_DoubleMuon_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_DoubleElectron_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
@@ -58,6 +59,7 @@ SusyExoPostVal = cms.Sequence(SUSY_HLT_HT_MET_POSTPROCESSING +
                               SUSY_HLT_Razor_PostVal_POSTPROCESSING + 
                               SUSY_HLT_CaloHT_POSTPROCESSING + 
                               SUSY_HLT_PhotonHT_POSTPROCESSING +                             
+                              SUSY_HLT_PhotonMET_POSTPROCESSING +
                               SUSY_HLT_HT_DoubleMuon_POSTPROCESSING +
                               SUSY_HLT_HT_DoubleEle_POSTPROCESSING +
                               SUSY_HLT_HT_MuEle_POSTPROCESSING +

--- a/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
@@ -82,7 +82,9 @@ HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_CaloHT350 +
                                 SUSY_HLT_CaloHT400 +
                                 SUSY_HLT_PhotonHT +
-                                SUSY_HLT_PhotonMET +
+                                SUSY_HLT_PhotonMET_pt36 +
+                                SUSY_HLT_PhotonMET_pt50 +
+                                SUSY_HLT_PhotonMET_pt75 +
                                 SUSY_HLT_HT_DoubleMuon +
                                 SUSY_HLT_HT_DoubleEle +
                                 SUSY_HLT_HT_MuEle +

--- a/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
@@ -26,6 +26,7 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_HT_MUON_BTAG_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_Razor_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_caloHT_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_PhotonHT_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_PhotonMET_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_DoubleMuon_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_DoubleElectron_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
@@ -81,6 +82,7 @@ HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_CaloHT350 +
                                 SUSY_HLT_CaloHT400 +
                                 SUSY_HLT_PhotonHT +
+                                SUSY_HLT_PhotonMET +
                                 SUSY_HLT_HT_DoubleMuon +
                                 SUSY_HLT_HT_DoubleEle +
                                 SUSY_HLT_HT_MuEle +

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_PhotonMET.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_PhotonMET.cc
@@ -1,0 +1,134 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h"
+
+
+SUSY_HLT_PhotonMET::SUSY_HLT_PhotonMET(const edm::ParameterSet& ps)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "Constructor SUSY_HLT_PhotonMET::SUSY_HLT_PhotonMET " << std::endl;
+  // Get parameters from configuration file
+  thePfMETCollection_ = consumes<reco::PFMETCollection>(ps.getParameter<edm::InputTag>("pfMETCollection"));
+  thePhotonCollection_ = consumes<reco::PhotonCollection>(ps.getParameter<edm::InputTag>("photonCollection"));
+  triggerResults_ = consumes<edm::TriggerResults>(ps.getParameter<edm::InputTag>("TriggerResults"));
+  triggerPath_ = ps.getParameter<std::string>("TriggerPath");
+  triggerPathBase_ = ps.getParameter<std::string>("TriggerPathBase");
+  ptThrOffline_ = ps.getUntrackedParameter<double>("ptThrOffline");
+  metThrOffline_ = ps.getUntrackedParameter<double>("metThrOffline");
+}
+
+SUSY_HLT_PhotonMET::~SUSY_HLT_PhotonMET()
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "Destructor SUSY_HLT_PhotonMET::~SUSY_HLT_PhotonMET " << std::endl;
+}
+
+void SUSY_HLT_PhotonMET::dqmBeginRun(edm::Run const &, edm::EventSetup const &)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::beginRun" << std::endl;
+}
+
+void SUSY_HLT_PhotonMET::bookHistograms(DQMStore::IBooker & ibooker_, edm::Run const &, edm::EventSetup const &)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::bookHistograms" << std::endl;
+  //book at beginRun
+  bookHistos(ibooker_);
+}
+
+void SUSY_HLT_PhotonMET::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
+                                              edm::EventSetup const& context)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::beginLuminosityBlock" << std::endl;
+}
+
+void SUSY_HLT_PhotonMET::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::analyze" << std::endl;
+
+  //-------------------------------
+  //--- MET
+  //-------------------------------
+  edm::Handle<reco::PFMETCollection> pfMETCollection;
+  e.getByToken(thePfMETCollection_, pfMETCollection);
+  if ( !pfMETCollection.isValid() ){
+    edm::LogError ("SUSY_HLT_PhotonMET") << "invalid met collection" << "\n";
+    return;
+  }
+  //-------------------------------
+  //--- Photon
+  //-------------------------------
+  edm::Handle<reco::PhotonCollection> photonCollection;
+  e.getByToken (thePhotonCollection_, photonCollection);
+  if ( !photonCollection.isValid() ){
+    edm::LogError ("SUSY_HLT_PhotonMET") << "invalid egamma collection" << "\n";
+    return;
+  }
+
+  //check what is in the menu
+  edm::Handle<edm::TriggerResults> hltresults;
+  e.getByToken(triggerResults_,hltresults);
+  if(!hltresults.isValid()){
+    edm::LogError ("SUSY_HLT_PhotonMET") << "invalid collection: TriggerResults" << "\n";
+    return;
+  }
+
+  // use only events with leading photon in barrel
+  if (photonCollection->size()==0 || abs(photonCollection->begin()->superCluster()->eta()) > 1.4442) return;
+
+  // get reco photon and met
+  float const recoPhotonPt = photonCollection->size() ? photonCollection->begin()->et() : 0;
+  float const recoMET = pfMETCollection->size() ? pfMETCollection->begin()->et() : 0;
+  h_recoPhotonPt->Fill(recoPhotonPt);
+  h_recoMet->Fill(recoMET);
+
+  // the actual trigger efficiencies
+  bool hasFired = false, hasFiredBaseTrigger=false;
+  edm::TriggerNames const &trigNames = e.triggerNames(*hltresults);
+  unsigned int const numTriggers = trigNames.size();
+  for( unsigned int hltIndex=0; hltIndex<numTriggers; ++hltIndex ){
+    if (trigNames.triggerName(hltIndex).find(triggerPath_) != std::string::npos && hltresults->wasrun(hltIndex) && hltresults->accept(hltIndex)) hasFired = true;
+    if (trigNames.triggerName(hltIndex).find(triggerPathBase_) != std::string::npos && hltresults->wasrun(hltIndex) && hltresults->accept(hltIndex)) hasFiredBaseTrigger = true;
+  }
+
+  if(hasFiredBaseTrigger || !e.isRealData()) {
+    // passed base trigger
+    if (recoPhotonPt>ptThrOffline_) h_metTurnOn_den->Fill(recoMET);
+    if (recoMET>metThrOffline_) h_photonTurnOn_den->Fill(recoPhotonPt);
+    if (hasFired){
+      // passed base and signal trigger
+      if (recoPhotonPt>ptThrOffline_) h_metTurnOn_num->Fill(recoMET);
+      if (recoMET>metThrOffline_) h_photonTurnOn_num->Fill(recoPhotonPt);
+    }
+  }
+}
+
+void SUSY_HLT_PhotonMET::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::endLuminosityBlock" << std::endl;
+}
+
+
+void SUSY_HLT_PhotonMET::endRun(edm::Run const& run, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::endRun" << std::endl;
+}
+
+void SUSY_HLT_PhotonMET::bookHistos(DQMStore::IBooker & ibooker_)
+{
+  ibooker_.cd();
+  ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);
+
+  //offline quantities
+  h_recoPhotonPt = ibooker_.book1D("recoPhotonPt", "reco Photon transverse momentum; p_{T} (GeV)", 20, 0, 1000);
+  h_recoMet = ibooker_.book1D("recoMet", "reco Missing transverse energy;E_{T}^{miss} (GeV)", 20, 0, 1000);
+  h_metTurnOn_num = ibooker_.book1D("pfMetTurnOn_num", "PF MET Turn On Numerator",   20, 0, 500);
+  h_metTurnOn_den = ibooker_.book1D("pfMetTurnOn_den", "PF MET Turn On Denominator", 20, 0, 500);
+  h_photonTurnOn_num = ibooker_.book1D("photonTurnOn_num", "Photon Turn On Numerator",   20, 0, 1000);
+  h_photonTurnOn_den = ibooker_.book1D("photonTurnOn_den", "Photon Turn On Denominator", 20, 0, 1000);
+
+  ibooker_.cd();
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SUSY_HLT_PhotonMET);


### PR DESCRIPTION
This adds a module for `HLT_PhotonXX_R9Id90_HE10_Iso40_EBOnly_PFMET40` (`XX`=`36`,`50`,`75`) to the SUSYBSM HLT DQM.

@olivito: FYI
