### PR TITLE
Adds option to EcalDeadCellTriggerPrimitiveFilter to consider kTPSaturated flag

### DIFF
--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -162,9 +162,6 @@ private:
 
   bool useTPmethod_, useHITmethod_;
 
-  bool exclusivelykTPSaturated_;
-  bool considerkTPSaturated_;
-
   void loadEventInfoForFilter(const edm::Event& iEvent);
 
 // Only for EB since the dead front-end has one-to-one map to TT

--- a/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
+++ b/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
@@ -24,5 +24,6 @@ EcalDeadCellTriggerPrimitiveFilter = cms.EDFilter(
     makeProfileRoot = cms.untracked.bool( False ),
     profileRootName = cms.untracked.string("deadCellFilterProfile.root" ),
 
-    modekTPSaturated = cms.int32 ( 0 )
+    useTTsum = cms.bool ( True ),
+    usekTPSaturated = cms.bool ( False)
 )

--- a/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
+++ b/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
@@ -24,4 +24,5 @@ EcalDeadCellTriggerPrimitiveFilter = cms.EDFilter(
     makeProfileRoot = cms.untracked.bool( False ),
     profileRootName = cms.untracked.string("deadCellFilterProfile.root" ),
 
+    modekTPSaturated = cms.int32 ( 0 )
 )


### PR DESCRIPTION
Ecal rechits have the flag, kTPSaturated, available. The filter has be updated and given a configurable option to consider this flag. The default configuration maintains the classical behavior.

Validation of the use of kTPSaturated is presented here: https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/2015D-EcalTP.pdf

Regards,
Ken Call
