### PR TITLE
Fix photon regression inputs missing variables

### DIFF
--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -58,6 +58,7 @@ float MuonTagger::discriminator(const TagInfoHelper& tagInfo) const {
   // If there are multiple leptons, look for the highest tag result
   for (unsigned int i=0; i<info.leptons(); i++) {
     const reco::SoftLeptonProperties& properties = info.properties(i);
+    if(!m_selector(properties)) continue;
     bool flip(false);
     if(m_selector.isNegative()) {
       int seed=1+round(10000.*properties.deltaR);

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -560,7 +560,7 @@ void EGExtraInfoModifierFromDB::modifyObject(pat::Electron& ele) const {
 void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   // regression calculation needs no additional valuemaps
   
-  std::array<float, 31> eval;
+  std::array<float, 35> eval;
   const reco::SuperClusterRef& the_sc = pho.superCluster();
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
   
@@ -604,8 +604,16 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   if (iseb) {
     EBDetId ebseedid(theseed->seed());
     eval[26] = pho.e5x5()/theseed->energy();
-    eval[27] = ebseedid.ieta();
-    eval[28] = ebseedid.iphi();
+    int ieta = ebseedid.ieta();
+    int iphi = ebseedid.iphi();
+    eval[27] = ieta;
+    eval[28] = iphi;
+    eval[29] = (ieta-1*abs(ieta)/ieta)%5;
+    eval[30] = (iphi-1)%2;
+    eval[31] = (abs(ieta)<=25)*((ieta-1*abs(ieta)/ieta)%25) + (abs(ieta)>25)*((ieta-26*abs(ieta)/ieta)%20);
+    eval[32] = (iphi-1)%20;
+    eval[33] = ieta;  /// duplicated variables but this was trained like that
+    eval[34] = iphi;  /// duplicated variables but this was trained like that
   } else {
     EEDetId eeseedid(theseed->seed());
     eval[26] = the_sc->preshowerEnergy()/raw_energy;

--- a/SimTracker/TrackHistory/python/TrackQuality_cff.py
+++ b/SimTracker/TrackHistory/python/TrackQuality_cff.py
@@ -11,6 +11,8 @@ trackQuality = cms.PSet(
 		associatePixel = cms.bool(True),
 		associateStrip = cms.bool(True),
 		associateRecoTracks = cms.bool(True),
-		ROUList = copy.deepcopy(tabh.trackAssociatorByHits.ROUList)
+		ROUList = copy.deepcopy(tabh.trackAssociatorByHits.ROUList),
+                pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+                stripSimLinkSrc = cms.InputTag("simSiStripDigis")
 	)
 )


### PR DESCRIPTION
Regression used for photon energy correction is slightly sub-optimal due to some variables missing.
The improvement in resolution has been tested in data and is small but non-negligible as the following plot indicates (red is the regression currently used and black is the regression we would like to use).

![image](https://cloud.githubusercontent.com/assets/5707503/12816487/0c88ff8e-cb4d-11e5-9ae7-40ea5fba1eeb.png)

The next plot shows an example of the improvement due to variables that indicates cracks/gaps as well as phi modulation. The plots shows how the energy scale in the gap is now better corrected (Ecal module boundaries are indicated with dashed lines).

![image](https://cloud.githubusercontent.com/assets/5707503/12816634/b5abd5c8-cb4d-11e5-8485-89c8866157b4.png)
