### PR TITLE
Enable Condor Statistics Service.

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -332,9 +332,7 @@ int main(int argc, char* argv[]) {
       defaultServices.push_back("AdaptorConfig");
       defaultServices.push_back("SiteLocalConfigService");
       defaultServices.push_back("StatisticsSenderService");
-      // This default is disabled pending widespread testing.  See conversation
-      // in PR #10056
-      //defaultServices.push_back("CondorStatusService");
+      defaultServices.push_back("CondorStatusService");
 
       // Default parameters will be used for the default services
       // if they are not overridden from the configuration files.


### PR DESCRIPTION
This has been testing for awhile in the T0 with no issues - try
to get this available for the DR80 campaign.

@davidlange6 - this is the service we were discussing yesterday.
