### PR TITLE
Implementation of online regression

### DIFF
--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -332,7 +332,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
     psd0.add<std::string>("uncertaintyKeyEB","pfscecal_EBUncertainty_offline_v1");
     psd0.add<std::string>("uncertaintyKeyEE","pfscecal_EEUncertainty_offline_v1");
     psd0.add<edm::InputTag>("vertexCollection",edm::InputTag("offlinePrimaryVertices")); 
-    psd0.add<double>("etRecHitThreshold", 1.);
+    psd0.add<double>("eRecHitThreshold", 1.);
     desc.add<edm::ParameterSetDescription>("regressionConfig",psd0);
   }
   desc.add<bool>("applyCrackCorrections",false);

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -70,6 +70,6 @@ class SCEnergyCorrectorSemiParm {
  private:
   bool isHLT_;
   int nHitsAboveThreshold_;
-  float etThreshold_;
+  float eThreshold_;
 };
 #endif


### PR DESCRIPTION
Implementation of the "high level" energy corrections for EGM objects at HLT.
This PR doesn't have any impact on the offline reconstruction; to be activated at HLT require a modification of the menu (i.e. useRegression = True).
In parallel the integration of the corresponding payloads into the GT have been requested.

Performance of the regression have been already tested on Run2015D RAW, see comparison below (black 2015 Z invariant-mass, blue new invariant-mass with regression).
![invmass_regr](https://cloud.githubusercontent.com/assets/4493857/13126667/b4acecec-d5cb-11e5-945f-00fd8331e5e0.png)
@Martin-Grunewald @perrotta @fwyzard 

Automatically ported from CMSSW_8_0_X #13333 (original by @matteosan1).
