### PR TITLE
FastSim: run standard Validation and DQM sequences.

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1091,7 +1091,6 @@ class ConfigBuilder(object):
 	if self._options.fast:
 		self.SIMDefaultCFF = 'FastSimulation.Configuration.SimIdeal_cff'
 		self.RECODefaultCFF= 'FastSimulation.Configuration.Reconstruction_AftMix_cff'
-                self.VALIDATIONDefaultCFF = "FastSimulation.Configuration.Validation_cff"
 		self.RECOBEFMIXDefaultCFF = 'FastSimulation.Configuration.Reconstruction_BefMix_cff'
 		self.RECOBEFMIXDefaultSeq = 'reconstruction_befmix'
 		self.L1RecoDefaultCFF='FastSimulation.Configuration.L1Reco_cff'
@@ -1939,7 +1938,8 @@ class ConfigBuilder(object):
 			self.renameHLTprocessInSequence(sequence)
 
 		# if both HLT and DQM are run in the same process, schedule [HLT]DQM in an EndPath
-		if 'HLT' in self.stepMap.keys():
+		# make an exception for fastsim, since it does not (yet) run HLT DQM
+		if 'HLT' in self.stepMap.keys() and not self._options.fast:
 			# need to put [HLT]DQM in an EndPath, to access the HLT trigger results
 			setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
 		else:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -542,14 +542,14 @@ steps['ZEEMM_13_HI']=merge([hiDefaults,steps['ZEEMM_13']])
 
 #### fastsim section ####
 ##no forseen to do things in two steps GEN-SIM then FASTIM->end: maybe later
-step1FastDefaults =merge([{'-s':'GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,L1Reco,RECO,EI,HLT:@fake,VALIDATION',
+step1FastDefaults =merge([{'-s':'GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,L1Reco,RECO,EI,HLT:@fake,VALIDATION:@standardValidation,DQM:@standardDQM',
                            '--fast':'',
                            '--beamspot'    : 'Realistic8TeVCollision',
                            '--eventcontent':'FEVTDEBUGHLT,DQM',
                            '--datatier':'GEN-SIM-DIGI-RECO,DQMIO',
                            '--relval':'27000,3000'},
                           step1Defaults])
-step1FastUpg2015Defaults =merge([{'-s':'GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,L1Reco,RECO,EI,HLT:@relval25ns,VALIDATION',
+step1FastUpg2015Defaults =merge([{'-s':'GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,L1Reco,RECO,EI,HLT:@relval25ns,VALIDATION:@standardValidation,DQM:@standardDQM',
                            '--fast':'',
                            '--conditions'  :'auto:run2_mc_'+autoHLT['relval25ns'],
                            '--beamspot'    : 'Realistic50ns13TeVCollision',
@@ -616,7 +616,7 @@ steps["FS_PREMIXUP15_PU25"] = merge([
 
 ### Fastsim: template to produce signal and overlay it with premixed minbias events
 FS_PREMIXUP15_PU25_OVERLAY = merge([
-        {"-s" : "GEN,SIM,RECOBEFMIX,DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,L1Reco,RECO,HLT:@relval25ns,VALIDATION",
+        {"-s" : "GEN,SIM,RECOBEFMIX,DIGIPREMIX_S2:pdigi_valid,DATAMIX,L1,L1Reco,RECO,HLT:@relval25ns,VALIDATION:@standardValidation,DQM:@standardDQM",
          "--datamix" : "PreMix",
          "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW"%(baseDataSetRelease[8],),
          "--customise":"SimGeneral/DataMixingModule/customiseForPremixingInput.customiseForPreMixingInput"

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -45,6 +45,13 @@ validation = cms.Sequence(cms.SequencePlaceholder("mix")
                          *globalValidation
                          *hltvalidation)
 
+# fastsim: remove bits that depend on digis, tracker simhits or tracker rechits
+def _validation_fastSimMods(sequence):
+    sequence.remove(globaldigisanalyze)
+    sequence.remove(globalhitsanalyze)
+    sequence.remove(globalrechitsanalyze)
+eras.fastSim.toModify(validation,func=_validation_fastSimMods)
+
 validationLiteTracking = cms.Sequence( validation )
 validationLiteTracking.replace(globalValidation,globalValidationLiteTracking)
 validationLiteTracking.remove(condDataValidation)

--- a/DQMOffline/Configuration/python/DQMOfflineMC_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineMC_cff.py
@@ -19,3 +19,10 @@ cscMonitor.FEDRawDataCollectionTag = 'rawDataCollector'
 
 # L1 Trigger - remove emulator and adapt labels for private unpacking
 from DQMOffline.L1Trigger.L1TriggerDqmOfflineMC_cff import *
+
+# put back one of the FastSim aliases, because DQM overwrites it
+from Configuration.StandardSequences.Eras import eras
+if eras.fastSim.isChosen():
+    from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
+    loadTriggerDigiAliases()
+    from FastSimulation.Configuration.DigiAliases_cff import caloStage1LegacyFormatDigis

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -61,6 +61,18 @@ DQMOfflinePrePOG = cms.Sequence( TrackingDQMSourceTier0 *
                                  produceDenoms *
                                  pfTauRunDQMValidation)
 
+# fastsim mods
+def _DQMOfflinePrePOG_fastSimMods(sequence):
+    for _entry in [ TrackingDQMSourceTier0,  # clashes with HLT customisation
+                    muonMonitors,            # needs some fastsim mods
+                    jetMETDQMOfflineSource,  # needs some fastsim mods
+                    egammaDQMOffline,        # clashes with HLT customisation
+                    triggerOfflineDQMSource, # needs some fastsim mods
+                    alcaBeamMonitor]:        # not compatible with fastsim
+        sequence.remove(_entry)
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(DQMOfflinePrePOG,_DQMOfflinePrePOG_fastSimMods)
+
 DQMOfflinePOG = cms.Sequence( DQMOfflinePrePOG *
                               DQMMessageLogger )
 
@@ -78,6 +90,15 @@ DQMOfflineFakeHLT.remove( HLTMonitoring )
 DQMOfflinePrePOGMC = cms.Sequence( pvMonitor *
                                    bTagPlotsDATA *
                                    dqmPhysics )
+
+# fastsim mods
+def _DQMOffline_fastSimMods(sequence):
+    for _entry in [DQMOfflinePreDPG,                 # needs some fastsim mods
+                   dqmFastTimerServiceLuminosity,    # not compatible with fastsim
+                   HLTMonitoring]:                   # needs some fastsim mods
+        sequence.remove(_entry)
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(DQMOffline,_DQMOffline_fastSimMods)
 
 DQMOfflinePOGMC = cms.Sequence( DQMOfflinePrePOGMC *
                                 DQMMessageLogger )


### PR DESCRIPTION
 FastSim modifications defined through fastSim era.

The Validation sequence if pretty complete.

The DQM sequence is still rather incomplete.
The reason why many subsequences are left out:
- their configuration clashes somehow with the HLT customisation
- some DQM modules depend on TriggerResults. 
  In FastSim, where DQM and HLT are run in one job,
  those modules must be run in an EndPath, while some other modules (EDFilters) cannot be run in and EndPath.
