### PR TITLE
update 2017 customs for pixels to use full DB conditions

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -44,37 +44,49 @@ def customise_RawToDigi(process):
     return process
 
 def customise_Digi(process):
-    process.mix.digitizers.pixel.MissCalibrate = False
-    process.mix.digitizers.pixel.LorentzAngle_DB = False
-    process.mix.digitizers.pixel.killModules = False
-    process.mix.digitizers.pixel.useDB = False
-    process.mix.digitizers.pixel.DeadModules_DB = False
+#    use defaults  d.k. 2/16
+#    process.mix.digitizers.pixel.MissCalibrate = False
+#    process.mix.digitizers.pixel.LorentzAngle_DB = False
+#    process.mix.digitizers.pixel.killModules = False
+#    process.mix.digitizers.pixel.useDB = False
+#    process.mix.digitizers.pixel.DeadModules_DB = False
     process.mix.digitizers.pixel.NumPixelBarrel = cms.int32(4)
     process.mix.digitizers.pixel.NumPixelEndcap = cms.int32(3)
+    # new thresholds 
     process.mix.digitizers.pixel.ThresholdInElectrons_FPix = cms.double(2000.0)
     process.mix.digitizers.pixel.ThresholdInElectrons_BPix = cms.double(2000.0)
     process.mix.digitizers.pixel.ThresholdInElectrons_BPix_L1 = cms.double(2000.0)
-    process.mix.digitizers.pixel.thePixelColEfficiency_BPix1 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelColEfficiency_BPix2 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelColEfficiency_BPix3 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelColEfficiency_BPix4 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_BPix1 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_BPix2 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_BPix3 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_BPix4 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix1 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix2 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix3 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix4 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelColEfficiency_FPix1 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelColEfficiency_FPix2 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelColEfficiency_FPix3 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_FPix1 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_FPix2 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelEfficiency_FPix3 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix1 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix2 = cms.double(0.999)
-    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix3 = cms.double(0.999)
+    # new ROC response 
+    process.mix.digitizers.pixel.FPix_SignalResponse_p0 = cms.double(0.00171)
+    process.mix.digitizers.pixel.FPix_SignalResponse_p1 = cms.double(0.711)
+    process.mix.digitizers.pixel.FPix_SignalResponse_p2 = cms.double(203.)
+    process.mix.digitizers.pixel.FPix_SignalResponse_p3 = cms.double(148.)
+    process.mix.digitizers.pixel.BPix_SignalResponse_p0 = cms.double(0.00171)
+    process.mix.digitizers.pixel.BPix_SignalResponse_p1 = cms.double(0.711)
+    process.mix.digitizers.pixel.BPix_SignalResponse_p2 = cms.double(203.)
+    process.mix.digitizers.pixel.BPix_SignalResponse_p3 = cms.double(148.) 
+    # no inefficiency for now
+    process.mix.digitizers.pixel.thePixelColEfficiency_BPix1 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelColEfficiency_BPix2 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelColEfficiency_BPix3 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelColEfficiency_BPix4 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_BPix1 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_BPix2 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_BPix3 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_BPix4 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix1 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix2 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix3 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix4 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelColEfficiency_FPix1 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelColEfficiency_FPix2 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelColEfficiency_FPix3 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_FPix1 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_FPix2 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelEfficiency_FPix3 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix1 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix2 = cms.double(1.)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix3 = cms.double(1.)
 # something broken in the configs above - turn off for now
     process.mix.digitizers.pixel.AddPixelInefficiency = cms.bool(False)
 
@@ -416,9 +428,10 @@ def customise_Reco(process,pileup):
     process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
     process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
     process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
-    process.templates.DoLorentz=False
-    process.templates.LoadTemplatesFromDB = cms.bool(False)
-    process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
+    # use defaults d.k. 2/16
+    #process.templates.DoLorentz=False
+    #process.templates.LoadTemplatesFromDB = cms.bool(False)
+    #process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
 
     # This probably breaks badly the "displaced muon" reconstruction,
     # but let's do it for now, until the upgrade tracking sequences

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_Phase1_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_Phase1_cff.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelFakeGainOfflineESSource = cms.ESSource("SiPixelFakeGainOfflineESSource",
-        file = cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseI/EmptyPixelSkimmedGeometry_phase1.txt')
-        )
-es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
+# I do not know why this is here, comment-out d.k. 2/16
+#siPixelFakeGainOfflineESSource = cms.ESSource("SiPixelFakeGainOfflineESSource",
+#        file = cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseI/Empt#yPixelSkimmedGeometry_phase1.txt')
+#        )
+#es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
 # from Geometry.TrackerGeometryBuilder.trackerGeometry_cfi import * Double check this later
 # TrackerDigiGeometryESModule.applyAlignment = False


### PR DESCRIPTION
Update 2017 customization settings for pixels to fully use all DB payloads for reconstruction and simulation. The raw2digi/digi2raw is still disabled since the cabling map does not yet work correctly 
 for pixel phase1.
