### PR TITLE
Extending HCAL unpacking to uTCA HBHE FEDs

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -31,22 +31,13 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   tok_data_ = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("InputLabel"));
 
   if (fedUnpackList_.empty()) {
+    // VME range for back-compatibility
     for (int i=FEDNumbering::MINHCALFEDID; i<=FEDNumbering::MAXHCALFEDID; i++)
       fedUnpackList_.push_back(i);
-    // HF uTCA
-    fedUnpackList_.push_back(1118);
-    fedUnpackList_.push_back(1120);
-    fedUnpackList_.push_back(1122);
-    // HBHE uTCA
-    fedUnpackList_.push_back(1100);     
-    fedUnpackList_.push_back(1102);     
-    fedUnpackList_.push_back(1104);     
-    fedUnpackList_.push_back(1106);     
-    fedUnpackList_.push_back(1108);     
-    fedUnpackList_.push_back(1110);     
-    fedUnpackList_.push_back(1112);     
-    fedUnpackList_.push_back(1114);     
-    fedUnpackList_.push_back(1116);     
+
+    // uTCA range 
+    for (int i=FEDNumbering::MINHCALuTCAFEDID; i<=FEDNumbering::MAXHCALuTCAFEDID; i++)
+      fedUnpackList_.push_back(i);
   } 
   
   unpacker_.setExpectedOrbitMessageTime(expectedOrbitMessageTime_);

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -37,6 +37,16 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
     fedUnpackList_.push_back(1118);
     fedUnpackList_.push_back(1120);
     fedUnpackList_.push_back(1122);
+    // HBHE uTCA
+    fedUnpackList_.push_back(1100);     
+    fedUnpackList_.push_back(1102);     
+    fedUnpackList_.push_back(1104);     
+    fedUnpackList_.push_back(1106);     
+    fedUnpackList_.push_back(1108);     
+    fedUnpackList_.push_back(1110);     
+    fedUnpackList_.push_back(1112);     
+    fedUnpackList_.push_back(1114);     
+    fedUnpackList_.push_back(1116);     
   } 
   
   unpacker_.setExpectedOrbitMessageTime(expectedOrbitMessageTime_);


### PR DESCRIPTION
Late (alas...) step in preparations for MWGR#2: 

(1) Emap submitted to AlCaDB  validation 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2228.html

(2) this small unpacker update needs 800 patch, if possible
