### PR TITLE
Replace boost::shared_ptr with std::shared_ptr

### DIFF
--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -1,8 +1,8 @@
 #ifndef CondCore_ESSources_DataProxy_H
 #define CondCore_ESSources_DataProxy_H
 //#include <iostream>
+#include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/DataProxyTemplate.h"
@@ -20,9 +20,9 @@ template< class RecordT, class DataT , typename Initializer=cond::DefaultInitial
 class DataProxy : public edm::eventsetup::DataProxyTemplate<RecordT, DataT >{
   public:
   typedef DataProxy<RecordT,DataT> self;
-    typedef boost::shared_ptr<cond::persistency::PayloadProxy<DataT> > DataP;
+    typedef std::shared_ptr<cond::persistency::PayloadProxy<DataT> > DataP;
 
-    explicit DataProxy(boost::shared_ptr<cond::persistency::PayloadProxy<DataT> > pdata) : m_data(pdata) { 
+    explicit DataProxy(std::shared_ptr<cond::persistency::PayloadProxy<DataT> > pdata) : m_data(pdata) { 
  
   }
   //virtual ~DataProxy();
@@ -51,7 +51,7 @@ class DataProxy : public edm::eventsetup::DataProxyTemplate<RecordT, DataT >{
   const DataProxy& operator=( const DataProxy& ); // stop default
   // ---------- member data --------------------------------
 
-  boost::shared_ptr<cond::persistency::PayloadProxy<DataT> >  m_data;
+  std::shared_ptr<cond::persistency::PayloadProxy<DataT> >  m_data;
   Initializer m_initializer;
 };
 
@@ -62,8 +62,8 @@ namespace cond {
    */
   class DataProxyWrapperBase {
   public:
-    typedef boost::shared_ptr<cond::persistency::BasePayloadProxy> ProxyP;
-    typedef boost::shared_ptr<edm::eventsetup::DataProxy> edmProxyP;
+    typedef std::shared_ptr<cond::persistency::BasePayloadProxy> ProxyP;
+    typedef std::shared_ptr<edm::eventsetup::DataProxy> edmProxyP;
     
     // limitation of plugin manager...
     typedef std::pair< std::string, std::string> Args;
@@ -104,7 +104,7 @@ class DataProxyWrapper : public  cond::DataProxyWrapperBase {
 public:
   typedef ::DataProxy<RecordT,DataT, Initializer> DataProxy;
   typedef cond::persistency::PayloadProxy<DataT> PayProxy;
-  typedef boost::shared_ptr<PayProxy> DataP;
+  typedef std::shared_ptr<PayProxy> DataP;
   
   
   DataProxyWrapper(cond::persistency::Session& session,
@@ -143,7 +143,7 @@ public:
 private:
   std::string m_source;
   edm::eventsetup::TypeTag m_type;
-  boost::shared_ptr<cond::persistency::PayloadProxy<DataT> >  m_proxy;
+  std::shared_ptr<cond::persistency::PayloadProxy<DataT> >  m_proxy;
   edmProxyP m_edmProxy;
 
 };

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -12,7 +12,6 @@
 //
 #include "CondDBESSource.h"
 
-#include "boost/shared_ptr.hpp"
 #include <boost/algorithm/string.hpp>
 #include "CondCore/CondDB/interface/Exception.h"
 #include "CondCore/CondDB/interface/Time.h"

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -13,6 +13,7 @@
 // system include files
 #include <string>
 #include <map>
+#include <memory>
 #include <set>
 // user include files
 #include "CondCore/CondDB/interface/ConnectionPool.h"
@@ -32,7 +33,7 @@ namespace cond{
 class CondDBESSource : public edm::eventsetup::DataProxyProvider,
 		       public edm::EventSetupRecordIntervalFinder{
  public:
-  typedef boost::shared_ptr<cond::DataProxyWrapperBase > ProxyP;
+  typedef std::shared_ptr<cond::DataProxyWrapperBase > ProxyP;
   typedef std::multimap< std::string,  ProxyP> ProxyMap;
 
   typedef enum { NOREFRESH, REFRESH_ALWAYS, REFRESH_OPEN_IOVS, REFRESH_EACH_RUN, RECONNECT_EACH_RUN } RefreshPolicy;

--- a/DataFormats/FWLite/test/BuildFile.xml
+++ b/DataFormats/FWLite/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use   name="boost"/>
   <use   name="cppunit"/>
 </environment>
 <bin   name="testDataFormatsFWLiteMakeInput" file="TestRunnerDataFormatsFWLite.cpp">

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/Provenance"/>
 <bin   name="testDataFormatsProvenance"file="testRunner.cpp,eventid_t.cppunit.cc,timestamp_t.cppunit.cc,parametersetid_t.cppunit.cc,indexIntoFile_t.cppunit.cc,indexIntoFile1_t.cppunit.cc,indexIntoFile2_t.cppunit.cc,indexIntoFile3_t.cppunit.cc,indexIntoFile4_t.cppunit.cc,indexIntoFile5_t.cppunit.cc,lumirange_t.cppunit.cc,eventrange_t.cppunit.cc">

--- a/FWCore/Concurrency/test/BuildFile.xml
+++ b/FWCore/Concurrency/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <bin   name="testFWCoreConcurrency" file="*.cppunit.cpp">
   <use   name="cppunit"/>
-  <use   name="boost"/>
   <use   name="FWCore/Concurrency"/>
 </bin>
 <bin file="test_xercesInitialize.cpp">

--- a/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
@@ -13,7 +13,6 @@
 #include <atomic>
 #include <thread>
 #include "tbb/task.h"
-#include "boost/shared_ptr.hpp"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
 
 class SerialTaskQueue_test : public CppUnit::TestFixture {
@@ -41,7 +40,7 @@ void SerialTaskQueue_test::testPush()
    
    edm::SerialTaskQueue queue;
    {
-      boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                             [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(1+3);
       tbb::task* pWaitTask = waitTask.get();
@@ -103,7 +102,7 @@ void SerialTaskQueue_test::testPause()
    {
       queue.pause();
       {
-         boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+         std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                              [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
          waitTask->set_ref_count(1+1);
          tbb::task* pWaitTask = waitTask.get();
@@ -120,7 +119,7 @@ void SerialTaskQueue_test::testPause()
       }
 
       {
-         boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+         std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                              [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
          waitTask->set_ref_count(1+3);
          tbb::task* pWaitTask = waitTask.get();
@@ -162,7 +161,7 @@ void SerialTaskQueue_test::stressTest()
    unsigned int index = 100;
    const unsigned int nTasks = 1000;
    while(0 != --index) {
-      boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                             [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(3);
       tbb::task* pWaitTask=waitTask.get();
@@ -193,7 +192,7 @@ void SerialTaskQueue_test::stressTest()
             });
          }
          pWaitTask->decrement_ref_count();
-         boost::shared_ptr<std::thread>(&pushThread,join_thread);
+         std::shared_ptr<std::thread>(&pushThread,join_thread);
       }
       waitTask->wait_for_all();
 

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -13,7 +13,6 @@
 #include <atomic>
 #include <thread>
 #include "tbb/task.h"
-#include "boost/shared_ptr.hpp"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
@@ -69,7 +68,7 @@ void WaitingTaskList_test::addThenDone()
    
    edm::WaitingTaskList waitList;
    {
-      boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                             [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(2);
       //NOTE: allocate_child does NOT increment the ref_count of waitTask!
@@ -91,7 +90,7 @@ void WaitingTaskList_test::addThenDone()
    called = false;
    
    {
-      boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                             [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(2);
    
@@ -113,7 +112,7 @@ void WaitingTaskList_test::doneThenAdd()
    std::atomic<bool> called{false};
    edm::WaitingTaskList waitList;
    {
-      boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                             [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(2);
    
@@ -145,7 +144,7 @@ void WaitingTaskList_test::stressTest()
    const unsigned int nTasks = 10000;
    while(0 != --index) {
       called = false;
-      boost::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
                                             [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(3);
       tbb::task* pWaitTask=waitTask.get();
@@ -159,14 +158,14 @@ void WaitingTaskList_test::stressTest()
          
             pWaitTask->decrement_ref_count();
             });
-         boost::shared_ptr<std::thread>(&makeTasksThread,join_thread);
+         std::shared_ptr<std::thread>(&makeTasksThread,join_thread);
          
          std::thread doneWaitThread([&waitList,&called,pWaitTask]{
             called=true;
             waitList.doneWaiting();
             pWaitTask->decrement_ref_count();
             });
-         boost::shared_ptr<std::thread>(&doneWaitThread,join_thread);
+         std::shared_ptr<std::thread>(&doneWaitThread,join_thread);
       }
       waitTask->wait_for_all();
    }

--- a/FWCore/FWLite/BuildFile.xml
+++ b/FWCore/FWLite/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
-<use   name="boost"/>
 <use   name="rootcore"/>
 <export>
   <lib   name="1"/>

--- a/FWCore/FWLite/test/BuildFile.xml
+++ b/FWCore/FWLite/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use   name="boost"/>
   <use   name="cppunit"/>
 </environment>
 <bin   name="testFWCoreFWLite" file="ref_t.cppunit.cpp">

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -20,8 +20,8 @@
 //
 
 // system include files
-#include "boost/shared_ptr.hpp"
 #include <cassert>
+#include <memory>
 
 // user include files
 #include "FWCore/Framework/interface/DataProxy.h"
@@ -41,7 +41,7 @@ namespace edm {
          typedef  typename produce::smart_pointer_traits<DataT>::type value_type;
          typedef  RecordT record_type;
          
-         CallbackProxy(boost::shared_ptr<CallbackT>& iCallback) :
+         CallbackProxy(std::shared_ptr<CallbackT>& iCallback) :
          data_(),
          callback_(iCallback) { 
             //The callback fills the data directly.  This is done so that the callback does not have to
@@ -74,7 +74,7 @@ namespace edm {
          
          // ---------- member data --------------------------------
          DataT data_;
-         edm::propagate_const<boost::shared_ptr<CallbackT>> callback_;
+         edm::propagate_const<std::shared_ptr<CallbackT>> callback_;
       };
       
    }

--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -21,8 +21,8 @@
 // system include files
 #include <string>
 #include <map>
+#include <memory>
 #include <exception>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/PluginManager/interface/PluginFactory.h"
@@ -47,10 +47,10 @@ template<typename T>
    //~ComponentFactory();
 
    typedef  ComponentMakerBase<T> Maker;
-   typedef std::map<std::string, boost::shared_ptr<Maker> > MakerMap;
+   typedef std::map<std::string, std::shared_ptr<Maker> > MakerMap;
    typedef typename T::base_type base_type;
       // ---------- const member functions ---------------------
-   boost::shared_ptr<base_type> addTo(EventSetupsController& esController,
+   std::shared_ptr<base_type> addTo(EventSetupsController& esController,
                                       EventSetupProvider& iProvider,
                                       edm::ParameterSet const& iConfiguration,
                                       bool replaceExisting = false) const
@@ -61,7 +61,7 @@ template<typename T>
          
          if(it == makers_.end())
          {
-            boost::shared_ptr<Maker> wm(edmplugin::PluginFactory<ComponentMakerBase<T>* ()>::get()->create(modtype));
+            std::shared_ptr<Maker> wm(edmplugin::PluginFactory<ComponentMakerBase<T>* ()>::get()->create(modtype));
             
             if(wm.get() == 0) {
 	      Exception::throwThis(errors::Configuration,
@@ -79,7 +79,7 @@ template<typename T>
             //cerr << "Factory: created the worker" << endl;
             
             std::pair<typename MakerMap::iterator,bool> ret =
-               makers_.insert(std::pair<std::string,boost::shared_ptr<Maker> >(modtype,wm));
+               makers_.insert(std::pair<std::string,std::shared_ptr<Maker> >(modtype,wm));
             
             if(ret.second == false) {
 	      Exception::throwThis(errors::Configuration,"Maker Factory map insert failed");
@@ -89,7 +89,7 @@ template<typename T>
          }
          
          try {
-           return convertException::wrap([&]() -> boost::shared_ptr<base_type> {
+           return convertException::wrap([&]() -> std::shared_ptr<base_type> {
              return it->second->addTo(esController, iProvider, iConfiguration, replaceExisting);
            });
          }
@@ -101,7 +101,7 @@ template<typename T>
            iException.addContext(ost.str());
            throw;
          }
-         return boost::shared_ptr<base_type>();
+         return std::shared_ptr<base_type>();
       }
    
       // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
+#include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ComponentDescription.h"
@@ -47,10 +47,10 @@ namespace edm {
       class ComponentMakerBase : public ComponentMakerBaseHelper {
       public:
          typedef typename T::base_type base_type;
-         virtual boost::shared_ptr<base_type> addTo(EventSetupsController& esController,
-                                                    EventSetupProvider& iProvider,
-                                                    ParameterSet const& iConfiguration,
-                                                    bool replaceExisting) const = 0;
+         virtual std::shared_ptr<base_type> addTo(EventSetupsController& esController,
+                                                  EventSetupProvider& iProvider,
+                                                  ParameterSet const& iConfiguration,
+                                                  bool replaceExisting) const = 0;
       };
       
    template <class T, class TComponent>
@@ -63,7 +63,7 @@ namespace edm {
    typedef typename T::base_type base_type;
 
       // ---------- const member functions ---------------------
-   virtual boost::shared_ptr<base_type> addTo(EventSetupsController& esController,
+   virtual std::shared_ptr<base_type> addTo(EventSetupsController& esController,
                                               EventSetupProvider& iProvider,
                                               ParameterSet const& iConfiguration,
                                               bool replaceExisting) const;
@@ -98,7 +98,7 @@ namespace edm {
 };
 
 template< class T, class TComponent>
-boost::shared_ptr<typename ComponentMaker<T,TComponent>::base_type>
+std::shared_ptr<typename ComponentMaker<T,TComponent>::base_type>
 ComponentMaker<T,TComponent>::addTo(EventSetupsController& esController,
                                     EventSetupProvider& iProvider,
                                     ParameterSet const& iConfiguration,
@@ -109,20 +109,20 @@ ComponentMaker<T,TComponent>::addTo(EventSetupsController& esController,
    // SubProcess or the top level process and add that.
 
    if (!replaceExisting) {
-      boost::shared_ptr<typename T::base_type> alreadyMadeComponent = T::getComponentAndRegisterProcess(esController, iConfiguration);
+      std::shared_ptr<typename T::base_type> alreadyMadeComponent = T::getComponentAndRegisterProcess(esController, iConfiguration);
 
       if (alreadyMadeComponent) {
          // This is for the case when a component is shared between
          // a SubProcess and a previous SubProcess or the top level process
          // because the component has an identical configuration to a component
          // from the top level process or earlier SubProcess.
-         boost::shared_ptr<TComponent> component(boost::static_pointer_cast<TComponent, typename T::base_type>(alreadyMadeComponent));
+         std::shared_ptr<TComponent> component(std::static_pointer_cast<TComponent, typename T::base_type>(alreadyMadeComponent));
          T::addTo(iProvider, component, iConfiguration, true);
          return component;
       }
    }
 
-   boost::shared_ptr<TComponent> component(new TComponent(iConfiguration));
+   std::shared_ptr<TComponent> component(new TComponent(iConfiguration));
    ComponentDescription description =
       this->createComponentDescription(iConfiguration);
 

--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -20,10 +20,10 @@
 
 // system include files
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
@@ -45,7 +45,7 @@ class DataProxyProvider
 
    public:   
       typedef std::vector< EventSetupRecordKey> Keys;
-      typedef std::vector<std::pair<DataKey, edm::propagate_const<boost::shared_ptr<DataProxy>>>> KeyedProxies;
+      typedef std::vector<std::pair<DataKey, edm::propagate_const<std::shared_ptr<DataProxy>>>> KeyedProxies;
       typedef std::map<EventSetupRecordKey, KeyedProxies> RecordProxies;
       
       DataProxyProvider();
@@ -111,7 +111,7 @@ class DataProxyProvider
 
 template<class ProxyT>
 inline void insertProxy(DataProxyProvider::KeyedProxies& iList,
-                        boost::shared_ptr<ProxyT> iProxy,
+                        std::shared_ptr<ProxyT> iProxy,
                         const char* iName="") {
    iList.push_back(DataProxyProvider::KeyedProxies::value_type(
                                              DataKey(DataKey::makeTypeTag<typename ProxyT::value_type>(),

--- a/FWCore/Framework/interface/DependentRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/DependentRecordIntervalFinder.h
@@ -21,8 +21,8 @@
 //
 
 // system include files
+#include <memory>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
@@ -48,9 +48,9 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-      void addProviderWeAreDependentOn(boost::shared_ptr<EventSetupRecordProvider>);
+      void addProviderWeAreDependentOn(std::shared_ptr<EventSetupRecordProvider>);
       
-      void setAlternateFinder(boost::shared_ptr<EventSetupRecordIntervalFinder>);
+      void setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder>);
    protected:
       virtual void setIntervalFor(const EventSetupRecordKey&,
                                    const IOVSyncValue& , 
@@ -62,10 +62,10 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
       const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&); // stop default
 
       // ---------- member data --------------------------------
-      typedef std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordProvider>>> Providers;
+      typedef std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordProvider>>> Providers;
       Providers providers_;
       
-      edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>> alternate_;
+      edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>> alternate_;
       std::vector<ValidityInterval> previousIOVs_;
 };
 

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -18,7 +18,7 @@
     If only one algorithm is being encapsulated then the user needs to
       1) add a method name 'produce' to the class.  The 'produce' takes as its argument a const reference
          to the record that is to hold the data item being produced.  If only one data item is being produced,
-         the 'produce' method must return either an 'std::auto_ptr' or 'boost::shared_ptr' to the object being
+         the 'produce' method must return either an 'std::auto_ptr' or 'std::shared_ptr' to the object being
          produced.  (The choice depends on if the EventSetup or the ESProducer is managing the lifetime of 
          the object).  If multiple items are being Produced they the 'produce' method must return an
          ESProducts<> object which holds all of the items.
@@ -155,7 +155,7 @@ class ESProducer : public ESProxyFactoryProducer
                               TReturn (T ::* iMethod)(const TRecord&),
                               const TArg& iDec,
                               const es::Label& iLabel = es::Label()) {
-            boost::shared_ptr<eventsetup::Callback<T,TReturn,TRecord, typename eventsetup::DecoratorFromArg<T, TRecord, TArg>::Decorator_t > >
+            std::shared_ptr<eventsetup::Callback<T,TReturn,TRecord, typename eventsetup::DecoratorFromArg<T, TRecord, TArg>::Decorator_t > >
             callback(new eventsetup::Callback<T,
                                           TReturn,
                                           TRecord, 
@@ -194,26 +194,26 @@ class ESProducer : public ESProxyFactoryProducer
          };
       */
       template<typename CallbackT, typename TList, typename TRecord>
-         void registerProducts(boost::shared_ptr<CallbackT> iCallback, const TList*, const TRecord* iRecord,
+         void registerProducts(std::shared_ptr<CallbackT> iCallback, const TList*, const TRecord* iRecord,
                                const es::Label& iLabel) {
             registerProduct(iCallback, static_cast<const typename TList::tail_type*>(nullptr), iRecord, iLabel);
             registerProducts(iCallback, static_cast<const typename TList::head_type*>(nullptr), iRecord, iLabel);
          }
       template<typename T, typename TRecord>
-         void registerProducts(boost::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*,const es::Label&) {
+         void registerProducts(std::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*,const es::Label&) {
             //do nothing
          }
       
       
       template<typename T, typename TProduct, typename TRecord>
-         void registerProduct(boost::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {
+         void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {
 	    typedef eventsetup::CallbackProxy<T, TRecord, TProduct> ProxyType;
-	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, boost::shared_ptr<T> > FactoryType;
+	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T> > FactoryType;
             registerFactory(std::auto_ptr<FactoryType>(new FactoryType(iCallback)), iLabel.default_);
          }
       
       template<typename T, typename TProduct, typename TRecord, int IIndex>
-         void registerProduct(boost::shared_ptr<T> iCallback, const es::L<TProduct,IIndex>*, const TRecord*,const es::Label& iLabel) {
+         void registerProduct(std::shared_ptr<T> iCallback, const es::L<TProduct,IIndex>*, const TRecord*,const es::Label& iLabel) {
             if(iLabel.labels_.size() <= IIndex ||
                iLabel.labels_[IIndex] == es::Label::def()) {
                Exception::throwThis(errors::Configuration,
@@ -222,13 +222,13 @@ class ESProducer : public ESProxyFactoryProducer
                  " was never assigned a name in the 'setWhatProduced' method");
             }
 	    typedef eventsetup::CallbackProxy<T, TRecord, es::L<TProduct, IIndex> > ProxyType;
-	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, boost::shared_ptr<T> > FactoryType;
+	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T> > FactoryType;
             registerFactory(std::auto_ptr<FactoryType>(new FactoryType(iCallback)), iLabel.labels_[IIndex]);
          }
       
       // ---------- member data --------------------------------
       // NOTE: the factories share ownership of the callback
-      //std::vector<boost::shared_ptr<CallbackBase> > callbacks_;
+      //std::vector<std::shared_ptr<CallbackBase> > callbacks_;
       
 };
 }

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -54,7 +54,6 @@ BarProd::BarProd(const edm::ParameterSet& iPS) {
 #include <map>
 #include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 
@@ -69,11 +68,11 @@ namespace edm {
       struct FactoryInfo {
          FactoryInfo() : key_(), factory_() {}
          FactoryInfo(const DataKey& iKey, 
-                      boost::shared_ptr<ProxyFactoryBase> iFactory)
+                      std::shared_ptr<ProxyFactoryBase> iFactory)
          : key_(iKey), 
          factory_(iFactory) {} 
          DataKey key_;
-         edm::propagate_const<boost::shared_ptr<ProxyFactoryBase>> factory_;
+         edm::propagate_const<std::shared_ptr<ProxyFactoryBase>> factory_;
       };
    }      
    

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -29,7 +29,6 @@ configured in the user's main() function, and is set running.
 
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-#include "boost/shared_ptr.hpp"
 #include "boost/thread/condition.hpp"
 
 #include <map>
@@ -258,8 +257,8 @@ namespace edm {
     std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
     std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
     std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
-    boost::shared_ptr<EDLooperBase const> looper() const {return get_underlying_safe(looper_);}
-    boost::shared_ptr<EDLooperBase>& looper() {return get_underlying_safe(looper_);}
+    std::shared_ptr<EDLooperBase const> looper() const {return get_underlying_safe(looper_);}
+    std::shared_ptr<EDLooperBase>& looper() {return get_underlying_safe(looper_);}
     //------------------------------------------------------------------
     //
     // Data members below.
@@ -274,7 +273,7 @@ namespace edm {
     ServiceToken                                  serviceToken_;
     edm::propagate_const<std::unique_ptr<InputSource>> input_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
-    edm::propagate_const<boost::shared_ptr<eventsetup::EventSetupProvider>> esp_;
+    edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     std::unique_ptr<ExceptionToActionTable const>          act_table_;
     std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
     ProcessContext                                processContext_;
@@ -284,7 +283,7 @@ namespace edm {
     edm::propagate_const<std::unique_ptr<HistoryAppender>> historyAppender_;
 
     edm::propagate_const<std::unique_ptr<FileBlock>> fb_;
-    edm::propagate_const<boost::shared_ptr<EDLooperBase>> looper_;
+    edm::propagate_const<std::shared_ptr<EDLooperBase>> looper_;
 
     //The atomic protects concurrent access of deferredExceptionPtr_
     std::atomic<bool>                             deferredExceptionPtrIsSet_;

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -23,10 +23,9 @@
 #include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
 
 // system include files
-#include "boost/shared_ptr.hpp"
 
-#include <memory>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -74,9 +73,9 @@ class EventSetupProvider {
       //called by specializations of EventSetupRecordProviders
       void addRecordToEventSetup(EventSetupRecord& iRecord);
 
-      void add(boost::shared_ptr<DataProxyProvider>);
-      void replaceExisting(boost::shared_ptr<DataProxyProvider>);
-      void add(boost::shared_ptr<EventSetupRecordIntervalFinder>);
+      void add(std::shared_ptr<DataProxyProvider>);
+      void replaceExisting(std::shared_ptr<DataProxyProvider>);
+      void add(std::shared_ptr<EventSetupRecordIntervalFinder>);
 
       void finishConfiguration();
 
@@ -126,7 +125,7 @@ class EventSetupProvider {
 
       // ---------- member data --------------------------------
       EventSetup eventSetup_;
-      typedef std::map<EventSetupRecordKey, boost::shared_ptr<EventSetupRecordProvider> > Providers;
+      typedef std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> > Providers;
       Providers providers_;
       std::unique_ptr<EventSetupKnownRecordsSupplier> knownRecordsSupplier_;
       bool mustFinishConfiguration_;
@@ -135,10 +134,10 @@ class EventSetupProvider {
       // The following are all used only during initialization and then cleared.
 
       std::unique_ptr<PreferredProviderInfo> preferredProviderInfo_;
-      std::unique_ptr<std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> > > finders_;
-      std::unique_ptr<std::vector<boost::shared_ptr<DataProxyProvider> > > dataProviders_;
+      std::unique_ptr<std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > > finders_;
+      std::unique_ptr<std::vector<std::shared_ptr<DataProxyProvider> > > dataProviders_;
       std::unique_ptr<std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription const*> > > referencedDataKeys_;
-      std::unique_ptr<std::map<EventSetupRecordKey, std::vector<boost::shared_ptr<EventSetupRecordIntervalFinder> > > > recordToFinders_;
+      std::unique_ptr<std::map<EventSetupRecordKey, std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > > > recordToFinders_;
       std::unique_ptr<std::map<ParameterSetIDHolder, std::set<EventSetupRecordKey> > > psetIDToRecordKey_;
       std::unique_ptr<std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription> > > recordToPreferred_;
       std::unique_ptr<std::set<EventSetupRecordKey> > recordsWithALooperProxy_;

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -24,7 +24,6 @@
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 // system include files
-#include "boost/shared_ptr.hpp"
 
 #include <map>
 #include <memory>
@@ -65,31 +64,31 @@ class EventSetupRecordProvider {
       std::set<ComponentDescription> proxyProviderDescriptions() const;
       
       ///returns the first matching DataProxyProvider or a 'null' if not found
-      boost::shared_ptr<DataProxyProvider> proxyProvider(ComponentDescription const&);
+      std::shared_ptr<DataProxyProvider> proxyProvider(ComponentDescription const&);
 
       ///returns the first matching DataProxyProvider or a 'null' if not found
-      boost::shared_ptr<DataProxyProvider> proxyProvider(ParameterSetIDHolder const&);
+      std::shared_ptr<DataProxyProvider> proxyProvider(ParameterSetIDHolder const&);
 
 
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
 
-      void resetProxyProvider(ParameterSetIDHolder const&, boost::shared_ptr<DataProxyProvider> const&);
+      void resetProxyProvider(ParameterSetIDHolder const&, std::shared_ptr<DataProxyProvider> const&);
 
       void addRecordTo(EventSetupProvider&);
       void addRecordToIfValid(EventSetupProvider&, IOVSyncValue const&) ;
 
-      void add(boost::shared_ptr<DataProxyProvider>);
+      void add(std::shared_ptr<DataProxyProvider>);
       ///For now, only use one finder
-      void addFinder(boost::shared_ptr<EventSetupRecordIntervalFinder>);
+      void addFinder(std::shared_ptr<EventSetupRecordIntervalFinder>);
       void setValidityInterval(ValidityInterval const&);
       
       ///sets interval to this time and returns true if have a valid interval for time
       bool setValidityIntervalFor(IOVSyncValue const&);
 
       ///If the provided Record depends on other Records, here are the dependent Providers
-      void setDependentProviders(std::vector<boost::shared_ptr<EventSetupRecordProvider> >const&);
+      void setDependentProviders(std::vector<std::shared_ptr<EventSetupRecordProvider> >const&);
 
       /**In the case of a conflict, sets what Provider to call.  This must be called after
          all providers have been added.  An empty map is acceptable. */
@@ -98,8 +97,8 @@ class EventSetupRecordProvider {
       ///This will clear the cache's of all the Proxies so that next time they are called they will run
       void resetProxies();
       
-      boost::shared_ptr<EventSetupRecordIntervalFinder const> finder() const {return get_underlying_safe(finder_);}
-      boost::shared_ptr<EventSetupRecordIntervalFinder>& finder() {return get_underlying_safe(finder_);}
+      std::shared_ptr<EventSetupRecordIntervalFinder const> finder() const {return get_underlying_safe(finder_);}
+      std::shared_ptr<EventSetupRecordIntervalFinder>& finder() {return get_underlying_safe(finder_);}
 
       void getReferencedESProducers(std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers);
 
@@ -108,15 +107,15 @@ class EventSetupRecordProvider {
       void resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap);
 
    protected:
-      void addProxiesToRecordHelper(edm::propagate_const<boost::shared_ptr<DataProxyProvider>>& dpp,
+      void addProxiesToRecordHelper(edm::propagate_const<std::shared_ptr<DataProxyProvider>>& dpp,
                               DataToPreferredProviderMap const& mp) {addProxiesToRecord(get_underlying_safe(dpp), mp);}
-      void addProxiesToRecord(boost::shared_ptr<DataProxyProvider>,
+      void addProxiesToRecord(std::shared_ptr<DataProxyProvider>,
                               DataToPreferredProviderMap const&);
       void cacheReset();
    
       virtual EventSetupRecord& record() = 0;
       
-      boost::shared_ptr<EventSetupRecordIntervalFinder> swapFinder(boost::shared_ptr<EventSetupRecordIntervalFinder> iNew) {
+      std::shared_ptr<EventSetupRecordIntervalFinder> swapFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iNew) {
         std::swap(iNew, finder());
         return iNew;
       }
@@ -131,9 +130,9 @@ class EventSetupRecordProvider {
       // ---------- member data --------------------------------
       EventSetupRecordKey const key_;
       ValidityInterval validityInterval_;
-      edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>> finder_;
-      std::vector<edm::propagate_const<boost::shared_ptr<DataProxyProvider>>> providers_;
-      std::unique_ptr<std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>> multipleFinders_;
+      edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>> finder_;
+      std::vector<edm::propagate_const<std::shared_ptr<DataProxyProvider>>> providers_;
+      std::unique_ptr<std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>> multipleFinders_;
       bool lastSyncWasBeginOfRun_;
 };
    }

--- a/FWCore/Framework/interface/LooperFactory.h
+++ b/FWCore/Framework/interface/LooperFactory.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
+#include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ComponentFactory.h"
@@ -39,9 +39,9 @@ namespace edm {
 
       namespace looper {
       template<class T>
-         void addProviderTo(EventSetupProvider& iProvider, boost::shared_ptr<T> iComponent, const DataProxyProvider*) 
+         void addProviderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const DataProxyProvider*) 
       {
-            boost::shared_ptr<DataProxyProvider> pProvider(iComponent);
+            std::shared_ptr<DataProxyProvider> pProvider(iComponent);
             ComponentDescription description = pProvider->description();
             description.isSource_=true;
             description.isLooper_=true;
@@ -53,15 +53,15 @@ namespace edm {
             iProvider.add(pProvider);
       }
       template<class T>
-         void addProviderTo(EventSetupProvider& /* iProvider */, boost::shared_ptr<T> /*iComponent*/, const void*) 
+         void addProviderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) 
       {
             //do nothing
       }
 
       template<class T>
-        void addFinderTo(EventSetupProvider& iProvider, boost::shared_ptr<T> iComponent, const EventSetupRecordIntervalFinder*) 
+        void addFinderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const EventSetupRecordIntervalFinder*) 
       {
-          boost::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
+          std::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
 
           ComponentDescription description = pFinder->descriptionForFinder();
           description.isSource_=true;
@@ -75,7 +75,7 @@ namespace edm {
           iProvider.add(pFinder);
       }
       template<class T>
-        void addFinderTo(EventSetupProvider& /* iProvider */, boost::shared_ptr<T> /*iComponent*/, const void*) 
+        void addFinderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) 
       {
           //do nothing
       }
@@ -85,7 +85,7 @@ namespace edm {
          static std::string name();
          template<class T>
          static void addTo(EventSetupProvider& iProvider,
-                           boost::shared_ptr<T> iComponent,
+                           std::shared_ptr<T> iComponent,
                            ParameterSet const&,
                            bool)
             {
@@ -94,13 +94,13 @@ namespace edm {
                looper::addFinderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
             }
 
-         static void replaceExisting(EventSetupProvider& iProvider, boost::shared_ptr<EDLooperBase> iComponent); 
+         static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<EDLooperBase> iComponent); 
 
-         static boost::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
+         static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
                                                                             ParameterSet const& iConfiguration);               
          static void putComponent(EventSetupsController& esController,
                                   ParameterSet const& iConfiguration,
-                                  boost::shared_ptr<base_type> const& component);
+                                  std::shared_ptr<base_type> const& component);
       };
       template< class TType>
          struct LooperMaker : public ComponentMaker<edm::eventsetup::LooperMakerTraits,TType> {};

--- a/FWCore/Framework/interface/ModuleFactory.h
+++ b/FWCore/Framework/interface/ModuleFactory.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
+#include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ComponentFactory.h"
@@ -39,15 +39,15 @@ namespace edm {
         
          static std::string name();
          static void addTo(EventSetupProvider& iProvider,
-                           boost::shared_ptr<DataProxyProvider> iComponent,
+                           std::shared_ptr<DataProxyProvider> iComponent,
                            ParameterSet const&,
                            bool);
-         static void replaceExisting(EventSetupProvider& iProvider, boost::shared_ptr<DataProxyProvider> iComponent); 
-         static boost::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
+         static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<DataProxyProvider> iComponent); 
+         static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
                                                                             ParameterSet const& iConfiguration);
          static void putComponent(EventSetupsController& esController,
                                   ParameterSet const& iConfiguration,
-                                  boost::shared_ptr<base_type> const& component);
+                                  std::shared_ptr<base_type> const& component);
       };
       template< class TType>
          struct ModuleMaker : public ComponentMaker<edm::eventsetup::ModuleMakerTraits,TType> {};

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -81,8 +81,6 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <map>
 #include <memory>
 #include <set>

--- a/FWCore/Framework/interface/SourceFactory.h
+++ b/FWCore/Framework/interface/SourceFactory.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
+#include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ComponentFactory.h"
@@ -38,16 +38,16 @@ namespace edm {
       class EventSetupsController;
       
       template<class T>
-         void addProviderTo(EventSetupProvider& iProvider, boost::shared_ptr<T> iComponent, const DataProxyProvider*) 
+         void addProviderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const DataProxyProvider*) 
       {
-            boost::shared_ptr<DataProxyProvider> pProvider(iComponent);
+            std::shared_ptr<DataProxyProvider> pProvider(iComponent);
             ComponentDescription description = pProvider->description();
             description.isSource_=true;
             pProvider->setDescription(description);
             iProvider.add(pProvider);
       }
       template<class T>
-         void addProviderTo(EventSetupProvider& /* iProvider */, boost::shared_ptr<T> /*iComponent*/, const void*) 
+         void addProviderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) 
       {
             //do nothing
       }
@@ -57,7 +57,7 @@ namespace edm {
          static std::string name();
          template<class T>
          static void addTo(EventSetupProvider& iProvider,
-                           boost::shared_ptr<T> iComponent,
+                           std::shared_ptr<T> iComponent,
                            ParameterSet const& iConfiguration,
                            bool matchesPreceding)
             {
@@ -66,17 +66,17 @@ namespace edm {
                }
                //a source does not always have to be a provider
                addProviderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
-               boost::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
+               std::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
                iProvider.add(pFinder);
             }
-         static void replaceExisting(EventSetupProvider& iProvider, boost::shared_ptr<EventSetupRecordIntervalFinder> iComponent); 
+         static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<EventSetupRecordIntervalFinder> iComponent); 
                
-         static boost::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
+         static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
                                                                             ParameterSet const& iConfiguration);
 
          static void putComponent(EventSetupsController& esController,
                                   ParameterSet const& iConfiguration,
-                                  boost::shared_ptr<base_type> const& component);
+                                  std::shared_ptr<base_type> const& component);
 
          static void logInfoWhenSharing(ParameterSet const& iConfiguration);
       };

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -18,8 +18,6 @@
 
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <map>
 #include <memory>
 #include <set>
@@ -311,7 +309,7 @@ namespace edm {
     std::vector<ProcessHistoryRegistry>           processHistoryRegistries_;
     std::vector<HistoryAppender>                  historyAppenders_;
     PrincipalCache                                principalCache_;
-    edm::propagate_const<boost::shared_ptr<eventsetup::EventSetupProvider>> esp_;
+    edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
     std::map<ProcessHistoryID, ProcessHistoryID>  parentToChildPhID_;
     edm::propagate_const<std::unique_ptr<std::vector<SubProcess>>> subProcesses_;

--- a/FWCore/Framework/interface/es_Label.h
+++ b/FWCore/Framework/interface/es_Label.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -36,15 +36,15 @@ namespace edm {
          typedef T element_type;
          
          L() : product_() {}
-         explicit L(boost::shared_ptr<T> iP) : product_(iP) {}
+         explicit L(std::shared_ptr<T> iP) : product_(iP) {}
          explicit L(T* iP) : product_(iP) {}
          
          T& operator*() { return *product_;}
          T* operator->() { return product_.get(); }
-         mutable boost::shared_ptr<T> product_;
+         mutable std::shared_ptr<T> product_;
       };
       template<int ILabel,typename T>
-         L<T,ILabel> l(boost::shared_ptr<T>& iP) { 
+         L<T,ILabel> l(std::shared_ptr<T>& iP) { 
             L<T,ILabel> temp(iP);
             return temp;
          }

--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -46,11 +46,17 @@ namespace edm {
          template< typename T> struct product_traits<T*> {
             typedef EndList<T*> type;
          };
+         template< typename T> struct product_traits<std::unique_ptr<T> > {
+            typedef EndList<std::unique_ptr<T> > type;
+         };
          template< typename T> struct product_traits<std::auto_ptr<T> > {
             typedef EndList<std::auto_ptr<T> > type;
          };
          template< typename T> struct product_traits<boost::shared_ptr<T> > {
             typedef EndList<boost::shared_ptr<T> > type;
+         };
+         template< typename T> struct product_traits<std::shared_ptr<T> > {
+            typedef EndList<std::shared_ptr<T> > type;
          };
          
          

--- a/FWCore/Framework/src/DependentRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/DependentRecordIntervalFinder.cc
@@ -60,13 +60,13 @@ DependentRecordIntervalFinder::~DependentRecordIntervalFinder()
 // member functions
 //
 void 
-DependentRecordIntervalFinder::addProviderWeAreDependentOn(boost::shared_ptr<EventSetupRecordProvider> iProvider)
+DependentRecordIntervalFinder::addProviderWeAreDependentOn(std::shared_ptr<EventSetupRecordProvider> iProvider)
 {
    providers_.push_back(iProvider);
 }
 
 void 
-DependentRecordIntervalFinder::setAlternateFinder(boost::shared_ptr<EventSetupRecordIntervalFinder> iOther)
+DependentRecordIntervalFinder::setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iOther)
 {
   alternate_ = iOther;
 }

--- a/FWCore/Framework/src/ESProxyFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProxyFactoryProducer.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/DataProxy.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include <algorithm>
 #include <cassert>
 //
 // constants, enums and typedefs
@@ -71,7 +72,7 @@ ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord,
    std::pair< Iterator, Iterator > range = record2Factories_.equal_range(iRecord);
    for(Iterator it = range.first; it != range.second; ++it) {
       
-      boost::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy().release());
+      std::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy().release());
       if(nullptr != proxy.get()) {
          iProxies.push_back(KeyedProxies::value_type((*it).second.key_,
                                          proxy));
@@ -91,7 +92,7 @@ ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecor
    
    usingRecordWithKey(iRecord);
    
-   boost::shared_ptr<ProxyFactoryBase> temp(iFactory.release());
+   std::shared_ptr<ProxyFactoryBase> temp(iFactory.release());
    FactoryInfo info(temp->makeKey(iLabel),
                     temp);
    

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -186,11 +186,11 @@ namespace edm {
   }
 
   // ---------------------------------------------------------------
-  boost::shared_ptr<EDLooperBase>
+  std::shared_ptr<EDLooperBase>
   fillLooper(eventsetup::EventSetupsController& esController,
              eventsetup::EventSetupProvider& cp,
                          ParameterSet& params) {
-    boost::shared_ptr<EDLooperBase> vLooper;
+    std::shared_ptr<EDLooperBase> vLooper;
 
     std::vector<std::string> loopers = params.getParameter<std::vector<std::string> >("@all_loopers");
 

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -28,13 +28,13 @@ namespace edm {
     EventSetupsController::EventSetupsController() : mustFinishConfiguration_(true) {
     }
 
-    boost::shared_ptr<EventSetupProvider>
+    std::shared_ptr<EventSetupProvider>
     EventSetupsController::makeProvider(ParameterSet& iPSet) {
 
       // Makes an EventSetupProvider
       // Also parses the prefer information from ParameterSets and puts
       // it in a map that is stored in the EventSetupProvider
-      boost::shared_ptr<EventSetupProvider> returnValue(makeEventSetupProvider(iPSet, providers_.size()) );
+      std::shared_ptr<EventSetupProvider> returnValue(makeEventSetupProvider(iPSet, providers_.size()) );
 
       // Construct the ESProducers and ESSources
       // shared_ptrs to them are temporarily stored in this
@@ -49,7 +49,7 @@ namespace edm {
     EventSetupsController::eventSetupForInstance(IOVSyncValue const& syncValue) {
 
       if (mustFinishConfiguration_) {
-        std::for_each(providers_.begin(), providers_.end(), [](boost::shared_ptr<EventSetupProvider> const& esp) {
+        std::for_each(providers_.begin(), providers_.end(), [](std::shared_ptr<EventSetupProvider> const& esp) {
           esp->finishConfiguration();
         });
         // When the ESSources and ESProducers were constructed a first pass was
@@ -64,19 +64,19 @@ namespace edm {
         mustFinishConfiguration_ = false;
       }
 
-      std::for_each(providers_.begin(), providers_.end(), [&syncValue](boost::shared_ptr<EventSetupProvider> const& esp) {
+      std::for_each(providers_.begin(), providers_.end(), [&syncValue](std::shared_ptr<EventSetupProvider> const& esp) {
         esp->eventSetupForInstance(syncValue);
       });
     }
 
     void
     EventSetupsController::forceCacheClear() const {
-      std::for_each(providers_.begin(), providers_.end(), [](boost::shared_ptr<EventSetupProvider> const& esp) {
+      std::for_each(providers_.begin(), providers_.end(), [](std::shared_ptr<EventSetupProvider> const& esp) {
         esp->forceCacheClear();
       });
     }
 
-    boost::shared_ptr<DataProxyProvider>
+    std::shared_ptr<DataProxyProvider>
     EventSetupsController::getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex) {
       // Try to find a DataProxyProvider with a matching ParameterSet
       auto elements = esproducers_.equal_range(pset.id());
@@ -90,18 +90,18 @@ namespace edm {
         }
       }
       // Could not find it
-      return boost::shared_ptr<DataProxyProvider>();
+      return std::shared_ptr<DataProxyProvider>();
     }
 
     void
-    EventSetupsController::putESProducer(ParameterSet const& pset, boost::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex) {
+    EventSetupsController::putESProducer(ParameterSet const& pset, std::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex) {
       auto newElement = esproducers_.insert(std::pair<ParameterSetID, ESProducerInfo>(pset.id(), 
                                                                                       ESProducerInfo(&pset, component)));
       // Register processes with an exact match
       newElement->second.subProcessIndexes().push_back(subProcessIndex);
     }
 
-    boost::shared_ptr<EventSetupRecordIntervalFinder>
+    std::shared_ptr<EventSetupRecordIntervalFinder>
     EventSetupsController::getESSourceAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex) {
       // Try to find a EventSetupRecordIntervalFinder with a matching ParameterSet
       auto elements = essources_.equal_range(pset.id());
@@ -115,11 +115,11 @@ namespace edm {
         }
       }
       // Could not find it
-      return boost::shared_ptr<EventSetupRecordIntervalFinder>();
+      return std::shared_ptr<EventSetupRecordIntervalFinder>();
     }
 
     void
-    EventSetupsController::putESSource(ParameterSet const& pset, boost::shared_ptr<EventSetupRecordIntervalFinder> const& component, unsigned subProcessIndex) {
+    EventSetupsController::putESSource(ParameterSet const& pset, std::shared_ptr<EventSetupRecordIntervalFinder> const& component, unsigned subProcessIndex) {
       auto newElement = essources_.insert(std::pair<ParameterSetID, ESSourceInfo>(pset.id(), 
                                                                                   ESSourceInfo(&pset, component)));
       // Register processes with an exact match

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -20,9 +20,8 @@
 
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace edm {
@@ -39,34 +38,34 @@ namespace edm {
       class ESProducerInfo {
       public:
          ESProducerInfo(ParameterSet const* ps,
-                        boost::shared_ptr<DataProxyProvider> const& pr) : 
+                        std::shared_ptr<DataProxyProvider> const& pr) : 
             pset_(ps), provider_(pr), subProcessIndexes_() { }
 
          ParameterSet const* pset() const { return pset_; }
-         boost::shared_ptr<DataProxyProvider> const& provider() const { return provider_; }
+         std::shared_ptr<DataProxyProvider> const& provider() const { return provider_; }
          std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
          std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
 
       private:
          ParameterSet const* pset_;
-         boost::shared_ptr<DataProxyProvider> provider_;
+         std::shared_ptr<DataProxyProvider> provider_;
          std::vector<unsigned> subProcessIndexes_;
       };
 
       class ESSourceInfo {
       public:
          ESSourceInfo(ParameterSet const* ps,
-                      boost::shared_ptr<EventSetupRecordIntervalFinder> const& fi) :
+                      std::shared_ptr<EventSetupRecordIntervalFinder> const& fi) :
             pset_(ps), finder_(fi), subProcessIndexes_() { }
 
          ParameterSet const* pset() const { return pset_; }
-         boost::shared_ptr<EventSetupRecordIntervalFinder> const& finder() const { return finder_; }
+         std::shared_ptr<EventSetupRecordIntervalFinder> const& finder() const { return finder_; }
          std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
          std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
 
       private:
          ParameterSet const* pset_;
-         boost::shared_ptr<EventSetupRecordIntervalFinder> finder_;
+         std::shared_ptr<EventSetupRecordIntervalFinder> finder_;
          std::vector<unsigned> subProcessIndexes_;
       };
 
@@ -75,17 +74,17 @@ namespace edm {
       public:
          EventSetupsController();
 
-         boost::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&);
+         std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&);
 
          void eventSetupForInstance(IOVSyncValue const& syncValue);
 
          void forceCacheClear() const;
 
-         boost::shared_ptr<DataProxyProvider> getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
-         void putESProducer(ParameterSet const& pset, boost::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex);
+         std::shared_ptr<DataProxyProvider> getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
+         void putESProducer(ParameterSet const& pset, std::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex);
 
-         boost::shared_ptr<EventSetupRecordIntervalFinder> getESSourceAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
-         void putESSource(ParameterSet const& pset, boost::shared_ptr<EventSetupRecordIntervalFinder> const& component, unsigned subProcessIndex);
+         std::shared_ptr<EventSetupRecordIntervalFinder> getESSourceAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
+         void putESSource(ParameterSet const& pset, std::shared_ptr<EventSetupRecordIntervalFinder> const& component, unsigned subProcessIndex);
 
          void clearComponents();
 
@@ -116,7 +115,7 @@ namespace edm {
          ParameterSet const* getESProducerPSet(ParameterSetID const& psetID,
                                                unsigned subProcessIndex) const;
 
-         std::vector<boost::shared_ptr<EventSetupProvider> > const& providers() const { return providers_; }
+         std::vector<std::shared_ptr<EventSetupProvider> > const& providers() const { return providers_; }
 
          std::multimap<ParameterSetID, ESProducerInfo> const& esproducers() const { return esproducers_; }
 
@@ -132,7 +131,7 @@ namespace edm {
          void checkESProducerSharing();
          
          // ---------- member data --------------------------------
-         std::vector<boost::shared_ptr<EventSetupProvider> > providers_;
+         std::vector<std::shared_ptr<EventSetupProvider> > providers_;
 
          // The following two multimaps have one entry for each unique
          // ParameterSet. The ESProducerInfo or ESSourceInfo object

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
@@ -58,7 +58,7 @@ IntersectingIOVRecordIntervalFinder::~IntersectingIOVRecordIntervalFinder()
 // member functions
 //
 void 
-IntersectingIOVRecordIntervalFinder::swapFinders(std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>& iFinders)
+IntersectingIOVRecordIntervalFinder::swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>& iFinders)
 {
    finders_.swap(iFinders);
 }

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
+#include <memory>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
@@ -41,7 +41,7 @@ namespace edm {
          // ---------- static member functions --------------------
          
          // ---------- member functions ---------------------------
-         void swapFinders(std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>>&);
+         void swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>&);
       protected:
          virtual void setIntervalFor(const EventSetupRecordKey&,
                                      const IOVSyncValue& , 
@@ -53,7 +53,7 @@ namespace edm {
          const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&); // stop default
          
          // ---------- member data --------------------------------
-         std::vector<edm::propagate_const<boost::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;
+         std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;
       };
    }
 }

--- a/FWCore/Framework/src/LooperFactory.cc
+++ b/FWCore/Framework/src/LooperFactory.cc
@@ -23,22 +23,22 @@ namespace edm {
       std::string LooperMakerTraits::name() { return "CMS EDM Framework EDLooper"; }
       
       void 
-      LooperMakerTraits::replaceExisting(EventSetupProvider&, boost::shared_ptr<EDLooperBase>) {
+      LooperMakerTraits::replaceExisting(EventSetupProvider&, std::shared_ptr<EDLooperBase>) {
          throw edm::Exception(edm::errors::LogicError)
             << "LooperMakerTraits::replaceExisting\n"
             << "This function is not implemented and should never be called.\n"
             << "Please report this to a Framework Developer\n";
       }
 
-      boost::shared_ptr<LooperMakerTraits::base_type>
+      std::shared_ptr<LooperMakerTraits::base_type>
       LooperMakerTraits::getComponentAndRegisterProcess(EventSetupsController&,
                                                         ParameterSet const&) {
-        return boost::shared_ptr<LooperMakerTraits::base_type>();
+        return std::shared_ptr<LooperMakerTraits::base_type>();
       }
 
       void LooperMakerTraits::putComponent(EventSetupsController&,
                                            ParameterSet const&,
-                                           boost::shared_ptr<base_type> const&) {
+                                           std::shared_ptr<base_type> const&) {
       }
    }
 }

--- a/FWCore/Framework/src/ModuleFactory.cc
+++ b/FWCore/Framework/src/ModuleFactory.cc
@@ -28,19 +28,19 @@ namespace edm {
 //
       std::string ModuleMakerTraits::name() { return "CMS EDM Framework ESModule"; }
       void ModuleMakerTraits::addTo(EventSetupProvider& iProvider,
-                                    boost::shared_ptr<DataProxyProvider> iComponent,
+                                    std::shared_ptr<DataProxyProvider> iComponent,
                                     ParameterSet const&,
                                     bool) 
       {
          iProvider.add(iComponent);
       }
 
-      void ModuleMakerTraits::replaceExisting(EventSetupProvider& iProvider, boost::shared_ptr<DataProxyProvider> iComponent) 
+      void ModuleMakerTraits::replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<DataProxyProvider> iComponent) 
       {
          iProvider.replaceExisting(iComponent);
       }
 
-      boost::shared_ptr<ModuleMakerTraits::base_type>
+      std::shared_ptr<ModuleMakerTraits::base_type>
       ModuleMakerTraits::getComponentAndRegisterProcess(EventSetupsController& esController,
                                                         ParameterSet const& iConfiguration) {
          return esController.getESProducerAndRegisterProcess(iConfiguration, esController.indexOfNextProcess());
@@ -48,7 +48,7 @@ namespace edm {
 
       void ModuleMakerTraits::putComponent(EventSetupsController& esController,
                                            ParameterSet const& iConfiguration,
-                                           boost::shared_ptr<base_type> const& component) {
+                                           std::shared_ptr<base_type> const& component) {
          esController.putESProducer(iConfiguration, component, esController.indexOfNextProcess());
       }
    }

--- a/FWCore/Framework/src/SourceFactory.cc
+++ b/FWCore/Framework/src/SourceFactory.cc
@@ -28,14 +28,14 @@ namespace edm {
       std::string SourceMakerTraits::name() { return "CMS EDM Framework ESSource"; }
 
       void 
-      SourceMakerTraits::replaceExisting(EventSetupProvider&, boost::shared_ptr<EventSetupRecordIntervalFinder> ) {
+      SourceMakerTraits::replaceExisting(EventSetupProvider&, std::shared_ptr<EventSetupRecordIntervalFinder> ) {
          throw edm::Exception(edm::errors::LogicError)
             << "SourceMakerTraits::replaceExisting\n"
             << "This function is not implemented and should never be called.\n"
             << "Please report this to a Framework Developer\n";
       }
 
-      boost::shared_ptr<SourceMakerTraits::base_type>
+      std::shared_ptr<SourceMakerTraits::base_type>
       SourceMakerTraits::getComponentAndRegisterProcess(EventSetupsController& esController,
                                                         ParameterSet const& iConfiguration) {
          return esController.getESSourceAndRegisterProcess(iConfiguration, esController.indexOfNextProcess());
@@ -43,7 +43,7 @@ namespace edm {
 
       void SourceMakerTraits::putComponent(EventSetupsController& esController,
                                            ParameterSet const& iConfiguration,
-                                           boost::shared_ptr<base_type> const& component) {
+                                           std::shared_ptr<base_type> const& component) {
          esController.putESSource(iConfiguration, component, esController.indexOfNextProcess());
       }
 

--- a/FWCore/Framework/test/DummyProxyProvider.h
+++ b/FWCore/Framework/test/DummyProxyProvider.h
@@ -61,7 +61,7 @@ protected:
    void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& iProxies) {
       //std::cout <<"registered proxy"<<std::endl;
       
-      boost::shared_ptr<WorkingDummyProxy> pProxy(new WorkingDummyProxy(&dummy_));
+      std::shared_ptr<WorkingDummyProxy> pProxy(new WorkingDummyProxy(&dummy_));
       insertProxy(iProxies, pProxy);
    }
    

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -42,8 +42,6 @@ Test program for edm::Event.
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <algorithm>
 #include <fstream>
 #include <iterator>

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -50,11 +50,11 @@ namespace callbacktest {
 
    struct SharedPtrProd {
       SharedPtrProd() : ptr_(new Data()) {}
-      boost::shared_ptr<Data> method(const Record&) {
+      std::shared_ptr<Data> method(const Record&) {
          ++ptr_->value_;
          return ptr_;
       }      
-      boost::shared_ptr<Data> ptr_;
+      std::shared_ptr<Data> ptr_;
    };
    
    struct PtrProductsProd {
@@ -165,14 +165,14 @@ void testCallback::autoPtrTest()
    
 }
 
-typedef Callback<SharedPtrProd, boost::shared_ptr<Data>, Record> SharedPtrCallback;
+typedef Callback<SharedPtrProd, std::shared_ptr<Data>, Record> SharedPtrCallback;
 
 void testCallback::sharedPtrTest()
 {
    SharedPtrProd prod;
    
    SharedPtrCallback callback(&prod, &SharedPtrProd::method);
-   boost::shared_ptr<Data> handle;
+   std::shared_ptr<Data> handle;
    
    
    callback.holdOntoPointer(&handle);

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -197,7 +197,7 @@ void testdependentrecord::dependentConstructorTest()
 
 void testdependentrecord::dependentFinder1Test()
 {
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider(
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider(
                                                           EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
    const edm::EventID eID_1(1, 1, 1);
@@ -205,7 +205,7 @@ void testdependentrecord::dependentFinder1Test()
    const edm::EventID eID_3(1, 1, 3);
    const edm::ValidityInterval definedInterval(sync_1, 
                                                 edm::IOVSyncValue(eID_3));
-   boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
    dummyFinder->setInterval(definedInterval);
    dummyProvider->addFinder(dummyFinder);
    
@@ -231,7 +231,7 @@ void testdependentrecord::dependentFinder1Test()
 
 void testdependentrecord::dependentFinder2Test()
 {
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
    
    const edm::EventID eID_1(1, 1, 1);
@@ -240,7 +240,7 @@ void testdependentrecord::dependentFinder2Test()
                                                  edm::IOVSyncValue(edm::EventID(1, 1, 5)));
    dummyProvider1->setValidityInterval(definedInterval1);
    
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
    
    const edm::EventID eID_2(1, 1, 2);
@@ -266,7 +266,7 @@ void testdependentrecord::dependentFinder2Test()
 void testdependentrecord::timeAndRunTest()
 {
   //test case where we have two providers, one synching on time the other on run/lumi/event
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
    
    const edm::EventID eID_1(1, 1, 1);
@@ -275,7 +275,7 @@ void testdependentrecord::timeAndRunTest()
                                                  edm::IOVSyncValue(edm::EventID(1, 1, 5)));
    dummyProvider1->setValidityInterval(definedInterval1);
    
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
    
    const edm::Timestamp time_1(1);
@@ -423,7 +423,7 @@ void testdependentrecord::timeAndRunTest()
    {
       //check for bug which only happens the first time we synchronize
       // have the second one invalid
-      boost::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
+      std::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
                                                                  .makeRecordProvider(DummyRecord::keyForClass()).release());
 
       const edm::EventID eID_1(1, 1, 1);
@@ -432,7 +432,7 @@ void testdependentrecord::timeAndRunTest()
                                                     edm::IOVSyncValue(edm::EventID(1, 1, 6)));
       dummyProvider1->setValidityInterval(definedInterval1);
 
-      boost::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
+      std::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
                                                                  .makeRecordProvider(DummyRecord::keyForClass()).release());
 
       dummyProvider2->setValidityInterval(invalid);
@@ -466,12 +466,12 @@ void testdependentrecord::timeAndRunTest()
       //check for bug which only happens the first time we synchronize
       // have the  first one invalid
       
-      boost::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
+      std::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
                                                                  .makeRecordProvider(DummyRecord::keyForClass()).release());
 
       dummyProvider1->setValidityInterval(invalid);
 
-      boost::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
+      std::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
                                                                  .makeRecordProvider(DummyRecord::keyForClass()).release());
 
       const edm::Timestamp time_1(1);
@@ -509,21 +509,21 @@ void testdependentrecord::timeAndRunTest()
    {
      //check that going all the way through EventSetup works properly
      edm::eventsetup::EventSetupProvider provider;
-     boost::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+     std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
      provider.add(dummyProv);
      
-     boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+     std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
      dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
 						    edm::IOVSyncValue(edm::EventID(1, 1, 5))));
-     provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
      
-     boost::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+     std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
      provider.add(depProv);
 
-     boost::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
+     std::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
      dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 1)), 
 						    edm::IOVSyncValue(edm::Timestamp( 5))));
-     provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
+     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
      {
        const edm::EventSetup& eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
        long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
@@ -557,21 +557,21 @@ void testdependentrecord::timeAndRunTest()
       //check that going all the way through EventSetup works properly
       // using two records with open ended IOVs
       edm::eventsetup::EventSetupProvider provider;
-      boost::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
       provider.add(dummyProv);
       
-      boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
       dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                      edm::IOVSyncValue::invalidIOVSyncValue()));
-      provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
       
-      boost::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+      std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
       provider.add(depProv);
       
-      boost::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
+      std::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
       dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 1)), 
                                                       edm::IOVSyncValue::invalidIOVSyncValue()));
-      provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
+      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
       {
          const edm::EventSetup& eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
          long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
@@ -609,17 +609,17 @@ void testdependentrecord::dependentSetproviderTest()
    std::auto_ptr<EventSetupRecordProvider> depProvider =
    EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(DepRecord::keyForClass());
    
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider(
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider(
        EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(DummyRecord::keyForClass()).release());
 
-   boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
    dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)),
                                                    edm::IOVSyncValue(edm::EventID(1, 1, 3))));
    dummyProvider->addFinder(dummyFinder);
    
    CPPUNIT_ASSERT(*(depProvider->dependentRecords().begin()) == dummyProvider->key());
    
-   std::vector< boost::shared_ptr<EventSetupRecordProvider> > providers;
+   std::vector< std::shared_ptr<EventSetupRecordProvider> > providers;
    providers.push_back(dummyProvider);
    depProvider->setDependentProviders(providers);
 }
@@ -627,15 +627,15 @@ void testdependentrecord::dependentSetproviderTest()
 void testdependentrecord::getTest()
 {
    edm::eventsetup::EventSetupProvider provider;
-   boost::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
    provider.add(dummyProv);
 
-   boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
    dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                    edm::IOVSyncValue(edm::EventID(1, 1, 3))));
-   provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
    
-   boost::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepRecordProxyProvider());
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepRecordProxyProvider());
    provider.add(depProv);
    {
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
@@ -653,15 +653,15 @@ void testdependentrecord::getTest()
 void testdependentrecord::oneOfTwoRecordTest()
 {
   edm::eventsetup::EventSetupProvider provider;
-  boost::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
   provider.add(dummyProv);
   
-  boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+  std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
   dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                  edm::IOVSyncValue(edm::EventID(1, 1, 3))));
-  provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
   
-  boost::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
   provider.add(depProv);
   {
     const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
@@ -683,15 +683,15 @@ void testdependentrecord::oneOfTwoRecordTest()
 void testdependentrecord::resetTest()
 {
   edm::eventsetup::EventSetupProvider provider;
-  boost::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
   provider.add(dummyProv);
   
-  boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+  std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
   dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                  edm::IOVSyncValue(edm::EventID(1, 1, 3))));
-  provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
   
-  boost::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepRecordProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepRecordProxyProvider());
   provider.add(depProv);
   {
     const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
@@ -707,7 +707,7 @@ void testdependentrecord::resetTest()
 }
 void testdependentrecord::alternateFinderTest()
 {
-  boost::shared_ptr<EventSetupRecordProvider> dummyProvider(
+  std::shared_ptr<EventSetupRecordProvider> dummyProvider(
                                                             EventSetupRecordProviderFactoryManager::instance()
                                                             .makeRecordProvider(DummyRecord::keyForClass()).release());
   const edm::EventID eID_1(1, 1, 1);
@@ -717,11 +717,11 @@ void testdependentrecord::alternateFinderTest()
   const edm::EventID eID_4(1, 1, 4);
   const edm::ValidityInterval definedInterval(sync_1, 
                                               edm::IOVSyncValue(eID_4));
-  boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+  std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
   dummyFinder->setInterval(definedInterval);
   dummyProvider->addFinder(dummyFinder);
   
-  boost::shared_ptr<DepRecordFinder> depFinder(new DepRecordFinder);
+  std::shared_ptr<DepRecordFinder> depFinder(new DepRecordFinder);
   const edm::EventID eID_2(1, 1, 2);
   const edm::IOVSyncValue sync_2(eID_2);
   const edm::ValidityInterval depInterval(sync_1, 
@@ -771,7 +771,7 @@ void testdependentrecord::alternateFinderTest()
 
 void testdependentrecord::invalidRecordTest()
 {
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider1(EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
 
    const edm::ValidityInterval invalid( edm::IOVSyncValue::invalidIOVSyncValue(),
@@ -779,7 +779,7 @@ void testdependentrecord::invalidRecordTest()
 
    dummyProvider1->setValidityInterval(invalid);
    
-   boost::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
+   std::shared_ptr<EventSetupRecordProvider> dummyProvider2(EventSetupRecordProviderFactoryManager::instance()
                                                               .makeRecordProvider(DummyRecord::keyForClass()).release());
    dummyProvider2->setValidityInterval(invalid);
 
@@ -831,23 +831,23 @@ void testdependentrecord::invalidRecordTest()
 void testdependentrecord::extendIOVTest()
 {
    edm::eventsetup::EventSetupProvider provider;
-   boost::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv{new DummyProxyProvider{}};
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv{new DummyProxyProvider{}};
    provider.add(dummyProv);
    
-   boost::shared_ptr<DummyFinder> dummyFinder{new DummyFinder};
+   std::shared_ptr<DummyFinder> dummyFinder{new DummyFinder};
    
    edm::IOVSyncValue startSyncValue{edm::EventID{1, 1, 1}};
    dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
                                                   edm::IOVSyncValue{edm::EventID{1, 1, 5}}});
-   provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>{dummyFinder});
+   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>{dummyFinder});
    
-   boost::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
    provider.add(depProv);
    
-   boost::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
+   std::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
    dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, 
                                                    edm::IOVSyncValue{edm::EventID{1, 1, 6}}});
-   provider.add(boost::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
+   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
    {
       const edm::EventSetup& eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
       unsigned long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -85,13 +85,13 @@ public:
       ptr_->value_ = 0;
       setWhatProduced(this);
    }
-   boost::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
       std::cout <<"produce called "<<ptr_->value_<<std::endl;
       return ptr_;
    }
 private:
-   boost::shared_ptr<DummyData> ptr_;
+   std::shared_ptr<DummyData> ptr_;
 };
 
 class LabelledProducer : public ESProducer {
@@ -105,7 +105,7 @@ public:
       setWhatProduced(this, &LabelledProducer::produceMore, edm::es::label("fi",kFi)("fum",kFum));
    }
    
-   boost::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
       std::cout <<"\"foo\" produce called "<<ptr_->value_<<std::endl;
       return ptr_;
@@ -122,8 +122,8 @@ public:
       return edm::es::products(fum, es::l<kFi>(fi_) );
    }
 private:
-   boost::shared_ptr<DummyData> ptr_;
-   boost::shared_ptr<DummyData> fi_;
+   std::shared_ptr<DummyData> ptr_;
+   std::shared_ptr<DummyData> fi_;
 };
 
 };
@@ -148,11 +148,11 @@ void testEsproducer::getFromTest()
 {
    EventSetupProvider provider;
    
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new Test1Producer);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new Test1Producer);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
@@ -170,11 +170,11 @@ void testEsproducer::getfromShareTest()
 {
    EventSetupProvider provider;
    
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new ShareProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new ShareProducer);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
@@ -193,11 +193,11 @@ void testEsproducer::labelTest()
    try {
    EventSetupProvider provider;
    
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new LabelledProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new LabelledProducer);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
@@ -247,24 +247,24 @@ public:
       ptr_->value_ = 0;
       setWhatProduced(this, TestDecorator());
    }
-   boost::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
       std::cout <<"produce called "<<ptr_->value_<<std::endl;
       return ptr_;
    }
 private:
-   boost::shared_ptr<DummyData> ptr_;
+   std::shared_ptr<DummyData> ptr_;
 };
 
 void testEsproducer::decoratorTest()
 {
    EventSetupProvider provider;
    
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new DecoratorProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new DecoratorProducer);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
@@ -291,7 +291,7 @@ public:
                                         &DepProducer::callWhenDummyChanges2,
                                         &DepProducer::callWhenDummyChanges3));
    }
-   boost::shared_ptr<DummyData> produce(const DepRecord& /*iRecord*/) {
+   std::shared_ptr<DummyData> produce(const DepRecord& /*iRecord*/) {
       return ptr_;
    }
    void callWhenDummyChanges(const DummyRecord&) {
@@ -308,18 +308,18 @@ public:
    }
    
 private:
-   boost::shared_ptr<DummyData> ptr_;
+   std::shared_ptr<DummyData> ptr_;
 };
 
 void testEsproducer::dependsOnTest()
 {
    EventSetupProvider provider;
    
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new DepProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new DepProducer);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
@@ -342,11 +342,11 @@ void testEsproducer::forceCacheClearTest()
 {
    EventSetupProvider provider;
    
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new Test1Producer);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new Test1Producer);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    const edm::Timestamp time(1);
    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -208,7 +208,7 @@ void testEventsetup::recordValidityTest()
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
 
-   boost::shared_ptr<DummyFinder> finder(new DummyFinder);
+   std::shared_ptr<DummyFinder> finder(new DummyFinder);
    dummyRecordProvider->addFinder(finder);
    
    provider.insert(dummyRecordProvider);
@@ -245,7 +245,7 @@ void testEventsetup::recordValidityExcTest()
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
 
-   boost::shared_ptr<DummyFinder> finder(new DummyFinder);
+   std::shared_ptr<DummyFinder> finder(new DummyFinder);
    dummyRecordProvider->addFinder(finder);
    
    provider.insert(dummyRecordProvider);
@@ -279,7 +279,7 @@ static eventsetup::EventSetupRecordProviderFactoryTemplate<DummyRecord> s_factor
 void testEventsetup::proxyProviderTest()
 {
    eventsetup::EventSetupProvider provider;
-   boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+   std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
    provider.add(dummyProv);
    
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
@@ -293,12 +293,12 @@ void testEventsetup::producerConflictTest()
    using edm::eventsetup::test::DummyProxyProvider;
    eventsetup::EventSetupProvider provider;
    {
-      boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
    {
-      boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
@@ -312,12 +312,12 @@ void testEventsetup::sourceConflictTest()
    using edm::eventsetup::test::DummyProxyProvider;
    eventsetup::EventSetupProvider provider;
    {
-      boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
    {
-      boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
@@ -333,14 +333,14 @@ void testEventsetup::twoSourceTest()
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider;
   {
-    boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
   {
-    boost::shared_ptr<edm::DummyEventSetupRecordRetriever> dummyProv(new edm::DummyEventSetupRecordRetriever());
-    boost::shared_ptr<eventsetup::DataProxyProvider> providerPtr(dummyProv);
-    boost::shared_ptr<edm::EventSetupRecordIntervalFinder> finderPtr(dummyProv);
+    std::shared_ptr<edm::DummyEventSetupRecordRetriever> dummyProv(new edm::DummyEventSetupRecordRetriever());
+    std::shared_ptr<eventsetup::DataProxyProvider> providerPtr(dummyProv);
+    std::shared_ptr<edm::EventSetupRecordIntervalFinder> finderPtr(dummyProv);
     edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever","",true);
     dummyProv->setDescription(description2);
     provider.add(providerPtr);
@@ -365,7 +365,7 @@ void testEventsetup::provenanceTest()
 	 ps.addParameter<std::string>("name", "test11");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -375,7 +375,7 @@ void testEventsetup::provenanceTest()
 	 ps.addParameter<std::string>("name", "test22");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -406,7 +406,7 @@ void testEventsetup::getDataWithLabelTest()
 	 ps.addParameter<std::string>("name", "test11");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -417,7 +417,7 @@ void testEventsetup::getDataWithLabelTest()
          ps.addParameter<std::string>("appendToDataLabel","blah");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
          dummyProv->setDescription(description);
          dummyProv->setAppendToDataLabel(ps);
          provider.add(dummyProv);
@@ -449,7 +449,7 @@ void testEventsetup::getDataWithESInputTagTest()
 	 ps.addParameter<std::string>("name", "test11");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -460,7 +460,7 @@ void testEventsetup::getDataWithESInputTagTest()
          ps.addParameter<std::string>("appendToDataLabel","blah");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
          dummyProv->setDescription(description);
          dummyProv->setAppendToDataLabel(ps);
          provider.add(dummyProv);
@@ -519,13 +519,13 @@ void testEventsetup::sourceProducerResolutionTest()
       eventsetup::EventSetupProvider provider;
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -545,13 +545,13 @@ void testEventsetup::sourceProducerResolutionTest()
       eventsetup::EventSetupProvider provider;
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-         boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -587,13 +587,13 @@ void testEventsetup::preferTest()
          eventsetup::EventSetupProvider provider(0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
-            boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-            boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
@@ -618,13 +618,13 @@ void testEventsetup::preferTest()
          eventsetup::EventSetupProvider provider(0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-            boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-            boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
@@ -650,13 +650,13 @@ void testEventsetup::preferTest()
          eventsetup::EventSetupProvider provider(0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-            boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-            boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
@@ -692,7 +692,7 @@ void testEventsetup::introspectionTest()
     ps.addParameter<std::string>("name", "test11");
     ps.registerIt();
     description.pid_ = ps.id();
-    boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
@@ -702,7 +702,7 @@ void testEventsetup::introspectionTest()
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
       description.pid_ = ps.id();
-      boost::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -726,7 +726,7 @@ void testEventsetup::iovExtentionTest()
   typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
   std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
   
-  boost::shared_ptr<DummyFinder> finder(new DummyFinder);
+  std::shared_ptr<DummyFinder> finder(new DummyFinder);
   dummyRecordProvider->addFinder(finder);
   
   provider.insert(dummyRecordProvider);

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -146,7 +146,7 @@ private:
 
 class WorkingDummyProvider : public edm::eventsetup::DataProxyProvider {
 public:
-  WorkingDummyProvider( const edm::eventsetup::DataKey& iKey, boost::shared_ptr<WorkingDummyProxy> iProxy) :
+  WorkingDummyProvider( const edm::eventsetup::DataKey& iKey, std::shared_ptr<WorkingDummyProxy> iProxy) :
   m_key(iKey),
   m_proxy(iProxy) {
     usingRecord<DummyRecord>();
@@ -162,7 +162,7 @@ protected:
   }
 private:
   edm::eventsetup::DataKey m_key;
-  boost::shared_ptr<WorkingDummyProxy> m_proxy;
+  std::shared_ptr<WorkingDummyProxy> m_proxy;
 
 };
 
@@ -464,12 +464,12 @@ void testEventsetupRecord::proxyResetTest()
 
   unsigned long long cacheID = dummyRecord.cacheIdentifier();
   Dummy myDummy;
-  boost::shared_ptr<WorkingDummyProxy> workingProxy( new WorkingDummyProxy(&myDummy) );
+  std::shared_ptr<WorkingDummyProxy> workingProxy( new WorkingDummyProxy(&myDummy) );
   
   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
                                "");
 
-  boost::shared_ptr<WorkingDummyProvider> wdProv( new WorkingDummyProvider(workingDataKey, workingProxy) );
+  std::shared_ptr<WorkingDummyProvider> wdProv( new WorkingDummyProvider(workingDataKey, workingProxy) );
   CPPUNIT_ASSERT(0 != wdProv.get());
   if(wdProv.get() == 0) return; // To silence Coverity
   prov->add( wdProv );
@@ -516,12 +516,12 @@ void testEventsetupRecord::transientTest()
    
    unsigned long long cacheID = dummyRecord.cacheIdentifier();
    Dummy myDummy;
-   boost::shared_ptr<WorkingDummyProxy> workingProxy( new WorkingDummyProxy(&myDummy) );
+   std::shared_ptr<WorkingDummyProxy> workingProxy( new WorkingDummyProxy(&myDummy) );
    
    const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
                                 "");
    
-   boost::shared_ptr<WorkingDummyProvider> wdProv( new WorkingDummyProvider(workingDataKey, workingProxy) );
+   std::shared_ptr<WorkingDummyProvider> wdProv( new WorkingDummyProvider(workingDataKey, workingProxy) );
    prov->add( wdProv );
    
    //this causes the proxies to actually be placed in the Record

--- a/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
@@ -12,10 +12,9 @@
 #include "FWCore/Framework/test/DummyProxyProvider.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
-
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
 class TestEventSetupsController: public CppUnit::TestFixture
 {
@@ -68,24 +67,24 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
 
   edm::ParameterSet pset1;
   pset1.registerIt();
-  boost::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider1(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider1(new edm::eventsetup::test::DummyProxyProvider());
 
   edm::ParameterSet pset2;
   pset2.addUntrackedParameter<int>("p1", 1); 
   pset2.registerIt();
-  boost::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider2(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider2(new edm::eventsetup::test::DummyProxyProvider());
   CPPUNIT_ASSERT(pset2.id() == pset1.id());
 
   edm::ParameterSet pset3;
   pset3.addUntrackedParameter<int>("p1", 2); 
   pset3.registerIt();
-  boost::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider3(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider3(new edm::eventsetup::test::DummyProxyProvider());
   CPPUNIT_ASSERT(pset3.id() == pset1.id());
 
   edm::ParameterSet pset4;
   pset4.addParameter<int>("p1", 1); 
   pset4.registerIt();
-  boost::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider4(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider4(new edm::eventsetup::test::DummyProxyProvider());
   CPPUNIT_ASSERT(pset4.id() != pset1.id());
 
   edm::eventsetup::ParameterSetIDHolder psetIDHolder1(pset1.id());
@@ -96,7 +95,7 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
   CPPUNIT_ASSERT(!(psetIDHolder1 == psetIDHolder4));
   CPPUNIT_ASSERT((pset1.id() < pset4.id()) == (psetIDHolder1 < psetIDHolder4));
 
-  boost::shared_ptr<edm::eventsetup::DataProxyProvider> ptrFromGet = esController.getESProducerAndRegisterProcess(pset1, 0);
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> ptrFromGet = esController.getESProducerAndRegisterProcess(pset1, 0);
   CPPUNIT_ASSERT(!ptrFromGet);
   esController.putESProducer(pset1, proxyProvider1, 0);
 
@@ -256,28 +255,28 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
 
   edm::ParameterSet pset1;
   pset1.registerIt();
-  boost::shared_ptr<DummyFinder> finder1(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder1(new DummyFinder());
 
   edm::ParameterSet pset2;
   pset2.addUntrackedParameter<int>("p1", 1); 
   pset2.registerIt();
-  boost::shared_ptr<DummyFinder> finder2(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder2(new DummyFinder());
   CPPUNIT_ASSERT(pset2.id() == pset1.id());
 
   edm::ParameterSet pset3;
   pset3.addUntrackedParameter<int>("p1", 2); 
   pset3.registerIt();
-  boost::shared_ptr<DummyFinder> finder3(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder3(new DummyFinder());
   CPPUNIT_ASSERT(pset3.id() == pset1.id());
 
   edm::ParameterSet pset4;
   pset4.addParameter<int>("p1", 1); 
   pset4.registerIt();
-  boost::shared_ptr<DummyFinder> finder4(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder4(new DummyFinder());
   CPPUNIT_ASSERT(pset4.id() != pset1.id());
 
 
-  boost::shared_ptr<edm::EventSetupRecordIntervalFinder> ptrFromGet = esController.getESSourceAndRegisterProcess(pset1, 0);
+  std::shared_ptr<edm::EventSetupRecordIntervalFinder> ptrFromGet = esController.getESSourceAndRegisterProcess(pset1, 0);
   CPPUNIT_ASSERT(!ptrFromGet);
   esController.putESSource(pset1, finder1, 0);
 

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -43,11 +43,11 @@ void testfullChain::getfromDataproxyproviderTest()
 {
    eventsetup::EventSetupProvider provider;
 
-   boost::shared_ptr<DataProxyProvider> pProxyProv(new DummyProxyProvider);
+   std::shared_ptr<DataProxyProvider> pProxyProv(new DummyProxyProvider);
    provider.add(pProxyProv);
    
-   boost::shared_ptr<DummyFinder> pFinder(new DummyFinder);
-   provider.add(boost::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
    const Timestamp time_1(1);
    const IOVSyncValue sync_1(time_1);

--- a/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
+++ b/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
@@ -86,8 +86,8 @@ testintersectingiovrecordintervalfinder::intersectionTest()
    const EventSetupRecordKey dummyRecordKey = DummyRecord::keyForClass();
 
    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-   std::vector<edm::propagate_const<boost::shared_ptr<edm::EventSetupRecordIntervalFinder>>> finders;
-   boost::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::vector<edm::propagate_const<std::shared_ptr<edm::EventSetupRecordIntervalFinder>>> finders;
+   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
    {
       const edm::EventID eID_1(1, 1, 1);
       const edm::IOVSyncValue sync_1(eID_1);
@@ -127,7 +127,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       dummyFinder->setInterval(definedInterval);
       finders.push_back(dummyFinder);
 
-      boost::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
       dummyFinder2->setInterval(edm::ValidityInterval(sync_3, sync_5));
       finders.push_back(dummyFinder2);
       IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
@@ -152,7 +152,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       dummyFinder->setInterval(definedInterval);
       finders.push_back(dummyFinder);
       
-      boost::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
       dummyFinder2->setInterval(edm::ValidityInterval::invalidInterval());
       finders.push_back(dummyFinder2);
       IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
@@ -178,7 +178,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       dummyFinder->setInterval(definedInterval);
       finders.push_back(dummyFinder);
       
-      boost::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
       dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
       finders.push_back(dummyFinder2);
       IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
@@ -203,7 +203,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       const edm::ValidityInterval definedInterval(sync_1, 
                                                   sync_4);
       
-      boost::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
       dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
       finders.push_back(dummyFinder2);
 

--- a/FWCore/Framework/test/stubs/DummyLooper.cc
+++ b/FWCore/Framework/test/stubs/DummyLooper.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/LooperFactory.h"
@@ -39,8 +38,8 @@ class DummyLooper : public edm::ESProducerLooper {
       DummyLooper(const edm::ParameterSet&);
       ~DummyLooper();
 
-      typedef boost::shared_ptr<DummyData> ReturnType;
-      typedef boost::shared_ptr<DummyData const> ConstReturnType;
+      typedef std::shared_ptr<DummyData> ReturnType;
+      typedef std::shared_ptr<DummyData const> ConstReturnType;
 
       ReturnType produce(const DummyRecord&);
       

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use   name="boost"/>
   <bin   name="TestFWCoreIntegrationStandalone" file="testRunner.cpp,standalone_t.cppunit.cc">
     <use   name="cppunit"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/ESTestProducers.cc
+++ b/FWCore/Integration/test/ESTestProducers.cc
@@ -5,23 +5,23 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 
-#include "boost/shared_ptr.hpp"
+#include<memory>
 
 namespace edmtest {
 
   class ESTestProducerA : public edm::ESProducer {
   public:
     ESTestProducerA(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataA> produce(ESTestRecordA const&);
+    std::shared_ptr<ESTestDataA> produce(ESTestRecordA const&);
   private:
-    boost::shared_ptr<ESTestDataA> data_;
+    std::shared_ptr<ESTestDataA> data_;
   };
 
   ESTestProducerA::ESTestProducerA(edm::ParameterSet const&) : data_(new ESTestDataA(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataA> ESTestProducerA::produce(ESTestRecordA const& rec) {
+  std::shared_ptr<ESTestDataA> ESTestProducerA::produce(ESTestRecordA const& rec) {
     ++data_->value();
     return data_;
   }
@@ -31,16 +31,16 @@ namespace edmtest {
   class ESTestProducerB : public edm::ESProducer {
   public:
     ESTestProducerB(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataB> produce(ESTestRecordB const&);
+    std::shared_ptr<ESTestDataB> produce(ESTestRecordB const&);
   private:
-    boost::shared_ptr<ESTestDataB> data_;
+    std::shared_ptr<ESTestDataB> data_;
   };
 
   ESTestProducerB::ESTestProducerB(edm::ParameterSet const&) : data_(new ESTestDataB(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataB> ESTestProducerB::produce(ESTestRecordB const& rec) {
+  std::shared_ptr<ESTestDataB> ESTestProducerB::produce(ESTestRecordB const& rec) {
     ++data_->value();
     return data_;
   }
@@ -50,16 +50,16 @@ namespace edmtest {
   class ESTestProducerC : public edm::ESProducer {
   public:
     ESTestProducerC(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataC> produce(ESTestRecordC const&);
+    std::shared_ptr<ESTestDataC> produce(ESTestRecordC const&);
   private:
-    boost::shared_ptr<ESTestDataC> data_;
+    std::shared_ptr<ESTestDataC> data_;
   };
 
   ESTestProducerC::ESTestProducerC(edm::ParameterSet const&) : data_(new ESTestDataC(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataC> ESTestProducerC::produce(ESTestRecordC const& rec) {
+  std::shared_ptr<ESTestDataC> ESTestProducerC::produce(ESTestRecordC const& rec) {
     ++data_->value();
     return data_;
   }
@@ -69,16 +69,16 @@ namespace edmtest {
   class ESTestProducerD : public edm::ESProducer {
   public:
     ESTestProducerD(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataD> produce(ESTestRecordD const&);
+    std::shared_ptr<ESTestDataD> produce(ESTestRecordD const&);
   private:
-    boost::shared_ptr<ESTestDataD> data_;
+    std::shared_ptr<ESTestDataD> data_;
   };
 
   ESTestProducerD::ESTestProducerD(edm::ParameterSet const&) : data_(new ESTestDataD(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataD> ESTestProducerD::produce(ESTestRecordD const& rec) {
+  std::shared_ptr<ESTestDataD> ESTestProducerD::produce(ESTestRecordD const& rec) {
     ++data_->value();
     return data_;
   }
@@ -88,16 +88,16 @@ namespace edmtest {
   class ESTestProducerE : public edm::ESProducer {
   public:
     ESTestProducerE(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataE> produce(ESTestRecordE const&);
+    std::shared_ptr<ESTestDataE> produce(ESTestRecordE const&);
   private:
-    boost::shared_ptr<ESTestDataE> data_;
+    std::shared_ptr<ESTestDataE> data_;
   };
 
   ESTestProducerE::ESTestProducerE(edm::ParameterSet const&) : data_(new ESTestDataE(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataE> ESTestProducerE::produce(ESTestRecordE const& rec) {
+  std::shared_ptr<ESTestDataE> ESTestProducerE::produce(ESTestRecordE const& rec) {
     ++data_->value();
     return data_;
   }
@@ -107,16 +107,16 @@ namespace edmtest {
   class ESTestProducerF : public edm::ESProducer {
   public:
     ESTestProducerF(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataF> produce(ESTestRecordF const&);
+    std::shared_ptr<ESTestDataF> produce(ESTestRecordF const&);
   private:
-    boost::shared_ptr<ESTestDataF> data_;
+    std::shared_ptr<ESTestDataF> data_;
   };
 
   ESTestProducerF::ESTestProducerF(edm::ParameterSet const&) : data_(new ESTestDataF(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataF> ESTestProducerF::produce(ESTestRecordF const& rec) {
+  std::shared_ptr<ESTestDataF> ESTestProducerF::produce(ESTestRecordF const& rec) {
     ++data_->value();
     return data_;
   }
@@ -126,16 +126,16 @@ namespace edmtest {
   class ESTestProducerG : public edm::ESProducer {
   public:
     ESTestProducerG(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataG> produce(ESTestRecordG const&);
+    std::shared_ptr<ESTestDataG> produce(ESTestRecordG const&);
   private:
-    boost::shared_ptr<ESTestDataG> data_;
+    std::shared_ptr<ESTestDataG> data_;
   };
 
   ESTestProducerG::ESTestProducerG(edm::ParameterSet const&) : data_(new ESTestDataG(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataG> ESTestProducerG::produce(ESTestRecordG const& rec) {
+  std::shared_ptr<ESTestDataG> ESTestProducerG::produce(ESTestRecordG const& rec) {
     ++data_->value();
     return data_;
   }
@@ -145,16 +145,16 @@ namespace edmtest {
   class ESTestProducerH : public edm::ESProducer {
   public:
     ESTestProducerH(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataH> produce(ESTestRecordH const&);
+    std::shared_ptr<ESTestDataH> produce(ESTestRecordH const&);
   private:
-    boost::shared_ptr<ESTestDataH> data_;
+    std::shared_ptr<ESTestDataH> data_;
   };
 
   ESTestProducerH::ESTestProducerH(edm::ParameterSet const&) : data_(new ESTestDataH(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataH> ESTestProducerH::produce(ESTestRecordH const& rec) {
+  std::shared_ptr<ESTestDataH> ESTestProducerH::produce(ESTestRecordH const& rec) {
     ++data_->value();
     return data_;
   }
@@ -164,16 +164,16 @@ namespace edmtest {
   class ESTestProducerI : public edm::ESProducer {
   public:
     ESTestProducerI(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataI> produce(ESTestRecordI const&);
+    std::shared_ptr<ESTestDataI> produce(ESTestRecordI const&);
   private:
-    boost::shared_ptr<ESTestDataI> data_;
+    std::shared_ptr<ESTestDataI> data_;
   };
 
   ESTestProducerI::ESTestProducerI(edm::ParameterSet const&) : data_(new ESTestDataI(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataI> ESTestProducerI::produce(ESTestRecordI const& rec) {
+  std::shared_ptr<ESTestDataI> ESTestProducerI::produce(ESTestRecordI const& rec) {
     ++data_->value();
     return data_;
   }
@@ -183,16 +183,16 @@ namespace edmtest {
   class ESTestProducerJ : public edm::ESProducer {
   public:
     ESTestProducerJ(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataJ> produce(ESTestRecordJ const&);
+    std::shared_ptr<ESTestDataJ> produce(ESTestRecordJ const&);
   private:
-    boost::shared_ptr<ESTestDataJ> data_;
+    std::shared_ptr<ESTestDataJ> data_;
   };
 
   ESTestProducerJ::ESTestProducerJ(edm::ParameterSet const&) : data_(new ESTestDataJ(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataJ> ESTestProducerJ::produce(ESTestRecordJ const& rec) {
+  std::shared_ptr<ESTestDataJ> ESTestProducerJ::produce(ESTestRecordJ const& rec) {
     ++data_->value();
     return data_;
   }
@@ -202,16 +202,16 @@ namespace edmtest {
   class ESTestProducerK : public edm::ESProducer {
   public:
     ESTestProducerK(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataK> produce(ESTestRecordK const&);
+    std::shared_ptr<ESTestDataK> produce(ESTestRecordK const&);
   private:
-    boost::shared_ptr<ESTestDataK> data_;
+    std::shared_ptr<ESTestDataK> data_;
   };
 
   ESTestProducerK::ESTestProducerK(edm::ParameterSet const&) : data_(new ESTestDataK(0)) {
     setWhatProduced(this);
   }
 
-  boost::shared_ptr<ESTestDataK> ESTestProducerK::produce(ESTestRecordK const& rec) {
+  std::shared_ptr<ESTestDataK> ESTestProducerK::produce(ESTestRecordK const& rec) {
     ++data_->value();
     return data_;
   }
@@ -221,11 +221,11 @@ namespace edmtest {
   class ESTestProducerAZ : public edm::ESProducer {
   public:
     ESTestProducerAZ(edm::ParameterSet const&);
-    boost::shared_ptr<ESTestDataA> produceA(ESTestRecordA const&);
-    boost::shared_ptr<ESTestDataZ> produceZ(ESTestRecordZ const&);
+    std::shared_ptr<ESTestDataA> produceA(ESTestRecordA const&);
+    std::shared_ptr<ESTestDataZ> produceZ(ESTestRecordZ const&);
   private:
-    boost::shared_ptr<ESTestDataA> dataA_;
-    boost::shared_ptr<ESTestDataZ> dataZ_;
+    std::shared_ptr<ESTestDataA> dataA_;
+    std::shared_ptr<ESTestDataZ> dataZ_;
   };
 
   ESTestProducerAZ::ESTestProducerAZ(edm::ParameterSet const&) :
@@ -235,12 +235,12 @@ namespace edmtest {
     setWhatProduced(this, &edmtest::ESTestProducerAZ::produceZ, edm::es::Label("foo"));
   }
 
-  boost::shared_ptr<ESTestDataA> ESTestProducerAZ::produceA(ESTestRecordA const& rec) {
+  std::shared_ptr<ESTestDataA> ESTestProducerAZ::produceA(ESTestRecordA const& rec) {
     ++dataA_->value();
     return dataA_;
   }
 
-  boost::shared_ptr<ESTestDataZ> ESTestProducerAZ::produceZ(ESTestRecordZ const& rec) {
+  std::shared_ptr<ESTestDataZ> ESTestProducerAZ::produceZ(ESTestRecordZ const& rec) {
     ++dataZ_->value();
     return dataZ_;
   }

--- a/FWCore/MessageLogger/doc/MessageLoggerDesign.txt
+++ b/FWCore/MessageLogger/doc/MessageLoggerDesign.txt
@@ -158,7 +158,7 @@ struct MessageSender {
     m->Object = ep;
     s->commit();
   }
-  boost::shared_ptr<ErrorObj> ep;
+  std::shared_ptr<ErrorObj> ep;
 };
 
 MessageLogger::MessageLogger ( const edm::parameter_set & p, ... ) {

--- a/FWCore/ServiceRegistry/BuildFile.xml
+++ b/FWCore/ServiceRegistry/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="DataFormats/Provenance"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -29,7 +29,6 @@ unscheduled execution. The tests are in FWCore/Integration/test:
 //
 
 // system include files
-//#include "boost/signal.hpp"
 #include <functional>
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/StreamID.h"

--- a/FWCore/Skeletons/doc/man/skeletons.1
+++ b/FWCore/Skeletons/doc/man/skeletons.1
@@ -324,7 +324,7 @@ class __class__ : public edm::ESProducer {
 #python_begin
     datatypes = []
     for dtype in __datatypes__:
-        datatypes.append("boost::shared_ptr<%s>" % dtype)
+        datatypes.append("std::shared_ptr<%s>" % dtype)
     print "      typedef edm::ESProducts<%s> ReturnType;" % \(aq,\(aq.join(datatypes)
 #python_end
 
@@ -383,7 +383,7 @@ __class__::produce(const __record__& iRecord)
     out1 = []
     out2 = []
     for dtype in __datatypes__:
-        out1.append("   boost::shared_ptr<%s> p%s;\en" % (dtype, dtype))
+        out1.append("   std::shared_ptr<%s> p%s;\en" % (dtype, dtype))
         out2.append("p%s" % dtype)
     output  = \(aq\en\(aq.join(out1)
     output += "   return products(%s);\en" % \(aq,\(aq.join(out2)

--- a/FWCore/Utilities/interface/value_ptr.h
+++ b/FWCore/Utilities/interface/value_ptr.h
@@ -13,9 +13,9 @@
 // The value_ptr_traits template is provided to allow specialization
 // of the copying behavior. See the notes below.
 //
-// Use value_ptr only when deep-copying of the pointed-to object is
-// desireable. Use boost::shared_ptr or std::shared_ptr when sharing
-// of the pointed-to  object is desirable. Use std::unique_ptr
+// Use value_ptr only when deep-copying of the pointed-to object
+// is desireable. Use std::shared_ptr when sharing of the
+// pointed-to  object is desirable. Use std::unique_ptr
 // when no copying is desirable.
 //
 // The design of value_ptr is taken from Herb Sutter's More

--- a/IOMC/RandomEngine/BuildFile.xml
+++ b/IOMC/RandomEngine/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="SimDataFormats/RandomEngine"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <use   name="rootcore"/>
 <use   name="rootmath"/>

--- a/IOPool/Output/BuildFile.xml
+++ b/IOPool/Output/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Version"/>
 <use   name="IOPool/Common"/>
-<use   name="boost"/>
 <use   name="rootcore"/>
 <export>
   <lib   name="1"/>

--- a/IOPool/SecondaryInput/test/BuildFile.xml
+++ b/IOPool/SecondaryInput/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use   name="boost"/>
   <bin   file="TestSecondaryInput.cpp">
     <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/SecondaryInput/test TestSecondaryInput.sh"/>
     <use   name="FWCore/Utilities"/>

--- a/IOPool/Streamer/BuildFile.xml
+++ b/IOPool/Streamer/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Version"/>
 <use   name="Utilities/StorageFactory"/>
-<use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="zlib"/>
 <export>

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use   name="boost"/>
   <use   name="FWCore/Framework"/>
   <bin   file="RunThat_t.cpp">
     <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test TestMultiprocess.sh"/>

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -163,7 +163,7 @@ class FWLiteESRecordWriterAnalyzer : public edm::EDAnalyzer {
       void update(const edm::EventSetup&);
 
       // ----------member data ---------------------------
-   std::vector<boost::shared_ptr<RecordHandler> > m_handlers;
+   std::vector<std::shared_ptr<RecordHandler> > m_handlers;
    
    std::map<std::string, std::vector<std::pair<std::string,std::string> > > m_recordToDataNames;
    TFile* m_file;
@@ -267,11 +267,11 @@ FWLiteESRecordWriterAnalyzer::update(const edm::EventSetup& iSetup)
             }
             dataInfos.push_back(DataInfo(tt,itData->second));
          }
-         m_handlers.push_back( boost::shared_ptr<RecordHandler>( new RecordHandler(rKey,m_file,dataInfos) ) );
+         m_handlers.push_back( std::shared_ptr<RecordHandler>( new RecordHandler(rKey,m_file,dataInfos) ) );
       }
    }
    
-   for(std::vector<boost::shared_ptr<RecordHandler> >::iterator it = m_handlers.begin(),itEnd = m_handlers.end();
+   for(std::vector<std::shared_ptr<RecordHandler> >::iterator it = m_handlers.begin(),itEnd = m_handlers.end();
        it != itEnd;
        ++it) {
       (*it)->update(iSetup);

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <memory>
 #include "TFile.h"
-#include <boost/shared_ptr.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/DataProxyProvider.h"
@@ -206,7 +205,7 @@ FWLiteESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRec
       if(tt != HCTypeTag() ) {
          edm::eventsetup::DataKey dk(tt,edm::eventsetup::IdTags(it->second.c_str()));
          aProxyList.push_back(std::make_pair(dk,
-                                             boost::shared_ptr<edm::eventsetup::DataProxy>(new FWLiteProxy(TypeID(tt.value()),&rec))));
+                                             std::shared_ptr<edm::eventsetup::DataProxy>(new FWLiteProxy(TypeID(tt.value()),&rec))));
       } else {
          LogDebug("UnknownESType")<<"The type '"<<it->first<<"' is unknown in this job";
          std::cout <<"    *****FAILED*****"<<std::endl;

--- a/PhysicsTools/MVATrainer/interface/MVATrainerContainer.h
+++ b/PhysicsTools/MVATrainer/interface/MVATrainerContainer.h
@@ -5,8 +5,6 @@
 #include <string>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 #include "CondFormats/PhysicsToolsObjects/interface/MVAComputer.h"
 #include "PhysicsTools/MVATrainer/interface/MVATrainer.h"
 #include "PhysicsTools/MVATrainer/interface/MVATrainerLooper.h"

--- a/PhysicsTools/MVATrainer/interface/MVATrainerLooper.h
+++ b/PhysicsTools/MVATrainer/interface/MVATrainerLooper.h
@@ -5,8 +5,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 #include "FWCore/Framework/interface/ESProducerLooper.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -26,8 +24,8 @@ class MVATrainerLooper : public edm::ESProducerLooper {
 	virtual Status endOfLoop(const edm::EventSetup &es,
 	                         unsigned int iteration);
 
-	typedef boost::shared_ptr<Calibration::MVAComputer> TrainObject;
-	typedef boost::shared_ptr<Calibration::MVAComputerContainer>
+	typedef std::shared_ptr<Calibration::MVAComputer> TrainObject;
+	typedef std::shared_ptr<Calibration::MVAComputerContainer>
 							TrainContainer;
 
 	template<class T>

--- a/PhysicsTools/MVATrainer/interface/MVATrainerLooperImpl.h
+++ b/PhysicsTools/MVATrainer/interface/MVATrainerLooperImpl.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESProducts.h"
@@ -27,7 +25,7 @@ class MVATrainerLooperImpl : public MVATrainerLooper {
 
 	virtual ~MVATrainerLooperImpl() {}
 
-	boost::shared_ptr<Calibration::MVAComputer>
+	std::shared_ptr<Calibration::MVAComputer>
 	produce(const Record_t &record)
 	{ return (*getTrainers().begin())->getCalibration(); }
 };
@@ -60,7 +58,7 @@ class MVATrainerContainerLooperImpl : public MVATrainerLooper {
 		edm::es::L<Calibration::MVAComputerContainer, kTrained> >
 	produce(const Record_t &record)
 	{
-		boost::shared_ptr<MVATrainerContainer> trainerCalib(
+		std::shared_ptr<MVATrainerContainer> trainerCalib(
 						new MVATrainerContainer());
 		TrainContainer trainedCalib;
 

--- a/PhysicsTools/MVATrainer/interface/TrainerMonitoring.h
+++ b/PhysicsTools/MVATrainer/interface/TrainerMonitoring.h
@@ -6,7 +6,6 @@
 #include <memory>
 #include <map>
 
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/or.hpp>
@@ -139,7 +138,7 @@ class TrainerMonitoring {
 		inline void reg(const std::string &name, T *object);
 
 		TDirectory						*dir;
-		std::map<std::string, boost::shared_ptr<Object> >	data;
+		std::map<std::string, std::shared_ptr<Object> >	data;
 	};
 
 	Module *book(const std::string &name);
@@ -178,7 +177,7 @@ class TrainerMonitoring {
 
     private:
 	std::auto_ptr<TFile>					rootFile;
-	std::map<std::string, boost::shared_ptr<Module> >	modules;
+	std::map<std::string, std::shared_ptr<Module> >	modules;
 };
 
 namespace helper {

--- a/PhysicsTools/MVATrainer/src/MVATrainerLooper.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerLooper.cc
@@ -3,8 +3,6 @@
 #include <string>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/PhysicsTools/MVATrainer/src/TrainerMonitoring.cc
+++ b/PhysicsTools/MVATrainer/src/TrainerMonitoring.cc
@@ -3,8 +3,6 @@
 #include <memory>
 #include <ostream>
 
-#include <boost/shared_ptr.hpp>
-
 #include <TFile.h>
 #include <TDirectory.h>
 #include <TObject.h>
@@ -44,7 +42,7 @@ void TrainerMonitoring::write()
 {
 	ROOTContextSentinel ctx;
 
-	typedef std::map<std::string, boost::shared_ptr<Module> > Map;
+	typedef std::map<std::string, std::shared_ptr<Module> > Map;
 	for(Map::const_iterator iter = modules.begin();
 	    iter != modules.end(); ++iter) {
 		rootFile->cd();
@@ -64,7 +62,7 @@ TrainerMonitoring::Module::~Module()
 
 void TrainerMonitoring::Module::write(TDirectory *dir)
 {
-	typedef std::map<std::string, boost::shared_ptr<Object> > Map;
+	typedef std::map<std::string, std::shared_ptr<Object> > Map;
 	for(Map::const_iterator iter = data.begin();
 	    iter != data.end(); ++iter)
 		iter->second->write(dir);
@@ -72,7 +70,7 @@ void TrainerMonitoring::Module::write(TDirectory *dir)
 
 void TrainerMonitoring::Module::add(Object *object)
 {
-	boost::shared_ptr<Object> ptr(object);
+	std::shared_ptr<Object> ptr(object);
 	if (!data.insert(std::make_pair(object->getName(), ptr)).second)
 		throw cms::Exception("DuplicateNode")
 			<< "Node \"" << object->getName() << "\" already"
@@ -81,7 +79,7 @@ void TrainerMonitoring::Module::add(Object *object)
 
 TrainerMonitoring::Module *TrainerMonitoring::book(const std::string &name)
 {
-	boost::shared_ptr<Module> module(new Module);
+	std::shared_ptr<Module> module(new Module);
 	if (!modules.insert(std::make_pair(name, module)).second)
 		throw cms::Exception("DuplicateModule")
 			<< "Module \"" << name << "\" already"

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -1,12 +1,12 @@
 #ifndef STORAGE_FACTORY_STORAGE_ACCOUNT_H
 # define STORAGE_FACTORY_STORAGE_ACCOUNT_H
 
-# include <boost/shared_ptr.hpp>
 # include <stdint.h>
 # include <string>
 # include <chrono>
 # include <atomic>
 # include <map>
+# include <memory>
 # include "tbb/concurrent_unordered_map.h"
 
 class StorageAccount {

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -1,4 +1,5 @@
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
+#include <cassert>
 #include <mutex>
 #include <sstream>
 #include <unistd.h>

--- a/Utilities/StorageFactory/test/Test.h
+++ b/Utilities/StorageFactory/test/Test.h
@@ -6,10 +6,10 @@
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "boost/shared_ptr.hpp"
 #include <iostream>
+#include <memory>
 
-static boost::shared_ptr<edm::Presence> gobbleUpTheGoop;
+static std::shared_ptr<edm::Presence> gobbleUpTheGoop;
 static void initTest(void)
 {
   // Initialise the plug-in manager.
@@ -24,7 +24,7 @@ static void initTest(void)
   // logger.
   try
   {
-    gobbleUpTheGoop = boost::shared_ptr<edm::Presence>
+    gobbleUpTheGoop = std::shared_ptr<edm::Presence>
       (edm::PresenceFactory::get()->makePresence("SingleThreadMSPresence").release());
   }
   catch (cms::Exception &e)


### PR DESCRIPTION
Replace almost all uses of boost::shared_ptr in the framework with std::shared_ptr. boost::shared_ptr
is still used (now along with std::shared_ptr) in produce_helpers.h because it is used in many packages outside the framework.
Three packages outside the framework needed to be modified due to this change.
These are CondCore/ESSources, PhysicsTools/CondLiteIO, and PhysicsTools/MVATrainer.
The changes in these packages are the minimal ones necessary to adapt to the framework change,
and are confined to changing boost::shared_ptr to std::shared_ptr.
This PR should resolve issue #12949 .
