### PR TITLE
Quiet errors from missing RCT payload, which is expected for MC

### DIFF
--- a/EventFilter/RctRawToDigi/plugins/RctRawToDigi.cc
+++ b/EventFilter/RctRawToDigi/plugins/RctRawToDigi.cc
@@ -80,8 +80,12 @@ void RctRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     //check header size
     if ( rctRcd.size() < sLinkHeaderSize_ + sLinkTrailerSize_ + amc13HeaderSize_ + amc13TrailerSize_ + MIN_DATA) {
-      LogError("L1T") << "Cannot unpack: empty/invalid L1T raw data (size = "
-		      << rctRcd.size() << ") for ID " << fedId_ << ". Returning empty collections!";
+      if (rctRcd.size() > 0) {
+	LogError("L1T") << "Cannot unpack: empty/invalid L1T raw data (size = "
+			<< rctRcd.size() << ") for ID " << fedId_ << ". Returning empty collections!";
+      } else {
+	// there's no MC packer for this payload, so totally expected that sometimes it will be absent... no warning issued.
+      }
       //continue;
       return;
     }


### PR DESCRIPTION
For Stage-1 (2015) RCT readout capability was added, and an unpacker, but an MC emulation for this payload was never developed.  This PR quiets errors from the resulting oft-encountered situation that the RCT payload is missing.

This is of little interest to anyone!
