### PR TITLE
Use correct python version

### DIFF
--- a/Alignment/MuonAlignment/python/geometryDiff.py
+++ b/Alignment/MuonAlignment/python/geometryDiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from Alignment.MuonAlignment.geometryXMLparser import MuonGeometry, dtorder, cscorder
 import sys, getopt

--- a/Alignment/MuonAlignment/python/geometryXMLparser.py
+++ b/Alignment/MuonAlignment/python/geometryXMLparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # XML must come from MuonGeometryDBConverter; not hand-made
 # Example configuration that will work

--- a/CalibTracker/SiStripESProducers/test/python/CheckAllIOVs.py
+++ b/CalibTracker/SiStripESProducers/test/python/CheckAllIOVs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """ Helper functions for time conversions """
 

--- a/CondFormats/MFObjects/test/writeAllMagFieldConfigDB.py
+++ b/CondFormats/MFObjects/test/writeAllMagFieldConfigDB.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/DQMOffline/JetMET/test/publish/make_html_output.py
+++ b/DQMOffline/JetMET/test/publish/make_html_output.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-#!/usr/bin/python
-
 import ROOT
 import sys,os,string,errno,shutil
 import code

--- a/DQMServices/Diagnostic/scripts/Database/Python/WatchDog.sh
+++ b/DQMServices/Diagnostic/scripts/Database/Python/WatchDog.sh
@@ -12,7 +12,7 @@ Dir=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/HDQM/Cron/Scripts/RunSelection/Test
 PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg" | awk '{print $1}'`
 if [ ! "${PID}" ]; then
     echo "HDQMDatabaseProducer.py for StreamExpress not running, restarting it at" `date`
-    /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg
+    /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg
 else
     echo "HDQMDatabaseProducer.py for StreamExpress still running at" `date`
 fi
@@ -21,7 +21,7 @@ fi
 PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg" | awk '{print $1}'`
 if [ ! "${PID}" ]; then
     echo "HDQMDatabaseProducer.py for MinimumBias not running, restarting it at" `date`
-    /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg
+    /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg
 else
     echo "HDQMDatabaseProducer.py for MinimumBias still running at" `date`
 fi
@@ -30,7 +30,7 @@ fi
 PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg" | awk '{print $1}'`
 if [ ! "${PID}" ]; then
     echo "HDQMDatabaseProducer.py for Cosmics not running, restarting it at" `date`
-    /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg
+    /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg
 else
     echo "HDQMDatabaseProducer.py for Cosmics still running at" `date`
 fi
@@ -53,9 +53,9 @@ if [ ! "${PID1}" ]; then
 		    if [ ! "${PIDRPC3}" ]; then
 
 			echo "HDQMDatabaseProducer.py for StreamExpress not running, restarting it at" `date`
-			/usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpressRPC.cfg
-			/usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBiasRPC.cfg
-			/usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_CosmicsRPC.cfg
+			/usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpressRPC.cfg
+			/usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBiasRPC.cfg
+			/usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_CosmicsRPC.cfg
 		    fi
 		fi
 	    fi

--- a/DQMServices/Diagnostic/scripts/Database/Python/WatchDog_singleJob.sh
+++ b/DQMServices/Diagnostic/scripts/Database/Python/WatchDog_singleJob.sh
@@ -13,7 +13,7 @@ Dir=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/HDQM/Cron/Scripts/RunSelection/Test
 # PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py" | awk '{print $1}'`
 # if [ ! "${PID}" ]; then
 #     echo "HDQMDatabaseProducer.py for StreamExpress not running, restarting it at" `date`
-#     /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg
+#     /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg
 # else
 #     echo "HDQMDatabaseProducer.py for StreamExpress still running at" `date`
 # fi
@@ -23,7 +23,7 @@ Dir=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/HDQM/Cron/Scripts/RunSelection/Test
 # PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py" | awk '{print $1}'`
 # if [ ! "${PID}" ]; then
 #     echo "HDQMDatabaseProducer.py for MinimumBias not running, restarting it at" `date`
-#     /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg
+#     /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg
 # else
 #     echo "HDQMDatabaseProducer.py for MinimumBias still running at" `date`
 # fi
@@ -33,7 +33,7 @@ Dir=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/HDQM/Cron/Scripts/RunSelection/Test
 # PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py" | awk '{print $1}'`
 # if [ ! "${PID}" ]; then
 #     echo "HDQMDatabaseProducer.py for Cosmics not running, restarting it at" `date`
-#     /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg
+#     /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg
 # else
 #     echo "HDQMDatabaseProducer.py for Cosmics still running at" `date`
 # fi
@@ -42,9 +42,9 @@ PID=`ps ax | grep -v grep | grep "${Dir}/HDQMDatabaseProducer.py" | awk '{print 
 echo "PID = ${PID}"
 if [ ! "${PID}" ]; then
     echo "HDQMDatabaseProducer.py not running, starting it at" `date`
-    /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg
-    /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg
-    /usr/bin/python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg
+    /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_StreamExpress.cfg
+    /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_MinimumBias.cfg
+    /usr/bin/env python ${Dir}/HDQMDatabaseProducer.py ${Dir}/HDQMDatabaseProducerConfiguration_Cosmics.cfg
 else
     echo "HDQMDatabaseProducer.py still running at" `date`
 fi

--- a/HLTrigger/HLTanalyzers/test/CreateCFGs.py
+++ b/HLTrigger/HLTanalyzers/test/CreateCFGs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 
 import sys,string,time,os

--- a/HLTrigger/HLTanalyzers/test/CreateFileLists.py
+++ b/HLTrigger/HLTanalyzers/test/CreateFileLists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 
 import sys,string,time,os

--- a/HLTrigger/HLTanalyzers/test/RateEff/findL1SeedsFromHLThtml.py
+++ b/HLTrigger/HLTanalyzers/test/RateEff/findL1SeedsFromHLThtml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys,HTMLTableParser
 

--- a/HLTrigger/HLTanalyzers/test/RateEff/printPathsFromHLThtml.py
+++ b/HLTrigger/HLTanalyzers/test/RateEff/printPathsFromHLThtml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #import pprint
 import sys,HTMLTableParser

--- a/HLTrigger/HLTanalyzers/test/rates/findL1SeedsFromHLThtml.py
+++ b/HLTrigger/HLTanalyzers/test/rates/findL1SeedsFromHLThtml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys,HTMLTableParser
 

--- a/HLTrigger/HLTanalyzers/test/rates/printPathsFromHLThtml.py
+++ b/HLTrigger/HLTanalyzers/test/rates/printPathsFromHLThtml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #import pprint
 import sys,HTMLTableParser

--- a/RecoLuminosity/LumiDB/scripts/lumiDBFiller.py
+++ b/RecoLuminosity/LumiDB/scripts/lumiDBFiller.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 
 import string, os, time,re
 import commands

--- a/RecoLuminosity/LumiDB/test/loadValidationByDir.py
+++ b/RecoLuminosity/LumiDB/test/loadValidationByDir.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 import os,os.path,sys,fnmatch,commands
 dbname='oracle://cms_orcon_prod/cms_lumi_prod'
 authpath='/home/lumidb/auth/writer'

--- a/Utilities/RelMon/python/web/app_utils.py
+++ b/Utilities/RelMon/python/web/app_utils.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8
 '''
 Helper functions for CherryPy application ``browse_db.py``.

--- a/Utilities/RelMon/python/web/browse_db.py
+++ b/Utilities/RelMon/python/web/browse_db.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8
 '''
 CherryPy application, which enables dynamic SQLite3 database file with release

--- a/Utilities/RelMon/python/web/dbfile2html.py
+++ b/Utilities/RelMon/python/web/dbfile2html.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8
 '''
 Generates static HTML for the given database file.

--- a/Validation/CaloTowers/test/macros/RelValHarvest.py
+++ b/Validation/CaloTowers/test/macros/RelValHarvest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys, os
 

--- a/Validation/Performance/scripts/cmsBenchmark.py
+++ b/Validation/Performance/scripts/cmsBenchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Usage: ./cmsBenchmark.py [options]
        

--- a/Validation/RecoEgamma/test/makeWebpage.py
+++ b/Validation/RecoEgamma/test/makeWebpage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ## This script writes an index.html page
 ## displaying all plots contained in the 


### PR DESCRIPTION
If "/usr/bin/python" is hard coded, the version of python used may not match the intended CMS version.
This has been causing problems in /afs.
This PR replaces "/usr/bin/python" with "/usr/bin/env python", so that the intended version of python will be used.
