### PR TITLE
Fix trackingOnly tracking validation for FastSim and Phase1

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -510,8 +510,8 @@ trackValidatorBuildingTrackingOnly = trackValidatorTrackingOnly.clone(
     doSimPlots = False,
 )
 
-eras.fastSim.toModify(trackValidatorTrackingOnly, label =  _trackProducersForFastSim )
-eras.phase1Pixel.toModify(trackValidatorTrackingOnly, label = _trackProducersForPhase1Pixel)
+eras.fastSim.toModify(trackValidatorBuildingTrackingOnly, label =  _trackProducersForFastSim )
+eras.phase1Pixel.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForPhase1Pixel)
 
 trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
     dirName = "Tracking/TrackSeeding/",


### PR DESCRIPTION
This PR fixes a bug introduced in #13172 affecting the trackingOnly MultiTrackValidator configurations for FastSim and Phase1. An incorrect instance of MTV was modified. Thanks to @lveldere for reporting.

Tested in CMSSW_8_0_X_2016-02-07-2300, should have no effect in standard workflows.

@rovere @VinInn 
