### PR TITLE
With one letter, fix a subtle configuration bug

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -233,7 +233,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet) :
     unsigned int temp_numberPhysTriggers = 512;
  
     // Get prescale factors from CSV file for now
-    std::fstream inputPrescaleFile;
+    std::ifstream inputPrescaleFile;
     inputPrescaleFile.open(m_prescalesFile);
 
     std::vector<std::vector<int> > vec;


### PR DESCRIPTION
The configuration in L1TGlobal was failing when taken from the release, but working when local.

The configuration files all used edm::FileInPath(...) properly, so what gives?

It turns out a config files was being opened as fstream (instead of ifstream).  When local, with write access, this works.  When in release, this fails, due to no write access.

This is my first one letter pull request.
