### PR TITLE
FastSim: fix L1 muons

### DIFF
--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -174,7 +174,12 @@ def loadTriggerDigiAliases():
                 cms.VPSet(
                 cms.PSet(type = cms.string("L1GlobalTriggerEvmReadoutRecord")),
                 cms.PSet(type = cms.string("L1GlobalTriggerObjectMapRecord")),
-                cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord")))})
+                cms.PSet(type = cms.string("L1GlobalTriggerReadoutRecord"))),
+            "simGmtDigis" :
+                cms.VPSet(
+                cms.PSet(type = cms.string("L1MuGMTReadoutCollection")),
+                cms.PSet(type = cms.string("L1MuGMTCands")))
+            })
     
 
     gmtDigis = cms.EDAlias (

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 def dropSimDigis(outputCommands):
     outputCommands.append("drop *_sim*Digis*_*_*")
+    outputCommands.append("drop *_gmtDigis*_*_*")
  
 extraPremixContent = ['keep *_mix_generalTracks_*']
 


### PR DESCRIPTION
make L1 muon collections available under the same label as in FullSim and data
