### PR TITLE
Removed unused arguments from printCmsExceptionWarning

### DIFF
--- a/FWCore/MessageLogger/interface/ExceptionMessages.h
+++ b/FWCore/MessageLogger/interface/ExceptionMessages.h
@@ -9,6 +9,6 @@ namespace edm {
   class JobReport;
 
   void printCmsException(cms::Exception& e, edm::JobReport * jobRep = 0, int rc = -1);
-  void printCmsExceptionWarning(char const* behavior, cms::Exception const& e, edm::JobReport * jobRep = 0, int rc = -1);
+  void printCmsExceptionWarning(char const* behavior, cms::Exception const& e);
 }
 #endif

--- a/FWCore/MessageLogger/src/ExceptionMessages.cc
+++ b/FWCore/MessageLogger/src/ExceptionMessages.cc
@@ -25,7 +25,7 @@ namespace edm {
   }
 
   void
-  printCmsExceptionWarning(char const* behavior, cms::Exception const& e, edm::JobReport * jobRep, int rc) try {
+  printCmsExceptionWarning(char const* behavior, cms::Exception const& e) try {
     std::string shortDesc(behavior);
     shortDesc += " Exception";
     std::ostringstream longDesc;
@@ -36,7 +36,6 @@ namespace edm {
       << "-----------------------\n"
       << longDesc.str()
       << "----- End " << shortDesc << " -------------------------------------------------";
-    if(jobRep) jobRep->reportError(shortDesc, longDesc.str(), rc);
   } catch(...) {
   }
 }


### PR DESCRIPTION
The optional arguments to printCmsExceptionWarning where never used so they have been removed.
