### PR TITLE
Fix HF TP Scale.

### DIFF
--- a/CalibCalorimetry/CaloTPG/BuildFile.xml
+++ b/CalibCalorimetry/CaloTPG/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="CalibFormats/HcalObjects"/>
 <use   name="Geometry/CaloTopology"/>
 <use   name="Geometry/HcalTowerAlgo"/>
+<use   name="CalibCalorimetry/HcalTPGAlgos"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -62,6 +62,8 @@ private:
   std::vector<int> LUTfactor;
   double nominal_gain;
   double RCTLSB;
+  int NCTScaleShift;
+  int RCTScaleShift;  
 };
 
 //
@@ -96,6 +98,9 @@ CaloTPGTranscoderULUTs::CaloTPGTranscoderULUTs(const edm::ParameterSet& iConfig)
    nominal_gain = iConfig.getParameter<double>("nominal_gain");
    RCTLSB = iConfig.getParameter<double>("RCTLSB");
 
+   edm::ParameterSet hfSS=iConfig.getParameter<edm::ParameterSet>("HFTPScaleShift");
+   NCTScaleShift = hfSS.getParameter<int>("NCT");
+   RCTScaleShift = hfSS.getParameter<int>("RCT");
 }
 
 
@@ -157,7 +162,7 @@ CaloTPGTranscoderULUTs::produce(const CaloTPGRecord& iRecord)
    fullLut.setTopo(htopo.product());
 
    std::auto_ptr<CaloTPGTranscoderULUT> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
-   pTCoder->setup(fullLut, *theTrigTowerGeometry);
+   pTCoder->setup(fullLut, *theTrigTowerGeometry, NCTScaleShift, RCTScaleShift);
    return std::auto_ptr<CaloTPGTranscoder>( pTCoder );
 }
 

--- a/CalibCalorimetry/CaloTPG/python/CaloTPGTranscoder_cfi.py
+++ b/CalibCalorimetry/CaloTPG/python/CaloTPGTranscoder_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+hfTPScaleShift =cms.PSet(
+    NCT= cms.int32(1),
+    RCT= cms.int32(3)
+)
+
 CaloTPGTranscoder = cms.ESProducer("CaloTPGTranscoderULUTs",
     hcalLUT1 = cms.FileInPath('CalibCalorimetry/CaloTPG/data/outputLUTtranscoder_physics.dat'),
     hcalLUT2 = cms.FileInPath('CalibCalorimetry/CaloTPG/data/TPGcalcDecompress2.txt'),
@@ -10,5 +15,6 @@ CaloTPGTranscoder = cms.ESProducer("CaloTPGTranscoderULUTs",
     ZS = cms.vint32(4,2,1,0),
     LUTfactor = cms.vint32(1,2,5,0),
     nominal_gain = cms.double(0.177),
-    RCTLSB = cms.double(0.25)
+    RCTLSB = cms.double(0.25),
+    HFTPScaleShift = hfTPScaleShift,
 )

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -12,16 +12,14 @@
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/DataRecord/interface/HcalLutMetadataRcd.h"
+#include "CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h"
 
 using namespace std;
-
-constexpr float CaloTPGTranscoderULUT::LSB_HF;
-constexpr float CaloTPGTranscoderULUT::LSB_HBHE;
 
 CaloTPGTranscoderULUT::CaloTPGTranscoderULUT(const std::string& compressionFile,
                                              const std::string& decompressionFile)
                                                 : theTopology(0),
-                                                  nominal_gain_(0.), rctlsb_factor_(0.),
+                                                  nominal_gain_(0.), rctlsb_factor_(0.), nctlsb_factor_(0),
                                                   compressionFile_(compressionFile),
                                                   decompressionFile_(decompressionFile)
 {
@@ -92,7 +90,9 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	double cosh_ieta   = fabs(cosh((eta_low + eta_high)/2.));
 	double granularity =  meta->getLutGranularity(); 
 
-	double factor = isHBHE ?  (nominal_gain_ / cosh_ieta * granularity) : rctlsb_factor_;
+	double factor = isHBHE ?  
+			(nominal_gain_ / cosh_ieta * granularity) : 
+			(version==0 ? rctlsb_factor_ : nctlsb_factor_);
 
         LUT tpg = outputLUT_[index][0];
         int low = 0;
@@ -207,15 +207,13 @@ const std::vector<unsigned int>& CaloTPGTranscoderULUT::getCompressionLUT(const 
    return outputLUT_[itower];
 }
 
-void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry)
+void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry, int nctScaleShift, int rctScaleShift)
 {
-    theTopology = lutMetadata.topo();
-    nominal_gain_ = lutMetadata.getNominalGain();
-    float rctlsb =lutMetadata.getRctLsb();
-    if (rctlsb != LSB_HBHE && rctlsb != LSB_HF)
-	throw cms::Exception("RCTLSB") << " value=" << rctlsb << " (should be " << LSB_HBHE
-	    << " or " << LSB_HF << ")" << std::endl;
-    rctlsb_factor_ = rctlsb;
+    theTopology	    = lutMetadata.topo();
+    nominal_gain_   = lutMetadata.getNominalGain();
+
+    rctlsb_factor_  = HcaluLUTTPGCoder::lsb_*(1<<rctScaleShift);
+    nctlsb_factor_  = HcaluLUTTPGCoder::lsb_*(1<<nctScaleShift);
 
     if (compressionFile_.empty() && decompressionFile_.empty()) {
 	loadHCALCompress(lutMetadata,theTrigTowerGeometry);
@@ -224,4 +222,3 @@ void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTo
 	throw cms::Exception("Not Implemented") << "setup of CaloTPGTranscoderULUT from text files";
    }
 }
-

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -34,7 +34,7 @@ public:
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
   virtual bool HTvalid(const int ieta, const int iphi) const;
   virtual const std::vector<unsigned int>& getCompressionLUT(const HcalTrigTowerDetId& id) const;
-  virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&);
+  virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&, int, int);
   virtual int getOutputLUTId(const HcalTrigTowerDetId& id) const;
   virtual int getOutputLUTId(const int ieta, const int iphi) const;
 
@@ -50,15 +50,13 @@ public:
   static const unsigned int TPGMAX = 256;
   static const bool newHFphi = true;
 
-  static constexpr float LSB_HBHE = 0.25f;
-  static constexpr float LSB_HF = 0.5f;
-
   // Member functions
   void loadHCALCompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical compression tables
 
   // Member Variables
   double nominal_gain_;
   double rctlsb_factor_;
+  double nctlsb_factor_;
   std::string compressionFile_;
   std::string decompressionFile_;
   std::vector<int> ietal;

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -28,6 +28,7 @@ class HcalDbService;
   */
 class HcaluLUTTPGCoder : public HcalTPGCoder {
 public:
+  static const float  lsb_;
 
   HcaluLUTTPGCoder(const HcalTopology* topo);
   virtual ~HcaluLUTTPGCoder();
@@ -58,7 +59,6 @@ private:
   // constants
   static const size_t INPUT_LUT_SIZE = 128;
   static const int    nFi_ = 72;
-  static const float  lsb_;
   
   // member variables
   const HcalTopology* topo_;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -41,6 +41,9 @@ public:
                         const HcalElectronicsMap* emap,
                         HcalTrigPrimDigiCollection & result);
   void setPeakFinderAlgorithm(int algo);
+  void setNCTScaleShift(int);
+  void setRCTScaleShift(int);
+
  private:
 
   /// adds the signal to the map
@@ -77,6 +80,8 @@ public:
   int numberOfPresamplesHF_;
   uint32_t minSignalThreshold_;
   uint32_t PMT_NoiseThreshold_; 
+  int NCTScaleShift;
+  int RCTScaleShift;  
 
   // Algo1: isPeak = TS[i-1] < TS[i] && TS[i] >= TS[i+1]
   // Algo2: isPeak = TSS[i-1] < TSS[i] && TSS[i] >= TSS[i+1],

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi import hfTPScaleShift
+
 LSParameter =cms.untracked.PSet(
 HcalFeatureHFEMBit= cms.bool(False),
 Min_Long_Energy= cms.double(10),#makes a cut based on energy deposited in short vrs long
@@ -31,6 +33,7 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     InputTagFEDRaw = cms.InputTag("rawDataCollector"),
     RunZS = cms.bool(False),
     FrontEndFormatError = cms.bool(False), # Front End Format Error, for real data only
-    PeakFinderAlgorithm = cms.int32(2)
+    PeakFinderAlgorithm = cms.int32(2),
 
+    HFTPScaleShift = hfTPScaleShift,
 )

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -63,6 +63,11 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 
    produces<HcalTrigPrimDigiCollection>();
    theAlgo_.setPeakFinderAlgorithm(ps.getParameter<int>("PeakFinderAlgorithm"));
+
+   edm::ParameterSet hfSS=ps.getParameter<edm::ParameterSet>("HFTPScaleShift");
+
+   theAlgo_.setNCTScaleShift(hfSS.getParameter<int>("NCT"));
+   theAlgo_.setRCTScaleShift(hfSS.getParameter<int>("RCT"));
 }
 
 


### PR DESCRIPTION
Fixing new HF TP scale in the emulator and (un)-compression LUTs. 
Automatically ported from CMSSW_8_0_X #13290 (original by @akhukhun).
