### PR TITLE
Add cuts to SiStripMonitorTrack

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -93,7 +93,7 @@ private:
   void AllClusters(const edm::Event& ev, const edm::EventSetup& es); 
   void trackStudyFromTrack(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::EventSetup& es);
   void trackStudyFromTrajectory(edm::Handle<TrajTrackAssociationCollection> TItkAssociatorCollection, const edm::EventSetup& es);
-  void trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es);
+  void trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es, bool track_ok);
   void trackStudy(const edm::Event& ev, const edm::EventSetup& es);
   bool trackFilter(const reco::Track& track);
   //  LocalPoint project(const GeomDet *det,const GeomDet* projdet,LocalPoint position,LocalVector trackdirection)const;
@@ -102,9 +102,10 @@ private:
 		const SiStripMatchedRecHit2D*   matchedhit,
 		const SiStripRecHit2D*          hit2D,
 		const SiStripRecHit1D*          hit1D,
-		LocalVector localMomentum);
-  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, LocalVector LV, const Det2MEs& MEs);	
-  template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&);
+		      LocalVector               localMomentum,
+		const bool                      track_ok);
+  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, bool track_ok, LocalVector LV, const Det2MEs& MEs);	
+  template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&, bool ok);
 
   // fill monitorables 
 //  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -95,6 +95,7 @@ private:
   void trackStudyFromTrajectory(edm::Handle<TrajTrackAssociationCollection> TItkAssociatorCollection, const edm::EventSetup& es);
   void trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es);
   void trackStudy(const edm::Event& ev, const edm::EventSetup& es);
+  bool trackFilter(const reco::Track& track);
   //  LocalPoint project(const GeomDet *det,const GeomDet* projdet,LocalPoint position,LocalVector trackdirection)const;
   void hitStudy(const edm::EventSetup& es,
 		const ProjectedSiStripRecHit2D* projhit,

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -833,6 +833,16 @@ using namespace reco;
     }
   }
 }
+
+//------------------------------------------------------------------------
+// Should return true if the track is good, false if it should be discarded.
+bool SiStripMonitorTrack::trackFilter(const reco::Track& track) {
+  if (track.pt() < 0.8) return false;
+  if (track.p()  < 2.0) return false;
+  if (track.hitPattern().numberOfValidTrackerHits()  <= 6) return false;
+  if (track.normalizedChi2() < 10.0) return false;
+  return true;
+}
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::EventSetup& es) {
 
@@ -845,8 +855,8 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
   for (reco::TrackCollection::const_iterator track = trackCollection.begin(), etrack = trackCollection.end(); 
        track!=etrack; ++track) {
     
+    if ( trackFilter(*track) == false ) continue;
     //    const reco::TransientTrack transientTrack = transientTrackBuilder->build(track);
-    
      
     for (trackingRecHit_iterator hit = track->recHitsBegin(), ehit = track->recHitsEnd();
 	 hit!=ehit; ++hit) {
@@ -934,6 +944,7 @@ void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<TrajTrackAssociat
       //      <<"\n\t\touter PT "<< trackref->outerPt()<<std::endl;
 
     //    trajectoryStudy(traj_iterator,trackref,es);
+    if ( trackFilter(*(it->val)) == false ) continue;
     trajectoryStudy(traj_iterator,es);
 
   }

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -653,7 +653,7 @@ MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::IBooker & ibooker , c
 }
 
 //------------------------------------------------------------------------------------------
-void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es) {
+void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es, bool track_ok) {
   const std::vector<TrajectoryMeasurement> & measurements = traj->measurements();
   for(std::vector<TrajectoryMeasurement>::const_iterator traj_mes_iterator= measurements.begin(), traj_mes_end=measurements.end();
       traj_mes_iterator!=traj_mes_end;++traj_mes_iterator){//loop on measurements
@@ -695,13 +695,13 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
       statedirection=monodet->toLocal(gtrkdirup);
       SiStripRecHit2D m = matchedhit->monoHit();
       //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,trackref,es);
-      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es);
+      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es,track_ok);
       //stereo side
       const GeomDetUnit * stereodet=gdet->stereoDet();
       statedirection=stereodet->toLocal(gtrkdirup);
       SiStripRecHit2D s = matchedhit->stereoHit();
       //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,trackref,es);
-      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es);
+      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es,track_ok);
     }
     else if(projhit){
       LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found"<< std::endl;
@@ -716,21 +716,21 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es,track_ok);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es,track_ok);
       }
     }else if (hit2D){
       statedirection=updatedtsos.localMomentum();
-      if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es);
+      if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es,track_ok);
     } else if (hit1D) {
       statedirection=updatedtsos.localMomentum();
-      if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es);
+      if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es,track_ok);
     } else {
       LogDebug ("SiStripMonitorTrack")
 	<< " LocalMomentum: "<<statedirection
@@ -746,7 +746,8 @@ void SiStripMonitorTrack::hitStudy(const edm::EventSetup& es,
 				   const SiStripMatchedRecHit2D*   matchedhit,
 				   const SiStripRecHit2D*          hit2D,
 				   const SiStripRecHit1D*          hit1D,
-				   LocalVector localMomentum
+				         LocalVector               localMomentum,
+				   const bool                      track_ok
 				   ) {
   LocalVector statedirection;
   if(matchedhit){     // type=Matched;
@@ -760,13 +761,13 @@ void SiStripMonitorTrack::hitStudy(const edm::EventSetup& es,
     const GeomDetUnit * monodet=gdet->monoDet();
     statedirection=monodet->toLocal(gtrkdirup);
     SiStripRecHit2D m = matchedhit->monoHit();
-    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es);
+    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es,track_ok);
 
     //stereo side
     const GeomDetUnit * stereodet=gdet->stereoDet();
     statedirection=stereodet->toLocal(gtrkdirup);
     SiStripRecHit2D s = matchedhit->stereoHit();
-    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es);
+    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es,track_ok);
   }
   else if(projhit){    // type=Projected;
       LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found"<< std::endl;      
@@ -782,21 +783,21 @@ void SiStripMonitorTrack::hitStudy(const edm::EventSetup& es,
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es,track_ok);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es,track_ok);
       }
   } else if (hit2D){ // type=2D
     statedirection=localMomentum;
-    if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es);
+    if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es,track_ok);
   } else if (hit1D) { // type=1D
     statedirection=localMomentum;
-    if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es);
+    if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es,track_ok);
   } else {
     LogDebug ("SiStripMonitorTrack")
       << " LocalMomentum: "<<statedirection
@@ -855,7 +856,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
   for (reco::TrackCollection::const_iterator track = trackCollection.begin(), etrack = trackCollection.end(); 
        track!=etrack; ++track) {
     
-    if ( trackFilter(*track) == false ) continue;
+    bool track_ok = trackFilter(*track);
     //    const reco::TransientTrack transientTrack = transientTrackBuilder->build(track);
      
     for (trackingRecHit_iterator hit = track->recHitsBegin(), ehit = track->recHitsEnd();
@@ -886,7 +887,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
       //      reco::TrajectoryStateOnSurface stateOnSurface = transientTrack->stateOnSurface(globalPoint);
 
       LocalVector localMomentum;
-      hitStudy(es,projhit,matchedhit,hit2D,hit1D,localMomentum);
+      hitStudy(es,projhit,matchedhit,hit2D,hit1D,localMomentum,track_ok);
     }
     
     // hit pattern of the track
@@ -944,13 +945,13 @@ void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<TrajTrackAssociat
       //      <<"\n\t\touter PT "<< trackref->outerPt()<<std::endl;
 
     //    trajectoryStudy(traj_iterator,trackref,es);
-    if ( trackFilter(*(it->val)) == false ) continue;
-    trajectoryStudy(traj_iterator,es);
+    bool track_ok = trackFilter(*(it->val));
+    trajectoryStudy(traj_iterator,es,track_ok);
 
   }
 }
 //------------------------------------------------------------------------
-template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup& es){
+template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup& es, bool track_ok){
 
     if(!tkrecHit->isValid()){
       LogTrace("SiStripMonitorTrack") <<"\t\t Invalid Hit " << std::endl;
@@ -977,7 +978,7 @@ template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, Local
       SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_,es,detid);
 
       const Det2MEs MEs = findMEs(tTopo, detid);
-      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, LV, MEs))
+      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, track_ok, LV, MEs))
       {
         vPSiStripCluster.insert(SiStripCluster_);
       }
@@ -1015,7 +1016,7 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 
         if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end()) {
           SiStripClusterInfo SiStripClusterInfo_(*ClusIter,es,detid);
-          clusterInfos(&SiStripClusterInfo_,detid,OffTrack,LV,MEs);
+          clusterInfos(&SiStripClusterInfo_,detid,OffTrack, /*track_ok*/ false,LV,MEs);
         }
       }
     }
@@ -1058,7 +1059,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
 //------------------------------------------------------------------------
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
-bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, const LocalVector LV, const Det2MEs& MEs)
+bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, bool track_ok, const LocalVector LV, const Det2MEs& MEs)
 {
 
   if (cluster==NULL) return false;
@@ -1095,11 +1096,11 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
 
   if (TkHistoMap_On_ && (flag == OnTrack)) {
       uint32_t adet=cluster->detId();
-      tkhisto_ClChPerCMfromTrack->fill(adet,dQdx_fromTrack);
+      if(track_ok) tkhisto_ClChPerCMfromTrack->fill(adet,dQdx_fromTrack);
   }
   if (clchCMoriginTkHmap_On_ && (flag == OffTrack)){
     uint32_t adet=cluster->detId();
-    tkhisto_ClChPerCMfromOrigin->fill(adet,dQdx_fromOrigin);
+    if(track_ok) tkhisto_ClChPerCMfromOrigin->fill(adet,dQdx_fromOrigin);
   }
 
   if(flag==OnTrack){
@@ -1113,8 +1114,8 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iLayer->ClusterNoiseOnTrack, noise);
       fillME(MEs.iLayer->ClusterWidthOnTrack, width);
       fillME(MEs.iLayer->ClusterPosOnTrack, position);
-      fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
-      fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+      if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
+      if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
     }
     // ringMEs
     if (MEs.iRing != nullptr) {
@@ -1124,15 +1125,15 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iRing->ClusterChargeOnTrack, charge);
       fillME(MEs.iRing->ClusterNoiseOnTrack, noise);
       fillME(MEs.iRing->ClusterWidthOnTrack, width);
-      fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
-      fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+      if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
+      if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
     }
     // subdetMEs
     if(MEs.iSubdet != nullptr){
       fillME(MEs.iSubdet->ClusterChargeOnTrack,charge);
       if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrOnTrack,StoN*cosRZ);
-      fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
-      fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
+      if(track_ok) fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
+      if(track_ok) fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
     }
     //******** TkHistoMaps
     if (TkHistoMap_On_) {
@@ -1158,8 +1159,8 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
         fillME(iModME->second.ClusterWidth ,width);
         fillME(iModME->second.ClusterPos   ,position);
 
-        fillME(iModME->second.ClusterChargePerCMfromTrack,  dQdx_fromTrack);
-        fillME(iModME->second.ClusterChargePerCMfromOrigin, dQdx_fromOrigin);
+        if(track_ok) fillME(iModME->second.ClusterChargePerCMfromTrack,  dQdx_fromTrack);
+        if(track_ok) fillME(iModME->second.ClusterChargePerCMfromOrigin, dQdx_fromOrigin);
 
         //fill the PGV histo
         float PGVmax = cluster->maxCharge();

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -840,7 +840,7 @@ bool SiStripMonitorTrack::trackFilter(const reco::Track& track) {
   if (track.pt() < 0.8) return false;
   if (track.p()  < 2.0) return false;
   if (track.hitPattern().numberOfValidTrackerHits()  <= 6) return false;
-  if (track.normalizedChi2() < 10.0) return false;
+  if (track.normalizedChi2() > 10.0) return false;
   return true;
 }
 //------------------------------------------------------------------------


### PR DESCRIPTION
This commit introduces 4 cuts to select only good quality tracks for the track-based histograms of SiStripMonitorTrack:
- pT > 0.8
- P > 2
- numberOfValidTrackerHits > 6
- normalizedChi2 < 10

These parameters were suggested by @dimattia  and @jlagram, via @fioriNTU .

The cuts drop about 60% of all hits. They affect the track-based per-cm histograms in SiStripMonitorTrack. The off-track cluster based plots are unaffected.
