### PR TITLE
change name for compatibility with commit 2b9093f4f09716854d5f52f9fe2…

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1192,16 +1192,16 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 
     def updateJECs(self,process,jetCollection, patMetModuleSequence, postfix):
-        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetCorrFactorsUpdated
-        patJetCorrFactorsReapplyJEC = patJetCorrFactorsUpdated.clone(
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
+        patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
             src = jetCollection,
             levels = ['L1FastJet', 
                       'L2Relative', 
                       'L3Absolute'],
             payload = 'AK4PFchs' ) # always CHS from miniAODs
         
-        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetsUpdated
-        patJetsReapplyJEC = patJetsUpdated.clone(
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
+        patJetsReapplyJEC = updatedPatJets.clone(
             jetSource = cms.InputTag("slimmedJets"),
             jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"))
             )


### PR DESCRIPTION
…a329a6f686eb4

Change name order for compatibility with [this](https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/PhysicsTools/PatAlgos/python/producersLayer1/jetUpdater_cff.py) naming scheme, introduced in commit 2b9093f4f09716854d5f52f9fe2a329a6f686eb4
Automatically ported from CMSSW_8_0_X #13313 (original by @aminnj).
