### PR TITLE
Resolve ambiguity with TColor ctors

### DIFF
--- a/Fireworks/Core/src/FWColorManager.cc
+++ b/Fireworks/Core/src/FWColorManager.cc
@@ -227,7 +227,7 @@ void FWColorManager::initialize()
       ++it) {
     //NOTE: this constructor automatically places this color into the gROOT color list
     //std::cout <<" color "<< index <<" "<<(*it)[0]<<" "<<(*it)[1]<<" "<<(*it)[2]<<std::endl;
-    new TColor(index++,(*it)[0],(*it)[1],(*it)[2]);
+    new TColor(static_cast<Int_t>(index++),(*it)[0],(*it)[1],(*it)[2]);
   }
 }
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -153,7 +153,7 @@ void ListGroups::fillGradient(void)
   m_gradient.push_back(kBlue + 4); // Underflow lowest bin
   unsigned int ii = 0;
   for (unsigned int i = 0; i < steps; ++i, ++ii) {
-    new TColor(index + ii, r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
+    new TColor(static_cast<Int_t>(index + ii), r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
     m_gradient.push_back(index + ii);
   }
 
@@ -165,7 +165,7 @@ void ListGroups::fillGradient(void)
   delta_g = (g2 - g1) / (steps - 1);
   delta_b = (b2 - b1) / (steps - 1);
   for (unsigned int i = 0; i < steps; ++i, ++ii) {
-    new TColor(index + ii, r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
+    new TColor(static_cast<Int_t>(index + ii), r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
     m_gradient.push_back(index + ii);
   }
   m_gradient.push_back(kRed); // Overflow highest bin

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialPlotter.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialPlotter.cc
@@ -88,7 +88,7 @@ unsigned int TrackingMaterialPlotter::fill_gradient(const TColor & first, const 
 
   m_gradient.resize(steps);
   for (unsigned int i = 0; i < steps; ++i) {
-    new TColor(index + i, r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
+    new TColor(static_cast<Int_t>(index + i), r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
     m_gradient[i] = index + i;
   }
 


### PR DESCRIPTION
With recent change in ROOT: https://root.cern.ch/gitweb?p=root.git;a=commitdiff;h=8ebf9227adcf410134a5733086616ed70de55da3
We gained additional TColor ctor. The problem in CMSSW was that the
first argument was neither Int_t nor Float_t. It all 4 places it was
unsinged int. According to the compiler both TColor ctors are valid, it
can call either of them.

We have to be more explicit that we want the first ctor. Thus cast the
first argument to Int_t to match the first ctor signature.

This does not change behaviour, that was previously done by the compiler.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
