### PR TITLE
Updates in Run2 workflows: photon regressions for 2016, added e/gamma corrections for online, updated HLT JECs with L2L3 residuals and other fixes

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -18,7 +18,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v4',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,31 +10,31 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v4',
+    'run2_design'       :   '80X_mcRun2_design_v5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v4',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v4',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v2',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v5',
+    'run1_data'         :   '80X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v5',
+    'run2_data'         :   '80X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v0',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v2',
-    # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v0',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v3',
+    # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v2',
+    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v3',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,7 +34,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v4',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v5) as [80X_mcRun2_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v5/80X_mcRun2_design_v4): 
  - updated photon energy regressions for 2016
  - introduced e/gamma energy regressions for HLT 
  - changed Hcal LUT metadata to include 1x1 HF TPs topology
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu)
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v3) as [80X_mcRun2cosmics_startup_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v3/80X_mcRun2cosmics_startup_peak_v2): 
  - updated photon energy regressions for 2016
  - introduced e/gamma energy regressions for HLT 
  - changed Hcal LUT metadata to include 1x1 HF TPs topology
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v5) as [80X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v5/80X_mcRun2_asymptotic_v4): 
  - updated photon energy regressions for 2016
  - introduced e/gamma energy regressions for HLT 
  - changed Hcal LUT metadata to include 1x1 HF TPs topology
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu)
- **RunII Startup scenario** : [80X_mcRun2_startup_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v5) as [80X_mcRun2_startup_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v5/80X_mcRun2_startup_v4): 
  - updated photon energy regressions for 2016
  - introduced e/gamma energy regressions for HLT 
  - changed Hcal LUT metadata to include 1x1 HF TPs topology
- **RunII Heavy Ions scenario** : [80X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v4) as [80X_mcRun2_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_HeavyIon_v4/80X_mcRun2_HeavyIon_v3): 
  - updated photon energy regressions for 2016
  - introduced e/gamma energy regressions for HLT 
  - changed Hcal LUT metadata to include 1x1 HF TPs topology
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu)
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v6) as [80X_dataRun2_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v6/80X_dataRun2_v5): 
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu) .
  - updated photon energy regressions for 2016
  - updated Tracker alignment for 2015 0T IOVs 
  - updated Ecal Intercalibrations for 2015 0T IOVs
  - updated Ecal ADC to GeV scale constants for 2015 0T IOVs
  - updated Ecal Barrel and Endcaps alignment for 2015 0T IOvs
  - updated LS based beamspot for 2015 0T IOvs
  - updated Strip particle gains for 2015 0T IOVs
  - updated Strip bad channels for 2015 0T IOVs
- **RunII HLTHI processing** : [80X_dataRun2_HLTHI_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v3) as [80X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLTHI_frozen_v3/80X_dataRun2_HLTHI_frozen_v2): 
  - introduced e/gamma energy regressions for HLT 
  - corrected 2015 IOVs in ESEE and ES Intercalibrations records to take into account changes from PR #13074
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v1) as [80X_dataRun2_HLT_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v1/80X_dataRun2_HLT_relval_v0): 
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu) 
  - introduced e/gamma energy regressions for HLT 
  - corrected 2015 IOVs in ESEE and ES Intercalibrations records to take into account changes from PR #13074
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v3) as [80X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v3/80X_dataRun2_HLT_frozen_v2): 
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu) 
  - introduced e/gamma energy regressions for HLT 
  - corrected 2015 IOVs in ESEE and ES Intercalibrations records to take into account changes from PR #13074
- **RunII Offline relval processing** : [80X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v1) as [80X_dataRun2_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v1/80X_dataRun2_relval_v0): 
  - updated JEC and PF calibrations for HLT (to allow integration of residuals corrections in 2016 menu) .
  - updated photon energy regressions for 2016
  - updated Tracker alignment for 2015 0T IOVs 
  - updated Ecal Intercalibrations for 2015 0T IOVs
  - updated Ecal ADC to GeV scale constants for 2015 0T IOVs
  - updated Ecal Barrel and Endcaps alignment for 2015 0T IOvs
  - updated LS based beamspot for 2015 0T IOvs
  - updated Strip particle gains for 2015 0T IOVs
  - updated Strip bad channels for 2015 0T IOVs
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v4) as [80X_upgrade2017_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v4/80X_upgrade2017_design_v3): 
  - updated reco beamspot position (as in 2015 MC production)
  - Hcal geometry changes needed for 2017 upgrade
  - updated Pixel FED cabling, Gain calibrations for SIM, HLT and RECO step
