### PR TITLE
Bugfix for L1T OMTF emulator, fixing crash at run transition

### DIFF
--- a/L1Trigger/L1TMuonOverlap/interface/OMTFProcessor.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFProcessor.h
@@ -63,6 +63,9 @@ class OMTFProcessor{
   
  private:
 
+  ///Reset all configuration parameters
+  void resetConfiguration();
+
   ///Add GoldenPattern to pattern map.
   ///If GP key already exists in map, a new entry is ignored
   bool addGP(GoldenPattern *aGP);

--- a/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
@@ -30,7 +30,8 @@ OMTFProcessor::OMTFProcessor(const edm::ParameterSet & theConfig){
     for(auto it: theConfig.getParameter<std::vector<edm::ParameterSet> >("patternsXMLFiles")){
       fileNames.push_back(it.getParameter<edm::FileInPath>("patternsXMLFile").fullPath());
     }  
-    
+
+    resetConfiguration();
     XMLConfigReader myReader;
     for(auto it: fileNames){
       myReader.setPatternsFile(it);
@@ -47,7 +48,16 @@ OMTFProcessor::~OMTFProcessor(){
 }
 ///////////////////////////////////////////////
 ///////////////////////////////////////////////
+void OMTFProcessor::resetConfiguration(){
+
+  myResults.clear();
+  theGPs.clear();
+}
+///////////////////////////////////////////////
+///////////////////////////////////////////////
 bool OMTFProcessor::configure(XMLConfigReader *aReader){
+
+  resetConfiguration();
 
   myResults.assign(OMTFConfiguration::nTestRefHits,OMTFProcessor::resultsMap());
 
@@ -62,6 +72,8 @@ bool OMTFProcessor::configure(XMLConfigReader *aReader){
 ///////////////////////////////////////////////
 bool OMTFProcessor::configure( std::shared_ptr<L1TMuonOverlapParams> omtfParams){
 
+  resetConfiguration();
+  
   myResults.assign(OMTFConfiguration::nTestRefHits,OMTFProcessor::resultsMap());
   
   l1t::LUT* chargeLUT =  omtfParams->chargeLUT();


### PR DESCRIPTION
Add a configuration reset before loading a new OMTF configuration, to fix crash which otherwise results.
