### PR TITLE
Remove custom dynamic loader from any SLC version, expect SLC6

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<architecture name="slc[6-9]_amd64">
+<architecture name="slc6_amd64">
   <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
 </architecture>
 <release name=".*_ASAN_.*">

--- a/FWCore/ParameterSet/bin/BuildFile.xml
+++ b/FWCore/ParameterSet/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<architecture name="slc[6-9]_amd64">
+<architecture name="slc6_amd64">
  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
 </architecture>
 <release name=".*_ASAN_.*">

--- a/FWCore/PluginManager/bin/BuildFile.xml
+++ b/FWCore/PluginManager/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<architecture name="slc[6-9]_amd64">
+<architecture name="slc6_amd64">
   <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
 </architecture>
 <release name=".*_ASAN_.*">

--- a/HLTrigger/Tools/bin/BuildFile.xml
+++ b/HLTrigger/Tools/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<architecture name="slc[6-9]_amd64">
+<architecture name="slc6_amd64">
   <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
 </architecture>
 


### PR DESCRIPTION
The following bugs has been backported to RHEL 7.2 on our request:
- BZ #13862 // Reuse of cached stack can cause bounds overrun of thread
  DTV
- BZ #17090 // Assertion failure (map->l_tls_modid == cnt) when
  dlopen()ing initial-exec TLS shared objects under certain circumstances
- BZ #17620 // DTV_SURPLUS limits loading of Static TLS-requiring modules
  in multi-threaded programs
- BZ #17621 // DTV update for Static TLS dlopened modules is racy
- BZ #17628 // nptl_db's td_thr_tls\* don't check DTV generation

There is no need to continue shipping a custom version of dynamic loader
for CentOS 7.2.1511 or above.

All the fixes are within glibc-rh1189278.patch and glibc-rh1202952.patch
on glibc source RPM.

Will resolve cmsRun segfaults on CentOS 7.2.1511.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
