### PR TITLE
premixing : digi step : replace postls1 customisation functions with run2 era

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -879,12 +879,12 @@ digiPremixUp2015Defaults25ns = {
     '--eventcontent' : 'FEVTDEBUGHLT',
     '--datatier'     : 'GEN-SIM-DIGI-RAW-HLTDEBUG',
     '--datamix'      : 'PreMix',
-    '--customise'    : 'SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1' 
+    '--era'          : 'Run2_25ns' 
     }
 digiPremixUp2015Defaults50ns=merge([{'-s':'DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval50ns'},
                                     {'--conditions':'auto:run2_mc_'+autoHLT['relval50ns']},
                                     {'--pileup_input' : 'das:/RelValPREMIXUP15_PU50/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[6]},
-                                    {'--customise': 'SLHCUpgradeSimulations/Configuration/postLS1CustomsPreMixing.customisePostLS1_50ns'},
+                                    {'era'            : 'Run2_50ns'},
                                     digiPremixUp2015Defaults25ns])
 steps['DIGIPRMXUP15_PU25']=merge([digiPremixUp2015Defaults25ns])
 steps['DIGIPRMXUP15_PU50']=merge([digiPremixUp2015Defaults50ns])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -884,7 +884,7 @@ digiPremixUp2015Defaults25ns = {
 digiPremixUp2015Defaults50ns=merge([{'-s':'DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval50ns'},
                                     {'--conditions':'auto:run2_mc_'+autoHLT['relval50ns']},
                                     {'--pileup_input' : 'das:/RelValPREMIXUP15_PU50/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[6]},
-                                    {'era'            : 'Run2_50ns'},
+                                    {'--era'            : 'Run2_50ns'},
                                     digiPremixUp2015Defaults25ns])
 steps['DIGIPRMXUP15_PU25']=merge([digiPremixUp2015Defaults25ns])
 steps['DIGIPRMXUP15_PU50']=merge([digiPremixUp2015Defaults50ns])


### PR DESCRIPTION
rebase of #13072 

postLS1 customisation functions are no longer necessary for premixing:
Indeed, the customisation function in

```
SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
```

takes the following actions
- the deprecated customisePostLS1 function is called. 
  This is now replaced by adding the appropriate era option to the digi step in relval_steps.py
- the customisation function in Configuration/python/muonCustomsPreMixing.py is called
  This function has actually zero effect
  - line 5 is taken care of by the eras
  - line 8 and 9 are redundant (the correct settings are loaded in the premix digi step anyway)
  - line 13,14,17 and 18 have no effect on the digi step

Tests: workflows 250200,500200 run properly.

@mdhildreth 
