### PR TITLE
Add missing variables for photon regression with optimal performance

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -608,9 +608,11 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
     int iphi = ebseedid.iphi();
     eval[27] = ieta;
     eval[28] = iphi;
-    eval[29] = (ieta-1*abs(ieta)/ieta)%5;
+    int signieta = ieta > 0 ? +1 : -1; /// this is 1*abs(ieta)/ieta in original training
+    eval[29] = (ieta-signieta)%5;
     eval[30] = (iphi-1)%2;
-    eval[31] = (abs(ieta)<=25)*((ieta-1*abs(ieta)/ieta)%25) + (abs(ieta)>25)*((ieta-26*abs(ieta)/ieta)%20);
+    //    eval[31] = (abs(ieta)<=25)*((ieta-signieta)%25) + (abs(ieta)>25)*((ieta-26*signieta)%20); //%25 is unnescessary in this formula
+    eval[31] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);  
     eval[32] = (iphi-1)%20;
     eval[33] = ieta;  /// duplicated variables but this was trained like that
     eval[34] = iphi;  /// duplicated variables but this was trained like that

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -560,7 +560,7 @@ void EGExtraInfoModifierFromDB::modifyObject(pat::Electron& ele) const {
 void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   // regression calculation needs no additional valuemaps
   
-  std::array<float, 31> eval;
+  std::array<float, 35> eval;
   const reco::SuperClusterRef& the_sc = pho.superCluster();
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
   
@@ -604,8 +604,16 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   if (iseb) {
     EBDetId ebseedid(theseed->seed());
     eval[26] = pho.e5x5()/theseed->energy();
-    eval[27] = ebseedid.ieta();
-    eval[28] = ebseedid.iphi();
+    int ieta = ebseedid.ieta();
+    int iphi = ebseedid.iphi();
+    eval[27] = ieta;
+    eval[28] = iphi;
+    eval[29] = (ieta-1*abs(ieta)/ieta)%5;
+    eval[30] = (iphi-1)%2;
+    eval[31] = (abs(ieta)<=25)*((ieta-1*abs(ieta)/ieta)%25) + (abs(ieta)>25)*((ieta-26*abs(ieta)/ieta)%20);
+    eval[32] = (iphi-1)%20;
+    eval[33] = ieta;  /// duplicated variables but this was trained like that
+    eval[34] = iphi;  /// duplicated variables but this was trained like that
   } else {
     EEDetId eeseedid(theseed->seed());
     eval[26] = the_sc->preshowerEnergy()/raw_energy;


### PR DESCRIPTION
The currently used photon regression is suboptimal and needs an update, the updated regression will have more variables (added in the end of the list with respect to the current variables). This PR adds these input variables for the upcoming computation. The change is backward compatible.

The improvement in resolution has been tested in data and is small but non-negligible as the following plot indicates (red is the regression currently used and black is the regression we would like to use).

![image](https://cloud.githubusercontent.com/assets/5707503/12830968/48c89424-cb92-11e5-9008-860096ceea89.png)

The next plot shows an example of the improvement due to variables that indicates cracks/gaps as well as phi modulation. The plots shows how the energy scale in the gap is now better corrected (Ecal module boundaries are indicated with dashed lines).

![image](https://cloud.githubusercontent.com/assets/5707503/12830977/50a86dc2-cb92-11e5-8814-ecfbc57a93b6.png)
