### PR TITLE
Make the checks and loading of missing dictionaries thread-safe

### DIFF
--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -26,15 +26,6 @@
 #include <ostream>
 
 namespace edm {
-  namespace {
-    void checkDicts(BranchDescription const& productDesc) {
-      if(productDesc.transient()) {
-        checkClassDictionaries(TypeID(productDesc.wrappedType().typeInfo()), false);
-      } else {
-        checkClassDictionaries(TypeID(productDesc.wrappedType().typeInfo()), true);
-      }
-    }
-  }
 
   ProductRegistry::ProductRegistry() :
       productList_(),
@@ -87,7 +78,6 @@ namespace edm {
                               bool fromListener) {
     assert(productDesc.produced());
     throwIfFrozen();
-    checkDicts(productDesc);
     std::pair<ProductList::iterator, bool> ret =
          productList_.insert(std::make_pair(BranchKey(productDesc), productDesc));
     if(!ret.second) {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -38,16 +38,18 @@ namespace edm {
   void
   maybeThrowMissingDictionaryException(TypeID const& productType, bool isElement, std::vector<TypeID> const& missingDictionaries) {
     if(isElement) {
+      TypeSet missingTypes;
       if(binary_search_all(missingDictionaries, productType)) {
-        checkTypeDictionary(productType);
-        throwMissingDictionariesException();
+        checkTypeDictionary(productType,missingTypes);
+        throwMissingDictionariesException(missingTypes);
       }
     } else {
       TClass* cl = TClass::GetClass(wrappedClassName(productType.className()).c_str());
       TypeID wrappedProductType = TypeID(cl->GetTypeInfo());
+      TypeSet missingTypes;
       if(binary_search_all(missingDictionaries, wrappedProductType)) {
-        checkClassDictionary(wrappedProductType);
-        throwMissingDictionariesException();
+        checkClassDictionary(wrappedProductType,missingTypes);
+        throwMissingDictionariesException(missingTypes);
       }
     }
   }

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -20,7 +20,6 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 
 #include "boost/graph/graph_traits.hpp"
 #include "boost/graph/adjacency_list.hpp"
@@ -453,8 +452,6 @@ namespace edm {
     });
     // Now that the output workers are filled in, set any output limits or information.
     limitOutput(proc_pset, branchIDListHelper.branchIDLists());
-
-    loadMissingDictionaries();
 
     // Sanity check: make sure nobody has added a worker after we've
     // already relied on the WorkerManager being full.

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -102,7 +102,6 @@ namespace edm {
     }
     
     for_all(allWorkers_, std::bind(&Worker::beginJob, std::placeholders::_1));
-    loadMissingDictionaries();
   }
 
   void

--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -20,13 +20,12 @@ class TypeID;
 class TypeWithDict;
 using TypeSet = std::set<TypeID>;
 
-bool checkClassDictionary(TypeID const& type);
-void checkClassDictionaries(TypeID const& type, bool recursive = true);
-bool checkTypeDictionary(TypeID const& type);
-void checkTypeDictionaries(TypeID const& type, bool recursive = true);
-void throwMissingDictionariesException();
-void loadMissingDictionaries();
-TypeSet& missingTypes();
+bool checkClassDictionary(TypeID const& type, TypeSet& missingTypes);
+void checkClassDictionaries(TypeID const& type, TypeSet& missingTypes, bool recursive = true);
+bool checkTypeDictionary(TypeID const& type, TypeSet& missingTypes);
+void checkTypeDictionaries(TypeID const& type, TypeSet& missingTypes, bool recursive = true);
+void throwMissingDictionariesException(TypeSet const&);
+void loadMissingDictionaries(TypeSet missingTypes);
 
 void public_base_classes(TypeWithDict const& type,
                          std::vector<TypeWithDict>& baseTypes);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -88,13 +88,6 @@ namespace edm {
   }
 
   void PoolOutputModule::beginJob() {
-    for(int i = InEvent; i < NumBranchTypes; ++i) {
-      BranchType branchType = static_cast<BranchType>(i);
-      SelectedProducts const& keptVector = keptProducts()[branchType];
-      for(auto const& prod : keptVector) {
-        checkClassDictionaries(TypeID(prod->wrappedType().typeInfo()), false);
-      }
-    }
   }
 
   std::string const& PoolOutputModule::currentFileName() const {

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -15,11 +15,10 @@
 
 namespace edm {
   void loadType(TypeID const& type) {
-    checkClassDictionaries(type, true);
-    if (!missingTypes().empty()) {
-      TypeSet missing = missingTypes();
-      missingTypes().clear();
-      for_all(missing, loadType);
+    TypeSet missingTypes;
+    checkClassDictionaries(type,missingTypes,true);
+    if (!missingTypes.empty()) {
+      for_all(missingTypes, loadType);
     }
   }
 


### PR DESCRIPTION
Removed the use of a non-thread-safe global list of missing dictionaries. Now centralized checking and loading missing dictionaries to allow only a local list of missing dictionaries.
