### PR TITLE
Sort module summary reports by module label

### DIFF
--- a/FWCore/Framework/interface/TriggerReport.h
+++ b/FWCore/Framework/interface/TriggerReport.h
@@ -56,6 +56,10 @@ namespace edm {
     std::string moduleLabel;
   };
 
+  inline
+  bool operator<(WorkerSummary const& a, WorkerSummary const& b) {
+    return a.moduleLabel < b.moduleLabel;
+  }
 
   struct TriggerReport
   {

--- a/FWCore/Framework/interface/TriggerTimingReport.h
+++ b/FWCore/Framework/interface/TriggerTimingReport.h
@@ -50,6 +50,10 @@ namespace edm {
     std::string moduleLabel;
   };
 
+  inline
+  bool operator<(WorkerTimingSummary const& a, WorkerTimingSummary const& b) {
+    return a.moduleLabel < b.moduleLabel;
+  }
 
   struct TriggerTimingReport
   {

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -704,6 +704,7 @@ namespace edm {
     fill_summary(trig_paths_,  rep.trigPathSummaries, &fillPathSummary);
     fill_summary(end_paths_,   rep.endPathSummaries,  &fillPathSummary);
     fill_summary(allWorkers(), rep.workerSummaries,   &fillWorkerSummary);
+    sort_all(rep.workerSummaries);
   }
 
   void

--- a/FWCore/Framework/src/SystemTimeKeeper.cc
+++ b/FWCore/Framework/src/SystemTimeKeeper.cc
@@ -23,6 +23,7 @@
 #include "DataFormats/Common/interface/HLTPathStatus.h"
 #include "FWCore/Framework/interface/TriggerTimingReport.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Utilities/interface/Algorithms.h"
 #include "SystemTimeKeeper.h"
 
 using namespace edm;
@@ -294,6 +295,7 @@ SystemTimeKeeper::fillTriggerTimingReport(TriggerTimingReport& rep) const {
       ++modIndex;
     }
   }
+  sort_all(rep.workerSummaries);
   
   //Per path summary
   {


### PR DESCRIPTION
The modules in the trigger summary report and timing summary report are output in an order that is meaningless to the user. This PR orders the module summary reports by the module label.
This PR should solve issue #13195, as revised to sort by module label, rather than by time spent.
