### PR TITLE
Ep combination protection reco 76

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -93,6 +93,7 @@ private:
   edm::InputTag vtxTag_;
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   edm::Handle<reco::VertexCollection> vtxH_;
+  bool applyExtraHighEnergyProtection_;
 
   const edm::EventSetup* iSetup_;
 
@@ -112,6 +113,7 @@ EGExtraInfoModifierFromDB::EGExtraInfoModifierFromDB(const edm::ParameterSet& co
 
   bunchspacing_ = 450;
   autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
+  applyExtraHighEnergyProtection_ = conf.getParameter<bool>("applyExtraHighEnergyProtection");
 
   rhoTag_ = conf.getParameter<edm::InputTag>("rhoCollection");
   vtxTag_ = conf.getParameter<edm::InputTag>("vertexCollection");
@@ -531,7 +533,9 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
   // CODE FOR STANDARD BDT
   double weight = 0.;
   if ( eOverP > 0.025 && 
-       std::abs(ep-ecor) < 15.*std::sqrt( momentumError*momentumError + sigmacor*sigmacor ) ) {
+       std::abs(ep-ecor) < 15.*std::sqrt( momentumError*momentumError + sigmacor*sigmacor ) &&
+       (!applyExtraHighEnergyProtection_ || ((momentumError < 10.*ep) || (ecor < 200.)))
+       ) {
     // protection against crazy track measurement
     weight = ep_forestH_weight_->GetResponse(eval_ep);
     if(weight>1.) 

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 regressionModifier = \
     cms.PSet( modifierName    = cms.string('EGExtraInfoModifierFromDB'),  
               autoDetectBunchSpacing = cms.bool(True),
+              applyExtraHighEnergyProtection = cms.bool(False),
               bunchSpacingTag = cms.InputTag("bunchSpacingProducer"),
               manualBunchSpacing = cms.int32(50),              
               rhoCollection = cms.InputTag("fixedGridRhoFastjetAll"),


### PR DESCRIPTION
Similar to #13293, but also in reco part (the reason I am submitting as a different PR is that some of the analysis PR have been already merged).

The W' group reported that the electron Ep combination was returning unphysical values at high energies when the track pT was consistent with 0. We added a protection in the combination code to only use the Ep combination MVA at high energies when the track pT error is smaller than 10 times the track pT. It is a pretty safe cut that removes these badly measured tracks from the determination of the electron energy.

Reference: https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3446/1/1/1/1.html
