### PR TITLE
ECALbyLumi+Timing

### DIFF
--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -48,7 +48,7 @@ namespace ecaldqm
     };
 
   protected:
-    void setME(edm::ParameterSet const& _ps) final { DQWorker::setME(_ps); }
+    void setME(edm::ParameterSet const& _ps) final;
     void setSource(edm::ParameterSet const&) override;
 
     bool using_(std::string const& _name, ProcessType _type = kJob) const

--- a/DQM/EcalMonitorClient/python/CalibrationSummaryClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/CalibrationSummaryClient_cfi.py
@@ -8,7 +8,7 @@ from DQM.EcalMonitorClient.PedestalClient_cfi import ecalPedestalClient
 
 from DQM.EcalCommon.CommonParams_cfi import *
 
-activeSources = ['Laser', 'Led', 'TestPulse']
+activeSources = ['Laser', 'Led']
 
 ecalCalibrationSummaryClient = cms.untracked.PSet(
     params = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/EcalMonitorClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalMonitorClient_cfi.py
@@ -20,6 +20,7 @@ ecalMonitorClient = cms.EDAnalyzer("EcalDQMonitorClient",
         "PresampleClient",
         "RawDataClient",
         "TrigPrimClient",
+        "TimingClient",
         "SummaryClient"
     ),
     # task parameters (included from indivitual cfis)

--- a/DQM/EcalMonitorClient/python/TimingClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TimingClient_cfi.py
@@ -144,6 +144,21 @@ ecalTimingClient = cms.untracked.PSet(
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Distribution of per-channel timing mean. Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
+        ),
+        TrendMean = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TimingClient %(prefix)s timing mean'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of timing mean. Plots simple average of all channel timing means at each lumisection.')
+        ),
+        TrendRMS = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TimingClient %(prefix)s timing rms'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of timing rms. Plots simple average of all channel timing rms at each lumisection.')
         )
     )
 )
+

--- a/DQM/EcalMonitorClient/src/DQWorkerClient.cc
+++ b/DQM/EcalMonitorClient/src/DQWorkerClient.cc
@@ -22,12 +22,6 @@ namespace ecaldqm
     hasLumiPlots_(false),
     statusManager_(0)
   {
-    for(MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr){
-      if(mItr->second->getLumiFlag()){
-        hasLumiPlots_ = true;
-        break;
-      }
-    }
   }
 
   /*static*/
@@ -43,6 +37,25 @@ namespace ecaldqm
     sourceParameters.addNode(edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireZeroOrMore, false, sourceNodeParameters));
     _desc.addUntracked("sources", sourceParameters);
   }
+
+
+  void
+  DQWorkerClient::setME(edm::ParameterSet const& _ps)
+  {
+    DQWorker::setME(_ps);
+
+    // Flags the Client ME to run as lumibased:
+    // In offline mode will save the ME client at the end of the LS
+    // See: EcalDQMonitorClient::dqmEndLuminosityBlock
+    for(MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr){
+      if(mItr->second->getLumiFlag()){
+        hasLumiPlots_ = true;
+        break;
+      }
+    }
+
+  }
+
 
   void
   DQWorkerClient::setSource(edm::ParameterSet const& _params)
@@ -123,6 +136,11 @@ namespace ecaldqm
   {
     for(MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr){
       MESet* meset(mItr->second);
+
+      // Protects Trend-type Client MEs from being reset at the end of the LS
+      // See: EcalDQMonitorClient::runWorkers 
+      if(meset->getBinType() == ecaldqm::binning::kTrend)
+        continue;
 
       if(qualitySummaries_.find(mItr->first) != qualitySummaries_.end()){
         MESetMulti* multi(dynamic_cast<MESetMulti*>(meset));

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -119,7 +119,8 @@ namespace ecaldqm
       if(rawdata == kBad && rawDataByLumi[iDCC] == 0.) rawdata = kGood;
 
       int status(kGood);
-      if(integrity == kBad || presample == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
+      //if(integrity == kBad || presample == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
+      if(integrity == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
         status = kBad;
       else if(integrity == kUnknown && presample == kUnknown && timing == kUnknown && rawdata == kUnknown && trigprim == kUnknown)
         status = kUnknown;

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -54,8 +54,6 @@ namespace ecaldqm
   void
   SummaryClient::producePlots(ProcessType _pType)
   {
-    if(_pType == kLumi && !onlineMode_) return;
-    // TODO: Implement offline per-lumi summary
 
     MESet& meReportSummaryContents(MEs_.at("ReportSummaryContents"));
     MESet& meReportSummary(MEs_.at("ReportSummary"));
@@ -80,7 +78,7 @@ namespace ecaldqm
     MESet& meQualitySummary(MEs_.at("QualitySummary"));
     MESet& meReportSummaryMap(MEs_.at("ReportSummaryMap"));
 
-    MESet const& sIntegrity(sources_.at("Integrity"));
+    MESet const* sIntegrity(using_("Integrity") ? &sources_.at("Integrity") : 0);
     MESet const& sRawData(sources_.at("RawData"));
     MESet const* sPresample(using_("Presample") ? &sources_.at("Presample") : 0);
     MESet const* sTiming(using_("Timing") ? &sources_.at("Timing") : 0);
@@ -98,19 +96,16 @@ namespace ecaldqm
     std::map<uint32_t, int> badChannelsCount;
 
     MESet::iterator qEnd(meQualitySummary.end());
-    MESet::const_iterator iItr(sIntegrity);
     for(MESet::iterator qItr(meQualitySummary.beginChannel()); qItr != qEnd; qItr.toNextChannel()){
 
       DetId id(qItr->getId());
       unsigned iDCC(dccId(id) - 1);
 
-      iItr = qItr;
-
-      int integrity(iItr->getBinContent());
+      int integrity(sIntegrity ? sIntegrity->getBinContent(id) : kUnknown);
 
       if(integrity == kUnknown || integrity == kMUnknown){
         qItr->setBinContent(integrity);
-        continue;
+        if ( onlineMode_ ) continue;
       }
 
       int presample(sPresample ? sPresample->getBinContent(id) : kUnknown);
@@ -225,6 +220,3 @@ namespace ecaldqm
 
   DEFINE_ECALDQM_WORKER(SummaryClient);
 }
-
-
-


### PR DESCRIPTION
Fixed bugs in:
- setting hasLumiPlots_ flag of client MEs
- preventing unintended reset of Trend client MEs

Added features:
- by lumi reportSummaryContents for offline dqm (presample check temporary disabled pending better understanding of persistent kBad values)
- timing for offline dqm
- timing mean & rms trend plots

Removed Test Pulse from activeSources of calibration quality summary
Automatically ported from CMSSW_8_0_X #13295 (original by @mbandrews).
