### PR TITLE
Ep combination protection

### DIFF
--- a/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
+++ b/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
@@ -99,6 +99,7 @@ void EpCombinationTool::combine(SimpleElectron & mySimpleElectron)
     float weight = 0.;
     if(eOverP>0.025 
        &&fabs(momentum-energy)<15.*sqrt(momentumError*momentumError + energyError*energyError)
+       &&momentumError < 10.*momentum
            ) // protection against crazy track measurement
    {
         weight = m_forest->GetResponse(regressionInputs);

--- a/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
+++ b/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
@@ -99,7 +99,7 @@ void EpCombinationTool::combine(SimpleElectron & mySimpleElectron)
     float weight = 0.;
     if(eOverP>0.025 
        &&fabs(momentum-energy)<15.*sqrt(momentumError*momentumError + energyError*energyError)
-       &&momentumError < 10.*momentum
+       &&((momentumError < 10.*momentum) || (energy < 200.))
            ) // protection against crazy track measurement
    {
         weight = m_forest->GetResponse(regressionInputs);


### PR DESCRIPTION
The W' group reported that the electron Ep combination was returning unphysical values at high energies when the track pT was consistent with 0. We added a protection in the combination code to only use the Ep combination MVA at high energies when the track pT error is smaller than 10 times the track pT. It is a pretty safe cut that removes these badly measured tracks from the determination of the electron energy.

Reference: https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3446/1/1/1/1.html
