### PR TITLE
Added DaqSource emulator using DaqFakeReader

### DIFF
--- a/IORawData/DTCommissioning/BuildFile.xml
+++ b/IORawData/DTCommissioning/BuildFile.xml
@@ -1,0 +1,9 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="DataFormats/FEDRawData"/>
+<use   name="DataFormats/Provenance"/>
+<use   name="castor"/>
+<flags   EDM_PLUGIN="1"/>
+<use   name="xrootd"/>
+<flags   cppflags="-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64"/>
+<lib   name="XrdPosixPreload"/>

--- a/IORawData/DTCommissioning/doc/DTCommissioning.doc
+++ b/IORawData/DTCommissioning/doc/DTCommissioning.doc
@@ -1,0 +1,36 @@
+/*!
+<!-- Substitute IORawData and DTCommissioning with the proper names! -->
+
+\page IORawData_DTCommissioning Package IORawData/DTCommissioning
+<center>
+<small>
+<a href=http://cmsdoc.cern.ch/swdev/viewcvs/viewcvs.cgi/CMSSW/IORawData/DTCommissioning/?cvsroot=CMSSW&only_with_tag=@CVS_TAG@>Source code (CVS tag: @CVS_TAG@)</a> - 
+<a href=http://cmsdoc.cern.ch/swdev/viewcvs/viewcvs.cgi/CMSSW/IORawData/DTCommissioning/.admin/developers?rev=HEAD&cvsroot=CMSSW&content-type=text/vnd.viewcvs-markup>Administrative privileges</a>
+</small>
+</center>
+
+
+\section desc Description
+<!-- Short description of what this package is supposed to provide -->
+Special input source to read raw data files of DT commissioning, sector test and DT testbeam, and put them to the event.
+
+\subsection interface Public interface
+<!-- List the classes that are provided for use in other packages (if any) -->
+None.
+
+\subsection modules Modules
+<!-- Describe modules implemented in this package and their parameter set -->
+<!--FIXME: add explanation>
+
+\subsection tests Unit tests and examples
+<!-- Describe cppunit tests and example configuration files -->
+- readFile.cfg : example cards to create a digi files reading the raw data from a raw file
+- checkPool.cfg: example cards to read back the digi file created with readFile.cfg.
+
+\section status Status and planned development
+<!-- e.g. completed, stable, missing features -->
+Completed, stable.
+
+<hr>
+Last updated: @DATE@ Author: Nicola Amapane
+*/

--- a/IORawData/DTCommissioning/doc/html/index.html
+++ b/IORawData/DTCommissioning/doc/html/index.html
@@ -1,0 +1,11 @@
+<! Template File - Modify as required.>
+<! Use as an index to other html documents>
+<! References to local pages should be relative to this directory>
+<! This makes it easy for both users of the web project space and>
+<! any others who might simply look at html files directly in the source code.>
+<! e.g. href=page1.html or  href=mysubdir/page2.html > 
+<html>
+<body>
+This Text Inserted from File doc/html/index.html
+</body>
+</html>

--- a/IORawData/DTCommissioning/doc/html/overview.html
+++ b/IORawData/DTCommissioning/doc/html/overview.html
@@ -1,0 +1,12 @@
+<! Template File - Modify as required.>
+<! Use as a brief project description that appears on your main page>
+<! Links are not encouraged from this section - use index.html for this>
+This Text Inserted from File doc/html/overview.html
+<table border=0 width=100%>
+<tr>
+<td align=center><b>Status :</b></td>
+<td align=center>
+Unknown
+</td>
+</tr>
+</table>

--- a/IORawData/DTCommissioning/plugins/BuildFile.xml
+++ b/IORawData/DTCommissioning/plugins/BuildFile.xml
@@ -1,0 +1,12 @@
+<library   file="*.cc" name="IORawDataDTCommissioningPlugins">
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="DataFormats/FEDRawData"/>
+  <use   name="DataFormats/Provenance"/>
+  <use   name="IORawData/DTCommissioning"/>
+  <use   name="castor"/>
+  <flags   EDM_PLUGIN="1"/>
+  <use   name="xrootd"/>
+  <flags   cppflags="-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64"/>
+  <lib   name="XrdPosixPreload"/>
+</library>

--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.cc
@@ -47,7 +47,7 @@ DTDDUFileReader::DTDDUFileReader(const edm::ParameterSet& pset) :
     cout << "DTDDUFileReader: DaqSource file '" << filename << "' was succesfully opened" << endl;
   }
 
-  uint32_t runNumber_tmp;
+  uint32_t runNumber_tmp=1;
   inputFile.read(dataPointer<uint32_t>( &runNumber_tmp ), 4);
   runNumber = runNumber_tmp;
 

--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.cc
@@ -1,0 +1,255 @@
+/** \file
+ *
+ *  $Date: 2010/03/12 10:04:19 $
+ *  $Revision: 1.22 $
+ *  \author M. Zanetti
+ */
+
+
+#include <IORawData/DTCommissioning/plugins/DTDDUFileReader.h>
+#include <IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h>
+
+#include <DataFormats/FEDRawData/interface/FEDHeader.h>
+#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
+#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include <DataFormats/Provenance/interface/Timestamp.h>
+#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/Exception.h>
+
+#include <string>
+#include <iosfwd>
+#include <iostream>
+#include <algorithm>
+   
+using namespace std;
+using namespace edm;
+
+
+DTDDUFileReader::DTDDUFileReader(const edm::ParameterSet& pset) : 
+  runNumber(1), eventNumber(1) {
+
+  const string & filename = pset.getUntrackedParameter<string>("fileName");
+
+  readFromDMA = pset.getUntrackedParameter<bool>("readFromDMA",true);
+  numberOfHeaderWords = pset.getUntrackedParameter<int>("numberOfHeaderWords",10);
+  skipEvents = pset.getUntrackedParameter<int>("skipEvents",0);  
+
+  inputFile.open(filename.c_str());
+  if( inputFile.fail() ) {
+    throw cms::Exception("InputFileMissing") 
+      << "[DTDDUFileReader]: the input file: " << filename <<" is not present";
+  } else {
+    cout << "DTDDUFileReader: DaqSource file '" << filename << "' was succesfully opened" << endl;
+  }
+
+  uint32_t runNumber_tmp;
+  inputFile.read(dataPointer<uint32_t>( &runNumber_tmp ), 4);
+  runNumber = runNumber_tmp;
+
+  inputFile.ignore(4*(numberOfHeaderWords-1));
+  
+  if (skipEvents) { 
+    cout<<""<<endl;
+    cout<<"   Dear user, please be patient, "<<skipEvents<<" are being skipped .."<<endl;
+    cout<<""<<endl;
+  }
+
+  produces<FEDRawDataCollection>();
+}
+
+
+DTDDUFileReader::~DTDDUFileReader(){
+      inputFile.close();
+}
+
+int DTDDUFileReader::fillRawData(Event& e,
+//				 Timestamp& tstamp, 
+				 FEDRawDataCollection*& data){
+  EventID eID = e.id();
+  data = new FEDRawDataCollection();
+
+  vector<uint64_t> eventData;
+  size_t estimatedEventDimension = 102400; // dimensione hardcoded
+  eventData.reserve(estimatedEventDimension); 
+  uint64_t word = 0;
+
+  bool haederTag = false;
+  bool dataTag = true;
+  bool headerAlreadyFound = false;
+  
+  int wordCount = 0;
+  
+  // getting the data word by word from the file
+  // do it until you get the DDU trailer
+  while ( !isTrailer(word, dataTag, wordCount) ) {
+    //while ( !isTrailer(word) ) { 
+    
+    if (readFromDMA) {
+      int nread;
+      word = dmaUnpack(dataTag,nread);
+      if ( nread<=0 ) {
+	cout<<"[DTDDUFileReader]: ERROR! no more words and failed to get the trailer"<<endl;
+	delete data; data=0;
+	return false;
+      }
+    }
+    
+    else {
+      int nread = inputFile.read(dataPointer<uint64_t>( &word ), dduWordLength);
+      dataTag = false;
+      if ( nread<=0 ) {
+	cout<<"[DTDDUFileReader]: ERROR! failed to get the trailer"<<endl;
+	delete data; data=0;
+	return false;
+      }
+    }
+    
+    // get the DDU header
+    if (!headerAlreadyFound) 
+      if ( isHeader(word,dataTag)) {
+	headerAlreadyFound=true; 
+	haederTag=true;
+      }
+    
+    // from now on fill the eventData with the ROS data
+    if (haederTag) {
+      
+      if (readFromDMA) {
+	// swapping only the 8 byte words
+	if (dataTag) {
+	  swap(word);
+	} // WARNING also the ddu status words have been swapped!
+	// Control the correct interpretation in DDUUnpacker
+      }
+      
+      eventData.push_back(word);
+      wordCount++;
+    }
+    
+  } 
+  
+  //     FEDTrailer candidate(reinterpret_cast<const unsigned char*>(&word));
+  //     cout<<"EventSize: pushed back "<<eventData.size()
+  // 	<<";  From trailer "<<candidate.lenght()<<endl;
+  
+  // next event reading will start with meaningless trailer+header from DTLocalDAQ
+  // those will be skipped automatically when seeking for the DDU header
+  //if (eventData.size() > estimatedEventDimension) throw 2;
+  
+  // Eventually skipping events
+  if ((int)eventNumber >= skipEvents) {
+
+    // Setting the Event ID
+    eID = EventID( runNumber, 1U, eventNumber);
+    
+    // eventDataSize = (Number Of Words)* (Word Size)
+    int eventDataSize = eventData.size()*dduWordLength;
+    
+
+    if ( dduID<770 || dduID > 775 ) {
+      cout<<"[DTDDUFileReader]: ERROR. DDU ID out of range. DDU id="<<dduID<<endl;
+      // The FED ID is always the first in the DT range
+      dduID = FEDNumbering::MINDTFEDID;
+    } 
+    FEDRawData& fedRawData = data->FEDData( dduID );
+    fedRawData.resize(eventDataSize);
+    
+    copy(reinterpret_cast<unsigned char*>(&eventData[0]),
+	 reinterpret_cast<unsigned char*>(&eventData[0]) + eventDataSize, fedRawData.data());
+
+  }
+
+  return true;
+    
+}
+
+void DTDDUFileReader::produce(Event&e, EventSetup const&es){
+   edm::Handle<FEDRawDataCollection> rawdata;
+   FEDRawDataCollection *fedcoll = 0;
+   fillRawData(e,fedcoll);
+   std::auto_ptr<FEDRawDataCollection> bare_product(fedcoll);
+   e.put(bare_product);
+ }
+
+void DTDDUFileReader::swap(uint64_t & word) {
+  
+  twoNibble64* newWorld = reinterpret_cast<twoNibble64*>(&word);
+
+  uint32_t msBits_tmp = newWorld->msBits;
+  newWorld->msBits = newWorld->lsBits;
+  newWorld->lsBits = msBits_tmp;
+}
+
+
+uint64_t DTDDUFileReader::dmaUnpack(bool & isData, int & nread) {
+  
+  uint64_t dduWord = 0;
+
+  uint32_t td[4];
+  // read 4 32-bits word from the file;
+  nread = inputFile.read(dataPointer<uint32_t>( &td[0] ), 4);
+  nread += inputFile.read(dataPointer<uint32_t>( &td[1] ), 4);
+  nread += inputFile.read(dataPointer<uint32_t>( &td[2] ), 4);
+  nread += inputFile.read(dataPointer<uint32_t>( &td[3] ), 4);
+
+  uint32_t data[2] = {0, 0};
+  // adjust 4 32-bits words  into 2 32-bits words
+  data[0] |= td[3] & 0x3ffff;
+  data[0] |= (td[2] << 18 ) & 0xfffc0000;
+  data[1] |= (td[2] >> 14 ) & 0x0f;
+  data[1] |= (td[1] << 4 ) & 0x3ffff0;
+  data[1] |= (td[0] << 22 ) & 0xffc00000;
+
+  isData = ( td[0] >> 10 ) & 0x01;
+
+  // push_back to a 64 word
+  dduWord = (uint64_t(data[1]) << 32) | data[0];
+
+  return dduWord;
+}
+
+bool DTDDUFileReader::isHeader(uint64_t word, bool dataTag) {
+
+  bool it_is = false;
+  FEDHeader candidate(reinterpret_cast<const unsigned char*>(&word));
+  if ( candidate.check() ) {
+    // if ( candidate.check() && !dataTag) {
+    it_is = true;
+    dduID = candidate.sourceID();
+    eventNumber++;
+  }
+ 
+  return it_is;
+}
+
+
+bool DTDDUFileReader::isTrailer(uint64_t word, bool dataTag, int wordCount) {
+
+  bool it_is = false;
+  FEDTrailer candidate(reinterpret_cast<const unsigned char*>(&word));
+  if ( candidate.check() ) {
+    //  if ( candidate.check() && !dataTag) {
+    //cout<<"[DTDDUFileReader] "<<wordCount<<" - "<<candidate.lenght()<<endl;
+    if ( wordCount == candidate.lenght())
+      it_is = true;
+  }
+ 
+  return it_is;
+}
+
+
+bool DTDDUFileReader::checkEndOfFile(){
+
+  bool retval=false;
+  if ( inputFile.eof() ) retval=true;
+  return retval;
+
+}
+
+
+

--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
@@ -1,0 +1,73 @@
+#ifndef DaqSource_DTDDUFileReader_h
+#define DaqSource_DTDDUFileReader_h
+
+/** \class DTDDUFileReader
+ *  Read DT ROS8 raw data files
+ *
+ *  $Date: 2010/02/03 16:58:24 $
+ *  $Revision: 1.11 $
+ *  \author M. Zanetti - INFN Padova
+ */
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "IORawData/DTCommissioning/plugins/RawFile.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <ostream>
+#include <fstream>
+#include <boost/cstdint.hpp>
+
+class DTDDUFileReader : public edm::EDProducer {
+ public:
+  /// Constructor
+  DTDDUFileReader(const edm::ParameterSet& pset);
+
+  /// Destructor
+  virtual ~DTDDUFileReader();
+
+  /// Generate and fill FED raw data for a full event
+  virtual int fillRawData(edm::Event& e,
+//			  edm::Timestamp& tstamp, 
+			  FEDRawDataCollection*& data);
+
+  virtual void produce(edm::Event&, edm::EventSetup const&);
+
+  /// check for a 64 bits word to be a DDU header
+  bool isHeader(uint64_t word, bool dataTag);
+
+  /// check for a 64 bits word to be a DDU trailer
+  bool isTrailer(uint64_t word, bool dataTag, int wordCount);
+
+  /// pre-unpack the data if read via DMA
+  //  std::pair<uint64_t,bool> dmaUnpack();
+  uint64_t dmaUnpack(bool & isData, int & nread);
+
+
+  /// swapping the lsBits with the msBits
+  void swap(uint64_t & word);
+ 
+
+  virtual bool checkEndOfFile();
+
+ private:
+
+  RawFile inputFile;
+
+  edm::RunNumber_t runNumber;
+  edm::EventNumber_t eventNumber;
+
+  int dduID;
+
+  bool readFromDMA;
+  int skipEvents;
+  int numberOfHeaderWords;
+
+  static const int dduWordLength = 8;
+
+};
+#endif
+
+
+

--- a/IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h
+++ b/IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h
@@ -1,0 +1,37 @@
+#ifndef DaqSource_DTFileReaderHelpers_h
+#define DaqSource_DTFileReaderHelpers_h
+
+#include <boost/cstdint.hpp>
+
+template<class T> char* dataPointer( const T* ptr ) {
+  union bPtr {
+    const T* dataP;
+    char*    fileP;
+  };
+  union bPtr buf;
+  buf.dataP = ptr;
+  return buf.fileP;
+}
+
+
+template<class T> T* typePointer( const char* ptr ) {
+  union bPtr {
+    T*          dataP;
+    const char* fileP;
+  };
+  union bPtr buf;
+  buf.fileP = ptr;
+  return buf.dataP;
+}
+
+struct twoNibble {
+  uint16_t lsBits;
+  uint16_t msBits;
+};
+
+struct twoNibble64 {
+  uint32_t lsBits;
+  uint32_t msBits;
+};
+
+#endif

--- a/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.cc
@@ -97,7 +97,7 @@ int DTNewROS8FileReader::fillRawData(Event& e,
     int numberEventHeadWords=8;
 
     //1.- Get the total NUMBER OF WORDs from the 1st word in the payload
-    int numberOfWords;
+    int numberOfWords=0;
     int nread = 0;
     nread = inputFile.read(dataPointer<int>( &numberOfWords ), ros8WordLenght); // ros8WordLength=4
     if ( nread<=0 ) throw 1;

--- a/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.cc
@@ -1,0 +1,203 @@
+/** \file
+ *
+ *  $Date: 2015/07/10 
+ *  \author M.C Fouz 
+ *  Updated from class DTROS8FileReader to a new class: DTNewROS8FileReader  
+ *    to read ROS8 for MB1 GIF++ 2015 data  (for CMSSW_5X versions)
+ *    include also the PU Data (Chamber Trigger info)
+ *  
+ */
+
+
+#include <IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h>
+#include <IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h>
+
+#include <DataFormats/FEDRawData/interface/FEDHeader.h>
+#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
+#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include <DataFormats/Provenance/interface/Timestamp.h>
+#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/Exception.h>
+
+#include <string>
+#include <iosfwd>
+#include <iostream>
+#include <algorithm>
+   
+using namespace std;
+using namespace edm;
+
+
+DTNewROS8FileReader::DTNewROS8FileReader(const edm::ParameterSet& pset) : 
+  runNumber(1), eventNum(0) {
+      
+  const string & filename = pset.getUntrackedParameter<string>("fileName");
+
+  inputFile.open(filename.c_str());
+  if( inputFile.fail() ) {
+    throw cms::Exception("InputFileMissing") 
+      << "DTNewROS8FileReader: the input file: " << filename <<" is not present";
+  }
+ 
+  produces<FEDRawDataCollection>();
+}
+
+
+DTNewROS8FileReader::~DTNewROS8FileReader(){
+  inputFile.close();
+}
+
+
+int DTNewROS8FileReader::fillRawData(Event& e,
+//				  Timestamp& tstamp, 
+				  FEDRawDataCollection*& data){
+  EventID eID = e.id();
+  data = new FEDRawDataCollection();
+
+  try {
+    /* Structure of the DATA 
+
+     1.- NUMBER OF WORDS (it includes this word and the last counter)
+     2.- HEADER: 8 Words
+           Header word 0: run number
+           Header word 1: spill number
+           Header word 2: event number
+           Header word 3: reserved
+           Header word 4: ROS data offset
+           Header word 5: PU data offset
+           Header word 6: reserved
+           Header word 7: reserved
+     3.- ROS DATA ==> DECODE BY THE DTROS8Unpacker.cc in EventFilter 
+           3.1 NUMBER OF ROS WORDS (it includes this counter)
+           3.2 Lock status Word
+           3.3 ROS DATA
+                 3.3.1 ROS BOARD ID/ROS CHANNEL - 1 word
+                 3.3.2 GLOBAL HEADER - 1 word
+                 3.3.3 TDC Data Words - X words (depends on event)
+                 3.3.4 GLOBAL TRAILER
+     4.- PU DATA (trigger) ==> DECODE BY THE DTROS8Unpacker.cc in EventFilter  
+                 Not always. If chamber is autotriggered doesn't have PU data except
+                             the Number of PU words
+           4.1.- NUMBER OF WORDS (it includes this word, always present 
+                                  even if there is not PU data)
+           4.2.- PATTERN UNIT ID - 1 word (data counter & PU-ID)
+           4.3.- DATA - X Words ?????
+     5.- NUMBER OF WORDS (include this word and the first counter)
+    */
+
+
+    if( checkEndOfFile() ) throw 1; 
+    
+    // Number of words in the header, including the first word of header that is the number of words in the event
+    int numberEventHeadWords=8;
+
+    //1.- Get the total NUMBER OF WORDs from the 1st word in the payload
+    int numberOfWords;
+    int nread = 0;
+    nread = inputFile.read(dataPointer<int>( &numberOfWords ), ros8WordLenght); // ros8WordLength=4
+    if ( nread<=0 ) throw 1;
+
+    // inputFile.ignore(4*(numberEventHeadWords-1)); // Skip the header. The first word of header has been already read 
+       
+    //2.- Get the HEADER  ============================================================================
+    int datahead[numberEventHeadWords];
+    for(int iih=0;iih<numberEventHeadWords;iih++)
+    {
+        nread = inputFile.read(dataPointer<int>( &datahead[iih] ), ros8WordLenght); 
+    }
+
+    //3.- ROS DATA  &  4.- PU DATA (Trigger)   =======================================================
+    // Get the event data (all words but the header and the first and the last counter)
+    int numberOfDataWords=numberOfWords-numberEventHeadWords-2; 
+    int* eventData = new int[numberOfDataWords];
+    nread = inputFile.read(dataPointer<int>( eventData ), numberOfDataWords * ros8WordLenght );
+    if ( nread<=0 ) throw 1;
+
+    //5.- Get the total NUMBER OF WORDs from the last word in the payload
+    // Check that the event data size corresponds to the 1st word datum 
+    int LastCounter=0;
+    nread=inputFile.read(dataPointer<int>( &LastCounter ), ros8WordLenght); 
+    if ( nread<=0 ) throw 1;
+      
+    if ( LastCounter != numberOfWords ) {
+      cout << "[DTNewROS8FileReader]: word counter mismatch exception: "
+	   << numberOfWords << " " << LastCounter << endl;
+      throw 99;
+    }
+
+   //The first word in the header is the run number 
+   runNumber= datahead[0];
+      cout << "[DTNewROS8FileReader]: Run Number: "<<dec<<runNumber<<endl;
+     
+   //The third word in the header is the event number (without any reset)
+   //eventNum= datahead[2];  //francos system
+   eventNum= datahead[1];  //linux system
+   //cout<<"ëventNum  "<<dec<<eventNum<<endl;
+   if(eventNum<1)eventNum=1;// Event number must start at 1 but at TDCs it starts at cero,if not the program crashes
+                           // files used for testing start in 1, but... just in case...
+
+   eID = EventID(runNumber, 1U, eventNum);  
+
+   //cout << " EEEEE eID: " << eID << endl;
+   // Even if we have introducing the correct runNumber when running the runNumber appears always as =1
+
+   int eventDataSize = numberOfDataWords * ros8WordLenght;
+   int adjustment = (eventDataSize/4)%2 == 1 ? 4 : 0;   
+
+   // The FED ID is always the first in the DT range
+   FEDRawData& fedRawData = data->FEDData( FEDNumbering::MINDTFEDID );
+   fedRawData.resize(eventDataSize+adjustment);  // the size must be multiple of 8 bytes
+    
+   // Passing the data to the Event
+   copy(reinterpret_cast<unsigned char*>(eventData), 
+	 reinterpret_cast<unsigned char*>(eventData) + eventDataSize, fedRawData.data());
+
+   // needed to get rid of memory leaks (?)
+   delete[] eventData;
+
+   return true;
+
+  }
+  catch( int i ) {
+
+    if ( i == 1 ){
+      cout << "[DTNewROS8FileReader]: END OF FILE REACHED. "
+           << "No information read for the requested event" << endl;
+      delete data; data=0;
+      return false;
+    }    
+    else {
+      cout << "[DTNewROS8FileReader]: PROBLEM WITH EVENT INFORMATION ON THE FILE. "
+           << "EVENT DATA READING FAILED  code= " << i << endl;
+      delete data; data=0;
+      return false;
+    }
+
+  }
+
+}
+
+
+void DTNewROS8FileReader::produce(Event&e, EventSetup const&es){
+
+   edm::Handle<FEDRawDataCollection> rawdata;
+   FEDRawDataCollection *fedcoll = 0;
+   fillRawData(e,fedcoll);
+   std::auto_ptr<FEDRawDataCollection> bare_product(fedcoll);
+   e.put(bare_product);
+}
+
+
+bool DTNewROS8FileReader::checkEndOfFile(){
+
+  bool retval=false;
+  if ( inputFile.eof() ) retval=true;
+  return retval;
+
+}
+

--- a/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h
@@ -1,0 +1,47 @@
+#ifndef DaqSource_DTNewROS8FileReader_h
+#define DaqSource_DTNewROS8FileReader_h
+
+/** \class DTNewROS8FileReader
+ *  Read DT ROS8 raw data files
+ *  From DTROS8FileReader
+ *
+ *  $Date: 2015/12/17$
+ */
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include <fstream>
+
+class DTNewROS8FileReader : public edm::EDProducer {
+ public:
+  /// Constructor
+  DTNewROS8FileReader(const edm::ParameterSet& pset);
+
+  /// Destructor
+  virtual ~DTNewROS8FileReader();
+
+  /// Generate and fill FED raw data for a full event
+  virtual int fillRawData(edm::Event& e,
+//			  edm::Timestamp& tstamp, 
+			  FEDRawDataCollection*& data);
+
+  virtual void produce(edm::Event&, edm::EventSetup const&);
+
+  virtual bool checkEndOfFile();
+
+ private:
+
+  RawFile inputFile;
+
+  edm::RunNumber_t runNumber; 
+  edm::EventNumber_t eventNum;
+
+  static const int ros8WordLenght = 4;
+
+};
+#endif
+

--- a/IORawData/DTCommissioning/plugins/DTROS25FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTROS25FileReader.cc
@@ -1,0 +1,181 @@
+/** \file
+ *
+ *  $Date: 2010/03/12 10:04:19 $
+ *  $Revision: 1.14 $
+ *  \author M. Zanetti
+ */
+
+#include <IORawData/DTCommissioning/plugins/DTROS25FileReader.h>
+#include <IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h>
+
+#include <DataFormats/FEDRawData/interface/FEDHeader.h>
+#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
+#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+
+#include "DataFormats/Provenance/interface/EventID.h" 	 
+#include <DataFormats/Provenance/interface/Timestamp.h>
+#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/Exception.h>
+
+#include <string>
+#include <iosfwd>
+#include <iostream>
+#include <algorithm>
+   
+using namespace std;
+using namespace edm;
+
+
+DTROS25FileReader::DTROS25FileReader(const edm::ParameterSet& pset) : 
+  runNumber(1), eventNumber(0) {
+      
+  const string & filename = pset.getUntrackedParameter<string>("fileName");
+
+  inputFile.open(filename.c_str());
+  if( inputFile.fail() ) {
+    throw cms::Exception("InputFileMissing") 
+      << "DTROS25FileReader: the input file: " << filename <<" is not present";
+  }
+ produces<FEDRawDataCollection>();
+}
+
+
+DTROS25FileReader::~DTROS25FileReader(){
+  inputFile.close();
+}
+
+
+int DTROS25FileReader::fillRawData(Event& e,
+//				   Timestamp& tstamp, 
+				   FEDRawDataCollection*& data){
+  EventID eID = e.id();
+  data = new FEDRawDataCollection();
+
+  vector<uint32_t> eventData;
+  size_t estimatedEventDimension = 102400; // dimensione hardcoded
+  eventData.reserve(estimatedEventDimension); 
+  uint32_t word = 0;
+  
+
+  try {   
+
+    bool marked = false;
+
+    // getting the data word by word from the file
+    // do it until you get the ROS25 trailer
+    while ( !isTrailer(word) ) { 
+      
+      // get the first word
+      int nread = inputFile.read(dataPointer<uint32_t>( &word ), rosWordLenght);
+      
+      // WARNING!!! ||swapping it|| (Check whether it is necessary) 
+      swap(word);
+
+      if ( nread<=0 ) throw 1;
+
+      // get the ROS25 header
+      if (isHeader(word)) marked=true;
+
+      // from now on fill the eventData with the ROS data
+      if (marked) {
+	eventData.push_back(word);
+
+      }
+    } 
+
+    // next event reading will start with meaningless trailer+header from DTLocalDAQ
+    // those will be skipped automatically when seeking for the ROS25 header
+
+    //if (eventData.size() > estimatedEventDimension) throw 2;
+    
+    // Setting the Event ID
+    eID = EventID( runNumber, 1U, eventNumber);
+
+    // eventDataSize = (Number Of Words)* (Word Size)
+    int eventDataSize = eventData.size()*rosWordLenght;
+    // It has to be a multiple of 8 bytes. if not, adjust the size of the FED payload
+    int adjustment = (eventDataSize/4)%2 == 1 ? 4 : 0; 
+
+    // The FED ID is always the first in the DT range
+    FEDRawData& fedRawData = data->FEDData( FEDNumbering::MINDTFEDID );
+    fedRawData.resize(eventDataSize+adjustment);
+    
+    copy(reinterpret_cast<unsigned char*>(&eventData[0]),
+	 reinterpret_cast<unsigned char*>(&eventData[0]) + eventDataSize, fedRawData.data());
+
+    return true;
+  }
+
+  catch( int i ) {
+
+    if ( i == 1 ){
+      cout<<"[DTROS25FileReader]: ERROR! failed to get the trailer"<<endl;
+      delete data; data=0;
+      return false;
+    }    
+    else {
+      cout<<"[DTROS25FileReader]:"
+	  <<" ERROR! ROS data exceeding estimated event dimension. Event size = "
+	  <<eventData.size()<<endl;
+      delete data; data=0;
+      return false;
+    }
+    
+  }
+
+}
+
+void DTROS25FileReader::produce(Event&e, EventSetup const&es){
+   edm::Handle<FEDRawDataCollection> rawdata;
+   FEDRawDataCollection *fedcoll = 0;
+   fillRawData(e,fedcoll);
+   std::auto_ptr<FEDRawDataCollection> bare_product(fedcoll);
+   e.put(bare_product);
+ }
+
+void DTROS25FileReader::swap(uint32_t & word) {
+  
+  twoNibble* newWorld = reinterpret_cast<twoNibble*>(&word);
+
+  uint16_t msBits_tmp = newWorld->msBits;
+  newWorld->msBits = newWorld->lsBits;
+  newWorld->lsBits = msBits_tmp;
+}
+
+
+bool DTROS25FileReader::isHeader(uint32_t word) {
+
+  bool it_is = false;
+  if ( (word >> 24 ) == 31 ) {
+    it_is = true;
+    ++eventNumber;
+  }
+ 
+  return it_is;
+}
+
+
+bool DTROS25FileReader::isTrailer(uint32_t word) {
+ 
+  bool it_is = false;
+  if ( (word >> 24 ) == 63 ) {
+    it_is = true;
+  }
+ 
+  return it_is;
+}
+
+
+bool DTROS25FileReader::checkEndOfFile(){
+
+  bool retval=false;
+  if ( inputFile.eof() ) retval=true;
+  return retval;
+
+}
+
+
+

--- a/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
@@ -1,0 +1,64 @@
+#ifndef DaqSource_DTROS25FileReader_h
+#define DaqSource_DTROS25FileReader_h
+
+/** \class DTROS25FileReader
+ *  Read DT ROS8 raw data files
+ *
+ *  $Date: 2010/02/03 16:58:24 $
+ *  $Revision: 1.6 $
+ *  \author M. Zanetti - INFN Padova
+ */
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <ostream>
+#include <fstream>
+#include <boost/cstdint.hpp>
+
+class DTROS25FileReader : public edm::EDProducer {
+ public:
+  /// Constructor
+  DTROS25FileReader(const edm::ParameterSet& pset);
+
+  /// Destructor
+  virtual ~DTROS25FileReader();
+
+  /// Generate and fill FED raw data for a full event
+  virtual int fillRawData(edm::Event& e,
+//			  edm::Timestamp& tstamp, 
+			  FEDRawDataCollection*& data);
+
+  virtual void produce(edm::Event&, edm::EventSetup const&);
+
+  /// check for a 32 bits word to be a ROS25 header
+  bool isHeader(uint32_t word);
+
+  /// check for a 32 bits word to be a ROS25 trailer
+  bool isTrailer(uint32_t word);
+
+  /// swapping the lsBits with the msBits
+  void swap(uint32_t & word);
+ 
+
+  virtual bool checkEndOfFile();
+
+ private:
+
+
+  RawFile inputFile;
+
+  edm::RunNumber_t runNumber;
+  edm::EventNumber_t eventNumber;
+
+  static const int rosWordLenght = 4;
+
+};
+#endif
+
+
+

--- a/IORawData/DTCommissioning/plugins/DTROS8FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTROS8FileReader.cc
@@ -1,0 +1,165 @@
+/** \file
+ *
+ *  $Date: 2010/03/12 10:04:19 $
+ *  $Revision: 1.16 $
+ *  \author M. Zanetti
+ */
+
+
+#include <IORawData/DTCommissioning/plugins/DTROS8FileReader.h>
+#include <IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h>
+
+#include <DataFormats/FEDRawData/interface/FEDHeader.h>
+#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
+#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include <DataFormats/Provenance/interface/Timestamp.h>
+#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/Exception.h>
+
+#include <string>
+#include <iosfwd>
+#include <iostream>
+#include <algorithm>
+   
+using namespace std;
+using namespace edm;
+
+
+DTROS8FileReader::DTROS8FileReader(const edm::ParameterSet& pset) : 
+  runNum(1), eventNum(0) {
+      
+  //const string & filename = pset.getParameter<string>("fileName");  // Don't work, it produces an error saying that the DTNewROS8FileReader plugin doesn't exist!!!
+ 
+  const string & filename = pset.getUntrackedParameter<string>("fileName");
+
+  inputFile.open(filename.c_str());
+  if( inputFile.fail() ) {
+    throw cms::Exception("InputFileMissing") 
+      << "DTROS8FileReader: the input file: " << filename <<" is not present";
+  }
+
+ produces<FEDRawDataCollection>();
+}
+
+
+DTROS8FileReader::~DTROS8FileReader(){
+  inputFile.close();
+}
+
+
+int DTROS8FileReader::fillRawData(Event& e,
+//				  Timestamp& tstamp, 
+				  FEDRawDataCollection*& data){
+  EventID eID = e.id();
+  data = new FEDRawDataCollection();
+
+  try {
+    
+
+    if( checkEndOfFile() ) throw 1; 
+    
+
+    // Get the total number of words from the 1st word in the payload
+    int numberOfWords;
+    int nread = 0;
+    nread = inputFile.read(dataPointer<int>( &numberOfWords ), ros8WordLenght);
+    if ( nread<=0 )  throw 1;
+
+
+    // Get the event data (all words but the 1st)
+    int* eventData = new int[numberOfWords];
+    nread = inputFile.read(dataPointer<int>( eventData + 1 ), (numberOfWords-1) * ros8WordLenght );
+    if ( nread<=0 ) throw 1;
+    
+
+    // Check that the event data size corresponds to the 1st word datum 
+    if ( eventData[numberOfWords-1] != numberOfWords ) {
+      cout << "[DTROS8FileReader]: word counter mismatch exception: "
+	   << numberOfWords << " " << eventData[numberOfWords-1] << endl;
+      throw 99;
+    }
+
+    // The header added by the local DAQ occupies 8 words, starting from the 2nd 
+    int* head = eventData + 1;
+    
+    /* 
+      Header word 0: run number
+      Header word 1: spill number
+      Header word 2: event number
+      Header word 3: reserved
+      Header word 4: ROS data offset
+      Header word 5: PU data offset
+      Header word 6: reserved
+      Header word 7: reserved
+    */
+
+    // WARNING: the event number is reset at a new spill
+    eID = EventID( head[0], 1U, head[1]*head[2]);
+
+    // The pointer to the ROS payload (the 1st word being the ROS words counter)
+    int* rosData = eventData + head[4];
+
+    // The ROS payload size
+    int eventDataSize = *rosData * ros8WordLenght;
+    // It has to be a multiple of 8 bytes. if not, adjust the size of the FED payload
+    int adjustment = (eventDataSize/4)%2 == 1 ? 4 : 0;   
+    
+    //if ( (eventDataSize/4)%2 ) adjustment = 4;
+
+
+    // The FED ID is always the first in the DT range
+    FEDRawData& fedRawData = data->FEDData( FEDNumbering::MINDTFEDID );
+    fedRawData.resize(eventDataSize+adjustment);
+    
+    // I pass only the ROS data to the Event
+    copy(reinterpret_cast<unsigned char*>(rosData), 
+	 reinterpret_cast<unsigned char*>(rosData) + eventDataSize, fedRawData.data());
+
+    // needed to get rid of memory leaks (?)
+    delete[] eventData;
+
+    return true;
+  }
+
+  catch( int i ) {
+
+    if ( i == 1 ){
+      cout << "[DTROS8FileReader]: END OF FILE REACHED. "
+           << "No information read for the requested event" << endl;
+      delete data; data=0;
+      return false;
+    }    
+    else {
+      cout << "[DTROS8FileReader]: PROBLEM WITH EVENT INFORMATION ON THE FILE. "
+           << "EVENT DATA READING FAILED  code= " << i << endl;
+      delete data; data=0;
+      return false;
+    }
+
+  }
+
+}
+
+void DTROS8FileReader::produce(Event&e, EventSetup const&es){
+   edm::Handle<FEDRawDataCollection> rawdata;
+   FEDRawDataCollection *fedcoll = 0;
+   fillRawData(e,fedcoll);
+   std::auto_ptr<FEDRawDataCollection> bare_product(fedcoll);
+   e.put(bare_product);
+ }
+
+bool DTROS8FileReader::checkEndOfFile(){
+
+  bool retval=false;
+  if ( inputFile.eof() ) retval=true;
+  return retval;
+
+}
+
+
+

--- a/IORawData/DTCommissioning/plugins/DTROS8FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTROS8FileReader.cc
@@ -65,7 +65,7 @@ int DTROS8FileReader::fillRawData(Event& e,
     
 
     // Get the total number of words from the 1st word in the payload
-    int numberOfWords;
+    int numberOfWords=0;
     int nread = 0;
     nread = inputFile.read(dataPointer<int>( &numberOfWords ), ros8WordLenght);
     if ( nread<=0 )  throw 1;

--- a/IORawData/DTCommissioning/plugins/DTROS8FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS8FileReader.h
@@ -1,0 +1,49 @@
+#ifndef DaqSource_DTROS8FileReader_h
+#define DaqSource_DTROS8FileReader_h
+
+/** \class DTROS8FileReader
+ *  Read DT ROS8 raw data files
+ *
+ *  $Date: 2010/02/03 16:58:24 $
+ *  $Revision: 1.8 $
+ *  \author M. Zanetti - INFN Padova
+ */
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <fstream>
+
+class DTROS8FileReader : public edm::EDProducer {
+ public:
+  /// Constructor
+  DTROS8FileReader(const edm::ParameterSet& pset);
+
+  /// Destructor
+  virtual ~DTROS8FileReader();
+
+  /// Generate and fill FED raw data for a full event
+  virtual int fillRawData(edm::Event& e,
+//			  edm::Timestamp& tstamp, 
+			  FEDRawDataCollection*& data);
+
+  virtual void produce(edm::Event&, edm::EventSetup const&);
+
+  virtual bool checkEndOfFile();
+
+ private:
+
+  RawFile inputFile;
+
+  edm::RunNumber_t runNum;
+  edm::EventNumber_t eventNum;
+
+  static const int ros8WordLenght = 4;
+
+};
+#endif
+

--- a/IORawData/DTCommissioning/plugins/DTSpy.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpy.cc
@@ -1,0 +1,95 @@
+/*
+ *  DTSpy.cc
+ *  
+ *
+ *  Created by Sandro Ventura on 7/28/07.
+ *  Copyright 2007 __MyCompanyName__. All rights reserved.
+ *
+ */
+
+#include "DTSpy.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define DTSPY_HEAD_SIZE 36
+#define DTSPY_MAX_MSG  512*1024
+
+
+DTSpy::DTSpy():DTCtcp(0)
+{
+  spybuf=(char *)malloc(DTSPY_MAX_MSG);
+  givenonce=0;
+}
+
+
+DTSpy::~DTSpy()
+{
+  free(spybuf);
+}
+
+
+DTSpy::DTSpy(char *hostaddr,int port):DTCtcp(0)
+{
+     Connect(hostaddr,port);
+     givenonce=0;
+}
+
+
+int
+DTSpy::getNextBuffer()
+{
+
+	if (!connected) return -1;
+	if (givenonce)
+		if ((lastpointer - spybuf) < getBuffSize())
+			return (getBuffSize() - (lastpointer - spybuf));
+	givenonce=0;
+
+	memset(spybuf,0x0,DTSPY_MAX_MSG); /* init buffer */
+    
+    	int howm=Receive(spybuf,DTSPY_HEAD_SIZE);
+	
+	unsigned short *i2ohea = (unsigned short *) (spybuf+2);
+	if (howm == DTSPY_HEAD_SIZE ) 
+         {
+		howm = Receive(spybuf+DTSPY_HEAD_SIZE,((*i2ohea) * 4)-DTSPY_HEAD_SIZE);
+
+               // for (int ii=0; ii<12; ii++)
+               //       printf("%d: %x %x %x %x \n",ii*4,spybuf[ii*4],
+               //             spybuf[ii*4+1],spybuf[ii*4+2],spybuf[ii*4+3]);
+
+	        return howm+DTSPY_HEAD_SIZE;;
+         }
+         else return -1;
+}
+
+int
+DTSpy::getBuffSize()
+{
+  	unsigned short *i2ohea = (unsigned short *) (spybuf+2);
+	return *i2ohea;
+}
+
+
+
+int
+DTSpy::getRunNo()
+{
+    unsigned short *i2ohea = (unsigned short *) (spybuf+28);
+    return *i2ohea;
+}
+
+const char *
+DTSpy::getEventPointer()
+{
+  if (givenonce) return lastpointer;
+  lastpointer = spybuf+DTSPY_HEAD_SIZE;
+  givenonce = 1;
+  return lastpointer;
+}
+
+void 
+DTSpy::setlastPointer(char * thep)
+{
+  lastpointer=thep;
+}

--- a/IORawData/DTCommissioning/plugins/DTSpy.h
+++ b/IORawData/DTCommissioning/plugins/DTSpy.h
@@ -1,0 +1,43 @@
+#ifndef DaqSource_DTSpy_h
+#define DaqSource_DTSpy_h
+
+/*
+ *  DTSpy.h
+ *  
+ *
+ *  Created by Sandro Ventura on 7/28/07.
+ *  Copyright 2007 __MyCompanyName__. All rights reserved.
+ *
+ */
+
+
+#include "DTSpyHelper.h"
+
+
+class DTSpy : public DTCtcp {
+protected:
+   
+  char * spybuf;
+  short givenonce;
+	 
+public:
+
+  char * lastpointer;	   
+  
+	   
+  DTSpy();
+  DTSpy(char *hostaddr,int port);
+  ~DTSpy();
+	
+  int getNextBuffer();
+
+  int getBuffSize();
+  int getRunNo();
+  const char * getEventPointer();
+  void setlastPointer(char * data);
+
+};
+
+
+#endif
+

--- a/IORawData/DTCommissioning/plugins/DTSpyHelper.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpyHelper.cc
@@ -1,0 +1,223 @@
+#include "DTSpyHelper.h"
+#include <errno.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <string.h>
+
+#ifdef __wasAPPLE__
+typedef int socklen_t;
+#endif
+
+DTCtcp::DTCtcp()
+{
+   DTCtcp(0);
+}
+
+DTCtcp::DTCtcp(int localport)
+{
+//  struct sockaddr_in myaddr;
+ 
+    connected=false;
+
+     printf("zeroing...\n");
+    bzero ((char *) &myaddr, sizeof(myaddr));
+     printf("zeroing done..\n");
+
+
+   sock = socket (AF_INET, SOCK_STREAM, 0);
+     printf("create socket..\n");
+
+   if (sock < 0)
+   {
+     printf("no socket...\n");
+      throw DTtcpExcp(errno);
+   }
+  
+
+    myaddr.sin_family       = AF_INET;
+    myaddr.sin_port         = htons (localport);
+ 
+    //int blen = 65536;
+    int blen = 65536*8;
+
+//     printf("setting socket opts buf...\n");
+//    if(setsockopt(sock,SOL_SOCKET,SO_SNDBUF,(char *)&blen,sizeof(blen))<0)
+//      throw DTtcpExcp(errno);
+//    if(setsockopt(sock,SOL_SOCKET,SO_RCVBUF,(char *)&blen,sizeof(blen))<0)
+//      throw DTtcpExcp(errno);
+     printf("setting socket opts reuse...\n");
+    if(setsockopt(sock,SOL_SOCKET,SO_REUSEADDR,(char *)&blen,sizeof(blen))<0)
+      throw DTtcpExcp(errno);
+//     printf("setting socket opts nodelay...\n");
+//    if(setsockopt(sock,SOL_SOCKET,TCP_NODELAY,(char *)&blen,sizeof(blen))<0)
+//      throw;
+     printf("binding...\n");
+
+    port = localport;
+
+    if (port)
+        if(bind(sock,(struct sockaddr *)&myaddr,sizeof (myaddr)) < 0)
+        { perror ("bind failed");
+          throw DTtcpExcp(errno);
+        }
+
+          
+}
+
+DTCtcp::DTCtcp(int snew, int opt)
+{
+
+   connected = true;
+   port =0;
+
+   sock = snew;
+}
+
+DTCtcp::DTCtcp(DTCtcp* aconn)
+{
+
+   connected = aconn->connected;
+   port = aconn->port;
+
+   sock = aconn->sock;
+}
+
+DTCtcp::~DTCtcp()
+{
+  printf("deleting DTCtcp\n");
+  //if (connected) shutdown(sock,2);
+  shutdown(sock,SHUT_RDWR);
+  close (sock);
+}
+
+short 
+DTCtcp::Id()
+{
+    long maddr = clientAddr.sin_addr.s_addr;
+    maddr = htonl (maddr);
+    return maddr&0xff;
+}
+
+unsigned long
+DTCtcp::addr()
+{
+    unsigned long maddr = clientAddr.sin_addr.s_addr;
+    maddr = htonl (maddr);
+    return maddr;
+}
+
+int
+DTCtcp::Disconnect()
+{
+  connected = false;
+  return shutdown(sock,SHUT_RDWR);
+}
+
+DTCtcp *
+DTCtcp::Accept()
+{
+
+ //   struct sockaddr_in  clientAddr; /* client's address */    
+
+    bzero ((char *) &clientAddr, sizeof (clientAddr));
+
+    if (listen (sock, 2) < 0)
+        {
+        perror ("listen failed");
+        throw DTtcpExcp(errno);
+        }
+
+    int len = sizeof (clientAddr);
+
+    int snew = accept (sock, (struct sockaddr *) &clientAddr,(socklen_t *) &len);
+    if (snew <=0) 
+    {
+        perror ("accept failed");
+        throw DTtcpExcp(errno);
+    }
+ 
+    return new DTCtcp(snew,0);
+}
+
+void 
+DTCtcp::Connect(unsigned long in,int toport)
+{
+    clientAddr.sin_family      = AF_INET;
+    clientAddr.sin_addr.s_addr = htonl (in);
+    clientAddr.sin_port        = htons (toport);
+  
+ if (connect (sock, (struct sockaddr  *)&clientAddr, sizeof (clientAddr)) < 0)
+{
+        perror ("connect failed");
+        throw DTtcpExcp(errno);
+}
+  connected = true;
+}
+
+void 
+DTCtcp::Connect(const char *host,int toport)
+{
+    clientAddr.sin_family      = AF_INET;
+    clientAddr.sin_addr.s_addr = inet_addr (host);
+    clientAddr.sin_port        = htons (toport);
+  
+ if (connect (sock, (struct sockaddr  *)&clientAddr, sizeof (clientAddr)) < 0)
+{
+        perror ("connect failed");
+        throw DTtcpExcp(errno);
+}
+  connected = true;
+}
+
+int
+DTCtcp::WaitData(int timeout)
+{
+//    return  read (sock, buffer,size) ;
+     fd_set rfds;
+     struct timeval tv;
+   
+    FD_ZERO(&rfds);
+    FD_SET(sock,&rfds);
+
+    tv.tv_sec = timeout;
+    tv.tv_usec = 0;
+ 
+     int retva = select (1,&rfds,0,&rfds,&tv);
+     if (retva)
+         if (FD_ISSET(0,&rfds)) return 1;
+         else return -1;
+     else return 0; 
+}
+
+int
+DTCtcp::Receive(char *buffer,int size)
+{
+//    return  read (sock, buffer,size) ;
+ 
+    int howmany = 0;
+    int toberead = size;
+    do
+    {
+      //int readnow = recv (sock, &buffer[howmany], toberead,MSG_WAITALL) ;
+      int readnow = recv (sock, &buffer[howmany], toberead,0) ;
+      //if (readnow < 0 ) {printf("some rrorrs...%d\n",errno); return -1;}
+      if (readnow <= 0 ) 
+           {printf("some rrorrs...%d\n",errno); throw DTtcpExcp(errno);}
+      else { 
+        howmany+=readnow; toberead-=readnow;}
+    } while (toberead>0);
+    return howmany;
+}
+
+int
+DTCtcp::Send(char *buffer,int size)
+{
+  if (connected==false) throw DTtcpExcp(EPIPE);
+    int myret =  write (sock, buffer, size) ;
+    if (myret<0) throw DTtcpExcp(errno);
+    return myret;
+}

--- a/IORawData/DTCommissioning/plugins/DTSpyHelper.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyHelper.h
@@ -1,0 +1,52 @@
+#ifndef DaqSource_DTSpyHelper_h
+#define DaqSource_DTSpyHelper_h
+
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <netdb.h>
+
+class DTtcpExcp
+{
+     int errornumber;
+  public:
+   DTtcpExcp(int err):errornumber(err){};
+};
+
+class DTCtcp
+{
+  protected:
+
+    int port;
+    int sock;
+
+    int connected;
+    struct sockaddr_in clientAddr;
+    struct sockaddr_in myaddr;
+
+
+  public:
+
+    DTCtcp();
+    DTCtcp(int port);
+    DTCtcp(int sock,int opt);
+    DTCtcp(DTCtcp *);
+    ~DTCtcp();
+
+    DTCtcp * Accept();
+    void Connect(const char *hostaddr,int port);
+    void Connect(unsigned long hostaddr,int port);
+    int Disconnect();
+   
+    short Id();
+    unsigned long addr();
+    int Send(char * buffer,int size); 
+    int Receive(char *buffer,int size);
+    int WaitData(int timeout);
+
+};
+
+#endif

--- a/IORawData/DTCommissioning/plugins/DTSpyReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpyReader.cc
@@ -1,0 +1,206 @@
+/** \file
+ *
+ *  $Date: 2010/02/03 16:58:24 $
+ *  $Revision: 1.10 $
+ *  \author M. Zanetti
+ */
+
+#include <IORawData/DTCommissioning/plugins/DTSpyReader.h>
+#include <IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h>
+
+#include <DataFormats/FEDRawData/interface/FEDHeader.h>
+#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
+#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include <DataFormats/Provenance/interface/Timestamp.h>
+
+#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+
+#include <string>
+#include <iosfwd>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+
+   
+using namespace std;
+using namespace edm;
+
+
+DTSpyReader::DTSpyReader(const edm::ParameterSet& pset) : 
+  runNumber(1), eventNumber(0) {
+
+  // instatiating Sandro's spy (My name is Bond, Sandro Bond)
+  mySpy = new  DTSpy(); 
+
+  /// connecting to XDAQ note ("0.0.0.0" = localhost)
+  string connectionParameters = pset.getUntrackedParameter<string>("connectionParameters");
+  mySpy->Connect(connectionParameters.c_str(),10000);  
+
+  cout<<endl;
+  cout<<"DT Local DAQ online spy. Connected to IP "<<connectionParameters.c_str()
+      <<". Waiting for the data to be flushed"<<endl;
+  cout<<endl;
+
+  debug = pset.getUntrackedParameter<bool>("debug",false);
+  dduID = pset.getUntrackedParameter<int32_t>("dduID",770); // NOT needed
+
+  produces<FEDRawDataCollection>();
+}
+
+
+DTSpyReader::~DTSpyReader() {
+  delete mySpy;
+}
+
+
+int DTSpyReader::fillRawData(Event& e, 
+	//Timestamp& tstamp, 
+		FEDRawDataCollection*& data){
+ 
+  EventID eID = e.id();
+ 
+  // ask for a new buffer
+  mySpy->getNextBuffer();
+
+  // get the pointer to the beginning of the buffer
+  const char * rawDTData = mySpy->getEventPointer();
+  
+  const uint32_t * rawDTData32 = reinterpret_cast<const uint32_t*>(rawDTData);
+
+  // instantiate the FEDRawDataCollection
+  data = new FEDRawDataCollection();
+
+  vector<uint64_t> eventData;  uint64_t word = 0;  
+  int wordCount = 0; int wordCountCheck = 0;
+
+  bool headerTag = false; bool dataTag = true;
+  
+  // Advance at long-word steps until the trailer is reached. 
+  // Skipped whatever else is in the buffer (e.g. another event..)
+  while ( !isTrailer(word, dataTag, wordCount) ) {
+    
+    // dma gets 4 32-bits words and create a 64 bit one
+    word = dmaUnpack(rawDTData32, dataTag);
+
+    // look for the DDU header
+    if (isHeader(word,dataTag))  headerTag=true;
+
+    // check whether the first word is a DDU header
+    if ( wordCountCheck > 0 && !headerTag && debug) 
+      cout<<"[DTSpyReader]: WARNING: header still not found!!"<<endl;
+
+    // from now on fill the eventData with the ROS data
+    if (headerTag) {
+      
+      // swapping only the 32 bits words
+      if (dataTag) swap(word);
+      // WARNING also the ddu status words have been swapped!
+      // Control the correct interpretation in DDUUnpacker
+      
+      eventData.push_back(word);
+      wordCount++; 
+    }
+
+    // advancing by 4 32-bits words
+    rawDTData32 += 4;
+
+    // counting the total number of group of 128 bits (=4*32) in the buffer 
+    wordCountCheck++; 
+  }
+
+  // Setting the Event ID
+  runNumber = mySpy->getRunNo(); 
+  eID = EventID( runNumber, 1U, eventNumber);
+  
+  // eventDataSize = (Number Of Words)* (Word Size)
+  int eventDataSize = eventData.size()*dduWordLength; 
+  
+  if (debug) cout<<" DDU ID = "<<dduID<<endl;
+ 
+  FEDRawData& fedRawData = data->FEDData( dduID );
+  fedRawData.resize(eventDataSize);
+  
+  copy(reinterpret_cast<unsigned char*>(&eventData[0]),
+       reinterpret_cast<unsigned char*>(&eventData[0]) + eventDataSize, fedRawData.data());
+
+
+  mySpy->setlastPointer( (char*) rawDTData32 );
+
+  return true;
+    
+}
+
+void DTSpyReader::produce(Event&e, EventSetup const&es){
+   edm::Handle<FEDRawDataCollection> rawdata;
+   FEDRawDataCollection *fedcoll = 0;
+   fillRawData(e,fedcoll);
+   std::auto_ptr<FEDRawDataCollection> bare_product(fedcoll);
+   e.put(bare_product);
+ }
+
+void DTSpyReader::swap(uint64_t & word) {
+  
+  twoNibble64* newWorld = reinterpret_cast<twoNibble64*>(&word);
+
+  uint32_t msBits_tmp = newWorld->msBits;
+  newWorld->msBits = newWorld->lsBits;
+  newWorld->lsBits = msBits_tmp;
+}
+
+
+uint64_t DTSpyReader::dmaUnpack(const uint32_t* dmaData, bool & isData) {
+  
+  uint32_t unpackedData[2] = {0, 0};
+  // adjust 4 32-bits words  into 2 32-bits words
+  unpackedData[0] |= dmaData[3] & 0x3ffff;
+  unpackedData[0] |= (dmaData[2] << 18 ) & 0xfffc0000;
+  unpackedData[1] |= (dmaData[2] >> 14 ) & 0x0f;
+  unpackedData[1] |= (dmaData[1] << 4 ) & 0x3ffff0;
+  unpackedData[1] |= (dmaData[0] << 22 ) & 0xffc00000;
+
+  isData = ( dmaData[0] >> 10 ) & 0x01;
+
+  //printf ("Lower part: %x \n", unpackedData[0]);
+  //printf ("Upper part: %x \n", unpackedData[1]);
+
+  // push_back to a 64 word
+  uint64_t dduWord = ( uint64_t(unpackedData[1]) << 32 ) | unpackedData[0];
+
+  return dduWord;
+}
+
+bool DTSpyReader::isHeader(uint64_t word, bool dataTag) {
+
+  bool it_is = false;
+  FEDHeader candidate(reinterpret_cast<const unsigned char*>(&word));
+  if ( candidate.check() ) {
+    // if ( candidate.check() && !dataTag) {
+    it_is = true;
+    dduID = candidate.sourceID();
+    eventNumber++;
+  }
+  return it_is;
+}
+
+
+bool DTSpyReader::isTrailer(uint64_t word, bool dataTag, int wordCount) {
+
+  bool it_is = false;
+  FEDTrailer candidate(reinterpret_cast<const unsigned char*>(&word));
+  if ( candidate.check() ) {
+    //  if ( candidate.check() && !dataTag) {
+    if ( wordCount == candidate.lenght())
+      it_is = true;
+  }
+  return it_is;
+}
+
+
+
+
+
+

--- a/IORawData/DTCommissioning/plugins/DTSpyReader.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyReader.h
@@ -1,0 +1,69 @@
+#ifndef DaqSource_DTSpyReader_h
+#define DaqSource_DTSpyReader_h
+
+/** \class DTSpyReader
+ *  Read DT ROS8 raw data files
+ *
+ *  $Date: 2010/02/03 16:58:24 $
+ *  $Revision: 1.4 $
+ *  \author M. Zanetti - INFN Padova
+ */
+#include "FWCore/Framework/interface/EDProducer.h"
+#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "IORawData/DTCommissioning/plugins/DTSpy.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <ostream>
+#include <fstream>
+#include <boost/cstdint.hpp>
+
+class DTSpyReader : public edm::EDProducer {
+ public:
+  /// Constructor
+  DTSpyReader(const edm::ParameterSet& pset);
+
+  /// Destructor
+  virtual ~DTSpyReader();
+
+  /// Generate and fill FED raw data for a full event
+  virtual int fillRawData(edm::Event& e,
+//			  edm::Timestamp& tstamp, 
+			  FEDRawDataCollection*& data);
+
+  virtual void produce(edm::Event&, edm::EventSetup const&);
+
+  /// check for a 64 bits word to be a DDU header
+  bool isHeader(uint64_t word, bool dataTag);
+
+  /// check for a 64 bits word to be a DDU trailer
+  bool isTrailer(uint64_t word, bool dataTag, int wordCount);
+
+  /// pre-unpack the data if read via DMA
+  //  std::pair<uint64_t,bool> dmaUnpack();
+  uint64_t dmaUnpack(const uint32_t *dmaData ,bool & isData);
+
+  /// swapping the lsBits with the msBits
+  void swap(uint64_t & word);
+ 
+
+ private:
+
+  DTSpy * mySpy;
+
+  edm::RunNumber_t runNumber;
+  edm::EventNumber_t eventNumber;
+
+  bool debug;
+  int dduID; 
+
+  static const int dduWordLength = 8;
+
+};
+#endif
+
+
+

--- a/IORawData/DTCommissioning/plugins/RawFile.cc
+++ b/IORawData/DTCommissioning/plugins/RawFile.cc
@@ -1,0 +1,135 @@
+/** \file
+ *
+ *  \author J. Alcaraz
+ */
+
+#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include <cstring>
+#include <cstdio>
+
+#include <XrdPosix/XrdPosixExtern.hh> 
+
+using namespace std;
+
+extern "C" {
+  extern FILE* rfio_fopen(char *path, char *mode);
+  extern int   rfio_fread(void*, size_t, size_t, void*);
+  extern int   rfio_fclose(FILE *fd);
+  extern int   rfio_fseek(FILE *fp, long offset, int whence);
+  extern int   rfio_feof(FILE *fp);
+  extern long  rfio_ftell(FILE *fp);
+}
+
+RawFile::RawFile() : inputFile(0), rfioFlag(false), xrootdFlag(false) {}
+
+RawFile::RawFile(const char* path) : inputFile(0), rfioFlag(false), xrootdFlag(false) {
+  open(path);
+}
+
+RawFile* RawFile::open(const char* path) {
+
+  //cout << " Full path: " << path << endl;
+
+  char* chaux = new char[strlen(path)+1];
+  strcpy(chaux,path);
+  char* prefix = strtok(chaux,":");
+  //cout << " Prefix: " << prefix << endl;
+
+  char* filename = prefix;
+  if (strlen(prefix)<strlen(path)) filename = strtok(0,":");
+  //cout << " Filename: " << filename << endl;
+
+  if (strcmp(prefix,"rfio")==0) rfioFlag = true;
+  if (strcmp(prefix,"castor")==0) rfioFlag = true;
+  if (strcmp(prefix,"root")==0) xrootdFlag = true;
+
+  if (xrootdFlag) {
+    char chopt[] = "rb";
+    inputFile = XrdPosix_Fopen(path,chopt);
+  } else if (rfioFlag) {
+    char chopt[] = "r";
+    inputFile = rfio_fopen(filename,chopt);
+  } else {
+    char chopt[] = "rb";
+    inputFile = fopen(filename,chopt);
+  }
+  if( !inputFile ) {
+      cout << "RawFile: the input file '" << path << "' is not present" << endl;
+  } else {
+      cout << "RawFile: DAQ file '" << path << "' was succesfully opened" << endl;
+  }
+
+  return this;
+
+}
+
+int RawFile::close() {
+  int flag = -1;
+  if (!inputFile) return flag;
+
+  if (xrootdFlag) {
+    flag = XrdPosix_Fclose(inputFile);
+  }
+  else if (rfioFlag) {
+      flag = rfio_fclose(inputFile);
+  } else {
+      flag = fclose(inputFile);
+  }
+  inputFile = 0;
+  return flag;
+}
+
+RawFile::~RawFile(){close();}
+
+FILE* RawFile::GetPointer(){ return inputFile;}
+
+bool RawFile::ok(){ return (inputFile!=0);}
+
+bool RawFile::fail(){ return !ok();}
+
+bool RawFile::isRFIO() { return rfioFlag;}
+
+bool RawFile::isXROOTD() { return xrootdFlag;}
+
+int RawFile::read(void* data, size_t nbytes) {
+  if (xrootdFlag) {
+    return XrdPosix_Fread(data,nbytes,1,inputFile);
+  }
+  else if (rfioFlag) {
+    return rfio_fread(data, nbytes, 1, inputFile);
+  } else {
+    return fread(data, nbytes, 1, inputFile);
+  }
+}
+
+int RawFile::seek(long offset, int whence) {
+  if (xrootdFlag) {
+    return XrdPosix_Fseek(inputFile, offset, whence);
+  }
+  else if (rfioFlag) {
+    return rfio_fseek(inputFile, offset, whence);
+  } else {
+    return fseek(inputFile, offset, whence);
+  }
+}
+
+int RawFile::ignore(long offset) { return seek(offset, SEEK_CUR);}
+
+int RawFile::eof() {
+  if (rfioFlag) {
+      return rfio_feof(inputFile);
+  } else {
+    return feof(inputFile);  // Also for XROOTD
+  }
+}
+
+long RawFile::tell() {
+  if (xrootdFlag) {
+    return XrdPosix_Ftell(inputFile);
+  }
+  else if (rfioFlag) {
+      return rfio_ftell(inputFile);
+  } else {
+      return ftell(inputFile);
+  }
+}

--- a/IORawData/DTCommissioning/plugins/RawFile.h
+++ b/IORawData/DTCommissioning/plugins/RawFile.h
@@ -1,0 +1,67 @@
+#ifndef DaqSource_RawFile_h
+#define DaqSource_RawFile_h
+
+/** \class RawFile
+ *  Utility class to open, read and manage local and rfio files
+ *  in a transparent way
+ *
+ *  \author J. Alcaraz - CIEMAT, Madrid
+ */
+
+#include <iostream>
+//#include <boost/cstdint.hpp>
+
+class RawFile {
+ public:
+  /// Default constructor
+  RawFile();
+
+  /// Usual constructor
+  RawFile(const char* path);
+
+  /// Open file
+  RawFile* open(const char* path);
+
+  /// Close file if necessary
+  int close();
+
+  /// Destructor
+  virtual ~RawFile();
+
+  /// Get file pointer
+  FILE* GetPointer();
+
+  /// It is OK (i.e. file was correctly opened)
+  bool ok();
+
+  /// It is not OK
+  bool fail();
+
+  /// Castor flag
+  bool isRFIO();
+
+  /// XROOTD flag
+  bool isXROOTD();
+
+  /// Read from file
+  int read(void* data, size_t nbytes);
+
+  /// Go somewhere
+  int seek(long offset, int whence);
+
+  /// Ignore some bytes
+  int ignore(long offset);
+
+  /// Check end of file
+  int eof();
+
+  /// Tell instruction
+  long tell();
+
+ private:
+
+  FILE* inputFile;
+  bool  rfioFlag;
+  bool  xrootdFlag;
+};
+#endif

--- a/IORawData/DTCommissioning/plugins/SealModule.cc
+++ b/IORawData/DTCommissioning/plugins/SealModule.cc
@@ -1,0 +1,14 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h"
+#include "IORawData/DTCommissioning/plugins/DTROS8FileReader.h"
+#include "IORawData/DTCommissioning/plugins/DTROS25FileReader.h"
+#include "IORawData/DTCommissioning/plugins/DTDDUFileReader.h"
+#include "IORawData/DTCommissioning/plugins/DTSpyReader.h"
+
+DEFINE_FWK_MODULE ( DTNewROS8FileReader);
+DEFINE_FWK_MODULE ( DTROS8FileReader);
+DEFINE_FWK_MODULE ( DTROS25FileReader);
+DEFINE_FWK_MODULE ( DTDDUFileReader);
+DEFINE_FWK_MODULE ( DTSpyReader);

--- a/IORawData/DTCommissioning/test/runDTTreeROS8.py
+++ b/IORawData/DTCommissioning/test/runDTTreeROS8.py
@@ -21,25 +21,13 @@ process.rawDataCollector = cms.EDProducer('DTNewROS8FileReader',
          eventsAnalysisRate = cms.untracked.int32(1),
 
          fileName = cms.untracked.string(
-         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/data/eosdir/eos/cms/store/caf/user/dtdqm/InputLocalRuns/testpulses_YB2_test_vmepcs2g18-16_r213178.i0'
-         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/testpuslsedefrancoprovaros8'
-         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/test18032015.dat'
-         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/test01072015.dat'
-         #'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/test01072015_2.dat'
-         #'file:/afs/cern.ch/user/b/bedoya/public/FM_cosmic_30mV_3020'
-         #'file:/afs/cern.ch/user/b/bedoya/public/FM_try3_3008'
-         #'file:/afs/cern.ch/user/b/bedoya/cms_offline/CMSSW_5_3_26/src/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/FM_cosmic_30mV_3020'
-	 # 'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/meneguz/GIF/FM_cosmic_30mV_3025'
- 	 #'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/meneguz/GIF/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/run28082015_3192'
-        #'file:/afs/cern.ch/user/b/bedoya/cms_offline/CMSSW_5_3_26/src/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/run27082015_3159'
-        #'file:/afs/cern.ch/user/b/bedoya/cms_offline/CMSSW_5_3_26/src/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/GIF++_004_verticalonly.dat'
         'file:./run27082015_3163'
          )
     
 )                                                
 
 
-from CondCore.DBCommon.CondDBSetup_cfi import *
+from  CondCore.CondDB.CondDB_cfi import *
 
 ###### MAP ############################################################################
 ###process.mappingsource = cms.ESSource("PoolDBESSource",

--- a/IORawData/DTCommissioning/test/runDTTreeROS8.py
+++ b/IORawData/DTCommissioning/test/runDTTreeROS8.py
@@ -1,0 +1,161 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTDPGAnalyis")
+
+
+##process.load("UserCode.DTDPGAnalysis.dt_dpganalysis_common_cff_cosmics_miniDAQ")
+##process.load("UserCode.DTDPGAnalysis.testLocalDAQ")
+process.load("UserCode.DTDPGAnalysis.testLocalDAQ_ROS8")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source("EmptySource",
+      firstRun= cms.untracked.uint32(3163),
+      numberEventsInLuminosityBlock = cms.untracked.uint32(200),
+      numberEventsInRun       = cms.untracked.uint32(0)
+ )
+
+process.rawDataCollector = cms.EDProducer('DTNewROS8FileReader',
+         isRaw = cms.untracked.bool(True),
+         numberOfHeaderWords = cms.untracked.int32(10),  ## No esta incluido en el default del codigo de la ROS8
+         eventsAnalysisRate = cms.untracked.int32(1),
+
+         fileName = cms.untracked.string(
+         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/data/eosdir/eos/cms/store/caf/user/dtdqm/InputLocalRuns/testpulses_YB2_test_vmepcs2g18-16_r213178.i0'
+         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/testpuslsedefrancoprovaros8'
+         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/test18032015.dat'
+         ##'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/test01072015.dat'
+         #'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/marycruz/testROS8/data/test01072015_2.dat'
+         #'file:/afs/cern.ch/user/b/bedoya/public/FM_cosmic_30mV_3020'
+         #'file:/afs/cern.ch/user/b/bedoya/public/FM_try3_3008'
+         #'file:/afs/cern.ch/user/b/bedoya/cms_offline/CMSSW_5_3_26/src/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/FM_cosmic_30mV_3020'
+	 # 'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/meneguz/GIF/FM_cosmic_30mV_3025'
+ 	 #'file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/tmpanalysis/meneguz/GIF/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/run28082015_3192'
+        #'file:/afs/cern.ch/user/b/bedoya/cms_offline/CMSSW_5_3_26/src/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/run27082015_3159'
+        #'file:/afs/cern.ch/user/b/bedoya/cms_offline/CMSSW_5_3_26/src/eosdir/eos/cms/store/group/dpg_dt/comm_dt/gif++/GIF++_004_verticalonly.dat'
+        'file:./run27082015_3163'
+         )
+    
+)                                                
+
+
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+###### MAP ############################################################################
+###process.mappingsource = cms.ESSource("PoolDBESSource",
+###    CondDBSetup,
+###    timetype = cms.string('runnumber'),
+###    toGet = cms.VPSet(cms.PSet(record = cms.string('DTReadOutMappingRcd'),
+###                               tag = cms.string('DTReadoutMapping_Rob3Mb1')
+######                               tag = cms.string('DTReadOutMapping_compact_V04')
+###                               )
+###                      ),
+###    connect = cms.string('frontier://Frontier/CMS_COND_31X_DT'),
+###    authenticationMethod = cms.untracked.uint32(1)
+###    )
+###
+###process.es_prefer_mappingsource = cms.ESPrefer('PoolDBESSource','mappingsource')
+###### END MAP ########################################################################
+
+###### tTrig  #########################################################################
+process.ttrigsource = cms.ESSource("PoolDBESSource", 
+    CondDBSetup,
+    timetype = cms.string('runnumber'),
+    toGet = cms.VPSet(cms.PSet(record = cms.string('DTTtrigRcd'),
+                               label = cms.untracked.string('cosmics'),  ## ONLY if using cosmic reconstruction  
+                               tag = cms.string('ttrig')
+                               )
+                      ),
+    ## connect = cms.string('frontier://Frontier/CMS_COND_31X_DT'),
+    ## connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/GIF2015/LocalDataBases/ttrig_ROS8_1.db'),
+    ## connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/GIF2015/LocalDataBases/ttrig_ROS8_1_p520.db'),
+    ## connect = cms.string('sqlite_file:ttrig_ROS8_1_p530.db'),
+    connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/GIF2015/LocalDataBases/ttrig_ROS8_Tbox410.db'),
+    authenticationMethod = cms.untracked.uint32(0)
+    )
+
+process.es_prefer_ttrigsource = cms.ESPrefer('PoolDBESSource','ttrigsource')
+###### END tTRIG  #####################################################################
+
+
+
+###process.MessageLogger = cms.Service("MessageLogger",
+###                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING')),
+###                                    destinations = cms.untracked.vstring('cout')
+###                                    )
+
+#------------------
+# DT Analyisis
+#------------------
+
+# MAGNETIC FIELD
+#### B = 0 Tesla ###############################################################
+process.load("Configuration.StandardSequences.MagneticField_0T_cff")
+####process.SteppingHelixPropagator.useInTeslaFromMagField = True
+####process.SteppingHelixPropagator.SetVBFPointer = True
+#### B = 3.8 Tesla #############################################################
+##process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+
+#--------------------------------------------------------
+
+from UserCode.DTDPGAnalysis.DTOfflineAnalyzer_cfi import *
+process.DTOfflineAnalyzer.DTLocalTriggerLabel = 'dtunpacker'
+process.DTOfflineAnalyzer.doSA = False
+##process.DTOfflineAnalyzer.doWheelm2 = False
+##process.DTOfflineAnalyzer.doWheelm1 = False
+##process.DTOfflineAnalyzer.doWheel0 = False
+##process.DTOfflineAnalyzer.doWheel1 = False
+##process.DTOfflineAnalyzer.doWheel2 = False
+
+process.DTOfflineAnalyzer.doTBox = False
+process.DTOfflineAnalyzer.doTBoxWhm2 = False
+process.DTOfflineAnalyzer.doTBoxWhm1 = False
+process.DTOfflineAnalyzer.doTBoxWh0 = False
+process.DTOfflineAnalyzer.doTBoxWh1 = False
+process.DTOfflineAnalyzer.doTBoxWh2 = False
+process.DTOfflineAnalyzer.doTBoxSector  = 0 ## =0 => All Sectors, =N => Sector N
+process.DTOfflineAnalyzer.doTBoxChamber = 3 ## =0 => All Chambers,=N => Chamber N
+process.DTOfflineAnalyzer.doTBoxSuperLayer = 0 ## =0 => All SuperLayers,=N => SuperLayer N
+process.DTOfflineAnalyzer.doTBoxLayer = 0 ## =0 => All Layers,=N => Layer N
+
+
+process.load("DQM.DTMonitorModule.dtTriggerTask_cfi")
+process.dtTriggerMonitor.process_dcc = True
+process.dtTriggerMonitor.dcc_label   = 'dttfunpacker'
+process.dtTriggerMonitor.process_seg = True
+
+#--------------------------------------------------------
+##process.UpdaterService = cms.Service("UpdaterService")  ###  Only needed for STA reco
+#--------------------------------------------------------
+
+
+process.load("UserCode/DTDPGAnalysis/DTTTreGenerator_cfi")
+process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
+
+process.myDTNtuple.outputFile = "DTNtuple_LocalRun.root"
+##process.myDTNtuple.dtTrigSimDCCLabel = cms.InputTag("dtTriggerPrimitiveDigis")
+process.myDTNtuple.dtDigiLabel = cms.InputTag("dtunpacker")
+process.myDTNtuple.localDTmuons = cms.untracked.bool(True)
+process.myDTNtuple.localDTmuonsWithoutTrigger = cms.untracked.bool(True)  ## This avoid the "standard DCC & DDU triggers  if uncommented
+                                                                          ## the program will probably crash
+process.myDTNtuple.localDTmuonsWithROS8Trigger = cms.untracked.bool(True) ## << To include the ROS8 Trigger data in the root tree
+                                                                          ## Can be put as true even if there is not this triggers but
+                                                                          ## only in case the ROS8 unpacker is used 
+## Uncomment and change the next parameters in case you need to increase the 
+##total number of digis/segments... per event allowed in the root size
+##process.myDTNtuple.dtDigiSize = cms.int32(300),
+##process.myDTNtuple.dtSegmentSize = cms.int32(50),
+##process.myDTNtuple.dtTrigROS8Size = cms.int32(50),
+
+
+process.out = cms.OutputModule("PoolOutputModule",
+                               outputCommands = cms.untracked.vstring('drop *', 
+                                                                      'keep *_MEtoEDMConverter_*_*'),
+                               fileName = cms.untracked.string('DQMOfflineDTDPG.root')
+                               )
+
+##process.p = cms.Path( process.dtunpacker )
+process.p = cms.Path( process.rawDataCollector+process.dtunpacker * process.reco  + process.sources + process.MEtoEDMConverter  + process.DTOfflineAnalyzer +process.myDTNtuple) 
+
+process.ep = cms.EndPath( process.out )
+


### PR DESCRIPTION
Ported all plugins from the old (CMSSW_6_X_Y or older) to recent CMSSW versions making use of DaqFakeReader 
Automatically ported from CMSSW_8_0_X #12985 (original by @jfernan2).
