### PR TITLE
Make Calo Jet/EGamma/Tau packing consistent with unpacking, wrt HW Eta

### DIFF
--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/EGammaPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/EGammaPacker.cc
@@ -30,10 +30,15 @@ namespace stage2 {
       for (int i = egs->getFirstBX(); i <= egs->getLastBX(); ++i) {
 	
 	for (auto j = egs->begin(i); j != egs->end(i); ++j) {
+
+	  uint32_t packed_eta = abs(j->hwEta()) & 0x7F;
+	  if (j->hwEta() < 0){
+	    packed_eta = (128 - packed_eta) | 1<<7;
+	  }
+
 	  uint32_t word =					\
 	    std::min(j->hwPt(), 0x1FF) |
-	    (abs(j->hwEta()) & 0x7F) << 9 |
-	    ((j->hwEta() < 0) & 0x1) << 16 |
+	    packed_eta << 9 |
 	    (j->hwPhi() & 0xFF) << 17 |
 	    (j->hwIso() & 0x1) << 25 |
 	    (j->hwQual() & 0x7) << 26;

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/JetPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/JetPacker.cc
@@ -33,10 +33,14 @@ namespace stage2 {
 	 // get jets from this BX
 	for (auto j = jets->begin(i); j != jets->end(i); ++j ) {
 
+	  uint32_t packed_eta = abs(j->hwEta()) & 0x7F;
+	  if (j->hwEta() < 0){
+	    packed_eta = (128 - packed_eta) | 1<<7;
+	  }
+
 	  uint32_t word =			\
 	    std::min(j->hwPt(), 0x7FF) |
-	    (abs(j->hwEta()) & 0x7F) << 11 |
-	    ((j->hwEta() < 0) & 0x1) << 18 |
+	    packed_eta << 11 |
 	    (j->hwPhi() & 0xFF) << 19 |
 	    (j->hwQual() & 0x7) << 27;
 	  

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/TauPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/TauPacker.cc
@@ -31,10 +31,14 @@ namespace stage2 {
 
 	for (auto j = taus->begin(i); j != taus->end(i); ++j) {
 
+	    uint32_t packed_eta = abs(j->hwEta()) & 0x7F;
+	    if (j->hwEta() < 0){
+	       packed_eta = (128 - packed_eta) | 1<<7;
+	    }
+
             uint32_t word = \
                             std::min(j->hwPt(), 0x1FF) |
-                            (abs(j->hwEta()) & 0x7F) << 9 |
-                            ((j->hwEta() < 0) & 0x1) << 16 |
+                            packed_eta << 9 |
                             (j->hwPhi() & 0xFF) << 17 |
                             (j->hwIso() & 0x1) << 25 |
                             (j->hwQual() & 0x7) << 26;


### PR DESCRIPTION
This makes the packing of hardware eta for Calo Stage2 objects consistent with the firmware and unpacker.
