### PR TITLE
Support ESProducrs returning std::unique_ptr.

### DIFF
--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -18,16 +18,17 @@
     If only one algorithm is being encapsulated then the user needs to
       1) add a method name 'produce' to the class.  The 'produce' takes as its argument a const reference
          to the record that is to hold the data item being produced.  If only one data item is being produced,
-         the 'produce' method must return either an 'std::auto_ptr' or 'std::shared_ptr' to the object being
+         the 'produce' method must return either an 'std::unique_ptr' or 'std::shared_ptr' to the object being
          produced.  (The choice depends on if the EventSetup or the ESProducer is managing the lifetime of 
          the object).  If multiple items are being Produced they the 'produce' method must return an
          ESProducts<> object which holds all of the items.
+         Note: std::auto_ptr and boost::shared_ptr are also supported, but are deprecated.
       2) add 'setWhatProduced(this);' to their classes constructor
 
 Example: one algorithm creating only one object
 \code
     class FooProd : public edm::ESProducer {
-       std::auto_ptr<Foo> produce(const FooRecord&);
+       std::unique_ptr<Foo> produce(const FooRecord&);
        ...
     };
     FooProd::FooProd(const edm::ParameterSet&) {
@@ -38,7 +39,7 @@ Example: one algorithm creating only one object
 Example: one algorithm creating two objects
 \code
    class FoosProd : public edm::ESProducer {
-      edm::ESProducts<std::auto_ptr<Foo1>, std::auto_ptr<Foo2> > produce(const FooRecord&);
+      edm::ESProducts<std::unique_ptr<Foo1>, std::unique_ptr<Foo2> > produce(const FooRecord&);
       ...
    };
 \endcode
@@ -51,8 +52,8 @@ Example: one algorithm creating two objects
 Example: two algorithms each creating only one objects
 \code
    class FooBarProd : public edm::eventsetup::ESProducer {
-      std::auto_ptr<Foo> produceFoo(const FooRecord&);
-      std::auto_ptr<Bar> produceBar(const BarRecord&);
+      std::unique_ptr<Foo> produceFoo(const FooRecord&);
+      std::unique_ptr<Bar> produceBar(const BarRecord&);
       ...
    };
    FooBarProd::FooBarProd(const edm::ParameterSet&) {

--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -34,6 +34,10 @@ namespace edm {
        iTo = iFrom;
      }
 
+     template<typename FromT, typename ToT> void copyFromTo(std::unique_ptr<FromT>& iFrom, ToT & iTo) {
+       iTo = std::move(iFrom);
+     }
+
      namespace produce { 
          struct Null {};
          template <typename T> struct EndList {
@@ -48,6 +52,9 @@ namespace edm {
          };
          template< typename T> struct product_traits<std::auto_ptr<T> > {
             typedef EndList<std::auto_ptr<T> > type;
+         };
+         template< typename T> struct product_traits<std::unique_ptr<T> > {
+            typedef EndList<std::unique_ptr<T> > type;
          };
          template< typename T> struct product_traits<boost::shared_ptr<T> > {
             typedef EndList<boost::shared_ptr<T> > type;
@@ -81,8 +88,11 @@ namespace edm {
             iTo = iFrom;
          }
 
-         
-         
+         template<typename FromT, typename ToT> void copyFromTo(std::unique_ptr<FromT>& iFrom, ToT & iTo) {
+           iTo = std::move(iFrom);
+         }
+
+
          template<typename ContainerT, typename EntryT, typename FindT> struct find_index_impl {
             typedef typename product_traits<ContainerT>::type container_type;
             enum { value = find_index_impl<typename container_type::head_type, typename container_type::tail_type,  FindT>::value + 1 };

--- a/FWCore/Framework/test/DummyEventSetupRecordRetriever.h
+++ b/FWCore/Framework/test/DummyEventSetupRecordRetriever.h
@@ -40,8 +40,8 @@ namespace edm {
          setWhatProduced(this);
       }
       
-      std::auto_ptr<DummyEventSetupData> produce(const DummyEventSetupRecord&) {
-         std::auto_ptr<DummyEventSetupData> data(new DummyEventSetupData(1));
+      std::unique_ptr<DummyEventSetupData> produce(const DummyEventSetupRecord&) {
+         std::unique_ptr<DummyEventSetupData> data(new DummyEventSetupData(1));
          return data;
       }
    protected:

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -29,6 +29,8 @@ CPPUNIT_TEST_SUITE(testEsproducer);
 CPPUNIT_TEST(registerTest);
 CPPUNIT_TEST(getFromTest);
 CPPUNIT_TEST(getfromShareTest);
+CPPUNIT_TEST(getfromUniqueTest);
+CPPUNIT_TEST(getfromAutoTest);
 CPPUNIT_TEST(decoratorTest);
 CPPUNIT_TEST(dependsOnTest);
 CPPUNIT_TEST(labelTest);
@@ -43,6 +45,8 @@ public:
   void registerTest();
   void getFromTest();
   void getfromShareTest();
+  void getfromUniqueTest();
+  void getfromAutoTest();
   void decoratorTest();
   void dependsOnTest();
   void labelTest();
@@ -58,7 +62,6 @@ public:
    }
    const DummyData* produce(const DummyRecord& /*iRecord*/) {
       ++data_.value_;
-      std::cout <<"produce called "<<data_.value_<<std::endl;
       return &data_;
    }
 private:
@@ -78,7 +81,6 @@ private:
    DummyData data_;
 };
 
-
 class ShareProducer : public ESProducer {
 public:
    ShareProducer(): ptr_(new DummyData){
@@ -87,11 +89,38 @@ public:
    }
    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
-      std::cout <<"produce called "<<ptr_->value_<<std::endl;
       return ptr_;
    }
 private:
    std::shared_ptr<DummyData> ptr_;
+};
+
+class UniqueProducer : public ESProducer {
+public:
+   UniqueProducer() {
+      setWhatProduced(this);
+   }
+   std::unique_ptr<DummyData> produce(const DummyRecord&) {
+      ++data_.value_;
+      std::unique_ptr<DummyData> ptr(new DummyData(data_));
+      return std::move(ptr);
+   }
+private:
+   DummyData data_;
+};
+
+class AutoProducer : public ESProducer {
+public:
+   AutoProducer() {
+      setWhatProduced(this);
+   }
+   std::auto_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+      ++data_.value_;
+      std::auto_ptr<DummyData> ptr(new DummyData(data_));
+      return ptr;
+   }
+private:
+   DummyData data_;
 };
 
 class LabelledProducer : public ESProducer {
@@ -107,7 +136,6 @@ public:
    
    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
-      std::cout <<"\"foo\" produce called "<<ptr_->value_<<std::endl;
       return ptr_;
    }
    
@@ -161,7 +189,6 @@ void testEsproducer::getFromTest()
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
    }
 }
@@ -183,7 +210,48 @@ void testEsproducer::getfromShareTest()
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
+      CPPUNIT_ASSERT(iTime == pDummy->value_);
+   }
+}
+
+void testEsproducer::getfromUniqueTest()
+{
+   EventSetupProvider provider;
+   
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<UniqueProducer>();
+   provider.add(pProxyProv);
+   
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   
+   for(int iTime=1; iTime != 6; ++iTime) {
+      const edm::Timestamp time(iTime);
+      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
+      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+      edm::ESHandle<DummyData> pDummy;
+      eventSetup.get<DummyRecord>().get(pDummy);
+      CPPUNIT_ASSERT(0 != pDummy.product());
+      CPPUNIT_ASSERT(iTime == pDummy->value_);
+   }
+}
+
+void testEsproducer::getfromAutoTest()
+{
+   EventSetupProvider provider;
+   
+   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<AutoProducer>();
+   provider.add(pProxyProv);
+   
+   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
+   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+   
+   for(int iTime=1; iTime != 6; ++iTime) {
+      const edm::Timestamp time(iTime);
+      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
+      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+      edm::ESHandle<DummyData> pDummy;
+      eventSetup.get<DummyRecord>().get(pDummy);
+      CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
    }
 }
@@ -206,17 +274,14 @@ void testEsproducer::labelTest()
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get("foo",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
       
       eventSetup.get<DummyRecord>().get("fi",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
       
       eventSetup.get<DummyRecord>().get("fum",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
    }
    } catch(const cms::Exception& iException) {
@@ -249,7 +314,6 @@ public:
    }
    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
-      std::cout <<"produce called "<<ptr_->value_<<std::endl;
       return ptr_;
    }
 private:
@@ -276,7 +340,6 @@ void testEsproducer::decoratorTest()
       CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_post);
       eventSetup.get<DummyRecord>().get(pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<"pre "<<TestDecorator::s_pre << " post " << TestDecorator::s_post << std::endl;
       CPPUNIT_ASSERT(iTime == TestDecorator::s_pre);
       CPPUNIT_ASSERT(iTime == TestDecorator::s_post);
       CPPUNIT_ASSERT(iTime == pDummy->value_);
@@ -296,15 +359,12 @@ public:
    }
    void callWhenDummyChanges(const DummyRecord&) {
       ++ptr_->value_;
-      std::cout <<"callWhenDummyChanges called "<<ptr_->value_<<std::endl;
    }
    void callWhenDummyChanges2(const DummyRecord&) {
       ++ptr_->value_;
-      std::cout <<"callWhenDummyChanges2 called "<<ptr_->value_<<std::endl;
    }
    void callWhenDummyChanges3(const DummyRecord&) {
       ++ptr_->value_;
-      std::cout <<"callWhenDummyChanges3 called "<<ptr_->value_<<std::endl;
    }
    
 private:
@@ -355,7 +415,6 @@ void testEsproducer::forceCacheClearTest()
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(1 == pDummy->value_);
    }
    provider.forceCacheClear();
@@ -363,7 +422,6 @@ void testEsproducer::forceCacheClearTest()
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
-      std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(2 == pDummy->value_);
    }
 }

--- a/FWCore/Integration/test/DoodadESProducer.cc
+++ b/FWCore/Integration/test/DoodadESProducer.cc
@@ -37,7 +37,7 @@ class DoodadESProducer : public edm::ESProducer {
       DoodadESProducer(edm::ParameterSet const&);
       ~DoodadESProducer();
 
-      typedef std::auto_ptr<Doodad> ReturnType;
+      typedef std::unique_ptr<Doodad> ReturnType;
 
       ReturnType produce(GadgetRcd const&);
    private:
@@ -83,7 +83,7 @@ DoodadESProducer::produce(GadgetRcd const& /*iRecord*/) {
 
    using namespace edmtest;
 
-   std::auto_ptr<Doodad> pDoodad(new Doodad) ;
+   std::unique_ptr<Doodad> pDoodad(new Doodad) ;
 
    pDoodad->a = 1;
 

--- a/FWCore/Integration/test/DoodadESSource.cc
+++ b/FWCore/Integration/test/DoodadESSource.cc
@@ -32,7 +32,7 @@ class DoodadESSource :
 public:
    DoodadESSource(edm::ParameterSet const& pset);
    
-   std::auto_ptr<Doodad> produce(const GadgetRcd&) ;
+   std::unique_ptr<Doodad> produce(const GadgetRcd&) ;
 
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -82,9 +82,9 @@ DoodadESSource::DoodadESSource(edm::ParameterSet const& pset)
 // member functions
 //
 
-std::auto_ptr<Doodad> 
+std::unique_ptr<Doodad> 
 DoodadESSource::produce(const GadgetRcd&) {
-   std::auto_ptr<Doodad> data(new Doodad());
+   std::unique_ptr<Doodad> data(new Doodad());
    data->a = nCalls_;
    ++nCalls_;
    return data;

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -43,7 +43,7 @@ class WhatsItESProducer : public edm::ESProducer {
       WhatsItESProducer(edm::ParameterSet const& pset);
       ~WhatsItESProducer();
 
-      typedef std::auto_ptr<WhatsIt> ReturnType;
+      typedef std::unique_ptr<WhatsIt> ReturnType;
 
       ReturnType produce(const GadgetRcd &);
 
@@ -103,7 +103,7 @@ WhatsItESProducer::produce(const GadgetRcd& iRecord)
    edm::ESHandle<Doodad> doodad;
    iRecord.get(dataLabel_,doodad);
    
-   std::auto_ptr<WhatsIt> pWhatsIt(new WhatsIt) ;
+   std::unique_ptr<WhatsIt> pWhatsIt(new WhatsIt) ;
 
    pWhatsIt->a = doodad->a;
 


### PR DESCRIPTION
ESProducers can return a shared_ptr or an auto_ptr to the produced product. This PR adds the ability for an ESProducer to return a unique_ptr to the product.
This should complete the solution of issue #13114
