### PR TITLE
Remove non-functional support of unique_ptr in produce_helpers.

### DIFF
--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -46,9 +46,6 @@ namespace edm {
          template< typename T> struct product_traits<T*> {
             typedef EndList<T*> type;
          };
-         template< typename T> struct product_traits<std::unique_ptr<T> > {
-            typedef EndList<std::unique_ptr<T> > type;
-         };
          template< typename T> struct product_traits<std::auto_ptr<T> > {
             typedef EndList<std::auto_ptr<T> > type;
          };


### PR DESCRIPTION
A very recent PR was added that included the addition of a template to produce_helpers in an attempt to support the use of unique_ptr in this context. This addition was not sufficient to support unique_ptr here, and may mislead users to believe that it is supported. As adding support for unique_ptr in produce_helpers is non-trivial, we just back this out for now so that users will not be mislead.
