### PR TITLE
add HLTJetL1TMatchProducer as simplified stage2L1-version - backport of #13468

### DIFF
--- a/HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h
+++ b/HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h
@@ -1,0 +1,37 @@
+#ifndef HLTJetL1TMatchProducer_h
+#define HLTJetL1TMatchProducer_h
+
+#include <string>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/TrackJetCollection.h"
+#include "DataFormats/JetReco/interface/BasicJetCollection.h"
+
+template<typename T>
+class HLTJetL1TMatchProducer : public edm::stream::EDProducer<> {
+ public:
+  explicit HLTJetL1TMatchProducer(const edm::ParameterSet&);
+  ~HLTJetL1TMatchProducer();
+  static  void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  virtual void beginJob() ; 
+  virtual void produce(edm::Event &, const edm::EventSetup&);
+ private:
+  edm::EDGetTokenT<std::vector<T>> m_theJetToken;
+  edm::EDGetTokenT<l1t::JetBxCollection> m_theL1JetToken;
+  edm::InputTag jetsInput_;
+  edm::InputTag L1Jets_;
+  //  std::string jetType_;
+  double DeltaR_;         // DeltaR(HLT,L1)
+};
+
+#endif

--- a/HLTrigger/JetMET/plugins/SealModule.cc
+++ b/HLTrigger/JetMET/plugins/SealModule.cc
@@ -58,6 +58,9 @@
 #include "HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h"
 #include "HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc"
 //
+#include "HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h"
+#include "HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc"
+//
 #include "HLTrigger/JetMET/interface/HLTMonoJetFilter.h"
 #include "HLTrigger/JetMET/src/HLTMonoJetFilter.cc"
 //
@@ -117,6 +120,9 @@ typedef HLTJetSortedVBFFilter<  PFJet> HLTPFJetSortedVBFFilter;
 
 typedef HLTJetL1MatchProducer<CaloJet> HLTCaloJetL1MatchProducer;
 typedef HLTJetL1MatchProducer<  PFJet> HLTPFJetL1MatchProducer;
+
+typedef HLTJetL1TMatchProducer<CaloJet> HLTCaloJetL1TMatchProducer;
+typedef HLTJetL1TMatchProducer<  PFJet> HLTPFJetL1TMatchProducer;
 
 typedef HLTMonoJetFilter<CaloJet> HLTMonoCaloJetFilter;
 typedef HLTMonoJetFilter<  PFJet> HLTMonoPFJetFilter;
@@ -227,6 +233,9 @@ DEFINE_FWK_MODULE(HLTPFJetEtaTopologyFilter);
 
 DEFINE_FWK_MODULE(HLTCaloJetL1MatchProducer);
 DEFINE_FWK_MODULE(HLTPFJetL1MatchProducer);
+
+DEFINE_FWK_MODULE(HLTCaloJetL1TMatchProducer);
+DEFINE_FWK_MODULE(HLTPFJetL1TMatchProducer);
 
 DEFINE_FWK_MODULE(HLTCaloJetVBFFilter);
 DEFINE_FWK_MODULE(HLTPFJetVBFFilter);

--- a/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
@@ -68,13 +68,11 @@ void HLTJetL1TMatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetu
       for (int ibx = l1Jets->getFirstBX(); ibx <= l1Jets->getLastBX(); ++ibx) {
 	if (trigger_bx_only && (ibx != 0)) continue;  
 	for (auto it=l1Jets->begin(ibx); it!=l1Jets->end(ibx); it++){
+	  if (it->et() == 0) continue; // if you don't care about L1T candidates with zero ET.
 	  const double deltaeta=jet_iter->eta()-it->eta();
 	  const double deltaphi=deltaPhi(jet_iter->phi(),it->phi());
 	  if (sqrt(deltaeta*deltaeta+deltaphi*deltaphi) < DeltaR_) isMatched=true;
-
-	  
-	  if (it->et() == 0) continue; // if you don't care about L1T candidates with zero ET.
-	  cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
+	  //cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
 	}
       }
       if (isMatched==true) result->push_back(*jet_iter);

--- a/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
@@ -1,0 +1,83 @@
+#include <string>
+
+#include "HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
+template<typename T>
+HLTJetL1TMatchProducer<T>::HLTJetL1TMatchProducer(const edm::ParameterSet& iConfig)
+{
+  jetsInput_ = iConfig.template getParameter<edm::InputTag>("jetsInput");
+  L1Jets_ = iConfig.template getParameter<edm::InputTag>("L1Jets");
+  DeltaR_ = iConfig.template getParameter<double>("DeltaR");
+
+  typedef std::vector<T> TCollection;
+  m_theJetToken = consumes<TCollection>(jetsInput_);
+  m_theL1JetToken = consumes<l1t::JetBxCollection>(L1Jets_);
+  produces<TCollection> ();
+
+}
+
+template<typename T>
+void HLTJetL1TMatchProducer<T>::beginJob()
+{
+
+}
+
+template<typename T>
+HLTJetL1TMatchProducer<T>::~HLTJetL1TMatchProducer()
+{
+
+}
+
+template<typename T>
+void HLTJetL1TMatchProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("jetsInput",edm::InputTag("hltAntiKT5PFJets"));
+  desc.add<edm::InputTag>("L1Jets",edm::InputTag("hltCaloStage2Digis"));
+  desc.add<double>("DeltaR",0.5);
+  descriptions.add(defaultModuleLabel<HLTJetL1TMatchProducer<T>>(), desc);
+}
+
+template<typename T>
+void HLTJetL1TMatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  typedef std::vector<T> TCollection;
+
+  edm::Handle<TCollection> jets;
+  iEvent.getByToken(m_theJetToken, jets);
+
+  std::auto_ptr<TCollection> result (new TCollection);
+
+
+  edm::Handle<l1t::JetBxCollection> l1Jets;
+  iEvent.getByToken(m_theL1JetToken,l1Jets);
+
+  typename TCollection::const_iterator jet_iter;
+  for (jet_iter = jets->begin(); jet_iter != jets->end(); ++jet_iter) {
+
+    bool isMatched=false;
+
+    for (unsigned int jetc=0;jetc<l1Jets->size();++jetc)
+    {
+      const double deltaeta=jet_iter->eta()-(*l1Jets)[jetc].eta();
+      const double deltaphi=deltaPhi(jet_iter->phi(),(*l1Jets)[jetc].phi());
+      if (sqrt(deltaeta*deltaeta+deltaphi*deltaphi) < DeltaR_) isMatched=true;
+    }
+
+
+    if (isMatched==true) result->push_back(*jet_iter);
+
+  } // jet_iter
+
+  iEvent.put( result);
+
+}
+
+


### PR DESCRIPTION
add HLTJetL1TMatchProducer as simplified stage2L1-version with corresponding filldescriptions and dropped Tau/Central/Forward inputs
