### PR TITLE
Further cleanup of Condition access in AlCaDB, online DQM, Geometry, HLT, Simulation, and standard configuration

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/python/FrontierConditions_GlobalTag_cff.py
+++ b/Alignment/HIPAlignmentAlgorithm/python/FrontierConditions_GlobalTag_cff.py
@@ -35,5 +35,5 @@ from L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskVetoTechTrigConfig_cff i
 
 # end fake calibrations
 
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi import *
+from CondCore.ESSources.CondDBESSource_cfi import GlobalTag
 

--- a/Alignment/HIPAlignmentAlgorithm/python/FrontierConditions_GlobalTag_cff.py
+++ b/Alignment/HIPAlignmentAlgorithm/python/FrontierConditions_GlobalTag_cff.py
@@ -35,5 +35,5 @@ from L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskVetoTechTrigConfig_cff i
 
 # end fake calibrations
 
-from CondCore.ESSources.CondDBESSource_cfi import GlobalTag
+from Configuration.StandardSequences.CondDBESSource_cff import GlobalTag
 

--- a/Alignment/OfflineValidation/python/GlobalTag_cff.py
+++ b/Alignment/OfflineValidation/python/GlobalTag_cff.py
@@ -23,4 +23,4 @@ sistripconn = cms.ESProducer("SiStripConnectivity")
 
 # end fake calibrations
 
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi import *
+from CondCore.ESSources.CondDBESSource_cfi import GlobalTag

--- a/Alignment/OfflineValidation/python/GlobalTag_cff.py
+++ b/Alignment/OfflineValidation/python/GlobalTag_cff.py
@@ -23,4 +23,4 @@ sistripconn = cms.ESProducer("SiStripConnectivity")
 
 # end fake calibrations
 
-from CondCore.ESSources.CondDBESSource_cfi import GlobalTag
+from Configuration.StandardSequences.CondDBESSource_cff import GlobalTag

--- a/CalibCalorimetry/CastorCalib/python/CastorDbProducer_cfi.py
+++ b/CalibCalorimetry/CastorCalib/python/CastorDbProducer_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
 CastorDbProducer = cms.ESProducer( "CastorDbProducer",
-appendToDataLabel = cms.string( "" )
-)
+                                   appendToDataLabel = cms.string( "" )
+                                   )

--- a/CalibCalorimetry/HcalAlgos/test/BuildFile.xml
+++ b/CalibCalorimetry/HcalAlgos/test/BuildFile.xml
@@ -1,10 +1,8 @@
-<use   name="clhep"/>
-<use   name="DataFormats/HcalDetId"/>
 <use   name="CalibCalorimetry/HcalAlgos"/>
 <use   name="CondFormats/HcalObjects"/>
-<use   name="CondFormats/DataRecord"/>
-<use   name="Geometry/Records"/>
 <use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="Geometry/Records"/>
 <bin file="HcalShapeIntegrator.cpp"/>
 <bin file="HcalPulseContainmentTest.cpp"/>
 <library name="MapTester" file="MapTester.cc">

--- a/CondCore/DBCommon/python/CondDBCommon_cfi.py
+++ b/CondCore/DBCommon/python/CondDBCommon_cfi.py
@@ -1,7 +1,7 @@
-print " ################################################################### "  
-print " # WARNING: this module is deprecated.                             # "                                                                              
-print " # Please use CondCore.CondDB.CondDB_cfi.py                        # "                                                                             
-print " ################################################################### "
+print " ##################################################################### "  
+print " # WARNING: the module CondCore.DBCommon.CondDBCommon is deprecated. # "                                                                              
+print " # Please import CondCore.CondDB.CondDB_cfi                          # "                                                                             
+print " ##################################################################### "
 
 from CondCore.CondDB.CondDB_cfi import *
 CondDBCommon = CondDB.clone()

--- a/CondCore/DBCommon/python/CondDBSetup_cfi.py
+++ b/CondCore/DBCommon/python/CondDBSetup_cfi.py
@@ -1,7 +1,7 @@
-print " ################################################################### "
-print " # WARNING: this module is deprecated.                             # "  
-print " # Please use CondCore.CondDB.CondDB_cfi.py                        # "
-print " ################################################################### "
+print " ##################################################################### "
+print " # WARNING: the module CondCore.DBCommon.CondDBSetup is deprecated.  # "
+print " # Please import CondCore.CondDB.CondDB_cfi                          # "
+print " ##################################################################### "
 
 from CondCore.CondDB.CondDB_cfi import *
 CondDBSetup = CondDB.clone()

--- a/CondCore/ESSources/python/CondDBESSource_cfi.py
+++ b/CondCore/ESSources/python/CondDBESSource_cfi.py
@@ -1,10 +1,15 @@
 #This is the default configuration for the connection to the frontier servlets
 #in order to fetch the condition payloads in CMSSW.
+import socket
 import FWCore.ParameterSet.Config as cms
 from CondCore.CondDB.CondDB_cfi import *
 
 CondDBConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ) )
-print '# Conditions read from  CMS_CONDITIONS  via FrontierProd '
+if socket.getfqdn().find('.cms') != -1:
+    CondDBConnection.connect = cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS')
+    print '# Conditions read from  CMS_CONDITIONS  via squid running in localhost and pointing to FrontierOnProd '
+else:
+    print '# Conditions read from  CMS_CONDITIONS  via FrontierProd '
 GlobalTag = cms.ESSource( "PoolDBESSource",
                           CondDBConnection,
                           globaltag        = cms.string( '' ),

--- a/CondCore/ESSources/python/CondDBESSource_condDBv2_cfi.py
+++ b/CondCore/ESSources/python/CondDBESSource_condDBv2_cfi.py
@@ -1,0 +1,1 @@
+from CondCore.ESSources.CondDBESSource_cfi import *

--- a/CondCore/ESSources/test/python/load_from_prodglobaltag_cfg.py
+++ b/CondCore/ESSources/test/python/load_from_prodglobaltag_cfg.py
@@ -80,7 +80,7 @@ process = cms.Process("TEST")
 
 process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("CondCore.ESSources.CondDBESSource_cfi")
 process.GlobalTag.globaltag = gName
 
 process.GlobalTag.RefreshEachRun=cms.untracked.bool(False)

--- a/CondCore/ESSources/test/python/loadall_from_prodglobaltag_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_prodglobaltag_cfg.py
@@ -16,7 +16,7 @@ options.parseArguments()
 
 process = cms.Process("TEST")
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("CondCore.ESSources.CondDBESSource_cfi")
 process.GlobalTag.globaltag = options.globalTag
 process.GlobalTag.RefreshEachRun=cms.untracked.bool(False)
 process.GlobalTag.DumpStat=cms.untracked.bool(True)

--- a/CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_OrcoffOnly_cfi.py
+++ b/CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_OrcoffOnly_cfi.py
@@ -1,16 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMStore_cfg import *
-from CondCore.DBCommon.CondDBSetup_cfi import *
-
-CondDBSetup.DBParameters.authenticationPath = cms.untracked.string('/build/diguida/conddb')
+from CondCore.CondDB.CondDB_cfi import *
+CondDBReference = CondDB.clone(connect = cms.string('oracle://cms_orcoff_prep/CMS_COND_TEMP'))
+CondDBReference.DBParameters.messageLevel = cms.untracked.int32(1) #3 for high verbosity
 
 ReferenceRetrieval = cms.ESSource("PoolDBESSource",
-                                  CondDBSetup,
-                                  connect = cms.string('oracle://cms_orcoff_prep/CMS_COND_TEMP'),
-                                  BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-                                  messageLevel = cms.untracked.int32(1), #3 for high verbosity
-                                  timetype = cms.string('runnumber'),
+                                  CondDBReference,
                                   toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
                                                              tag = cms.string('DQM_Cosmics_prompt')
                                                              )

--- a/CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_SQLiteOnly_cfi.py
+++ b/CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_SQLiteOnly_cfi.py
@@ -1,16 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMStore_cfg import *
-from CondCore.DBCommon.CondDBSetup_cfi import *
-
-#CondDBSetup.DBParameters.authenticationPath = cms.untracked.string('/build/diguida/conddb')
+from CondCore.CondDB.CondDB_cfi import *
+CondDBReference = CondDB.clone(connect = cms.string('sqlite_file:ROOTFILE_Test.db'))
+CondDBReference.DBParameters.messageLevel = cms.untracked.int32(1) #3 for high verbosity
 
 ReferenceRetrieval = cms.ESSource("PoolDBESSource",
-                                  CondDBSetup,
-                                  connect = cms.string('sqlite_file:ROOTFILE_Test.db'),
-                                  BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-                                  messageLevel = cms.untracked.int32(1), #3 for high verbosity
-                                  timetype = cms.string('runnumber'),
+                                  CondDBReference,
                                   toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
                                                              tag = cms.string('ROOTFILE_Test')
                                                              )

--- a/CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi.py
+++ b/CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi.py
@@ -1,16 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMStore_cfg import *
-from CondCore.DBCommon.CondDBSetup_cfi import *
 
 dqmRefHistoRootFileGetter=cms.EDAnalyzer("DQMReferenceHistogramRootFileEventSetupAnalyzer") 
 
+## from CondCore.CondDB.CondDB_cfi import *
+## CondDBReference = CondDB.clone(connect = cms.string('sqlite_file:DQMReferenceHistogramTest.db'))
+## CondDBReference.DBParameters.messageLevel = cms.untracked.int32(1) #3 for high verbosity
 ## ReferenceRetrieval = cms.ESSource("PoolDBESSource",
-##                                   CondDBSetup,
-##                                   connect = cms.string('sqlite_file:DQMReferenceHistogramTest.db'),
-##                                   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-##                                   messageLevel = cms.untracked.int32(1), #3 for high verbosity
-##                                   timetype = cms.string('runnumber'),
+##                                   CondDBReference,
 ##                                   toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
 ##                                                              tag = cms.string('ROOTFILE_DQM_Test10')
 ##                                                              )

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
@@ -29,7 +29,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(250000) )
 # Input for AlCaRecoTriggerBitsRcd,
 # either via GloblalTag (use of _cfi instead of _cff sufficient and faster):
 from Configuration.AlCa.autoCond import autoCond
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("CondCore.ESSources.CondDBESSource_cfi")
 process.GlobalTag.globaltag = autoCond['run2_data'] #choose your tag
 
 # ...or specify database and tag:  

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
@@ -27,26 +27,26 @@ process.source = cms.Source("EmptySource",
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(250000) )
 
 # Input for AlCaRecoTriggerBitsRcd,
-# either via GloblalTag (use of _cfi instead of _cff sufficient and faster):
+# either via GlobalTag
+# (loading of Configuration.StandardSequences.CondDBESSource_cff equivalent to CondCore.ESSources.CondDBESSource_cfi
+# as entry point for condition records in the EventSetup,
+# but sufficient and faster than Configuration.StandardSequences.FrontierConditions_GlobalTag_cff):
 from Configuration.AlCa.autoCond import autoCond
-process.load("CondCore.ESSources.CondDBESSource_cfi")
+process.load("Configuration.StandardSequences.CondDBESSource_cff")
 process.GlobalTag.globaltag = autoCond['run2_data'] #choose your tag
 
 # ...or specify database and tag:  
-#import CondCore.DBCommon.CondDBSetup_cfi
-#process.dbInput = cms.ESSource(
-#    "PoolDBESSource",
-#    CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup,
-##    connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
-#    connect = cms.string('frontier://FrontierProd/CMS_COND_31X_HLT'),
-#    toGet = cms.VPSet(cms.PSet(
-#        record = cms.string('AlCaRecoTriggerBitsRcd'),
-##        tag = cms.string('TestTag') # choose tag you want
-#        tag = cms.string('AlCaRecoHLTpaths8e29_1e31_v5_hlt') # choose tag you want
-#
-#        )
-#                      )
-#    )
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDBTriggerBits = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_COND_31X_HLT'))
+##CondDBTriggerBits = CondDB.clone(connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'))
+#process.dbInput = cms.ESSource("PoolDBESSource",
+#                               CondDBTriggerBits,
+#                               toGet = cms.VPSet(cms.PSet(record = cms.string('AlCaRecoTriggerBitsRcd'),
+##                                                          tag = cms.string('TestTag') # choose tag you want
+#                                                          tag = cms.string('AlCaRecoHLTpaths8e29_1e31_v5_hlt') # choose tag you want
+#                                                          )
+#                                                 )
+#                               )
 
 # Put module in path:
 process.p = cms.Path(process.AlCaRecoTriggerBitsRcdRead)

--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -57,7 +57,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # if no GlobalTag ESSource module is given, load a "default" configuration
     if essource is None:
-        from Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi import GlobalTag as essource
+        from CondCore.ESSources.CondDBESSource_cfi import GlobalTag as essource
 
     # if a Global Tag is given, check for an "auto" tag, and look it up in autoCond.py
     # if a match is found, load the actual Global Tag and optional conditions

--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -57,7 +57,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # if no GlobalTag ESSource module is given, load a "default" configuration
     if essource is None:
-        from CondCore.ESSources.CondDBESSource_cfi import GlobalTag as essource
+        from Configuration.StandardSequences.CondDBESSource_cff import GlobalTag as essource
 
     # if a Global Tag is given, check for an "auto" tag, and look it up in autoCond.py
     # if a match is found, load the actual Global Tag and optional conditions

--- a/Configuration/StandardSequences/python/AdditionalConditions_cff.py
+++ b/Configuration/StandardSequences/python/AdditionalConditions_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+# the following are needed for non PoolDBESSources
+from CalibCalorimetry.EcalLaserCorrection.ecalLaserCorrectionService_cfi import *
+from CalibCalorimetry.HcalPlugins.Hcal_Conditions_forGlobalTag_cff import *
+from CalibCalorimetry.CastorCalib.CastorDbProducer_cfi import *
+from CalibTracker.Configuration.Tracker_DependentRecords_forGlobalTag_nofakes_cff import *

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -9,15 +9,14 @@ from Alignment.CommonAlignmentProducer.AlcaSiPixelAliHarvester_cff import *
 from Calibration.TkAlCaRecoProducers.PCLMetadataWriter_cfi import *
 
 # common ingredients
-from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
-CondDBCommon.connect = "sqlite_file:promptCalibConditions.db"
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDBOutput = CondDB.clone(connect = cms.string("sqlite_file:promptCalibConditions.db"))
 
 PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                  CondDBCommon,
+                                  CondDBOutput,
                                   toPut = cms.VPSet(),
-                                  loadBlobStreamer = cms.untracked.bool(False),
-                                  #    timetype   = cms.untracked.string('lumiid')
-                                  #    timetype   = cms.untracked.string('runnumber')
+                                  #timetype = cms.untracked.string("runnumber"),
+                                  #timetype = cms.untracked.string("lumiid"),
                                   )
 
 

--- a/Configuration/StandardSequences/python/CondDBESSource_cff.py
+++ b/Configuration/StandardSequences/python/CondDBESSource_cff.py
@@ -1,0 +1,1 @@
+from CondCore.ESSources.CondDBESSource_cfi import GlobalTag

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cff.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cff.py
@@ -1,10 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi import *
-
-# the following are needed for non PoolDBESSources
-from CalibCalorimetry.EcalLaserCorrection.ecalLaserCorrectionService_cfi import *
-from CalibCalorimetry.HcalPlugins.Hcal_Conditions_forGlobalTag_cff import *
-from CalibTracker.Configuration.Tracker_DependentRecords_forGlobalTag_nofakes_cff import *
-# FIXME: should be moved to a cfi in a castor package
-CastorDbProducer = cms.ESProducer("CastorDbProducer")
+from CondCore.ESSources.CondDBESSource_cfi import GlobalTag
+from Configuration.StandardSequences.AdditionalConditions_cff import *

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cff.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-from CondCore.ESSources.CondDBESSource_cfi import GlobalTag
+from Configuration.StandardSequences.CondDBESSource_cff import *
 from Configuration.StandardSequences.AdditionalConditions_cff import *

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cfi.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cfi.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from CondCore.ESSources.CondDBESSource_cfi import GlobalTag

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cfi.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cfi.py
@@ -1,1 +1,0 @@
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi import *

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -4,9 +4,6 @@ import FWCore.ParameterSet.Config as cms
 # scenarios. In this case it makes changes for Run 2.
 from Configuration.StandardSequences.Eras import eras
 
-from CondCore.DBCommon.CondDBSetup_cfi import *
-
-
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import *
 
 from EventFilter.SiStripRawToDigi.SiStripDigis_cfi import *

--- a/DQM/BeamMonitor/test/beam_dqm_sourceclient-file_cfg.py
+++ b/DQM/BeamMonitor/test/beam_dqm_sourceclient-file_cfg.py
@@ -71,7 +71,7 @@ process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cf
 #--------------------------
 # Calibration
 #--------------------------
-process.load("DQM.Integration.test.FrontierCondition_GT_cfi")
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/BeamMonitor/test/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/BeamMonitor/test/beam_dqm_sourceclient-live_cfg.py
@@ -55,7 +55,7 @@ process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cf
 #--------------------------
 # Calibration
 #--------------------------
-process.load("DQM.Integration.test.FrontierCondition_GT_cfi")
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/BeamMonitor/test/beam_dqm_sourceclient-playback_cfg.py
+++ b/DQM/BeamMonitor/test/beam_dqm_sourceclient-playback_cfg.py
@@ -67,7 +67,7 @@ process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cf
 #--------------------------
 # Calibration
 #--------------------------
-process.load("DQM.Integration.test.FrontierCondition_GT_cfi")
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/DTMonitorModule/test/dt_dqm_offlinesources_Cosmics_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlinesources_Cosmics_cfg.py
@@ -22,12 +22,9 @@ process.maxEvents = cms.untracked.PSet(
 
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
-
-
 # Conditions (Global Tag is used here):
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = "GR09_31X_V5P::All"
 #process.prefer("GlobalTag")
 

--- a/DQM/DTMonitorModule/test/dt_dqm_offlinesources_Cosmics_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlinesources_Cosmics_cfg.py
@@ -24,11 +24,11 @@ process.maxEvents = cms.untracked.PSet(
 
 # Conditions (Global Tag is used here):
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.CondDBESSource_cff")
 process.GlobalTag.globaltag = "GR09_31X_V5P::All"
 #process.prefer("GlobalTag")
 
-# Magnetic fiuld: force mag field to be 3.8 tesla
+# Magnetic field: force mag field to be 3.8 tesla
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 
 #Geometry

--- a/DQM/DTMonitorModule/test/dt_dqm_offlinesources_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlinesources_cfg.py
@@ -22,12 +22,9 @@ process.maxEvents = cms.untracked.PSet(
 
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
-
-
 # Conditions (Global Tag is used here):
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = "GR09_31X_V5P::All"
 #process.prefer("GlobalTag")
 

--- a/DQM/DTMonitorModule/test/dt_dqm_offlinesources_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlinesources_cfg.py
@@ -24,7 +24,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Conditions (Global Tag is used here):
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.CondDBESSource_cff")
 process.GlobalTag.globaltag = "GR09_31X_V5P::All"
 #process.prefer("GlobalTag")
 

--- a/DQM/DTMonitorModule/test/dt_fedtest_sourceclient-file_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_fedtest_sourceclient-file_cfg.py
@@ -36,7 +36,7 @@ process.MessageLogger = cms.Service("MessageLogger",
                                     )
 
 # Global tag
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("CondCore.ESSources.CondDBESSource_cfi")
 process.GlobalTag.globaltag ="GR10_P_V4::All"
 
 #-----------------------------

--- a/DQM/DTMonitorModule/test/dt_fedtest_sourceclient-file_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_fedtest_sourceclient-file_cfg.py
@@ -35,9 +35,10 @@ process.MessageLogger = cms.Service("MessageLogger",
                                     cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'))
                                     )
 
-# Global tag
-process.load("CondCore.ESSources.CondDBESSource_cfi")
-process.GlobalTag.globaltag ="GR10_P_V4::All"
+# Global tag: load the standard configuration fragment, then change and possibly customise the GT
+process.load("Configuration.StandardSequences.CondDBESSource_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #-----------------------------
 #### Sub-system configuration follows

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -59,8 +59,9 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 #---------------
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 # Change Beam Monitor variables
 if process.dqmRunConfig.type.value() is "playback":

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -33,12 +33,10 @@ process.dqmSaver.tag = "BeamPixel"
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
-# Use this to run locally (for testing purposes)
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+# Use this to run locally (for testing purposes), choose the right GT
 #from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 #process.GlobalTag = GlobalTag(process.GlobalTag, "74X_dataRun2_Prompt_v0", "")
-# Otherwise use this
-process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -27,7 +27,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 #============================================
 # Castor Conditions: from Global Conditions Tag 
 #============================================
-process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+process.load('Configuration.StandardSequences.CondDBESSource_cff')
 #FIXME: they should use an official GT, not define custom records and conditions on their own!!!
 process.GlobalTag.toGet = cms.VPSet( cms.PSet( record = cms.string('CastorGainsRcd'),
                                                tag = cms.string('CastorGains_v2.1_hlt'), 

--- a/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
@@ -122,8 +122,9 @@ del cscConditions
 #---------------------------------------
 
 
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #--------------------------
 # Service

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -32,9 +32,9 @@ process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("DQM.DTMonitorModule.dt_dqm_sourceclient_common_cff")
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-#---- for offline DB
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
-
+#---- for offline DB: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
@@ -14,8 +14,9 @@ process.load("DQM.Integration.config.inputsource_cfi")
 
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 process.load("EventFilter.ESRawToDigi.esRawToDigi_cfi")
 #process.ecalPreshowerDigis = EventFilter.ESRawToDigi.esRawToDigi_cfi.esRawToDigi.clone()

--- a/DQM/Integration/python/clients/fedtest_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fedtest_dqm_sourceclient-live_cfg.py
@@ -35,8 +35,9 @@ process.MessageLogger = cms.Service("MessageLogger",
 # Global tag
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
-# Need for test in lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi")
+# Need for test in lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 
 #-----------------------------

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -25,11 +25,11 @@ useMap		= False
 #	Central DQM Stuff imports
 #-------------------------------------
 from DQM.Integration.config.online_customizations_cfi import *
+process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useOfflineGT:
-	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '74X_dataRun2_HLT_v1'
-else:
-	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+	# DB condition for offline test: change and possibly customise the GT
+	from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+	process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_hlt', '')
 if useFileInput:
 	process.load("DQM.Integration.config.fileinputsource_cfi")
 else:

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -25,11 +25,11 @@ useMap		= False
 #	Central DQM Stuff imports
 #-------------------------------------
 from DQM.Integration.config.online_customizations_cfi import *
+process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useOfflineGT:
-	process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
-	process.GlobalTag.globaltag = '74X_dataRun2_HLT_v1'
-else:
-	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+	# DB condition for offline test: change and possibly customise the GT
+	from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+	process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_hlt', '')
 if useFileInput:
 	process.load("DQM.Integration.config.fileinputsource_cfi")
 else:

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -24,8 +24,9 @@ process.TkDetMap = cms.Service("TkDetMap")
 
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 process.load("DQM.HLTEvF.HLTObjectMonitor_cff")
 # added for hlt scalars

--- a/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
@@ -46,9 +46,9 @@ process.dqmSaver.tag = "HLTRates"
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
-#---- for offline DB access
-#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-#process.GlobalTag.globaltag = 'GR_E_V19::All'
+#---- for offline DB access: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, "74X_dataRun2_Express_v3", "")
 
 
 

--- a/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
@@ -32,10 +32,10 @@ process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/l1t_reference.root"
 
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-es_prefer_GlobalTag = cms.ESPrefer('GlobalTag')
 process.GlobalTag.RefreshEachRun = cms.untracked.bool(True)
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/l1temulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1temulator_dqm_sourceclient-live_cfg.py
@@ -37,8 +37,9 @@ process.dqmSaver.tag = 'L1TEMU'
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.RefreshEachRun = cms.untracked.bool(True)
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 

--- a/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
@@ -33,10 +33,10 @@ process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/l1t_reference.root"
 
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-es_prefer_GlobalTag = cms.ESPrefer('GlobalTag')
 process.GlobalTag.RefreshEachRun = cms.untracked.bool(True)
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus:: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
@@ -36,8 +36,9 @@ process.dqmSaver.tag = 'L1TEMUStage1'
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.RefreshEachRun = cms.untracked.bool(True)
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 

--- a/DQM/Integration/python/clients/lumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/lumi_dqm_sourceclient-live_cfg.py
@@ -37,7 +37,6 @@ process.expressLumiProducer=cms.EDProducer("ExpressLumiProducer",
 #----------------------------
 ### @@@@@@ Comment when running locally @@@@@@ ###
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-process.GlobalTag.DBParameters.authenticationPath  = process.DBService.authPath
 ### @@@@@@ Comment when running locally @@@@@@ ###
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
@@ -29,8 +29,9 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cff')

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -59,8 +59,9 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 #-------------------------------------------------
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -55,8 +55,9 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 #-------------------------------------------------
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -28,8 +28,9 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 ################ Condition ######################
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 process.GlobalTag.RefreshEachRun = cms.untracked.bool(True)
 
 ############# DQM Cetral Modules ################

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -81,9 +81,10 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 # Condition for P5 cluster
 if (live):
     process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
+# Condition for lxplus: change and possibly customise the GT
 elif(offlineTesting):
-    process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+    from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #--------------------------------------------
 ## Patch to avoid using Run Info information in reconstruction

--- a/DQM/Integration/python/clients/sistriplas_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistriplas_dqm_sourceclient-live_cfg.py
@@ -24,9 +24,10 @@ process.siStripDigis.ProductLabel = "source"#"hltCalibrationRaw"
 # Calibration
 #--------------------------
 # Condition for P5 cluster
-#process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus
-process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #----------------------------
 # DQM Live Environment

--- a/DQM/Integration/python/config/FrontierCondition_GT_Offline_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_Offline_cfi.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
-from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-
-GlobalTag = gtCustomise(GlobalTag, 'auto:run2_data', '')

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,9 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS"
-GlobalTag.pfnPrefix = cms.untracked.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/")
 GlobalTag.globaltag = "80X_dataRun2_Express_v0"
-es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.globaltag = "80X_dataRun2_Express_v0"
+GlobalTag.globaltag = "80X_dataRun2_Express_v1"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,5 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
-GlobalTag.globaltag = "80X_dataRun2_HLT_v2"
-es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
+GlobalTag.globaltag = "80X_dataRun2_HLT_v4"

--- a/Geometry/CSCGeometry/test/cgac_db_withb_cfg.py
+++ b/Geometry/CSCGeometry/test/cgac_db_withb_cfg.py
@@ -22,7 +22,7 @@ process.GlobalTag.globaltag = 'START42_V6::All'
 ##process.load('Geometry.CSCGeometryBuilder.cscGeometryDB_cfi')
 ##process.load('Geometry.CSCGeometryBuilder.idealForDigiCscGeometryDB_cff')
 # note following is cfi not cff (unnec for csc geom)
-##process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi')
+##process.load('CondCore.ESSources.CondDBESSource_cfi')
 # Any 'MC' tag is always ideal !BEWARE!
 ##process.GlobalTag.globaltag = 'MC_42_V6::All'
 ##process.GlobalTag.globaltag = 'START42_V6::All'

--- a/Geometry/CSCGeometry/test/cgac_db_withb_cfg.py
+++ b/Geometry/CSCGeometry/test/cgac_db_withb_cfg.py
@@ -9,8 +9,8 @@ process = cms.Process("GeometryAsChambersWithB")
 
 # To access the FULL geometry requires
 # ====================================
-process.load('Configuration/StandardSequences/GeometryDB_cff')
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 # Any 'MC' tag is always ideal !BEWARE!
 ##process.GlobalTag.globaltag = 'MC_42_V6::All'
 process.GlobalTag.globaltag = 'START42_V6::All'
@@ -21,8 +21,8 @@ process.GlobalTag.globaltag = 'START42_V6::All'
 ##process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 ##process.load('Geometry.CSCGeometryBuilder.cscGeometryDB_cfi')
 ##process.load('Geometry.CSCGeometryBuilder.idealForDigiCscGeometryDB_cff')
-# note following is cfi not cff (unnec for csc geom)
-##process.load('CondCore.ESSources.CondDBESSource_cfi')
+# note: the following is the standard entry point for condition records (necessary for CSC geometry)
+##process.load('Configuration.StandardSequences.CondDBESSource_cff')
 # Any 'MC' tag is always ideal !BEWARE!
 ##process.GlobalTag.globaltag = 'MC_42_V6::All'
 ##process.GlobalTag.globaltag = 'START42_V6::All'

--- a/HLTrigger/HLTanalyzers/test/HLTOfflineReproducibility_cfg.py
+++ b/HLTrigger/HLTanalyzers/test/HLTOfflineReproducibility_cfg.py
@@ -33,11 +33,9 @@ if DQM:
     process.load('Configuration.EventContent.EventContent_cff')
     process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi')
+process.load('CondCore.ESSources.CondDBESSource_cfi')
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['hltonline']
-process.GlobalTag.connect   = 'frontier://FrontierProd/CMS_COND_31X_GLOBALTAG'
-process.GlobalTag.pfnPrefix = cms.untracked.string('frontier://FrontierProd/')
 
 #INPUTFILE="rfio:/castor/cern.ch/user/j/jalimena/177139/HT/out_177139_HT_0.root"
 INPUTFILE="rfio:/castor/cern.ch/user/j/jalimena/194050/MinimumBias/out_194050_MinimumBias_xxx.root"

--- a/HLTrigger/HLTanalyzers/test/HLTOfflineReproducibility_cfg.py
+++ b/HLTrigger/HLTanalyzers/test/HLTOfflineReproducibility_cfg.py
@@ -33,7 +33,7 @@ if DQM:
     process.load('Configuration.EventContent.EventContent_cff')
     process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.load('CondCore.ESSources.CondDBESSource_cfi')
+process.load('Configuration.StandardSequences.CondDBESSource_cff')
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['hltonline']
 

--- a/HLTrigger/special/test/dtMonitorStream_cfg.py
+++ b/HLTrigger/special/test/dtMonitorStream_cfg.py
@@ -25,7 +25,7 @@ process.load("Configuration.StandardSequences.Geometry_cff")
 
 
 # Conditions (Global Tag is used here):
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+process.load("CondCore.ESSources.CondDBESSource_cfi")
 process.GlobalTag.globaltag = "GR09_31X_V2P::All"
 
 process.load("HLTrigger.special.hltDTROMonitorFilter_cfi")

--- a/HLTrigger/special/test/dtMonitorStream_cfg.py
+++ b/HLTrigger/special/test/dtMonitorStream_cfg.py
@@ -25,7 +25,7 @@ process.load("Configuration.StandardSequences.Geometry_cff")
 
 
 # Conditions (Global Tag is used here):
-process.load("CondCore.ESSources.CondDBESSource_cfi")
+process.load("Configuration.StandardSequences.CondDBESSource_cff")
 process.GlobalTag.globaltag = "GR09_31X_V2P::All"
 
 process.load("HLTrigger.special.hltDTROMonitorFilter_cfi")

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from SimCalorimetry.HcalSimProducers.hcalSimParameters_cfi import *
-from CondCore.DBCommon.CondDBSetup_cfi import *
 from Geometry.HcalEventSetup.HcalRelabel_cfi import HcalReLabel
 
 # make a block so other modules, such as the data mixing module, can
@@ -51,15 +50,16 @@ from Configuration.StandardSequences.Eras import eras
 if eras.fastSim.isChosen():
     hcalSimBlock.hitsProducer = cms.string('famosSimHits')
     
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDB_cholesky = CondDB.clone( connect = cms.string('sqlite_file:CondFormats/HcalObjects/data/cholesky_sql.db') )
 #es_cholesky = cms.ESSource("PoolDBESSource",
-#    CondDBSetup,
+#    CondDB_cholesky,
 #    timetype = cms.string('runnumber'),
 #    toGet = cms.VPSet(
 #        cms.PSet(
 #            record = cms.string("HcalCholeskyMatricesRcd"),
 #            tag = cms.string("TestCholesky")
 #        )),
-#    connect = cms.string('sqlite_file:CondFormats/HcalObjects/data/cholesky_sql.db'),
 #    appendToDataLabel = cms.string('reference'),
 #    authenticationMethod = cms.untracked.uint32(0),
 #)

--- a/SimMuon/GEMDigitizer/BuildFile.xml
+++ b/SimMuon/GEMDigitizer/BuildFile.xml
@@ -1,8 +1,6 @@
 <use   name="boost"/>
-<use   name="CondCore/DBCommon"/>
+<use   name="CondCore/CondDB"/>
 <use   name="CondCore/DBOutputService"/>
-<use   name="CondCore/IOVService"/>
-<use   name="CondCore/MetaDataService"/>
 <use   name="CondCore/PopCon"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/RPCObjects"/>

--- a/SimMuon/RPCDigitizer/BuildFile.xml
+++ b/SimMuon/RPCDigitizer/BuildFile.xml
@@ -1,8 +1,6 @@
 <use   name="boost"/>
-<use   name="CondCore/DBCommon"/>
+<use   name="CondCore/CondDB"/>
 <use   name="CondCore/DBOutputService"/>
-<use   name="CondCore/IOVService"/>
-<use   name="CondCore/MetaDataService"/>
 <use   name="CondCore/PopCon"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/RPCObjects"/>

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -30,10 +30,10 @@ git cms-addpkg GeometryReaders/XMLIdealGeometryESSource
 git cms-addpkg Geometry/CaloEventSetup
 
 if ($loctag != '') then 
-    git cms-addpkg Configuration/StandardSequences
-    cd Configuration/StandardSequences/python
+    git cms-addpkg CondCore/ESSources
+    cd CondCore/ESSources/python
     set escloctag = `(echo $loctag | sed '{s/\//\\\//g}')`
-    sed -i "{s/frontier:\/\/FrontierProd\/CMS_COND_31X_GLOBALTAG/${escloctag}/g}" FrontierConditions_GlobalTag_cfi.py 
+    sed -i "{s/frontier:\/\/FrontierProd\/CMS_CONDITIONS/${escloctag}/g}" CondDBESSource_cfi.py 
 endif
 
 cd $CMSSW_BASE/src

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation_local_test.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation_local_test.sh
@@ -62,9 +62,9 @@ addpkg CondTools/Geometry
 #cvs update -r V05-00-11 Geometry/TrackerGeometryBuilder
 
 if ($loctag != '') then 
-    cd Configuration/StandardSequences/python
+    cd CondCore/ESSources/python
     set escloctag = `(echo $loctag | sed '{s/\//\\\//g}')`
-    sed -i "{s/frontier:\/\/FrontierProd\/CMS_COND_31X_GLOBALTAG/${escloctag}/g}" FrontierConditions_GlobalTag_cfi.py 
+    sed -i "{s/frontier:\/\/FrontierProd\/CMS_CONDITIONS/${escloctag}/g}" CondDBESSource_cfi.py 
 endif
 
 cd $CMSSW_BASE/src


### PR DESCRIPTION
This is the next step of cleanup and improvement for condition access:
- Revision of the configuration initialisation and fragments for Condition 
  access:
  - Added `CondCore/ESSources/python/CondDBESSources_condDBv2_cfi.py` in order to keep compatibility with the explicit or implicit usage of the condition software version;
  - Added `Configuration/StandardSequences/python/AdditionalConditions_cff.py`: this fragment is used in order to load conditions not provided by Global Tag and/or Condition records;
  - Dropped `Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cfi.py` and `Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cfi.py`: they are not needed, as the initialisation of the `ESSource` for loading conditions is done in the proper package;
  - Dropped references to `Configuration/StandardSequences/python/FrontierConditions_GlobalTag_cfi.py`in client code.
  - Improved deprecation message for modules `CondCore/DBCommon/python/CondDBCommon_cfi.py` and `CondCore/DBCommon/python/CondDBSetup_cfi.py`.
- Define the default connection string after checking the cluster where the job is run: if in GPN or WAN, use the usual one, if in the online network, fetch conditions from the squid running on localhost.
- Revision of Condition access in Online DQM:
  - Cleanup of `DQM/Integration/python/config/FrontierCondition_GT_cfi.py` and `DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py`: the connection string is established centrally;
  - Dropped `DQM/Integration/python/config/FrontierCondition_GT_Offline_cfi.py`;
  - Correspondent changes in client applications, where the GT customisation is enabled.
- Clean-up some `BuildFile` from dependencies upon removed packages.
- Improved test configuration file.
- Cleaned up spurious includes of `CondDBSetup_cfi` and `CondDBCommon_cfi` in `CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_OrcoffOnly_cfi.py`, 
  `CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_SQLiteOnly_cfi.py`, `CondTools/DQM/python/DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi.py`, `Configuration/StandardSequences/python/RawToDigi_cff.py`, and `SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py`.

Unit tests ran OK:
EDIT: on `CMSSW_8_0_X_2016-02-16-2300` IB`

```
$ git cms-ckeckdeps -a
$ scram b -r -j 4 runtests
```

Short matrix tests passed, and, as expected, no CondDB python `cfi` deprecation warning is seen:
EDIT: on `CMSSW_8_0_X_2016-02-16-2300` IB

```
4.22_RunCosmics2011A+RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Feb  2 15:16:58 2016-date Tue Feb  2 15:12:56 2016; exit: 0 0 0 0 0
5.1_TTbar+TTbarFS+HARVESTFS Step0-PASSED Step1-PASSED  - time date Tue Feb  2 15:18:48 2016-date Tue Feb  2 15:12:57 2016; exit: 0 0
8.0_BeamHalo+BeamHaloINPUT+DIGICOS+RECOCOS+ALCABH+HARVESTCOS Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Feb  2 15:17:01 2016-date Tue Feb  2 15:13:00 2016; exit: 0 0 0 0 0
25.0_TTbar+TTbarINPUT+DIGI+RECOAlCaCalo+HARVEST+ALCATT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Feb  2 15:20:38 2016-date Tue Feb  2 15:13:04 2016; exit: 0 0 0 0 0
134.911_RunSinglePh2015D+RunSinglePh2015D+HLTDR2_25ns+RECODR2_25nsreHLT+HARVESTDR2_25nsreHLT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Feb  2 15:26:21 2016-date Tue Feb  2 15:16:59 2016; exit: 0 0 0 0
135.4_ZEE_13+ZEEFS_13+HARVESTUP15FS+MINIAODMCUP15FS Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Feb  2 15:29:02 2016-date Tue Feb  2 15:17:11 2016; exit: 0 0 0
140.53_RunHI2011+RunHI2011+RECOHID11+HARVESTDHI Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Feb  2 15:22:55 2016-date Tue Feb  2 15:18:55 2016; exit: 0 0 0
1330.0_ZMM_13+ZMM_13INPUT+DIGIUP15+RECOUP15+HARVESTUP15 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Feb  2 15:31:50 2016-date Tue Feb  2 15:20:46 2016; exit: 0 0 0 0
1000.0_RunMinBias2011A+RunMinBias2011A+TIER0+SKIMD+HARVESTDfst2+ALCASPLIT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Feb  2 15:30:41 2016-date Tue Feb  2 15:22:57 2016; exit: 0 0 0 0 0
1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED Step6-PASSED  - time date Tue Feb  2 15:33:40 2016-date Tue Feb  2 15:26:31 2016; exit: 0 0 0 0 0 0 0
10 10 9 7 5 1 1 tests passed, 0 0 0 0 0 0 0 failed
```

Full matrix test running on `CMSSW_8_0_X_2016-02-16-2300` IB.

No regressions expected.
Automatically ported from CMSSW_8_0_X #13170 (original by @diguida).
