### PR TITLE
Add a simplified way for eras to modify the whole process

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -511,6 +511,8 @@ class Process(object):
         moduleName = moduleName.replace("/",".")
         module = __import__(moduleName)
         self.extend(sys.modules[moduleName])
+        for m in self.__modifiers:
+            m._applyAndRemoveProcessModifiers(self)
     def extend(self,other,items=()):
         """Look in other and find types that we can use"""
         # enable explicit check to avoid overwriting of existing objects
@@ -1123,6 +1125,12 @@ class Modifier(object):
        In order to work, the value returned from this function must be assigned to a uniquely named variable.
     """
     return ProcessModifier(self,func)
+  def toModifyProcess(self,func):
+    """ Creates a ProcessModifier and stores it. This can later be run using the _applyAndRemoveProcessModifiers
+        function. In this way config fragments will call toModifyProcess and once they have finished being loaded
+        the process object will apply the functions then remove them from the list.
+    """
+    self.__processModifiers.append( ProcessModifier(self,func) )
   def toModify(self,obj, func=None,**kw):
     """This is used to register an action to be performed on the specific object. Two different forms are allowed
     Form 1: A callable object (e.g. function) can be passed as the second. This callable object is expected to take one argument
@@ -1142,6 +1150,11 @@ class Modifier(object):
   def _setChosen(self):
     """Should only be called by cms.Process instances"""
     self.__chosen = True
+  def _applyAndRemoveProcessModifiers(self,process):
+    """Should only be called by cms.Process instances"""
+    for processModifier in self.__processModifiers :
+        processModifier.apply(process)
+    self.__processModifiers = []
   def isChosen(self):
     return self.__chosen
 
@@ -1161,6 +1174,10 @@ class ModifierChain(object):
         self.__chosen = True
         for m in self.__chain:
             m._setChosen()
+    def _applyAndRemoveProcessModifiers(self,process):
+        """Should only be called by cms.Process instances"""
+        for m in self.__chain:
+            m._applyAndRemoveProcessModifiers(process)
     def isChosen(self):
         return self.__chosen
 


### PR DESCRIPTION
**Current code**
Currently the only way for an era to make a modification to the whole process object is to create a ProcessModifier and assign it a unique name, e.g.:

``` python
def _modificationFunction( theProcess ) :
    theProcess.someThing = blah
someUniqueName_ = eras.run2_common.makeProcessModifier( _modificationFunction )
```

When the process object scans the imported objects at the end of the `load(...)` it sees that `someUniqueName_` is an instance of ProcessModifier and applies the change to itself.

This has the disadvantage of requiring a unique name, and also that it can be easily broken depending on how the file with the era change is imported.  For example, if the file above is imported with

``` python
from SomePackage.SubPackage.file import somePSet
```

Then only `somePSet` is imported and not the ProcessModifier object, hence the era changes are never applied.

**Proposal**
This pull request adds the method `toModifyProcess` to the era which stores the ProcessModifier object inside the era itself.  When the process object has finished the `load(...)` it scans all its active eras and applies any stored ProcessModifiers, then clears the list ready for the next `load(...)`.  This bypasses the import problem above and also (I think) looks much cleaner.  The new way of modifying the process object would be:

``` python
def _modificationFunction( theProcess ) :
    theProcess.someThing = blah
eras.run2_common.toModifyProcess( _modificationFunction )
```

The old way of modifying the process is still available.  If this PR is accepted then we could mark it as deprecated or remove it later.

@Dr15Jones let me know if you can see any disadvantages or have any comments.  Note that as well as adding methods I've made use of the `__processModifiers` attribute which doesn't appear to be used elsewhere.  If this is a problem I can easily modify it to use a different attribute.
Automatically ported from CMSSW_8_0_X #12256 (original by @mark-grimes).
