### PR TITLE
Fixes for misc. threading problems found by static analysis and helgrind

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HPDIonFeedbackSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HPDIonFeedbackSim.cc
@@ -27,7 +27,7 @@ using namespace edm;
 using namespace std;
 
 // constants for simulation/parameterization
-double pe2Charge = 0.333333;    // fC/p.e.
+const double pe2Charge = 0.333333;    // fC/p.e.
 
 HPDIonFeedbackSim::HPDIonFeedbackSim(const edm::ParameterSet & iConfig, const CaloShapes * shapes)
 : theDbService(0), theShapes(shapes)

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -24,8 +24,6 @@
 //
 #include "DataMixingHcalDigiWorker.h"
 
-std::vector<size_t> ids;
-
 using namespace std;
 
 namespace {
@@ -191,7 +189,6 @@ namespace edm
 
   void DataMixingHcalDigiWorker::addHcalSignals(const edm::Event &e,const edm::EventSetup& ES) { 
     // Calibration stuff will look like this:                                                 
-    ids.clear();
     // get conditions                                                                         
     edm::ESHandle<HcalDbService> conditions;                                                
     ES.get<HcalDbRecord>().get(conditions);                                         

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
@@ -225,10 +225,10 @@ void DataMixingSiPixelMCDigiWorker::init_DynIneffDB(const edm::EventSetup& es, c
 void DataMixingSiPixelMCDigiWorker::PixelEfficiencies::init_from_db(const edm::ESHandle<TrackerGeometry>& geom, const edm::ESHandle<SiPixelDynamicInefficiency>& SiPixelDynamicInefficiency) {
 
   theInstLumiScaleFactor = SiPixelDynamicInefficiency->gettheInstLumiScaleFactor();
-  std::map<uint32_t, double> PixelGeomFactorsDB = SiPixelDynamicInefficiency->getPixelGeomFactors();
-  std::map<uint32_t, double> ColGeomFactorsDB = SiPixelDynamicInefficiency->getColGeomFactors();
-  std::map<uint32_t, double> ChipGeomFactorsDB = SiPixelDynamicInefficiency->getChipGeomFactors();
-  std::map<uint32_t, std::vector<double> > PUFactors = SiPixelDynamicInefficiency->getPUFactors();
+  const std::map<uint32_t, double>& PixelGeomFactorsDB = SiPixelDynamicInefficiency->getPixelGeomFactors();
+  const std::map<uint32_t, double>& ColGeomFactorsDB = SiPixelDynamicInefficiency->getColGeomFactors();
+  const std::map<uint32_t, double>& ChipGeomFactorsDB = SiPixelDynamicInefficiency->getChipGeomFactors();
+  const std::map<uint32_t, std::vector<double> >& PUFactors = SiPixelDynamicInefficiency->getPUFactors();
   std::vector<uint32_t > DetIdmasks = SiPixelDynamicInefficiency->getDetIdmasks();
   
   // Loop on all modules, calculate geometrical scale factors and store in map for easy access

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -491,10 +491,10 @@ void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es, const
 void SiPixelDigitizerAlgorithm::PixelEfficiencies::init_from_db(const edm::ESHandle<TrackerGeometry>& geom, const edm::ESHandle<SiPixelDynamicInefficiency>& SiPixelDynamicInefficiency) {
 
   theInstLumiScaleFactor = SiPixelDynamicInefficiency->gettheInstLumiScaleFactor();
-  std::map<uint32_t, double> PixelGeomFactorsDB = SiPixelDynamicInefficiency->getPixelGeomFactors();
-  std::map<uint32_t, double> ColGeomFactorsDB = SiPixelDynamicInefficiency->getColGeomFactors();
-  std::map<uint32_t, double> ChipGeomFactorsDB = SiPixelDynamicInefficiency->getChipGeomFactors();
-  std::map<uint32_t, std::vector<double> > PUFactors = SiPixelDynamicInefficiency->getPUFactors();
+  const std::map<uint32_t, double>& PixelGeomFactorsDB = SiPixelDynamicInefficiency->getPixelGeomFactors();
+  const std::map<uint32_t, double>& ColGeomFactorsDB = SiPixelDynamicInefficiency->getColGeomFactors();
+  const std::map<uint32_t, double>& ChipGeomFactorsDB = SiPixelDynamicInefficiency->getChipGeomFactors();
+  const std::map<uint32_t, std::vector<double> >& PUFactors = SiPixelDynamicInefficiency->getPUFactors();
   std::vector<uint32_t > DetIdmasks = SiPixelDynamicInefficiency->getDetIdmasks();
   
   // Loop on all modules, calculate geometrical scale factors and store in map for easy access

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -13,6 +13,8 @@
 
 namespace {
   struct Count {
+#ifdef SISTRIP_COUNT
+    // note: this code is not thread safe, counts will be inaccurate if run with multiple threads
     double ncall=0;
     double ndep=0, ndep2=0, maxdep=0;
     double nstr=0, nstr2=0;
@@ -23,13 +25,17 @@ namespace {
     void val(double d) { ncv++; nval+=d; nval2+=d*d; maxv=std::max(d,maxv);}
     void zero() { dzero++;}    
     ~Count() {
-#ifdef SISTRIP_COUNT
       std::cout << "deposits " << ncall << " " << maxdep << " " << ndep/ncall << " " << std::sqrt(ndep2*ncall -ndep*ndep)/ncall << std::endl;
       std::cout << "zeros " << dzero << std::endl;
       std::cout << "strips  " << nstr/ndep << " " << std::sqrt(nstr2*ndep -nstr*nstr)/ndep << std::endl;
       std::cout << "vaules  " << ncv << " " << maxv << " " << nval/ncv << " " << std::sqrt(nval2*ncv -nval*nval)/ncv << std::endl;
-#endif
     }
+#else
+    void dep(double) {}
+    void str(double) {}
+    void val(double) {}
+    void zero() {}    
+#endif
   };
   
  Count count;


### PR DESCRIPTION
Miscellaneous small fixes to simulation routines found by static analysis and helgrind runs with the multithreaded mixing module.  Issues are all harmless, these are all either quieting warnings or improving efficiency.
