### PR TITLE
Make TrackExtra::setSeedRef() to take RefToBase<TrajectorySeed> via const reference

### DIFF
--- a/DataFormats/TrackReco/interface/TrackExtra.h
+++ b/DataFormats/TrackReco/interface/TrackExtra.h
@@ -172,7 +172,7 @@ public:
     edm::RefToBase<TrajectorySeed> seedRef() const {
         return seedRef_;
     }
-    void setSeedRef(edm::RefToBase<TrajectorySeed> &r) {
+    void setSeedRef(const edm::RefToBase<TrajectorySeed> &r) {
         seedRef_ = r;
     }
     /// set the residuals


### PR DESCRIPTION
This PR modifies `TrackExtra::setSeedRef()` to take `RefToBase<TrajectorySeed>` via **const** reference instead of non-const reference. This change allows temporary Ref objects be passed, e.g.

```
trackExtra.setSeedRef(edm::RefToBase<TrajectorySeed>(seedHandle, iSeed));
```

I encountered this issue while exploring something else and thought to commit it separately (as there are many dependent packages).

Tested in 8_0_0_pre5, purely technical, no changes expected.
