### PR TITLE
Use std::make_shared in EventSetup system

### DIFF
--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -122,7 +122,7 @@ ComponentMaker<T,TComponent>::addTo(EventSetupsController& esController,
       }
    }
 
-   std::shared_ptr<TComponent> component(new TComponent(iConfiguration));
+   std::shared_ptr<TComponent> component = std::make_shared<TComponent>(iConfiguration);
    ComponentDescription description =
       this->createComponentDescription(iConfiguration);
 

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -109,8 +109,7 @@ void
 EventSetupRecordProvider::setDependentProviders(const std::vector< std::shared_ptr<EventSetupRecordProvider> >& iProviders)
 {
    using std::placeholders::_1;
-   std::shared_ptr< DependentRecordIntervalFinder > newFinder(
-                                                                new DependentRecordIntervalFinder(key()));
+   std::shared_ptr<DependentRecordIntervalFinder> newFinder = std::make_shared<DependentRecordIntervalFinder>(key());
    
    std::shared_ptr<EventSetupRecordIntervalFinder> old = swapFinder(newFinder);
    for_all(iProviders, std::bind(std::mem_fun(&DependentRecordIntervalFinder::addProviderWeAreDependentOn), &(*newFinder), _1));
@@ -127,7 +126,7 @@ EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap)
   for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper,this,_1,iMap));
   if (1 < multipleFinders_->size()) {
      
-     std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder(new IntersectingIOVRecordIntervalFinder(key_));
+     std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder = std::make_shared<IntersectingIOVRecordIntervalFinder>(key_);
      intFinder->swapFinders(*multipleFinders_);
      finder_ = intFinder;
   }

--- a/FWCore/Framework/test/DummyProxyProvider.h
+++ b/FWCore/Framework/test/DummyProxyProvider.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include<memory>
 
 // user include files
 #include "FWCore/Framework/test/DummyRecord.h"
@@ -61,7 +62,7 @@ protected:
    void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& iProxies) {
       //std::cout <<"registered proxy"<<std::endl;
       
-      std::shared_ptr<WorkingDummyProxy> pProxy(new WorkingDummyProxy(&dummy_));
+      std::shared_ptr<WorkingDummyProxy> pProxy = std::make_shared<WorkingDummyProxy>(&dummy_);
       insertProxy(iProxies, pProxy);
    }
    

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -205,7 +205,7 @@ void testdependentrecord::dependentFinder1Test()
    const edm::EventID eID_3(1, 1, 3);
    const edm::ValidityInterval definedInterval(sync_1, 
                                                 edm::IOVSyncValue(eID_3));
-   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
    dummyFinder->setInterval(definedInterval);
    dummyProvider->addFinder(dummyFinder);
    
@@ -509,18 +509,18 @@ void testdependentrecord::timeAndRunTest()
    {
      //check that going all the way through EventSetup works properly
      edm::eventsetup::EventSetupProvider provider;
-     std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+     std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
      provider.add(dummyProv);
      
-     std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+     std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
      dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
 						    edm::IOVSyncValue(edm::EventID(1, 1, 5))));
      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
      
-     std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+     std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
      provider.add(depProv);
 
-     std::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
+     std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
      dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 1)), 
 						    edm::IOVSyncValue(edm::Timestamp( 5))));
      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
@@ -557,18 +557,18 @@ void testdependentrecord::timeAndRunTest()
       //check that going all the way through EventSetup works properly
       // using two records with open ended IOVs
       edm::eventsetup::EventSetupProvider provider;
-      std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       provider.add(dummyProv);
       
-      std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
       dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                      edm::IOVSyncValue::invalidIOVSyncValue()));
       provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
       
-      std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+      std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
       provider.add(depProv);
       
-      std::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
+      std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
       dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 1)), 
                                                       edm::IOVSyncValue::invalidIOVSyncValue()));
       provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
@@ -612,7 +612,7 @@ void testdependentrecord::dependentSetproviderTest()
    std::shared_ptr<EventSetupRecordProvider> dummyProvider(
        EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(DummyRecord::keyForClass()).release());
 
-   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
    dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)),
                                                    edm::IOVSyncValue(edm::EventID(1, 1, 3))));
    dummyProvider->addFinder(dummyFinder);
@@ -627,15 +627,15 @@ void testdependentrecord::dependentSetproviderTest()
 void testdependentrecord::getTest()
 {
    edm::eventsetup::EventSetupProvider provider;
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
    provider.add(dummyProv);
 
-   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
    dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                    edm::IOVSyncValue(edm::EventID(1, 1, 3))));
    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
    
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepRecordProxyProvider());
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
    provider.add(depProv);
    {
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
@@ -653,15 +653,15 @@ void testdependentrecord::getTest()
 void testdependentrecord::oneOfTwoRecordTest()
 {
   edm::eventsetup::EventSetupProvider provider;
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
   provider.add(dummyProv);
   
-  std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
   dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                  edm::IOVSyncValue(edm::EventID(1, 1, 3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
   
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
   provider.add(depProv);
   {
     const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
@@ -683,15 +683,15 @@ void testdependentrecord::oneOfTwoRecordTest()
 void testdependentrecord::resetTest()
 {
   edm::eventsetup::EventSetupProvider provider;
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
   provider.add(dummyProv);
   
-  std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
   dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
                                                  edm::IOVSyncValue(edm::EventID(1, 1, 3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
   
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepRecordProxyProvider());
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
   provider.add(depProv);
   {
     const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
@@ -717,11 +717,11 @@ void testdependentrecord::alternateFinderTest()
   const edm::EventID eID_4(1, 1, 4);
   const edm::ValidityInterval definedInterval(sync_1, 
                                               edm::IOVSyncValue(eID_4));
-  std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
   dummyFinder->setInterval(definedInterval);
   dummyProvider->addFinder(dummyFinder);
   
-  std::shared_ptr<DepRecordFinder> depFinder(new DepRecordFinder);
+  std::shared_ptr<DepRecordFinder> depFinder = std::make_shared<DepRecordFinder>();
   const edm::EventID eID_2(1, 1, 2);
   const edm::IOVSyncValue sync_2(eID_2);
   const edm::ValidityInterval depInterval(sync_1, 
@@ -831,20 +831,20 @@ void testdependentrecord::invalidRecordTest()
 void testdependentrecord::extendIOVTest()
 {
    edm::eventsetup::EventSetupProvider provider;
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv{new DummyProxyProvider{}};
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
    provider.add(dummyProv);
    
-   std::shared_ptr<DummyFinder> dummyFinder{new DummyFinder};
+   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
    
    edm::IOVSyncValue startSyncValue{edm::EventID{1, 1, 1}};
    dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
                                                   edm::IOVSyncValue{edm::EventID{1, 1, 5}}});
    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>{dummyFinder});
    
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv(new DepOn2RecordProxyProvider());
+   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
    provider.add(depProv);
    
-   std::shared_ptr<Dummy2RecordFinder> dummy2Finder(new Dummy2RecordFinder);
+   std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
    dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, 
                                                    edm::IOVSyncValue{edm::EventID{1, 1, 6}}});
    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -148,10 +148,10 @@ void testEsproducer::getFromTest()
 {
    EventSetupProvider provider;
    
-   std::shared_ptr<DataProxyProvider> pProxyProv(new Test1Producer);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<Test1Producer>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
@@ -170,10 +170,10 @@ void testEsproducer::getfromShareTest()
 {
    EventSetupProvider provider;
    
-   std::shared_ptr<DataProxyProvider> pProxyProv(new ShareProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<ShareProducer>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
@@ -193,10 +193,10 @@ void testEsproducer::labelTest()
    try {
    EventSetupProvider provider;
    
-   std::shared_ptr<DataProxyProvider> pProxyProv(new LabelledProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<LabelledProducer>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
@@ -260,10 +260,10 @@ void testEsproducer::decoratorTest()
 {
    EventSetupProvider provider;
    
-   std::shared_ptr<DataProxyProvider> pProxyProv(new DecoratorProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DecoratorProducer>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
@@ -315,10 +315,10 @@ void testEsproducer::dependsOnTest()
 {
    EventSetupProvider provider;
    
-   std::shared_ptr<DataProxyProvider> pProxyProv(new DepProducer);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DepProducer>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    for(int iTime=1; iTime != 6; ++iTime) {
@@ -342,10 +342,10 @@ void testEsproducer::forceCacheClearTest()
 {
    EventSetupProvider provider;
    
-   std::shared_ptr<DataProxyProvider> pProxyProv(new Test1Producer);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<Test1Producer>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
    
    const edm::Timestamp time(1);

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -208,7 +208,7 @@ void testEventsetup::recordValidityTest()
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
 
-   std::shared_ptr<DummyFinder> finder(new DummyFinder);
+   std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
    dummyRecordProvider->addFinder(finder);
    
    provider.insert(dummyRecordProvider);
@@ -245,7 +245,7 @@ void testEventsetup::recordValidityExcTest()
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
 
-   std::shared_ptr<DummyFinder> finder(new DummyFinder);
+   std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
    dummyRecordProvider->addFinder(finder);
    
    provider.insert(dummyRecordProvider);
@@ -279,7 +279,7 @@ static eventsetup::EventSetupRecordProviderFactoryTemplate<DummyRecord> s_factor
 void testEventsetup::proxyProviderTest()
 {
    eventsetup::EventSetupProvider provider;
-   std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+   std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
    provider.add(dummyProv);
    
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
@@ -293,12 +293,12 @@ void testEventsetup::producerConflictTest()
    using edm::eventsetup::test::DummyProxyProvider;
    eventsetup::EventSetupProvider provider;
    {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
    {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
@@ -312,12 +312,12 @@ void testEventsetup::sourceConflictTest()
    using edm::eventsetup::test::DummyProxyProvider;
    eventsetup::EventSetupProvider provider;
    {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
    {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       dummyProv->setDescription(description);
       provider.add(dummyProv);
    }
@@ -333,12 +333,12 @@ void testEventsetup::twoSourceTest()
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider;
   {
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider());
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
   {
-    std::shared_ptr<edm::DummyEventSetupRecordRetriever> dummyProv(new edm::DummyEventSetupRecordRetriever());
+    std::shared_ptr<edm::DummyEventSetupRecordRetriever> dummyProv = std::make_shared<edm::DummyEventSetupRecordRetriever>();
     std::shared_ptr<eventsetup::DataProxyProvider> providerPtr(dummyProv);
     std::shared_ptr<edm::EventSetupRecordIntervalFinder> finderPtr(dummyProv);
     edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever","",true);
@@ -365,7 +365,7 @@ void testEventsetup::provenanceTest()
 	 ps.addParameter<std::string>("name", "test11");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -375,7 +375,7 @@ void testEventsetup::provenanceTest()
 	 ps.addParameter<std::string>("name", "test22");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -406,7 +406,7 @@ void testEventsetup::getDataWithLabelTest()
 	 ps.addParameter<std::string>("name", "test11");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -417,7 +417,7 @@ void testEventsetup::getDataWithLabelTest()
          ps.addParameter<std::string>("appendToDataLabel","blah");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
          dummyProv->setDescription(description);
          dummyProv->setAppendToDataLabel(ps);
          provider.add(dummyProv);
@@ -449,7 +449,7 @@ void testEventsetup::getDataWithESInputTagTest()
 	 ps.addParameter<std::string>("name", "test11");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -460,7 +460,7 @@ void testEventsetup::getDataWithESInputTagTest()
          ps.addParameter<std::string>("appendToDataLabel","blah");
 	 ps.registerIt();
          description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
          dummyProv->setDescription(description);
          dummyProv->setAppendToDataLabel(ps);
          provider.add(dummyProv);
@@ -519,13 +519,13 @@ void testEventsetup::sourceProducerResolutionTest()
       eventsetup::EventSetupProvider provider;
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -545,13 +545,13 @@ void testEventsetup::sourceProducerResolutionTest()
       eventsetup::EventSetupProvider provider;
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
          dummyProv->setDescription(description);
          provider.add(dummyProv);
       }
@@ -587,13 +587,13 @@ void testEventsetup::preferTest()
          eventsetup::EventSetupProvider provider(0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
@@ -618,13 +618,13 @@ void testEventsetup::preferTest()
          eventsetup::EventSetupProvider provider(0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
@@ -650,13 +650,13 @@ void testEventsetup::preferTest()
          eventsetup::EventSetupProvider provider(0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
             dummyProv->setDescription(description);
             provider.add(dummyProv);
          }
@@ -692,7 +692,7 @@ void testEventsetup::introspectionTest()
     ps.addParameter<std::string>("name", "test11");
     ps.registerIt();
     description.pid_ = ps.id();
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kBad));
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
@@ -702,7 +702,7 @@ void testEventsetup::introspectionTest()
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv(new DummyProxyProvider(kGood));
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -726,7 +726,7 @@ void testEventsetup::iovExtentionTest()
   typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
   std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
   
-  std::shared_ptr<DummyFinder> finder(new DummyFinder);
+  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
   dummyRecordProvider->addFinder(finder);
   
   provider.insert(dummyRecordProvider);
@@ -757,3 +757,4 @@ void testEventsetup::iovExtentionTest()
   }
 
 }
+

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -464,12 +464,12 @@ void testEventsetupRecord::proxyResetTest()
 
   unsigned long long cacheID = dummyRecord.cacheIdentifier();
   Dummy myDummy;
-  std::shared_ptr<WorkingDummyProxy> workingProxy( new WorkingDummyProxy(&myDummy) );
+  std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
   
   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
                                "");
 
-  std::shared_ptr<WorkingDummyProvider> wdProv( new WorkingDummyProvider(workingDataKey, workingProxy) );
+  std::shared_ptr<WorkingDummyProvider> wdProv = std::make_shared<WorkingDummyProvider>(workingDataKey, workingProxy);
   CPPUNIT_ASSERT(0 != wdProv.get());
   if(wdProv.get() == 0) return; // To silence Coverity
   prov->add( wdProv );
@@ -516,12 +516,12 @@ void testEventsetupRecord::transientTest()
    
    unsigned long long cacheID = dummyRecord.cacheIdentifier();
    Dummy myDummy;
-   std::shared_ptr<WorkingDummyProxy> workingProxy( new WorkingDummyProxy(&myDummy) );
+   std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
    
    const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
                                 "");
    
-   std::shared_ptr<WorkingDummyProvider> wdProv( new WorkingDummyProvider(workingDataKey, workingProxy) );
+   std::shared_ptr<WorkingDummyProvider> wdProv = std::make_shared<WorkingDummyProvider>(workingDataKey, workingProxy);
    prov->add( wdProv );
    
    //this causes the proxies to actually be placed in the Record

--- a/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
@@ -67,24 +67,24 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
 
   edm::ParameterSet pset1;
   pset1.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider1(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider1 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
 
   edm::ParameterSet pset2;
   pset2.addUntrackedParameter<int>("p1", 1); 
   pset2.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider2(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider2 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
   CPPUNIT_ASSERT(pset2.id() == pset1.id());
 
   edm::ParameterSet pset3;
   pset3.addUntrackedParameter<int>("p1", 2); 
   pset3.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider3(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider3 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
   CPPUNIT_ASSERT(pset3.id() == pset1.id());
 
   edm::ParameterSet pset4;
   pset4.addParameter<int>("p1", 1); 
   pset4.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider4(new edm::eventsetup::test::DummyProxyProvider());
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider4 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
   CPPUNIT_ASSERT(pset4.id() != pset1.id());
 
   edm::eventsetup::ParameterSetIDHolder psetIDHolder1(pset1.id());
@@ -255,24 +255,24 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
 
   edm::ParameterSet pset1;
   pset1.registerIt();
-  std::shared_ptr<DummyFinder> finder1(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder1 = std::make_shared<DummyFinder>();
 
   edm::ParameterSet pset2;
   pset2.addUntrackedParameter<int>("p1", 1); 
   pset2.registerIt();
-  std::shared_ptr<DummyFinder> finder2(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder2 = std::make_shared<DummyFinder>();
   CPPUNIT_ASSERT(pset2.id() == pset1.id());
 
   edm::ParameterSet pset3;
   pset3.addUntrackedParameter<int>("p1", 2); 
   pset3.registerIt();
-  std::shared_ptr<DummyFinder> finder3(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder3 = std::make_shared<DummyFinder>();
   CPPUNIT_ASSERT(pset3.id() == pset1.id());
 
   edm::ParameterSet pset4;
   pset4.addParameter<int>("p1", 1); 
   pset4.registerIt();
-  std::shared_ptr<DummyFinder> finder4(new DummyFinder());
+  std::shared_ptr<DummyFinder> finder4 = std::make_shared<DummyFinder>();
   CPPUNIT_ASSERT(pset4.id() != pset1.id());
 
 

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -43,10 +43,10 @@ void testfullChain::getfromDataproxyproviderTest()
 {
    eventsetup::EventSetupProvider provider;
 
-   std::shared_ptr<DataProxyProvider> pProxyProv(new DummyProxyProvider);
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DummyProxyProvider>();
    provider.add(pProxyProv);
    
-   std::shared_ptr<DummyFinder> pFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
    const Timestamp time_1(1);

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -456,7 +456,7 @@ testGlobalModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& i
 
 void testGlobalModule::basicTest()
 {
-  std::shared_ptr<BasicProd> testProd{ new BasicProd };
+  std::shared_ptr<BasicProd> testProd = std::make_shared<BasicProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent});
@@ -464,7 +464,7 @@ void testGlobalModule::basicTest()
 
 void testGlobalModule::streamTest()
 {
-  std::shared_ptr<StreamProd> testProd{ new StreamProd };
+  std::shared_ptr<StreamProd> testProd = std::make_shared<StreamProd>();
   edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(testProd,nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
   
@@ -475,7 +475,7 @@ void testGlobalModule::streamTest()
 
 void testGlobalModule::runTest()
 {
-  std::shared_ptr<RunProd> testProd{ new RunProd };
+  std::shared_ptr<RunProd> testProd = std::make_shared<RunProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
@@ -483,7 +483,7 @@ void testGlobalModule::runTest()
 
 void testGlobalModule::runSummaryTest()
 {
-  std::shared_ptr<RunSummaryProd> testProd{ new RunSummaryProd };
+  std::shared_ptr<RunSummaryProd> testProd = std::make_shared<RunSummaryProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
@@ -491,7 +491,7 @@ void testGlobalModule::runSummaryTest()
 
 void testGlobalModule::lumiTest()
 {
-  std::shared_ptr<LumiProd> testProd{ new LumiProd };
+  std::shared_ptr<LumiProd> testProd = std::make_shared<LumiProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -303,7 +303,7 @@ void testGlobalOutputModule::fileTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::shared_ptr<FileOutputModule> testProd{ new FileOutputModule(pset) };
+  std::shared_ptr<FileOutputModule> testProd = std::make_shared<FileOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});

--- a/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
+++ b/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
@@ -87,7 +87,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
 
    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
    std::vector<edm::propagate_const<std::shared_ptr<edm::EventSetupRecordIntervalFinder>>> finders;
-   std::shared_ptr<DummyFinder> dummyFinder(new DummyFinder);
+   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
    {
       const edm::EventID eID_1(1, 1, 1);
       const edm::IOVSyncValue sync_1(eID_1);
@@ -127,7 +127,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       dummyFinder->setInterval(definedInterval);
       finders.push_back(dummyFinder);
 
-      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
       dummyFinder2->setInterval(edm::ValidityInterval(sync_3, sync_5));
       finders.push_back(dummyFinder2);
       IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
@@ -152,7 +152,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       dummyFinder->setInterval(definedInterval);
       finders.push_back(dummyFinder);
       
-      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
       dummyFinder2->setInterval(edm::ValidityInterval::invalidInterval());
       finders.push_back(dummyFinder2);
       IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
@@ -178,7 +178,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       dummyFinder->setInterval(definedInterval);
       finders.push_back(dummyFinder);
       
-      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
       dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
       finders.push_back(dummyFinder2);
       IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
@@ -203,7 +203,7 @@ testintersectingiovrecordintervalfinder::intersectionTest()
       const edm::ValidityInterval definedInterval(sync_1, 
                                                   sync_4);
       
-      std::shared_ptr<DummyFinder> dummyFinder2(new DummyFinder);
+      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
       dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
       finders.push_back(dummyFinder2);
 

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -405,7 +405,7 @@ void testOneOutputModule::fileTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::shared_ptr<FileOutputModule> testProd{ new FileOutputModule(pset) };
+  std::shared_ptr<FileOutputModule> testProd = std::make_shared<FileOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});


### PR DESCRIPTION
A very recent PR changed the EventSetup code in the framework to use std::shared_ptr instead of boost::shared_ptr. However, it did not use std::make_shared where it was appropriate.
This PR implements std:::make_shared in the EventSetup code.
