### PR TITLE
Small performance improvement in Tracking

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
+++ b/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
@@ -22,6 +22,7 @@ namespace siStripClusterTools {
     else return 1.f/0.027f;
   }
 
+
   template<typename Iter>
   inline float chargePerCM(DetId detid, Iter a, Iter b) {
     return float(std::accumulate(a,b,int(0)))*sensorThicknessInverse(detid);
@@ -37,6 +38,12 @@ namespace siStripClusterTools {
   inline float	chargePerCM(DetId detid, Clus const & cl, LocalTrajectoryParameters const & tp) {
     return chargePerCM(detid,cl)*tp.absdz();
   }
+
+  template<typename Clus>
+  inline float  chargePerCM(Clus const & cl, LocalTrajectoryParameters const & tp, float invThick) {
+    return  cl.charge()*invThick*tp.absdz();
+  }
+
 
   template<typename Clus>
   inline float chargePerCM(DetId detid, Clus const & cl, const LocalVector & ldir) {

--- a/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
+++ b/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
@@ -23,23 +23,23 @@ namespace siStripClusterTools {
   }
 
   template<typename Iter>
-  float chargePerCM(DetId detid, Iter a, Iter b) {
+  inline float chargePerCM(DetId detid, Iter a, Iter b) {
     return float(std::accumulate(a,b,int(0)))*sensorThicknessInverse(detid);
   }
 
   template<typename Clus>
-  float chargePerCM(DetId detid, Clus const & cl) {
+  inline float chargePerCM(DetId detid, Clus const & cl) {
     return cl.charge()*sensorThicknessInverse(detid);
   }
 
 
   template<typename Clus>
-  float	chargePerCM(DetId detid, Clus const & cl, LocalTrajectoryParameters const & tp) {
+  inline float	chargePerCM(DetId detid, Clus const & cl, LocalTrajectoryParameters const & tp) {
     return chargePerCM(detid,cl)*tp.absdz();
   }
 
   template<typename Clus>
-  float chargePerCM(DetId detid, Clus const & cl, const LocalVector & ldir) {
+  inline float chargePerCM(DetId detid, Clus const & cl, const LocalVector & ldir) {
     return chargePerCM(detid,cl)*std::abs(ldir.z())/ldir.mag();
   }
 

--- a/DataFormats/SiStripDetId/interface/SiStripDetId.h
+++ b/DataFormats/SiStripDetId/interface/SiStripDetId.h
@@ -112,23 +112,7 @@ private:
 // ---------- inline methods ----------
 
 SiStripDetId::SubDetector SiStripDetId::subDetector() const {
-  SiStripDetId::SubDetector result;
-  if ( det() == DetId::Tracker) {
-    if ( subdetId() == static_cast<int>(SiStripDetId::TEC) ) {
-      result = SiStripDetId::TEC;
-    } else if ( subdetId() == static_cast<int>(SiStripDetId::TID) ) {
-      result = SiStripDetId::TID;
-    } else if ( subdetId() == static_cast<int>(SiStripDetId::TOB) ) {
-      result = SiStripDetId::TOB;
-    } else if ( subdetId() == static_cast<int>(SiStripDetId::TIB) ) {
-      result = SiStripDetId::TIB;
-    } else {
-      result = SiStripDetId::UNKNOWN;
-    }
-  } else {
-    result = SiStripDetId::UNKNOWN;
-  }
-  return result;
+  return det() == DetId::Tracker ? static_cast<SiStripDetId::SubDetector>(subdetId()) : SiStripDetId::UNKNOWN;
 }
 
 SiStripDetId::ModuleGeometry SiStripDetId::moduleGeometry() const {

--- a/DataFormats/SiStripDetId/interface/SiStripDetId.h
+++ b/DataFormats/SiStripDetId/interface/SiStripDetId.h
@@ -112,7 +112,7 @@ private:
 // ---------- inline methods ----------
 
 SiStripDetId::SubDetector SiStripDetId::subDetector() const {
-  return det() == DetId::Tracker ? static_cast<SiStripDetId::SubDetector>(subdetId()) : SiStripDetId::UNKNOWN;
+  return static_cast<SiStripDetId::SubDetector>(subdetId());
 }
 
 SiStripDetId::ModuleGeometry SiStripDetId::moduleGeometry() const {

--- a/MagneticField/ParametrizedEngine/BuildFile.xml
+++ b/MagneticField/ParametrizedEngine/BuildFile.xml
@@ -1,5 +1,5 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="DataFormats/GeometryVector"/>
-<!--use   name="FWCore/Framework"/-->
 <use   name="FWCore/ParameterSet"/>
 <use   name="MagneticField/Engine"/>
 <use   name="MagneticField/UniformEngine"/>

--- a/MagneticField/ParametrizedEngine/plugins/BuildFile.xml
+++ b/MagneticField/ParametrizedEngine/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>

--- a/MagneticField/ParametrizedEngine/src/BCyl.h
+++ b/MagneticField/ParametrizedEngine/src/BCyl.h
@@ -23,11 +23,9 @@
 namespace magfieldparam {
   template<typename T>
   struct BCylParam {
-    //  constexpr BCylParam(std::initializer_list<T> init) :
     template<typename ... Args>
     constexpr BCylParam(Args... init) :
       prm{std::forward<Args>(init)...},
-    //prm(std::forward<Args>(init)...), 
       ap2(4*prm[0]*prm[0]/(prm[1]*prm[1])), 
       hb0(0.5*prm[2]*std::sqrt(1.0+ap2)),
       hlova(1/std::sqrt(ap2)),
@@ -48,11 +46,12 @@ namespace magfieldparam {
     template<typename T>
     inline void ffunkti(T u, T * __restrict__ ff) {
       // Function and its 3 derivatives
-      T a,b,a2,u2;
-      u2=u*u; 
-      a=T(1)/(T(1)+u2);
-      a2=-T(3)*a*a;
-      b=std::sqrt(a);
+      auto u2=u*u; 
+      // a=T(1)/(T(1)+u2);
+      // b=std::sqrt(a);
+      auto b=T(1)/std::sqrt(T(1)+u2);
+      auto a=b*b;
+      auto a2=-T(3)*a*a;
       ff[0]=u*b;
       ff[1]=a*b;
       ff[2]=a2*ff[0];

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
@@ -61,34 +61,36 @@
 #define N2D 500
 
 #include <vector>
-#include "boost/multi_array.hpp"
 
 
-namespace SiPixelTemplateReco 
- {
- 
-    typedef boost::multi_array<float, 2> array_2d;
+namespace SiPixelTemplateReco {
 
-	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, array_2d& cluster, 
-				std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+     struct ClusMatrix {
+      float & operator()(int x, int y) { return matrix[mcol*x+y];} 
+      float operator()(int x, int y) const { return matrix[mcol*x+y];} 
+      float * matrix;
+      bool const * xdouble;
+      bool const * ydouble;
+      int mrow, mcol;
+     };
+
+	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, ClusMatrix & cluster, 
 				SiPixelTemplate& templ, 
-				float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed, bool deadpix, std::vector<std::pair<int, int> >& zeropix,
+				float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed, bool deadpix, 
+                                std::vector<std::pair<int, int> >& zeropix,
 				float& probQ);
 
-	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, array_2d& cluster, 
-				std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, ClusMatrix & cluster,
 				SiPixelTemplate& templ, 
 				float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
 				float& probQ);
 	 
-	 int PixelTempReco2D(int id, float cotalpha, float cotbeta, array_2d& cluster, 
-						 std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+	 int PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster,
 						 SiPixelTemplate& templ, 
 						 float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
 						 float& probQ);
 	 
-	 int PixelTempReco2D(int id, float cotalpha, float cotbeta, array_2d& cluster, 
-								std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+	 int PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster,
 								SiPixelTemplate& templ, 
 								float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed);
  }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -176,37 +176,49 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       lp = theDetParam.theTopol->localPosition( MeasurementPoint(tmp_x, tmp_y) );
     }
     
+  // first compute matrix size
+  int mrow=0, mcol=0;
+  for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i )
+    {
+      auto pix = theClusterParam.theCluster->pixel(i);
+      int irow = int(pix.x); 
+      int icol = int(pix.y);
+      mrow = std::max(mrow,irow);
+      mcol = std::max(mcol,icol);
+     }
+     mrow -= row_offset; mrow+=1; mrow = std::min(mrow,cluster_matrix_size_x);
+     mcol -= col_offset; mcol+=1; mcol = std::min(mcol,cluster_matrix_size_y);
+     assert(mrow>0); assert(mcol>0);
+
+     float clustMatrix[mrow][mcol];
+
   // Copy clust's pixels (calibrated in electrons) into clust_array_2d;
   for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i ) 
     {
       auto pix = theClusterParam.theCluster->pixel(i);
-      // *pixIter dereferences to Pixel struct, with public vars x, y, adc (all float)
-      // 02/13/2008 ggiurgiu@fnal.gov: type of x, y and adc has been changed to unsigned char, unsigned short, unsigned short
-      // in DataFormats/SiPixelCluster/interface/SiPixeltheClusterParam.theCluster->h so the type cast to int is redundant. Leave it there, it 
-      // won't hurt. 
-      int irow = int(pix.x) - row_offset;   // &&& do we need +0.5 ???
-      int icol = int(pix.y) - col_offset;   // &&& do we need +0.5 ???
+      int irow = int(pix.x) - row_offset;
+      int icol = int(pix.y) - col_offset;
       
       // Gavril : what do we do here if the row/column is larger than cluster_matrix_size_x/cluster_matrix_size_y = 7/21 ?
       // Ignore them for the moment...
-      if ( irow<cluster_matrix_size_x && icol<cluster_matrix_size_y )
-	// 02/13/2008 ggiurgiu@fnal.gov typecast pixIter->adc to float
-	clust_array_2d[irow][icol] = (float)pix.adc;
+      if ( (irow<mrow) & (icol<mcol) )
+	// 02/13/2008 ggiurgiu@fnal.gov typecast adc to float
+        clustMatrix[irow][icol] =  float(pix.adc);
     }
   
+
+
   // Make and fill the bool arrays flagging double pixels
-  std::vector<bool> ydouble(cluster_matrix_size_y), xdouble(cluster_matrix_size_x);
+  bool ydouble[mrow], xdouble[mcol];
   // x directions (shorter), rows
-  for (int irow = 0; irow < cluster_matrix_size_x; ++irow)
-    {
+  for (int irow = 0; irow < mrow; ++irow)
       xdouble[irow] = theDetParam.theRecTopol->isItBigPixelInX( irow+row_offset );
-    }
-      
-  // y directions (longer), columns
-  for (int icol = 0; icol < cluster_matrix_size_y; ++icol) 
-    {
+
+   // y directions (longer), columns
+  for (int icol = 0; icol < mcol; ++icol) 
       ydouble[icol] = theDetParam.theRecTopol->isItBigPixelInY( icol+col_offset );
-    }
+
+  SiPixelTemplateReco::ClusMatrix clusterPayload{&clustMatrix[0][0], xdouble, ydouble, mrow,mcol};
 
   // Output:
   float nonsense = -99999.9f; // nonsense init value
@@ -231,7 +243,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
   theClusterParam.ierr =
     PixelTempReco2D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
 		     locBz, 
-		     clust_array_2d, ydouble, xdouble,
+		     clusterPayload,
 		     templ,
 		     theClusterParam.templYrec_, theClusterParam.templSigmaY_, theClusterParam.templProbY_,
 		     theClusterParam.templXrec_, theClusterParam.templSigmaX_, theClusterParam.templProbX_, 
@@ -292,7 +304,8 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       SiPixelTemplate2D::pushfile(ID, thePixelTemp2D_);
       SiPixelTemplate2D templ2D_(thePixelTemp2D_);
       	
-      theClusterParam.ierr =
+      theClusterParam.ierr = -123;
+      /*
 	SiPixelTemplateSplit::PixelTempSplit( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
 					      clust_array_2d, 
 					      ydouble, xdouble,
@@ -305,7 +318,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
 					      dchisq, 
 					      templ2D_ );
       
-
+      */
       if ( theClusterParam.ierr != 0 )
 	{
 	  LogDebug("PixelCPETemplateReco::localPosition") <<

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -189,7 +189,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
     float clustMatrix[mrow][mcol];
     memset(clustMatrix,0,sizeof(float)*mrow*mcol);
 
-  // Copy clust's pixels (calibrated in electrons) into clust_array_2d;
+  // Copy clust's pixels (calibrated in electrons) into clusMatrix;
    for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i ) 
     {
       auto pix = theClusterParam.theCluster->pixel(i);
@@ -198,15 +198,13 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       
       // Gavril : what do we do here if the row/column is larger than cluster_matrix_size_x/cluster_matrix_size_y  ?
       // Ignore them for the moment...
-      if ( (irow<mrow) & (icol<mcol) )
-	// 02/13/2008 ggiurgiu@fnal.gov typecast adc to float
-        clustMatrix[irow][icol] =  float(pix.adc);
-      }
+      if ( (irow<mrow) & (icol<mcol) ) clustMatrix[irow][icol] =  float(pix.adc);
+     
     }
   
 
   // Make and fill the bool arrays flagging double pixels
-  bool ydouble[mrow], xdouble[mcol];
+  bool xdouble[mrow], ydouble[mcol];
   // x directions (shorter), rows
   for (int irow = 0; irow < mrow; ++irow)
       xdouble[irow] = theDetParam.theRecTopol->isItBigPixelInX( irow+row_offset );

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -137,10 +137,6 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
   
   SiPixelTemplate templ(thePixelTemp_);
 
-  // Make from cluster (a SiPixelCluster) a boost multi_array_2d called 
-  // clust_array_2d.
-  boost::multi_array<float, 2> clust_array_2d(boost::extents[cluster_matrix_size_x][cluster_matrix_size_y]);
-  
   // Preparing to retrieve ADC counts from the SiPixeltheClusterParam.theCluster->  In the cluster,
   // we have the following:
   //   int minPixelRow(); // Minimum pixel index in the x direction (low edge).
@@ -185,28 +181,29 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       int icol = int(pix.y);
       mrow = std::max(mrow,irow);
       mcol = std::max(mcol,icol);
-     }
-     mrow -= row_offset; mrow+=1; mrow = std::min(mrow,cluster_matrix_size_x);
-     mcol -= col_offset; mcol+=1; mcol = std::min(mcol,cluster_matrix_size_y);
-     assert(mrow>0); assert(mcol>0);
+    }
+    mrow -= row_offset; mrow+=1; mrow = std::min(mrow,cluster_matrix_size_x);
+    mcol -= col_offset; mcol+=1; mcol = std::min(mcol,cluster_matrix_size_y);
+    assert(mrow>0); assert(mcol>0);
 
-     float clustMatrix[mrow][mcol];
+    float clustMatrix[mrow][mcol];
+    memset(clustMatrix,0,sizeof(float)*mrow*mcol);
 
   // Copy clust's pixels (calibrated in electrons) into clust_array_2d;
-  for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i ) 
+   for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i ) 
     {
       auto pix = theClusterParam.theCluster->pixel(i);
       int irow = int(pix.x) - row_offset;
       int icol = int(pix.y) - col_offset;
       
-      // Gavril : what do we do here if the row/column is larger than cluster_matrix_size_x/cluster_matrix_size_y = 7/21 ?
+      // Gavril : what do we do here if the row/column is larger than cluster_matrix_size_x/cluster_matrix_size_y  ?
       // Ignore them for the moment...
       if ( (irow<mrow) & (icol<mcol) )
 	// 02/13/2008 ggiurgiu@fnal.gov typecast adc to float
         clustMatrix[irow][icol] =  float(pix.adc);
+      }
     }
   
-
 
   // Make and fill the bool arrays flagging double pixels
   bool ydouble[mrow], xdouble[mcol];

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -293,15 +293,15 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       //		templQbin_ );
 
 
-      float dchisq;
-      float templProbQ_;
       std::vector< SiPixelTemplateStore2D > thePixelTemp2D_;
       SiPixelTemplate2D::pushfile(ID, thePixelTemp2D_);
       SiPixelTemplate2D templ2D_(thePixelTemp2D_);
       	
       theClusterParam.ierr = -123;
       /*
-	SiPixelTemplateSplit::PixelTempSplit( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
+      float dchisq;
+      float templProbQ_;
+      SiPixelTemplateSplit::PixelTempSplit( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
 					      clust_array_2d, 
 					      ydouble, xdouble,
 					      templ,

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -122,8 +122,7 @@ using namespace SiPixelTemplateReco;
 //! \param    zeropix - (input)  vector of index pairs pointing to the dead pixels
 //! \param      probQ - (output) the Vavilov-distribution-based cluster charge probability
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, array_2d& clust, 
-		    std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, ClusMatrix & cluster,
 		    SiPixelTemplate& templ, 
 		    float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed, bool deadpix, std::vector<std::pair<int, int> >& zeropix,
 			 float& probQ)
@@ -160,10 +159,6 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	   return 20;
 	}
 	
-// Make a local copy of the cluster container so that we can muck with it
-	
-	array_2d cluster = clust;
-	
 // Check to see if Q probability is selected
 	
 	calc_probQ = false;
@@ -196,44 +191,25 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
     
 // Check that the cluster container is (up to) a 7x21 matrix and matches the dimensions of the double pixel flags
 
-	if(cluster.num_dimensions() != 2) {
-	   LOGERROR("SiPixelTemplateReco") << "input cluster container (BOOST Multiarray) has wrong number of dimensions" << ENDL;	
-	   return 3;
-	}
-	nclusx = (int)cluster.shape()[0];
-	nclusy = (int)cluster.shape()[1];
-	if(nclusx != (int)xdouble.size()) {
-	   LOGERROR("SiPixelTemplateReco") << "input cluster container x-size is not equal to double pixel flag container size" << ENDL;	
-	   return 4;
-	}
-	if(nclusy != (int)ydouble.size()) {
-	   LOGERROR("SiPixelTemplateReco") << "input cluster container y-size is not equal to double pixel flag container size" << ENDL;	
-	   return 5;
-	}
-	
-// enforce maximum size	
-	
-	if(nclusx > TXSIZE) {nclusx = TXSIZE;}
-	if(nclusy > TYSIZE) {nclusy = TYSIZE;}
-	
-// First, rescale all pixel charges       
+	nclusx = cluster.mrow;
+	nclusy = (int)cluster.mcol;
+	auto const xdouble = cluster.xdouble;
+	auto const ydouble = cluster.ydouble;
 
-	for(j=0; j<nclusx; ++j)
-    for(i=0; i<nclusy; ++i)
-		  if(cluster[j][i] > 0) {cluster[j][i] *= qscale;}
+// First, rescale all pixel charges and compute total charge
+        qtotal = 0.f;
+	for(i=0; i<nclusx*nclusy; ++i)
+	   cluster.matrix[i] *= qscale; qtotal +=cluster.matrix[i];
 	
 // Next, sum the total charge and "decapitate" big pixels         
-
-	qtotal = 0.f;
-	minmax = templ.pixmax();
-	for(i=0; i<nclusy; ++i) {
-	   maxpix = minmax;
-	   if(ydouble[i]) {maxpix *=2.f;}
-	   for(j=0; j<nclusx; ++j) {
-		  qtotal += cluster[j][i];
-		  if(cluster[j][i] > maxpix) {cluster[j][i] = maxpix;}
+          minmax = templ.pixmax();
+	  for(j=0; j<nclusx; ++j) 
+             for(i=0; i<nclusy; ++i) {
+                maxpix = minmax;
+                if(ydouble[i]) {maxpix *=2.f;}
+		 if(cluster(j,i) > maxpix) {cluster(j,i) = maxpix;}
 	   }
-	}
+	
 	
 // Do the cluster repair here	
 	
@@ -243,7 +219,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	      ysum[i] = 0.f; nyzero[i] = 0;
 // Do preliminary cluster projection in y
 	      for(j=0; j<nclusx; ++j) {
-		     ysum[i] += cluster[j][i];
+		     ysum[i] += cluster(j,i);
 		  }
 		  if(ysum[i] > 0.f) {
 // identify ends of cluster to determine what the missing charge should be
@@ -281,7 +257,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 		  if(ydouble[i]) {maxpix *=2.;}
 		  if(nyzero[i] > 0 && nyzero[i] < 3) {qpixel = (maxpix - ysum[i])/(float)nyzero[i];} else {qpixel = 1.;}
 		  if(qpixel < 1.) {qpixel = 1.;}
-          cluster[j][i] = qpixel;
+          cluster(j,i) = qpixel;
 // Adjust the total cluster charge to reflect the charge of the "repaired" cluster
 		  qtotal += qpixel;
 	   }
@@ -295,7 +271,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	anyyd = false;
     for(i=0; i<nclusy; ++i) {
 	   for(j=0; j<nclusx; ++j) {
-		  ysum[k] += cluster[j][i];
+		  ysum[k] += cluster(j,i);
 	   }
     
 // If this is a double pixel, put 1/2 of the charge in 2 consective single pixels  
@@ -319,9 +295,9 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
     for(i=0; i<BXSIZE; ++i) { xsum[i] = 0.f; xd[i] = false;}
 	k=0;
 	anyxd = false;
-    for(j=0; j<nclusx; ++j) {
+        for(j=0; j<nclusx; ++j) {
 	   for(i=0; i<nclusy; ++i) {
-		  xsum[k] += cluster[j][i];
+		  xsum[k] += cluster(j,i);
 	   }
     
 // If this is a double pixel, put 1/2 of the charge in 2 consective single pixels  
@@ -1025,8 +1001,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 //!                      4       fastest w/ Q prob, searches same range as 1 but at 1/4 density (no big pix) and 1/2 density (big pix in cluster), calculates Q probability
 //! \param      probQ - (output) the Vavilov-distribution-based cluster charge probability
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, array_2d& cluster, 
-		    std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, ClusMatrix & cluster, 
 		    SiPixelTemplate& templ, 
 		    float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
 			 float& probQ)
@@ -1036,7 +1011,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	const bool deadpix = false;
 	std::vector<std::pair<int, int> > zeropix;
     
-	return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, cluster, ydouble, xdouble, templ, 
+	return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, cluster, templ, 
 		yrec, sigmay, proby, xrec, sigmax, probx, qbin, speed, deadpix, zeropix, probQ);
 
 } // PixelTempReco2D
@@ -1069,8 +1044,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 //!                      4       fastest w/ Q prob, searches same range as 1 but at 1/4 density (no big pix) and 1/2 density (big pix in cluster), calculates Q probability
 //! \param      probQ - (output) the Vavilov-distribution-based cluster charge probability
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, array_2d& cluster, 
-										 std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix& cluster, 
 										 SiPixelTemplate& templ, 
 										 float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
 										 float& probQ)
@@ -1082,7 +1056,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	float locBz = -1.f;
 	if(cotbeta < 0.) {locBz = -locBz;}
     
-	return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, cluster, ydouble, xdouble, templ, 
+	return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, cluster, templ, 
 												yrec, sigmay, proby, xrec, sigmax, probx, qbin, speed, deadpix, zeropix, probQ);
 	
 } // PixelTempReco2D
@@ -1113,8 +1087,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 //!                      2       faster yet, searches same range as 1 but at 1/2 density
 //!                      3       fastest, searches same range as 1 but at 1/4 density (no big pix) and 1/2 density (big pix in cluster)
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, array_2d& cluster, 
-													  std::vector<bool>& ydouble, std::vector<bool>& xdouble, 
+int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster, 
 													  SiPixelTemplate& templ, 
 													  float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed)
 
@@ -1128,7 +1101,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	if(speed < 0) speed = 0;
    if(speed > 3) speed = 3;
 	
-	return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, cluster, ydouble, xdouble, templ, 
+	return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, cluster, templ, 
 															  yrec, sigmay, proby, xrec, sigmax, probx, qbin, speed, deadpix, zeropix, probQ);
 	
 } // PixelTempReco2D

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
@@ -39,10 +39,10 @@ public:
   std::vector<float> xtalk2;
 
   struct Param {
-    Param() : topology(0) {}
+    Param() : topology(nullptr) {}
     StripTopology const * topology;
     LocalVector drift;
-    float thickness, pitch_rel_err2, maxLength;
+    float thickness, invThickness,pitch_rel_err2, maxLength;
     int nstrips;
     float backplanecorrection;
     SiStripDetId::ModuleGeometry moduleGeom;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -24,36 +24,26 @@ private:
   // (overridden by useLegacyError; negative value disables the cut)
   const float maxChgOneMIP;
 
+  enum class Algo { legacy, mergeCK, chargeCK };
+
+  Algo m_algo;
+
 public:  
+
   StripClusterParameterEstimator::LocalValues
   localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const;
   
   float stripErrorSquared(const unsigned N, const float uProj, const SiStripDetId::SubDetector loc ) const ;
   float legacyStripErrorSquared(const unsigned N, const float uProj) const;
 
-  StripCPEfromTrackAngle( edm::ParameterSet & conf, 
-			  const MagneticField& mag, 
-			  const TrackerGeometry& geom, 
-			  const SiStripLorentzAngle& lorentz,
-                          const SiStripBackPlaneCorrection& backPlaneCorrection,
-			  const SiStripConfObject& confObj,
-			  const SiStripLatency& latency) 
-  : StripCPE(conf, mag, geom, lorentz, backPlaneCorrection, confObj, latency )
-  , useLegacyError(conf.existsAs<bool>("useLegacyError") ? conf.getParameter<bool>("useLegacyError") : true)
-  , maxChgOneMIP(conf.existsAs<float>("maxChgOneMIP") ? conf.getParameter<double>("maxChgOneMIP") : -6000.)
-  {
-    mLC_P[0] = conf.existsAs<double>("mLC_P0") ? conf.getParameter<double>("mLC_P0") : -.326;
-    mLC_P[1] = conf.existsAs<double>("mLC_P1") ? conf.getParameter<double>("mLC_P1") :  .618;
-    mLC_P[2] = conf.existsAs<double>("mLC_P2") ? conf.getParameter<double>("mLC_P2") :  .300;
 
-    mHC_P[SiStripDetId::TIB - 3][0] = conf.existsAs<double>("mTIB_P0") ? conf.getParameter<double>("mTIB_P0") : -.742  ;
-    mHC_P[SiStripDetId::TIB - 3][1] = conf.existsAs<double>("mTIB_P1") ? conf.getParameter<double>("mTIB_P1") :  .202  ;
-    mHC_P[SiStripDetId::TID - 3][0] = conf.existsAs<double>("mTID_P0") ? conf.getParameter<double>("mTID_P0") : -1.026 ;
-    mHC_P[SiStripDetId::TID - 3][1] = conf.existsAs<double>("mTID_P1") ? conf.getParameter<double>("mTID_P1") :  .253  ;
-    mHC_P[SiStripDetId::TOB - 3][0] = conf.existsAs<double>("mTOB_P0") ? conf.getParameter<double>("mTOB_P0") : -1.427 ;
-    mHC_P[SiStripDetId::TOB - 3][1] = conf.existsAs<double>("mTOB_P1") ? conf.getParameter<double>("mTOB_P1") :  .433  ;
-    mHC_P[SiStripDetId::TEC - 3][0] = conf.existsAs<double>("mTEC_P0") ? conf.getParameter<double>("mTEC_P0") : -1.885 ;
-    mHC_P[SiStripDetId::TEC - 3][1] = conf.existsAs<double>("mTEC_P1") ? conf.getParameter<double>("mTEC_P1") :  .471  ;  
-  }
+  StripCPEfromTrackAngle( edm::ParameterSet & conf,
+                          const MagneticField& mag,
+                          const TrackerGeometry& geom,
+                          const SiStripLorentzAngle& lorentz,
+                          const SiStripBackPlaneCorrection& backPlaneCorrection,
+                          const SiStripConfObject& confObj,
+                          const SiStripLatency& latency);
+
 };
 #endif

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPE.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPE.cc
@@ -117,6 +117,7 @@ StripCPE::fillParams() {
     const Bounds& bounds = stripdet->specificSurface().bounds();
     p.maxLength = std::sqrt( std::pow(bounds.length(),2.f)+std::pow(bounds.width(),2.f) );
     p.thickness = bounds.thickness();
+    p.invThickness = 1.f/p.thickness;
     p.drift = driftDirection(stripdet) * p.thickness;
     p.topology=(StripTopology*)(&stripdet->topology());    
     p.nstrips = p.topology->nstrips(); 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -55,10 +55,7 @@ StripCPEfromTrackAngle::localParameters( const SiStripCluster& cluster, const Ge
   SiStripDetId ssdid = SiStripDetId( det.geographicalId() );  
  
   LocalVector track = ltp.momentum();
-  track *= 
-    (track.z()<0) ?  std::abs(p.thickness/track.z()) : 
-    (track.z()>0) ? -std::abs(p.thickness/track.z()) :  
-                         p.maxLength/track.mag() ;
+  track *= -p.thickness/track.z();
 
   const unsigned N = cluster.amplitudes().size();
   const float fullProjection = p.coveredStrips( track+p.drift, ltp.position());
@@ -67,7 +64,7 @@ StripCPEfromTrackAngle::localParameters( const SiStripCluster& cluster, const Ge
   switch (m_algo) {
     case Algo::chargeCK :
        {
-       auto dQdx = siStripClusterTools::chargePerCM(ssdid, cluster, ltp);
+       auto dQdx = siStripClusterTools::chargePerCM(cluster, ltp, p.invThickness);
        uerr2 = dQdx > maxChgOneMIP ? legacyStripErrorSquared(N,std::abs(fullProjection)) : stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() );
        }
        break;

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -31,9 +31,6 @@ StripCPEfromTrackAngle::StripCPEfromTrackAngle( edm::ParameterSet & conf,
   }
 
 float StripCPEfromTrackAngle::stripErrorSquared(const unsigned N, const float uProj, const SiStripDetId::SubDetector loc ) const {
-  if( loc == SiStripDetId::UNKNOWN)
-    throw cms::Exception("StripCPEfromTrackAngle::stripErrorSquared", "Incompatible sub-detector.");
-
   auto fun = [&] (float x)  -> float { return mLC_P[0]*x*vdt::fast_expf(-x*mLC_P[1])+mLC_P[2];};
   auto uerr = (N <= 4) ?  fun(uProj) :  mHC_P[loc-3][0]+float(N)*mHC_P[loc-3][1];
   return uerr*uerr;

--- a/TrackingTools/MaterialEffects/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>

--- a/TrackingTools/MaterialEffects/interface/CombinedMaterialEffectsUpdator.h
+++ b/TrackingTools/MaterialEffects/interface/CombinedMaterialEffectsUpdator.h
@@ -27,7 +27,7 @@ public:
   /// If ptMin > 0, then the rms muliple scattering angle will be calculated taking into account the uncertainty
   /// in the reconstructed track momentum. (By default, it is neglected). However, a lower limit on the possible
   /// value of the track Pt will be applied at ptMin, to avoid the rms multiple scattering becoming too big.
-  CombinedMaterialEffectsUpdator(double mass, double ptMin = -1. ) :
+  CombinedMaterialEffectsUpdator(float mass, float ptMin = -1. ) :
     MaterialEffectsUpdator(mass),
     theMSUpdator(mass, ptMin),
     theELUpdator(mass) {}

--- a/TrackingTools/MaterialEffects/interface/EnergyLossUpdator.h
+++ b/TrackingTools/MaterialEffects/interface/EnergyLossUpdator.h
@@ -25,7 +25,7 @@ class EnergyLossUpdator final : public MaterialEffectsUpdator
   }
 
 public:
-  EnergyLossUpdator( double mass ) :
+  EnergyLossUpdator( float mass ) :
     MaterialEffectsUpdator(mass) {}
 
   // here comes the actual computation of the values

--- a/TrackingTools/MaterialEffects/interface/MaterialEffectsUpdator.h
+++ b/TrackingTools/MaterialEffects/interface/MaterialEffectsUpdator.h
@@ -15,8 +15,6 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
-
 namespace materialEffect {
   enum CovIndex { elos=0, msxx=1, msxy=2, msyy=3};
   class Covariance {
@@ -61,7 +59,7 @@ public:
 
   /** Constructor with explicit mass hypothesis
    */
-  MaterialEffectsUpdator ( double mass );
+  MaterialEffectsUpdator ( float mass );
   virtual ~MaterialEffectsUpdator ();
 
   /** Updates TrajectoryStateOnSurface with material effects
@@ -83,7 +81,7 @@ public:
 
   /** Particle mass assigned at construction.
    */
-  inline double mass () const {
+  inline float mass () const {
     return theMass;
   }
 
@@ -93,7 +91,7 @@ public:
   virtual void compute (const TrajectoryStateOnSurface&, const PropagationDirection, Effect & effect) const = 0;
  
  private:
-  double theMass;
+  float theMass;
 
 };
 

--- a/TrackingTools/MaterialEffects/interface/MultipleScatteringUpdator.h
+++ b/TrackingTools/MaterialEffects/interface/MultipleScatteringUpdator.h
@@ -23,7 +23,7 @@ public:
   /// If ptMin > 0, then the rms muliple scattering angle will be calculated taking into account the uncertainty
   /// in the reconstructed track momentum. (By default, it is neglected). However, a lower limit on the possible
   /// value of the track Pt will be applied at ptMin, to avoid the rms multiple scattering becoming too big.
-  MultipleScatteringUpdator(double mass, double ptMin=-1. ) :
+  MultipleScatteringUpdator(float mass, float ptMin=-1. ) :
     MaterialEffectsUpdator(mass),
     thePtMin(ptMin) {}
   /// destructor
@@ -36,7 +36,7 @@ public:
 
 private:  
 
-  double thePtMin;
+  float thePtMin;
 
 };
 

--- a/TrackingTools/MaterialEffects/plugins/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/MaterialEffects"/>
 <library   file="*.cc" name="TrackingToolsMaterialEffectsPlugins">

--- a/TrackingTools/MaterialEffects/src/MaterialEffectsUpdator.cc
+++ b/TrackingTools/MaterialEffects/src/MaterialEffectsUpdator.cc
@@ -6,7 +6,7 @@ using namespace SurfaceSideDefinition;
 
 /** Constructor with explicit mass hypothesis
  */
-MaterialEffectsUpdator::MaterialEffectsUpdator ( double mass ) :
+MaterialEffectsUpdator::MaterialEffectsUpdator ( float mass ) :
   theMass(mass) {}
 
 MaterialEffectsUpdator::~MaterialEffectsUpdator () {}


### PR DESCRIPTION
This PR addresses some performance hotspots in tracking code.
the main improvement is to reduce the size of the "cluster" for the Template computation.
Negligible regressions are expected due to numerics and to a different behavior in PixelCPETemplateReco for some extreme cases (large cluster)
