### PR TITLE
Improve print_trace in DQMStore

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -791,7 +791,7 @@ DQMStore::book(const std::string &dir, const std::string &name,
                HISTO *h, COLLATE collate)
 {
   assert(name.find('/') == std::string::npos);
-  //if (verbose_ > 3)
+  if (verbose_ > 3)
     print_trace(dir, name);
   std::string path;
   mergePath(path, dir, name);
@@ -860,7 +860,7 @@ DQMStore::book(const std::string &dir,
                const char *context)
 {
   assert(name.find('/') == std::string::npos);
-  //if (verbose_ > 3)
+  if (verbose_ > 3)
     print_trace(dir, name);
 
   // Check if the request monitor element already exists.


### PR DESCRIPTION
The DQMStore supports logging the caller for all booking calls, which can be very useful to understand what the DQM codebase is doing.

This PR improves this functionality by searching for the first “interesting” caller in the stack trace. The previous implementation sometimes reported helpers within the DQMStore, or functions with missing debug symbols that could not be printed. With these improvements, it gives a meaningful attribution for all histogram bookings.
