### PR TITLE
Add back support for L1 tech triggers before stage-2

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.SimL1Emulator_cff import *
+from Configuration.StandardSequences.Eras import eras
 
 # Modifications for DataMixer input:
 simDtTriggerPrimitiveDigis.digiTag = 'mixData'
@@ -13,3 +14,5 @@ simRpcTechTrigDigis.RPCDigiLabel = 'mixData'
 simHcalTechTrigDigis.ttpDigiCollection = "DMHcalTTPDigis"
 simRctDigis.hcalDigis=cms.VInputTag(cms.InputTag("DMHcalTriggerPrimitiveDigis"))
 simRctDigis.ecalDigis=cms.VInputTag(cms.InputTag("DMEcalTriggerPrimitiveDigis"))
+
+

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -29,25 +29,7 @@ import FWCore.ParameterSet.Config as cms
 # so these missing (required!) inputs are presently ignored by downstream modules.
 #
 
-# Ignoring Technical Triggers for now...
-
-# BSC Technical Trigger
-#import L1TriggerOffline.L1Analyzer.bscTrigger_cfi
-#simBscDigis = L1TriggerOffline.L1Analyzer.bscTrigger_cfi.bscTrigger.clone()
-
-# RPC Technical Trigger
-#import L1Trigger.RPCTechnicalTrigger.rpcTechnicalTrigger_cfi
-#simRpcTechTrigDigis = L1Trigger.RPCTechnicalTrigger.rpcTechnicalTrigger_cfi.rpcTechnicalTrigger.clone()
-
-#simRpcTechTrigDigis.RPCDigiLabel = 'simMuonRPCDigis'
-
-# HCAL Technical Trigger
-#import SimCalorimetry.HcalTrigPrimProducers.hcalTTPRecord_cfi
-#simHcalTechTrigDigis = SimCalorimetry.HcalTrigPrimProducers.hcalTTPRecord_cfi.simHcalTTPRecord.clone()
-
-# CASTOR Techical Trigger
-#import SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi
-#simCastorTechTrigDigis = SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi.simCastorTTRecord.clone()
+from L1Trigger.Configuration.SimL1TechnicalTriggers_cff import *
 
 from L1Trigger.L1TCalorimeter.simDigis_cff import *
 from L1Trigger.L1TMuon.simDigis_cff import *
@@ -57,7 +39,7 @@ from L1Trigger.L1TGlobal.simDigis_cff import *
 SimL1EmulatorCore = cms.Sequence(
     SimL1TCalorimeter +
     SimL1TMuon +
-#    SimL1TTechnical +
+    SimL1TechnicalTriggers +
     SimL1TGlobal
     )
 

--- a/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
+++ b/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+SimL1TechnicalTriggers = cms.Sequence()
+
+# BSC Technical Trigger
+import L1TriggerOffline.L1Analyzer.bscTrigger_cfi
+simBscDigis = L1TriggerOffline.L1Analyzer.bscTrigger_cfi.bscTrigger.clone()
+
+# RPC Technical Trigger
+import L1Trigger.RPCTechnicalTrigger.rpcTechnicalTrigger_cfi
+simRpcTechTrigDigis = L1Trigger.RPCTechnicalTrigger.rpcTechnicalTrigger_cfi.rpcTechnicalTrigger.clone()
+
+simRpcTechTrigDigis.RPCDigiLabel = 'simMuonRPCDigis'
+
+# HCAL Technical Trigger
+import SimCalorimetry.HcalTrigPrimProducers.hcalTTPRecord_cfi
+simHcalTechTrigDigis = SimCalorimetry.HcalTrigPrimProducers.hcalTTPRecord_cfi.simHcalTTPRecord.clone()
+
+# CASTOR Techical Trigger
+import SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi
+simCastorTechTrigDigis = SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi.simCastorTTRecord.clone()
+
+if not (eras.stage2L1Trigger.isChosen()):
+    SimL1TechnicalTriggers = cms.Sequence( 
+        simBscDigis + 
+        simRpcTechTrigDigis + 
+        simHcalTechTrigDigis +
+        simCastorTechTrigDigis )
+


### PR DESCRIPTION
Fix for relvals failing due to lack of support for legacy L1 tech triggers since standard sequence update.

It appears SimL1EmulatorDM_cff.py likely still need a minor update to work in 2016 scenarios (this slipped by me since not in PR RelVal tests.)
