### PR TITLE
 era-aware T0 data processing setup

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCa.py
+++ b/Configuration/DataProcessing/python/Impl/AlCa.py
@@ -14,6 +14,9 @@ from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dqmIOSource,harv
 import FWCore.ParameterSet.Config as cms
 
 class AlCa(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
+
     """
     _AlCa_
 
@@ -37,7 +40,7 @@ class AlCa(Scenario):
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
         
-        process = cms.Process('RECO')
+        process = cms.Process('RECO', self.eras)
         cb = ConfigBuilder(options, process = process, with_output = True)
 
         # Input source
@@ -65,7 +68,7 @@ class AlCa(Scenario):
 
         options.triggerResultsProcess = 'RECO'
         
-        process = cms.Process('ALCA')
+        process = cms.Process('ALCA', self.eras)
         cb = ConfigBuilder(options, process = process)
 
         # Input source
@@ -92,7 +95,7 @@ class AlCa(Scenario):
         options.name = "EDMtoMEConvert"
         options.conditions = gtNameAndConnect(globalTag, args)
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = dqmIOSource(args)
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()

--- a/Configuration/DataProcessing/python/Impl/AlCaLumiPixels.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaLumiPixels.py
@@ -10,6 +10,7 @@ from Configuration.DataProcessing.Impl.AlCa import AlCa
 
 class AlCaLumiPixels(AlCa):
     def __init__(self):
+        AlCa.__init__(self)
         self.skims=['LumiPixels']
     """
     _AlCaLumiPixels_

--- a/Configuration/DataProcessing/python/Impl/AlCaP0.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaP0.py
@@ -10,6 +10,7 @@ from Configuration.DataProcessing.Impl.AlCa import AlCa
 
 class AlCaP0(AlCa):
     def __init__(self):
+        AlCa.__init__(self)
         self.skims=['@AlCaP0']
     """
     _AlCaP0_

--- a/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal.py
@@ -10,6 +10,7 @@ from Configuration.DataProcessing.Impl.AlCa import AlCa
 
 class AlCaPhiSymEcal(AlCa):
     def __init__(self):
+        AlCa.__init__(self)
         self.skims=['@AlCaPhiSym']
     """
     _AlCaPhiSymEcal_

--- a/Configuration/DataProcessing/python/Impl/AlCaTestEnable.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaTestEnable.py
@@ -10,6 +10,7 @@ from Configuration.DataProcessing.Impl.AlCa import AlCa
 
 class AlCaTestEnable(AlCa):
     def __init__(self):
+        AlCa.__init__(self)
         self.skims=['TkAlLAS']
     """
     _AlCaTestEnable_

--- a/Configuration/DataProcessing/python/Impl/DataScouting.py
+++ b/Configuration/DataProcessing/python/Impl/DataScouting.py
@@ -16,6 +16,8 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
 class DataScouting(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _DataScouting_
 
@@ -40,7 +42,7 @@ class DataScouting(Scenario):
         dictIO(options,args)        
         options.conditions = gtNameAndConnect(globalTag, args)
                 
-        process = cms.Process('DataScouting')
+        process = cms.Process('DataScouting', self.eras)
         cb = ConfigBuilder(options, process = process, with_output = True)
 
         # Input source
@@ -64,7 +66,7 @@ class DataScouting(Scenario):
         options.name = "EDMtoMEConvert"
         options.conditions = gtNameAndConnect(globalTag, args)
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = dqmIOSource(args)
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()

--- a/Configuration/DataProcessing/python/Impl/HeavyIons.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIons.py
@@ -17,14 +17,14 @@ class HeavyIons(Reco):
         Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='HeavyIons'
-        self.promptCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2PromptHI'
-        self.expressCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2ExpressHI'
-        self.visCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2ExpressHI'
+        self.promptCustoms='Configuration/DataProcessing/RecoTLR.customisePromptHI'
+        self.expressCustoms='Configuration/DataProcessing/RecoTLR.customiseExpressHI'
+        self.visCustoms='Configuration/DataProcessing/RecoTLR.customiseExpressHI'
     """
     _HeavyIons_
 
     Implement configuration building for data processing for Heavy Ions
-    collision data taking for Run2
+    collision data taking
 
     """
 

--- a/Configuration/DataProcessing/python/Impl/HeavyIons.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIons.py
@@ -52,11 +52,10 @@ class HeavyIons(Reco):
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
 
-        customsFunction = self.promptCustoms
         if not 'customs' in args:
-            args['customs']=[ customsFunction ]
-        else:
-            args['customs'].append(customsFunction)
+            args['customs']=[ ]
+
+        args['customs'].append(self.promptCustoms)
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -76,11 +75,10 @@ class HeavyIons(Reco):
         if not 'skims' in args:
             args['skims']=['@allForExpress']
 
-        customsFunction = self.expressCustoms
         if not 'customs' in args:
-            args['customs']=[ customsFunction ]
-        else:
-            args['customs'].append( customsFunction )
+            args['customs']=[ ]
+
+        args['customs'].append( self.expressCustoms )
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -96,11 +94,10 @@ class HeavyIons(Reco):
         self._checkMINIAOD(**args)
         self._setRepackedFlag(args)
 
-        customsFunction = self.visCustoms
         if not 'customs' in args:
-            args['customs']=[ customsFunction ]
-        else:
-            args['customs'].append( customsFunction )
+            args['customs']=[ ]
+
+        args['customs'].append( self.visCustoms )
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/HeavyIonsEra_Run2_HI.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsEra_Run2_HI.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+_HeavyIonsEra_Run2_HI_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+import Configuration.StandardSequences.Eras as eras
+
+from Configuration.DataProcessing.Impl.HeavyIons import HeavyIons
+
+class HeavyIonsEra_Run2_HI(HeavyIons):
+    def __init__(self):
+        HeavyIons.__init__(self)
+        self.eras = eras.eras.Run2_HI
+    """
+    _HeavyIonsEra_Run2_HI_
+
+    Implement configuration building for data processing for Heavy Ions
+    collision data taking for Run2
+
+    """
+

--- a/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
@@ -17,9 +17,9 @@ class HeavyIonsRun2(Reco):
         Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='HeavyIons'
-        self.promptCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2PromptHI'
-        self.expressCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2ExpressHI'
-        self.visCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2ExpressHI'
+        self.promptCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2DeprecatedPromptHI'
+        self.expressCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2DeprecatedExpressHI'
+        self.visCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2DeprecatedExpressHI'
     """
     _HeavyIonsRun2_
 

--- a/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
@@ -14,6 +14,7 @@ import FWCore.ParameterSet.Config as cms
 
 class HeavyIonsRun2(Reco):
     def __init__(self):
+        Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='HeavyIons'
         self.promptCustoms='Configuration/DataProcessing/RecoTLR.customiseRun2PromptHI'

--- a/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIonsRun2.py
@@ -33,6 +33,11 @@ class HeavyIonsRun2(Reco):
                 if a['dataTier'] == 'MINIAOD':
                     raise RuntimeError("MINIAOD is not supported in HeavyIonsRun2")
 
+                
+    def _setRepackedFlag(self,args):
+        if not 'repacked' in args:
+            args['repacked']= True
+
     def promptReco(self, globalTag, **args):
         """
         _promptReco_
@@ -41,6 +46,7 @@ class HeavyIonsRun2(Reco):
 
         """
         self._checkMINIAOD(**args)
+        self._setRepackedFlag(args)
 
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
@@ -64,6 +70,7 @@ class HeavyIonsRun2(Reco):
 
         """
         self._checkMINIAOD(**args)
+        self._setRepackedFlag(args)
 
         if not 'skims' in args:
             args['skims']=['@allForExpress']
@@ -86,6 +93,7 @@ class HeavyIonsRun2(Reco):
 
         """
         self._checkMINIAOD(**args)
+        self._setRepackedFlag(args)
 
         customsFunction = self.visCustoms
         if not 'customs' in args:

--- a/Configuration/DataProcessing/python/Impl/Test.py
+++ b/Configuration/DataProcessing/python/Impl/Test.py
@@ -13,6 +13,8 @@ from Configuration.DataProcessing.Scenario import Scenario
 import FWCore.ParameterSet.Config as cms
 
 class Test(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _Test_
 
@@ -28,7 +30,7 @@ class Test(Scenario):
         Returns skeleton process object
 
         """
-        return cms.Process("RECO")
+        return cms.Process("RECO", self.eras)
 
 
     def expressProcessing(self, globalTag):
@@ -38,7 +40,7 @@ class Test(Scenario):
         Returns skeleton process object
 
         """
-        return cms.Process("Express")
+        return cms.Process("Express", self.eras)
 
 
     def alcaSkim(self, skims):
@@ -48,7 +50,7 @@ class Test(Scenario):
         Returns skeleton process object
 
         """
-        return cms.Process("ALCARECO")
+        return cms.Process("ALCARECO", self.eras)
         
         
     def dqmHarvesting(self, datasetName, runNumber,  globalTag, **args):
@@ -85,7 +87,7 @@ class Test(Scenario):
 
         options.__dict__.update(args)
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = cms.Source("PoolSource")
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()
@@ -114,4 +116,4 @@ class Test(Scenario):
         Returns skeleton process object
 
         """
-        return cms.Process("Skimming")
+        return cms.Process("Skimming", self.eras)

--- a/Configuration/DataProcessing/python/Impl/cosmics.py
+++ b/Configuration/DataProcessing/python/Impl/cosmics.py
@@ -12,11 +12,15 @@ import sys
 from Configuration.DataProcessing.Reco import Reco
 
 class cosmics(Reco):
+    def __init__(self):
+        Reco.__init__(self)
+        self.recoSeq=''
+        self.cbSc='cosmics'
     """
     _cosmics_
 
     Implement configuration building for data processing for cosmic
-    data taking
+    data taking in Run2
 
     """
 
@@ -30,12 +34,10 @@ class cosmics(Reco):
         """
         if not 'skims' in args:
             args['skims']= ['@allForPromptCosmics']
-
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
-
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
         process = Reco.promptReco(self,globalTag, **args)
 
         return process
@@ -51,11 +53,10 @@ class cosmics(Reco):
 
         if not 'skims' in args:
             args['skims']= ['@allForExpressCosmics']
-
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
         process = Reco.expressProcessing(self,globalTag, **args)
 
         return process
@@ -69,9 +70,9 @@ class cosmics(Reco):
         """
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
         process = Reco.visualizationProcessing(self,globalTag, **args)
 
         process.reconstructionCosmics.remove(process.lumiProducer)
@@ -85,6 +86,7 @@ class cosmics(Reco):
         Proton collisions data taking AlCa Harvesting
 
         """
+
         if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['SiStripQuality']
             

--- a/Configuration/DataProcessing/python/Impl/cosmics.py
+++ b/Configuration/DataProcessing/python/Impl/cosmics.py
@@ -20,7 +20,7 @@ class cosmics(Reco):
     _cosmics_
 
     Implement configuration building for data processing for cosmic
-    data taking in Run2
+    data taking
 
     """
 
@@ -35,9 +35,9 @@ class cosmics(Reco):
         if not 'skims' in args:
             args['skims']= ['@allForPromptCosmics']
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
         process = Reco.promptReco(self,globalTag, **args)
 
         return process
@@ -54,9 +54,9 @@ class cosmics(Reco):
         if not 'skims' in args:
             args['skims']= ['@allForExpressCosmics']
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
         process = Reco.expressProcessing(self,globalTag, **args)
 
         return process
@@ -70,9 +70,9 @@ class cosmics(Reco):
         """
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
         process = Reco.visualizationProcessing(self,globalTag, **args)
 
         process.reconstructionCosmics.remove(process.lumiProducer)

--- a/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2016.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2016_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+import Configuration.StandardSequences.Eras as eras
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsEra_Run2_2016(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.eras = eras.eras.Run2_2016
+    """
+    _cosmicsEra_Run2_2016_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_25ns.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_25ns_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+import Configuration.StandardSequences.Eras as eras
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsEra_Run2_25ns(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.eras = eras.eras.Run2_25ns
+    """
+    _cosmicsEra_Run2_25ns_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_50ns.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_50ns.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_50ns_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+import Configuration.StandardSequences.Eras as eras
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsEra_Run2_50ns(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.eras = eras.eras.Run2_50ns
+    """
+    _cosmicsEra_Run2_50ns_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
@@ -35,9 +35,9 @@ class cosmicsRun2(Reco):
         if not 'skims' in args:
             args['skims']= ['@allForPromptCosmics']
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2Deprecated')
         process = Reco.promptReco(self,globalTag, **args)
 
         return process
@@ -54,9 +54,9 @@ class cosmicsRun2(Reco):
         if not 'skims' in args:
             args['skims']= ['@allForExpressCosmics']
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2Deprecated')
         process = Reco.expressProcessing(self,globalTag, **args)
 
         return process
@@ -70,9 +70,9 @@ class cosmicsRun2(Reco):
         """
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2Deprecated')
         process = Reco.visualizationProcessing(self,globalTag, **args)
 
         process.reconstructionCosmics.remove(process.lumiProducer)

--- a/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
@@ -13,6 +13,7 @@ from Configuration.DataProcessing.Reco import Reco
 
 class cosmicsRun2(Reco):
     def __init__(self):
+        Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='cosmics'
     """

--- a/Configuration/DataProcessing/python/Impl/hcalnzs.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzs.py
@@ -13,6 +13,7 @@ from Configuration.DataProcessing.Impl.pp import pp
 
 class hcalnzs(pp):
     def __init__(self):
+        pp.__init__(self)
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
     """
@@ -31,5 +32,7 @@ class hcalnzs(pp):
         """
         if not 'skims' in args:
             args['skims']=['HcalCalMinBias']
+
         process = pp.promptReco(self,globalTag,**args)
+        
         return process

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2016.py
@@ -18,6 +18,9 @@ class hcalnzsEra_Run2_2016(hcalnzs):
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
         self.eras = eras.eras.Run2_2016
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
     """
     _hcalnzsEra_Run2_2016_
 

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2016.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+_hcalnzsEra_Run2_2016_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+import Configuration.StandardSequences.Eras as eras
+
+class hcalnzsEra_Run2_2016(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.recoSeq=':reconstruction_HcalNZS'
+        self.cbSc='pp'
+        self.eras = eras.eras.Run2_2016
+    """
+    _hcalnzsEra_Run2_2016_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_25ns.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+_hcalnzsEra_Run2_25ns_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+import Configuration.StandardSequences.Eras as eras
+
+class hcalnzsEra_Run2_25ns(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.recoSeq=':reconstruction_HcalNZS'
+        self.cbSc='pp'
+        self.eras = eras.eras.Run2_25ns
+    """
+    _hcalnzsEra_Run2_25ns_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_25ns.py
@@ -18,6 +18,10 @@ class hcalnzsEra_Run2_25ns(hcalnzs):
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
         self.eras = eras.eras.Run2_25ns
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+
     """
     _hcalnzsEra_Run2_25ns_
 

--- a/Configuration/DataProcessing/python/Impl/hcalnzsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsRun2.py
@@ -34,9 +34,9 @@ class hcalnzsRun2(pp):
             args['skims']=['HcalCalMinBias']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2Deprecated')
 
         process = pp.promptReco(self,globalTag,**args)
         

--- a/Configuration/DataProcessing/python/Impl/hcalnzsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsRun2.py
@@ -13,6 +13,7 @@ from Configuration.DataProcessing.Impl.pp import pp
 
 class hcalnzsRun2(pp):
     def __init__(self):
+        pp.__init__(self)
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
     """

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -21,7 +21,7 @@ class pp(Reco):
     _pp_
 
     Implement configuration building for data processing for proton
-    collision data taking for Run2
+    collision data taking
 
     """
 
@@ -37,9 +37,9 @@ class pp(Reco):
             args['skims']=['@allForPrompt']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePrompt']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePrompt')
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -57,9 +57,9 @@ class pp(Reco):
             args['skims']=['@allForExpress']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -73,9 +73,9 @@ class pp(Reco):
 
         """
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -17,6 +17,9 @@ class pp(Reco):
         Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.promptCustoms= [ 'Configuration/DataProcessing/RecoTLR.customisePrompt' ]
+        self.expressCustoms=[ 'Configuration/DataProcessing/RecoTLR.customiseExpress' ]
+        self.visCustoms=[ 'Configuration/DataProcessing/RecoTLR.customiseExpress' ]
     """
     _pp_
 
@@ -37,9 +40,10 @@ class pp(Reco):
             args['skims']=['@allForPrompt']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePrompt']
-        else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePrompt')
+            args['customs']= [ ]
+
+        for c in self.promptCustoms:
+            args['customs'].append(c)
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -57,9 +61,10 @@ class pp(Reco):
             args['skims']=['@allForExpress']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
-        else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
+            args['customs']=[ ]
+
+        for c in self.expressCustoms:
+            args['customs'].append(c)
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -73,9 +78,10 @@ class pp(Reco):
 
         """
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
-        else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
+            args['customs']=[ ]
+
+        for c in self.visCustoms:
+            args['customs'].append(c)
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -13,11 +13,15 @@ from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
 
 class pp(Reco):
+    def __init__(self):
+        Reco.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
     """
     _pp_
 
     Implement configuration building for data processing for proton
-    collision data taking
+    collision data taking for Run2
 
     """
 
@@ -33,9 +37,9 @@ class pp(Reco):
             args['skims']=['@allForPrompt']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePrompt']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePrompt')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2')
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -53,9 +57,9 @@ class pp(Reco):
             args['skims']=['@allForExpress']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -68,11 +72,10 @@ class pp(Reco):
         Proton collision data taking visualization processing
 
         """
-
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         
@@ -85,6 +88,7 @@ class pp(Reco):
         Proton collisions data taking AlCa Harvesting
 
         """
+
 
         if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['BeamSpotByRun',

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
@@ -21,9 +21,9 @@ class ppEra_Run2_2016(pp):
         self.recoSeq=''
         self.cbSc='pp'
         self.eras=eras.eras.Run2_2016
-        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
-        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
-        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
     """
     _ppEra_Run2_2016_
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2016_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+import Configuration.StandardSequences.Eras as eras
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2016(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=eras.eras.Run2_2016
+    """
+    _ppEra_Run2_2016_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
@@ -21,6 +21,9 @@ class ppEra_Run2_2016(pp):
         self.recoSeq=''
         self.cbSc='pp'
         self.eras=eras.eras.Run2_2016
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
     """
     _ppEra_Run2_2016_
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_25ns.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_25ns_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+import Configuration.StandardSequences.Eras as eras
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_25ns(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=eras.eras.Run2_25ns
+    """
+    _ppEra_Run2_25ns_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_25ns.py
@@ -21,6 +21,9 @@ class ppEra_Run2_25ns(pp):
         self.recoSeq=''
         self.cbSc='pp'
         self.eras=eras.eras.Run2_25ns
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
     """
     _ppEra_Run2_25ns_
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_50ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_50ns.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_50ns_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+import Configuration.StandardSequences.Eras as eras
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_50ns(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=eras.eras.Run2_50ns
+    """
+    _ppEra_Run2_50ns_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -37,9 +37,9 @@ class ppRun2(Reco):
             args['skims']=['@allForPrompt']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2Deprecated')
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -57,9 +57,9 @@ class ppRun2(Reco):
             args['skims']=['@allForExpress']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated')
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -73,9 +73,9 @@ class ppRun2(Reco):
 
         """
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated')
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -14,6 +14,7 @@ import FWCore.ParameterSet.Config as cms
 
 class ppRun2(Reco):
     def __init__(self):
+        Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
     """

--- a/Configuration/DataProcessing/python/Impl/ppRun2B0T.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2B0T.py
@@ -37,9 +37,9 @@ class ppRun2B0T(Reco):
             args['skims']=['@allForPrompt']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2B0T']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2DeprecatedB0T']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2B0T')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2DeprecatedB0T')
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -56,9 +56,9 @@ class ppRun2B0T(Reco):
         if not 'skims' in args:
             args['skims']=['@allForExpress']
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2DeprecatedB0T']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2DeprecatedB0T')
 
 
         process = Reco.expressProcessing(self,globalTag, **args)
@@ -73,9 +73,9 @@ class ppRun2B0T(Reco):
 
         """
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2DeprecatedB0T']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2DeprecatedB0T')
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/ppRun2B0T.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2B0T.py
@@ -14,6 +14,7 @@ import FWCore.ParameterSet.Config as cms
 
 class ppRun2B0T(Reco):
     def __init__(self):
+        Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
     """

--- a/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
@@ -14,6 +14,7 @@ import FWCore.ParameterSet.Config as cms
 
 class ppRun2at50ns(Reco):
     def __init__(self):
+        Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
     """

--- a/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
@@ -37,9 +37,9 @@ class ppRun2at50ns(Reco):
             args['skims']=['@allForPrompt']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2_50ns']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2Deprecated_50ns']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2_50ns')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2Deprecated_50ns')
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -57,9 +57,9 @@ class ppRun2at50ns(Reco):
             args['skims']=['@allForExpress']
 
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated_50ns']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated_50ns')
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -73,9 +73,9 @@ class ppRun2at50ns(Reco):
 
         """
         if not 'customs' in args:
-            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns']
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated_50ns']
         else:
-            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns')
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2Deprecated_50ns')
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/preprodmc.py
+++ b/Configuration/DataProcessing/python/Impl/preprodmc.py
@@ -14,6 +14,8 @@ import FWCore.ParameterSet.Config as cms
 
 
 class preprodmc(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _preprodmc_
 
@@ -41,7 +43,7 @@ class preprodmc(Scenario):
         options.evt_type = ""
         options.filein = []
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         if args.get('newDQMIO', False):
             process.source = cms.Source("DQMRootSource")
         else:

--- a/Configuration/DataProcessing/python/Impl/prodmc.py
+++ b/Configuration/DataProcessing/python/Impl/prodmc.py
@@ -13,6 +13,8 @@ from Configuration.DataProcessing.Scenario import *
 import FWCore.ParameterSet.Config as cms
 
 class prodmc(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _prodmc_
 
@@ -40,7 +42,7 @@ class prodmc(Scenario):
         options.evt_type = ""
         options.filein = []
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         if args.get('newDQMIO', False):
             process.source = cms.Source("DQMRootSource")
         else:

--- a/Configuration/DataProcessing/python/Impl/relvalgen.py
+++ b/Configuration/DataProcessing/python/Impl/relvalgen.py
@@ -13,6 +13,8 @@ from Configuration.DataProcessing.Scenario import *
 import FWCore.ParameterSet.Config as cms
 
 class relvalgen(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _relvalgen_
 
@@ -42,7 +44,7 @@ class relvalgen(Scenario):
         options.filein = []
         options.harvesting = "AtJobEnd"
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = cms.Source("PoolSource")
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()

--- a/Configuration/DataProcessing/python/Impl/relvalmc.py
+++ b/Configuration/DataProcessing/python/Impl/relvalmc.py
@@ -14,6 +14,8 @@ import FWCore.ParameterSet.Config as cms
 
 
 class relvalmc(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _relvalmc_
 
@@ -41,7 +43,7 @@ class relvalmc(Scenario):
         options.evt_type = ""
         options.filein = []
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = cms.Source("PoolSource")
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()

--- a/Configuration/DataProcessing/python/Impl/relvalmcfs.py
+++ b/Configuration/DataProcessing/python/Impl/relvalmcfs.py
@@ -14,6 +14,8 @@ import FWCore.ParameterSet.Config as cms
 
 
 class relvalmcfs(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
     """
     _relvalmcfs_
 
@@ -38,7 +40,7 @@ class relvalmcfs(Scenario):
         options.name = "EDMtoMEConvert"
         options.conditions = globalTag
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = cms.Source("PoolSource")
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -26,6 +26,16 @@ class Reco(Scenario):
 
     """
 
+
+    def _checkRepackedFlag(self, options, **args):
+        if 'repacked' in args:
+            if args['repacked'] == True:
+                options.isRepacked = True
+            else:
+                options.isRepacked = False
+                
+
+
     def promptReco(self, globalTag, **args):
         """
         _promptReco_
@@ -55,6 +65,7 @@ class Reco(Scenario):
         """
         options.runUnscheduled=True
                     
+        self._checkRepackedFlag(options, **args)
 
         if 'customs' in args:
             options.customisation_file=args['customs']
@@ -117,6 +128,8 @@ class Reco(Scenario):
         if 'customs' in args:
             options.customisation_file=args['customs']
 
+        self._checkRepackedFlag(options,**args)
+
         cb = ConfigBuilder(options, process = process, with_output = True, with_input = True)
 
         cb.prepare()
@@ -165,6 +178,8 @@ class Reco(Scenario):
 
         if 'customs' in args:
             options.customisation_file=args['customs']
+
+        self._checkRepackedFlag(options, **args)
 
         cb = ConfigBuilder(options, process = process, with_output = True, with_input = True)
 

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -16,6 +16,7 @@ from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpres
 
 class Reco(Scenario):
     def __init__(self):
+        Scenario.__init__(self)
         self.recoSeq=''
         self.cbSc=self.__class__.__name__
     """
@@ -80,7 +81,7 @@ class Reco(Scenario):
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
         
-        process = cms.Process('RECO')
+        process = cms.Process('RECO', self.eras)
         cb = ConfigBuilder(options, process = process, with_output = True)
 
         # Input source
@@ -123,7 +124,7 @@ class Reco(Scenario):
         options.filein = 'tobeoverwritten.xyz'
         if 'inputSource' in args:
             options.filetype = args['inputSource']
-        process = cms.Process('RECO')
+        process = cms.Process('RECO', self.eras)
 
         if 'customs' in args:
             options.customisation_file=args['customs']
@@ -174,7 +175,7 @@ class Reco(Scenario):
 
         print "Using %s source"%options.filetype            
 
-        process = cms.Process('RECO')
+        process = cms.Process('RECO', self.eras)
 
         if 'customs' in args:
             options.customisation_file=args['customs']
@@ -229,7 +230,7 @@ class Reco(Scenario):
         if 'customs' in args:
             options.customisation_file=args['customs']
         
-        process = cms.Process('ALCA')
+        process = cms.Process('ALCA', self.eras)
         cb = ConfigBuilder(options, process = process)
 
         # Input source
@@ -262,7 +263,7 @@ class Reco(Scenario):
         options.name = "EDMtoMEConvert"
         options.conditions = gtNameAndConnect(globalTag, args)
  
-        process = cms.Process("HARVESTING")
+        process = cms.Process("HARVESTING", self.eras)
         process.source = dqmIOSource(args)
 
         if 'customs' in args:
@@ -297,7 +298,7 @@ class Reco(Scenario):
         options.name = "ALCAHARVEST"
         options.conditions = gtNameAndConnect(globalTag, args)
  
-        process = cms.Process("ALCAHARVEST")
+        process = cms.Process("ALCAHARVEST", self.eras)
         process.source = cms.Source("PoolSource")
 
         if 'customs' in args:
@@ -328,7 +329,7 @@ class Reco(Scenario):
         options.step = "SKIM:"+('+'.join(skims))
         options.name = "SKIM"
         options.conditions = gtNameAndConnect(globalTag, args)
-        process = cms.Process("SKIM")
+        process = cms.Process("SKIM", self.eras)
         process.source = cms.Source("PoolSource")
 
         if 'customs' in args:
@@ -346,7 +347,7 @@ class Reco(Scenario):
         options.filein='file.dat'
         options.filetype='DAT'
         options.scenario = self.cbSc if hasattr(self,'cbSc') else self.__class__.__name__
-        process = cms.Process('REPACK')
+        process = cms.Process('REPACK', self.eras)
         cb = ConfigBuilder(options, process = process, with_output = True,with_input=True)
         cb.prepare()
         print cb.pythonCfgCode

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -48,11 +48,64 @@ def customisePPMC(process):
 
 ##############################################################################
 def customiseCosmicData(process):
-
     return process
 
 
 
+##############################################################################
+def customiseCosmicMC(process):
+    return process
+        
+##############################################################################
+def customiseVALSKIM(process):
+    print "WARNING"
+    print "this method is outdated, please use RecoTLR.customisePPData"
+    process= customisePPData(process)
+    return process
+
+                
+##############################################################################
+def customiseExpress(process):
+    process= customisePPData(process)
+    process = _swapOfflineBSwithOnline(process)
+    
+    return process
+
+##############################################################################
+def customisePrompt(process):
+    process= customisePPData(process)
+    process = _addLumiProducer(process)
+
+    return process
+
+##############################################################################
+# Heavy Ions
+##############################################################################
+# keep it in case modification is needed
+def customiseCommonHI(process):
+    return process
+
+##############################################################################
+def customiseExpressHI(process):
+    process = customiseCommonHI(process)
+    process = _swapOfflineBSwithOnline(process)
+    
+    return process
+
+##############################################################################
+def customisePromptHI(process):
+    process = customiseCommonHI(process)
+
+    process = _addLumiProducer(process)
+
+    return process
+
+##############################################################################
+##############################################################################
+##
+##  ALL FUNCTIONS BELOW ARE GOING TO BE REMOVED IN 81X
+##
+##############################################################################
 ##############################################################################
 # this is supposed to be added on top of other (Run1) data customs
 def customiseDataRun2Common(process):
@@ -108,96 +161,6 @@ def customiseDataRun2Common_50nsRunsAfter253000(process):
     return process
 
 ##############################################################################
-def customiseCosmicDataRun2(process):
-    process = customiseCosmicData(process)
-    process = customiseDataRun2Common_25ns(process)
-    return process
-
-
-##############################################################################
-def customiseCosmicMC(process):
-    
-    return process
-        
-##############################################################################
-def customiseVALSKIM(process):
-    print "WARNING"
-    print "this method is outdated, please use RecoTLR.customisePPData"
-    process= customisePPData(process)
-    return process
-
-                
-##############################################################################
-def customiseExpress(process):
-    process= customisePPData(process)
-    process = _swapOfflineBSwithOnline(process)
-    
-    return process
-
-##############################################################################
-def customiseExpressRun2(process):
-    process = customiseExpress(process)
-    process = customiseDataRun2Common_25ns(process)
-    return process
-
-def customiseExpressRun2_50ns(process):
-    process = customiseExpress(process)
-    process = customiseDataRun2Common_50nsRunsAfter253000(process)
-    return process
-
-def customiseExpressRun2B0T(process):
-    process=customiseForRunI(process)
-    process=customiseExpressRun2(process)
-    return process
-
-##############################################################################
-def customisePrompt(process):
-    process= customisePPData(process)
-    process = _addLumiProducer(process)
-
-    return process
-
-##############################################################################
-def customisePromptRun2(process):
-    process = customisePrompt(process)
-    process = customiseDataRun2Common_25ns(process)
-    return process
-
-def customisePromptRun2_50ns(process):
-    process = customisePrompt(process)
-    process = customiseDataRun2Common_50nsRunsAfter253000(process)
-    return process
-
-def customisePromptRun2B0T(process):
-    process=customiseForRunI(process)
-    process=customisePromptRun2(process)
-    return process
-
-
-##############################################################################
-# Heavy Ions
-##############################################################################
-# keep it in case modification is needed
-def customiseCommonHI(process):
-    return process
-
-##############################################################################
-def customiseExpressHI(process):
-    process = customiseCommonHI(process)
-    process = _swapOfflineBSwithOnline(process)
-    
-    return process
-
-##############################################################################
-def customisePromptHI(process):
-    process = customiseCommonHI(process)
-    process = _swapOfflineBSwithOnline(process)
-
-    process = _addLumiProducer(process)
-
-    return process
-
-##############################################################################
 # keep it in case modification is needed
 def customiseRun2CommonHI(process):
     process = customiseDataRun2Common_withStage1(process)
@@ -210,14 +173,52 @@ def customiseRun2CommonHI(process):
     return process
 
 ##############################################################################
-def customiseRun2ExpressHI(process):
+def customiseCosmicDataRun2Deprecated(process):
+    process = customiseCosmicData(process)
+    process = customiseDataRun2Common_25ns(process)
+    return process
+
+##############################################################################
+def customiseExpressRun2Deprecated(process):
+    process = customiseExpress(process)
+    process = customiseDataRun2Common_25ns(process)
+    return process
+
+def customiseExpressRun2Deprecated_50ns(process):
+    process = customiseExpress(process)
+    process = customiseDataRun2Common_50nsRunsAfter253000(process)
+    return process
+
+def customiseExpressRun2DeprecatedB0T(process):
+    process=customiseForRunI(process)
+    process=customiseExpressRun2Deprecated(process)
+    return process
+
+##############################################################################
+def customisePromptRun2Deprecated(process):
+    process = customisePrompt(process)
+    process = customiseDataRun2Common_25ns(process)
+    return process
+
+def customisePromptRun2Deprecated_50ns(process):
+    process = customisePrompt(process)
+    process = customiseDataRun2Common_50nsRunsAfter253000(process)
+    return process
+
+def customisePromptRun2DeprecatedB0T(process):
+    process=customiseForRunI(process)
+    process=customisePromptRun2Deprecated(process)
+    return process
+
+##############################################################################
+def customiseRun2DeprecatedExpressHI(process):
     process = customiseRun2CommonHI(process)
     process = _swapOfflineBSwithOnline(process)
     
     return process
 
 ##############################################################################
-def customiseRun2PromptHI(process):
+def customiseRun2DeprecatedPromptHI(process):
     process = customiseRun2CommonHI(process)
 
     process = _addLumiProducer(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -21,6 +21,12 @@ def _addLumiProducer(process):
 
     return process
 
+def _overridesFor50ns(process):
+    process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(50)
+    process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
+    
+    return process
+
 #gone with the fact that there is no difference between production and development sequence
 #def customiseCommon(process):
 #    return (process)
@@ -97,12 +103,7 @@ def customiseDataRun2Common_25ns(process):
 def customiseDataRun2Common_50nsRunsAfter253000(process):
     process = customiseDataRun2Common_withStage1(process)
 
-    if hasattr(process,'particleFlowClusterECAL'):
-        process.particleFlowClusterECAL.energyCorrector.autoDetectBunchSpacing = False
-        process.particleFlowClusterECAL.energyCorrector.bunchSpacing = cms.int32(50)
-    if hasattr(process,'ecalMultiFitUncalibRecHit'):
-        process.ecalMultiFitUncalibRecHit.algoPSet.useLumiInfoRunHeader = False
-        process.ecalMultiFitUncalibRecHit.algoPSet.bunchSpacing = cms.int32(50)
+    process = _overridesFor50ns(process)
 
     return process
 
@@ -201,6 +202,7 @@ def customisePromptHI(process):
 def customiseRun2CommonHI(process):
     process = customiseDataRun2Common_withStage1(process)
     
+    process = _overridesFor50ns(process)
     # HI Specific additional customizations:
     # from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_Additional_HI
     # process = customiseSimL1EmulatorForPostLS1_Additional_HI(process)
@@ -217,7 +219,6 @@ def customiseRun2ExpressHI(process):
 ##############################################################################
 def customiseRun2PromptHI(process):
     process = customiseRun2CommonHI(process)
-    process = _swapOfflineBSwithOnline(process)
 
     process = _addLumiProducer(process)
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -27,9 +27,23 @@ def _overridesFor50ns(process):
     
     return process
 
-#gone with the fact that there is no difference between production and development sequence
-#def customiseCommon(process):
-#    return (process)
+##############################################################################
+# post-era customizations
+# these are here instead of generating Data-specific eras
+##############################################################################
+def _hcalCustoms25ns(process):
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
+    return process
+
+def customisePostEra_Run2_25ns(process):
+    _hcalCustoms25ns(process)
+    return process
+
+def customisePostEra_Run2_2016(process):
+    _hcalCustoms25ns(process)
+    return process
 
 
 ##############################################################################
@@ -143,9 +157,7 @@ def customiseDataRun2Common_withStage1(process):
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common_withStage1(process)
 
-    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
+    _hcalCustoms25ns(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):

--- a/Configuration/DataProcessing/python/Scenario.py
+++ b/Configuration/DataProcessing/python/Scenario.py
@@ -27,7 +27,7 @@ class Scenario(object):
 
     """
     def __init__(self):
-        pass
+        self.eras=cms.Modifier()
 
 
     def promptReco(self, globalTag, **options):

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import traceback
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -105,7 +106,7 @@ class RunPromptReco:
             return
         except Exception as ex:
             msg = "Error creating Prompt Reco config:\n"
-            msg += str(ex)
+            msg += traceback.format_exc()
             raise RuntimeError(msg)
 
         process.source.fileNames.append(self.inputLFN)

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -29,6 +29,8 @@ class RunPromptReco:
         self.alcaRecos = None
         self.PhysicsSkims = None
         self.dqmSeq = None
+        self.setRepacked = False
+        self.isRepacked = False
 
     def __call__(self):
         if self.scenario == None:
@@ -93,6 +95,9 @@ class RunPromptReco:
                 if self.dqmSeq:
                     kwds['dqmSeq'] = self.dqmSeq
 
+                if self.setRepacked:
+                    kwds['repacked'] = self.isRepacked
+
             process = scenario.promptReco(self.globalTag, **kwds)
 
         except NotImplementedError as ex:
@@ -119,7 +124,7 @@ class RunPromptReco:
 
 if __name__ == '__main__':
     valid = ["scenario=", "reco", "aod", "miniaod","dqm", "dqmio", "no-output",
-             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=", "dqmSeq=" ]
+             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=", "dqmSeq=", "isRepacked", "isNotRepacked" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -131,6 +136,7 @@ Where options are:
  --miniaod (to enable MiniAOD output)
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
+ --isRepacked --isNotRepacked (to override default repacked flags)
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
@@ -182,5 +188,12 @@ python RunPromptReco.py --scenario=ppRun2 --reco --aod --dqmio --global-tag GLOB
             recoinator.PhysicsSkims = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--dqmSeq":
             recoinator.dqmSeq = [ x for x in arg.split('+') if len(x) > 0 ]
+        if opt == "--isRepacked":
+            recoinator.setRepacked = True
+            recoinator.isRepacked = True
+        if opt == "--isNotRepacked":
+            recoinator.setRepacked = True
+            recoinator.isRepacked = False
+
 
     recoinator()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "HeavyIons" "ppRun2at50ns")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,13 +22,13 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
-declare -a arr=("HeavyIonsRun2")
+declare -a arr=("HeavyIonsRun2" "HeavyIonsEra_Run2_HI")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBiasHI+SiStripCalMinBias "
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "HeavyIonsRun2" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns")
+declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" )
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,7 +36,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -5,8 +5,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 # no bunchspacing in cosmics
-bunchSpacingProducer.overrideBunchSpacing=True
-bunchSpacingProducer.bunchSpacingOverride=50
+bunchSpacingProducer.overrideBunchSpacing= cms.bool(True)
+bunchSpacingProducer.bunchSpacingOverride= cms.uint32(50)
 
 #
 # tracker

--- a/DPGAnalysis/Skims/python/logErrorSkim_cff.py
+++ b/DPGAnalysis/Skims/python/logErrorSkim_cff.py
@@ -1,10 +1,17 @@
 from FWCore.Modules.logErrorFilter_cfi import *
-from Configuration.StandardSequences.RawToDigi_Data_cff import gtEvmDigis
+
 stableBeam = cms.EDFilter("HLTBeamModeFilter",
                           L1GtEvmReadoutRecordTag = cms.InputTag("gtEvmDigis"),
                           AllowedBeamMode = cms.vuint32(11),
                           saveTags = cms.bool(False)
                           )
+from L1Trigger.Configuration.L1TRawToDigi_cff import L1TRawToDigi
+if not "gtEvmDigis" in L1TRawToDigi.moduleNames():
+    import EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi
+    gtEvmDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi.l1GtEvmUnpack.clone()
+    gtEvmDigis.EvmGtInputTag = 'rawDataCollector'
+else:
+    from L1Trigger.Configuration.L1TRawToDigi_cff import gtEvmDigis
 
 logerrorseq=cms.Sequence(gtEvmDigis+stableBeam+logErrorSkimFilter)
 logerrormonitorseq=cms.Sequence(gtEvmDigis+stableBeam+logErrorFilter)

--- a/DPGAnalysis/Skims/python/logErrorSkim_cff.py
+++ b/DPGAnalysis/Skims/python/logErrorSkim_cff.py
@@ -1,17 +1,4 @@
 from FWCore.Modules.logErrorFilter_cfi import *
 
-stableBeam = cms.EDFilter("HLTBeamModeFilter",
-                          L1GtEvmReadoutRecordTag = cms.InputTag("gtEvmDigis"),
-                          AllowedBeamMode = cms.vuint32(11),
-                          saveTags = cms.bool(False)
-                          )
-from L1Trigger.Configuration.L1TRawToDigi_cff import L1TRawToDigi
-if not "gtEvmDigis" in L1TRawToDigi.moduleNames():
-    import EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi
-    gtEvmDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi.l1GtEvmUnpack.clone()
-    gtEvmDigis.EvmGtInputTag = 'rawDataCollector'
-else:
-    from L1Trigger.Configuration.L1TRawToDigi_cff import gtEvmDigis
-
-logerrorseq=cms.Sequence(gtEvmDigis+stableBeam+logErrorSkimFilter)
-logerrormonitorseq=cms.Sequence(gtEvmDigis+stableBeam+logErrorFilter)
+logerrorseq=cms.Sequence(logErrorSkimFilter)
+logerrormonitorseq=cms.Sequence(logErrorFilter)

--- a/RecoLuminosity/LumiProducer/python/bunchSpacingProducer_cfi.py
+++ b/RecoLuminosity/LumiProducer/python/bunchSpacingProducer_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+bunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
+
+from Configuration.StandardSequences.Eras import eras
+eras.run2_50ns_specific.toModify( bunchSpacingProducer, bunchSpacingOverride = cms.uint32(50))
+eras.run2_50ns_specific.toModify( bunchSpacingProducer, overrideBunchSpacing = cms.bool(True))

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -788,7 +788,8 @@ def customise_L1Emulator(process):
 
 
 def customise_RawToDigi(process):
-    process.RawToDigi.remove(process.gtEvmDigis)
+    if hasattr(process,'gtEvmDigis'):
+        process.RawToDigi.remove(process.gtEvmDigis)
     return process
 
 


### PR DESCRIPTION
Added era-based T0 scenarios
- HeavyIonsEra_Run2_HI
- cosmicsEra_Run2_2016, cosmicsEra_Run2_25ns, cosmicsEra_Run2_50ns
- hcalnzsEra_Run2_2016, hcalnzsEra_Run2_25ns
- ppEra_Run2_2016, ppEra_Run2_25ns, ppEra_Run2_50ns
  The naming convention is to have a suffix matching the era name.

Tested in 800, in particular, by inspection and comparison of the T0 config files generated with Configuration/DataProcessing/test/RunPromptReco.py.
The reco parts in matching old and new scenarios are functionally identical.

There are some relevant discrepancies in L1-related pieces; they are apparently due to missing modifiers in eras
- csc trigger primitive emulator used in validation DQM needs #13243
- CSCTF emulator used in validation is missing gangedME1a setting to False (current era implementation has it functionally set to true in run2 scenarios)
- 2016 l1extra and other pre-stage2 algorithms are set to read inputs from GCT, while it should probably be from stage1.

Old scenarios are still in place and will give the same results, but the plan is to remove them at some point in 81X cycle.

@hengne 
It should be now also possible to move to eras in the relval matrix for data processing, however for some eras additional customizations are still needed (customisePostEra_Run2_25ns and customisePostEra_Run2_2016 are needed for the 25ns setups) 
