### PR TITLE
Implement 'scan once' mode in online DQM input sources

### DIFF
--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -18,6 +18,12 @@ options.register('runInputDir',
                  VarParsing.VarParsing.varType.string,
                  "Directory where the DQM files will appear.")
 
+options.register('scanOnce',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't repeat file scans: use what was found during the initial scan. EOR file is ignored and the state is set to 'past end of run'.")
+
 options.register('skipFirstLumis',
                  False, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -45,17 +51,25 @@ if not options.runkey.strip():
 runType.setRunType(options.runkey.strip())
 
 # Input source
+nextLumiTimeoutMillis = 90000
+endOfRunKills = True
+
+if options.scanOnce:
+    endOfRunKills = False
+    nextLumiTimeoutMillis = 0
+
 source = cms.Source("DQMStreamerReader",
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
     SelectEvents = cms.untracked.vstring('*'),
     streamLabel = cms.untracked.string('streamDQM'),
+    scanOnce = cms.untracked.bool(options.scanOnce),
     minEventsPerLumi = cms.untracked.int32(1),
     delayMillis = cms.untracked.uint32(500),
-    nextLumiTimeoutMillis = cms.untracked.int32(90000),
+    nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
     deleteDatFiles = cms.untracked.bool(False),
-    endOfRunKills  = cms.untracked.bool(True),
+    endOfRunKills  = cms.untracked.bool(endOfRunKills),
 )
 
 print "Source:", source

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -18,6 +18,12 @@ options.register('runInputDir',
                  VarParsing.VarParsing.varType.string,
                  "Directory where the DQM files will appear.")
 
+options.register('scanOnce',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't repeat file scans: use what was found during the initial scan. EOR file is ignored and the state is set to 'past end of run'.")
+
 options.register('skipFirstLumis',
                  False, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -45,16 +51,25 @@ if not options.runkey.strip():
 runType.setRunType(options.runkey.strip())
 
 # Input source
+nextLumiTimeoutMillis = 120000
+endOfRunKills = True
+
+if options.scanOnce:
+    endOfRunKills = False
+    nextLumiTimeoutMillis = 0
+
 source = cms.Source("DQMProtobufReader",
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
 
     streamLabel = cms.untracked.string('streamDQMHistograms'),
+    scanOnce = cms.untracked.bool(options.scanOnce),
 
     delayMillis = cms.untracked.uint32(500),
-    nextLumiTimeoutMillis = cms.untracked.int32(120000),
+    nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
     deleteDatFiles = cms.untracked.bool(False),
-    endOfRunKills  = cms.untracked.bool(True),
+    endOfRunKills  = cms.untracked.bool(endOfRunKills),
 )
 
+print "Source:", source

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.h
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.h
@@ -92,6 +92,7 @@ class DQMFileIterator {
   unsigned long delayMillis_;
   long nextLumiTimeoutMillis_;
   long forceFileCheckTimeoutMillis_;
+  bool flagScanOnce_;
 
   // file name position in the json file
   unsigned int datafnPosition_;

--- a/DQMServices/StreamerIO/python/DQMProtobufReader_cff.py
+++ b/DQMServices/StreamerIO/python/DQMProtobufReader_cff.py
@@ -27,6 +27,12 @@ options.register('streamLabel',
                  VarParsing.VarParsing.varType.string,
                  "Stream label used in json discovery.")
 
+options.register('scanOnce',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't repeat file scans: use what was found during the initial scan. EOR file is ignored and the state is set to 'past end of run'.")
+
 options.register('delayMillis',
                  500, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -64,6 +70,7 @@ DQMProtobufReader = cms.Source("DQMProtobufReader",
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
     streamLabel = cms.untracked.string(options.streamLabel),
+    scanOnce = cms.untracked.bool(options.scanOnce),
     datafnPosition = cms.untracked.uint32(options.datafnPosition),
 
     delayMillis = cms.untracked.uint32(options.delayMillis),

--- a/DQMServices/StreamerIO/python/DQMStreamerReader_cff.py
+++ b/DQMServices/StreamerIO/python/DQMStreamerReader_cff.py
@@ -27,6 +27,12 @@ options.register('streamLabel',
                  VarParsing.VarParsing.varType.string,
                  "Stream label used in json discovery.")
 
+options.register('scanOnce',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't repeat file scans: use what was found during the initial scan. EOR file is ignored and the state is set to 'past end of run'.")
+
 options.register('minEventsPerLumi',
                  1, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -63,6 +69,14 @@ options.register('endOfRunKills',
                  VarParsing.VarParsing.varType.bool,
                  "Kill the processing as soon as the end-of-run file appears, even if there are/will be unprocessed lumisections.")
 
+options.register('endOfRunKills',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Kill the processing as soon as the end-of-run file appears, even if there are/will be unprocessed lumisections.")
+
+
+
 options.parseArguments()
 
 # Input source
@@ -71,6 +85,7 @@ DQMStreamerReader = cms.Source("DQMStreamerReader",
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
     streamLabel = cms.untracked.string(options.streamLabel),
+    scanOnce = cms.untracked.bool(options.scanOnce),
     datafnPosition = cms.untracked.uint32(options.datafnPosition),
 
     minEventsPerLumi = cms.untracked.int32(options.minEventsPerLumi),


### PR DESCRIPTION
Completely ignores file "streaming" and uses only files found
at the initial scan. Useful for testing and development.
