### PR TITLE
Fix to get synchronization type (default) from v1 format

### DIFF
--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -69,7 +69,7 @@ namespace cond {
     }
       
     bool OraTagTable::select( const std::string& name, cond::TimeType& timeType, std::string& objectType, 
-			      cond::SynchronizationType&, cond::Time_t& endOfValidity, 
+			      cond::SynchronizationType& synchronizationType, cond::Time_t& endOfValidity, 
 			      std::string& description, cond::Time_t& lastValidatedTime ){
       if(!m_cache.load( name )) return false;
       if( m_cache.iovSequence().size()==0 ) return false;
@@ -78,6 +78,7 @@ namespace cond {
       objectType = m_cache.session().classNameForItem( ptok );
       //if( m_cache.iovSequence().payloadClasses().size()==0 ) throwException( "No payload type information found.","OraTagTable::select");
       //objectType = *m_cache.iovSequence().payloadClasses().begin();
+      synchronizationType = cond::SYNCH_ANY;
       endOfValidity = m_cache.iovSequence().lastTill();
       description = m_cache.iovSequence().comment();
       lastValidatedTime = m_cache.iovSequence().tail(1).back().since();

--- a/CondCore/CondDB/src/Types.cc
+++ b/CondCore/CondDB/src/Types.cc
@@ -7,6 +7,10 @@
 
 namespace cond {
 
+  template<size_t SIZE, class T> inline size_t array_size(T (&arr)[SIZE]){
+    return SIZE;
+  }
+
   void Iov_t::clear(){
     since = time::MAX_VAL;
     till = time::MIN_VAL;
@@ -44,6 +48,8 @@ namespace cond {
 											       std::make_pair("Prompt", SYNCH_PROMPT),
 											       std::make_pair("Pcl", SYNCH_PCL) };
   std::string synchronizationTypeNames(SynchronizationType type) {
+    if ( type>=array_size( s_synchronizationTypeArray ) )
+      throwException( "SynchronizationType \""+boost::lexical_cast<std::string>(type)+"\" is unknown.","synchronizationTypeNames");      
     return s_synchronizationTypeArray[type].first;
   }
 
@@ -56,3 +62,4 @@ namespace cond {
   }
 
 }
+


### PR DESCRIPTION
In conddb v1 the synchronization type is not available as a Tag attribute.
This fix set the value to 'any'.  This allows the import tool to work properly when importing from v1 database.
