### PR TITLE
fix MET miniAOD validation sequence

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -49,7 +49,7 @@ validationLiteTracking = cms.Sequence( validation )
 validationLiteTracking.replace(globalValidation,globalValidationLiteTracking)
 validationLiteTracking.remove(condDataValidation)
 
-validationMiniAOD = cms.Sequence(JetValidationMiniAOD * METValidationMiniAOD * type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD)
+validationMiniAOD = cms.Sequence(type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD * JetValidationMiniAOD * METValidationMiniAOD)
 
 prevalidation_preprod = cms.Sequence( preprodPrevalidation )
 


### PR DESCRIPTION
type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD
was in front of the METValidationMiniAOD, but was moved after by mistake.

restoring the proper ordering.
