### PR TITLE
Add const-correct physical-value-only EtSumHelper and L1T demo

### DIFF
--- a/DataFormats/L1Trigger/interface/EtSumHelper.h
+++ b/DataFormats/L1Trigger/interface/EtSumHelper.h
@@ -1,0 +1,28 @@
+//
+// EtSumHelper:  Helper Class for Interpreting L1T EtSum output
+// 
+
+#ifndef L1T_ETSUMHELPER_H
+#define L1T_ETSUMHELPER_H
+
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+
+namespace l1t {
+
+  class EtSumHelper{
+  public:
+    EtSumHelper(const edm::Handle<l1t::EtSumBxCollection> & sum ):sum_(sum) {} // class assumes sum has been checked to be valid. 
+    double MissingEt() const;
+    double MissingEtPhi() const;
+    double MissingHt() const;
+    double MissingHtPhi() const;
+    double TotalEt() const;
+    double TotalHt() const;
+
+  private:
+    const edm::Handle<l1t::EtSumBxCollection> & sum_;
+  };
+}
+
+#endif
+

--- a/DataFormats/L1Trigger/src/EtSumHelper.cc
+++ b/DataFormats/L1Trigger/src/EtSumHelper.cc
@@ -1,0 +1,48 @@
+
+#include "DataFormats/L1Trigger/interface/EtSumHelper.h"
+
+using namespace l1t;
+
+
+double EtSumHelper::MissingEt() const {
+  for (auto it=sum_->begin(0); it!=sum_->end(0); it++){      
+    if (it->getType() == EtSum::kMissingEt) return it->et();
+  }
+  return -999.0;
+}  
+
+double EtSumHelper::MissingEtPhi() const {
+  for (auto it=sum_->begin(0); it!=sum_->end(0); it++){      
+    if (it->getType() == EtSum::kMissingEt) return it->phi();
+  }
+  return -999.0;
+}  
+
+double EtSumHelper::MissingHt() const {
+  for (auto it=sum_->begin(0); it!=sum_->end(0); it++){      
+    if (it->getType() == EtSum::kMissingHt) return it->et();
+  }
+  return -999.0;
+}  
+
+double EtSumHelper::MissingHtPhi() const {
+  for (auto it=sum_->begin(0); it!=sum_->end(0); it++){      
+    if (it->getType() == EtSum::kMissingHt) return it->phi();
+  }
+  return -999.0;
+}  
+
+double EtSumHelper::TotalEt() const {
+  for (auto it=sum_->begin(0); it!=sum_->end(0); it++){      
+    if (it->getType() == EtSum::kTotalEt) return it->et();
+  }
+  return -999.0;
+}  
+
+double EtSumHelper::TotalHt() const {
+  for (auto it=sum_->begin(0); it!=sum_->end(0); it++){      
+    if (it->getType() == EtSum::kTotalHt) return it->et();
+  }
+  return -999.0;
+}  
+

--- a/L1Trigger/L1TCommon/plugins/L1TBasicDemo.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TBasicDemo.cc
@@ -1,0 +1,151 @@
+// -*- C++ -*-
+//
+// L1TBasicDemo:  demonstrate basic access of L1T objects
+// 
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/L1Trigger/interface/EtSumHelper.h"
+
+// leaving out the following namespaces, so namespaces are explicit in the demo code:
+// using namespace l1t;
+// using namespace edm;
+
+class L1TBasicDemo : public edm::EDAnalyzer {
+public:
+  explicit L1TBasicDemo(const edm::ParameterSet&);
+  ~L1TBasicDemo();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+private:
+
+  virtual void analyze(edm::Event const&, edm::EventSetup const&);
+
+  // EDM tokens:
+  edm::EDGetTokenT<l1t::EGammaBxCollection> egToken_;
+  edm::EDGetTokenT<l1t::TauBxCollection>    tauToken_;
+  edm::EDGetTokenT<l1t::JetBxCollection>    jetToken_;
+  edm::EDGetTokenT<l1t::EtSumBxCollection>  sumToken_;
+  edm::EDGetTokenT<l1t::MuonBxCollection>   muonToken_;
+
+  int trigger_bx_only;
+
+};
+
+L1TBasicDemo::L1TBasicDemo(const edm::ParameterSet& iConfig) { 
+  egToken_   = consumes<l1t::EGammaBxCollection> (iConfig.getParameter<edm::InputTag>("EgTag"));
+  tauToken_  = consumes<l1t::TauBxCollection>    (iConfig.getParameter<edm::InputTag>("TauTag"));
+  jetToken_  = consumes<l1t::JetBxCollection>    (iConfig.getParameter<edm::InputTag>("JetTag"));
+  sumToken_  = consumes<l1t::EtSumBxCollection>  (iConfig.getParameter<edm::InputTag>("SumTag"));
+  muonToken_ = consumes<l1t::MuonBxCollection>   (iConfig.getParameter<edm::InputTag>("MuonTag"));
+  trigger_bx_only = iConfig.getParameter<bool>("UseTriggerBxOnly");
+}
+
+
+L1TBasicDemo::~L1TBasicDemo(){}
+
+void 
+L1TBasicDemo::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)
+{
+  cout << "INFO:  dumping EGamma BX collection:\n";
+  edm::Handle<l1t::EGammaBxCollection> eg;    
+  iEvent.getByToken(egToken_, eg);
+  if (eg.isValid()){ 
+    for (int ibx = eg->getFirstBX(); ibx <= eg->getLastBX(); ++ibx) {
+      if (trigger_bx_only && (ibx != 0)) continue;  
+      for (auto it=eg->begin(ibx); it!=eg->end(ibx); it++){      
+	if (it->et() == 0) continue; // if you don't care about L1T candidates with zero ET.
+	cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
+      }
+    }
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade e-gamma bx collection not found." << std::endl;
+  }
+
+  cout << "INFO:  dumping Tau BX collection:\n";
+  edm::Handle<l1t::TauBxCollection> tau;    
+  iEvent.getByToken(tauToken_, tau);
+  if (tau.isValid()){ 
+    for (int ibx = tau->getFirstBX(); ibx <= tau->getLastBX(); ++ibx) {
+      if (trigger_bx_only && (ibx != 0)) continue;  
+      for (auto it=tau->begin(ibx); it!=tau->end(ibx); it++){      
+	if (it->et() == 0) continue; // if you don't care about L1T candidates with zero ET.
+	cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
+      }
+    }
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade tau bx collection not found." << std::endl;
+  }
+
+  cout << "INFO:  dumping Jet BX collection:\n";
+  edm::Handle<l1t::JetBxCollection> jet;    
+  iEvent.getByToken(jetToken_, jet);
+  if (jet.isValid()){ 
+    for (int ibx = jet->getFirstBX(); ibx <= jet->getLastBX(); ++ibx) {
+      if (trigger_bx_only && (ibx != 0)) continue;  
+      for (auto it=jet->begin(ibx); it!=jet->end(ibx); it++){      
+	if (it->et() == 0) continue; // if you don't care about L1T candidates with zero ET.
+	cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
+      }
+    }
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade jet bx collection not found." << std::endl;
+  }
+
+  cout << "INFO:  dumping EtSum BX collection:\n";
+  edm::Handle<l1t::EtSumBxCollection> sum;    
+  iEvent.getByToken(sumToken_, sum);
+  if (sum.isValid()){ 
+    l1t::EtSumHelper hsum(sum);
+    cout << "met:     " << hsum.MissingEt() << "\n";
+    cout << "met phi: " << hsum.MissingEtPhi() << "\n";
+    cout << "mht:     " << hsum.MissingHt() << "\n";
+    cout << "mht phi: " << hsum.MissingHtPhi() << "\n";
+    cout << "sum et:  " << hsum.TotalEt() << "\n";
+    cout << "sum ht:  " << hsum.TotalHt() << "\n";
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade sum bx collection not found." << std::endl;
+  }
+
+  cout << "INFO:  dumping Muon BX collection:\n";
+  edm::Handle<l1t::MuonBxCollection> muon;    
+  iEvent.getByToken(muonToken_, muon);
+  if (muon.isValid()){ 
+    for (int ibx = muon->getFirstBX(); ibx <= muon->getLastBX(); ++ibx) {
+      if (trigger_bx_only && (ibx != 0)) continue;  
+      for (auto it=muon->begin(ibx); it!=muon->end(ibx); it++){      
+	if (it->et() == 0) continue; // if you don't care about L1T candidates with zero ET.
+	cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
+      }
+    }
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade muon bx collection not found." << std::endl;
+  }
+}
+
+
+
+
+
+
+void
+L1TBasicDemo::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+
+DEFINE_FWK_MODULE(L1TBasicDemo);

--- a/L1Trigger/L1TCommon/python/customiseDemo.py
+++ b/L1Trigger/L1TCommon/python/customiseDemo.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+import os
+
+##############################################################################
+# customisations for L1T demos
+#
+# Add demonstration modules to cmsDriver customs.
+#
+##############################################################################
+
+def L1TBasicDemo(process):
+    print "L1T INFO:  adding basic demo module to the process."
+    process.load('L1Trigger.L1TCommon.l1tBasicDemo_cfi')
+    process.l1tBasicDemoPath = cms.Path(process.l1tBasicDemo)
+    process.schedule.append(process.l1tBasicDemoPath)
+    return process
+

--- a/L1Trigger/L1TCommon/python/l1tBasicDemo_cfi.py
+++ b/L1Trigger/L1TCommon/python/l1tBasicDemo_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tBasicDemo = cms.EDAnalyzer(
+    "L1TBasicDemo",
+    UseTriggerBxOnly = cms.bool(True),
+    EgTag            = cms.InputTag("caloStage2Digis"),
+    TauTag           = cms.InputTag("caloStage2Digis"),
+    JetTag           = cms.InputTag("caloStage2Digis"),
+    SumTag           = cms.InputTag("caloStage2Digis"),
+    MuonTag          = cms.InputTag("gmtStage2Digis", ""),
+)
+
+


### PR DESCRIPTION
This PR replaces #13312.

This is for downstream consumers of the L1T output. A Helper class for interpreting somewhat confusing new format for the L1T EtSums is provided, along with demonstration code for all of L1T upgrade objects.

This version is const-correct and only accesses physical ET values.
