### PR TITLE
Updates to the new HLT L1T Seeds Module for 2016 (pass2)

### DIFF
--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -53,17 +53,22 @@ namespace trigger
       size_type pfjets_;
       size_type pftaus_;
       size_type pfmets_;
+      size_type l1tmuon_;
+      size_type l1tegamma_;
+      size_type l1tjet_;
+      size_type l1ttau_;
+      size_type l1tetsum_;
 
       /// constructor
       TriggerFilterObject() :
 	filterTag_(),
-        photons_(0), electrons_(0), muons_(0), jets_(0), composites_(0), basemets_(0), calomets_(0), pixtracks_(0), l1em_(0), l1muon_(0), l1jet_(0), l1etmiss_(0), l1hfrings_(0), pfjets_(0), pftaus_(0), pfmets_(0) {
+        photons_(0), electrons_(0), muons_(0), jets_(0), composites_(0), basemets_(0), calomets_(0), pixtracks_(0), l1em_(0), l1muon_(0), l1jet_(0), l1etmiss_(0), l1hfrings_(0), pfjets_(0), pftaus_(0), pfmets_(0), l1tmuon_(0), l1tegamma_(0), l1tjet_(0), l1ttau_(0), l1tetsum_(0)  {
       filterTag_=edm::InputTag().encode();
       }
       TriggerFilterObject(const edm::InputTag& filterTag,
-			  size_type np, size_type ne, size_type nm, size_type nj, size_type nc, size_type nB, size_type nC, size_type nt, size_type l1em, size_type l1muon, size_type l1jet, size_type l1etmiss, size_type l1hfrings, size_type pfjets, size_type pftaus, size_type pfmets) :
+			  size_type np, size_type ne, size_type nm, size_type nj, size_type nc, size_type nB, size_type nC, size_type nt, size_type l1em, size_type l1muon, size_type l1jet, size_type l1etmiss, size_type l1hfrings, size_type pfjets, size_type pftaus, size_type pfmets, size_type l1tmuon, size_type l1tegamma, size_type l1tjet, size_type l1ttau, size_type l1tetsum) :
 	filterTag_(filterTag.encode()),
-	  photons_(np), electrons_(ne), muons_(nm), jets_(nj), composites_(nc), basemets_(nB), calomets_(nC), pixtracks_(nt), l1em_(l1em), l1muon_(l1muon), l1jet_(l1jet), l1etmiss_(l1etmiss), l1hfrings_(l1hfrings), pfjets_(pfjets), pftaus_(pftaus), pfmets_(pfmets) { }
+	  photons_(np), electrons_(ne), muons_(nm), jets_(nj), composites_(nc), basemets_(nB), calomets_(nC), pixtracks_(nt), l1em_(l1em), l1muon_(l1muon), l1jet_(l1jet), l1etmiss_(l1etmiss), l1hfrings_(l1hfrings), pfjets_(pfjets), pftaus_(pftaus), pfmets_(pfmets), l1tmuon_(l1tmuon), l1tegamma_(l1tegamma), l1tjet_(l1tjet), l1ttau_(l1ttau), l1tetsum_(l1tetsum)  { }
     };
 
   /// data members
@@ -87,7 +92,9 @@ namespace trigger
 
     /// setters - to build EDProduct
     void addFilterObject(const edm::InputTag& filterTag, const TriggerFilterObjectWithRefs& tfowr) {
+       
       filterObjects_.push_back(
+
         TriggerFilterObject(filterTag, 
 			    addObjects(tfowr.photonIds(),tfowr.photonRefs()),
 			    addObjects(tfowr.electronIds(),tfowr.electronRefs()),
@@ -104,9 +111,16 @@ namespace trigger
 			    addObjects(tfowr.l1hfringsIds(),tfowr.l1hfringsRefs()),
 			    addObjects(tfowr.pfjetIds(),tfowr.pfjetRefs()),
 			    addObjects(tfowr.pftauIds(),tfowr.pftauRefs()),
-			    addObjects(tfowr.pfmetIds(),tfowr.pfmetRefs())
+			    addObjects(tfowr.pfmetIds(),tfowr.pfmetRefs()),
+			    addObjects(tfowr.l1tmuonIds(),tfowr.l1tmuonRefs()),
+			    addObjects(tfowr.l1tegammaIds(),tfowr.l1tegammaRefs()),
+			    addObjects(tfowr.l1tjetIds(),tfowr.l1tjetRefs()),
+			    addObjects(tfowr.l1ttauIds(),tfowr.l1ttauRefs()),
+			    addObjects(tfowr.l1tetsumIds(),tfowr.l1tetsumRefs())
 			   )
-	);
+
+	    );
+
     }
 
     /// getters - for user access
@@ -225,6 +239,36 @@ namespace trigger
     std::pair<size_type,size_type> pfmetSlice(size_type filter) const {
       const size_type begin(filter==0? 0 : filterObjects_.at(filter-1).pfmets_);
       const size_type end(filterObjects_.at(filter).pfmets_);
+      return std::pair<size_type,size_type>(begin,end);
+    }
+
+    std::pair<size_type,size_type> l1tmuonSlice(size_type filter) const {
+      const size_type begin(filter==0? 0 : filterObjects_.at(filter-1).l1tmuon_);
+      const size_type end(filterObjects_.at(filter).l1tmuon_);
+      return std::pair<size_type,size_type>(begin,end);
+    }
+
+    std::pair<size_type,size_type> l1tegammaSlice(size_type filter) const {
+      const size_type begin(filter==0? 0 : filterObjects_.at(filter-1).l1tegamma_);
+      const size_type end(filterObjects_.at(filter).l1tegamma_);
+      return std::pair<size_type,size_type>(begin,end);
+    }
+
+    std::pair<size_type,size_type> l1tjetSlice(size_type filter) const {
+      const size_type begin(filter==0? 0 : filterObjects_.at(filter-1).l1tjet_);
+      const size_type end(filterObjects_.at(filter).l1tjet_);
+      return std::pair<size_type,size_type>(begin,end);
+    }
+
+    std::pair<size_type,size_type> l1ttauSlice(size_type filter) const {
+      const size_type begin(filter==0? 0 : filterObjects_.at(filter-1).l1ttau_);
+      const size_type end(filterObjects_.at(filter).l1ttau_);
+      return std::pair<size_type,size_type>(begin,end);
+    }
+
+    std::pair<size_type,size_type> l1tetsumSlice(size_type filter) const {
+      const size_type begin(filter==0? 0 : filterObjects_.at(filter-1).l1tetsum_);
+      const size_type end(filterObjects_.at(filter).l1tetsum_);
       return std::pair<size_type,size_type>(begin,end);
     }
 
@@ -405,6 +449,61 @@ namespace trigger
       const size_type begin(pfmetSlice(filter).first);
       const size_type   end(pfmetSlice(filter).second);
       TriggerRefsCollections::getObjects(id,pfmets,begin,end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tmuon& l1tmuon) const {
+      const size_type begin(l1tmuonSlice(filter).first);
+      const size_type   end(l1tmuonSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids,l1tmuon,begin,end);
+    }
+    void getObjects(size_type filter, int id, VRl1tmuon& l1tmuon) const {
+      const size_type begin(l1tmuonSlice(filter).first);
+      const size_type   end(l1tmuonSlice(filter).second);
+      TriggerRefsCollections::getObjects(id,l1tmuon,begin,end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tegamma& l1tegamma) const {
+      const size_type begin(l1tegammaSlice(filter).first);
+      const size_type   end(l1tegammaSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids,l1tegamma,begin,end);
+    }
+    void getObjects(size_type filter, int id, VRl1tegamma& l1tegamma) const {
+      const size_type begin(l1tegammaSlice(filter).first);
+      const size_type   end(l1tegammaSlice(filter).second);
+      TriggerRefsCollections::getObjects(id,l1tegamma,begin,end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tjet& l1tjet) const {
+      const size_type begin(l1tjetSlice(filter).first);
+      const size_type   end(l1tjetSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids,l1tjet,begin,end);
+    }
+    void getObjects(size_type filter, int id, VRl1tjet& l1tjet) const {
+      const size_type begin(l1tjetSlice(filter).first);
+      const size_type   end(l1tjetSlice(filter).second);
+      TriggerRefsCollections::getObjects(id,l1tjet,begin,end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1ttau& l1ttau) const {
+      const size_type begin(l1ttauSlice(filter).first);
+      const size_type   end(l1ttauSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids,l1ttau,begin,end);
+    }
+    void getObjects(size_type filter, int id, VRl1ttau& l1ttau) const {
+      const size_type begin(l1ttauSlice(filter).first);
+      const size_type   end(l1ttauSlice(filter).second);
+      TriggerRefsCollections::getObjects(id,l1ttau,begin,end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tetsum& l1tetsum) const {
+      const size_type begin(l1tetsumSlice(filter).first);
+      const size_type   end(l1tetsumSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids,l1tetsum,begin,end);
+    }
+    void getObjects(size_type filter, int id, VRl1tetsum& l1tetsum) const {
+      const size_type begin(l1tetsumSlice(filter).first);
+      const size_type   end(l1tetsumSlice(filter).second);
+      TriggerRefsCollections::getObjects(id,l1tetsum,begin,end);
     }
 
   };

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -47,6 +47,9 @@
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
 #include <cassert>
 #include <vector>
 
@@ -191,11 +194,16 @@ namespace trigger
       std::swap(l1hfringsIds_,  other.l1hfringsIds_);
       std::swap(l1hfringsRefs_, other.l1hfringsRefs_);
 
-      std::swap(l1tmuonIds_,     other.l1tmuonIds_);
-      std::swap(l1tegammaIds_,   other.l1tegammaIds_);
-      std::swap(l1tjetIds_,      other.l1tjetIds_);
-      std::swap(l1ttauIds_,      other.l1ttauIds_);
-      std::swap(l1tetsumIds_,      other.l1tetsumIds_);
+      std::swap(l1tmuonIds_,    other.l1tmuonIds_);
+      std::swap(l1tmuonRefs_,   other.l1tmuonRefs_);
+      std::swap(l1tegammaIds_,  other.l1tegammaIds_);
+      std::swap(l1tegammaRefs_, other.l1tegammaRefs_);
+      std::swap(l1tjetIds_,     other.l1tjetIds_);
+      std::swap(l1tjetRefs_,    other.l1tjetRefs_);
+      std::swap(l1ttauIds_,     other.l1ttauIds_);
+      std::swap(l1ttauRefs_,    other.l1ttauRefs_);
+      std::swap(l1tetsumIds_,   other.l1tetsumIds_);
+      std::swap(l1tetsumRefs_,  other.l1tetsumRefs_);
 
       std::swap(pfjetIds_,      other.pfjetIds_);
       std::swap(pfjetRefs_,     other.pfjetRefs_);
@@ -838,6 +846,23 @@ namespace trigger
       }
       return;
     }
+
+    void getObjects(Vids& ids, VRl1tmuon& refs) const {
+      getObjects(ids,refs,0,l1tmuonIds_.size());
+    }
+    void getObjects(Vids& ids, VRl1tmuon& refs, size_type begin, size_type end) const {
+      assert (begin<=end);
+      assert (end<=l1tmuonIds_.size());
+      const size_type n(end-begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i=begin; i!=end; ++i) {
+	ids[j]=l1tmuonIds_[i];
+	refs[j]=l1tmuonRefs_[i];
+	++j;
+      }
+    }
     void getObjects(int id, VRl1tmuon& refs) const {
       getObjects(id,refs,0,l1tmuonIds_.size());
     } 
@@ -852,6 +877,23 @@ namespace trigger
 	if (id==l1tmuonIds_[i]) {refs[j]=l1tmuonRefs_[i]; ++j;}
       }
       return;
+    }
+
+    void getObjects(Vids& ids, VRl1tegamma& refs) const {
+      getObjects(ids,refs,0,l1tegammaIds_.size());
+    }
+    void getObjects(Vids& ids, VRl1tegamma& refs, size_type begin, size_type end) const {
+      assert (begin<=end);
+      assert (end<=l1tegammaIds_.size());
+      const size_type n(end-begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i=begin; i!=end; ++i) {
+	ids[j]=l1tegammaIds_[i];
+	refs[j]=l1tegammaRefs_[i];
+	++j;
+      }
     }
     void getObjects(int id, VRl1tegamma& refs) const {
       getObjects(id,refs,0,l1tegammaIds_.size());
@@ -868,6 +910,23 @@ namespace trigger
       }
       return;
     }
+
+    void getObjects(Vids& ids, VRl1tjet& refs) const {
+      getObjects(ids,refs,0,l1tjetIds_.size());
+    }
+    void getObjects(Vids& ids, VRl1tjet& refs, size_type begin, size_type end) const {
+      assert (begin<=end);
+      assert (end<=l1tjetIds_.size());
+      const size_type n(end-begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i=begin; i!=end; ++i) {
+	ids[j]=l1tjetIds_[i];
+	refs[j]=l1tjetRefs_[i];
+	++j;
+      }
+    }
     void getObjects(int id, VRl1tjet& refs) const {
       getObjects(id,refs,0,l1tjetIds_.size());
     } 
@@ -882,6 +941,23 @@ namespace trigger
 	if (id==l1tjetIds_[i]) {refs[j]=l1tjetRefs_[i]; ++j;}
       }
       return;
+    }
+
+    void getObjects(Vids& ids, VRl1ttau& refs) const {
+      getObjects(ids,refs,0,l1ttauIds_.size());
+    }
+    void getObjects(Vids& ids, VRl1ttau& refs, size_type begin, size_type end) const {
+      assert (begin<=end);
+      assert (end<=l1ttauIds_.size());
+      const size_type n(end-begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i=begin; i!=end; ++i) {
+	ids[j]=l1ttauIds_[i];
+	refs[j]=l1ttauRefs_[i];
+	++j;
+      }
     }
     void getObjects(int id, VRl1ttau& refs) const {
       getObjects(id,refs,0,l1ttauIds_.size());
@@ -898,6 +974,23 @@ namespace trigger
       }
       return;
     }
+
+    void getObjects(Vids& ids, VRl1tetsum& refs) const {
+      getObjects(ids,refs,0,l1tetsumIds_.size());
+    }
+    void getObjects(Vids& ids, VRl1tetsum& refs, size_type begin, size_type end) const {
+      assert (begin<=end);
+      assert (end<=l1tetsumIds_.size());
+      const size_type n(end-begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i=begin; i!=end; ++i) {
+	ids[j]=l1tetsumIds_[i];
+	refs[j]=l1tetsumRefs_[i];
+	++j;
+      }
+    }
     void getObjects(int id, VRl1tetsum& refs) const {
       getObjects(id,refs,0,l1tetsumIds_.size());
     } 
@@ -913,6 +1006,7 @@ namespace trigger
       }
       return;
     }
+
     void getObjects(Vids& ids, VRpfjet& refs) const {
       getObjects(ids,refs,0,pfjetIds_.size());
     }
@@ -1088,7 +1182,7 @@ namespace trigger
 
     size_type          l1ttauSize()     const {return l1ttauIds_.size();}
     const Vids&        l1ttauIds()      const {return l1ttauIds_;}
-    const VRl1ttau&     l1ttauRefs()     const {return l1ttauRefs_;}
+    const VRl1ttau&    l1ttauRefs()     const {return l1ttauRefs_;}
 
     size_type          l1tetsumSize()  const {return l1tetsumIds_.size();}
     const Vids&        l1tetsumIds()   const {return l1tetsumIds_;}

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -62,7 +62,8 @@
    <version ClassVersion="11" checksum="3351458717"/>
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
-  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="13">
+  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="14">
+   <version ClassVersion="14" checksum="1673531968"/>
    <version ClassVersion="13" checksum="1672519577"/>
    <version ClassVersion="12" checksum="2301242282"/>
   </class>

--- a/DataFormats/L1Trigger/interface/BXVector.h
+++ b/DataFormats/L1Trigger/interface/BXVector.h
@@ -66,6 +66,9 @@ class BXVector  {
   // get N objects for a given BX
   unsigned size( int bx ) const;
 
+  // get N objects for all BXs together
+  unsigned size( ) const { return data_.size();}
+
   // add element with given BX index
   void push_back( int bx, T object );
  
@@ -95,6 +98,10 @@ class BXVector  {
   const_iterator end() const {return data_.end(); }
   //int bx(const_iterator & iter) const; (potentially useful)
   unsigned int key(const_iterator & iter) const { return iter - begin(); }
+
+  // array subscript operator (incited by TriggerSummaryProducerAOD::fillTriggerObject...)
+  T& operator[](std::size_t i) { return data_[i]; }
+  const T& operator[](std::size_t i) const { return data_[i]; }
 
 
  private:

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -52,9 +52,63 @@ namespace DataFormats_L1Trigger {
     edm::Wrapper<l1t::CaloSpareBxCollection> w_caloSpareColl;
     edm::Wrapper<l1t::L1DataEmulResultBxCollection>   w_deResult;
 
+    l1t::L1CandidateRef   refL1Candidate_;
+    l1t::L1CandidateRefVector   refVecL1Candidate_;
+    l1t::L1CandidateVectorRef   vecRefL1Candidate_;
+    edm::Wrapper<l1t::L1CandidateRef>   w_refL1Candidate_;
+    edm::Wrapper<l1t::L1CandidateRefVector>   w_refVecL1Candidate_;
+    edm::Wrapper<l1t::L1CandidateVectorRef>   w_vecRefL1Candidate_;
+
+    l1t::EGammaRef   refEGamma_;
+    l1t::EGammaRefVector   refVecEGamma_;
+    l1t::EGammaVectorRef   vecRefEGamma_;
+    edm::Wrapper<l1t::EGammaRef>   w_refEGamma_;
+    edm::Wrapper<l1t::EGammaRefVector>   w_refVecEGamma_;
+    edm::Wrapper<l1t::EGammaVectorRef>   w_vecRefEGamma_;
+
+    l1t::EtSumRef   refEtSum_;
+    l1t::EtSumRefVector   refVecEtSum_;
+    l1t::EtSumVectorRef   vecRefEtSum_;
+    edm::Wrapper<l1t::EtSumRef>   w_refEtSum_;
+    edm::Wrapper<l1t::EtSumRefVector>   w_refVecEtSum_;
+    edm::Wrapper<l1t::EtSumVectorRef>   w_vecRefEtSum_;
+
+    l1t::JetRef   refJet_;
+    l1t::JetRefVector   refVecJet_;
+    l1t::JetVectorRef   vecRefJet_;
+    edm::Wrapper<l1t::JetRef>   w_refJet_;
+    edm::Wrapper<l1t::JetRefVector>   w_refVecJet_;
+    edm::Wrapper<l1t::JetVectorRef>   w_vecRefJet_;
+
     l1t::MuonRef   refMuon_;
     l1t::MuonRefVector   refVecMuon_;
     l1t::MuonVectorRef   vecRefMuon_;
+    edm::Wrapper<l1t::MuonRef>   w_refMuon_;
+    edm::Wrapper<l1t::MuonRefVector>   w_refVecMuon_;
+    edm::Wrapper<l1t::MuonVectorRef>   w_vecRefMuon_;
+
+    l1t::TauRef   refTau_;
+    l1t::TauRefVector   refVecTau_;
+    l1t::TauVectorRef   vecRefTau_;
+    edm::Wrapper<l1t::TauRef>   w_refTau_;
+    edm::Wrapper<l1t::TauRefVector>   w_refVecTau_;
+    edm::Wrapper<l1t::TauVectorRef>   w_vecRefTau_;
+
+    //l1t::CaloSpareRef   refCaloSpare_;
+    //l1t::CaloSpareRefVector   refVecCaloSpare_;
+    //l1t::CaloSpareVectorRef   vecRefCaloSpare_;
+    //edm::Wrapper<l1t::CaloSpareRef>   w_refCaloSpare_;
+    //edm::Wrapper<l1t::CaloSpareRefVector>   w_refVecCaloSpare_;
+    //edm::Wrapper<l1t::CaloSpareVectorRef>   w_vecRefCaloSpare_;
+
+    //l1t::L1DataEmulResultRef   refL1DataEmulResult_;
+    //l1t::L1DataEmulResultRefVector   refVecL1DataEmulResult_;
+    //l1t::L1DataEmulResultVectorRef   vecRefL1DataEmulResult_;
+    //edm::Wrapper<l1t::L1DataEmulResultRef>   w_refL1DataEmulResult_;
+    //edm::Wrapper<l1t::L1DataEmulResultRefVector>   w_refVecL1DataEmulResult_;
+    //edm::Wrapper<l1t::L1DataEmulResultVectorRef>   w_vecRefL1DataEmulResult_;
+
+
 
     l1extra::L1EmParticleCollection emColl ;
     l1extra::L1JetParticleCollection jetColl ;

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -6,6 +6,12 @@
   </class>
   <class name="l1t::L1CandidateBxCollection"/>
   <class name="edm::Wrapper<l1t::L1CandidateBxCollection>"/>
+  <class name="l1t::L1CandidateRef"/>
+  <class name="edm::Wrapper<l1t::L1CandidateRef>"/>
+  <class name="l1t::L1CandidateRefVector"/>
+  <class name="edm::Wrapper<l1t::L1CandidateRefVector>"/>
+  <class name="l1t::L1CandidateVectorRef"/>
+  <class name="edm::Wrapper<l1t::L1CandidateVectorRef>"/>
 
   <class name="l1t::Jet" ClassVersion="12">
    <version ClassVersion="12" checksum="380555501"/>
@@ -14,6 +20,13 @@
   </class>
   <class name="l1t::JetBxCollection"/>
   <class name="edm::Wrapper<l1t::JetBxCollection>"/>
+  <class name="l1t::JetRef"/>
+  <class name="edm::Wrapper<l1t::JetRef>"/>
+  <class name="l1t::JetRefVector"/>
+  <class name="edm::Wrapper<l1t::JetRefVector>"/>
+  <class name="l1t::JetVectorRef"/>
+  <class name="edm::Wrapper<l1t::JetVectorRef>"/>
+
 
   <class name="l1t::EGamma" ClassVersion="12">
    <version ClassVersion="12" checksum="1332125006"/>
@@ -22,6 +35,12 @@
   </class>
   <class name="l1t::EGammaBxCollection"/>
   <class name="edm::Wrapper<l1t::EGammaBxCollection>"/>
+  <class name="l1t::EGammaRef"/>
+  <class name="edm::Wrapper<l1t::EGammaRef>"/>
+  <class name="l1t::EGammaRefVector"/>
+  <class name="edm::Wrapper<l1t::EGammaRefVector>"/>
+  <class name="l1t::EGammaVectorRef"/>
+  <class name="edm::Wrapper<l1t::EGammaVectorRef>"/>
 
   <class name="l1t::EtSum" ClassVersion="13">
    <version ClassVersion="13" checksum="914893879"/>
@@ -31,6 +50,12 @@
   </class>
   <class name="l1t::EtSumBxCollection"/>
   <class name="edm::Wrapper<l1t::EtSumBxCollection>"/>
+  <class name="l1t::EtSumRef"/>
+  <class name="edm::Wrapper<l1t::EtSumRef>"/>
+  <class name="l1t::EtSumRefVector"/>
+  <class name="edm::Wrapper<l1t::EtSumRefVector>"/>
+  <class name="l1t::EtSumVectorRef"/>
+  <class name="edm::Wrapper<l1t::EtSumVectorRef>"/>
 
   <class name="l1t::Tau" ClassVersion="12">
    <version ClassVersion="12" checksum="1992693786"/>
@@ -39,6 +64,12 @@
   </class>
   <class name="l1t::TauBxCollection"/>
   <class name="edm::Wrapper<l1t::TauBxCollection>"/>
+  <class name="l1t::TauRef"/>
+  <class name="edm::Wrapper<l1t::TauRef>"/>
+  <class name="l1t::TauRefVector"/>
+  <class name="edm::Wrapper<l1t::TauRefVector>"/>
+  <class name="l1t::TauVectorRef"/>
+  <class name="edm::Wrapper<l1t::TauVectorRef>"/>
 
   <class name="l1t::Muon" ClassVersion="14">
    <version ClassVersion="14" checksum="1302394108"/>
@@ -50,8 +81,11 @@
   <class name="l1t::MuonBxCollection"/>
   <class name="edm::Wrapper<l1t::MuonBxCollection>"/>
   <class name="l1t::MuonRef"/>
+  <class name="edm::Wrapper<l1t::MuonRef>"/>
   <class name="l1t::MuonRefVector"/>
+  <class name="edm::Wrapper<l1t::MuonRefVector>"/>
   <class name="l1t::MuonVectorRef"/>
+  <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
   <class name="l1t::CaloSpare" ClassVersion="13">
    <version ClassVersion="13" checksum="50826133"/>

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -180,5 +180,10 @@ class TriggerSummaryProducerAOD : public edm::stream::EDProducer<edm::GlobalCach
   edm::GetterOfProducts<l1extra::L1HFRingsCollection> getL1HFRingsCollection_;
   edm::GetterOfProducts<reco::PFJetCollection> getPFJetCollection_;
   edm::GetterOfProducts<reco::PFTauCollection> getPFTauCollection_;
+  edm::GetterOfProducts<l1t::MuonBxCollection> getL1TMuonParticleCollection_;
+  edm::GetterOfProducts<l1t::EGammaBxCollection> getL1TEGammaParticleCollection_;
+  edm::GetterOfProducts<l1t::JetBxCollection> getL1TJetParticleCollection_;
+  edm::GetterOfProducts<l1t::TauBxCollection> getL1TTauParticleCollection_;
+  edm::GetterOfProducts<l1t::EtSumBxCollection> getL1TEtSumParticleCollection_;
 };
 #endif

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
@@ -42,6 +42,7 @@ TriggerSummaryAnalyzerRAW::analyze(const edm::Event& iEvent, const edm::EventSet
    using namespace reco;
    using namespace l1extra;
    using namespace trigger;
+   using namespace l1t;
 
    LogVerbatim("TriggerSummaryAnalyzerRAW") << endl;
    LogVerbatim("TriggerSummaryAnalyzerRAW") << "TriggerSummaryAnalyzerRAW: content of TriggerEventWithRefs: " << inputTag_.encode();
@@ -121,6 +122,27 @@ TriggerSummaryAnalyzerRAW::analyze(const edm::Event& iEvent, const edm::EventSet
 				  handle->pfmetSlice(iFO).first);
        if (nPFMETs>0) LogVerbatim("TriggerSummaryAnalyzerRAW") << " PFMETs: " << nPFMETs;
 
+       const unsigned int nL1TMuon(handle->l1tmuonSlice(iFO).second-
+				  handle->l1tmuonSlice(iFO).first);
+       if (nL1TMuon>0) LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TMuon: " << nL1TMuon;
+
+       const unsigned int nL1TEGamma(handle->l1tegammaSlice(iFO).second-
+				  handle->l1tegammaSlice(iFO).first);
+       if (nL1TEGamma>0) LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TEGamma: " << nL1TEGamma;
+
+       const unsigned int nL1TJet(handle->l1tjetSlice(iFO).second-
+				  handle->l1tjetSlice(iFO).first);
+       if (nL1TJet>0) LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TJet: " << nL1TJet;
+
+       const unsigned int nL1TTau(handle->l1ttauSlice(iFO).second-
+				  handle->l1ttauSlice(iFO).first);
+       if (nL1TTau>0) LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TTau: " << nL1TTau;
+
+       const unsigned int nL1TEtSum(handle->l1tetsumSlice(iFO).second-
+				  handle->l1tetsumSlice(iFO).first);
+       if (nL1TEtSum>0) LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TEtSum: " << nL1TEtSum;
+
+
        LogVerbatim("TriggerSummaryAnalyzerRAW") << endl;
      }
      LogVerbatim("TriggerSummaryAnalyzerRAW") << "Elements in linearised collections of Refs: " << endl;
@@ -140,6 +162,11 @@ TriggerSummaryAnalyzerRAW::analyze(const edm::Event& iEvent, const edm::EventSet
      LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFJets:     " << handle->pfjetSize()     << endl;
      LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFTaus:     " << handle->pftauSize()     << endl;
      LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFMETs:     " << handle->pfmetSize()     << endl;
+     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TMuon:    " << handle->l1tmuonSize()   << endl;
+     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEGamma:  " << handle->l1tegammaSize() << endl;
+     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TJet:     " << handle->l1tjetSize()    << endl;
+     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTau:     " << handle->l1ttauSize()    << endl;
+     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEtSum:   " << handle->l1tetsumSize()  << endl;
    } else {
      LogVerbatim("TriggerSummaryAnalyzerRAW") << "Handle invalid! Check InputTag provided." << endl;
    }

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -40,6 +40,12 @@
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
 #include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
 
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 
@@ -97,6 +103,11 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   getL1JetParticleCollection_ = edm::GetterOfProducts<l1extra::L1JetParticleCollection>(edm::ProcessMatch(pn_), this);
   getL1EtMissParticleCollection_ = edm::GetterOfProducts<l1extra::L1EtMissParticleCollection>(edm::ProcessMatch(pn_), this);
   getL1HFRingsCollection_ = edm::GetterOfProducts<l1extra::L1HFRingsCollection>(edm::ProcessMatch(pn_), this);
+  getL1TMuonParticleCollection_ = edm::GetterOfProducts<l1t::MuonBxCollection>(edm::ProcessMatch(pn_), this);
+  getL1TEGammaParticleCollection_ = edm::GetterOfProducts<l1t::EGammaBxCollection>(edm::ProcessMatch(pn_), this);
+  getL1TJetParticleCollection_ = edm::GetterOfProducts<l1t::JetBxCollection>(edm::ProcessMatch(pn_), this);
+  getL1TTauParticleCollection_ = edm::GetterOfProducts<l1t::TauBxCollection>(edm::ProcessMatch(pn_), this);
+  getL1TEtSumParticleCollection_ = edm::GetterOfProducts<l1t::EtSumBxCollection>(edm::ProcessMatch(pn_), this);
   getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(edm::ProcessMatch(pn_), this);
   getPFTauCollection_ = edm::GetterOfProducts<reco::PFTauCollection>(edm::ProcessMatch(pn_), this);
   getPFMETCollection_ = edm::GetterOfProducts<reco::PFMETCollection>(edm::ProcessMatch(pn_), this);
@@ -116,6 +127,11 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
     getL1JetParticleCollection_(bd);
     getL1EtMissParticleCollection_(bd);
     getL1HFRingsCollection_(bd);
+    getL1TMuonParticleCollection_(bd);
+    getL1TEGammaParticleCollection_(bd);
+    getL1TJetParticleCollection_(bd);
+    getL1TTauParticleCollection_(bd);
+    getL1TEtSumParticleCollection_(bd);
     getPFJetCollection_(bd);
     getPFTauCollection_(bd);
     getPFMETCollection_(bd);
@@ -173,6 +189,7 @@ TriggerSummaryProducerAOD::produce(edm::Event& iEvent, const edm::EventSetup& iS
    using namespace reco;
    using namespace l1extra;
    using namespace trigger;
+   using namespace l1t;
 
    std::vector<edm::Handle<trigger::TriggerFilterObjectWithRefs> > fobs;
    getTriggerFilterObjectWithRefs_.fillHandles(iEvent, fobs);
@@ -265,6 +282,11 @@ TriggerSummaryProducerAOD::produce(edm::Event& iEvent, const edm::EventSetup& iS
    fillTriggerObjectCollections<              L1JetParticleCollection>(iEvent, getL1JetParticleCollection_);
    fillTriggerObjectCollections<           L1EtMissParticleCollection>(iEvent, getL1EtMissParticleCollection_);
    fillTriggerObjectCollections<                  L1HFRingsCollection>(iEvent, getL1HFRingsCollection_);
+   fillTriggerObjectCollections<                     MuonBxCollection>(iEvent, getL1TMuonParticleCollection_);
+   fillTriggerObjectCollections<                   EGammaBxCollection>(iEvent, getL1TEGammaParticleCollection_);
+   fillTriggerObjectCollections<                      JetBxCollection>(iEvent, getL1TJetParticleCollection_);
+   fillTriggerObjectCollections<                      TauBxCollection>(iEvent, getL1TTauParticleCollection_);
+   fillTriggerObjectCollections<                    EtSumBxCollection>(iEvent, getL1TEtSumParticleCollection_);
    ///
    fillTriggerObjectCollections<                      PFJetCollection>(iEvent, getPFJetCollection_);
    fillTriggerObjectCollections<                      PFTauCollection>(iEvent, getPFTauCollection_);
@@ -305,6 +327,11 @@ TriggerSummaryProducerAOD::produce(edm::Event& iEvent, const edm::EventSetup& iS
        fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1jetIds()    ,fobs[ifob]->l1jetRefs());
        fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1etmissIds() ,fobs[ifob]->l1etmissRefs());
        fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1hfringsIds(),fobs[ifob]->l1hfringsRefs());
+       fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1tmuonIds()  ,fobs[ifob]->l1tmuonRefs());
+       fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1tegammaIds(),fobs[ifob]->l1tegammaRefs());
+       fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1tjetIds()   ,fobs[ifob]->l1tjetRefs());
+       fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1ttauIds()   ,fobs[ifob]->l1ttauRefs());
+       fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->l1tetsumIds() ,fobs[ifob]->l1tetsumRefs());
        fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->pfjetIds()    ,fobs[ifob]->pfjetRefs());
        fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->pftauIds()    ,fobs[ifob]->pftauRefs());
        fillFilterObjectMembers(iEvent,filterTag,fobs[ifob]->pfmetIds()    ,fobs[ifob]->pfmetRefs());
@@ -330,6 +357,7 @@ void TriggerSummaryProducerAOD::fillTriggerObjectCollections(const edm::Event& i
   using namespace reco;
   using namespace l1extra;
   using namespace trigger;
+  using namespace l1t;
 
   vector<Handle<C> > collections;
   getter.fillHandles(iEvent, collections);

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -21,7 +21,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include <memory>
-#include<vector>
+#include <vector>
 
 //
 // constructors and destructor
@@ -105,7 +105,27 @@ TriggerSummaryProducerRAW::produce(edm::Event& iEvent, const edm::EventSetup&)
        << " E/" << fobs[ifob]->pfjetSize()
        << " F/" << fobs[ifob]->pftauSize()
        << " G/" << fobs[ifob]->pfmetSize()
+       << " I/" << fobs[ifob]->l1tmuonSize()
+       << " J/" << fobs[ifob]->l1tegammaSize()
+       << " K/" << fobs[ifob]->l1tjetSize()
+       << " L/" << fobs[ifob]->l1ttauSize()
+       << " M/" << fobs[ifob]->l1tetsumSize()
        << endl;
+       LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )" 
+       << "\n fobs[ifob]->l1tmuonIds().size() = " << fobs[ifob]->l1tmuonIds().size() 
+       << "\n fobs[ifob]->l1tmuonRefs().size() = " << fobs[ifob]->l1tmuonRefs().size() << endl;
+       LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )" 
+       << "\n fobs[ifob]->l1tegammaIds().size() = " << fobs[ifob]->l1tegammaIds().size() 
+       << "\n fobs[ifob]->l1tegammaRefs().size() = " << fobs[ifob]->l1tegammaRefs().size() << endl;
+       LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )" 
+       << "\n fobs[ifob]->l1tjetIds().size() = " << fobs[ifob]->l1tjetIds().size() 
+       << "\n fobs[ifob]->l1tjetRefs().size() = " << fobs[ifob]->l1tjetRefs().size() << endl;
+       LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )" 
+       << "\n fobs[ifob]->l1ttauIds().size() = " << fobs[ifob]->l1ttauIds().size() 
+       << "\n fobs[ifob]->l1ttauRefs().size() = " << fobs[ifob]->l1ttauRefs().size() << endl;
+       LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )" 
+       << "\n fobs[ifob]->l1tetsumIds().size() = " << fobs[ifob]->l1tetsumIds().size() 
+       << "\n fobs[ifob]->l1tetsumRefs().size() = " << fobs[ifob]->l1tetsumRefs().size() << endl;
      product->addFilterObject(tag,*fobs[ifob]);
    }
 

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -31,40 +31,26 @@ HLTL1TSeed::HLTL1TSeed(const edm::ParameterSet& parSet) :
   HLTStreamFilter(parSet),
   //useObjectMaps_(parSet.getParameter<bool>("L1UseL1TriggerObjectMaps")),
   m_l1SeedsLogicalExpression(parSet.getParameter<string>("L1SeedsLogicalExpression")),
-  // InputTag for the L1 Global Trigger DAQ readout record
-  //m_l1GtReadoutRecordTag(parSet.getParameter<edm::InputTag> ( "L1GtReadoutRecordTag")),
-  //m_l1GtReadoutRecordToken(consumes<L1GlobalTriggerReadoutRecord>(m_l1GtReadoutRecordTag)),
-  // InputTag for L1 Global Trigger object maps
-  m_l1GtObjectMapTag(parSet.getParameter<edm::InputTag> ("L1GtObjectMapTag")),
+  m_l1GtObjectMapTag(parSet.getParameter<edm::InputTag> ("L1ObjectMapInputTag")),
   m_l1GtObjectMapToken(consumes<L1GlobalTriggerObjectMapRecord>(m_l1GtObjectMapTag)),
-  //dummyTag(parSet.getParameter<edm::InputTag>("myDummyTag")), // FIX WHEN UNPACKERS ADDED
-  m_l1MuonCollectionsTag(parSet.getParameter<edm::InputTag>("muonCollectionsTag")), // FIX WHEN UNPACKERS ADDED
+  m_l1MuonCollectionsTag(parSet.getParameter<edm::InputTag>("L1MuonInputTag")), // FIX WHEN UNPACKERS ADDED
   m_l1MuonTag(m_l1MuonCollectionsTag),
   m_l1MuonToken(consumes<l1t::MuonBxCollection>(m_l1MuonTag)),
-  m_l1EGammaCollectionsTag(parSet.getParameter<edm::InputTag>("egammaCollectionsTag")), // FIX WHEN UNPACKERS ADDED
+  m_l1EGammaCollectionsTag(parSet.getParameter<edm::InputTag>("L1EGammaInputTag")), // FIX WHEN UNPACKERS ADDED
   m_l1EGammaTag(m_l1EGammaCollectionsTag),
   m_l1EGammaToken(consumes<l1t::EGammaBxCollection>(m_l1EGammaTag)),
-  m_l1JetCollectionsTag(parSet.getParameter<edm::InputTag>("jetCollectionsTag")), // FIX WHEN UNPACKERS ADDED
+  m_l1JetCollectionsTag(parSet.getParameter<edm::InputTag>("L1JetInputTag")), // FIX WHEN UNPACKERS ADDED
   m_l1JetTag(m_l1JetCollectionsTag),
   m_l1JetToken(consumes<l1t::JetBxCollection>(m_l1JetTag)),
-  m_l1TauCollectionsTag(parSet.getParameter<edm::InputTag>("tauCollectionsTag")), // FIX WHEN UNPACKERS ADDED
+  m_l1TauCollectionsTag(parSet.getParameter<edm::InputTag>("L1TauInputTag")), // FIX WHEN UNPACKERS ADDED
   m_l1TauTag(m_l1TauCollectionsTag),
   m_l1TauToken(consumes<l1t::TauBxCollection>(m_l1TauTag)),
-  m_l1EtSumCollectionsTag(parSet.getParameter<edm::InputTag>("etsumCollectionsTag")), // FIX WHEN UNPACKERS ADDED
+  m_l1EtSumCollectionsTag(parSet.getParameter<edm::InputTag>("L1EtSumInputTag")), // FIX WHEN UNPACKERS ADDED
   m_l1EtSumTag(m_l1EtSumCollectionsTag),
   m_l1EtSumToken(consumes<l1t::EtSumBxCollection>(m_l1EtSumTag)),
   m_isDebugEnabled(edm::isDebugEnabled())
 {
 
-
-  //m_l1SeedsLogicalExpression = parSet.getParameter<string>("L1SeedsLogicalExpression");
-
-  //m_l1GtObjectMapTag = edm::InputTag("simGtStage2Digis");
-  //m_l1GtObjectMapTag = edm::InputTag("L1GtObjectMapTag");
-  //m_l1GtObjectMapToken = consumes<L1GlobalTriggerObjectMapRecord>(m_l1GtObjectMapTag);
-  
-
-  
   if (m_l1SeedsLogicalExpression != "L1GlobalDecision") {
 
         // check also the logical expression - add/remove spaces if needed
@@ -86,13 +72,6 @@ HLTL1TSeed::HLTL1TSeed(const edm::ParameterSet& parSet) :
 
   }
 
-  //LogDebug("HLTL1TSeed") 
-  //<< "\n";
-    //<< "L1 Seeding using L1 trigger object maps:       "
-    //<< useL1TriggerObjectMaps_ << "\n"
-    //<< "  if false: seeding with all L1T objects\n"
-    //<< "L1 Seeds Logical Expression:                   " << "\n      "
-    //<< logicalExpression_ << "\n";
 }
 
 // destructor
@@ -107,15 +86,6 @@ HLTL1TSeed::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
 
-  // # default: true
-  // #    seeding done via L1 trigger object maps, with objects that fired
-  // #    only objects from the central BxInEvent (L1A) are used
-  // # if false:
-  // #    seeding is done ignoring if a L1 object fired or not,
-  // #    adding all L1EXtra objects corresponding to the object types
-  // #    used in all conditions from the algorithms in logical expression
-  // #    for a given number of BxInEvent
-  //desc.add<bool>("L1UseL1TriggerObjectMaps",true);
 
   // # logical expression for the required L1 algorithms;
   // # the algorithms are specified by name
@@ -123,16 +93,15 @@ HLTL1TSeed::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // #
   // # by convention, "L1GlobalDecision" logical expression means global decision
   desc.add<string>("L1SeedsLogicalExpression","");
-  desc.add<edm::InputTag>("L1GtObjectMapTag",edm::InputTag("simGtStage2Digis"));
-
-  desc.add<edm::InputTag>("muonCollectionsTag",edm::InputTag("simGmtStage2Digis"));
-  desc.add<edm::InputTag>("egammaCollectionsTag",edm::InputTag("simCaloStage2Digis"));
-  desc.add<edm::InputTag>("jetCollectionsTag",edm::InputTag("simCaloStage2Digis"));
-  desc.add<edm::InputTag>("tauCollectionsTag",edm::InputTag("simCaloStage2Digis"));
-  desc.add<edm::InputTag>("etsumCollectionsTag",edm::InputTag("simCaloStage2Digis"));
-
+  desc.add<bool>("SaveTags",true);
+  desc.add<edm::InputTag>("L1ObjectMapInputTag",edm::InputTag("hltGtStage2ObjectMap"));
+  desc.add<edm::InputTag>("L1GlobalInputTag",edm::InputTag("hltGtStage2Digis"));
+  desc.add<edm::InputTag>("L1MuonInputTag",edm::InputTag("hltGmtStage2Digis"));
+  desc.add<edm::InputTag>("L1EGammaInputTag",edm::InputTag("hltCaloStage2Digis"));
+  desc.add<edm::InputTag>("L1JetInputTag",edm::InputTag("hltCaloStage2Digis"));
+  desc.add<edm::InputTag>("L1TauInputTag",edm::InputTag("hltCaloStage2Digis"));
+  desc.add<edm::InputTag>("L1EtSumInputTag",edm::InputTag("hltCaloStage2Digis"));
   descriptions.add("hltL1TSeed", desc);
-  //descriptions.add("hltL1TSeed", desc);
 }
 
 bool HLTL1TSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
@@ -167,6 +136,11 @@ bool HLTL1TSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, t
   if (m_isDebugEnabled) {
         dumpTriggerFilterObjectWithRefs(filterproduct);
   }
+
+  LogTrace("HLTL1TSeed")
+  << "HLTL1Seed::hltFilter(..., trigger::TriggerFilterObjectWithRefs & filterproduct)"
+  << "\n\tfilterproduct.l1tjetIds().size() = " << filterproduct.l1tjetIds().size() 
+  << "\n\tfilterproduct.l1tjetRefs().size() = " << filterproduct.l1tjetRefs().size() << endl;
   return rc;
 
 }
@@ -656,12 +630,6 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
       //
       for (size_t condNumber = 0; condNumber < opTokenVecObjMap.size(); condNumber++) {
 
-        //LogTrace("HLTL1TSeed")
-        //<< "\ttokenName = " << opTokenVecObjMap[condNumber].tokenName
-        //<< "\ttokenNumber = " << opTokenVecObjMap[condNumber].tokenNumber 
-        //<< "\ttokenResult = " << opTokenVecObjMap[condNumber].tokenResult 
-        //<< endl;
-        
         std::vector<L1GtObject> condObjType = condObjTypeVec[condNumber];
 
         for (size_t jOb =0; jOb < condObjType.size(); jOb++) {
@@ -802,17 +770,10 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
           } // end for itObj
 
         } // end for itComb
-        //LogTrace("HLTL1TSeed")
-        //<< "Finished with all combinations" << endl;
 
       } // end for condition
-      //LogTrace("HLTL1TSeed")
-      //<< "Finished with all conditions" << endl;
 
     } // end for itSeed
-    //LogTrace("HLTL1TSeed")
-    //<< "Finished with all seeds" << endl;
-
 
 
     // eliminate duplicates
@@ -846,7 +807,6 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
     
     // record the L1 physics objects in the HLT filterproduct
-    //
     // //////////////////////////////////////////////////////
 
     // Muon

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -137,10 +137,6 @@ bool HLTL1TSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, t
         dumpTriggerFilterObjectWithRefs(filterproduct);
   }
 
-  LogTrace("HLTL1TSeed")
-  << "HLTL1Seed::hltFilter(..., trigger::TriggerFilterObjectWithRefs & filterproduct)"
-  << "\n\tfilterproduct.l1tjetIds().size() = " << filterproduct.l1tjetIds().size() 
-  << "\n\tfilterproduct.l1tjetRefs().size() = " << filterproduct.l1tjetRefs().size() << endl;
   return rc;
 
 }
@@ -161,18 +157,18 @@ bool HLTL1TSeed::seedsAll(edm::Event & iEvent, trigger::TriggerFilterObjectWithR
     iEvent.getByToken(m_l1MuonToken, muons);
     if (!muons.isValid()){ 
       edm::LogWarning("HLTL1TSeed")
-	<< "\nWarning: L1MuonBxCollection with input tag "
-	<< m_l1MuonTag
-	<< "\nrequested in configuration, but not found in the event."
-	<< "\nNo muons added to filterproduct."
-	<< endl;	
+	    << "\nWarning: L1MuonBxCollection with input tag "
+	    << m_l1MuonTag
+	    << "\nrequested in configuration, but not found in the event."
+	    << "\nNo muons added to filterproduct."
+	    << endl;	
     } else {
 
       l1t::MuonBxCollection::const_iterator iter;
       for (iter = muons->begin(0); iter != muons->end(0); ++iter){
-	//objectsInFilter = true;
-	l1t::MuonRef myref(muons, muons->key(iter));
-	filterproduct.addObject(trigger::TriggerL1Mu, myref);
+	      //objectsInFilter = true;
+	      l1t::MuonRef myref(muons, muons->key(iter));
+	      filterproduct.addObject(trigger::TriggerL1Mu, myref);
       }
     }
 
@@ -184,18 +180,18 @@ bool HLTL1TSeed::seedsAll(edm::Event & iEvent, trigger::TriggerFilterObjectWithR
     iEvent.getByToken(m_l1EGammaToken, egammas);
     if (!egammas.isValid()){ 
       edm::LogWarning("HLTL1TSeed")
-	<< "\nWarning: L1EGammaBxCollection with input tag "
-	<< m_l1EGammaTag
-	<< "\nrequested in configuration, but not found in the event."
-	<< "\nNo egammas added to filterproduct."
-	<< endl;	
+	    << "\nWarning: L1EGammaBxCollection with input tag "
+	    << m_l1EGammaTag
+	    << "\nrequested in configuration, but not found in the event."
+	    << "\nNo egammas added to filterproduct."
+	    << endl;	
     } else {
 
       l1t::EGammaBxCollection::const_iterator iter;
       for (iter = egammas->begin(0); iter != egammas->end(0); ++iter){
-	//objectsInFilter = true;
-	l1t::EGammaRef myref(egammas, egammas->key(iter));
-	filterproduct.addObject(trigger::TriggerL1EG, myref);
+	      //objectsInFilter = true;
+	      l1t::EGammaRef myref(egammas, egammas->key(iter));
+	      filterproduct.addObject(trigger::TriggerL1EG, myref);
       }
     }
 
@@ -207,18 +203,18 @@ bool HLTL1TSeed::seedsAll(edm::Event & iEvent, trigger::TriggerFilterObjectWithR
     iEvent.getByToken(m_l1JetToken, jets);
     if (!jets.isValid()){ 
       edm::LogWarning("HLTL1TSeed")
-	<< "\nWarning: L1JetBxCollection with input tag "
-	<< m_l1JetTag
-	<< "\nrequested in configuration, but not found in the event."
-	<< "\nNo jets added to filterproduct."
-	<< endl;	
+	    << "\nWarning: L1JetBxCollection with input tag "
+	    << m_l1JetTag
+	    << "\nrequested in configuration, but not found in the event."
+	    << "\nNo jets added to filterproduct."
+	    << endl;	
     } else {
 
       l1t::JetBxCollection::const_iterator iter;
       for (iter = jets->begin(0); iter != jets->end(0); ++iter){
-	//objectsInFilter = true;
-	l1t::JetRef myref(jets, jets->key(iter));
-	filterproduct.addObject(trigger::TriggerL1Jet, myref); 
+	      //objectsInFilter = true;
+	      l1t::JetRef myref(jets, jets->key(iter));
+	      filterproduct.addObject(trigger::TriggerL1Jet, myref); 
       }
     }
 
@@ -230,18 +226,18 @@ bool HLTL1TSeed::seedsAll(edm::Event & iEvent, trigger::TriggerFilterObjectWithR
     iEvent.getByToken(m_l1TauToken, taus);
     if (!taus.isValid()){ 
       edm::LogWarning("HLTL1TSeed")
-	<< "\nWarning: L1TauBxCollection with input tag "
-	<< m_l1TauTag
-	<< "\nrequested in configuration, but not found in the event."
-	<< "\nNo taus added to filterproduct."
-	<< endl;	
+	    << "\nWarning: L1TauBxCollection with input tag "
+	    << m_l1TauTag
+	    << "\nrequested in configuration, but not found in the event."
+	    << "\nNo taus added to filterproduct."
+	    << endl;	
     } else {
 
       l1t::TauBxCollection::const_iterator iter;
       for (iter = taus->begin(0); iter != taus->end(0); ++iter){
-	//objectsInFilter = true;
-	l1t::TauRef myref(taus, taus->key(iter));
-	filterproduct.addObject(trigger::TriggerL1Tau, myref); 
+	      //objectsInFilter = true;
+	      l1t::TauRef myref(taus, taus->key(iter));
+	      filterproduct.addObject(trigger::TriggerL1Tau, myref); 
       }
     }
 
@@ -253,29 +249,34 @@ bool HLTL1TSeed::seedsAll(edm::Event & iEvent, trigger::TriggerFilterObjectWithR
     iEvent.getByToken(m_l1EtSumToken, etsums);
     if (!etsums.isValid()){ 
       edm::LogWarning("HLTL1TSeed")
-	<< "\nWarning: L1EtSumBxCollection with input tag "
-	<< m_l1EtSumTag
-	<< "\nrequested in configuration, but not found in the event."
-	<< "\nNo etsums added to filterproduct."
-	<< endl;	
+	    << "\nWarning: L1EtSumBxCollection with input tag "
+	    << m_l1EtSumTag
+	    << "\nrequested in configuration, but not found in the event."
+	    << "\nNo etsums added to filterproduct."
+	    << endl;	
     } else {
 
+      LogTrace("HLTL1TSeed") << "\nHLT1TSeed::seedsAll: L1EtSum objects found in the EtSumBxCollection " << endl;
       l1t::EtSumBxCollection::const_iterator iter;
       for (iter = etsums->begin(0); iter != etsums->end(0); ++iter){
-	//objectsInFilter = true;
-	l1t::EtSumRef myref(etsums, etsums->key(iter));
+
+	      //objectsInFilter = true;
+	      l1t::EtSumRef myref(etsums, etsums->key(iter));
+
+        LogTrace("HLTL1TSeed") << "pt="<<myref->pt() << "\ttype = " << iter->getType() << endl;
+
         switch(iter->getType()) {
           case l1t::EtSum::kTotalEt : 
-	    filterproduct.addObject(trigger::TriggerL1ETT, myref); 
+	          filterproduct.addObject(trigger::TriggerL1ETT, myref); 
             break;
           case l1t::EtSum::kTotalHt : 
-	    filterproduct.addObject(trigger::TriggerL1HTT, myref); 
+	          filterproduct.addObject(trigger::TriggerL1HTT, myref); 
             break;
           case l1t::EtSum::kMissingEt: 
-	    filterproduct.addObject(trigger::TriggerL1ETM, myref); 
+	          filterproduct.addObject(trigger::TriggerL1ETM, myref); 
             break;
           case l1t::EtSum::kMissingHt: 
-	    filterproduct.addObject(trigger::TriggerL1HTM, myref); 
+	          filterproduct.addObject(trigger::TriggerL1HTM, myref); 
             break;
           default:
             LogTrace("HLTL1TSeed") << "  L1EtSum seed of currently unsuported HLT TriggerType. l1t::EtSum type:      " << iter->getType() << "\n";
@@ -469,7 +470,6 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
     std::list<int> listJetCounts;
 
-
     // get handle to object maps (one object map per algorithm)
     edm::Handle<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord;
     iEvent.getByToken(m_l1GtObjectMapToken, gtObjectMapRecord);
@@ -494,7 +494,9 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
       for (size_t imap =0; imap < objMaps.size(); imap++) {
 
         LogTrace("HLTL1TSeed")
-        << "\t map = " << imap << "\talgoName = " << objMaps[imap].algoName() << "\tGtlResult  = " <<  objMaps[imap].algoGtlResult();
+        << "\t map = " << imap << "\talgoName = " << objMaps[imap].algoName() 
+        << "\tGtlResult = " <<  objMaps[imap].algoGtlResult()
+        << endl;
 
       }
       LogTrace("HLTL1TSeed") << endl;
@@ -670,8 +672,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
                 const L1GtObject objTypeVal = condObjType.at(iType);
 
                 LogTrace("HLTL1TSeed")
-                << "\tAdd object of type " << objTypeVal
-                << " and index " << (*itObject) << " to the seed list."
+                << "\tAdd object of type " << objTypeVal << " and index " << (*itObject) << " to the seed list."
                 << std::endl;
 
                 switch (objTypeVal) {
@@ -812,50 +813,54 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
     // Muon
     if (!listMuon.empty()) {
 
-        edm::Handle<l1t::MuonBxCollection> muons;
-        iEvent.getByToken(m_l1MuonToken, muons);
-        if (!muons.isValid()){ 
+      edm::Handle<l1t::MuonBxCollection> muons;
+      iEvent.getByToken(m_l1MuonToken, muons);
+
+      if (!muons.isValid()){ 
           edm::LogWarning("HLTL1TSeed")
-    	<< "\nWarning: L1MuonBxCollection with input tag "
-    	<< m_l1MuonTag
-    	<< "\nrequested in configuration, but not found in the event."
-    	<< "\nNo muons added to filterproduct."
-    	<< endl;	
-        } else {
+    	  << "\nWarning: L1MuonBxCollection with input tag "
+    	  << m_l1MuonTag
+    	  << "\nrequested in configuration, but not found in the event."
+    	  << "\nNo muons added to filterproduct."
+    	  << endl;	
+      } 
+      else {
     
-          l1t::MuonBxCollection::const_iterator iter;
-          for (std::list<int>::const_iterator itObj = listMuon.begin(); itObj != listMuon.end(); ++itObj) {
+        for (std::list<int>::const_iterator itObj = listMuon.begin(); itObj != listMuon.end(); ++itObj) {
     	
     	    l1t::MuonRef myref(muons, *itObj);
     	    filterproduct.addObject(trigger::TriggerL1Mu, myref);
 
-          }
         }
+
+      } 
+
     }
 
     // EG (isolated)
     if (!listEG.empty()) {
 
-        edm::Handle<l1t::EGammaBxCollection> egammas;
-        iEvent.getByToken(m_l1EGammaToken, egammas);
-        if (!egammas.isValid()){ 
-          edm::LogWarning("HLTL1TSeed")
-    	<< "\nWarning: L1EGammaBxCollection with input tag " << m_l1EGammaTag
-    	<< "\nrequested in configuration, but not found in the event."
-    	<< "\nNo egammas added to filterproduct."
-    	<< endl;	
-        } else {
+      edm::Handle<l1t::EGammaBxCollection> egammas;
+      iEvent.getByToken(m_l1EGammaToken, egammas);
+      if (!egammas.isValid()){ 
+        edm::LogWarning("HLTL1TSeed")
+        << "\nWarning: L1EGammaBxCollection with input tag " << m_l1EGammaTag
+        << "\nrequested in configuration, but not found in the event."
+        << "\nNo egammas added to filterproduct."
+        << endl;	
+      } 
+      else {
     
-          l1t::EGammaBxCollection::const_iterator iter;
-          for (std::list<int>::const_iterator itObj = listEG.begin(); itObj != listEG.end(); ++itObj) {
+        for (std::list<int>::const_iterator itObj = listEG.begin(); itObj != listEG.end(); ++itObj) {
 
     	    l1t::EGammaRef myref(egammas, *itObj);
     	    filterproduct.addObject(trigger::TriggerL1EG, myref);
 
-          }
-        }
+        } 
+
+      } 
     
-    }
+    } 
 
     // Jet
     if (!listJet.empty()) {
@@ -865,18 +870,20 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
       if (!jets.isValid()){ 
         edm::LogWarning("HLTL1TSeed")
-  	<< "\nWarning: L1JetBxCollection with input tag " << m_l1JetTag
-  	<< "\nrequested in configuration, but not found in the event."
-  	<< "\nNo jets added to filterproduct."
-  	<< endl;	
-      } else {
+        << "\nWarning: L1JetBxCollection with input tag " << m_l1JetTag
+        << "\nrequested in configuration, but not found in the event."
+        << "\nNo jets added to filterproduct."
+        << endl;	
+      } 
+      else {
   
-        l1t::JetBxCollection::const_iterator iter;
         for (std::list<int>::const_iterator itObj = listJet.begin(); itObj != listJet.end(); ++itObj) {
-  	l1t::JetRef myref(jets, *itObj);
-  	filterproduct.addObject(trigger::TriggerL1Jet, myref); 
+          l1t::JetRef myref(jets, *itObj);
+          filterproduct.addObject(trigger::TriggerL1Jet, myref); 
         }
+
       }
+
     }
 
     // Tau
@@ -887,115 +894,67 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
       if (!taus.isValid()){ 
         edm::LogWarning("HLTL1TSeed")
-  	<< "\nWarning: L1TauBxCollection with input tag " << m_l1TauTag
-  	<< "\nrequested in configuration, but not found in the event."
-  	<< "\nNo taus added to filterproduct."
-  	<< endl;	
-      } else {
+        << "\nWarning: L1TauBxCollection with input tag " << m_l1TauTag
+        << "\nrequested in configuration, but not found in the event."
+        << "\nNo taus added to filterproduct."
+        << endl;	
+      } 
+      else {
   
-        l1t::TauBxCollection::const_iterator iter;
         for (std::list<int>::const_iterator itObj = listTau.begin(); itObj != listTau.end(); ++itObj) {
-  	l1t::TauRef myref(taus, *itObj);
-  	filterproduct.addObject(trigger::TriggerL1Tau, myref); 
+          l1t::TauRef myref(taus, *itObj);
+          filterproduct.addObject(trigger::TriggerL1Tau, myref); 
         }
+
       }
+
     }
 
-    // ETM
-    if (!listETM.empty()) {
-      
-	edm::Handle<l1t::EtSumBxCollection> etsums;
-	iEvent.getByToken(m_l1EtSumToken, etsums);
-	if (!etsums.isValid()){ 
-	  edm::LogWarning("HLTL1TSeed")
-	    << "\nWarning: L1EtSumBxCollection with input tag "
-	    << m_l1EtSumTag
-	    << "\nrequested in configuration, but not found in the event."
-	    << "\nNo etsums added to filterproduct."
-	    << endl;	
-        } else {
-    
-          l1t::EtSumBxCollection::const_iterator iter;
-          for (std::list<int>::const_iterator itObj = listETM.begin(); itObj != listETM.end(); ++itObj) {
+    // ETT, HTT, ETM, HTM
+		edm::Handle<l1t::EtSumBxCollection> etsums;
+		iEvent.getByToken(m_l1EtSumToken, etsums);
+		if (!etsums.isValid()){ 
+		  edm::LogWarning("HLTL1TSeed")
+		    << "\nWarning: L1EtSumBxCollection with input tag "
+		    << m_l1EtSumTag
+		    << "\nrequested in configuration, but not found in the event."
+		    << "\nNo etsums added to filterproduct."
+		    << endl;	
+		} else {
+		  
+			l1t::EtSumBxCollection::const_iterator iter;
+			
+			for (iter = etsums->begin(0); iter != etsums->end(0); ++iter){
+			
+			  l1t::EtSumRef myref(etsums, etsums->key(iter));
+			
+			  switch(iter->getType()) {
 
-    	    l1t::EtSumRef myref(etsums, *itObj);
-    	    filterproduct.addObject(trigger::TriggerL1ETM, myref);
+			    case l1t::EtSum::kTotalEt : 
+            if(!listETT.empty())
+			        filterproduct.addObject(trigger::TriggerL1ETT, myref); 
+			      break;
+			    case l1t::EtSum::kTotalHt : 
+            if(!listHTT.empty())
+			        filterproduct.addObject(trigger::TriggerL1HTT, myref); 
+			      break;
+			    case l1t::EtSum::kMissingEt: 
+            if(!listETM.empty())
+			        filterproduct.addObject(trigger::TriggerL1ETM, myref); 
+			      break;
+			    case l1t::EtSum::kMissingHt: 
+            if(!listHTM.empty())
+			        filterproduct.addObject(trigger::TriggerL1HTM, myref); 
+			      break;
+			    default:
+			      LogTrace("HLTL1TSeed") << "  L1EtSum seed of currently unsuported HLT TriggerType. l1t::EtSum type:      " << iter->getType() << "\n";
 
-          }
-        }
-    }
+			  } // end switch
 
-    // ETT
-    if (!listETT.empty()) {
-      
-	edm::Handle<l1t::EtSumBxCollection> etsums;
-	iEvent.getByToken(m_l1EtSumToken, etsums);
-	if (!etsums.isValid()){ 
-	  edm::LogWarning("HLTL1TSeed")
-	    << "\nWarning: L1EtSumBxCollection with input tag "
-	    << m_l1EtSumTag
-	    << "\nrequested in configuration, but not found in the event."
-	    << "\nNo etsums added to filterproduct."
-	    << endl;	
-        } else {
-    
-          l1t::EtSumBxCollection::const_iterator iter;
-          for (std::list<int>::const_iterator itObj = listETT.begin(); itObj != listETT.end(); ++itObj) {
+			} // end for
 
-    	    l1t::EtSumRef myref(etsums, *itObj);
-    	    filterproduct.addObject(trigger::TriggerL1ETT, myref);
+		} // end else
 
-          }
-        }
-    }
-
-    // HTM
-    if (!listHTM.empty()) {
-      
-	edm::Handle<l1t::EtSumBxCollection> etsums;
-	iEvent.getByToken(m_l1EtSumToken, etsums);
-	if (!etsums.isValid()){ 
-	  edm::LogWarning("HLTL1TSeed")
-	    << "\nWarning: L1EtSumBxCollection with input tag "
-	    << m_l1EtSumTag
-	    << "\nrequested in configuration, but not found in the event."
-	    << "\nNo etsums added to filterproduct."
-	    << endl;	
-        } else {
-    
-          l1t::EtSumBxCollection::const_iterator iter;
-          for (std::list<int>::const_iterator itObj = listHTM.begin(); itObj != listHTM.end(); ++itObj) {
-
-    	    l1t::EtSumRef myref(etsums, *itObj);
-    	    filterproduct.addObject(trigger::TriggerL1HTM, myref);
-
-          }
-        }
-    }
-
-    // HTT
-    if (!listHTT.empty()) {
-      
-	edm::Handle<l1t::EtSumBxCollection> etsums;
-	iEvent.getByToken(m_l1EtSumToken, etsums);
-	if (!etsums.isValid()){ 
-	  edm::LogWarning("HLTL1TSeed")
-	    << "\nWarning: L1EtSumBxCollection with input tag "
-	    << m_l1EtSumTag
-	    << "\nrequested in configuration, but not found in the event."
-	    << "\nNo etsums added to filterproduct."
-	    << endl;	
-        } else {
-    
-          l1t::EtSumBxCollection::const_iterator iter;
-          for (std::list<int>::const_iterator itObj = listHTT.begin(); itObj != listHTT.end(); ++itObj) {
-
-    	    l1t::EtSumRef myref(etsums, *itObj);
-    	    filterproduct.addObject(trigger::TriggerL1HTT, myref);
-
-          }
-        }
-    }
 
     // TODO FIXME uncomment if block when JetCounts implemented
 

--- a/HLTrigger/HLTfilters/src/TestBXVectorRefProducer.cc
+++ b/HLTrigger/HLTfilters/src/TestBXVectorRefProducer.cc
@@ -1,0 +1,199 @@
+// -*- C++ -*-
+//
+// Package:    HLTrigger/TestBXVectorRefProducer
+// Class:      TestBXVectorRefProducer
+// 
+/**\class TestBXVectorRefProducer TestBXVectorRefProducer.cc HLTrigger/TestBXVectorRefProducer/plugins/TestBXVectorRefProducer.cc
+
+ Description: Simple testing producer to test storing of Ref<BXVector>  (example of <l1t::JetRef>) in the Event.
+
+ Implementation:
+     Pick up the BXVector<l1t::Jet> from the event and try to store the Refs back into the Event.
+*/
+//
+// Original Author:  Vladimir Rekovic
+//         Created:  Fri, 12 Feb 2016 09:56:04 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+//#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+
+//
+// class declaration
+//
+
+class TestBXVectorRefProducer : public edm::stream::EDProducer<> {
+   public:
+      explicit TestBXVectorRefProducer(const edm::ParameterSet&);
+      ~TestBXVectorRefProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginStream(edm::StreamID) override;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      virtual void endStream() override;
+
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+      bool doRefs_;
+      edm::InputTag src_;
+      edm::EDGetTokenT<l1t::JetBxCollection> token_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+TestBXVectorRefProducer::TestBXVectorRefProducer(const edm::ParameterSet& iConfig)
+{
+
+   //now do what ever other initialization is needed
+   src_       = iConfig.getParameter<edm::InputTag>( "src" );
+   doRefs_    = iConfig.getParameter<bool>("doRefs");
+   token_     = consumes<l1t::JetBxCollection>(src_);
+
+   //register your products
+   produces<vector<int>>( "jetPt" ).setBranchAlias( "jetPt");
+
+   if(doRefs_) {
+
+    produces<l1t::JetRefVector>( "l1tJetRef" ).setBranchAlias( "l1tJetRef");
+
+   }
+
+}
+
+
+TestBXVectorRefProducer::~TestBXVectorRefProducer()
+{
+ 
+   // do anything here that needs to be done at destruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+TestBXVectorRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   auto_ptr<vector<int>> jetMom ( new vector<int> );
+   auto_ptr<l1t::JetRefVector> jetRef ( new l1t::JetRefVector );
+
+   // retrieve the tracks
+   Handle<l1t::JetBxCollection> jets;
+   iEvent.getByToken( token_, jets );
+   if(!jets.isValid()) return;
+
+   const int size = jets->size();
+   jetMom->reserve( size );
+
+   l1t::JetBxCollection::const_iterator iter;
+
+   for (iter = jets->begin(0); iter != jets->end(0); ++iter){
+
+    jetMom->push_back(iter->pt());
+
+    l1t::JetRef myref(jets, jets->key(iter ));
+    jetRef->push_back(myref);
+
+
+   } // end for 
+
+   iEvent.put(jetMom,"jetPt");
+   
+   if (doRefs_) iEvent.put(jetRef,"l1tJetRef");
+
+   return;
+ 
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+TestBXVectorRefProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+TestBXVectorRefProducer::endStream() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+TestBXVectorRefProducer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+TestBXVectorRefProducer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+TestBXVectorRefProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+TestBXVectorRefProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+TestBXVectorRefProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(TestBXVectorRefProducer);

--- a/HLTrigger/Muon/interface/HLTMuonL1TFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1TFilter.h
@@ -1,0 +1,48 @@
+#ifndef HLTMuonL1TFilter_h
+#define HLTMuonL1TFilter_h
+
+/* \class HLTMuonL1TFilter
+ *
+ * This is an HLTFilter implementing filtering on L1T Stage2 GMT objects
+ * 
+ * \author:  V. Rekovic
+*/
+
+// user include files
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+
+class HLTMuonL1TFilter : public HLTFilter {
+
+   public:
+
+      explicit HLTMuonL1TFilter(const edm::ParameterSet&);
+      ~HLTMuonL1TFilter();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+
+   private:
+
+    //input tag identifying the product containing muons
+    edm::InputTag                           candTag_;
+    edm::EDGetTokenT<l1t::MuonBxCollection> candToken_;
+
+    /// input tag identifying the product containing refs to muons passing the previous level
+    edm::InputTag                                          previousCandTag_;
+    edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
+    
+    /// max Eta cut
+    double maxEta_;
+    
+    /// pT threshold
+    double minPt_;
+    
+    /// min N objects
+    double minN_;
+    
+};
+
+#endif //HLTMuonL1TFilter_h

--- a/HLTrigger/Muon/src/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1TFilter.cc
@@ -1,0 +1,136 @@
+/* \class HLTMuonL1TFilter
+ *
+ * This is an HLTFilter implementing filtering on L1T Stage2 GMT objects
+ * 
+ * \author:  V. Rekovic
+ *
+ */
+
+#include "HLTrigger/Muon/interface/HLTMuonL1TFilter.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerRefsCollections.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "TMath.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <vector>
+
+HLTMuonL1TFilter::HLTMuonL1TFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
+  candTag_( iConfig.getParameter<edm::InputTag>("CandTag") ),
+  candToken_( consumes<l1t::MuonBxCollection>(candTag_)),
+  previousCandTag_( iConfig.getParameter<edm::InputTag>("PreviousCandTag") ),
+  previousCandToken_( consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
+  maxEta_( iConfig.getParameter<double>("MaxEta") ),
+  minPt_( iConfig.getParameter<double>("MinPt") ),
+  minN_( iConfig.getParameter<int>("MinN") )
+{
+
+  // dump parameters for debugging
+  if(edm::isDebugEnabled()){
+    LogTrace("HLTMuonL1TFilter")
+    <<"Constructed with parameters:"<<endl
+    <<"    CandTag = "<<candTag_.encode()<<endl
+    <<"    PreviousCandTag = "<<previousCandTag_.encode()<<endl
+    <<"    MaxEta = "<<maxEta_<<endl
+    <<"    MinPt = "<<minPt_<<endl;
+    LogTrace("HLTMuonL1TFilter")<< endl;
+  }
+
+}
+
+
+HLTMuonL1TFilter::~HLTMuonL1TFilter()
+{
+}
+
+
+ 
+void
+HLTMuonL1TFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("CandTag",edm::InputTag("hltGmtStage2Digis"));
+  desc.add<edm::InputTag>("PreviousCandTag",edm::InputTag(""));
+  desc.add<double>("MaxEta",2.5);
+  desc.add<double>("MinPt",0.0);
+  desc.add<int>("MinN",1);
+  descriptions.add("hltMuonL1TFilter",desc);
+}
+
+bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+  using namespace std;
+  using namespace edm;
+  using namespace trigger;
+  using namespace l1t;
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // get hold of all muons
+  Handle<MuonBxCollection> allMuons;
+  iEvent.getByToken(candToken_, allMuons);
+
+  // get hold of TFOWRs that fired the previous level
+  Handle<TriggerFilterObjectWithRefs> previousLevelTFOWR;
+  iEvent.getByToken(previousCandToken_, previousLevelTFOWR);
+
+  vector<MuonRef> prevMuons;
+  previousLevelTFOWR->getObjects(TriggerL1Mu, prevMuons);
+
+  // look at all muon candidates, check cuts and add to filter object
+  int n = 0;
+  for(size_t i = 0; i < allMuons->size(); i++){
+    
+    MuonRef muon(allMuons, i);
+
+    // Only select muons that were selected in the previous level 
+    if(find(prevMuons.begin(), prevMuons.end(), muon) == prevMuons.end()) continue;
+
+    //check maxEta cut
+    if(fabs(muon->eta()) > maxEta_) continue;
+
+    //check pT cut
+    if(muon->pt() < minPt_) continue;
+
+    //we have a good candidate
+    n++;
+    filterproduct.addObject(TriggerL1Mu,muon);
+
+  }
+
+  if (saveTags()) filterproduct.addCollectionTag(candTag_);
+
+  // filter decision
+  const bool accept(n >= minN_);
+
+  // dump event for debugging
+  if(edm::isDebugEnabled()){
+
+    LogTrace("HLTMuonL1TFilter")<<"\nHLTMuonL1TFilter -----------------------------------------------" << endl;
+    LogTrace("HLTMuonL1TFilter")<<"Decision of filter is "<<accept<<", number of muons passing = "<<filterproduct.l1tmuonSize() << endl;
+    LogTrace("HLTMuonL1TFilter")<<"L1mu#"<<'\t'<<"q" << "\t" << "pt"<<'\t'<<'\t'<<"eta"<<'\t'<<"phi" "\t (|maxEta| = " << maxEta_ << ")" <<endl;
+    LogTrace("HLTMuonL1TFilter")<<"--------------------------------------------------------------------------"<<endl;
+
+    vector<MuonRef> firedMuons;
+    filterproduct.getObjects(TriggerL1Mu, firedMuons);
+    for(size_t i=0; i<firedMuons.size(); i++){
+      l1t::MuonRef mu = firedMuons[i]; 
+      LogTrace("HLTMuonL1TFilter")<<i<<'\t'<<setprecision(2) << scientific<<mu->charge() <<'\t' << mu->pt()<<'\t'<<fixed<<mu->eta()<<'\t'<<mu->phi()<<endl;
+    }
+    LogTrace("HLTMuonL1TFilter")<<"--------------------------------------------------------------------------"<<endl;
+    LogTrace("HLTMuonL1TFilter")<<"Decision of this filter is "<<accept<<", number of muons passing = "<<filterproduct.l1tmuonSize();
+  }
+
+  return accept;
+}

--- a/HLTrigger/Muon/src/SealModule.cc
+++ b/HLTrigger/Muon/src/SealModule.cc
@@ -1,6 +1,7 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
+#include "HLTrigger/Muon/interface/HLTMuonL1TFilter.h"
 #include "HLTrigger/Muon/interface/HLTMuonL1Filter.h"
 #include "HLTrigger/Muon/interface/HLTMuonL1RegionalFilter.h"
 #include "HLTrigger/Muon/interface/HLTMuonL2PreFilter.h"
@@ -15,6 +16,7 @@
 #include "HLTrigger/Muon/interface/HLTMuonTrkFilter.h"
 #include "HLTrigger/Muon/interface/HLTL1MuonSelector.h"
 #include "HLTrigger/Muon/interface/HLTScoutingMuonProducer.h"
+DEFINE_FWK_MODULE(HLTMuonL1TFilter);
 DEFINE_FWK_MODULE(HLTMuonL1Filter);
 DEFINE_FWK_MODULE(HLTMuonL1RegionalFilter);
 DEFINE_FWK_MODULE(HLTMuonL2PreFilter);

--- a/L1Trigger/L1TCommon/test/runHLT.py
+++ b/L1Trigger/L1TCommon/test/runHLT.py
@@ -10,13 +10,6 @@ from Configuration.StandardSequences.Eras import eras
 #process = cms.Process('L1SEQS',eras.Run2_25ns)
 process = cms.Process('L1SEQS',eras.Run2_2016)
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    destinations = cms.untracked.vstring('l1tdebug','cerr'),
-    l1tdebug = cms.untracked.PSet(threshold = cms.untracked.string('DEBUG')),
-    cerr = cms.untracked.PSet(threshold  = cms.untracked.string('WARNING')),
-    debugModules = cms.untracked.vstring('*'))
-
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -32,7 +25,14 @@ process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
-#
+#process.MessageLogger = cms.Service(
+#    "MessageLogger",
+#    destinations = cms.untracked.vstring('l1tdebug','cerr'),
+#    l1tdebug = cms.untracked.PSet(threshold = cms.untracked.string('DEBUG')),
+#    cerr = cms.untracked.PSet(threshold  = cms.untracked.string('WARNING')),
+#    debugModules = cms.untracked.vstring('*'))
+
+
 # LOCAL CONDITIONS NEEDED FOR RE-EMULATION OF GT
 #
 
@@ -81,6 +81,31 @@ process.HLTL1UnpackerSequence = cms.Sequence(
 # END HLT UNPACKER SEQUENCE FOR STAGE 2
 #
 
+#
+# BEGIN L1T SEEDS EXAMPLE FOR STAGE 2
+#
+
+
+process.hltL1TSeed = cms.EDFilter( "HLTL1TSeed",
+    L1SeedsLogicalExpression = cms.string( "L1_SingleS1Jet36 AND L1_SingleEG10" ),
+    SaveTags             = cms.bool( True ),
+    L1ObjectMapInputTag  = cms.InputTag("hltGtStage2ObjectMap"),
+    L1GlobalInputTag     = cms.InputTag("hltGtStage2Digis"),
+    L1MuonInputTag       = cms.InputTag("hltGmtStage2Digis"),
+    L1EGammaInputTag     = cms.InputTag("hltCaloStage2Digis"),
+    L1JetInputTag        = cms.InputTag("hltCaloStage2Digis"),
+    L1TauInputTag        = cms.InputTag("hltCaloStage2Digis"),
+    L1EtSumInputTag      = cms.InputTag("hltCaloStage2Digis"),
+)
+
+# HLT testing sequence
+process.HLTTesting  = cms.Sequence( 
+    process.hltL1TSeed 
+)
+
+#
+# END L1T SEEDS EXAMPLE FOR STAGE 2
+#
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10)
@@ -151,6 +176,7 @@ process.digitisation_step = cms.Path(process.pdigi_valid)
 process.L1simulation_step = cms.Path(process.SimL1Emulator)
 process.digi2raw_step = cms.Path(process.DigiToRaw)
 process.hlt_step = cms.Path(process.HLTL1UnpackerSequence)
+process.hlt_step2 = cms.Path(process.HLTTesting)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
@@ -161,14 +187,15 @@ process.load('L1Trigger.L1TCommon.l1tSummaryStage2SimDigis_cfi')
 process.load('L1Trigger.L1TCommon.l1tSummaryStage2HltDigis_cfi')
 
 process.debug_step = cms.Path(
+    process.dumpES + 
 #    process.dumpES + 
-#    process.dumpED +
+    process.dumpED +
     process.l1tSummaryStage2SimDigis +
     process.l1tSummaryStage2HltDigis
 )
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.hlt_step,process.debug_step,process.endjob_step,process.FEVTDEBUGHLToutput_step)
+process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.hlt_step,process.hlt_step2,process.debug_step,process.endjob_step,process.FEVTDEBUGHLToutput_step)
 
 #print "L1T Emulation Sequence is:  "
 #print process.SimL1Emulator


### PR DESCRIPTION
This is a replacement for #13277 after rebasing to latest CMSSW 8_0_X.

Updates the new HLT L1T Seed Module, needed for the 2016, including parsing of object map to determine seeds, low-level object fixes to ensure Trigger Filter Object with References (to L1T seeds) is successfully written to the event record with desired payload. (A number of technical problems with L1T objects were uncovered, and now fixed, when this module attempted to write edm::Ref of L1T BXVectors.)
