### PR TITLE
Use consumes info to populate lookup tables

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -21,6 +21,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -51,6 +52,8 @@ namespace edm {
     void copyProduct(BranchDescription const& productdesc);
 
     void setFrozen(bool initializeLookupInfo = true);
+
+    void setFrozen(std::set<TypeID> const& typesConsumed);
 
     std::string merge(ProductRegistry const& other,
         std::string const& fileName,
@@ -165,7 +168,7 @@ namespace edm {
 
     void freezeIt(bool frozen = true) {transient_.frozen_ = frozen;}
 
-    void initializeLookupTables();
+    void initializeLookupTables(std::set<TypeID> const* typesConsumed);
     virtual void addCalled(BranchDescription const&, bool iFromListener);
     void throwIfNotFrozen() const;
     void throwIfFrozen() const;

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -53,6 +53,14 @@ namespace edm {
     EDConsumerBase() : frozen_(false) {}
     virtual ~EDConsumerBase();
     
+    // disallow copying
+    EDConsumerBase(EDConsumerBase const&) = delete;
+    EDConsumerBase const& operator=(EDConsumerBase const&) = delete;
+    
+    // allow moving
+    EDConsumerBase(EDConsumerBase&&) = default;
+    EDConsumerBase& operator=(EDConsumerBase&&) = default;
+
     // ---------- const member functions ---------------------
     ProductHolderIndexAndSkipBit indexFrom(EDGetToken, BranchType, TypeID const&) const;
 
@@ -139,10 +147,6 @@ namespace edm {
     }
 
   private:
-    EDConsumerBase(const EDConsumerBase&) = delete;
-    
-    const EDConsumerBase& operator=(const EDConsumerBase&) = delete;
-    
     unsigned int recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets);
 
     void throwTypeMismatch(edm::TypeID const&, EDGetToken) const;

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
 #include "FWCore/Framework/src/PrincipalCache.h"
 #include "FWCore/Framework/interface/ScheduleItems.h"
@@ -36,7 +37,7 @@ namespace edm {
   namespace eventsetup {
     class EventSetupsController;
   }
-  class SubProcess {
+  class SubProcess : public EDConsumerBase {
   public:
     SubProcess(ParameterSet& parameterSet,
                ParameterSet const& topLevelParameterSet,
@@ -291,7 +292,7 @@ namespace edm {
     std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
     std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
-    
+
     std::shared_ptr<ActivityRegistry>             actReg_; // We do not use propagate_const because the registry itself is mutable.
     ServiceToken                                  serviceToken_;
     std::shared_ptr<ProductRegistry const>        parentPreg_;
@@ -322,7 +323,6 @@ namespace edm {
     SelectedProductsForBranchType keptProducts_;
     ProductSelectorRules productSelectorRules_;
     ProductSelector productSelector_;
-
 
     //EventSelection
     bool wantAllEvents_;

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <map>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -55,7 +56,8 @@ namespace edm {
 
       void setup(std::vector<parsed_path_spec_t> const& path_specs,
 		 std::vector<std::string> const& triggernames,
-                 const std::string& process_name);
+                 std::string const& process_name,
+                 ConsumesCollector&& iC);
 
       bool wantEvent(EventPrincipal const& e, ModuleCallingContext const*);
 
@@ -69,7 +71,8 @@ namespace edm {
     bool configureEventSelector(edm::ParameterSet const& iPSet,
                                 std::string const& iProcessName,
                                 std::vector<std::string> const& iAllTriggerNames,
-                                edm::detail::TriggerResultsBasedEventSelector& oSelector);
+                                edm::detail::TriggerResultsBasedEventSelector& oSelector,
+                                edm::ConsumesCollector&& iC);
     /** Takes the user specified SelectEvents PSet and creates a new one
      which conforms to the canonical format required for provenance
      */

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -548,7 +548,7 @@ namespace edm {
       ep->postModuleDelayedGetSignal_.connect(std::cref(actReg_->postModuleEventDelayedGetSignal_));
       principalCache_.insert(ep);
     }
-    // initialize the subprocess, if there is one
+    // initialize the subprocesses, if there are any
     if(hasSubProcesses) {
       if(subProcesses_ == nullptr) {
         subProcesses_ = std::make_unique<std::vector<SubProcess> >();

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
@@ -65,7 +66,8 @@ namespace edm {
     wantAllEvents_ = detail::configureEventSelector(selectEvents_,
                                                           process_name_,
                                                           getAllTriggerNames(),
-                                                          selectors_[0]);
+                                                          selectors_[0],
+                                                          consumesCollector());
 
     SharedResourcesRegistry::instance()->registerSharedResource(
                                                                 SharedResourcesRegistry::kLegacyModuleResourceName);
@@ -183,7 +185,8 @@ namespace edm {
         detail::configureEventSelector(selectEvents_,
                                        process_name_,
                                        getAllTriggerNames(),
-                                       s);
+                                       s,
+                                       consumesCollector());
       }
       seenFirst = true;
     }

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -45,6 +45,7 @@ namespace edm {
                          serviceregistry::ServiceLegacy iLegacy,
                          PreallocationConfiguration const& preallocConfig,
                          ProcessContext const* parentProcessContext) :
+      EDConsumerBase(),
       serviceToken_(),
       parentPreg_(parentProductRegistry),
       preg_(),
@@ -75,7 +76,8 @@ namespace edm {
     wantAllEvents_ = detail::configureEventSelector(selectevents,
                                                     tns->getProcessName(),
                                                     getAllTriggerNames(),
-                                                    selectors_);
+                                                    selectors_,
+                                                    consumesCollector());
     std::map<std::string, std::vector<std::pair<std::string, int> > > outputModulePathPositions;
     selector_config_id_ = detail::registerProperSelectionInfo(selectevents,
                                                               "",

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -72,7 +72,8 @@ namespace edm {
       wantAllEvents_ = detail::configureEventSelector(selectEvents_,
                                                       process_name_,
                                                       getAllTriggerNames(),
-                                                      selectors_[0]);
+                                                      selectors_[0],
+                                                      consumesCollector());
 
     }
     
@@ -187,7 +188,8 @@ namespace edm {
           detail::configureEventSelector(selectEvents_,
                                          process_name_,
                                          getAllTriggerNames(),
-                                         s);
+                                         s,
+                                         consumesCollector());
         } else {
           seenFirst = true;
         }

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -74,7 +74,8 @@ namespace edm {
       wantAllEvents_ = detail::configureEventSelector(selectEvents_,
                                                       process_name_,
                                                       getAllTriggerNames(),
-                                                      selectors_[0]);
+                                                      selectors_[0],
+                                                      consumesCollector());
 
     }
     
@@ -193,7 +194,8 @@ namespace edm {
           detail::configureEventSelector(selectEvents_,
                                          process_name_,
                                          getAllTriggerNames(),
-                                         s);
+                                         s,
+                                         consumesCollector());
         } else {
           seenFirst = true;
         }

--- a/FWCore/Utilities/interface/RandomNumberGenerator.h
+++ b/FWCore/Utilities/interface/RandomNumberGenerator.h
@@ -137,6 +137,7 @@ namespace CLHEP {
 
 namespace edm {
 
+  class ConsumesCollector;
   class Event;
   class LuminosityBlock;
   class LuminosityBlockIndex;
@@ -182,6 +183,8 @@ namespace edm {
 
     virtual std::vector<RandomEngineState> const& getEventCache(StreamID const&) const = 0;
     virtual std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const = 0;
+
+    virtual void consumes(ConsumesCollector&& iC) const = 0;
 
     /// For debugging purposes only.
     virtual void print(std::ostream& os) const = 0;

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -14,6 +14,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
@@ -201,6 +202,12 @@ namespace edm {
     }
 
     RandomNumberGeneratorService::~RandomNumberGeneratorService() {
+    }
+
+    void
+    RandomNumberGeneratorService::consumes(ConsumesCollector&& iC) const {
+       iC.consumes<RandomEngineStates, InLumi>(restoreStateBeginLumiTag_);
+       iC.consumes<RandomEngineStates>(restoreStateTag_);
     }
 
     CLHEP::HepRandomEngine&

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -35,6 +35,7 @@ namespace CLHEP {
 namespace edm {
   class ActivityRegistry;
   class ConfigurationDescriptions;
+  class ConsumesCollector;
   class Event;
   class LuminosityBlock;
   class LuminosityBlockIndex;
@@ -109,6 +110,8 @@ namespace edm {
       /// These two are used by the RandomEngineStateProducer
       virtual std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const override;
       virtual std::vector<RandomEngineState> const& getEventCache(StreamID const&) const override;
+
+      virtual void consumes(ConsumesCollector&& iC) const override;
 
       /// For debugging
       virtual void print(std::ostream& os) const override;


### PR DESCRIPTION
Currently, the lookup tables used by getByLabel() or getByToken() are populated for all possible products or views, regardless of whether the products or views are consumed. This PR restricts the population of the lookup tables to those types that are actually consumed or produced.
This PR satisfies issue #12850 but it goes further in using the consumes info for all products, not just for views.
This PR also adds consumes information that was previously missing for output modules, and non-modules, such as the SubProcess class and the RandomNumberGenerator service.
