### PR TITLE
FastSim : HLT SUSYBSM validation : remove dependence on non-existing collection 'conversions'

### DIFF
--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
@@ -53,3 +53,6 @@ SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericCli
                                                                   resolution = cms.vstring('')
                                                                   )
 
+# fastsim has no conversion collection (yet)
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(SUSY_HLT_Ele_HT_BTag_SingleLepton,conversionCollection=cms.InputTag(''))

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
@@ -51,3 +51,7 @@ SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGeneric
                                                                      resolution = cms.vstring('')
                                                                      )
 
+
+# fastsim has no conversion collection (yet)
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(SUSY_HLT_Ele_HT_Control_SingleLepton,conversionCollection=cms.InputTag(''))

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
@@ -52,3 +52,7 @@ SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClie
                                                                  resolution = cms.vstring('')
                                                                  )
 
+
+# fastsim has no conversion collection (yet)
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(SUSY_HLT_Ele_HT_MET_SingleLepton,conversionCollection=cms.InputTag(''))

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
@@ -50,3 +50,7 @@ SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
         ),
                                                              resolution = cms.vstring('')
                                                              )
+
+# fastsim has no conversion collection (yet)
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(SUSY_HLT_Ele_HT_SingleLepton,conversionCollection=cms.InputTag(''))

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
@@ -29,36 +29,6 @@ SUSY_HLT_Mu_VBF = cms.EDAnalyzer("SUSY_HLT_VBF_Mu",
                                  
                                  )
 
-SUSY_HLT_Mu_VBF_FASTSIM = cms.EDAnalyzer("SUSY_HLT_VBF_Mu",
-                                         trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
-                                         #trigSummary = cms.InputTag("hltTriggerSummaryAOD"),
-                                         MuonCollection = cms.InputTag("muons"),
-                                         pfMETCollection = cms.InputTag("pfMet"),
-                                         pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
-                                         caloJetCollection = cms.InputTag("ak4CaloJets"),
-                                         caloMETCollection = cms.InputTag("caloMet"),
-                                         TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
-                                         HLTProcess = cms.string('HLT'),
-                                         TriggerPath = cms.string('HLT_Mu10_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT350_PFMETNoMu60_v'),
-                                         TriggerFilterMuon  = cms.InputTag('hltMuon10RelTrkIsoVVLFiltered0p4','','HLT'),
-                                         TriggerFilterMJJ  = cms.InputTag('hltDiPFJet40MJJ750DEta3p5','','HLT'),
-                                         TriggerFilterHT = cms.InputTag('hltPFHT350','','HLT'),
-                                         TriggerFilterMET  = cms.InputTag('hltPFMETNoMu60','','HLT'), #60
-
-                                         TriggerFilterCaloMET  = cms.InputTag('hltMETCleanUsingJetID20','','HLT'),
-                                         PtThrJet = cms.untracked.double(40.0),
-                                         EtaThrJet = cms.untracked.double(3.0),
-                                         PtThrJetTrig  = cms.untracked.double(40.0),
-                                         EtaThrJetTrig  = cms.untracked.double(5.0),
-
-                                         DeltaEtaVBFJets  = cms.untracked.double(3.5),
-                                         PFMetCutOnline  = cms.untracked.double(60.0),
-                                         MuonCutOnline  = cms.untracked.double(10.0),
-                                         HTCutOnline = cms.untracked.double(350.0),
-                                         MJJCutOnline = cms.untracked.double(750.0)
-                                         )
-
-
 SUSY_HLT_Mu_VBF_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
                                                 subDirs        = cms.untracked.vstring("HLT/SUSYBSM/SUSY_HLT_VBF_Mu_v"),
                                                 verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
@@ -70,21 +40,3 @@ SUSY_HLT_Mu_VBF_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
         "pfMETTurnOn_eff 'Turn-on vs pf MET; MET (GeV) ; #epsilon' h_num_met h_den_met", 
         )
                                                 )
-
-
-SUSY_HLT_Mu_VBF_FASTSIM_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
-                                                        subDirs        = cms.untracked.vstring("HLT/SUSYBSM/SUSY_HLT_VBF_Mu_v"),
-                                                        verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
-                                                        resolution     = cms.vstring(""),
-                                                        efficiency     = cms.vstring(
-        "MuonTurnOn_eff 'Turn-on vs Mu pT; pT (GeV); #epsilon' h_num_muonpt h_den_muonpt",
-        "MJJTurnOn_eff 'Turn-on vs Mjj; Mjj (GeV); #epsilon' h_num_mjj h_den_mjj",
-        "pfHTTurnOn_eff 'Turn-on vs pf HT; pf HT (GeV); #epsilon' h_num_ht h_den_ht",
-        "pfMETTurnOn_eff 'Turn-on vs pf MET; MET (GeV) ; #epsilon' h_num_met h_den_met", 
-        
-        )
-                                                        )
-
-
-
-


### PR DESCRIPTION
gets rid of a whole list of warnings when running the validation sequence on FastSim

remove some obsolete configuration from SUSYBSM_HLT_VBF_Mu_cff.py
