### PR TITLE
Validation module for ME0 Detector (Phase2 Upgrade)

### DIFF
--- a/Validation/MuonME0Validation/BuildFile.xml
+++ b/Validation/MuonME0Validation/BuildFile.xml
@@ -1,0 +1,20 @@
+<use name="boost"/>
+<use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/GEMDigi"/>
+<use name="DataFormats/GEMRecHit"/>
+<use name="DataFormats/Scalers"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/GEMGeometry"/>
+<use name="Geometry/CommonTopologies"/>
+<use name="SimDataFormats/TrackingHit"/>
+<use name="SimDataFormats/Track"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="DQMServices/Core"/>
+<use name="rootcore"/>
+<export>
+   <lib name="1"/>
+</export>

--- a/Validation/MuonME0Validation/interface/ME0BaseValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0BaseValidation.h
@@ -1,0 +1,41 @@
+#ifndef ME0BaseValidation_H
+#define ME0BaseValidation_H
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/ME0EtaPartitionSpecs.h"
+#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+
+class ME0BaseValidation : public DQMEDAnalyzer
+{
+public:
+  explicit ME0BaseValidation( const edm::ParameterSet& ps );
+  virtual ~ME0BaseValidation();
+  virtual void analyze(const edm::Event& e, const edm::EventSetup&) = 0 ;
+  MonitorElement* BookHistZR( DQMStore::IBooker &, const char* name, const char* label, unsigned int region_num, unsigned int layer_num =99 ); 
+  MonitorElement* BookHistXY( DQMStore::IBooker &, const char* name, const char* label, unsigned int region_num, unsigned int layer_num =99 ); 
+protected:
+  std::vector< std::string > regionLabel;
+  std::vector< std::string > layerLabel;
+  std::vector<double> nBinZR_;
+  std::vector<double> RangeZR_;
+  edm::EDGetToken InputTagToken_;
+  int nBinXY_;
+
+private :
+};
+
+#endif

--- a/Validation/MuonME0Validation/interface/ME0DigisValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0DigisValidation.h
@@ -1,0 +1,32 @@
+#ifndef ME0DigisValidation_H
+#define ME0DigisValidation_H
+
+#include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
+//Data Formats
+#include "DataFormats/GEMDigi/interface/ME0DigiPreReco.h"
+#include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
+
+
+class ME0DigisValidation : public ME0BaseValidation
+{
+public:
+  explicit ME0DigisValidation( const edm::ParameterSet& );
+  ~ME0DigisValidation();
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(const edm::Event& e, const edm::EventSetup&) override;
+ private:
+
+  MonitorElement* me0_strip_dg_xy[2][6];
+  MonitorElement* me0_strip_dg_xy_Muon[2][6];
+  MonitorElement* me0_strip_dg_zr[2][6];
+  MonitorElement* me0_strip_dg_zr_tot[2];
+  MonitorElement* me0_strip_dg_zr_tot_Muon[2];
+
+  edm::EDGetToken InputTagToken_Digi;
+
+  Int_t npart;
+
+
+};
+
+#endif

--- a/Validation/MuonME0Validation/interface/ME0HitsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0HitsValidation.h
@@ -1,0 +1,31 @@
+#ifndef ME0HitsValidation_H
+#define ME0HitsValidation_H
+
+#include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
+
+
+
+class ME0HitsValidation : public ME0BaseValidation
+{
+public:
+  explicit ME0HitsValidation( const edm::ParameterSet& );
+  ~ME0HitsValidation();
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(const edm::Event& e, const edm::EventSetup&) override;
+ private:
+
+  MonitorElement* me0_sh_xy[2][6];
+  MonitorElement* me0_sh_zr[2][6];
+  MonitorElement* me0_sh_tot_zr[2];
+
+  MonitorElement* me0_sh_tof[2][6];
+  MonitorElement* me0_sh_tofMu[2][6];
+  MonitorElement* me0_sh_eloss[2][6];
+  MonitorElement* me0_sh_elossMu[2][6];
+
+  Int_t npart;
+  
+
+};
+
+#endif

--- a/Validation/MuonME0Validation/interface/ME0RecHitsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0RecHitsValidation.h
@@ -1,0 +1,38 @@
+#ifndef ME0RecHitsValidation_H
+#define ME0RecHitsValidation_H
+
+#include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
+
+//Data Format
+#include <DataFormats/GEMRecHit/interface/ME0RecHit.h>
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMRecHit/interface/ME0RecHitCollection.h"
+
+
+
+
+class ME0RecHitsValidation : public ME0BaseValidation
+{
+public:
+  explicit ME0RecHitsValidation( const edm::ParameterSet& );
+  ~ME0RecHitsValidation();
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(const edm::Event& e, const edm::EventSetup&) override;
+ private:
+
+  MonitorElement* me0_rh_xy[2][6];
+  MonitorElement* me0_rh_zr[2];
+
+  MonitorElement* me0_rh_DeltaX[2][6];
+  MonitorElement* me0_rh_DeltaY[2][6];
+  MonitorElement* me0_rh_PullX[2][6];
+  MonitorElement* me0_rh_PullY[2][6];
+
+  edm::EDGetToken InputTagToken_RecHit;
+
+  Int_t npart;
+
+
+};
+
+#endif

--- a/Validation/MuonME0Validation/interface/ME0SegmentsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0SegmentsValidation.h
@@ -1,0 +1,42 @@
+#ifndef ME0SegmentsValidation_H
+#define ME0SegmentsValidation_H
+
+#include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
+
+#include <DataFormats/GEMRecHit/interface/ME0Segment.h>
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
+
+
+
+
+class ME0SegmentsValidation : public ME0BaseValidation
+{
+public:
+  explicit ME0SegmentsValidation( const edm::ParameterSet& );
+  ~ME0SegmentsValidation();
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(const edm::Event& e, const edm::EventSetup&) override;
+ private:
+
+  MonitorElement* me0_specRH_xy[2][6];
+  MonitorElement* me0_rh_xy_Muon[2][6];
+  MonitorElement* me0_specRH_zr[2];
+  
+  MonitorElement* me0_segment_chi2;
+  MonitorElement *me0_segment_time, *me0_segment_timeErr;
+  MonitorElement* me0_segment_numRH;
+  MonitorElement *me0_segment_EtaRH,*me0_segment_PhiRH;
+  
+  MonitorElement* me0_specRH_DeltaX[2][6];
+  MonitorElement* me0_specRH_DeltaY[2][6];
+  MonitorElement* me0_specRH_PullX[2][6];
+  MonitorElement* me0_specRH_PullY[2][6];
+  
+  edm::EDGetToken InputTagToken_Segments;
+  
+  Int_t npart;
+  
+  
+};
+  
+#endif

--- a/Validation/MuonME0Validation/plugins/BuildFile.xml
+++ b/Validation/MuonME0Validation/plugins/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="FWCore/Framework"/>
+<use name="Validation/MuonME0Validation"/>
+<use name="DQMServices/Core"/>
+<use name="HepMC"/>
+<library file="Module.cc" name="ValidationMuonME0Plugins">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/Validation/MuonME0Validation/plugins/Module.cc
+++ b/Validation/MuonME0Validation/plugins/Module.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//
+// Package:    MuonME0Hits
+// Class:      MuonME0Hits
+// 
+/**\class Module.cc
+
+ Description: Declaration of the ME0 plugins for the local validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author: Claudio Caputo, INFN Bari  
+//         Created:  14 Jan 2016 17:00:00 GMT
+// $Id$
+//
+//
+#include "Validation/MuonME0Validation/interface/ME0HitsValidation.h"
+#include "Validation/MuonME0Validation/interface/ME0DigisValidation.h"
+#include "Validation/MuonME0Validation/interface/ME0RecHitsValidation.h"
+#include "Validation/MuonME0Validation/interface/ME0SegmentsValidation.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE (ME0HitsValidation) ;
+DEFINE_FWK_MODULE (ME0DigisValidation) ;
+DEFINE_FWK_MODULE (ME0RecHitsValidation) ;
+DEFINE_FWK_MODULE (ME0SegmentsValidation) ;

--- a/Validation/MuonME0Validation/python/MuonME0Digis_cfi.py
+++ b/Validation/MuonME0Validation/python/MuonME0Digis_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+
+me0DigiValidation = cms.EDAnalyzer('ME0DigisValidation',
+    verboseSimHit = cms.untracked.int32(1),
+    stripDigiLabel = cms.InputTag("simMuonME0Digis"),
+    simInputLabel = cms.InputTag('g4SimHits',"MuonME0Hits"),
+    digiInputLabel = cms.InputTag("simMuonME0Digis"),
+    # st1, st2_short, st2_long of xbin, st1,st2_short,st2_long of ybin
+    nBinGlobalZR = cms.untracked.vdouble(80,120),
+    # st1 xmin, xmax, st2_short xmin, xmax, st2_long xmin, xmax, st1 ymin, ymax...
+    RangeGlobalZR = cms.untracked.vdouble(515,555,20,160),
+    nBinGlobalXY = cms.untracked.int32(360),
+)

--- a/Validation/MuonME0Validation/python/MuonME0Hits_cfi.py
+++ b/Validation/MuonME0Validation/python/MuonME0Hits_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+
+me0HitsValidation = cms.EDAnalyzer('ME0HitsValidation',
+    verboseSimHit = cms.untracked.int32(1),
+    simInputLabel = cms.InputTag('g4SimHits',"MuonME0Hits"),
+    # st1, st2_short, st2_long of xbin, st1,st2_short,st2_long of ybin
+    nBinGlobalZR = cms.untracked.vdouble(80,120),
+    # st1 xmin, xmax, st2_short xmin, xmax, st2_long xmin, xmax, st1 ymin, ymax...
+    RangeGlobalZR = cms.untracked.vdouble(520,555,20,160),
+    nBinGlobalXY = cms.untracked.int32(360),
+)

--- a/Validation/MuonME0Validation/python/MuonME0RecHits_cfi.py
+++ b/Validation/MuonME0Validation/python/MuonME0RecHits_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+
+me0RecHitsValidation = cms.EDAnalyzer('ME0RecHitsValidation',
+    verboseSimHit = cms.untracked.int32(1),
+    simInputLabel = cms.InputTag('g4SimHits',"MuonME0Hits"),
+    recHitInputLabel = cms.InputTag("me0RecHits"),
+    segmentInputLabel = cms.InputTag("me0Segments"),
+    # st1, st2_short, st2_long of xbin, st1,st2_short,st2_long of ybin
+    nBinGlobalZR = cms.untracked.vdouble(80,120),
+    # st1 xmin, xmax, st2_short xmin, xmax, st2_long xmin, xmax, st1 ymin, ymax...
+    RangeGlobalZR = cms.untracked.vdouble(515,555,20,160),
+    nBinGlobalXY = cms.untracked.int32(360),
+)
+
+me0SegmentsValidation = cms.EDAnalyzer('ME0SegmentsValidation',
+    verboseSimHit = cms.untracked.int32(1),
+    segmentInputLabel = cms.InputTag("me0Segments"),
+    # st1, st2_short, st2_long of xbin, st1,st2_short,st2_long of ybin
+    nBinGlobalZR = cms.untracked.vdouble(80,120),
+    # st1 xmin, xmax, st2_short xmin, xmax, st2_long xmin, xmax, st1 ymin, ymax...
+    RangeGlobalZR = cms.untracked.vdouble(515,555,20,160),
+    nBinGlobalXY = cms.untracked.int32(360),
+)
+
+
+me0LocalRecoValidation = cms.Sequence( me0RecHitsValidation + me0SegmentsValidation )

--- a/Validation/MuonME0Validation/python/me0Custom.py
+++ b/Validation/MuonME0Validation/python/me0Custom.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+def customise2023(process):
+ # if hasattr(process,'digitisation_step') :
+ #   process=customise_digitization(process)
+  if hasattr(process,'dqmHarvesting'):
+    process=customise_harvesting(process)
+  if hasattr(process,'validation_step'):
+    process=customise_Validation(process)
+  return process
+def customise_digitization(process):
+  from SimMuon.GEMDigitizer.customizeGEMDigi import customize_digi_addGEM_muon_only
+  process = customize_digi_addGEM_muon_only(process)
+  process.simMuonGEMDigis.mixLabel = cms.string("mix")
+  #process.simMuonRPCDigis.digiModel = cms.string('RPCSimParam')
+  #process.simMuonME0Digis.mixLabel = cms.string("mix")
+  process.digitisation_step.remove(process.simMuonRPCDigis)
+  return process
+
+def customise_Validation(process):
+  #process.load('Validation.MuonGEMHits.MuonGEMHits_cfi')
+  process.load('Validation.MuonME0Validation.me0SimValid_cff')
+  process.genvalid_all += process.me0SimValid
+  return process
+
+def customise_harvesting(process):
+  #process.load('Validation.MuonGEMHits.MuonGEMHits_cfi')
+  #process.load('Validation.MuonME0Hits.me0PostValidation_cff')
+  #process.genHarvesting += process.me0PostValidation
+  process.load('DQMServices.Components.EDMtoMEConverter_cff')
+  process.genHarvesting += process.EDMtoMEConverter
+  return process
+
+

--- a/Validation/MuonME0Validation/python/me0SimValid_cff.py
+++ b/Validation/MuonME0Validation/python/me0SimValid_cff.py
@@ -1,0 +1,10 @@
+#### This file must be moved to "Validation/Configuration/"
+import FWCore.ParameterSet.Config as cms
+
+from Validation.MuonME0Validation.MuonME0Hits_cfi import *
+from Validation.MuonME0Validation.MuonME0Digis_cfi import *
+from Validation.MuonME0Validation.MuonME0RecHits_cfi import *
+
+#me0SimValid = cms.Sequence(me0HitsValidation)
+#me0SimValid = cms.Sequence(me0HitsValidation*me0DigiValidation)
+me0SimValid = cms.Sequence(me0HitsValidation*me0DigiValidation*me0LocalRecoValidation)

--- a/Validation/MuonME0Validation/python/simTrackMatching_cfi.py
+++ b/Validation/MuonME0Validation/python/simTrackMatching_cfi.py
@@ -1,0 +1,50 @@
+import FWCore.ParameterSet.Config as cms
+
+SimTrackMatching = cms.PSet(
+    # common
+    useCSCChamberTypes = cms.untracked.vint32(0,1,2),
+    ntupleTrackChamberDelta = cms.bool(True),
+    ntupleTrackEff = cms.bool(True),
+    overrideminNHitsChamber = cms.bool(False),
+    minNHitsChamber = cms.untracked.int32(4),
+    verbose = cms.bool(False),
+    ## per collection params
+    simTrack = cms.PSet(
+        verbose = cms.int32(0),
+        input = cms.InputTag('g4SimHits'),
+        minPt = cms.double(1.5),
+        maxPt = cms.double(999.),
+        minEta = cms.double(1.45),
+        maxEta = cms.double(4.0),
+        onlyMuon = cms.bool(True),
+        requireVertex = cms.bool(True),
+        requireGenPart = cms.bool(True),
+    ),
+
+    me0SimHit = cms.PSet(
+        verbose = cms.int32(0),
+        input = cms.InputTag('g4SimHits','MuonME0Hits'),
+        simMuOnly = cms.bool(True),
+        discardEleHits = cms.bool(True),
+    ),
+    me0StripDigi = cms.PSet(
+        verbose = cms.int32(0),
+        input = cms.InputTag("simMuonME0Digis"),
+        minBX = cms.int32(-1),
+        maxBX = cms.int32(1),
+        matchDeltaStrip = cms.int32(1),
+    ),
+    me0RecHit = cms.PSet(
+        verbose = cms.int32(0),
+        input = cms.InputTag('me0RecHits'),
+        simMuOnly = cms.bool(True),
+        discardEleHits = cms.bool(True),
+    ),
+    me0Seg = cms.PSet(
+        verbose = cms.int32(0),
+        input = cms.InputTag('me0Segments'),
+        simMuOnly = cms.bool(True),
+        discardEleHits = cms.bool(True),
+    ),
+
+)

--- a/Validation/MuonME0Validation/src/ME0BaseValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0BaseValidation.cc
@@ -1,0 +1,68 @@
+#include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+using namespace std;
+ME0BaseValidation::ME0BaseValidation( const edm::ParameterSet& ps)
+{
+  nBinZR_ = ps.getUntrackedParameter<std::vector<double>>("nBinGlobalZR") ;
+  RangeZR_ = ps.getUntrackedParameter< std::vector<double> >("RangeGlobalZR");
+  nBinXY_ = ps.getUntrackedParameter<int>("nBinGlobalXY",360) ;
+
+  regionLabel.push_back("-1");
+  regionLabel.push_back("1" );
+
+  layerLabel.push_back("1");
+  layerLabel.push_back("2");
+  layerLabel.push_back("3");
+  layerLabel.push_back("4");
+  layerLabel.push_back("5");
+  layerLabel.push_back("6");
+
+}
+
+
+ME0BaseValidation::~ME0BaseValidation() {
+}
+
+MonitorElement* ME0BaseValidation::BookHistZR( DQMStore::IBooker& ibooker, const char* name, const char* label, unsigned int region_num, unsigned int layer_num) {
+  string hist_name, hist_label;
+  if ( layer_num == 0 || layer_num==1 || layer_num==2 || layer_num==3 || layer_num==4 || layer_num==5 || layer_num==6 ) {
+    hist_name  = name+string("_zr_r") + regionLabel[region_num]+"_l"+layerLabel[layer_num];
+    hist_label = label+string(" occupancy : region")+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; globalZ [cm]; globalR[cm]";
+  }
+  else {
+    hist_name  = name+string("_zr_r") + regionLabel[region_num];
+    hist_label = label+string(" occupancy : region")+regionLabel[region_num]+" ; globalZ [cm]; globalR[cm]";
+  }
+  int xbin = (int)nBinZR_[0];
+  int ybin = (int)nBinZR_[1];
+  double xmin = 0;
+  double xmax = 0; 
+  double ymin = 0;
+  double ymax = 0;
+  ymin = RangeZR_[ RangeZR_.size()/2 + 0];;
+  ymax = RangeZR_[ RangeZR_.size()/2 + 1];;
+  if ( region_num ==0 ) {
+    xmin = -RangeZR_[1];
+    xmax = -RangeZR_[0];
+  }
+  else {
+    xmin = RangeZR_[0];
+    xmax = RangeZR_[1];
+  }
+  return ibooker.book2D( hist_name, hist_label, xbin, xmin, xmax, ybin,ymin, ymax);
+}
+
+MonitorElement* ME0BaseValidation::BookHistXY( DQMStore::IBooker& ibooker, const char* name, const char* label, unsigned int region_num, unsigned int layer_num) {
+  string hist_name, hist_label;
+  if ( layer_num == 0 || layer_num==1 || layer_num==2 || layer_num==3 || layer_num==4 || layer_num==5 || layer_num==6 ) {
+    hist_name  = name+string("_xy_r") + regionLabel[region_num]+"_l"+layerLabel[layer_num];
+    hist_label = label+string(" occupancy : region")+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; globalX [cm]; globalY[cm]";
+  }
+  else {
+    hist_name  = name+string("_xy_r") + regionLabel[region_num];
+    hist_label = label+string(" occupancy : region")+regionLabel[region_num]+" ; globalX [cm]; globalY[cm]";
+  } 
+  return ibooker.book2D( hist_name, hist_label, nBinXY_, -360,360,nBinXY_,-360,360); 
+}
+

--- a/Validation/MuonME0Validation/src/ME0DigisValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0DigisValidation.cc
@@ -1,0 +1,97 @@
+#include "Validation/MuonME0Validation/interface/ME0DigisValidation.h"
+#include <TMath.h>
+
+ME0DigisValidation::ME0DigisValidation(const edm::ParameterSet& cfg):  ME0BaseValidation(cfg)
+{
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
+  InputTagToken_Digi = consumes<ME0DigiPreRecoCollection>(cfg.getParameter<edm::InputTag>("digiInputLabel"));
+}
+
+void ME0DigisValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & Run, edm::EventSetup const & iSetup ) {
+
+  LogDebug("MuonME0DigisValidation")<<"Info : Loading Geometry information\n";
+  ibooker.setCurrentFolder("MuonME0DigisV/ME0DigisTask");
+
+  unsigned int nregion  = 2;
+
+  edm::LogInfo("MuonME0DigisValidation")<<"+++ Info : # of region : "<<nregion<<std::endl;
+
+  LogDebug("MuonME0DigisValidation")<<"+++ Info : finish to get geometry information from ES.\n";
+
+
+  for( unsigned int region_num = 0 ; region_num < nregion ; region_num++ ) {
+      me0_strip_dg_zr_tot[region_num] = BookHistZR(ibooker,"me0_strip_dg_tot","Digi",region_num);
+      me0_strip_dg_zr_tot_Muon[region_num] = BookHistZR(ibooker,"me0_strip_dg_tot","Digi Muon",region_num);
+      for( unsigned int layer_num = 0 ; layer_num < 6 ; layer_num++) {
+
+          me0_strip_dg_xy[region_num][layer_num] = BookHistXY(ibooker,"me0_strip_dg","Digi",region_num,layer_num);
+          me0_strip_dg_xy_Muon[region_num][layer_num] = BookHistXY(ibooker,"me0_strip_dg","Digi Muon",region_num,layer_num);
+      }
+  }
+}
+
+
+ME0DigisValidation::~ME0DigisValidation() {
+}
+
+
+void ME0DigisValidation::analyze(const edm::Event& e,
+                                     const edm::EventSetup& iSetup)
+{
+ edm::ESHandle<ME0Geometry> hGeom;
+ iSetup.get<MuonGeometryRecord>().get(hGeom);
+ const ME0Geometry* ME0Geometry_ =( &*hGeom);
+  edm::Handle<edm::PSimHitContainer> ME0Hits;
+  e.getByToken(InputTagToken_, ME0Hits);
+
+  edm::Handle<ME0DigiPreRecoCollection> ME0Digis;
+  e.getByToken(InputTagToken_Digi, ME0Digis);
+
+  if (!ME0Hits.isValid() | !ME0Digis.isValid() ) {
+    edm::LogError("ME0DigisValidation") << "Cannot get ME0Hits/ME0Digis by Token simInputTagToken";
+    return ;
+  }
+
+  for (ME0DigiPreRecoCollection::DigiRangeIterator cItr=ME0Digis->begin(); cItr!=ME0Digis->end(); cItr++) {
+    ME0DetId id = (*cItr).first;
+
+    const GeomDet* gdet = ME0Geometry_->idToDet(id);
+    if ( gdet == nullptr) {
+      std::cout<<"Getting DetId failed. Discard this gem strip hit.Maybe it comes from unmatched geometry."<<std::endl;
+      continue;
+    }
+    const BoundPlane & surface = gdet->surface();
+
+    Short_t region = (Short_t) id.region();
+    Short_t layer = (Short_t) id.layer();
+
+    ME0DigiPreRecoCollection::const_iterator digiItr;
+    for (digiItr = (*cItr ).second.first; digiItr != (*cItr ).second.second; ++digiItr)
+    {
+      Short_t particleType = digiItr->pdgid();
+      LocalPoint lp(digiItr->x(), digiItr->y(), 0);
+
+      GlobalPoint gp = surface.toGlobal(lp);
+
+      Float_t g_r = (Float_t) gp.perp();
+      Float_t g_x = (Float_t) gp.x();
+      Float_t g_y = (Float_t) gp.y();
+      Float_t g_z = (Float_t) gp.z();
+      // fill hist
+      int region_num=0 ;
+      if ( region ==-1 ) region_num = 0 ;
+      else if ( region==1) region_num = 1;
+      int layer_num = layer-1;
+
+      if ( abs(particleType) == 13) {
+        me0_strip_dg_zr_tot_Muon[region_num]->Fill(g_z,g_r);
+        me0_strip_dg_xy_Muon[region_num][layer_num]->Fill(g_x,g_y);
+      }
+      else {
+        me0_strip_dg_zr_tot[region_num]->Fill(g_z,g_r);
+        me0_strip_dg_xy[region_num][layer_num]->Fill(g_x,g_y);
+      }
+    }
+}
+
+}

--- a/Validation/MuonME0Validation/src/ME0HitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0HitsValidation.cc
@@ -1,0 +1,111 @@
+#include "Validation/MuonME0Validation/interface/ME0HitsValidation.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include <TMath.h>
+
+ME0HitsValidation::ME0HitsValidation(const edm::ParameterSet& cfg):  ME0BaseValidation(cfg)
+{
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
+}
+
+void ME0HitsValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & Run, edm::EventSetup const & iSetup ) {
+
+  LogDebug("MuonME0HitsValidation")<<"Info : Loading Geometry information\n";
+  ibooker.setCurrentFolder("MuonME0HitsV/ME0HitsTask");
+
+  unsigned int nregion  = 2;
+
+  edm::LogInfo("MuonME0HitsValidation")<<"+++ Info : # of region : "<<nregion<<std::endl;
+
+  LogDebug("MuonME0HitsValidation")<<"+++ Info : finish to get geometry information from ES.\n";
+
+
+  for( unsigned int region_num = 0 ; region_num < nregion ; region_num++ ) {
+          me0_sh_tot_zr[region_num] = BookHistZR(ibooker,"me0_sh","SimHit",region_num);
+      for( unsigned int layer_num = 0 ; layer_num < 6 ; layer_num++) {
+          me0_sh_zr[region_num][layer_num] = BookHistZR(ibooker,"me0_sh","SimHit",region_num,layer_num);
+          me0_sh_xy[region_num][layer_num] = BookHistXY(ibooker,"me0_sh","SimHit",region_num,layer_num);
+          std::string hist_name_for_tof  = std::string("me0_sh_tof_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string hist_name_for_tofMu  = std::string("me0_sh_tofMuon_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string hist_name_for_eloss  = std::string("me0_sh_energyloss_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string hist_name_for_elossMu  = std::string("me0_sh_energylossMuon_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string hist_label_for_xy = "SimHit occupancy : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" ; globalX [cm]; globalY[cm]";
+          std::string hist_label_for_tof = "SimHit TOF : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; Time of flight [ns] ; entries";
+          std::string hist_label_for_tofMu = "SimHit TOF(Muon only) : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; Time of flight [ns] ; entries";
+          std::string hist_label_for_eloss = "SimHit energy loss : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; Energy loss [eV] ; entries";
+          std::string hist_label_for_elossMu = "SimHit energy loss(Muon only) : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; Energy loss [eV] ; entries";
+
+
+          double tof_min, tof_max;
+          tof_min = 10; tof_max = 30;
+          me0_sh_tof[region_num][layer_num] = ibooker.book1D( hist_name_for_tof.c_str(), hist_label_for_tof.c_str(), 40,tof_min,tof_max);
+          me0_sh_tofMu[region_num][layer_num] = ibooker.book1D( hist_name_for_tofMu.c_str(), hist_label_for_tofMu.c_str(), 40,tof_min,tof_max);
+          me0_sh_eloss[region_num][layer_num] = ibooker.book1D( hist_name_for_eloss.c_str(), hist_label_for_eloss.c_str(), 60,0.,6000.);
+          me0_sh_elossMu[region_num][layer_num] = ibooker.book1D( hist_name_for_elossMu.c_str(), hist_label_for_elossMu.c_str(), 60,0.,6000.);
+      }
+  }
+}
+
+
+ME0HitsValidation::~ME0HitsValidation() {
+}
+
+
+void ME0HitsValidation::analyze(const edm::Event& e,
+                                     const edm::EventSetup& iSetup)
+{
+ edm::ESHandle<ME0Geometry> hGeom;
+ iSetup.get<MuonGeometryRecord>().get(hGeom);
+ const ME0Geometry* ME0Geometry_ =( &*hGeom);
+
+  edm::Handle<edm::PSimHitContainer> ME0Hits;
+  e.getByToken(InputTagToken_, ME0Hits);
+  if (!ME0Hits.isValid()) {
+    edm::LogError("ME0HitsValidation") << "Cannot get ME0Hits by Token simInputTagToken";
+    return ;
+  }
+
+  Float_t timeOfFlightMuon = 0.;
+  Float_t energyLossMuon = 0;
+
+  for (auto hits=ME0Hits->begin(); hits!=ME0Hits->end(); hits++) {
+
+    const ME0DetId id(hits->detUnitId());
+    Int_t region = id.region();
+    Int_t layer = id.layer();
+
+
+
+    //Int_t even_odd = id.chamber()%2;
+    if ( ME0Geometry_->idToDet(hits->detUnitId()) == nullptr) {
+      std::cout<<"simHit did not matched with GEMGeometry."<<std::endl;
+      continue;
+    }
+
+    const LocalPoint hitLP(hits->localPosition());
+
+    const GlobalPoint hitGP(ME0Geometry_->idToDet(hits->detUnitId())->surface().toGlobal(hitLP));
+    Float_t g_r = hitGP.perp();
+    Float_t g_x = hitGP.x();
+    Float_t g_y = hitGP.y();
+    Float_t g_z = hitGP.z();
+    Float_t energyLoss = hits->energyLoss();
+    Float_t timeOfFlight = hits->timeOfFlight();
+
+    if (abs(hits-> particleType()) == 13)
+    {
+      timeOfFlightMuon = hits->timeOfFlight();
+      energyLossMuon = hits->energyLoss();
+      //fill histos for Muons only
+      me0_sh_tofMu[(int)(region/2.+0.5)][layer-1]->Fill(timeOfFlightMuon);
+      me0_sh_elossMu[(int)(region/2.+0.5)][layer-1]->Fill(energyLossMuon*1.e9);
+
+    }
+    
+    me0_sh_zr[(int)(region/2.+0.5)][layer-1]->Fill(g_z,g_r);
+    me0_sh_tot_zr[(int)(region/2.+0.5)]->Fill(g_z,g_r);
+    me0_sh_xy[(int)(region/2.+0.5)][layer-1]->Fill(g_x,g_y);
+    me0_sh_tof[(int)(region/2.+0.5)][layer-1]->Fill(timeOfFlight);
+    me0_sh_eloss[(int)(region/2.+0.5)][layer-1]->Fill(energyLoss*1.e9);
+
+   }
+}

--- a/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
@@ -1,0 +1,156 @@
+#include "Validation/MuonME0Validation/interface/ME0RecHitsValidation.h"
+#include <TMath.h>
+
+ME0RecHitsValidation::ME0RecHitsValidation(const edm::ParameterSet& cfg):  ME0BaseValidation(cfg)
+{
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
+  InputTagToken_RecHit = consumes<ME0RecHitCollection>(cfg.getParameter<edm::InputTag>("recHitInputLabel"));
+}
+
+void ME0RecHitsValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & Run, edm::EventSetup const & iSetup ) {
+
+  LogDebug("MuonME0RecHitsValidation")<<"Info : Loading Geometry information\n";
+  ibooker.setCurrentFolder("MuonME0RecHitsV/ME0RecHitsTask");
+
+  unsigned int nregion  = 2;
+
+  edm::LogInfo("MuonME0RecHitsValidation")<<"+++ Info : # of region : "<<nregion<<std::endl;
+
+  LogDebug("MuonME0RecHitsValidation")<<"+++ Info : finish to get geometry information from ES.\n";
+
+
+  for( unsigned int region_num = 0 ; region_num < nregion ; region_num++ ) {
+      me0_rh_zr[region_num] = BookHistZR(ibooker,"me0_rh_tot","Digi",region_num);
+      for( unsigned int layer_num = 0 ; layer_num < 6 ; layer_num++) {
+          me0_rh_xy[region_num][layer_num] = BookHistXY(ibooker,"me0_rh","RecHit",region_num,layer_num);
+
+          std::string histo_name_DeltaX = std::string("me0_rh_DeltaX_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_name_DeltaY = std::string("me0_rh_DeltaY_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_label_DeltaX = "RecHit Delta X : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; x_{SimHit} - x_{RecHit} ; entries";
+          std::string histo_label_DeltaY = "RecHit Delta Y : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; y_{SimHit} - y_{RecHit} ; entries";
+
+          me0_rh_DeltaX[region_num][layer_num] = ibooker.book1D(histo_name_DeltaX.c_str(), histo_label_DeltaX.c_str(),100,-10,10);
+          me0_rh_DeltaY[region_num][layer_num] = ibooker.book1D(histo_name_DeltaY.c_str(), histo_label_DeltaY.c_str(),100,-10,10);
+
+          std::string histo_name_PullX = std::string("me0_rh_PullX_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_name_PullY = std::string("me0_rh_PullY_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_label_PullX = "RecHit Pull X : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; #frac{x_{SimHit} - x_{RecHit}}{#sigma_{x,RecHit}} ; entries";
+          std::string histo_label_PullY = "RecHit Pull Y : region"+regionLabel[region_num]+" layer "+layerLabel[layer_num]+" "+" ; #frac{y_{SimHit} - y_{RecHit}}{#sigma_{y,RecHit}} ; entries";
+
+          me0_rh_PullX[region_num][layer_num] = ibooker.book1D(histo_name_PullX.c_str(), histo_label_DeltaX.c_str(),100,-10,10);
+          me0_rh_PullY[region_num][layer_num] = ibooker.book1D(histo_name_PullY.c_str(), histo_label_DeltaY.c_str(),100,-10,10);
+      }
+  }
+}
+
+
+ME0RecHitsValidation::~ME0RecHitsValidation() {
+}
+
+
+void ME0RecHitsValidation::analyze(const edm::Event& e,
+                                     const edm::EventSetup& iSetup)
+{
+ edm::ESHandle<ME0Geometry> hGeom;
+ iSetup.get<MuonGeometryRecord>().get(hGeom);
+ const ME0Geometry* ME0Geometry_ =( &*hGeom);
+  edm::Handle<edm::PSimHitContainer> ME0Hits;
+  e.getByToken(InputTagToken_, ME0Hits);
+
+  edm::Handle<ME0RecHitCollection> ME0RecHits;
+  e.getByToken(InputTagToken_RecHit, ME0RecHits);
+
+  if (!ME0Hits.isValid() | !ME0RecHits.isValid() ) {
+    edm::LogError("ME0RecHitsValidation") << "Cannot get ME0Hits/ME0RecHits by Token simInputTagToken";
+    return ;
+  }
+
+
+
+ for (auto hits=ME0Hits->begin(); hits!=ME0Hits->end(); hits++) {
+
+   const ME0DetId id(hits->detUnitId());
+   Int_t sh_region = id.region();
+   Int_t sh_layer = id.layer();
+   Int_t sh_station = 0;
+   Int_t sh_chamber = id.chamber();
+   Int_t sh_roll = id.roll();
+
+
+   //Int_t even_odd = id.chamber()%2;
+   if ( ME0Geometry_->idToDet(hits->detUnitId()) == nullptr) {
+     std::cout<<"simHit did not matched with GEMGeometry."<<std::endl;
+     continue;
+   }
+
+   const LocalPoint hitLP(hits->localPosition());
+
+   for (ME0RecHitCollection::const_iterator recHit = ME0RecHits->begin(); recHit != ME0RecHits->end(); ++recHit)
+   {
+
+       Float_t x = recHit->localPosition().x();
+       Float_t xErr = recHit->localPositionError().xx();
+       Float_t y = recHit->localPosition().y();
+       Float_t yErr = recHit->localPositionError().yy();
+      // Float_t detId = (Short_t) (*recHit).me0Id();
+       Float_t bx = 0;
+       Float_t clusterSize = 0;
+       Float_t firstClusterStrip = 0;
+
+       ME0DetId id((*recHit).me0Id());
+
+       Short_t region = (Short_t) id.region();
+       Short_t station = 0;
+       Short_t layer = (Short_t) id.layer();
+       Short_t chamber = (Short_t) id.chamber();
+       Short_t roll = (Short_t) id.roll();
+
+       LocalPoint rhLP = recHit->localPosition();
+       GlobalPoint rhGP = ME0Geometry_->idToDet((*recHit).me0Id())->surface().toGlobal(rhLP);
+
+       Float_t globalR = rhGP.perp();
+       Float_t globalX = rhGP.x();
+       Float_t globalY = rhGP.y();
+       Float_t globalZ = rhGP.z();
+
+       Float_t x_sim = hitLP.x();
+       Float_t y_sim = hitLP.y();
+       Float_t pullX = (x_sim - x) / sqrt(xErr);
+       Float_t pullY = (y_sim - y) / sqrt(yErr);
+
+
+       if(bx != 0) continue;
+
+       std::vector<int> stripsFired;
+       for(int i = firstClusterStrip; i < (firstClusterStrip + clusterSize); i++){
+
+           stripsFired.push_back(i);
+
+       }
+
+
+       const bool cond1(sh_region==region and sh_layer==layer and sh_station==station);
+       const bool cond2(sh_chamber==chamber and sh_roll==roll);
+       const bool cond3((std::find(stripsFired.begin(), stripsFired.end(), (firstClusterStrip + 1)) != stripsFired.end()) or clusterSize==0);
+
+       int region_num=0 ;
+       if ( region ==-1 ) region_num = 0 ;
+       else if ( region==1) region_num = 1;
+       int layer_num = layer-1;
+
+       if(cond1 and cond2 and cond3){
+
+         me0_rh_xy[region_num][layer_num]->Fill(globalX,globalY);
+         me0_rh_zr[region_num]->Fill(globalZ,globalR);
+
+         me0_rh_DeltaX[region_num][layer_num]->Fill(x_sim - x);
+         me0_rh_DeltaY[region_num][layer_num]->Fill(y_sim - y);
+         me0_rh_PullX[region_num][layer_num]->Fill(pullX);
+         me0_rh_PullY[region_num][layer_num]->Fill(pullY);
+
+       }
+
+  }
+}
+
+}

--- a/Validation/MuonME0Validation/src/ME0SegmentsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0SegmentsValidation.cc
@@ -1,0 +1,174 @@
+#include "Validation/MuonME0Validation/interface/ME0SegmentsValidation.h"
+#include "DataFormats/Scalers/interface/DcsStatus.h"
+#include <TMath.h>
+
+ME0SegmentsValidation::ME0SegmentsValidation(const edm::ParameterSet& cfg):  ME0BaseValidation(cfg)
+{
+  InputTagToken_Segments = consumes<ME0SegmentCollection>(cfg.getParameter<edm::InputTag>("segmentInputLabel"));
+}
+
+void ME0SegmentsValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & Run, edm::EventSetup const & iSetup ) {
+   //edm::ESHandle<ME0Geometry> hGeom;
+   //iSetup.get<MuonGeometryRecord>().get(hGeom);
+   //const ME0Geometry* ME0Geometry_ =( &*hGeom);
+
+  LogDebug("MuonME0SegmentsValidation")<<"Info : Loading Geometry information\n";
+  ibooker.setCurrentFolder("MuonME0RecHitsV/ME0SegmentsTask");
+
+  unsigned int nregion  = 2;
+
+  edm::LogInfo("MuonME0SegmentsValidation")<<"+++ Info : # of region : "<<nregion<<std::endl;
+
+  LogDebug("MuonME0SegmentsValidation")<<"+++ Info : finish to get geometry information from ES.\n";
+
+  me0_segment_chi2    = ibooker.book1D("me0_seg_ReducedChi2","#chi^{2}/ndof; #chi^{2}/ndof; # Segments",100,0,5);
+  me0_segment_numRH   = ibooker.book1D("me0_seg_NumberRH","Number of fitted RecHits; # RecHits; entries",11,-0.5,10.5);
+  //me0_segment_EtaRH   = ibooker.book1D("me0_specRH_globalEta","Fitted RecHits Eta Distribution; #eta; entries",200,-4.0,4.0);
+  //me0_segment_PhiRH   = ibooker.book1D("me0_specRH_globalPhi","Fitted RecHits Phi Distribution; #eta; entries",18,-3.14,3.14);
+  me0_segment_time    = ibooker.book1D("me0_seg_time","Segment Timing; ns; entries",40,15,25);
+  me0_segment_timeErr = ibooker.book1D("me0_seg_timErr","Segment Timing Error; ns; entries",50,0,0.5);
+
+  for( unsigned int region_num = 0 ; region_num < nregion ; region_num++ ) {
+      me0_specRH_zr[region_num] = BookHistZR(ibooker,"me0_specRH_tot","Segment RecHits",region_num);
+      for( unsigned int layer_num = 0 ; layer_num < 6 ; layer_num++) {
+          //me0_strip_dg_zr[region_num][layer_num] = BookHistZR(ibooker,"me0_strip_dg","SimHit",region_num,layer_num);
+          me0_specRH_xy[region_num][layer_num] = BookHistXY(ibooker,"me0_specRH","Segment RecHits",region_num,layer_num);
+          //me0_rh_xy_Muon[region_num][layer_num] = BookHistXY(ibooker,"me0_rh","RecHit Muon",region_num,layer_num);
+
+          std::string histo_name_DeltaX = std::string("me0_specRH_DeltaX_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_name_DeltaY = std::string("me0_specRH_DeltaY_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_label_DeltaX = "Segment RecHits Delta X : region"+regionLabel[region_num]+
+                " layer "+layerLabel[layer_num]+" "+" ; x_{SimHit} - x_{Segment RecHits} ; entries";
+          std::string histo_label_DeltaY = "Segment RecHits Delta Y : region"+regionLabel[region_num]+
+                " layer "+layerLabel[layer_num]+" "+" ; y_{SimHit} - y_{Segment RecHit} ; entries";
+
+          me0_specRH_DeltaX[region_num][layer_num] = ibooker.book1D(histo_name_DeltaX.c_str(), histo_label_DeltaX.c_str(),100,-10,10);
+          me0_specRH_DeltaY[region_num][layer_num] = ibooker.book1D(histo_name_DeltaY.c_str(), histo_label_DeltaY.c_str(),100,-10,10);
+
+          std::string histo_name_PullX = std::string("me0_specRH_PullX_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_name_PullY = std::string("me0_specRH_PullY_r")+regionLabel[region_num]+"_l"+layerLabel[layer_num];
+          std::string histo_label_PullX = "Segment RecHits Pull X : region"+regionLabel[region_num]+
+                " layer "+layerLabel[layer_num]+" "+" ; #frac{x_{SimHit} - x_{Segment RecHit}}{#sigma_{x,RecHit}} ; entries";
+          std::string histo_label_PullY = "Segment RecHits Pull Y : region"+regionLabel[region_num]+
+                " layer "+layerLabel[layer_num]+" "+" ; #frac{y_{SimHit} - y_{Segment RecHit}}{#sigma_{y,RecHit}} ; entries";
+
+          me0_specRH_PullX[region_num][layer_num] = ibooker.book1D(histo_name_PullX.c_str(), histo_label_DeltaX.c_str(),100,-10,10);
+          me0_specRH_PullY[region_num][layer_num] = ibooker.book1D(histo_name_PullY.c_str(), histo_label_DeltaY.c_str(),100,-10,10);
+      }
+  }
+}
+
+
+ME0SegmentsValidation::~ME0SegmentsValidation() {
+}
+
+
+void ME0SegmentsValidation::analyze(const edm::Event& e,
+                                     const edm::EventSetup& iSetup)
+{
+ edm::ESHandle<ME0Geometry> hGeom;
+ iSetup.get<MuonGeometryRecord>().get(hGeom);
+ const ME0Geometry* ME0Geometry_ =( &*hGeom);
+
+  edm::Handle<ME0SegmentCollection> ME0Segments;
+  e.getByToken(InputTagToken_Segments, ME0Segments);
+
+  if (!ME0Segments.isValid() ) {
+    edm::LogError("ME0SegmentsValidation") << "Cannot get ME0RecHits/ME0Segments by Token InputTagToken";
+    return ;
+  }
+
+
+
+ for (auto me0s = ME0Segments->begin(); me0s != ME0Segments->end(); me0s++) {
+
+   // The ME0 Ensamble DetId refers to layer = 1
+   ME0DetId id = me0s->me0DetId();
+   //std::cout <<" Original ME0DetID "<<id<<std::endl;
+   auto roll = ME0Geometry_->etaPartition(id);
+   //std::cout <<"Global Segment Position "<< roll->toGlobal(me0s->localPosition())<<std::endl;
+   auto segLP = me0s->localPosition();
+   auto segLD = me0s->localDirection();
+   //std::cout <<" Global Direction theta = "<<segLD.theta()<<" phi="<<segLD.phi()<<std::endl;
+   auto me0rhs = me0s->specificRecHits();
+   //std::cout <<"ME0 Ensamble Det Id "<<id<<" Number of RecHits "<<me0rhs.size()<<std::endl;
+
+//   Int_t detId = id;
+//   Float_t localX = segLP.x();
+//   Float_t localY = segLP.y();
+//   Float_t localZ = segLP.z();
+//   Float_t dirTheta = segLD.theta();
+//   Float_t dirPhi = segLD.phi();
+   Short_t numberRH = me0rhs.size();
+   Float_t chi2 = (Float_t) me0s->chi2();
+   Float_t ndof = me0s->degreesOfFreedom();
+   Double_t time = me0s->time();   
+   Double_t timeErr = me0s->timeErr();   
+
+   Float_t reducedChi2 = chi2/ndof;
+
+   me0_segment_chi2->Fill(reducedChi2);
+   me0_segment_numRH->Fill(numberRH);
+   me0_segment_time->Fill(time);
+   me0_segment_timeErr->Fill(timeErr);
+
+   for (auto rh = me0rhs.begin(); rh!= me0rhs.end(); rh++)
+   {
+
+     auto me0id = rh->me0Id();
+     auto rhr = ME0Geometry_->etaPartition(me0id);
+     auto rhLP = rh->localPosition();
+     auto erhLEP = rh->localPositionError();
+     auto rhGP = rhr->toGlobal(rhLP);
+     auto rhLPSegm = roll->toLocal(rhGP);
+     float xe = segLP.x()+segLD.x()*rhLPSegm.z()/segLD.z();
+     float ye = segLP.y()+segLD.y()*rhLPSegm.z()/segLD.z();
+     float ze = rhLPSegm.z();
+     LocalPoint extrPoint(xe,ye,ze); // in segment rest frame
+     auto extSegm = rhr->toLocal(roll->toGlobal(extrPoint)); // in layer restframe
+
+//     Int_t detId = me0id;
+
+     Short_t region = me0id.region();
+//     Short_t station = 0;
+//     Short_t ring = 0;
+     Short_t layer = me0id.layer();
+//     Short_t chamber = me0id.chamber();
+//     Short_t roll = me0id.roll();
+
+     Float_t x = rhLP.x();
+     Float_t xErr = erhLEP.xx();
+     Float_t y = rhLP.y();
+     Float_t yErr = erhLEP.yy();
+
+     Float_t globalR = rhGP.perp();
+     Float_t globalX = rhGP.x();
+     Float_t globalY = rhGP.y();
+     Float_t globalZ = rhGP.z();
+//     Float_t globalEta = rhGP.eta();
+//     Float_t globalPhi = rhGP.phi();
+
+     Float_t xExt = extSegm.x();
+     Float_t yExt = extSegm.y();
+
+     Float_t pull_x = (x - xExt) / sqrt(xErr);
+     Float_t pull_y = (y - yExt) / sqrt(yErr);
+
+     int region_num=0 ;
+     if ( region ==-1 ) region_num = 0 ;
+     else if ( region==1) region_num = 1;
+     int layer_num = layer-1;
+
+     me0_specRH_xy[region_num][layer_num]->Fill(globalX,globalY);
+     me0_specRH_zr[region_num]->Fill(globalZ,globalR);
+
+     me0_specRH_DeltaX[region_num][layer_num]->Fill(x - xExt);
+     me0_specRH_DeltaY[region_num][layer_num]->Fill(y - yExt);
+     me0_specRH_PullX[region_num][layer_num]->Fill(pull_x);
+     me0_specRH_PullY[region_num][layer_num]->Fill(pull_y);
+
+
+  }
+}
+
+}

--- a/Validation/MuonME0Validation/test/Generate.sh
+++ b/Validation/MuonME0Validation/test/Generate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# VALIDATION STEP
+cmsDriver.py validation --conditions auto:run2_design -n 1000 --eventcontent FEVTDEBUGHLT -s VALIDATION:genvalid_all --customise=Validation/MuonME0Validation/me0Custom.customise2023,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixCSCAlignmentConditions --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --no_exec --filein file:out_local_reco_me0segment.root --fileout file:out_valid.root --python_filename=me0_valid_cfg.py
+
+# HARVESTING STEP
+cmsDriver.py harvest --conditions auto:run2_design -n 1000 --eventcontent FEVTDEBUGHLT -s HARVESTING:genHarvesting --customise=Validation/MuonME0Validation/me0Custom.customise2023,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixCSCAlignmentConditions --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --no_exec --filein file:out_valid.root --python_filename=me0_harvest_cfg.py

--- a/Validation/MuonME0Validation/test/me0_harvest_cfg.py
+++ b/Validation/MuonME0Validation/test/me0_harvest_cfg.py
@@ -1,0 +1,84 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: harvest --conditions auto:run2_design -n 1000 --eventcontent FEVTDEBUGHLT -s HARVESTING:genHarvesting --customise=Validation/MuonME0Hits/me0Custom.customise2023,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixCSCAlignmentConditions --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --no_exec --filein file:out_valid.root --python_filename=me0_harvest_cfg.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('HARVESTING')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2015MuonGEMDevReco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:out_valid.root'),
+    processingMode = cms.untracked.string('RunsAndLumis'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('harvest nevts:1000'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_design', '')
+
+# Path and EndPath definitions
+process.validationprodHarvesting = cms.Path(process.hltpostvalidation_prod+process.postValidation_gen)
+process.validationHarvesting = cms.Path(process.postValidation+process.hltpostvalidation+process.postValidation_gen)
+process.dqmHarvestingPOGMC = cms.Path(process.DQMOffline_SecondStep_PrePOGMC)
+process.validationHarvestingFS = cms.Path(process.HarvestingFastSim)
+process.validationpreprodHarvesting = cms.Path(process.postValidation_preprod+process.hltpostvalidation_preprod+process.postValidation_gen)
+process.validationHarvestingMiniAOD = cms.Path(process.JetPostProcessor+process.METPostProcessorHarvesting)
+process.validationHarvestingHI = cms.Path(process.postValidationHI)
+process.dqmHarvestingPOG = cms.Path(process.DQMOffline_SecondStep_PrePOG)
+process.alcaHarvesting = cms.Path()
+process.dqmHarvesting = cms.Path(process.DQMOffline_SecondStep+process.DQMOffline_Certification)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.genHarvesting,process.dqmsave_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Validation.MuonME0Hits.me0Custom
+from Validation.MuonME0Hits.me0Custom import customise2023 
+
+#call to customisation function customise2023 imported from Validation.MuonME0Hits.me0Custom
+process = customise2023(process)
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads
+from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads import fixCSCAlignmentConditions 
+
+#call to customisation function fixCSCAlignmentConditions imported from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads
+process = fixCSCAlignmentConditions(process)
+
+# End of customisation functions
+

--- a/Validation/MuonME0Validation/test/me0_valid_cfg.py
+++ b/Validation/MuonME0Validation/test/me0_valid_cfg.py
@@ -1,0 +1,94 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: validation --conditions auto:run2_design -n 1000 --eventcontent FEVTDEBUGHLT -s VALIDATION:genvalid_all --customise=Validation/MuonME0Hits/me0Custom.customise2023,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixCSCAlignmentConditions --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --no_exec --filein file:out_local_reco_me0segment.root --fileout file:out_valid.root --python_filename=me0_valid_cfg.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2015MuonGEMDevReco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:out_local_reco_me0segment.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('validation nevts:1000'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(1048576),
+    fileName = cms.untracked.string('file:out_valid.root'),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_design', '')
+
+# Path and EndPath definitions
+process.validation_step = cms.EndPath(process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.validation_step,process.endjob_step,process.FEVTDEBUGHLToutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Validation.MuonME0Hits.me0Custom
+from Validation.MuonME0Hits.me0Custom import customise2023 
+
+#call to customisation function customise2023 imported from Validation.MuonME0Hits.me0Custom
+process = customise2023(process)
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads
+from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads import fixCSCAlignmentConditions 
+
+#call to customisation function fixCSCAlignmentConditions imported from SLHCUpgradeSimulations.Configuration.fixMissingUpgradeGTPayloads
+process = fixCSCAlignmentConditions(process)
+
+# Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff
+from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn 
+
+#call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
+process = setCrossingFrameOn(process)
+
+# End of customisation functions
+


### PR DESCRIPTION
## Validation module for ME0 Detector (Phase2 Upgrade)

This PR involve a new version of the ME0 validation package. Now all the modules are in the same packages, defined as a plugins.
- MuonGEMHits plugin is related to SimHit on ME0 Detector.
- MuonGEMDigis plugin is related to Digi step about ME0.
- MuonGEMRecHits plugin is related both to ME0 RecHits and ME0 Segments.

This PR does not affect other modules.

These module are only run by a specific customize options. (_Validation/MuonME0Validation/python/me0Custom.py_)
Automatically ported from CMSSW_8_0_X #13325 (original by @clacaputo).
