### PR TITLE
Update phase1 (2017) tracking sequence

### DIFF
--- a/RecoTracker/Configuration/python/RecoTrackerPhase1_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerPhase1_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
+# Iterative steps
+from RecoTracker.IterativeTracking.Phase1_iterativeTk_cff import *
+from RecoTracker.IterativeTracking.Phase1_ElectronSeeds_cff import *
+
+
+import copy
+
+#dEdX reconstruction
+from RecoTracker.DeDx.dedxEstimators_cff import *
+
+#BeamHalo tracking
+from RecoTracker.Configuration.RecoTrackerBHM_cff import *
+
+
+#special sequences, such as pixel-less
+from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
+
+ckftracks_woBH = cms.Sequence(iterTracking*electronSeedsSeq*doAlldEdXEstimators)
+ckftracks = ckftracks_woBH.copy() #+ beamhaloTracksSeq) # temporarily out, takes too much resources
+
+ckftracks_wodEdX = ckftracks.copy()
+ckftracks_wodEdX.remove(doAlldEdXEstimators)
+
+ckftracks_plus_pixelless = cms.Sequence(ckftracks*ctfTracksPixelLess)
+
+
+from RecoJets.JetAssociationProducers.trackExtrapolator_cfi import *
+trackingGlobalReco = cms.Sequence(ckftracks*trackExtrapolator)

--- a/RecoTracker/FinalTrackSelectors/python/Phase1_earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/Phase1_earlyGeneralTracks_cfi.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
+
+# FIXME: detachedTripletStep is dropped temporarily
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+earlyGeneralTracks =  TrackCollectionMerger.clone()
+earlyGeneralTracks.trackProducers = ['initialStepTracks',
+                                     'highPtTripletStepTracks',
+                                     'jetCoreRegionalStepTracks',
+                                     'lowPtQuadStepTracks',
+                                     'lowPtTripletStepTracks',
+                                     'detachedQuadStepTracks',
+#                                     'detachedTripletStepTracks', # FIXME: disabled for now
+                                     'mixedTripletStepTracks',
+                                     'pixelLessStepTracks',
+                                     'tobTecStepTracks'
+                                     ]
+earlyGeneralTracks.inputClassifiers =["initialStep",
+                                      "highPtTripletStep",
+                                      "jetCoreRegionalStep",
+                                      "lowPtQuadStep",
+                                      "lowPtTripletStep",
+                                      "detachedQuadStep",
+#                                      "detachedTripletStep", # FIXME: disabled for now
+                                      "mixedTripletStep",
+                                      "pixelLessStep",
+                                      "tobTecStep"
+                                      ]

--- a/RecoTracker/IterativeTracking/python/Phase1_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_DetachedQuadStep_cff.py
@@ -1,0 +1,150 @@
+import FWCore.ParameterSet.Config as cms
+
+###############################################
+# Low pT and detached tracks from pixel quadruplets
+###############################################
+
+# REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
+
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+detachedQuadStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("highPtTripletStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("highPtTripletStepClusters"),
+    trackClassifier                          = cms.InputTag('highPtTripletStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+detachedQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
+detachedQuadStepSeedLayers.BPix.skipClusters = cms.InputTag('detachedQuadStepClusters')
+detachedQuadStepSeedLayers.FPix.skipClusters = cms.InputTag('detachedQuadStepClusters')
+
+# SEEDS
+from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
+PixelTripletLargeTipGenerator.extraHitRZtolerance = 0.0
+PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+detachedQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+detachedQuadStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'detachedQuadStepSeedLayers'
+detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
+detachedQuadStepSeeds.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'
+detachedQuadStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 0.3
+detachedQuadStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 15.0
+detachedQuadStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 1.5
+detachedQuadStepSeeds.SeedMergerPSet = cms.PSet(
+    layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+    addRemainingTriplets = cms.bool(False),
+    mergeTriplets = cms.bool(True),
+    ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+)
+detachedQuadStepSeeds.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+    )
+detachedQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+detachedQuadStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+#    maxLostHitsFraction = cms.double(1./10.),
+#    constantValueForLostHitsFractionFilter = cms.double(0.701),
+    minimumNumberOfHits = 3,
+    minPt = 0.075,
+    maxCCCLostHits = 2,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+detachedQuadStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('detachedQuadStepTrajectoryFilterBase')),
+    ),
+)
+
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+detachedQuadStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('detachedQuadStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('detachedQuadStepTrajectoryFilter')),
+    maxCand = 3,
+    alwaysUseInvalidHits = True,
+    estimator = cms.string('detachedQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('detachedQuadStepSeeds'),
+    clustersToSkip = cms.InputTag('detachedQuadStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('detachedQuadStepTrajectoryBuilder')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+detachedQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('detachedQuadStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.13),
+            allowSharedFirstHit = cms.bool(True)
+            )
+detachedQuadStepTrackCandidates.TrajectoryCleaner = 'detachedQuadStepTrajectoryCleanerBySharedHits'
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('detachedQuadStep'),
+    src = 'detachedQuadStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+    )
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+
+
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+detachedQuadStepClassifier1 = TrackMVAClassifierDetached.clone()
+detachedQuadStepClassifier1.src = 'detachedQuadStepTracks'
+detachedQuadStepClassifier1.GBRForestLabel = 'MVASelectorIter3_13TeV'
+detachedQuadStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
+detachedQuadStepClassifier2 = TrackMVAClassifierPrompt.clone()
+detachedQuadStepClassifier2.src = 'detachedQuadStepTracks'
+detachedQuadStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+detachedQuadStepClassifier2.qualityCuts = [-0.2,0.0,0.4]
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+detachedQuadStep = ClassifierMerger.clone()
+detachedQuadStep.inputClassifiers=['detachedQuadStepClassifier1','detachedQuadStepClassifier2']
+
+
+DetachedQuadStep = cms.Sequence(detachedQuadStepClusters*
+                                detachedQuadStepSeedLayers*
+                                detachedQuadStepSeeds*
+                                detachedQuadStepTrackCandidates*
+                                detachedQuadStepTracks*
+                                detachedQuadStepClassifier1*detachedQuadStepClassifier2*
+                                detachedQuadStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_DetachedTripletStep_cff.py
@@ -1,0 +1,162 @@
+import FWCore.ParameterSet.Config as cms
+
+###############################################
+# Low pT and detached tracks from pixel triplets
+###############################################
+
+# REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
+
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+detachedTripletStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("detachedQuadStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("detachedQuadStepClusters"),
+    trackClassifier                          = cms.InputTag('detachedQuadStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+detachedTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4',
+        'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+    ]
+)
+detachedTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
+detachedTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
+
+# SEEDS
+from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
+PixelTripletLargeTipGenerator.extraHitRZtolerance = 0.0
+PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+detachedTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+detachedTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'detachedTripletStepSeedLayers'
+detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
+detachedTripletStepSeeds.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'
+detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 0.3
+detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 15.0
+detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 1.5
+
+detachedTripletStepSeeds.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+    )
+detachedTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+#    maxLostHitsFraction = cms.double(1./10.),
+#    constantValueForLostHitsFractionFilter = cms.double(0.701),
+    minimumNumberOfHits = 3,
+    minPt = 0.075,
+    maxCCCLostHits = 2,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+detachedTripletStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('detachedTripletStepTrajectoryFilterBase')),
+    ),
+)
+
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('detachedTripletStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryFilter')),
+    maxCand = 3,
+    alwaysUseInvalidHits = True,
+    estimator = cms.string('detachedTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+detachedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('detachedTripletStepSeeds'),
+    clustersToSkip = cms.InputTag('detachedTripletStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryBuilder')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+detachedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('detachedTripletStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.13),
+            allowSharedFirstHit = cms.bool(True)
+            )
+detachedTripletStepTrackCandidates.TrajectoryCleaner = 'detachedTripletStepTrajectoryCleanerBySharedHits'
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+detachedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('detachedTripletStep'),
+    src = 'detachedTripletStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+    )
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+
+
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+detachedTripletStepClassifier1 = TrackMVAClassifierDetached.clone()
+detachedTripletStepClassifier1.src = 'detachedTripletStepTracks'
+detachedTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter3_13TeV'
+detachedTripletStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
+detachedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone()
+detachedTripletStepClassifier2.src = 'detachedTripletStepTracks'
+detachedTripletStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+detachedTripletStepClassifier2.qualityCuts = [-0.2,0.0,0.4]
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+detachedTripletStep = ClassifierMerger.clone()
+detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
+
+
+DetachedTripletStep = cms.Sequence(detachedTripletStepClusters*
+                                   detachedTripletStepSeedLayers*
+                                   detachedTripletStepSeeds*
+                                   detachedTripletStepTrackCandidates*
+                                   detachedTripletStepTracks*
+                                   detachedTripletStepClassifier1*detachedTripletStepClassifier2*
+                                   detachedTripletStep)
+

--- a/RecoTracker/IterativeTracking/python/Phase1_ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_ElectronSeeds_cff.py
@@ -1,0 +1,155 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
+initialStepSeedClusterMask = seedClusterRemover.clone(
+    trajectories = cms.InputTag("initialStepSeeds"),
+    oldClusterRemovalInfo = cms.InputTag("pixelLessStepClusters")
+)
+# This is a pure guess to use lowPtTripletStep here instead of the pixelPair in Run2 configuration
+lowPtTripletStepSeedClusterMask = seedClusterRemover.clone(
+    trajectories = cms.InputTag("lowPtTripletStepSeeds"),
+    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+)
+mixedTripletStepSeedClusterMask = seedClusterRemover.clone(
+    trajectories = cms.InputTag("mixedTripletStepSeeds"),
+    oldClusterRemovalInfo = cms.InputTag("lowPtTripletStepSeedClusterMask")
+)
+pixelLessStepSeedClusterMask = seedClusterRemover.clone(
+    trajectories = cms.InputTag("pixelLessStepSeeds"),
+    oldClusterRemovalInfo = cms.InputTag("mixedTripletStepSeedClusterMask")
+)
+
+tripletElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+                            'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+                            'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+                            'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+                            'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+                            'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+                            'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'),
+    BPix = cms.PSet(
+    TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
+    HitProducer = cms.string('siPixelRecHits'),
+    skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
+    ),
+    FPix = cms.PSet(
+    TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
+    HitProducer = cms.string('siPixelRecHits'),
+    skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
+    )
+)
+
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+tripletElectronSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+    RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+    ptMin = 1.0,
+    originRadius = 0.02,
+    nSigmaZ = 4.0
+    )
+    )
+)
+tripletElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('tripletElectronSeedLayers')
+
+from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
+tripletElectronClusterMask = seedClusterRemover.clone(
+    trajectories = cms.InputTag("tripletElectronSeeds"),
+    oldClusterRemovalInfo = cms.InputTag("pixelLessStepSeedClusterMask")
+)
+
+pixelPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix1+BPix4',
+                            'BPix2+BPix3', 'BPix2+BPix4',
+                            'BPix3+BPix4',
+                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+                            'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
+                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+                            'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
+                            'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg'),
+    BPix = cms.PSet(
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    HitProducer = cms.string('siPixelRecHits'),
+    skipClusters = cms.InputTag('tripletElectronClusterMask')
+    ),
+    FPix = cms.PSet(
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    HitProducer = cms.string('siPixelRecHits'),
+    skipClusters = cms.InputTag('tripletElectronClusterMask')
+    )
+)
+
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
+pixelPairElectronSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff.globalSeedsFromPairsWithVertices.clone()
+pixelPairElectronSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.0
+pixelPairElectronSeeds.RegionFactoryPSet.RegionPSet.originRadius = 0.015
+pixelPairElectronSeeds.RegionFactoryPSet.RegionPSet.fixedError = 0.03
+pixelPairElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('pixelPairElectronSeedLayers')
+
+stripPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
+                            'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
+                            'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'),
+    TIB = cms.PSet(
+    TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+    skipClusters = cms.InputTag('tripletElectronClusterMask')
+    ),
+    TID = cms.PSet(
+    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+    skipClusters = cms.InputTag('tripletElectronClusterMask'),
+    useRingSlector = cms.bool(True),
+    TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+    minRing = cms.int32(1),
+    maxRing = cms.int32(2)
+    ),
+    TEC = cms.PSet(
+    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+    skipClusters = cms.InputTag('tripletElectronClusterMask'),
+    useRingSlector = cms.bool(True),
+    TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+    minRing = cms.int32(1),
+    maxRing = cms.int32(2)
+    )
+)
+
+import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+stripPairElectronSeeds = RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone()
+stripPairElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'stripPairElectronSeedLayers'
+stripPairElectronSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.0
+stripPairElectronSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 12.0
+stripPairElectronSeeds.RegionFactoryPSet.RegionPSet.originRadius = 0.4
+
+###This seed collection is produced for electron reconstruction
+import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
+newCombinedSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
+    seedCollections = cms.VInputTag(
+      cms.InputTag('initialStepSeeds'),
+      cms.InputTag('highPtTripletStepSeeds'),
+      cms.InputTag('mixedTripletStepSeeds'),
+      cms.InputTag('pixelLessStepSeeds'),
+      cms.InputTag('tripletElectronSeeds'),
+      cms.InputTag('pixelPairElectronSeeds'),
+      cms.InputTag('stripPairElectronSeeds')
+      )
+)
+
+electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
+                                 lowPtTripletStepSeedClusterMask*
+                                 mixedTripletStepSeedClusterMask*
+                                 pixelLessStepSeedClusterMask*
+                                 tripletElectronSeedLayers*
+                                 tripletElectronSeeds*
+                                 tripletElectronClusterMask*
+                                 pixelPairElectronSeedLayers*
+                                 pixelPairElectronSeeds*
+                                 stripPairElectronSeedLayers*
+                                 stripPairElectronSeeds*
+                                 newCombinedSeeds)
+

--- a/RecoTracker/IterativeTracking/python/Phase1_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_HighPtTripletStep_cff.py
@@ -1,0 +1,165 @@
+import FWCore.ParameterSet.Config as cms
+
+### high-pT triplets ###
+
+# NEW CLUSTERS (remove previously used clusters)
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+highPtTripletStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("initialStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag(""),
+    trackClassifier                          = cms.InputTag('initialStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+highPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4',
+        'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+    ]
+)
+highPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('highPtTripletStepClusters')
+highPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('highPtTripletStepClusters')
+
+# seeding
+from RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+highPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.6,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    )
+)
+highPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'highPtTripletStepSeedLayers'
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+highPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+highPtTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# building
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+highPtTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.2,
+    maxCCCLostHits = 2,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+highPtTripletStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('highPtTripletStepTrajectoryFilterBase')),
+    ),
+)
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+highPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('highPtTripletStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+    pTChargeCutThreshold = cms.double(15.)
+)
+
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+highPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('highPtTripletStepTrajectoryFilter')),
+    alwaysUseInvalidHits = True,
+    maxCand = 3,
+    estimator = cms.string('highPtTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+    )
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+highPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('highPtTripletStepSeeds'),
+    clustersToSkip = cms.InputTag('highPtTripletStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('highPtTripletStepTrajectoryBuilder')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+# fitting
+import RecoTracker.TrackProducer.TrackProducer_cfi
+highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'highPtTripletStepTrackCandidates',
+    AlgorithmName = cms.string('highPtTripletStep'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+    )
+
+
+# Final selection
+# MVA selection to be enabled after re-training, for time being we go with cut-based selector
+#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+#
+#highPtTripletStepClassifier1 = TrackMVAClassifierPrompt.clone()
+#highPtTripletStepClassifier1.src = 'highPtTripletStepTracks'
+#highPtTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
+#highPtTripletStepClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
+#
+#from RecoTracker.IterativeTracking.Phase1_DetachedTripletStep_cff import detachedTripletStepClassifier1
+#from RecoTracker.IterativeTracking.Phase1_LowPtTripletStep_cff import lowPtTripletStep
+#highPtTripletStepClassifier2 = detachedTripletStepClassifier1.clone()
+#highPtTripletStepClassifier2.src = 'highPtTripletStepTracks'
+#highPtTripletStepClassifier3 = lowPtTripletStep.clone()
+#highPtTripletStepClassifier3.src = 'highPtTripletStepTracks'
+#
+#
+#from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+#highPtTripletStep = ClassifierMerger.clone()
+#highPtTripletStep.inputClassifiers=['highPtTripletStepClassifier1','highPtTripletStepClassifier2','highPtTripletStepClassifier3']
+#highPtTripletStep.inputClassifiers=['highPtTripletStepClassifier1','highPtTripletStepClassifier2','highPtTripletStepClassifier3']
+
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier
+highPtTripletStep = TrackCutClassifier.clone(
+    src = "highPtTripletStepTracks",
+    vertices = "firstStepPrimaryVertices",
+)
+highPtTripletStep.mva.minPixelHits = [1,1,1]
+highPtTripletStep.mva.maxChi2 = [9999.,9999.,9999.]
+highPtTripletStep.mva.maxChi2n = [2.0,1.0,0.7]
+highPtTripletStep.mva.minLayers = [3,3,3]
+highPtTripletStep.mva.min3DLayers = [3,3,3]
+highPtTripletStep.mva.maxLostLayers = [3,2,2]
+highPtTripletStep.mva.dr_par.dr_par1 = [0.7,0.6,0.5]
+highPtTripletStep.mva.dz_par.dz_par1 = [0.8,0.7,0.7]
+highPtTripletStep.mva.dr_par.dr_par2 = [0.4,0.35,0.25]
+highPtTripletStep.mva.dz_par.dz_par2 = [0.6,0.5,0.4]
+highPtTripletStep.mva.dr_par.d0err_par = [0.002,0.002,0.001]
+
+
+# Final sequence
+HighPtTripletStep = cms.Sequence(highPtTripletStepClusters*
+                                 highPtTripletStepSeedLayers*
+                                 highPtTripletStepSeeds*
+                                 highPtTripletStepTrackCandidates*
+                                 highPtTripletStepTracks*
+#                                 highPtTripletStepClassifier1*highPtTripletStepClassifier2*highPtTripletStepClassifier3*
+                                 highPtTripletStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_InitialStepPreSplitting_cff.py
@@ -1,0 +1,158 @@
+### STEP 0 ###
+
+# hit building
+from RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff import *
+from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+initialStepSeedLayersPreSplitting = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
+initialStepSeedLayersPreSplitting.FPix.HitProducer = 'siPixelRecHitsPreSplitting'
+initialStepSeedLayersPreSplitting.BPix.HitProducer = 'siPixelRecHitsPreSplitting'
+# seeding
+from RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+initialStepSeedsPreSplitting = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.6,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadrupletsPreSplitting")),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayersPreSplitting'
+
+# The following clone is a bit stupid given that QuadrupletSeedMerger
+# does not even read the hits. Oh well, since the plan is to replace
+# the merger with something better, maybe it is better to live with
+# this than to modify the seeding layer code to avoid calling
+# consumes() when not needed.
+import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
+PixelSeedMergerQuadrupletsPreSplitting = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.clone()
+PixelSeedMergerQuadrupletsPreSplitting.BPix.HitProducer = "siPixelRecHitsPreSplitting"
+PixelSeedMergerQuadrupletsPreSplitting.FPix.HitProducer = "siPixelRecHitsPreSplitting"
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
+initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
+initialStepSeedsPreSplitting.ClusterCheckPSet.PixelClusterCollectionLabel = 'siPixelClustersPreSplitting'
+initialStepSeedsPreSplitting.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# building
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+initialStepTrajectoryFilterBasePreSplitting = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.2,
+    maxCCCLostHits = 2,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+initialStepTrajectoryFilterShapePreSplitting = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
+initialStepTrajectoryFilterPreSplitting = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterBasePreSplitting')),
+        cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterShapePreSplitting'))),
+)
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('initialStepChi2EstPreSplitting'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+    pTChargeCutThreshold = cms.double(15.)
+)
+
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+initialStepTrajectoryBuilderPreSplitting = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilterPreSplitting')),
+    alwaysUseInvalidHits = True,
+    maxCand = 3,
+    estimator = cms.string('initialStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+    )
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+initialStepTrackCandidatesPreSplitting = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('initialStepSeedsPreSplitting'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilderPreSplitting')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+initialStepTrackCandidatesPreSplitting.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
+
+# fitting
+import RecoTracker.TrackProducer.TrackProducer_cfi
+initialStepTracksPreSplitting = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'initialStepTrackCandidatesPreSplitting',
+    AlgorithmName = cms.string('initialStep'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle')
+    )
+initialStepTracksPreSplitting.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
+
+#vertices
+import RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi
+firstStepPrimaryVerticesPreSplitting = RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi.offlinePrimaryVertices.clone()
+firstStepPrimaryVerticesPreSplitting.TrackLabel = cms.InputTag("initialStepTracksPreSplitting")
+firstStepPrimaryVerticesPreSplitting.vertexCollections = cms.VPSet(
+     [cms.PSet(label=cms.string(""),
+               algorithm=cms.string("AdaptiveVertexFitter"),
+               minNdof=cms.double(0.0),
+               useBeamConstraint = cms.bool(False),
+               maxDistanceToBeam = cms.double(1.0)
+               )
+      ]
+    )
+
+#Jet Core emulation to identify jet-tracks
+from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import initialStepTrackRefsForJets, caloTowerForTrk, ak4CaloJetsForTrk, jetsForCoreTracking
+initialStepTrackRefsForJetsPreSplitting = initialStepTrackRefsForJets.clone(
+    src = 'initialStepTracksPreSplitting')
+caloTowerForTrkPreSplitting = caloTowerForTrk.clone()
+ak4CaloJetsForTrkPreSplitting = ak4CaloJetsForTrk.clone(
+    src = 'caloTowerForTrkPreSplitting',
+    srcPVs = 'firstStepPrimaryVerticesPreSplitting')
+jetsForCoreTrackingPreSplitting = jetsForCoreTracking.clone(
+    src = 'ak4CaloJetsForTrkPreSplitting')
+
+#Cluster Splitting
+from RecoLocalTracker.SubCollectionProducers.jetCoreClusterSplitter_cfi import jetCoreClusterSplitter
+siPixelClusters = jetCoreClusterSplitter.clone(
+    pixelClusters = cms.InputTag('siPixelClustersPreSplitting'),
+    vertices      = 'firstStepPrimaryVerticesPreSplitting',
+    cores         = 'jetsForCoreTrackingPreSplitting'
+)
+
+# Final sequence
+from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import siPixelRecHits
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import MeasurementTrackerEvent
+from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
+InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
+                                       initialStepSeedsPreSplitting*
+                                       initialStepTrackCandidatesPreSplitting*
+                                       initialStepTracksPreSplitting*
+                                       firstStepPrimaryVerticesPreSplitting*
+                                       initialStepTrackRefsForJetsPreSplitting*
+                                       caloTowerForTrkPreSplitting*
+                                       ak4CaloJetsForTrkPreSplitting*
+                                       jetsForCoreTrackingPreSplitting*
+                                       siPixelClusters*
+                                       siPixelRecHits*
+                                       MeasurementTrackerEvent*
+                                       siPixelClusterShapeCache)
+

--- a/RecoTracker/IterativeTracking/python/Phase1_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_InitialStep_cff.py
@@ -1,0 +1,142 @@
+import FWCore.ParameterSet.Config as cms
+
+### STEP 0 ###
+
+# hit building
+from RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff import *
+from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+initialStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
+
+
+# seeding
+from RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.6,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+initialStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# building
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.2,
+    maxCCCLostHits = 2,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+initialStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterBase')),
+    ),
+)
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('initialStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+    pTChargeCutThreshold = cms.double(15.)
+)
+
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilter')),
+    alwaysUseInvalidHits = True,
+    maxCand = 3,
+    estimator = cms.string('initialStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+)
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('initialStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilder')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# fitting
+import RecoTracker.TrackProducer.TrackProducer_cfi
+initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'initialStepTrackCandidates',
+    AlgorithmName = cms.string('initialStep'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+)
+
+
+#vertices
+import RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi
+firstStepPrimaryVertices=RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi.offlinePrimaryVertices.clone()
+firstStepPrimaryVertices.TrackLabel = cms.InputTag("initialStepTracks")
+firstStepPrimaryVertices.vertexCollections = cms.VPSet(
+     [cms.PSet(label=cms.string(""),
+               algorithm=cms.string("AdaptiveVertexFitter"),
+               minNdof=cms.double(0.0),
+               useBeamConstraint = cms.bool(False),
+               maxDistanceToBeam = cms.double(1.0)
+               )
+      ]
+    )
+ 
+
+# Final selection
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+
+initialStepClassifier1 = TrackMVAClassifierPrompt.clone()
+initialStepClassifier1.src = 'initialStepTracks'
+initialStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
+initialStepClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
+
+from RecoTracker.IterativeTracking.Phase1_DetachedTripletStep_cff import detachedTripletStepClassifier1
+from RecoTracker.IterativeTracking.Phase1_LowPtTripletStep_cff import lowPtTripletStep
+initialStepClassifier2 = detachedTripletStepClassifier1.clone()
+initialStepClassifier2.src = 'initialStepTracks'
+initialStepClassifier3 = lowPtTripletStep.clone()
+initialStepClassifier3.src = 'initialStepTracks'
+
+
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+initialStep = ClassifierMerger.clone()
+initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
+
+
+
+# Final sequence
+InitialStep = cms.Sequence(initialStepSeedLayers*
+                           initialStepSeeds*
+                           initialStepTrackCandidates*
+                           initialStepTracks*
+                           firstStepPrimaryVertices*
+                           initialStepClassifier1*initialStepClassifier2*initialStepClassifier3*
+                           initialStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_JetCoreRegionalStep_cff.py
@@ -1,0 +1,185 @@
+import FWCore.ParameterSet.Config as cms
+
+# This step runs over all clusters
+
+# run only if there are high pT jets
+from RecoJets.JetProducers.TracksForJets_cff import trackRefsForJets
+initialStepTrackRefsForJets = trackRefsForJets.clone(src = cms.InputTag('initialStepTracks'))
+from RecoJets.JetProducers.caloJetsForTrk_cff import *
+jetsForCoreTracking = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4CaloJetsForTrk"), cut = cms.string("pt > 100 && abs(eta) < 2.5"))
+
+# care only at tracks from main PV
+firstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
+     filterParams = cms.PSet(
+     	     minNdof = cms.double(25.0),
+             maxZ = cms.double(15.0),
+             maxRho = cms.double(2.0)
+     ),
+     src=cms.InputTag('firstStepPrimaryVertices')
+)
+
+# SEEDING LAYERS
+jetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring(
+        'BPix1+BPix2',
+        'BPix1+BPix3',
+        'BPix1+BPix4',
+        'BPix2+BPix3',
+        'BPix2+BPix4',
+        'BPix3+BPix4',
+        'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+        'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
+        'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg',
+        #'BPix3+TIB1','BPix3+TIB2'
+        'BPix4+TIB1','BPix4+TIB2'
+    ),
+    TIB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    BPix = cms.PSet(
+        useErrorsFromParam = cms.bool(True),
+        hitErrorRPhi = cms.double(0.0027),
+        hitErrorRZ = cms.double(0.006),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
+    ),
+    FPix = cms.PSet(
+        useErrorsFromParam = cms.bool(True),
+        hitErrorRPhi = cms.double(0.0051),
+        hitErrorRZ = cms.double(0.0036),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
+    )
+)
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
+jetCoreRegionalStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff.globalSeedsFromPairsWithVertices.clone()
+jetCoreRegionalStepSeeds.RegionFactoryPSet = cms.PSet(
+      ComponentName = cms.string( "TauRegionalPixelSeedGenerator" ),#not so nice to depend on RecoTau...
+      RegionPSet = cms.PSet(
+        precise = cms.bool( True ),
+        originRadius = cms.double( 0.2 ),
+        ptMin = cms.double( 10. ),
+        originHalfLength = cms.double( 0.2 ),
+        deltaPhiRegion = cms.double( 0.20 ), 
+        deltaEtaRegion = cms.double( 0.20 ), 
+        JetSrc = cms.InputTag( "jetsForCoreTracking" ),
+#       JetSrc = cms.InputTag( "ak5CaloJets" ),
+        vertexSrc = cms.InputTag( "firstStepGoodPrimaryVertices" ),
+        measurementTrackerName = cms.string( "MeasurementTrackerEvent" ),
+        howToUseMeasurementTracker = cms.string( "Never" )
+      )
+)
+jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'jetCoreRegionalStepSeedLayers'
+jetCoreRegionalStepSeeds.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('none'),
+#PixelClusterShapeSeedComparitor'),
+#        FilterAtHelixStage = cms.bool(True),
+#        FilterPixelHits = cms.bool(True),
+#        FilterStripHits = cms.bool(False),
+#       ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter')
+    )
+jetCoreRegionalStepSeeds.SeedCreatorPSet.forceKinematicWithRegionDirection = cms.bool( True )
+jetCoreRegionalStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+jetCoreRegionalStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 4,
+    seedPairPenalty = 0,
+    minPt = 0.1
+)
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+jetCoreRegionalStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('jetCoreRegionalStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryFilter')),
+    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
+    maxCand = 50,
+    estimator = cms.string('jetCoreRegionalStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('jetCoreRegionalStepSeeds'),
+    maxSeedsBeforeCleaning = cms.uint32(10000),
+    TrajectoryBuilderPSet = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryBuilder')),
+    NavigationSchool = cms.string('SimpleNavigationSchool'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    #numHitsForSeedCleaner = cms.int32(50),
+    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+)
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+jetCoreRegionalStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('jetCoreRegionalStep'),
+    src = 'jetCoreRegionalStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder = 'WithTrackAngle', # FIXME: to be updated once we get the templates to GT
+    )
+
+# Final selection
+from RecoTracker.IterativeTracking.Phase1_InitialStep_cff import initialStepClassifier1
+#from RecoTracker.IterativeTracking.Phase1_DetachedTripletStep_cff import detachedTripletStepClassifier1
+
+#jetCoreRegionalStep = initialStepClassifier1.clone()
+#jetCoreRegionalStep.src='jetCoreRegionalStepTracks'
+#jetCoreRegionalStep.qualityCuts = [-0.3,0.0,0.2]
+#jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
+
+#jetCoreRegionalStepClassifier1 = initialStepClassifier1.clone()
+#jetCoreRegionalStepClassifier1.src = 'jetCoreRegionalStepTracks'
+#jetCoreRegionalStepClassifier1.qualityCuts = [-0.2,0.0,0.4]
+#jetCoreRegionalStepClassifier2 = detachedTripletStepClassifier1.clone()
+#jetCoreRegionalStepClassifier2.src = 'jetCoreRegionalStepTracks'
+
+
+
+#from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+#jetCoreRegionalStep = ClassifierMerger.clone()
+#jetCoreRegionalStep.inputClassifiers=['jetCoreRegionalStepClassifier1','jetCoreRegionalStepClassifier2']
+
+
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+jetCoreRegionalStep = TrackCutClassifier.clone()
+jetCoreRegionalStep.src='jetCoreRegionalStepTracks'
+jetCoreRegionalStep.mva.minPixelHits = [1,1,1]
+jetCoreRegionalStep.mva.maxChi2 = [9999.,9999.,9999.]
+jetCoreRegionalStep.mva.maxChi2n = [1.6,1.0,0.7]
+jetCoreRegionalStep.mva.minLayers = [3,5,5]
+jetCoreRegionalStep.mva.min3DLayers = [1,2,3]
+jetCoreRegionalStep.mva.maxLostLayers = [4,3,2]
+jetCoreRegionalStep.mva.maxDz = [0.5,0.35,0.2];
+jetCoreRegionalStep.mva.maxDr = [0.3,0.2,0.1];
+jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
+
+
+# Final sequence
+JetCoreRegionalStep = cms.Sequence(initialStepTrackRefsForJets*caloJetsForTrk*jetsForCoreTracking*
+                                   firstStepGoodPrimaryVertices*
+                                   #jetCoreRegionalStepClusters*
+                                   jetCoreRegionalStepSeedLayers*
+                                   jetCoreRegionalStepSeeds*
+                                   jetCoreRegionalStepTrackCandidates*
+                                   jetCoreRegionalStepTracks*
+#                                   jetCoreRegionalStepClassifier1*jetCoreRegionalStepClassifier2*
+                                   jetCoreRegionalStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_LowPtQuadStep_cff.py
@@ -1,0 +1,137 @@
+import FWCore.ParameterSet.Config as cms
+
+# NEW CLUSTERS (remove previously used clusters)
+# FIXME: detachedTriplet is dropped for time being, but may be enabled later
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+lowPtQuadStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+#    trajectories                             = cms.InputTag("detachedTripletStepTracks"),
+    trajectories                             = cms.InputTag("detachedQuadStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+#    oldClusterRemovalInfo                    = cms.InputTag("detachedTripletStepClusters"),
+#    trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
+    oldClusterRemovalInfo                    = cms.InputTag("detachedQuadStepClusters"),
+    trackClassifier                          = cms.InputTag('detachedQuadStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+lowPtQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
+lowPtQuadStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtQuadStepClusters')
+lowPtQuadStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtQuadStepClusters')
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+lowPtQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.2,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+lowPtQuadStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtQuadStepSeedLayers'
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+lowPtQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+lowPtQuadStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.075,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
+# Composite filter
+lowPtQuadStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
+    filters   = [cms.PSet(refToPSet_ = cms.string('lowPtQuadStepStandardTrajectoryFilter')),
+                 # cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))
+                ]
+    )
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+lowPtQuadStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('lowPtQuadStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtQuadStepTrajectoryFilter')),
+    maxCand = 4,
+    estimator = cms.string('lowPtQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('lowPtQuadStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtQuadStepTrajectoryBuilder')),
+    clustersToSkip = cms.InputTag('lowPtQuadStepClusters'),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'lowPtQuadStepTrackCandidates',
+    AlgorithmName = cms.string('lowPtQuadStep'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+lowPtQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('lowPtQuadStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.16),
+            allowSharedFirstHit = cms.bool(True)
+            )
+lowPtQuadStepTrackCandidates.TrajectoryCleaner = 'lowPtQuadStepTrajectoryCleanerBySharedHits'
+
+# Final selection
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+lowPtQuadStep =  TrackMVAClassifierPrompt.clone()
+lowPtQuadStep.src = 'lowPtQuadStepTracks'
+lowPtQuadStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
+lowPtQuadStep.qualityCuts = [-0.6,-0.3,-0.1]
+
+
+
+# Final sequence
+LowPtQuadStep = cms.Sequence(lowPtQuadStepClusters*
+                             lowPtQuadStepSeedLayers*
+                             lowPtQuadStepSeeds*
+                             lowPtQuadStepTrackCandidates*
+                             lowPtQuadStepTracks*
+                             lowPtQuadStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_LowPtTripletStep_cff.py
@@ -1,0 +1,161 @@
+import FWCore.ParameterSet.Config as cms
+
+# NEW CLUSTERS (remove previously used clusters)
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+lowPtTripletStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("lowPtQuadStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("lowPtQuadStepClusters"),
+    trackClassifier                          = cms.InputTag('lowPtQuadStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4',
+        'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+    ]
+)
+lowPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
+lowPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+lowPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.35, # FIXME: Phase1PU70 value, let's see if we can lower it to Run2 value (0.2)
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    )
+)
+lowPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtTripletStepSeedLayers'
+lowPtTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.075,
+    maxCCCLostHits = 1,
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    )
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
+# Composite filter
+lowPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
+    filters   = [cms.PSet(refToPSet_ = cms.string('lowPtTripletStepStandardTrajectoryFilter')),
+                 # cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))
+                ]
+    )
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('lowPtTripletStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryFilter')),
+    maxCand = 4,
+    estimator = cms.string('lowPtTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+lowPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('lowPtTripletStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryBuilder')),
+    clustersToSkip = cms.InputTag('lowPtTripletStepClusters'),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'lowPtTripletStepTrackCandidates',
+    AlgorithmName = cms.string('lowPtTripletStep'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('lowPtTripletStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.16),
+            allowSharedFirstHit = cms.bool(True)
+            )
+lowPtTripletStepTrackCandidates.TrajectoryCleaner = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
+
+# Final selection
+# MVA selection to be enabled after re-training, for time being we go with cut-based selector
+#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+#lowPtTripletStep =  TrackMVAClassifierPrompt.clone()
+#lowPtTripletStep.src = 'lowPtTripletStepTracks'
+#lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
+#lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
+
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier
+lowPtTripletStep = TrackCutClassifier.clone(
+    src = "lowPtTripletStepTracks",
+    vertices = "firstStepPrimaryVertices",
+)
+lowPtTripletStep.mva.minPixelHits = [1,1,1]
+lowPtTripletStep.mva.maxChi2 = [9999.,9999.,9999.]
+lowPtTripletStep.mva.maxChi2n = [2.0,0.9,0.5]
+lowPtTripletStep.mva.minLayers = [3,3,3]
+lowPtTripletStep.mva.min3DLayers = [3,3,3]
+lowPtTripletStep.mva.maxLostLayers = [2,2,2]
+lowPtTripletStep.mva.dr_par.dr_par1 = [0.8,0.7,0.6]
+lowPtTripletStep.mva.dz_par.dz_par1 = [0.7,0.6,0.45]
+lowPtTripletStep.mva.dr_par.dr_par2 = [0.5,0.4,0.3]
+lowPtTripletStep.mva.dz_par.dz_par2 = [0.5,0.4,0.4]
+lowPtTripletStep.mva.dr_par.d0err_par = [0.002,0.002,0.001]
+
+
+
+# Final sequence
+LowPtTripletStep = cms.Sequence(lowPtTripletStepClusters*
+                                lowPtTripletStepSeedLayers*
+                                lowPtTripletStepSeeds*
+                                lowPtTripletStepTrackCandidates*
+                                lowPtTripletStepTracks*
+                                lowPtTripletStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_MixedTripletStep_cff.py
@@ -1,0 +1,239 @@
+import FWCore.ParameterSet.Config as cms
+
+###############################################################
+# Large impact parameter Tracking using mixed-triplet seeding #
+###############################################################
+
+#here just for backward compatibility
+chargeCut2069Clusters =  cms.EDProducer("ClusterChargeMasker",
+    oldClusterRemovalInfo = cms.InputTag("lowPtTripletStepClusters"),
+    pixelClusters = cms.InputTag("siPixelClusters"),
+    stripClusters = cms.InputTag("siStripClusters"),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+mixedTripletStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("lowPtTripletStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+#    oldClusterRemovalInfo                    = cms.InputTag("lowPtTripletStepClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("chargeCut2069Clusters"),
+    trackClassifier                          = cms.InputTag('lowPtTripletStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
+     layerList = cms.vstring('BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'),
+#    layerList = cms.vstring('BPix1+BPix2+BPix3', 
+#        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
+#        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg', 
+#        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'),
+    BPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        skipClusters = cms.InputTag('mixedTripletStepClusters')
+    ),
+    FPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        skipClusters = cms.InputTag('mixedTripletStepClusters')
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(1),
+        skipClusters = cms.InputTag('mixedTripletStepClusters')
+    )
+)
+
+# SEEDS
+from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
+PixelTripletLargeTipGenerator.extraHitRZtolerance = 0.0
+PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+mixedTripletStepSeedsA = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+mixedTripletStepSeedsA.OrderedHitsFactoryPSet.SeedingLayers = 'mixedTripletStepSeedLayersA'
+mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
+mixedTripletStepSeedsA.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'
+mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.ptMin = 0.4
+mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originHalfLength = 15.0
+mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originRadius = 1.5
+mixedTripletStepSeedsA.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+import RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi
+mixedTripletStepClusterShapeHitFilter  = RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi.ClusterShapeHitFilterESProducer.clone(
+	ComponentName = cms.string('mixedTripletStepClusterShapeHitFilter'),
+        PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
+	clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+	)
+	
+mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+    )
+
+# SEEDING LAYERS
+mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('BPix3+BPix4+TIB1'),
+    BPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        skipClusters = cms.InputTag('mixedTripletStepClusters')
+    ),
+    TIB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        skipClusters = cms.InputTag('mixedTripletStepClusters')
+    )
+)
+
+# SEEDS
+from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
+PixelTripletLargeTipGenerator.extraHitRZtolerance = 0.0
+PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+mixedTripletStepSeedsB = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+mixedTripletStepSeedsB.OrderedHitsFactoryPSet.SeedingLayers = 'mixedTripletStepSeedLayersB'
+mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
+mixedTripletStepSeedsB.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'
+mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.ptMin = 0.6
+mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originHalfLength = 10.0
+mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originRadius = 1.5
+mixedTripletStepSeedsB.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+mixedTripletStepSeedsB.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+    )
+
+import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
+mixedTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
+mixedTripletStepSeeds.seedCollections = cms.VInputTag(
+        cms.InputTag('mixedTripletStepSeedsA'),
+        cms.InputTag('mixedTripletStepSeedsB'),
+        )
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+mixedTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+#    maxLostHits = 0,
+    constantValueForLostHitsFractionFilter = 1.4,
+    minimumNumberOfHits = 3,
+    minPt = 0.1
+    )
+
+# Propagator taking into account momentum uncertainty in multiple scattering calculation.
+import TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff
+import TrackingTools.MaterialEffects.MaterialPropagator_cfi
+mixedTripletStepPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone(
+#mixedTripletStepPropagator = TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff.MaterialPropagatorParabolicMF.clone(
+    ComponentName = 'mixedTripletStepPropagator',
+    ptMin = 0.1
+    )
+
+import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
+mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
+#mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff.OppositeMaterialPropagatorParabolicMF.clone(
+    ComponentName = 'mixedTripletStepPropagatorOpposite',
+    ptMin = 0.1
+    )
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('mixedTripletStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(16.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+mixedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryFilter')),
+    propagatorAlong = cms.string('mixedTripletStepPropagator'),
+    propagatorOpposite = cms.string('mixedTripletStepPropagatorOpposite'),
+    maxCand = 2,
+    estimator = cms.string('mixedTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+mixedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('mixedTripletStepSeeds'),
+    clustersToSkip = cms.InputTag('mixedTripletStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryBuilder')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+mixedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('mixedTripletStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.11),
+            allowSharedFirstHit = cms.bool(True)
+            )
+mixedTripletStepTrackCandidates.TrajectoryCleaner = 'mixedTripletStepTrajectoryCleanerBySharedHits'
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+mixedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('mixedTripletStep'),
+    src = 'mixedTripletStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+)
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+mixedTripletStepClassifier1 = TrackMVAClassifierDetached.clone()
+mixedTripletStepClassifier1.src = 'mixedTripletStepTracks'
+mixedTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter4_13TeV'
+mixedTripletStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
+mixedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone()
+mixedTripletStepClassifier2.src = 'mixedTripletStepTracks'
+mixedTripletStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+mixedTripletStepClassifier2.qualityCuts = [-0.2,-0.2,-0.2]
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+mixedTripletStep = ClassifierMerger.clone()
+mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
+
+
+
+
+
+MixedTripletStep = cms.Sequence(chargeCut2069Clusters*mixedTripletStepClusters*
+                                mixedTripletStepSeedLayersA*
+                                mixedTripletStepSeedsA*
+                                mixedTripletStepSeedLayersB*
+                                mixedTripletStepSeedsB*
+                                mixedTripletStepSeeds*
+                                mixedTripletStepTrackCandidates*
+                                mixedTripletStepTracks*
+                                mixedTripletStepClassifier1*mixedTripletStepClassifier2*
+                                mixedTripletStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_PixelLessStep_cff.py
@@ -1,0 +1,218 @@
+import FWCore.ParameterSet.Config as cms
+
+##########################################################################
+# Large impact parameter tracking using TIB/TID/TEC stereo layer seeding #
+##########################################################################
+
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+pixelLessStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("mixedTripletStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("mixedTripletStepClusters"),
+    trackClassifier                          = cms.InputTag('mixedTripletStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# SEEDING LAYERS
+from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring(
+    #TIB
+    'TIB1+TIB2+MTIB3','TIB1+TIB2+MTIB4',
+    #TIB+TID
+    'TIB1+TIB2+MTID1_pos','TIB1+TIB2+MTID1_neg',
+    #TID
+    'TID1_pos+TID2_pos+TID3_pos','TID1_neg+TID2_neg+TID3_neg',#ring 1-2 (matched)
+    'TID1_pos+TID2_pos+MTID3_pos','TID1_neg+TID2_neg+MTID3_neg',#ring 3 (mono)
+    'TID1_pos+TID2_pos+MTEC1_pos','TID1_neg+TID2_neg+MTEC1_neg',
+    #TID+TEC RING 1-3
+    'TID2_pos+TID3_pos+TEC1_pos','TID2_neg+TID3_neg+TEC1_neg',#ring 1-2 (matched)
+    'TID2_pos+TID3_pos+MTEC1_pos','TID2_neg+TID3_neg+MTEC1_neg',#ring 3 (mono)
+    #TEC RING 1-3
+    'TEC1_pos+TEC2_pos+TEC3_pos', 'TEC1_neg+TEC2_neg+TEC3_neg',
+    'TEC1_pos+TEC2_pos+MTEC3_pos','TEC1_neg+TEC2_neg+MTEC3_neg',
+    'TEC1_pos+TEC2_pos+TEC4_pos', 'TEC1_neg+TEC2_neg+TEC4_neg',
+    'TEC1_pos+TEC2_pos+MTEC4_pos','TEC1_neg+TEC2_neg+MTEC4_neg',
+    'TEC2_pos+TEC3_pos+TEC4_pos', 'TEC2_neg+TEC3_neg+TEC4_neg',
+    'TEC2_pos+TEC3_pos+MTEC4_pos','TEC2_neg+TEC3_neg+MTEC4_neg',
+    'TEC2_pos+TEC3_pos+TEC5_pos', 'TEC2_neg+TEC3_neg+TEC5_neg',
+    'TEC2_pos+TEC3_pos+TEC6_pos', 'TEC2_neg+TEC3_neg+TEC6_neg',
+    'TEC3_pos+TEC4_pos+TEC5_pos', 'TEC3_neg+TEC4_neg+TEC5_neg',
+    'TEC3_pos+TEC4_pos+MTEC5_pos','TEC3_neg+TEC4_neg+MTEC5_neg',
+    'TEC3_pos+TEC5_pos+TEC6_pos', 'TEC3_neg+TEC5_neg+TEC6_neg',
+    'TEC4_pos+TEC5_pos+TEC6_pos', 'TEC4_neg+TEC5_neg+TEC6_neg'    
+    ),
+    TIB = cms.PSet(
+         TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+         skipClusters   = cms.InputTag('pixelLessStepClusters')
+    ),
+    MTIB = cms.PSet(
+         TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+         skipClusters   = cms.InputTag('pixelLessStepClusters'),
+         rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
+    ),
+    TID = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('pixelLessStepClusters'),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(2)
+    ),
+    MTID = cms.PSet(
+        rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        skipClusters = cms.InputTag('pixelLessStepClusters'),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(3),
+        maxRing = cms.int32(3)
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('pixelLessStepClusters'),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(2)
+    ),
+    MTEC = cms.PSet(
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        skipClusters = cms.InputTag('pixelLessStepClusters'),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(3),
+        maxRing = cms.int32(3)
+    )
+)
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+pixelLessStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+#OrderedHitsFactory
+pixelLessStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'pixelLessStepSeedLayers'
+pixelLessStepSeeds.OrderedHitsFactoryPSet.ComponentName = 'StandardMultiHitGenerator'
+import RecoTracker.TkSeedGenerator.MultiHitGeneratorFromChi2_cfi
+pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet = RecoTracker.TkSeedGenerator.MultiHitGeneratorFromChi2_cfi.MultiHitGeneratorFromChi2.clone()
+#SeedCreator
+pixelLessStepSeeds.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'
+#RegionFactory
+pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 0.4
+pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 12.0
+pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 1.0
+#SeedComparitor
+import RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi
+pixelLessStepClusterShapeHitFilter  = RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi.ClusterShapeHitFilterESProducer.clone(
+	ComponentName = cms.string('pixelLessStepClusterShapeHitFilter'),
+        PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
+        doStripShapeCut = cms.bool(False),
+	clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+	)
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi
+pixelLessStepSeeds.SeedComparitorPSet = cms.PSet(
+    ComponentName = cms.string('CombinedSeedComparitor'),
+        mode = cms.string("and"),
+        comparitors = cms.VPSet(
+            cms.PSet(
+                ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+                FilterAtHelixStage = cms.bool(True),
+                FilterPixelHits = cms.bool(False),
+                FilterStripHits = cms.bool(True),
+                ClusterShapeHitFilterName = cms.string('pixelLessStepClusterShapeHitFilter'),
+                ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+            ), 
+            RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
+        )
+    )
+pixelLessStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+pixelLessStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    maxLostHits = 0,
+    minimumNumberOfHits = 4,
+    seedPairPenalty = 1,
+    minPt = 0.1
+    )
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('pixelLessStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(16.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+pixelLessStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryFilter')),
+    minNrOfHitsForRebuild = 4,
+    maxCand = 2,
+    alwaysUseInvalidHits = False,
+    estimator = cms.string('pixelLessStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+pixelLessStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('pixelLessStepSeeds'),
+    clustersToSkip = cms.InputTag('pixelLessStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryBuilder'))
+)
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+pixelLessStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+    ComponentName = cms.string('pixelLessStepTrajectoryCleanerBySharedHits'),
+    fractionShared = cms.double(0.11),
+    allowSharedFirstHit = cms.bool(True)
+    )
+pixelLessStepTrackCandidates.TrajectoryCleaner = 'pixelLessStepTrajectoryCleanerBySharedHits'
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+pixelLessStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'pixelLessStepTrackCandidates',
+    AlgorithmName = cms.string('pixelLessStep'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle') # FIXME: to be updated once we get the templates to GT
+    )
+
+
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+pixelLessStepClassifier1 = TrackMVAClassifierPrompt.clone()
+pixelLessStepClassifier1.src = 'pixelLessStepTracks'
+pixelLessStepClassifier1.GBRForestLabel = 'MVASelectorIter5_13TeV'
+pixelLessStepClassifier1.qualityCuts = [-0.4,0.0,0.4]
+pixelLessStepClassifier2 = TrackMVAClassifierPrompt.clone()
+pixelLessStepClassifier2.src = 'pixelLessStepTracks'
+pixelLessStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+pixelLessStepClassifier2.qualityCuts = [-0.0,0.0,0.0]
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+pixelLessStep = ClassifierMerger.clone()
+pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
+
+
+
+PixelLessStep = cms.Sequence(pixelLessStepClusters*
+                             pixelLessStepSeedLayers*
+                             pixelLessStepSeeds*
+                             pixelLessStepTrackCandidates*
+                             pixelLessStepTracks*
+                             pixelLessStepClassifier1*pixelLessStepClassifier2*
+                             pixelLessStep)

--- a/RecoTracker/IterativeTracking/python/Phase1_TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_TobTecStep_cff.py
@@ -1,0 +1,299 @@
+import FWCore.ParameterSet.Config as cms
+
+#######################################################################
+# Very large impact parameter tracking using TOB + TEC ring 5 seeding #
+#######################################################################
+
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+tobTecStepClusters = trackClusterRemover.clone(
+    maxChi2                                  = cms.double(9.0),
+    trajectories                             = cms.InputTag("pixelLessStepTracks"),
+    pixelClusters                            = cms.InputTag("siPixelClusters"),
+    stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("pixelLessStepClusters"),
+    trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
+    TrackQuality                             = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+)
+
+# TRIPLET SEEDING LAYERS
+from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring(
+    #TOB
+    'TOB1+TOB2+MTOB3','TOB1+TOB2+MTOB4',
+    #TOB+MTEC
+    'TOB1+TOB2+MTEC1_pos','TOB1+TOB2+MTEC1_neg',
+    ),
+    TOB = cms.PSet(
+         TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+         skipClusters   = cms.InputTag('tobTecStepClusters')
+    ),
+    MTOB = cms.PSet(
+         TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+         skipClusters   = cms.InputTag('tobTecStepClusters'),
+         rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
+    ),
+    MTEC = cms.PSet(
+        rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        skipClusters = cms.InputTag('tobTecStepClusters'),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(6),
+        maxRing = cms.int32(7)
+    )
+)
+# TRIPLET SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+tobTecStepSeedsTripl = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+#OrderedHitsFactory
+tobTecStepSeedsTripl.OrderedHitsFactoryPSet.SeedingLayers = 'tobTecStepSeedLayersTripl'
+tobTecStepSeedsTripl.OrderedHitsFactoryPSet.ComponentName = 'StandardMultiHitGenerator'
+import RecoTracker.TkSeedGenerator.MultiHitGeneratorFromChi2_cfi
+tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet = RecoTracker.TkSeedGenerator.MultiHitGeneratorFromChi2_cfi.MultiHitGeneratorFromChi2.clone(
+    extraPhiKDBox = 0.01
+    )
+#RegionFactory
+tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.ptMin = 0.55
+tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originHalfLength = 20.0
+tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originRadius = 3.5
+#SeedCreator
+tobTecStepSeedsTripl.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsCreator' #empirically better than 'SeedFromConsecutiveHitsTripletOnlyCreator'
+tobTecStepSeedsTripl.SeedCreatorPSet.OriginTransverseErrorMultiplier = 1.0
+#SeedComparitor
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi
+
+tobTecStepSeedsTripl.SeedComparitorPSet = cms.PSet(
+   ComponentName = cms.string('CombinedSeedComparitor'),
+   mode = cms.string("and"),
+   comparitors = cms.VPSet(
+     cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(False),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('tobTecStepClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    ),
+    RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
+  )
+)
+tobTecStepSeedsTripl.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+
+# PAIR SEEDING LAYERS
+tobTecStepSeedLayersPair = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('TOB1+TEC1_pos','TOB1+TEC1_neg', 
+                            'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
+                            'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
+                            'TEC3_pos+TEC4_pos','TEC3_neg+TEC4_neg', 
+                            'TEC4_pos+TEC5_pos','TEC4_neg+TEC5_neg', 
+                            'TEC5_pos+TEC6_pos','TEC5_neg+TEC6_neg', 
+                            'TEC6_pos+TEC7_pos','TEC6_neg+TEC7_neg'),
+    TOB = cms.PSet(
+         TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+         skipClusters   = cms.InputTag('tobTecStepClusters')
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('tobTecStepClusters'),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+        minRing = cms.int32(5),
+        maxRing = cms.int32(5)
+    )
+)
+# PAIR SEEDS
+import RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi
+tobTecStepClusterShapeHitFilter  = RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi.ClusterShapeHitFilterESProducer.clone(
+	ComponentName = cms.string('tobTecStepClusterShapeHitFilter'),
+        PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
+	clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+	doStripShapeCut  = cms.bool(False)
+	)
+
+import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+tobTecStepSeedsPair = RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone()
+#OrderedHitsFactory
+tobTecStepSeedsPair.OrderedHitsFactoryPSet.ComponentName = cms.string('StandardHitPairGenerator')
+tobTecStepSeedsPair.OrderedHitsFactoryPSet.SeedingLayers = 'tobTecStepSeedLayersPair'
+#RegionFactory
+tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.ptMin = 0.6
+tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originHalfLength = 30.0
+tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originRadius = 6.0
+#SeedCreator
+tobTecStepSeedsPair.SeedCreatorPSet.OriginTransverseErrorMultiplier = 1.0
+#SeedComparitor
+tobTecStepSeedsPair.SeedComparitorPSet = cms.PSet(
+   ComponentName = cms.string('CombinedSeedComparitor'),
+   mode = cms.string("and"),
+   comparitors = cms.VPSet(
+     cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(False),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('tobTecStepClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    ),
+    RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
+  )
+)
+tobTecStepSeedsPair.ClusterCheckPSet.doClusterCheck = cms.bool(False) # FIXME: cluster check condition to be updated
+import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
+tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
+tobTecStepSeeds.seedCollections = cms.VInputTag(cms.InputTag('tobTecStepSeedsTripl'),cms.InputTag('tobTecStepSeedsPair'))
+
+# QUALITY CUTS DURING TRACK BUILDING (for inwardss and outwards track building steps)
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+
+tobTecStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    maxLostHits = 0,
+    minimumNumberOfHits = 5,
+    seedPairPenalty = 1,
+    minPt = 0.1,
+    minHitsMinPt = 3
+    )
+
+tobTecStepInOutTrajectoryFilter = tobTecStepTrajectoryFilter.clone(
+    maxLostHits = 0,
+    minimumNumberOfHits = 4,
+    seedPairPenalty = 1,
+    minPt = 0.1,
+    minHitsMinPt = 3
+    )
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('tobTecStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(16.0),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryFilter')),
+    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter')),
+    useSameTrajFilter = False,
+    minNrOfHitsForRebuild = 4,
+    alwaysUseInvalidHits = False,
+    maxCand = 2,
+    estimator = cms.string('tobTecStepChi2Est'),
+    #startSeedHitsInRebuild = True
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+tobTecStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('tobTecStepSeeds'),
+    clustersToSkip = cms.InputTag('tobTecStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryBuilder')),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True,
+    cleanTrajectoryAfterInOut = True
+)
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+tobTecStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+    ComponentName = cms.string('tobTecStepTrajectoryCleanerBySharedHits'),
+    fractionShared = cms.double(0.09),
+    allowSharedFirstHit = cms.bool(True)
+    )
+tobTecStepTrackCandidates.TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
+
+# TRACK FITTING AND SMOOTHING OPTIONS
+import TrackingTools.TrackFitters.RungeKuttaFitters_cff
+tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
+    ComponentName = 'tobTecStepFitterSmoother',
+    EstimateCut = 30,
+    MinNumberOfHits = 7,
+    Fitter = cms.string('tobTecStepRKFitter'),
+    Smoother = cms.string('tobTecStepRKSmoother')
+    )
+
+tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
+    ComponentName = 'tobTecStepFitterSmootherForLoopers',
+    Fitter = cms.string('tobTecStepRKFitterForLoopers'),
+    Smoother = cms.string('tobTecStepRKSmootherForLoopers')
+)
+
+# Also necessary to specify minimum number of hits after final track fit
+tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectoryFitter.clone(
+    ComponentName = cms.string('tobTecStepRKFitter'),
+    minHits = 7
+)
+tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
+    ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
+    Propagator = cms.string('PropagatorWithMaterialForLoopers'),
+)
+
+tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectorySmoother.clone(
+    ComponentName = cms.string('tobTecStepRKSmoother'),
+    errorRescaling = 10.0,
+    minHits = 7
+)
+tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
+    ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),
+    Propagator = cms.string('PropagatorWithMaterialForLoopers'),
+)
+
+import TrackingTools.TrackFitters.FlexibleKFFittingSmoother_cfi
+tobTecFlexibleKFFittingSmoother = TrackingTools.TrackFitters.FlexibleKFFittingSmoother_cfi.FlexibleKFFittingSmoother.clone(
+    ComponentName = cms.string('tobTecFlexibleKFFittingSmoother'),
+    standardFitter = cms.string('tobTecStepFitterSmoother'),
+    looperFitter = cms.string('tobTecStepFitterSmootherForLoopers'),
+)
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+tobTecStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'tobTecStepTrackCandidates',
+    AlgorithmName = cms.string('tobTecStep'),
+    #Fitter = 'tobTecStepFitterSmoother',
+    Fitter = 'tobTecFlexibleKFFittingSmoother',
+    TTRHBuilder = 'WithTrackAngle', # FIXME: to be updated once we get the templates to GT
+    )
+
+
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+tobTecStepClassifier1 = TrackMVAClassifierDetached.clone()
+tobTecStepClassifier1.src = 'tobTecStepTracks'
+tobTecStepClassifier1.GBRForestLabel = 'MVASelectorIter6_13TeV'
+tobTecStepClassifier1.qualityCuts = [-0.6,-0.45,-0.3]
+tobTecStepClassifier2 = TrackMVAClassifierPrompt.clone()
+tobTecStepClassifier2.src = 'tobTecStepTracks'
+tobTecStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+tobTecStepClassifier2.qualityCuts = [0.0,0.0,0.0]
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+tobTecStep = ClassifierMerger.clone()
+tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
+
+
+
+
+TobTecStep = cms.Sequence(tobTecStepClusters*
+                          tobTecStepSeedLayersTripl*
+                          tobTecStepSeedsTripl*
+                          tobTecStepSeedLayersPair*
+                          tobTecStepSeedsPair*
+                          tobTecStepSeeds*
+                          tobTecStepTrackCandidates*
+                          tobTecStepTracks*
+                          tobTecStepClassifier1*tobTecStepClassifier2*
+                          tobTecStep)
+

--- a/RecoTracker/IterativeTracking/python/Phase1_iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1_iterativeTk_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.IterativeTracking.Phase1_InitialStepPreSplitting_cff import *
+from RecoTracker.IterativeTracking.Phase1_InitialStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_HighPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_DetachedQuadStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_DetachedTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_LowPtQuadStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_LowPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_MixedTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_PixelLessStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_TobTecStep_cff import *
+from RecoTracker.IterativeTracking.Phase1_JetCoreRegionalStep_cff import *
+
+from RecoTracker.FinalTrackSelectors.Phase1_earlyGeneralTracks_cfi import *
+from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
+from RecoTracker.FinalTrackSelectors.preDuplicateMergingGeneralTracks_cfi import *
+from RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
+from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import *
+
+iterTracking = cms.Sequence(
+    InitialStepPreSplitting
+    + InitialStep
+    + HighPtTripletStep
+    + DetachedQuadStep
+#    + DetachedTripletStep # FIXME: dropped for time being, but it may be enabled in the course of tuning
+    + LowPtQuadStep
+    + LowPtTripletStep
+    + MixedTripletStep
+    + PixelLessStep
+    + TobTecStep
+    + JetCoreRegionalStep
+    + earlyGeneralTracks
+    + muonSeededStep
+    + preDuplicateMergingGeneralTracks
+    + generalTracksSequence
+    + ConvStep
+    + conversionStepTracks
+)

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -20,6 +20,7 @@ def customise(process):
             sys.exit(1)
     if hasattr(process,'reconstruction'):
         process=customise_Reco(process,float(n))
+#        process=customise_Reco_v2(process)
                 
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
@@ -416,6 +417,255 @@ def customise_Reco(process,pileup):
     process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
     process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
     process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
+    process.templates.DoLorentz=False
+    process.templates.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
+
+    # This probably breaks badly the "displaced muon" reconstruction,
+    # but let's do it for now, until the upgrade tracking sequences
+    # are modernized
+    process.preDuplicateMergingDisplacedTracks.inputClassifiers.remove("muonSeededTracksInOutClassifier")
+    process.preDuplicateMergingDisplacedTracks.trackProducers.remove("muonSeededTracksInOut")
+
+    return process
+
+
+
+def customise_Reco_v2(process):
+    #use with latest pixel geometry
+    process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
+    # Need this line to stop error about missing siPixelDigis.
+    process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
+
+    # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
+    process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
+                                                        'BPix2+BPix3+BPix4',
+                                                        'BPix1+BPix3+BPix4',
+                                                        'BPix1+BPix2+BPix4',
+                                                        'BPix2+BPix3+FPix1_pos',
+                                                        'BPix2+BPix3+FPix1_neg',
+                                                        'BPix1+BPix2+FPix1_pos',
+                                                        'BPix1+BPix2+FPix1_neg',
+                                                        'BPix2+FPix1_pos+FPix2_pos',
+                                                        'BPix2+FPix1_neg+FPix2_neg',
+                                                        'BPix1+FPix1_pos+FPix2_pos',
+                                                        'BPix1+FPix1_neg+FPix2_neg',
+                                                        'FPix1_pos+FPix2_pos+FPix3_pos',
+                                                        'FPix1_neg+FPix2_neg+FPix3_neg' )
+
+    # New tracking.  This is really ugly because it redefines globalreco and reconstruction.
+    # It can be removed if change one line in Configuration/StandardSequences/python/Reconstruction_cff.py
+    # from RecoTracker_cff.py to RecoTrackerPhase1PU140_cff.py
+
+    # remove all the tracking first
+    itIndex=process.globalreco_tracking.index(process.trackingGlobalReco)
+    grIndex=process.globalreco.index(process.globalreco_tracking)
+
+    process.globalreco.remove(process.globalreco_tracking)
+    process.globalreco_tracking.remove(process.iterTracking)
+    process.globalreco_tracking.remove(process.electronSeedsSeq)
+    process.reconstruction_fromRECO.remove(process.trackingGlobalReco)
+    process.reconstruction_fromRECO.remove(process.electronSeedsSeq)
+    process.reconstruction_fromRECO.remove(process.initialStep)
+    process.reconstruction_fromRECO.remove(process.initialStepSeedLayers)
+    process.reconstruction_fromRECO.remove(process.initialStepSeeds)
+    process.reconstruction_fromRECO.remove(process.initialStepClassifier1)
+    process.reconstruction_fromRECO.remove(process.initialStepClassifier2)
+    process.reconstruction_fromRECO.remove(process.initialStepClassifier3)
+    process.reconstruction_fromRECO.remove(initialStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(initialStepTracks)
+    process.reconstruction_fromRECO.remove(process.initialStepTrackRefsForJets)
+    process.reconstruction_fromRECO.remove(process.firstStepPrimaryVertices)
+    process.reconstruction_fromRECO.remove(process.firstStepGoodPrimaryVertices)
+    process.reconstruction_fromRECO.remove(lowPtTripletStepClusters)
+    process.reconstruction_fromRECO.remove(lowPtTripletStepSeedLayers)
+    process.reconstruction_fromRECO.remove(lowPtTripletStepSeeds)
+    process.reconstruction_fromRECO.remove(lowPtTripletStep)
+    process.reconstruction_fromRECO.remove(lowPtTripletStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(lowPtTripletStepTracks)
+
+    process.reconstruction_fromRECO.remove(process.detachedTripletStep)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepClusters)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepSeedLayers)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepSeeds)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepTracks)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepClassifier1)
+    process.reconstruction_fromRECO.remove(process.detachedTripletStepClassifier2)
+
+    process.reconstruction_fromRECO.remove(mixedTripletStep)
+    process.reconstruction_fromRECO.remove(mixedTripletStepClusters)
+    process.reconstruction_fromRECO.remove(mixedTripletStepSeedLayersA)
+    process.reconstruction_fromRECO.remove(mixedTripletStepSeedLayersB)
+    process.reconstruction_fromRECO.remove(mixedTripletStepSeeds)
+    process.reconstruction_fromRECO.remove(mixedTripletStepSeedsA)
+    process.reconstruction_fromRECO.remove(mixedTripletStepSeedsB)
+    process.reconstruction_fromRECO.remove(mixedTripletStepClassifier1)
+    process.reconstruction_fromRECO.remove(mixedTripletStepClassifier2)
+    process.reconstruction_fromRECO.remove(mixedTripletStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(mixedTripletStepTracks)
+
+    process.reconstruction_fromRECO.remove(pixelPairStepClusters)
+    process.reconstruction_fromRECO.remove(pixelPairStepSeeds)
+    process.reconstruction_fromRECO.remove(pixelPairStepSeedLayers)
+    process.reconstruction_fromRECO.remove(pixelPairStep)
+    process.reconstruction_fromRECO.remove(pixelPairStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(pixelPairStepTracks)
+
+    process.reconstruction_fromRECO.remove(process.pixelLessStep)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepClusters)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepSeeds)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepSeedLayers)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepTracks)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepClassifier1)
+    process.reconstruction_fromRECO.remove(process.pixelLessStepClassifier2)
+    
+    process.reconstruction_fromRECO.remove(tobTecStepClusters)
+    process.reconstruction_fromRECO.remove(tobTecStepSeeds)
+    process.reconstruction_fromRECO.remove(process.tobTecStepSeedLayersPair)
+    process.reconstruction_fromRECO.remove(process.tobTecStepSeedLayersTripl)
+    process.reconstruction_fromRECO.remove(process.tobTecStepSeedsPair)
+    process.reconstruction_fromRECO.remove(process.tobTecStepSeedsTripl)
+    #process.reconstruction_fromRECO.remove(tobTecStepSeedLayers)
+    process.reconstruction_fromRECO.remove(tobTecStepClassifier1)
+    process.reconstruction_fromRECO.remove(tobTecStepClassifier2)
+    process.reconstruction_fromRECO.remove(tobTecStep)
+    process.reconstruction_fromRECO.remove(tobTecStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(tobTecStepTracks)
+
+    process.reconstruction_fromRECO.remove(process.jetCoreRegionalStep)
+    process.reconstruction_fromRECO.remove(process.jetCoreRegionalStepSeedLayers)
+    process.reconstruction_fromRECO.remove(process.jetCoreRegionalStepSeeds)
+    process.reconstruction_fromRECO.remove(process.jetCoreRegionalStepTrackCandidates)
+    process.reconstruction_fromRECO.remove(process.jetCoreRegionalStepTracks)
+    process.reconstruction_fromRECO.remove(process.jetsForCoreTracking)
+
+    # Yes, needs to be done twice for InOut...
+    process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
+    process.reconstruction_fromRECO.remove(process.muonSeededSeedsOutIn)
+    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesOutIn)
+    process.reconstruction_fromRECO.remove(process.muonSeededTracksOutIn)
+    # Why are these modules in this sequence (isn't iterTracking enough)?
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsInOut)
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededTrackCandidatesInOut)
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededTracksInOut)
+    process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsOutIn)
+    process.muonSeededStepExtraDisplaced.remove(process.muonSeededTracksInOutClassifier)
+
+    process.reconstruction_fromRECO.remove(process.convClusters)
+    process.reconstruction_fromRECO.remove(process.convLayerPairs)
+    process.reconstruction_fromRECO.remove(process.convStepSelector)
+    process.reconstruction_fromRECO.remove(process.convTrackCandidates)
+    process.reconstruction_fromRECO.remove(process.convStepTracks)
+    process.reconstruction_fromRECO.remove(process.photonConvTrajSeedFromSingleLeg)
+
+    process.reconstruction_fromRECO.remove(process.preDuplicateMergingGeneralTracks)
+
+    process.reconstruction_fromRECO.remove(process.chargeCut2069Clusters)
+
+    # Needed to make the loading of recoFromSimDigis_cff below to work
+    process.InitialStepPreSplitting.remove(siPixelClusters)
+
+    del process.iterTracking
+    del process.ckftracks
+    del process.ckftracks_woBH
+    del process.ckftracks_wodEdX
+    del process.ckftracks_plus_pixelless
+    del process.trackingGlobalReco
+    del process.electronSeedsSeq
+    del process.InitialStepPreSplitting
+    del process.InitialStep
+    del process.LowPtTripletStep
+    del process.PixelPairStep
+    del process.DetachedTripletStep
+    del process.MixedTripletStep
+    del process.PixelLessStep
+    del process.TobTecStep
+    del process.JetCoreRegionalStep
+    del process.earlyGeneralTracks
+    del process.muonSeededStep
+    del process.muonSeededStepCore
+    del process.muonSeededStepDebug
+    del process.muonSeededStepDebugDisplaced
+    del process.ConvStep
+
+    # Need these until pixel templates are used, and need to load this
+    # before the tracking configuration
+    process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
+
+    # add the correct tracking back in
+    process.load("RecoTracker.Configuration.RecoTrackerPhase1_cff")
+
+    process.globalreco_tracking.insert(itIndex,process.trackingGlobalReco)
+    process.globalreco.insert(grIndex,process.globalreco_tracking)
+    #Note process.reconstruction_fromRECO is broken
+    
+    # End of new tracking configuration which can be removed if new Reconstruction is used.
+
+
+    process.reconstruction.remove(process.castorreco)
+    process.reconstruction.remove(process.CastorTowerReco)
+    process.reconstruction.remove(process.ak5CastorJets)
+    process.reconstruction.remove(process.ak5CastorJetID)
+    process.reconstruction.remove(process.ak7CastorJets)
+    #process.reconstruction.remove(process.ak7BasicJets)
+    process.reconstruction.remove(process.ak7CastorJetID)
+
+    #the quadruplet merger configuration     
+    process.load("RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff")
+    process.PixelSeedMergerQuadruplets.BPix.TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
+    process.PixelSeedMergerQuadruplets.BPix.HitProducer = cms.string("siPixelRecHits" )
+    process.PixelSeedMergerQuadruplets.FPix.TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
+    process.PixelSeedMergerQuadruplets.FPix.HitProducer = cms.string("siPixelRecHits" )    
+    
+    # Need these until pixel templates are used
+    # PixelCPEGeneric #
+    process.PixelCPEGenericESProducer.Upgrade = cms.bool(True)
+    process.PixelCPEGenericESProducer.UseErrorsFromTemplates = cms.bool(False)
+    process.PixelCPEGenericESProducer.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.TruncatePixelCharge = cms.bool(False)
+    process.PixelCPEGenericESProducer.IrradiationBiasCorrection = False
+    process.PixelCPEGenericESProducer.DoCosmics = False
+    # CPE for other steps
+    process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
+    # Turn of template use in tracking (iterative steps handled inside their configs)
+    process.duplicateTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
+    process.convStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.mergedDuplicateTracks.TTRHBuilder = 'WithTrackAngle'
+    process.ctfWithMaterialTracks.TTRHBuilder = 'WithTrackAngle'
+    process.muonSeededSeedsInOut.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+    process.muonSeededTracksInOut.TTRHBuilder=cms.string('WithTrackAngle')
+    process.muonSeededTracksOutIn.TTRHBuilder=cms.string('WithTrackAngle')
+    process.muons1stStep.TrackerKinkFinderParameters.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+    process.regionalCosmicTracks.TTRHBuilder=cms.string('WithTrackAngle')
+    process.cosmicsVetoTracksRaw.TTRHBuilder=cms.string('WithTrackAngle')
+    process.trackerDrivenElectronSeeds.TTRHBuilder = 'WithTrackAngle'
+    process.globalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    process.tevMuons.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.tevMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    process.muonSeededTracksOutInDisplaced.TTRHBuilder = 'WithTrackAngle'
+    process.duplicateDisplacedTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
+    process.mergedDuplicateDisplacedTracks.TTRHBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    process.glbTrackQual.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    # End of pixel template needed section
+
     process.templates.DoLorentz=False
     process.templates.LoadTemplatesFromDB = cms.bool(False)
     process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -19,8 +19,8 @@ def customise(process):
             print 'Please provide one!'
             sys.exit(1)
     if hasattr(process,'reconstruction'):
-        process=customise_Reco(process,float(n))
-#        process=customise_Reco_new(process)
+#        process=customise_Reco(process,float(n))
+        process=customise_Reco_new(process)
 #        process=customise_Reco_Run2(process)
                 
     if hasattr(process,'digitisation_step'):

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -21,6 +21,7 @@ def customise(process):
     if hasattr(process,'reconstruction'):
         process=customise_Reco(process,float(n))
 #        process=customise_Reco_v2(process)
+#        process=customise_Reco_Run2(process)
                 
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
@@ -675,5 +676,89 @@ def customise_Reco_v2(process):
     # are modernized
     process.preDuplicateMergingDisplacedTracks.inputClassifiers.remove("muonSeededTracksInOutClassifier")
     process.preDuplicateMergingDisplacedTracks.trackProducers.remove("muonSeededTracksInOut")
+
+    return process
+
+def customise_Reco_Run2(process):
+    #use with latest pixel geometry
+    process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
+    # Need this line to stop error about missing siPixelDigis.
+    process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
+
+    # Needed to make the loading of recoFromSimDigis_cff below to work
+    pixelClusterIndex = process.InitialStepPreSplitting.index(process.siPixelClusters)
+    process.InitialStepPreSplitting.remove(siPixelClusters)
+
+    # Need these until pixel templates are used, and need to load this
+    # before the tracking configuration
+    process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
+
+    process.InitialStepPreSplitting.insert(pixelClusterIndex, process.siPixelClusters)
+
+    # End of new tracking configuration which can be removed if new Reconstruction is used.
+
+
+    process.reconstruction.remove(process.castorreco)
+    process.reconstruction.remove(process.CastorTowerReco)
+    process.reconstruction.remove(process.ak5CastorJets)
+    process.reconstruction.remove(process.ak5CastorJetID)
+    process.reconstruction.remove(process.ak7CastorJets)
+    #process.reconstruction.remove(process.ak7BasicJets)
+    process.reconstruction.remove(process.ak7CastorJetID)
+
+    # Need these until pixel templates are used
+    # PixelCPEGeneric #
+    process.PixelCPEGenericESProducer.Upgrade = cms.bool(True)
+    process.PixelCPEGenericESProducer.UseErrorsFromTemplates = cms.bool(False)
+    process.PixelCPEGenericESProducer.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.TruncatePixelCharge = cms.bool(False)
+    process.PixelCPEGenericESProducer.IrradiationBiasCorrection = False
+    process.PixelCPEGenericESProducer.DoCosmics = False
+    # CPE for other steps
+    process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
+    # Turn of template use in tracking
+    process.initialStepTracksPreSplitting.TTRHBuilder = 'WithTrackAngle'
+    process.initialStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.detachedTripletStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.lowPtTripletStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.pixelPairStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.mixedTripletStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.pixelLessStepTracks.TTRHBuilder = 'WithTrackAngle' 
+    process.tobTecStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.jetCoreRegionalStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.duplicateTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
+    process.convStepTracks.TTRHBuilder = 'WithTrackAngle'
+    process.mergedDuplicateTracks.TTRHBuilder = 'WithTrackAngle'
+    process.ctfWithMaterialTracks.TTRHBuilder = 'WithTrackAngle'
+    process.muonSeededSeedsInOut.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+    process.muonSeededTracksInOut.TTRHBuilder=cms.string('WithTrackAngle')
+    process.muonSeededTracksOutIn.TTRHBuilder=cms.string('WithTrackAngle')
+    process.muons1stStep.TrackerKinkFinderParameters.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+    process.regionalCosmicTracks.TTRHBuilder=cms.string('WithTrackAngle')
+    process.cosmicsVetoTracksRaw.TTRHBuilder=cms.string('WithTrackAngle')
+    process.trackerDrivenElectronSeeds.TTRHBuilder = 'WithTrackAngle'
+    process.globalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    process.tevMuons.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.tevMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    process.muonSeededTracksOutInDisplaced.TTRHBuilder = 'WithTrackAngle'
+    process.duplicateDisplacedTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
+    process.mergedDuplicateDisplacedTracks.TTRHBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.displacedGlobalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    process.glbTrackQual.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+    process.globalSETMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+    # End of pixel template needed section
+
+    process.templates.DoLorentz=False
+    process.templates.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
 
     return process

--- a/SLHCUpgradeSimulations/Geometry/python/recoFromSimDigis_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/recoFromSimDigis_cff.py
@@ -1,8 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import *
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi import *
 siPixelClusters.src = 'simSiPixelDigis'
 siPixelClusters.MissCalibrate = False
+siPixelClustersPreSplitting.src = 'simSiPixelDigis'
+siPixelClustersPreSplitting.MissCalibrate = False
 
 from RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi import *
 siStripZeroSuppression.RawDigiProducersList = cms.VInputTag( cms.InputTag('simSiStripDigis','VirginRaw'),


### PR DESCRIPTION
This PR updates the Phase1 tracking sequence from the `Phase1PU70` to the one presented in tracking POG meeting Feb 1st. The performance comparison against `Phase1PU70` and run2 tracking (in phase1 detector) can be found from
https://indico.cern.ch/event/489234/contribution/5/attachments/1220760/1784567/slides_phase1.pdf
Due to the situation of the phase1 workflows (see the points below), the main purposes of this PR are to allow review/discussion on the implementation, and the use of the sequence e.g. for track selection MVA training.

Since the era migration of the reconstruction part of the phase1 customization is still pending, the new sequence is added following the current pattern (full configuration fragments + customize function). The customize for the Phase1PU70 is kept, and another customize for running run2 tracking in phase1 detector is added for reference. The tracking configuration is selected by changing which line in `phase1TkCustoms.py` is uncommented (not too handy, but hopefully good-enough while waiting for better solutions, see e.g. https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3597/1/2/1.html and onwards).

Also the effects on phase1 can't be easily tested before #12806 gets merged one way or another, and MultiTrackValidator configuration gets additional tuning for the iterations (that depends on #12806 and hence is not included in here).

Tested in 8_0_0_pre5. No changes expected in run2 workflows, for phase1 `-w upgrade -l 10000` runs.

@rovere @VinInn 
