### PR TITLE
Add HGC RecHits / Reco Geometry to Fireworks

### DIFF
--- a/Fireworks/Calo/plugins/FWHGCRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCRecHitProxyBuilder.cc
@@ -1,0 +1,60 @@
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
+
+class FWHGCRecHitProxyBuilder : public FWCaloRecHitDigitSetProxyBuilder
+{
+public:
+   FWHGCRecHitProxyBuilder( void ) { invertBox(true); }
+   virtual ~FWHGCRecHitProxyBuilder( void ) {}
+
+   REGISTER_PROXYBUILDER_METHODS();
+
+private:
+   FWHGCRecHitProxyBuilder( const FWHGCRecHitProxyBuilder& );
+   const FWHGCRecHitProxyBuilder& operator=( const FWHGCRecHitProxyBuilder& );
+};
+
+REGISTER_FWPROXYBUILDER( FWHGCRecHitProxyBuilder, HGCRecHitCollection, "HGC RecHit", FWViewType::kISpyBit );
+
+
+// AMT: Refelct box. Previously used energyScaledBox3DCorners()
+
+/*
+void
+FWHBHERecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc)
+{
+   m_plotEt = vc->getEnergyScale()->getPlotEt();
+
+   const HBHERecHitCollection* collection = 0;
+   iItem->get( collection );
+
+   if( 0 == collection )
+   {
+      return;
+   }
+   std::vector<HBHERecHit>::const_iterator it = collection->begin();
+   std::vector<HBHERecHit>::const_iterator itEnd = collection->end();
+   std::vector<float> scaledCorners(24);
+
+   for( ; it != itEnd; ++it )
+   {
+      if(( *it ).energy() > m_maxEnergy )
+         m_maxEnergy = ( *it ).energy();
+   }
+
+   TEveBoxSet* boxSet = addBoxSetToProduct(product);
+   int index = 0;
+   for (std::vector<HBHERecHit>::const_iterator it = collection->begin() ; it != collection->end(); ++it)
+   {  
+      const float* corners = context().getGeom()->getCorners((*it).detid());
+      if (corners)
+      {
+         if (m_plotEt)
+            fireworks::etScaledBox3DCorners(corners, (*it).energy(), m_maxEnergy, scaledCorners, true);
+         else
+            fireworks::energyScaledBox3DCorners(corners, (*it).energy() / m_maxEnergy, scaledCorners, true);
+      }
+      addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
+   }
+}
+*/

--- a/Fireworks/Geometry/BuildFile.xml
+++ b/Fireworks/Geometry/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="Geometry/CSCGeometryBuilder"/>
 <use name="DetectorDescription/Core"/>
 <use name="Geometry/CaloGeometry"/>
+<use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/DTGeometry"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/RPCGeometry"/>

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -13,6 +13,7 @@ namespace edm
 }
 
 class CaloGeometry;
+class HGCalGeometry;
 class GlobalTrackingGeometry;
 class TrackerGeometry;
 class FWRecoGeometry;
@@ -48,10 +49,11 @@ private:
   void fillPoints( unsigned int id, std::vector<GlobalPoint>::const_iterator begin, std::vector<GlobalPoint>::const_iterator end );
   void fillShapeAndPlacement( unsigned int id, const GeomDet *det );
   
-  edm::ESHandle<GlobalTrackingGeometry> m_geomRecord;
-  edm::ESHandle<CaloGeometry>           m_caloGeom;
-  const TrackerGeometry*                m_trackerGeom;
-  boost::shared_ptr<FWRecoGeometry>     m_fwGeometry;
+  edm::ESHandle<GlobalTrackingGeometry>      m_geomRecord;
+  edm::ESHandle<CaloGeometry>                m_caloGeom;
+  std::vector<edm::ESHandle<HGCalGeometry> > m_hgcalGeoms;
+  const TrackerGeometry*                     m_trackerGeom;
+  boost::shared_ptr<FWRecoGeometry>          m_fwGeometry;
   
   unsigned int m_current;
 };

--- a/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
@@ -62,6 +62,15 @@ def recoGeoLoad(score):
       #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2019
       #process = cust_2019(process)
       
+    elif  score == "2023Dev":
+      from Configuration.AlCa.autoCond import autoCond
+      process.GlobalTag.globaltag = autoCond['mc']
+      #from Configuration.AlCa.GlobalTag import GlobalTag                                                            
+      #process.GlobalTag = GlobalTag(process.GlobalTag, 'PH2_1K_FB_V6::All', '')                                     
+      process.load('Configuration.Geometry.GeometryExtended2023DevReco_cff')
+      #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2019                                    
+      #process = cust_2019(process)
+
     elif  score == "2023Muon":
       from Configuration.AlCa.autoCond import autoCond
       process.GlobalTag.globaltag = autoCond['mc']


### PR DESCRIPTION
This PR adds the HGCal geometries (V5 and V7) such that they are processed and written to disk for the fireworks RECO geometry.

I also added a rechit proxy builder, showing that things look mostly reasonable (this is a jet gun event).
It would be useful if we could remove the scaling from RecHit view and just see the hits directly, right now they are scaled to be very tiny since they only contain energies of few tens-hundreds of keV.

Example of hex geometry:
<img width="641" alt="screen shot 2016-02-05 at 13 25 42" src="https://cloud.githubusercontent.com/assets/1068089/12847674/cc604528-cc0c-11e5-8ec9-ac140037ecb9.png">

@vandreev11 @sethzenz @kpedro88
