### PR TITLE
DQM new pixel residuals

### DIFF
--- a/DQM/TrackerMonitorTrack/BuildFile.xml
+++ b/DQM/TrackerMonitorTrack/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DQM/SiStripCommon"/>
+<use   name="DQM/SiPixelCommon"/>
 <use   name="DQMServices/Core"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>

--- a/DQM/TrackerMonitorTrack/README.md
+++ b/DQM/TrackerMonitorTrack/README.md
@@ -1,0 +1,94 @@
+### Purpose
+
+This code generates the `HitResiduals` and `NormalizedHitResiduals` histograms.
+
+### Data displayed
+
+The data shown in the histograms is computed by the Alignment/OfflineValidation code. It is computed for SiPixel and SiStrip in x- and y-direction (resXprime, resYprime values), however for the strips only the x-residual is relevant.
+
+### Options
+
+* `MonitorTrackResiduals.Mod_On` setting this to `True` will generate plots for every module. By default, only one plot per layer and wheel/disk is generated.
+
+### Bugs
+
+* The plots for pixel disks appear hidden in the shell and half cylinder folders, even though they cover the full layer/disk.
+
+### Currently generated histograms
+
+* `Pixel/Barrel/Shell_mI/Layer_1/HitResiduals_BPIX__Layer__1`
+* `Pixel/Barrel/Shell_mI/Layer_1/HitResiduals_BPIX__Layer__1_Y`
+* `Pixel/Barrel/Shell_mI/Layer_2/HitResiduals_BPIX__Layer__2`
+* `Pixel/Barrel/Shell_mI/Layer_2/HitResiduals_BPIX__Layer__2_Y`
+* `Pixel/Barrel/Shell_mI/Layer_3/HitResiduals_BPIX__Layer__3`
+* `Pixel/Barrel/Shell_mI/Layer_3/HitResiduals_BPIX__Layer__3_Y`
+* `Pixel/Endcap/HalfCylinder_pI/Disk_1/HitResiduals_FPIX__wheel__1`
+* `Pixel/Endcap/HalfCylinder_pI/Disk_1/HitResiduals_FPIX__wheel__1_Y`
+* `Pixel/Endcap/HalfCylinder_pI/Disk_2/HitResiduals_FPIX__wheel__2`
+* `Pixel/Endcap/HalfCylinder_pI/Disk_2/HitResiduals_FPIX__wheel__2_Y`
+* `Pixel/Endcap/HalfCylinder_mI/Disk_1/HitResiduals_FPIX__wheel__1`
+* `Pixel/Endcap/HalfCylinder_mI/Disk_1/HitResiduals_FPIX__wheel__1_Y`
+* `Pixel/Endcap/HalfCylinder_mI/Disk_2/HitResiduals_FPIX__wheel__2`
+* `Pixel/Endcap/HalfCylinder_mI/Disk_2/HitResiduals_FPIX__wheel__2_Y`
+* `SiStrip/MechanicalView/TIB/layer_1/HitResiduals_TIB__Layer__1`
+* `SiStrip/MechanicalView/TIB/layer_1/HitResiduals_TIB__Layer__1_Y`
+* `SiStrip/MechanicalView/TIB/layer_2/HitResiduals_TIB__Layer__2`
+* `SiStrip/MechanicalView/TIB/layer_2/HitResiduals_TIB__Layer__2_Y`
+* `SiStrip/MechanicalView/TIB/layer_3/HitResiduals_TIB__Layer__3`
+* `SiStrip/MechanicalView/TIB/layer_3/HitResiduals_TIB__Layer__3_Y`
+* `SiStrip/MechanicalView/TIB/layer_4/HitResiduals_TIB__Layer__4`
+* `SiStrip/MechanicalView/TIB/layer_4/HitResiduals_TIB__Layer__4_Y`
+* `SiStrip/MechanicalView/TID/PLUS/wheel_1/HitResiduals_TID__wheel__1`
+* `SiStrip/MechanicalView/TID/PLUS/wheel_1/HitResiduals_TID__wheel__1_Y`
+* `SiStrip/MechanicalView/TID/PLUS/wheel_2/HitResiduals_TID__wheel__2`
+* `SiStrip/MechanicalView/TID/PLUS/wheel_2/HitResiduals_TID__wheel__2_Y`
+* `SiStrip/MechanicalView/TID/PLUS/wheel_3/HitResiduals_TID__wheel__3`
+* `SiStrip/MechanicalView/TID/PLUS/wheel_3/HitResiduals_TID__wheel__3_Y`
+* `SiStrip/MechanicalView/TOB/layer_1/HitResiduals_TOB__Layer__1`
+* `SiStrip/MechanicalView/TOB/layer_1/HitResiduals_TOB__Layer__1_Y`
+* `SiStrip/MechanicalView/TOB/layer_2/HitResiduals_TOB__Layer__2`
+* `SiStrip/MechanicalView/TOB/layer_2/HitResiduals_TOB__Layer__2_Y`
+* `SiStrip/MechanicalView/TOB/layer_3/HitResiduals_TOB__Layer__3`
+* `SiStrip/MechanicalView/TOB/layer_3/HitResiduals_TOB__Layer__3_Y`
+* `SiStrip/MechanicalView/TOB/layer_4/HitResiduals_TOB__Layer__4`
+* `SiStrip/MechanicalView/TOB/layer_4/HitResiduals_TOB__Layer__4_Y`
+* `SiStrip/MechanicalView/TOB/layer_5/HitResiduals_TOB__Layer__5`
+* `SiStrip/MechanicalView/TOB/layer_5/HitResiduals_TOB__Layer__5_Y`
+* `SiStrip/MechanicalView/TOB/layer_6/HitResiduals_TOB__Layer__6`
+* `SiStrip/MechanicalView/TOB/layer_6/HitResiduals_TOB__Layer__6_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_1/HitResiduals_TEC__wheel__1`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_1/HitResiduals_TEC__wheel__1_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_2/HitResiduals_TEC__wheel__2`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_2/HitResiduals_TEC__wheel__2_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_3/HitResiduals_TEC__wheel__3`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_3/HitResiduals_TEC__wheel__3_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_4/HitResiduals_TEC__wheel__4`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_4/HitResiduals_TEC__wheel__4_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_5/HitResiduals_TEC__wheel__5`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_5/HitResiduals_TEC__wheel__5_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_6/HitResiduals_TEC__wheel__6`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_6/HitResiduals_TEC__wheel__6_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_7/HitResiduals_TEC__wheel__7`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_7/HitResiduals_TEC__wheel__7_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_8/HitResiduals_TEC__wheel__8`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_8/HitResiduals_TEC__wheel__8_Y`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_9/HitResiduals_TEC__wheel__9`
+* `SiStrip/MechanicalView/TEC/PLUS/wheel_9/HitResiduals_TEC__wheel__9_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_1/HitResiduals_TEC__wheel__1`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_1/HitResiduals_TEC__wheel__1_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_2/HitResiduals_TEC__wheel__2`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_2/HitResiduals_TEC__wheel__2_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_3/HitResiduals_TEC__wheel__3`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_3/HitResiduals_TEC__wheel__3_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_4/HitResiduals_TEC__wheel__4`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_4/HitResiduals_TEC__wheel__4_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_5/HitResiduals_TEC__wheel__5`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_5/HitResiduals_TEC__wheel__5_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_6/HitResiduals_TEC__wheel__6`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_6/HitResiduals_TEC__wheel__6_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_7/HitResiduals_TEC__wheel__7`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_7/HitResiduals_TEC__wheel__7_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_8/HitResiduals_TEC__wheel__8`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_8/HitResiduals_TEC__wheel__8_Y`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_9/HitResiduals_TEC__wheel__9`
+* `SiStrip/MechanicalView/TEC/MINUS/wheel_9/HitResiduals_TEC__wheel__9_Y`

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -11,6 +11,8 @@ Monitoring source for track residuals on each detector module
 */
 // Original Author:  Israel Goitom
 //         Created:  Fri May 26 14:12:01 CEST 2006
+// Author:  Marcel Schneider
+//         Extended to Pixel Residuals. 
 #include <memory>
 #include <fstream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -46,11 +48,13 @@ class MonitorTrackResiduals : public DQMEDAnalyzer {
   DQMStore * dqmStore_;
   edm::ParameterSet conf_;
   edm::ParameterSet Parameters;
+
+  std::pair<std::string, int32_t> findSubdetAndLayer(uint32_t ModuleID, const TrackerTopology* tTopo);
   std::map< std::pair<std::string,int32_t>, MonitorElement* > m_SubdetLayerResiduals;
   std::map< std::pair<std::string,int32_t>, MonitorElement* > m_SubdetLayerNormedResiduals;
+  
   HistoClass HitResidual;
   HistoClass NormedHitResiduals;
-  SiStripFolderOrganizer folder_organizer;
   unsigned long long m_cacheID_;
   bool ModOn;
   GenericTriggerEventFlag* genTriggerEventFlag_;

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -28,8 +28,6 @@ class DQMStore;
 class GenericTriggerEventFlag;
 namespace edm { class Event; }
 
-typedef std::map<int32_t, MonitorElement *> HistoClass;
-
 class MonitorTrackResiduals : public DQMEDAnalyzer {
  public:
   // constructors and EDAnalyzer Methods
@@ -50,11 +48,21 @@ class MonitorTrackResiduals : public DQMEDAnalyzer {
   edm::ParameterSet Parameters;
 
   std::pair<std::string, int32_t> findSubdetAndLayer(uint32_t ModuleID, const TrackerTopology* tTopo);
-  std::map< std::pair<std::string,int32_t>, MonitorElement* > m_SubdetLayerResiduals;
-  std::map< std::pair<std::string,int32_t>, MonitorElement* > m_SubdetLayerNormedResiduals;
   
-  HistoClass HitResidual;
-  HistoClass NormedHitResiduals;
+  struct HistoPair {
+    HistoPair() {base = nullptr; normed = nullptr;};
+    MonitorElement* base;
+    MonitorElement* normed;
+  };
+  struct HistoXY {
+    HistoPair x;
+    HistoPair y;
+  };
+  typedef std::map<std::pair<std::string, int32_t>, HistoXY> HistoSet;
+
+  HistoSet m_SubdetLayerResiduals;
+  HistoSet m_ModuleResiduals;
+  
   unsigned long long m_cacheID_;
   bool ModOn;
   GenericTriggerEventFlag* genTriggerEventFlag_;

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -160,11 +160,6 @@ void MonitorTrackResiduals::createMEs( DQMStore::IBooker & ibooker , const edm::
       }
 
       auto subdetandlayer = findSubdetAndLayer(ModuleID, tTopo);
-      
-
-	  //folder_organizer.setDetectorFolder(ModuleID, tTopo); //  detid sets appropriate detector folder
-	  // book layer level histogramms
-	  //std::pair<std::string,int32_t> subdetandlayer = folder_organizer.GetSubDetAndLayer(ModuleID, tTopo);
 
       if(! m_SubdetLayerResiduals[subdetandlayer ] ) {
 	
@@ -183,18 +178,23 @@ void MonitorTrackResiduals::createMEs( DQMStore::IBooker & ibooker , const edm::
 	}
 	
 	// book histogramms on layer level, check for barrel for correct labeling
-	std::string histoname = Form(subdetandlayer.first.find("B") != std::string::npos ?
-				     "HitResiduals_%s__Layer__%d" : "HitResiduals_%s__wheel__%d" ,
-				     subdetandlayer.first.c_str(),std::abs(subdetandlayer.second));
-	std::string normhistoname =
-	  Form(subdetandlayer.first.find("B") != std::string::npos ?
-	       "NormalizedHitResidual_%s__Layer__%d" : "NormalizedHitResidual_%s__wheel__%d" ,
-	       subdetandlayer.first.c_str(),std::abs(subdetandlayer.second));
+	
+	auto isBarrel = subdetandlayer.first.find("B") != std::string::npos;
+	std::string histoname = Form("HitResiduals_%s%s__%s__%d",
+		subdetandlayer.first.c_str(),
+		isBarrel ? "" : (subdetandlayer.second > 0 ? "+" : "-"),
+		isBarrel ? "Layer" : "wheel",
+		std::abs(subdetandlayer.second));
+	
+	std::string normhistoname = Form("Normalized%s", histoname.c_str());
+
 	std::cout << "##### Booking: " << ibooker.pwd() << " title " << histoname << std::endl;
+	
 	m_SubdetLayerResiduals[subdetandlayer] =
 	  ibooker.book1D(histoname.c_str(),histoname.c_str(),
 			 i_residuals_Nbins,d_residual_xmin,d_residual_xmax);
 	m_SubdetLayerResiduals[subdetandlayer]->setAxisTitle("(x_{pred} - x_{rec})' [cm]");
+
 	m_SubdetLayerNormedResiduals[subdetandlayer] =
 	  ibooker.book1D(normhistoname.c_str(),normhistoname.c_str(),
 			 i_normres_Nbins,d_normres_xmin,d_normres_xmax);

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -74,26 +74,38 @@ void MonitorTrackResiduals::createMEs( DQMStore::IBooker & ibooker , const edm::
   folder_organizer.setSiStripFolder(); // top SiStrip folder
 
   // take from eventSetup the SiStripDetCabling object
-  edm::ESHandle<SiStripDetCabling> tkmechstruct;
-  iSetup.get<SiStripDetCablingRcd>().get(tkmechstruct);
+  //edm::ESHandle<SiStripDetCabling> tkmechstruct;
+  //iSetup.get<SiStripDetCablingRcd>().get(tkmechstruct);
 
   // get list of active detectors from SiStripDetCabling
   std::vector<uint32_t> activeDets;
-  activeDets.clear(); // just in case
-  tkmechstruct->addActiveDetectorsRawIds(activeDets);
+  //activeDets.clear(); // just in case
+  //tkmechstruct->addActiveDetectorsRawIds(activeDets);
 
   // use SiStripSubStructure for selecting certain regions
-  SiStripSubStructure substructure;
-  std::vector<uint32_t> DetIds = activeDets;
+  //SiStripSubStructure substructure;
+  //std::vector<uint32_t> DetIds = activeDets;
+
+  // new handling using tracker geom
+
+  edm::ESHandle<TrackerGeometry> TG;
+  iSetup.get<TrackerDigiGeometryRecord>().get(TG);
+  auto ids = TG->detIds(); // or detUnitIds?
+  for (DetId id : ids) {
+    activeDets.push_back(id.rawId());
+  }
 
   // book histo per each detector module
-  for (std::vector<uint32_t>::const_iterator DetItr=activeDets.begin(),
-	 DetItrEnd = activeDets.end(); DetItr!=DetItrEnd; ++DetItr)
+  //for (std::vector<uint32_t>::const_iterator DetItr=activeDets.begin(),
+	 //DetItrEnd = activeDets.end(); DetItr!=DetItrEnd; ++DetItr)
+  for(auto ModuleID : activeDets)
     {
-      uint ModuleID = (*DetItr);
+      //uint ModuleID = (*DetItr);
 
       // is this a StripModule?
+      std::cout << "ID " << std::hex << ModuleID << " ";
       if( SiStripDetId(ModuleID).subDetector() != 0 ) {
+        std::cout << " (OK) " ;
 
 	folder_organizer.setDetectorFolder(ModuleID, tTopo); //  detid sets appropriate detector folder
 	// Book module histogramms?
@@ -129,6 +141,10 @@ void MonitorTrackResiduals::createMEs( DQMStore::IBooker & ibooker , const edm::
 	  m_SubdetLayerNormedResiduals[subdetandlayer]->setAxisTitle("(x_{pred} - x_{rec})'/#sigma");
 	}
       } // end 'is strip module'
+      else {
+          std::cout << " (PX) ";
+      }
+      std::cout << std::endl;
     } // end loop over activeDets
 }
 

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -65,7 +65,7 @@ std::pair<std::string, int32_t> findSubdetAndLayer(uint32_t ModuleID, const Trac
 	  break;
         case 2:
 	  subdet = "FPIX";
-          layer = tTopo->pxfDisk(id);
+          layer = tTopo->pxfDisk(id) * ( tTopo->pxfSide(ModuleID)==1 ? -1 : +1);
 	  break;
 	// Strip TIB, TID, TOB, TEC
 	case 3:
@@ -190,6 +190,7 @@ void MonitorTrackResiduals::createMEs( DQMStore::IBooker & ibooker , const edm::
 	  Form(subdetandlayer.first.find("B") != std::string::npos ?
 	       "NormalizedHitResidual_%s__Layer__%d" : "NormalizedHitResidual_%s__wheel__%d" ,
 	       subdetandlayer.first.c_str(),std::abs(subdetandlayer.second));
+	std::cout << "##### Booking: " << ibooker.pwd() << " title " << histoname << std::endl;
 	m_SubdetLayerResiduals[subdetandlayer] =
 	  ibooker.book1D(histoname.c_str(),histoname.c_str(),
 			 i_residuals_Nbins,d_residual_xmin,d_residual_xmax);


### PR DESCRIPTION
The current pixel DQM does not collect residuals data for the pixel endcaps (though the plots are booked).

This change creates _new_ pixel residual plots based on the SiStrip residual code (TrackerMonitorTrack, which in turn is based on Alignment/OfflineValidation). The code was also extended to create plots for the Y direction, which are not very useful for the strips but now also generated. For the pixels, plots are generated for each layer and each disk, note that the disk plots appear in the first half cylinder folder even though they cover the full disk.

The old pixel residual code was left in place. 
