### PR TITLE
Add back RCT digi packing for Stage-1 in L1T standard sequences

### DIFF
--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -54,9 +54,10 @@ if eras.stage1L1Trigger.isChosen() and not eras.stage2L1Trigger.isChosen():
     l1GtPack.MuGmtInputTag = 'simGmtDigis'
 
     # Initially, the stage-1 was packed via GCT... this is no longer needed.
-    #from EventFilter.GctRawToDigi.gctDigiToRaw_cfi import *
-    #gctDigiToRaw.gctInputLabel = 'simCaloStage1LegacyFormatDigis'
-    #gctDigiToRaw.rctInputLabel = 'simRctDigis'
+    # (but still needed for RCT digis!)
+    from EventFilter.GctRawToDigi.gctDigiToRaw_cfi import *
+    gctDigiToRaw.gctInputLabel = 'simCaloStage1LegacyFormatDigis'
+    gctDigiToRaw.rctInputLabel = 'simRctDigis'
     from EventFilter.L1TRawToDigi.caloStage1Raw_cfi import *
     L1TDigiToRaw = cms.Sequence(csctfpacker+dttfpacker+l1GtPack+caloStage1Raw)
 


### PR DESCRIPTION
This was omitted by mistake from standard sequences due to confusion about role of GCT packer. 

Now it is added back, which should fix several Stage-1 RelVal errors.
