### PR TITLE
update trajectory filters (minNumberOfHits --> minNumberOfHitsForLoopers)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -37,7 +37,8 @@ def customiseFor13753(process):
         if producer.CleanerPSet.ComponentName.value() == "PixelTrackCleanerBySharedHits" and not hasattr(producer.CleanerPSet, "useQuadrupletAlgo"):
             producer.CleanerPSet.useQuadrupletAlgo = cms.bool(False)
     return process
-def customiseForXXXXX(process):
+
+def customiseFor13421(process):
     for pset in process._Process__psets.values():
         if hasattr(pset,'ComponentType'):
             if (pset.ComponentType == 'CkfBaseTrajectoryFilter'):
@@ -71,7 +72,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     if cmsswVersion >= "CMSSW_8_0":
         process = customiseFor14282(process)
 #       process = customiseFor12718(process)
-        process = customiseForXXXXX(process)
+        process = customiseFor13421(process)
         pass
 
 #   stage-2 changes only if needed

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -37,6 +37,29 @@ def customiseFor13753(process):
         if producer.CleanerPSet.ComponentName.value() == "PixelTrackCleanerBySharedHits" and not hasattr(producer.CleanerPSet, "useQuadrupletAlgo"):
             producer.CleanerPSet.useQuadrupletAlgo = cms.bool(False)
     return process
+def customiseForXXXXX(process):
+    for pset in process._Process__psets.values():
+        if hasattr(pset,'ComponentType'):
+            if (pset.ComponentType == 'CkfBaseTrajectoryFilter'):
+                value = cms.int32(13)
+                if hasattr(pset,'minNumberOfHits'):
+                    value = getattr(pset,'minNumberOfHits')
+                    delattr(pset,'minNumberOfHits')
+                if not hasattr(pset,'minNumberOfHitsForLoopers'):
+                    pset.minNumberOfHitsForLoopers = value
+                if not hasattr(pset,'minNumberOfHitsPerLoop'):
+                    pset.minNumberOfHitsPerLoop = cms.int32(4)
+                if not hasattr(pset,'extraNumberOfHitsBeforeTheFirstLoop'):
+                    pset.extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4)
+                if not hasattr(pset,'maxLostHitsFraction'):
+                    pset.maxLostHitsFraction = cms.double(999.)
+                if not hasattr(pset,'constantValueForLostHitsFractionFilter'):
+                    pset.constantValueForLostHitsFractionFilter = cms.double(1.)
+                if not hasattr(pset,'minimumNumberOfHits'):
+                    pset.minimumNumberOfHits = cms.int32(5)
+                if not hasattr(pset,'seedPairPenalty'):
+                    pset.seedPairPenalty = cms.int32(0)
+    return process
 
 #
 # CMSSW version specific customizations
@@ -48,6 +71,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     if cmsswVersion >= "CMSSW_8_0":
         process = customiseFor14282(process)
 #       process = customiseFor12718(process)
+        process = customiseForXXXXX(process)
         pass
 
 #   stage-2 changes only if needed

--- a/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
@@ -51,6 +51,18 @@ public:
   virtual bool toBeContinued( TempTrajectory& traj) const {return TBC<TempTrajectory>(traj);}
 
   virtual  std::string name() const { return "CkfBaseTrajectoryFilter";}
+
+  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
+    edm::ParameterSetDescription descLooper           = theLooperTrajectoryFilter->getFilledConfigurationDescription();
+    edm::ParameterSetDescription descLostHitsFraction = theLostHitsFractionTrajectoryFilter->getFilledConfigurationDescription();
+    edm::ParameterSetDescription descMinHits          = theMinHitsTrajectoryFilter->getFilledConfigurationDescription();
+
+    edm::ParameterSetDescription desc;
+    desc.add<edm::ParameterSetDescription>("looperTrajectoryFilter",          descLooper);
+    desc.add<edm::ParameterSetDescription>("lostHitsFractionTrajectoryFilter",descLostHitsFraction);
+    desc.add<edm::ParameterSetDescription>("minHitsTrajectoryFilter",         descMinHits);
+    return desc;
+  }
   
 protected:
 

--- a/TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h
@@ -2,24 +2,22 @@
 #define LooperTrajectoryFilter_H
 
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 class LooperTrajectoryFilter final : public TrajectoryFilter {
 public:
 
-  explicit LooperTrajectoryFilter( int minNumberOfHits=13, 
+  explicit LooperTrajectoryFilter( int minNumberOfHitsForLoopers=13, 
 				   int minNumberOfHitsPerLoop=4,
 				   int extraNumberOfHitsBeforeTheFirstLoop=4): 
-  theMinNumberOfHits(minNumberOfHits), 
+  theMinNumberOfHitsForLoopers(minNumberOfHitsForLoopers), 
   theMinNumberOfHitsPerLoop(minNumberOfHitsPerLoop),
   theExtraNumberOfHitsBeforeTheFirstLoop(extraNumberOfHitsBeforeTheFirstLoop){}
   
   explicit LooperTrajectoryFilter( const edm::ParameterSet & pset, edm::ConsumesCollector& iC){
-    theMinNumberOfHits = pset.existsAs<int>("minNumberOfHits") ? 
-      pset.getParameter<int>("minNumberOfHits") : 13; 
-    theMinNumberOfHitsPerLoop= pset.existsAs<int>("minNumberOfHitsPerLoop") ? 
-      pset.getParameter<int>("minNumberOfHitsPerLoop") : 4; 
-    theExtraNumberOfHitsBeforeTheFirstLoop= pset.existsAs<int>("extraNumberOfHitsBeforeTheFirstLoop") ? 
-      pset.getParameter<int>("extraNumberOfHitsBeforeTheFirstLoop") : 4; 
+    theMinNumberOfHitsForLoopers           = pset.getParameter<int>("minNumberOfHitsForLoopers"); 
+    theMinNumberOfHitsPerLoop              = pset.getParameter<int>("minNumberOfHitsPerLoop"); 
+    theExtraNumberOfHitsBeforeTheFirstLoop = pset.getParameter<int>("extraNumberOfHitsBeforeTheFirstLoop"); 
 
   }
 
@@ -31,10 +29,19 @@ public:
 
   virtual std::string name() const{return "LooperTrajectoryFilter";}
 
+  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
+    edm::ParameterSetDescription desc;
+    desc.add<int>("minNumberOfHitsForLoopers",          13);
+    desc.add<int>("minNumberOfHitsPerLoop",              4);
+    desc.add<int>("extraNumberOfHitsBeforeTheFirstLoop", 4);
+    return desc;
+  }
+
+
 protected:
 
   template<class T> bool QF(const T & traj) const{
-    if ( traj.isLooper() && (traj.foundHits() < theMinNumberOfHits) ) return false;
+    if ( traj.isLooper() && (traj.foundHits() < theMinNumberOfHitsForLoopers) ) return false;
     else return true;
   }
 
@@ -47,7 +54,7 @@ protected:
     return ret;
   }
 
-  int theMinNumberOfHits;
+  int theMinNumberOfHitsForLoopers;
   int theMinNumberOfHitsPerLoop;
   int theExtraNumberOfHitsBeforeTheFirstLoop;
 

--- a/TrackingTools/TrajectoryFiltering/interface/LostHitsFractionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/LostHitsFractionTrajectoryFilter.h
@@ -6,15 +6,14 @@
 class LostHitsFractionTrajectoryFilter final : public TrajectoryFilter {
 public:
 
-  explicit LostHitsFractionTrajectoryFilter( float maxLostHitsFraction=1./10.,float constantValue=1 ): 
+  explicit LostHitsFractionTrajectoryFilter( float maxLostHitsFraction=999.,float constantValue=1. ): 
+  //  explicit LostHitsFractionTrajectoryFilter( float maxLostHitsFraction=1./10.,float constantValue=1 ): 
   theMaxLostHitsFraction( maxLostHitsFraction), 
   theConstantValue( constantValue) {}
   
   explicit LostHitsFractionTrajectoryFilter( const edm::ParameterSet & pset, edm::ConsumesCollector& iC){
-    theMaxLostHitsFraction = pset.existsAs<double>("maxLostHitsFraction") ? 
-      pset.getParameter<double>("maxLostHitsFraction") : 999; 
-    theConstantValue =  pset.existsAs<double>("constantValueForLostHitsFractionFilter") ? 
-      pset.getParameter<double>("constantValueForLostHitsFractionFilter") : 1; 
+    theMaxLostHitsFraction = pset.getParameter<double>("maxLostHitsFraction"); 
+    theConstantValue       = pset.getParameter<double>("constantValueForLostHitsFractionFilter"); 
   }
 
   virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
@@ -24,6 +23,13 @@ public:
   virtual bool toBeContinued( Trajectory& traj) const{ return TBC<Trajectory>(traj);}
 
   virtual std::string name() const{return "LostHitsFractionTrajectoryFilter";}
+
+  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
+    edm::ParameterSetDescription desc;
+    desc.add<double>("maxLostHitsFraction",                     999.);
+    desc.add<double>("constantValueForLostHitsFractionFilter",    1.);
+    return desc;
+  }
 
 protected:
 

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -2,7 +2,7 @@
 #define MinHitsTrajectoryFilter_H
 
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 /** A TrajectoryFilter that stops reconstruction if P_t drops
  *  below some value at some confidence level.
@@ -13,11 +13,12 @@
 class MinHitsTrajectoryFilter final : public TrajectoryFilter {
 public:
 
-  explicit MinHitsTrajectoryFilter( int minHits=-1, int seedPairPenalty=0):theMinHits( minHits), theSeedPairPenalty(seedPairPenalty) {}
+  explicit MinHitsTrajectoryFilter( int minHits=5, int seedPairPenalty=0):theMinHits( minHits), theSeedPairPenalty(seedPairPenalty) {}
+  //  explicit MinHitsTrajectoryFilter( int minHits=-1, int seedPairPenalty=0):theMinHits( minHits), theSeedPairPenalty(seedPairPenalty) {}
 
   MinHitsTrajectoryFilter( const edm::ParameterSet & pset, edm::ConsumesCollector& iC): 
-   theMinHits( pset.getParameter<int>("minimumNumberOfHits")),
-   theSeedPairPenalty(pset.exists("seedPairPenalty") ? pset.getParameter<int>("seedPairPenalty") : 0)
+   theMinHits(         pset.getParameter<int>("minimumNumberOfHits") ),
+   theSeedPairPenalty( pset.getParameter<int>("seedPairPenalty")     )
  {}
     
   virtual bool qualityFilter( const Trajectory& traj) const { return QF<Trajectory>(traj);}
@@ -27,6 +28,13 @@ public:
   virtual bool toBeContinued( Trajectory&) const { return TrajectoryFilter::toBeContinuedIfNotContributing ;}
 
   virtual std::string name() const {return "MinHitsTrajectoryFilter";}
+
+  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
+    edm::ParameterSetDescription desc;
+    desc.add<int>("minimumNumberOfHits",5);
+    desc.add<int>("seedPairPenalty",    0);
+    return desc;
+  }
 
 protected:
 

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -35,8 +35,8 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
     strictSeedExtension = cms.bool(False),
 
 # Cuts for looperTrajectoryFilter
-    minNumberOfHits = cms.int32(13),
-    minNumberOfHitsPerLoop = cms.int32(4),
+    minNumberOfHitsForLoopers           = cms.int32(13),
+    minNumberOfHitsPerLoop              = cms.int32(4),
     extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
 
 # Cut on CCC hits


### PR DESCRIPTION
this PR is meant to update the name of a trajectory filter parameter (minNumberOfHits --> minNumberOfHitsForLoopers)

I also take the opportunity of deleting few existAs checks which were still present in the TrackingTools/TrajectoryFiltering package
=> the HLT customization function (HLTrigger/Configuration/python/customizeHLTforCMSSW.py) has been updated in order to make the HLT menu compatible w/ this update ("usual" temporary solution waiting for the confDB update)

in addition, I noticed there were few cases in which the class constructor, where default input parameters were used, was not in synch w/ the default parameter values given by config
=> the default parameters have been updated as well

I ran 
HLTrigger/Configuration/test/cmsDriver.sh
and 
addOnTests.py
I got the few errors ([1] from cmsDriver and [2] from addOnTests, respectively)
but I think they are not related to my changes

@VinInn @rovere @perrotta @Martin-Grunewald 

[1]
Creating DigiL1RawHLT HIon_MC
DIGI:pdigi_valid,L1,DIGI2RAW,HLT:HIon,ENDJOB
entry /store/relval/CMSSW_7_6_0_pre6/RelValZEEMM_13_HI/GEN-SIM/76X_mcRun2_HeavyIon_v4-v1/00000/EA469164-6A69-E511-A361-008CFA008768.root
 ###################################################################
 # WARNING: this module is deprecated.                             #
 # Please use CondCore.CondDB.CondDB_cfi.py                        #
 ###################################################################
Step: DIGI Spec: ['pdigi_valid']
Step: L1 Spec:
L1TCalorimeter Sequence configured for Stage-1 (2015) trigger.
L1TMuon Sequence configured for Legacy trigger (Run1 and Run 2015).
L1TGlobal Sequence configured for Legacy trigger (Run1 and Run 2015).
L1TCalorimeter Conditions configured for Stage-1 (2015) trigger.
Step: DIGI2RAW Spec:
L1TDigiToRaw Sequence configured for Stage-1 (2015) trigger.
Step: HLT Spec: ['HIon']
Step: ENDJOB Spec:
# Conditions read from  CMS_CONDITIONS  via FrontierProd

customising the process with L1THLT from HLTrigger/Configuration/CustomConfigs
customising the process with customizeHLTforFullSim from HLTrigger/Configuration/customizeHLTforMC
Config file RelVal_DigiL1RawHLT_HIon_MC.py created

Creating FastSim HIon_MC
GEN,SIM,RECOBEFMIX,DIGI,L1,L1Reco,RECO,HLT:HIon,ENDJOB
Traceback (most recent call last):
  File "/afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc6_amd64_gcc493/cms/cmssw/CMSSW_8_0_X_2016-02-15-2300/bin/slc6_amd64_gcc493/cmsDriver.py", line 55, in <module>
    run()
  File "/afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc6_amd64_gcc493/cms/cmssw/CMSSW_8_0_X_2016-02-15-2300/bin/slc6_amd64_gcc493/cmsDriver.py", line 11, in run
    options = OptionsFromCommandLine()
  File "/afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc6_amd64_gcc493/cms/cmssw/CMSSW_8_0_X_2016-02-15-2300/python/Configuration/Applications/cmsDriverOptions.py", line 33, in OptionsFromCommandLine
    options=OptionsFromItems(sys.argv[1:])
  File "/afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc6_amd64_gcc493/cms/cmssw/CMSSW_8_0_X_2016-02-15-2300/python/Configuration/Applications/cmsDriverOptions.py", line 271, in OptionsFromItems
    raise Exception("ERROR: the --option fast is only compatible with the default scenario (--scenario=pp)")
Exception: ERROR: the --option fast is only compatible with the default scenario (--scenario=pp)

[2]
cmsDriver.py TTbar_Tauola_13TeV_cfi -s GEN,SIM,DIGI,L1,DIGI2RAW --mc --scenario=pp -n 10 --conditions auto:run2_mc_GRun --relval 9000,50 --datatier "GEN-SIM-RAW" --eventcontent RAWSIM --customise=HLTrigger/Configuration/CustomConfigs.L1T --era Run2_25ns --magField 38T_PostLS1 --fileout file:RelVal_Raw_GRun_MC.root : FAILED - time: date Wed Feb 17 17:52:54 2016-date Wed Feb 17 17:47:04 2016 s - exit: 34560

log file:
/afs/cern.ch/work/t/tosi/public/trackingHLT/update_trajectory_filtering/CMSSW_8_0_X_2016-02-15-2300/src/HLTrigger/Configuration/test/addOnTests/logs/cmsDriver-hlt_mc_GRun_cmsDriver.py_TTbar_Tauola_13TeV_cfi_-s_GEN,SIM,DIGI,L1,DIGI2RAW_--mc_--scenario=pp_-n_10_--conditions_auto:run2_mc_GRun_--relval_9000,50_--datatier_G.log
