### PR TITLE
increase eventAutoFlushCompressedSize for FEVTDEBUGHLT

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -303,7 +303,7 @@ FEVTDEBUGEventContent = cms.PSet(
 FEVTDEBUGHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(1*1024*1024)
+    eventAutoFlushCompressedSize=cms.untracked.int32(10*1024*1024)
 )
 
 #


### PR DESCRIPTION
The current small size leads to events that blow up RSS memory taken by the output model. This new setting works best for the test case I used (and is in line with other data tiers) 
