### PR TITLE
Fix the hcaletValue function.

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -132,31 +132,6 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, cons
   return(etvalue);
 }
 
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& version, const int& compET) const {
-// This is now an obsolete method; we return the AVERAGE over all the allowed iphi channels if it's invoked
-// The user is encouraged to use hcaletValue(const int& ieta, const int& iphi, const int& compET) instead
-
-  double etvalue = 0.;
-  if (compET < 0 || compET >= (int) TPGMAX) {
-    edm::LogError("CaloTPGTranscoderULUT") << "Compressed value out of range: eta, cET = " << ieta << ", " << compET;
-  } else {
-	int nphi = 0;
-	for (int iphi=1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta, iphi, version)) {
-			nphi++;
-			int itower = getOutputLUTId(ieta,iphi, version);
-			etvalue += hcaluncomp_[itower][compET];
-		}
-	}
-	if (nphi > 0) {
-		etvalue /= nphi;
-	} else {
-		edm::LogError("CaloTPGTranscoderULUT") << "No decompression LUTs found for any iphi for ieta = " << ieta;
-	}
-  }
-  return(etvalue);
-}
-
 double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const {
   int compET = hc.compressedEt();	// to be within the range by the class
   int itower = getOutputLUTId(hid);

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -119,9 +119,9 @@ HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTow
   return HcalTriggerPrimitiveSample(outputLUT_[itower][sample],fineGrain,0,0);
 }
 
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, const int& compET) const {
+double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compET) const {
   double etvalue = 0.;
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = getOutputLUTId(ieta,iphi, version);
   if (itower < 0) {
     edm::LogError("CaloTPGTranscoderULUT") << "No decompression LUT found for ieta, iphi = " << ieta << ", " << iphi;
   } else if (compET < 0 || compET >= (int) TPGMAX) {
@@ -132,7 +132,7 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, cons
   return(etvalue);
 }
 
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) const {
+double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& version, const int& compET) const {
 // This is now an obsolete method; we return the AVERAGE over all the allowed iphi channels if it's invoked
 // The user is encouraged to use hcaletValue(const int& ieta, const int& iphi, const int& compET) instead
 
@@ -142,9 +142,9 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) co
   } else {
 	int nphi = 0;
 	for (int iphi=1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta,iphi)) {
+		if (HTvalid(ieta, iphi, version)) {
 			nphi++;
-			int itower = getOutputLUTId(ieta,iphi);
+			int itower = getOutputLUTId(ieta,iphi, version);
 			etvalue += hcaluncomp_[itower][compET];
 		}
 	}
@@ -179,8 +179,9 @@ void CaloTPGTranscoderULUT::rctJetUncompress(const HcalTrigTowerDetId& hid, cons
   throw cms::Exception("Not Implemented") << "CaloTPGTranscoderULUT::rctJetUncompress";
 }
 
-bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
+bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin, const int version) const {
 	HcalTrigTowerDetId id(ieta, iphiin);
+	id.setVersion(version);
 	if (!theTopology) {
 		throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
 	}
@@ -194,11 +195,12 @@ int CaloTPGTranscoderULUT::getOutputLUTId(const HcalTrigTowerDetId& id) const {
     return theTopology->detId2denseIdHT(id);
 }
 
-int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
+int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin, const int version) const {
 	if (!theTopology) {
 		throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
 	}
 	HcalTrigTowerDetId id(ieta, iphiin);
+	id.setVersion(version);
 	return theTopology->detId2denseIdHT(id);
 }
 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -29,14 +29,14 @@ public:
   virtual void rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
 				   unsigned int& et) const;
-  virtual double hcaletValue(const int& ieta, const int& compressedValue) const;
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const;
+  virtual double hcaletValue(const int& ieta, const int& version, const int& compressedValue) const;
+  virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
-  virtual bool HTvalid(const int ieta, const int iphi) const;
+  virtual bool HTvalid(const int ieta, const int iphi, const int version) const;
   virtual const std::vector<unsigned int>& getCompressionLUT(const HcalTrigTowerDetId& id) const;
   virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&);
   virtual int getOutputLUTId(const HcalTrigTowerDetId& id) const;
-  virtual int getOutputLUTId(const int ieta, const int iphi) const;
+  virtual int getOutputLUTId(const int ieta, const int iphi, const int version) const;
 
  private:
   // Typedef

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -29,7 +29,6 @@ public:
   virtual void rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
 				   unsigned int& et) const;
-  virtual double hcaletValue(const int& ieta, const int& version, const int& compressedValue) const;
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
   virtual bool HTvalid(const int ieta, const int iphi, const int version) const;

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -40,7 +40,6 @@ public:
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
 				   unsigned int& et) const = 0;
 
-  virtual double hcaletValue(const int& ieta, const int& version, const int& compET) const = 0;  
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const = 0;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const = 0; 
   boost::shared_ptr<const HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -40,8 +40,8 @@ public:
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
 				   unsigned int& et) const = 0;
 
-  virtual double hcaletValue(const int& ieta, const int& compET) const = 0;  
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const = 0;
+  virtual double hcaletValue(const int& ieta, const int& version, const int& compET) const = 0;  
+  virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const = 0;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const = 0; 
   boost::shared_ptr<const HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
   boost::shared_ptr<const EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -565,7 +565,7 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 	   _set.eta_max[i] >= row->ieta &&
 	   _set.phi_min[i] <= row->iphi &&
 	   _set.phi_max[i] >= row->iphi &&
-	   _coder.HTvalid(row->ieta, row->iphi) ){
+	   _coder.HTvalid(row->ieta, row->iphi, row->idepth / 10) ){
 	lut_index=i;
       }
     }
@@ -878,7 +878,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 
     // only trigger tower channels
     // and valid (ieta,iphi)
-    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi) ){
+    const int tp_version = row->idepth / 10;
+    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi, tp_version) ){
       if ( _xml.count(row->crate) == 0 && split_by_crate ){
 	_xml.insert( std::pair<int,boost::shared_ptr<LutXml> >(row->crate,boost::shared_ptr<LutXml>(new LutXml())) );
       }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -192,6 +192,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
     std::vector< std::string > channelStrings;
     channelStrings.push_back("IPHI");
     channelStrings.push_back("IETA");
+    channelStrings.push_back("DEPTH");
     channelStrings.push_back("LUT_GRANULARITY");
     channelStrings.push_back("OUTPUT_LUT_THRESHOLD");
     channelStrings.push_back("OBJECTNAME");
@@ -209,6 +210,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
     coral::AttributeList myresult; 
     myresult.extend("IPHI", typeid(int)); 
     myresult.extend("IETA", typeid(int)); 
+    myresult.extend("DEPTH", typeid(int)); 
     myresult.extend("LUT_GRANULARITY", typeid(int)); 
     myresult.extend("OUTPUT_LUT_THRESHOLD", typeid(int)); 
     myresult.extend( ob,typeid(std::string));//, typeid(std::string)); 
@@ -247,28 +249,29 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
        chanResults.fillVariableFromRow("OBJECTNAME",i, objectName);
        //       int
        if(objectName == "HcalTrigTowerDetId") { //trig tower
-	 int ieta, iphi, lutGranularity, threshold;
+	 int ieta, iphi, depth, lutGranularity, threshold;
 	 
 	 
 	 chanResults.fillVariableFromRow("LUT_GRANULARITY",i,lutGranularity);
 	 chanResults.fillVariableFromRow("IPHI",i,iphi);
 	 chanResults.fillVariableFromRow("IETA",i,ieta);
+	 chanResults.fillVariableFromRow("DEPTH",i,depth);
 	 chanResults.fillVariableFromRow("OUTPUT_LUT_THRESHOLD",i,threshold);
 	 
 
 	 unsigned int outputLut[1024];
 
-	 uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi);
+	 const int tp_version = depth / 10;
+	 uint32_t lutId = caloTPG->getOutputLUTId(ieta, iphi, tp_version);
 
 	 double eta_low = 0., eta_high = 0.;
-	 const int version_of_hcal_TPs = 0;
-	 theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs, eta_low,eta_high); 
+	 theTrigTowerGeometry->towerEtaBounds(ieta, tp_version, eta_low, eta_high); 
 	 double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 
-	 if (!caloTPG->HTvalid(ieta, iphi)) continue;
+	 if (!caloTPG->HTvalid(ieta, iphi, tp_version)) continue;
 	 double factor = 0.;
-	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
+	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(tp_version))
 	   factor = rctlsb;
 	 else 
 	   factor = nominal_gain / cosh_ieta * lutGranularity;
@@ -276,7 +279,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   outputLut[k] = 0;
 	 
          for (unsigned int k = threshold; k < 1024; ++k)
-	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs)) ? analyticalLUT[k] : identityLUT[k];
+	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(tp_version)) ? analyticalLUT[k] : identityLUT[k];
 	 
 
 	   // tpg - compressed value
@@ -298,6 +301,8 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
      
 
 
+     // XXX L1CaloHcalScale is only setup for 2x3 TP
+     const int tp_version = 0;
      for( unsigned short ieta = 1 ; ieta <= L1CaloHcalScale::nBinEta; ++ieta ){
        for(int pos = 0; pos <=1; pos++){
 	 for( unsigned short irank = 0 ; irank < L1CaloHcalScale::nBinRank; ++irank ){
@@ -310,9 +315,9 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   
 
 	   for(int iphi = 1; iphi<=72; iphi++){
-	     if(!caloTPG->HTvalid(ieta, iphi))
+	     if(!caloTPG->HTvalid(ieta, iphi, tp_version))
 	       continue;
-	     uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi);
+	     uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi, tp_version);
 	     nphi++;
 	     etvalue += (double) hcaluncomp[lutId][irank];
 

--- a/Validation/HcalDigis/BuildFile.xml
+++ b/Validation/HcalDigis/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="boost"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
+<use   name="Geometry/HcalTowerAlgo"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="CalibFormats/HcalObjects"/>
 <use   name="DQMServices/Core"/>

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -536,7 +536,7 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
      HcalSubdetector subdet = (HcalSubdetector) 0;
      if      ( abs(ieta) <= 16 )
         subdet = HcalSubdetector::HcalBarrel ;
-     else if ( abs(ieta) <= tp_geometry->firstHFTower(itr->id().version()) ) 
+     else if ( abs(ieta) < tp_geometry->firstHFTower(itr->id().version()) ) 
         subdet = HcalSubdetector::HcalEndcap ;
      else if ( abs(ieta) <= 42 )
         subdet = HcalSubdetector::HcalForward;

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -16,6 +16,7 @@
 //
 //
 
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include <Validation/HcalDigis/interface/HcalDigisValidation.h>
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -468,6 +469,9 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     ESHandle<CaloTPGTranscoder> decoder;
     iSetup.get<CaloTPGRecord>().get(decoder);
 
+    ESHandle<HcalTrigTowerGeometry> tp_geometry;
+    iSetup.get<CaloGeometryRecord>().get(tp_geometry);
+
     iSetup.get<HcalRecNumberingRecord>().get(htopo);
 
     //Get all handles
@@ -528,17 +532,18 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
    for (HcalTrigPrimDigiCollection::const_iterator itr = dataTPs->begin(); itr != dataTPs->end(); ++itr) {
      int ieta  = itr->id().ieta();
-     int iphi  = itr->id().iphi();
 
      HcalSubdetector subdet = (HcalSubdetector) 0;
-     if      ( abs(ieta) <= 16 ) subdet = HcalSubdetector::HcalBarrel ;
-     else if ( abs(ieta) <= 28 ) subdet = HcalSubdetector::HcalEndcap ;
-     else if ( abs(ieta) <= 40 ) subdet = HcalSubdetector::HcalForward;
+     if      ( abs(ieta) <= 16 )
+        subdet = HcalSubdetector::HcalBarrel ;
+     else if ( abs(ieta) <= tp_geometry->firstHFTower(itr->id().version()) ) 
+        subdet = HcalSubdetector::HcalEndcap ;
+     else if ( abs(ieta) <= 42 )
+        subdet = HcalSubdetector::HcalForward;
      
      /*     HcalSubdetector subdet = (HcalSubdetector) itr->id().subdet(); */
 
-     float cen = itr->SOI_compressedEt();
-     float en = decoder->hcaletValue(ieta,iphi,cen);
+     float en = decoder->hcaletValue(itr->id(), itr->t0());
      
      if (en < 0.00001) continue;
 


### PR DESCRIPTION
As the current implementation does not work for fine granularity HF
TP, it needs the additional version parameter to give proper values
for version ==1 and allow to query |ieta| > 32.

As an alternative, the `hcaletValue` functions that take `ieta` parameters should be removed/deprecated.
