### PR TITLE
debugged MaterialBudgetAction and runP_*_cfg.py

### DIFF
--- a/Validation/Geometry/interface/MaterialBudgetAction.h
+++ b/Validation/Geometry/interface/MaterialBudgetAction.h
@@ -21,8 +21,10 @@
 class BeginOfTrack;
 class BeginOfRun;
 class BeginOfEvent;
+class EndOfEvent;
 class G4Step;
 class EndOfTrack;
+class EndOfRun;
 class G4StepPoint;
 class G4VTouchable;
 
@@ -30,7 +32,8 @@ class MaterialBudgetAction : public SimWatcher,
                              public Observer<const BeginOfRun*>,
 			     public Observer<const BeginOfTrack*>,
 			     public Observer<const G4Step*>,
-			     public Observer<const EndOfTrack*>
+                             public Observer<const EndOfTrack*>,
+			     public Observer<const EndOfRun*>
 {
  public:
   MaterialBudgetAction(const edm::ParameterSet&);
@@ -45,6 +48,7 @@ class MaterialBudgetAction : public SimWatcher,
   void update(const BeginOfTrack*);
   void update(const G4Step*);
   void update(const EndOfTrack*);
+  void update(const EndOfRun*);
   
   bool CheckTouchableInSelectedVolumes( const G4VTouchable* touch );
   bool StopAfterProcess( const G4Step* aStep );

--- a/Validation/Geometry/python/single_neutrino_cfg.py
+++ b/Validation/Geometry/python/single_neutrino_cfg.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TestProcess")
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+process.load("IOMC.EventVertexGenerators.VtxSmearedFlat_cfi")
+process.load("GeneratorInterface.Core.generatorSmeared_cfi")
 
 process.load("Configuration.EventContent.EventContent_cff")
 
@@ -11,6 +13,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.generator.initialSeed = 456789
+process.RandomNumberGeneratorService.VtxSmeared.engineName = cms.untracked.string('HepJamesRandom')
+process.RandomNumberGeneratorService.VtxSmeared.initialSeed = cms.untracked.uint32(98765432)
 
 process.source = cms.Source("EmptySource",
     firstRun        = cms.untracked.uint32(1),
@@ -36,6 +40,6 @@ process.o1 = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('single_neutrino_random.root')
 )
 
-process.p1 = cms.Path(process.generator)
+process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmeared)
 process.outpath = cms.EndPath(process.o1)
 

--- a/Validation/Geometry/src/MaterialBudgetAction.cc
+++ b/Validation/Geometry/src/MaterialBudgetAction.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimG4Core/Notification/interface/BeginOfRun.h"
+#include "SimG4Core/Notification/interface/EndOfRun.h"
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
 #include "SimG4Core/Notification/interface/EndOfTrack.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
@@ -123,11 +124,6 @@ MaterialBudgetAction::MaterialBudgetAction(const edm::ParameterSet& iPSet)
 //-------------------------------------------------------------------------
 MaterialBudgetAction::~MaterialBudgetAction()
 {
-  if (saveToTxt) delete theTxt;
-  if (saveToTree) delete theTree;
-  if (saveToHistos) delete theHistos;
-  if (theHistoMgr) delete theHistoMgr;
-  delete theData;
 }
 
 //-------------------------------------------------------------------------
@@ -309,6 +305,17 @@ void MaterialBudgetAction::update(const EndOfTrack* trk)
   if (saveToTree) theTree->fillEndTrack();
   if (saveToHistos) theHistos->fillEndTrack();
   if (saveToTxt) theTxt->fillEndTrack();  
+}
+
+//-------------------------------------------------------------------------
+void MaterialBudgetAction::update(const EndOfRun* )
+{
+  if (saveToTxt) delete theTxt;
+  if (saveToTree) delete theTree;
+  if (saveToHistos) delete theHistos;
+  if (theHistoMgr) delete theHistoMgr;
+  delete theData;
+  return;
 }
 
 //-------------------------------------------------------------------------

--- a/Validation/Geometry/test/runP_BeamPipe_cfg.py
+++ b/Validation/Geometry/test/runP_BeamPipe_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_BeamPipe_cfg.py
+++ b/Validation/Geometry/test/runP_BeamPipe_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_InnerServices_cfg.py
+++ b/Validation/Geometry/test/runP_InnerServices_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_InnerServices_cfg.py
+++ b/Validation/Geometry/test/runP_InnerServices_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_PixBar_cfg.py
+++ b/Validation/Geometry/test/runP_PixBar_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_PixBar_cfg.py
+++ b/Validation/Geometry/test/runP_PixBar_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_PixFwdMinus_cfg.py
+++ b/Validation/Geometry/test/runP_PixFwdMinus_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_PixFwdMinus_cfg.py
+++ b/Validation/Geometry/test/runP_PixFwdMinus_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_PixFwdPlus_cfg.py
+++ b/Validation/Geometry/test/runP_PixFwdPlus_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_PixFwdPlus_cfg.py
+++ b/Validation/Geometry/test/runP_PixFwdPlus_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_TEC_cfg.py
+++ b/Validation/Geometry/test/runP_TEC_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TEC_cfg.py
+++ b/Validation/Geometry/test/runP_TEC_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_TIB_cfg.py
+++ b/Validation/Geometry/test/runP_TIB_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TIB_cfg.py
+++ b/Validation/Geometry/test/runP_TIB_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_TIDB_cfg.py
+++ b/Validation/Geometry/test/runP_TIDB_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TIDB_cfg.py
+++ b/Validation/Geometry/test/runP_TIDB_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_TIDF_cfg.py
+++ b/Validation/Geometry/test/runP_TIDF_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TIDF_cfg.py
+++ b/Validation/Geometry/test/runP_TIDF_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_TOB_cfg.py
+++ b/Validation/Geometry/test/runP_TOB_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TOB_cfg.py
+++ b/Validation/Geometry/test/runP_TOB_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_TkStrct_cfg.py
+++ b/Validation/Geometry/test/runP_TkStrct_cfg.py
@@ -6,9 +6,10 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TkStrct_cfg.py
+++ b/Validation/Geometry/test/runP_TkStrct_cfg.py
@@ -6,7 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")

--- a/Validation/Geometry/test/runP_Tracker_cfg.py
+++ b/Validation/Geometry/test/runP_Tracker_cfg.py
@@ -3,10 +3,12 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PROD")
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
-
 #Geometry
 #
-process.load("Configuration.Geometry.GeometryExtended_cff")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #
@@ -60,7 +62,7 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
         TreeFile = cms.string('None'), ## is NOT requested
 
         StopAfterProcess = cms.string('None'),
-        # string TextFile = "matbdg_Tracker.txt"
+#        TextFile = cms.string("matbdg_Tracker.txt")
         TextFile = cms.string('None')
     )
 ))

--- a/Validation/Geometry/test/runP_Tracker_cfg.py
+++ b/Validation/Geometry/test/runP_Tracker_cfg.py
@@ -5,7 +5,7 @@ process = cms.Process("PROD")
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_cfi")
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.HcalCommonData.hcalParameters_cfi")
 process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
@@ -43,7 +43,7 @@ process.source = cms.Source("PoolSource",
 )
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(5)
 )
 
 process.p1 = cms.Path(process.g4SimHits)


### PR DESCRIPTION
These changes consist of debugging the material budget validation package in Validation/Geometry, which was found to be malfunctioning in CMSSW_8_X_Y. Modifications:
- fixed neutrino gun generator (added smeared HepMCProduct)
- fixed test/runP_*_cfg.py to load necessary cfi files
- fixed MaterialBudgetAction.cc and MaterialBudgetAction.h so that output root files are saved at the end of the run
