### PR TITLE
Implement propagate_const in FWLite

### DIFF
--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -26,6 +26,7 @@
 // user include files
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/EventBase.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {
@@ -100,7 +101,7 @@ namespace fwlite {
       Long64_t eventIndex() const { return eventIndex_; }
       virtual Long64_t fileIndex() const { return eventIndex_; }
 
-      void setGetter(std::shared_ptr<edm::EDProductGetter> getter){
+      void setGetter(std::shared_ptr<edm::EDProductGetter const> getter){
          event_->setGetter(getter);
       }
 
@@ -137,11 +138,11 @@ namespace fwlite {
       void switchToFile(Long64_t);
       // ---------- member data --------------------------------
       std::vector<std::string> fileNames_;
-      std::shared_ptr<TFile> file_;
-      std::shared_ptr<Event> event_;
+      edm::propagate_const<std::shared_ptr<TFile>> file_;
+      edm::propagate_const<std::shared_ptr<Event>> event_;
       Long64_t eventIndex_;
       std::vector<Long64_t> accumulatedSize_;
-      std::shared_ptr<edm::EDProductGetter> getter_;
+      edm::propagate_const<std::shared_ptr<edm::EDProductGetter>> getter_;
 
 };
 

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -24,6 +24,7 @@
 #include "DataFormats/FWLite/interface/HistoryGetterBase.h"
 #include "DataFormats/FWLite/interface/InternalDataKey.h"
 #include "FWCore/FWLite/interface/BranchMapReader.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "Rtypes.h"
 
@@ -79,11 +80,11 @@ namespace fwlite {
 
             // ---------- member functions ---------------------------
 
-            void setGetter(std::shared_ptr<edm::EDProductGetter> getter) {
+            void setGetter(std::shared_ptr<edm::EDProductGetter const> getter) {
                 getter_ = getter;
             }
 
-            edm::EDProductGetter* getter() {
+            edm::EDProductGetter const* getter() const {
                return getter_.get();
             }
 
@@ -95,7 +96,7 @@ namespace fwlite {
             typedef std::map<internal::DataKey, std::shared_ptr<internal::Data> > KeyToDataMap;
 
             internal::Data& getBranchDataFor(std::type_info const&, char const*, char const*, char const*) const;
-            void getBranchData(edm::EDProductGetter*, Long64_t, internal::Data&) const;
+            void getBranchData(edm::EDProductGetter const*, Long64_t, internal::Data&) const;
             bool getByBranchDescription(edm::BranchDescription const&, Long_t eventEntry, KeyToDataMap::iterator&) const;
             edm::WrapperBase const* getByBranchID(edm::BranchID const& bid, Long_t eventEntry) const;
             edm::WrapperBase const* wrapperBasePtr(edm::ObjectWithDict const&) const;
@@ -110,8 +111,8 @@ namespace fwlite {
 
             mutable std::map<std::pair<edm::ProductID, edm::BranchListIndex>,std::shared_ptr<internal::Data> > idToData_;
             mutable std::map<edm::BranchID, std::shared_ptr<internal::Data> > bidToData_;
-            std::shared_ptr<fwlite::HistoryGetterBase> historyGetter_;
-            std::shared_ptr<edm::EDProductGetter> getter_;
+            edm::propagate_const<std::shared_ptr<fwlite::HistoryGetterBase>> historyGetter_;
+            std::shared_ptr<edm::EDProductGetter const> getter_;
             mutable bool tcTrained_;
     };
 

--- a/DataFormats/FWLite/interface/ESHandle.h
+++ b/DataFormats/FWLite/interface/ESHandle.h
@@ -25,6 +25,7 @@
 
 // user include files
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace fwlite {
@@ -77,7 +78,7 @@ class ESHandle
 
       // ---------- member data --------------------------------
       const T* m_data;
-      std::shared_ptr<cms::Exception> m_exception;
+      std::shared_ptr<cms::Exception const> m_exception;
 };
 
 }

--- a/DataFormats/FWLite/interface/EntryFinder.h
+++ b/DataFormats/FWLite/interface/EntryFinder.h
@@ -35,7 +35,7 @@ namespace fwlite {
      EntryNumber_t findEvent(edm::RunNumber_t const& run, edm::LuminosityBlockNumber_t const& lumi, edm::EventNumber_t const& event) const;
      EntryNumber_t findLumi(edm::RunNumber_t const& run, edm::LuminosityBlockNumber_t const& lumi) const;
      EntryNumber_t findRun(edm::RunNumber_t const& run) const;
-     void fillIndex(BranchMapReader const& branchMap);
+     void fillIndex(BranchMapReader& branchMap);
      static EntryNumber_t const invalidEntry = -1LL;
    private:
      edm::IndexIntoFile indexIntoFile_;

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -173,10 +173,10 @@ namespace fwlite {
          edm::ProcessHistory const& history() const;
          void updateAux(Long_t eventIndex) const;
          void fillParameterSetRegistry() const;
-         void setGetter(std::shared_ptr<edm::EDProductGetter> getter) { return dataHelper_.setGetter(getter);}
+         void setGetter(std::shared_ptr<edm::EDProductGetter const> getter) { return dataHelper_.setGetter(getter);}
 
          // ---------- member data --------------------------------
-         TFile* file_;
+         mutable TFile* file_;
          // TTree* eventTree_;
          TTree* eventHistoryTree_;
          // Long64_t eventIndex_;
@@ -191,8 +191,8 @@ namespace fwlite {
          mutable std::vector<std::string> procHistoryNames_;
          mutable edm::EventAuxiliary aux_;
          mutable EntryFinder entryFinder_;
-         edm::EventAuxiliary* pAux_;
-         edm::EventAux* pOldAux_;
+         edm::EventAuxiliary const* pAux_;
+         edm::EventAux const* pOldAux_;
          TBranch* auxBranch_;
          int fileVersion_;
          mutable bool parameterSetRegistryFilled_;

--- a/DataFormats/FWLite/interface/EventSetup.h
+++ b/DataFormats/FWLite/interface/EventSetup.h
@@ -50,6 +50,7 @@
 // user include files
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 class TFile;
@@ -105,7 +106,7 @@ namespace fwlite
       edm::EventID m_syncedEvent;
       edm::Timestamp m_syncedTimestamp;
       
-      TFile* m_file;
+      mutable TFile* m_file;
 
       mutable std::vector<Record*> m_records;
    };

--- a/DataFormats/FWLite/interface/Handle.h
+++ b/DataFormats/FWLite/interface/Handle.h
@@ -253,7 +253,7 @@ class Handle
       const T* temp = data_;
       data_ = iOther.data_;
       iOther.data_ = temp;
-      ErrorThrower* tempE = errorThrower_;
+      ErrorThrower const* tempE = errorThrower_;
       errorThrower_ = iOther.errorThrower_;
       iOther.errorThrower_ = tempE;
    }
@@ -263,7 +263,7 @@ class Handle
 
       // ---------- member data --------------------------------
       const T* data_;
-      ErrorThrower*  errorThrower_;
+      ErrorThrower const*  errorThrower_;
 };
 
 }

--- a/DataFormats/FWLite/interface/InternalDataKey.h
+++ b/DataFormats/FWLite/interface/InternalDataKey.h
@@ -21,6 +21,7 @@
 
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include "TBranch.h"
 
@@ -78,7 +79,7 @@ namespace fwlite {
       };
 
       struct Data {
-            TBranch* branch_;
+            edm::propagate_const<TBranch*> branch_;
             Long64_t lastProduct_;
             edm::ObjectWithDict obj_; // For wrapped object
             void* pObj_; // ROOT requires the address of the pointer be stable

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -127,8 +127,8 @@ namespace fwlite {
          mutable std::vector<std::string> procHistoryNames_;
          mutable edm::LuminosityBlockAuxiliary aux_;
          mutable EntryFinder entryFinder_;
-         edm::LuminosityBlockAuxiliary* pAux_;
-         edm::LuminosityBlockAux* pOldAux_;
+         edm::LuminosityBlockAuxiliary const* pAux_;
+         edm::LuminosityBlockAux const* pOldAux_;
          TBranch* auxBranch_;
          int fileVersion_;
 

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -26,6 +26,7 @@
 // user include files
 #include "DataFormats/FWLite/interface/EventBase.h"
 #include "DataFormats/FWLite/interface/ChainEvent.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 namespace edm {
@@ -160,7 +161,7 @@ class MultiChainEvent: public EventBase
 
       std::shared_ptr<ChainEvent> event1_;  // primary files
       std::shared_ptr<ChainEvent> event2_;  // secondary files
-      std::shared_ptr<internal::MultiProductGetter> getter_;
+      std::shared_ptr<internal::MultiProductGetter const> getter_;
 
       // speed up secondary file access with a (run range)_1 ---> index_2 map,
       // when the files are sorted by run,event within the file.

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -120,8 +120,8 @@ namespace fwlite {
          mutable std::vector<std::string> procHistoryNames_;
          mutable edm::RunAuxiliary aux_;
          mutable EntryFinder entryFinder_;
-         edm::RunAuxiliary* pAux_;
-         edm::RunAux* pOldAux_;
+         edm::RunAuxiliary const* pAux_;
+         edm::RunAux const* pOldAux_;
          TBranch* auxBranch_;
          int fileVersion_;
 

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -111,7 +111,7 @@ namespace fwlite {
     }
 
     void
-    DataGetterHelper::getBranchData(edm::EDProductGetter* iGetter,
+    DataGetterHelper::getBranchData(edm::EDProductGetter const* iGetter,
                     Long64_t eventEntry,
                     internal::Data& iData) const
     {

--- a/DataFormats/FWLite/src/EntryFinder.cc
+++ b/DataFormats/FWLite/src/EntryFinder.cc
@@ -105,7 +105,7 @@ namespace fwlite {
    }
 
    void
-   EntryFinder::fillIndex(BranchMapReader const& branchMap) {
+   EntryFinder::fillIndex(BranchMapReader& branchMap) {
     if (empty()) {
       TTree* meta = dynamic_cast<TTree*>(branchMap.getFile()->Get(edm::poolNames::metaDataTreeName().c_str()));
       if (nullptr == meta) {

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -102,7 +102,7 @@ namespace fwlite {
                     return 0U;
                 }
 
-                Event* event_;
+                Event const* event_;
         };
     }
 //
@@ -119,9 +119,9 @@ namespace fwlite {
   fileVersion_(-1),
   parameterSetRegistryFilled_(false),
   dataHelper_(branchMap_.getEventTree(),
-              std::shared_ptr<HistoryGetterBase>(new EventHistoryGetter(this)),
+              std::make_shared<EventHistoryGetter>(this),
               std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
-              std::shared_ptr<edm::EDProductGetter>(new internal::ProductGetter(this)),
+              std::make_shared<internal::ProductGetter>(this),
               true) {
     if(nullptr == iFile) {
       throw cms::Exception("NoFile") << "The TFile pointer passed to the constructor was null";
@@ -159,7 +159,7 @@ namespace fwlite {
     if(fileVersion_ >= 7 && fileVersion_ < 17) {
       eventHistoryTree_ = dynamic_cast<TTree*>(iFile->Get(edm::poolNames::eventHistoryTreeName().c_str()));
     }
-    runFactory_ =  std::shared_ptr<RunFactory>(new RunFactory());
+    runFactory_ =  std::make_shared<RunFactory>();
 
 }
 

--- a/DataFormats/FWLite/src/LuminosityBlock.cc
+++ b/DataFormats/FWLite/src/LuminosityBlock.cc
@@ -48,7 +48,7 @@ namespace fwlite {
     pOldAux_(nullptr),
     fileVersion_(-1),
     dataHelper_(branchMap_->getLuminosityBlockTree(),
-                std::shared_ptr<HistoryGetterBase>(new LumiHistoryGetter(this)),
+                std::make_shared<LumiHistoryGetter>(this),
                 branchMap_)
   {
     if(nullptr == iFile) {
@@ -94,7 +94,7 @@ namespace fwlite {
     pOldAux_(nullptr),
     fileVersion_(-1),
     dataHelper_(branchMap_->getLuminosityBlockTree(),
-                std::shared_ptr<HistoryGetterBase>(new LumiHistoryGetter(this)),
+                std::make_shared<LumiHistoryGetter>(this),
                 branchMap_),
     runFactory_(runFactory)
   {

--- a/DataFormats/FWLite/src/Run.cc
+++ b/DataFormats/FWLite/src/Run.cc
@@ -47,7 +47,7 @@ namespace fwlite {
     pOldAux_(nullptr),
     fileVersion_(-1),
     dataHelper_(branchMap_->getRunTree(),
-                std::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
+                std::make_shared<RunHistoryGetter>(this),
                 branchMap_)
   {
     if(nullptr == iFile) {
@@ -84,7 +84,7 @@ namespace fwlite {
 //       auxBranch_->SetAddress(&pOldAux_);
     }
     branchMap_->updateRun(0);
-//     getter_ = std::shared_ptr<edm::EDProductGetter>(new ProductGetter(this));
+//     getter_ = std::make_shared<ProductGetter>(this);
 }
 
   Run::Run(std::shared_ptr<BranchMapReader> branchMap):
@@ -93,7 +93,7 @@ namespace fwlite {
     pOldAux_(nullptr),
     fileVersion_(-1),
     dataHelper_(branchMap_->getRunTree(),
-                std::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
+                std::make_shared<RunHistoryGetter>(this),
                 branchMap_)
   {
     if(nullptr == branchMap_->getRunTree()) {
@@ -129,7 +129,7 @@ namespace fwlite {
 //       eventHistoryTree_ = dynamic_cast<TTree*>(iFile->Get(edm::poolNames::eventHistoryTreeName().c_str()));
 //     }
 
-//     getter_ = std::shared_ptr<edm::EDProductGetter>(new ProductGetter(this));
+//     getter_ = std::make_shared<ProductGetter>(this);
 }
 
 Run::~Run()

--- a/FWCore/FWLite/interface/BranchMapReader.h
+++ b/FWCore/FWLite/interface/BranchMapReader.h
@@ -25,6 +25,7 @@
 // user include files
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 class TFile;
@@ -54,10 +55,10 @@ namespace fwlite {
       virtual const edm::BranchListIndexes& branchListIndexes() const = 0;
       virtual const edm::ThinnedAssociationsHelper& thinnedAssociationsHelper() const = 0;
 
-      TFile* currentFile_;
-      TTree* eventTree_;
-      TTree* luminosityBlockTree_;
-      TTree* runTree_;
+      edm::propagate_const<TFile*> currentFile_;
+      edm::propagate_const<TTree*> eventTree_;
+      edm::propagate_const<TTree*> luminosityBlockTree_;
+      edm::propagate_const<TTree*> runTree_;
       TUUID fileUUID_;
       Long_t eventEntry_;
       Long_t luminosityBlockEntry_;
@@ -86,10 +87,14 @@ namespace fwlite {
     int getFileVersion(TFile* file);
     int getFileVersion() const { return  fileVersion_;}
 
-    TFile* getFile() const { return strategy_->currentFile_; }
-    TTree* getEventTree() const { return strategy_->eventTree_; }
-    TTree* getLuminosityBlockTree() const { return strategy_->luminosityBlockTree_; }
-    TTree* getRunTree() const { return strategy_->runTree_; }
+    TFile const* getFile() const { return strategy_->currentFile_; }
+    TFile* getFile() { return strategy_->currentFile_; }
+    TTree const* getEventTree() const { return strategy_->eventTree_; }
+    TTree* getEventTree() { return strategy_->eventTree_; }
+    TTree const* getLuminosityBlockTree() const { return strategy_->luminosityBlockTree_; }
+    TTree* getLuminosityBlockTree() { return strategy_->luminosityBlockTree_; }
+    TTree const* getRunTree() const { return strategy_->runTree_; }
+    TTree* getRunTree() { return strategy_->runTree_; }
     TUUID getFileUUID() const { return strategy_->fileUUID_; }
     Long_t getEventEntry() const { return strategy_->eventEntry_; }
     Long_t getLuminosityBlockEntry() const { return strategy_->luminosityBlockEntry_; }
@@ -101,7 +106,7 @@ namespace fwlite {
       // ---------- member data --------------------------------
   private:
     std::unique_ptr<internal::BMRStrategy> newStrategy(TFile* file, int fileVersion);
-    std::unique_ptr<internal::BMRStrategy> strategy_;
+    std::unique_ptr<internal::BMRStrategy> strategy_; // Contains caches, so we do not propagate_const
     int fileVersion_;
   };
 }

--- a/FWCore/FWLite/src/BareRootProductGetter.cc
+++ b/FWCore/FWLite/src/BareRootProductGetter.cc
@@ -321,7 +321,7 @@ BareRootProductGetter::createNewBuffer(edm::BranchID const& branchID) const {
   //connect the instance to the branch
   //void* address  = wrapperObj.Address();
   Buffer b(prod, branch, address, rootClassType);
-  idToBuffers_[branchID] = b;
+  idToBuffers_[branchID] = std::move(b);
 
   //As of 5.13 ROOT expects the memory address held by the pointer passed to
   // SetAddress to be valid forever

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -22,6 +22,7 @@
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/Common/interface/EDProductGetter.h"
 #include "FWCore/FWLite/interface/BranchMapReader.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // system include files
 #include "Rtypes.h"
@@ -92,10 +93,10 @@ class BareRootProductGetter : public edm::EDProductGetter {
         Buffer() : product_(), branch_(), address_(), eventEntry_(-1), class_(nullptr) {}
 
         std::shared_ptr<edm::WrapperBase const> product_;
-        TBranch* branch_;
+        edm::propagate_const<TBranch*> branch_;
         void* address_; //the address to pass to Root since as of 5.13 they cache that info
         Long_t eventEntry_; //the event Entry used with the last GetEntry call
-        TClass* class_;
+        edm::propagate_const<TClass*> class_;
       };
 
       BareRootProductGetter(BareRootProductGetter const&); // stop default

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
@@ -50,6 +50,7 @@ class TList;
 // user include files
 
 #include "FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 template <class TWorker>
@@ -72,7 +73,7 @@ class TFWLiteSelector : public TFWLiteSelectorBasic
       const TFWLiteSelector& operator=(const TFWLiteSelector&); // stop default
 
       virtual void preProcessing(const TList*in, TList& out) {
-        worker_.reset(new TWorker(in,out));
+        worker_ = std::make_shared<TWorker>(in,out);
       }
       virtual void process(const edm::Event& iEvent) {
         worker_->process(iEvent);
@@ -82,7 +83,7 @@ class TFWLiteSelector : public TFWLiteSelectorBasic
       }
       
       // ---------- member data --------------------------------
-      std::shared_ptr<TWorker> worker_;
+      edm::propagate_const<std::shared_ptr<TWorker>> worker_;
       ClassDef(TFWLiteSelector,2)
 };
 

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h
@@ -24,6 +24,7 @@ allows you to access data using an edm::Event.
 #include "TSelector.h"
 
 // user include files
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
 class TFile;
@@ -96,7 +97,7 @@ class TFWLiteSelectorBasic : public TSelector
       
       void setupNewFile(TFile&);
       // ---------- member data --------------------------------
-      std::shared_ptr<edm::root::TFWLiteSelectorMembers> m_;
+      edm::propagate_const<std::shared_ptr<edm::root::TFWLiteSelectorMembers>> m_;
       bool everythingOK_;
   
   ClassDef(TFWLiteSelectorBasic,2)

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.cc
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.cc
@@ -18,7 +18,7 @@ void ThingsTSelector::begin(TList*&)
 void ThingsTSelector::preProcessing(const TList*, TList& out ) {
   if(nullptr != h_a) {
      out.Remove(h_a);
-     delete h_a;
+     delete h_a.get();
      h_a = nullptr;
   }
   h_a  = new TH1F( kA , "a"  , 100,  0, 20 );
@@ -26,7 +26,7 @@ void ThingsTSelector::preProcessing(const TList*, TList& out ) {
 
   if(nullptr != h_refA) {
      out.Remove(h_refA);
-     delete h_refA;
+     delete h_refA.get();
      h_refA = nullptr;
   }
   h_refA  = new TH1F( kRefA , "refA"  , 100,  0, 20 );

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h
@@ -8,8 +8,9 @@
  * \author Luca Lista, INFN
  *
  */
-#include <TH1.h>
+#include "TH1.h"
 #include "FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace tfwliteselectortest {
 class ThingsTSelector : public TFWLiteSelectorBasic {
@@ -23,7 +24,8 @@ public :
 
 private:
   /// histograms
-  TH1F * h_a, *h_refA;
+  edm::propagate_const<TH1F*> h_a;
+  edm::propagate_const<TH1F*> h_refA;
 
   ThingsTSelector(ThingsTSelector const&);
   ThingsTSelector operator=(ThingsTSelector const&);

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
@@ -8,7 +8,7 @@
  * \author Luca Lista, INFN
  *
  */
-#include <TH1.h>
+#include "TH1.h"
 #include "FWCore/TFWLiteSelector/interface/TFWLiteSelector.h"
 
 namespace tfwliteselectortest {
@@ -16,8 +16,8 @@ namespace tfwliteselectortest {
 	ThingsWorker(const TList*, TList&);
 	void process( const edm::Event& iEvent );
 	void postProcess(TList&);
-	TH1F* h_a;
-	TH1F* h_refA;
+        edm::propagate_const<TH1F*> h_a;
+        edm::propagate_const<TH1F*> h_refA;
   };
 
   class ThingsTSelector2 : public TFWLiteSelector<ThingsWorker> {


### PR DESCRIPTION
This PR partially implements deep const correctness in FWLite by using the propagate_const template around most pointers (bare or smart) that are data members of classes or structs, and making the other changes required to do this. Pointers to const and pointers declared mutable do not need propagate_const. A very few pointers were left undone because the changes involved would be complex enough that more attention is required.
