### PR TITLE
Remove remaining PixelCPEGeneric customizations for phase1

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -471,13 +471,6 @@ def customise_Reco(process,pileup):
     
     # Need these until pixel templates are used
     process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
-    # PixelCPEGeneric #
-    process.PixelCPEGenericESProducer.Upgrade = cms.bool(True)
-    process.PixelCPEGenericESProducer.UseErrorsFromTemplates = cms.bool(False)
-    process.PixelCPEGenericESProducer.LoadTemplatesFromDB = cms.bool(False)
-    process.PixelCPEGenericESProducer.TruncatePixelCharge = cms.bool(False)
-    process.PixelCPEGenericESProducer.IrradiationBiasCorrection = False
-    process.PixelCPEGenericESProducer.DoCosmics = False
     # CPE for other steps
     process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
     # Turn of template use in tracking (iterative steps handled inside their configs)


### PR DESCRIPTION
This PR complements #13300 by removing the last PixelCPEGenericESProducer customizations for phase1. According to @dkotlins we should use the same configuration for 2017 as for 2016/2015.

Tested in CMSSW_8_1_X_2016-02-19-2300, tiny variations in 2017 tracking are expected.

@rovere @VinInn
