### PR TITLE
Migrate 2017 tracking to eras

### DIFF
--- a/RecoMuon/Configuration/python/DisplacedMuonSeededStep_cff.py
+++ b/RecoMuon/Configuration/python/DisplacedMuonSeededStep_cff.py
@@ -2,16 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 ###### Muon reconstruction module #####
 from RecoMuon.MuonIdentification.earlyMuons_cfi import earlyDisplacedMuons
-from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
 
 ###### SEEDER MODELS ######
 #for displaced global muons
+import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 muonSeededSeedsOutInDisplaced = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
     src = "earlyDisplacedMuons",
 )
 muonSeededSeedsOutInDisplaced.fromVertex = cms.bool(False)
 ###------------- MeasurementEstimator, defining the searcgh window for pattern recongnition ----------------
 #for displaced global muons
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
 muonSeededMeasurementEstimatorForOutInDisplaced = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
     ComponentName = cms.string('muonSeededMeasurementEstimatorForOutInDisplaced'),
     MaxChi2 = cms.double(30.0), ## was 30 ## TO BE TUNED
@@ -20,7 +21,8 @@ muonSeededMeasurementEstimatorForOutInDisplaced = TrackingTools.KalmanUpdators.C
 
 ###------------- TrajectoryFilter, defining selections on the trajectories while building them ----------------
 #for displaced global muons
-muonSeededTrajectoryFilterForOutInDisplaced = muonSeededTrajectoryFilterForInOut.clone()
+import RecoTracker.IterativeTracking.MuonSeededStep_cff
+muonSeededTrajectoryFilterForOutInDisplaced = RecoTracker.IterativeTracking.MuonSeededStep_cff.muonSeededTrajectoryFilterForInOut.clone()
 muonSeededTrajectoryFilterForOutInDisplaced.constantValueForLostHitsFractionFilter = 10 ## allow more lost hits
 muonSeededTrajectoryFilterForOutInDisplaced.minimumNumberOfHits = 5 ## allow more lost hits
 ###------------- TrajectoryBuilders ----------------
@@ -55,19 +57,19 @@ muonSeededTracksOutInDisplaced = RecoTracker.TrackProducer.TrackProducer_cfi.Tra
 )
 
 #for displaced global muons
-muonSeededTracksOutInDisplacedClassifier = muonSeededTracksOutInClassifier.clone()
+muonSeededTracksOutInDisplacedClassifier = RecoTracker.IterativeTracking.MuonSeededStep_cff.muonSeededTracksOutInClassifier.clone()
 muonSeededTracksOutInDisplacedClassifier.src='muonSeededTracksOutInDisplaced'
 
 
 #for displaced global muons
 muonSeededStepCoreDisplaced = cms.Sequence(
-    muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut +
+    cms.SequencePlaceholder("muonSeededStepCoreInOut") +
     muonSeededSeedsOutInDisplaced + muonSeededTrackCandidatesOutInDisplaced + muonSeededTracksOutInDisplaced 
 )
 
 #for displaced global muons
 muonSeededStepExtraDisplaced = cms.Sequence(
-    muonSeededTracksInOutClassifier +
+    cms.SequencePlaceholder("muonSeededStepExtraInOut") +
     muonSeededTracksOutInDisplacedClassifier
 )
 #for displaced global muons
@@ -85,5 +87,5 @@ muonSeededTrackCandidatesOutInDisplacedAsTracks = cms.EDProducer("FakeTrackProdu
 #for displaced global muons
 muonSeededStepDebugDisplaced = cms.Sequence(
     muonSeededSeedsOutInDisplacedAsTracks + muonSeededTrackCandidatesOutInDisplacedAsTracks +
-    muonSeededSeedsInOutAsTracks + muonSeededTrackCandidatesInOutAsTracks
+    cms.SequencePlaceholder("muonSeededStepDebugInOut")
 )

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -12,6 +12,10 @@ duplicateDisplacedTrackCandidates = DuplicateTrackMerger.clone(
     useInnermostState  = cms.bool(True),
     ttrhBuilderName    = cms.string("WithAngleAndTemplate")
     )
+# This customization will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(duplicateDisplacedTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
 #for displaced global muons
 mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = cms.InputTag("duplicateDisplacedTrackCandidates","candidates"),

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -45,3 +45,7 @@ GlobalMuonRefitter = cms.PSet(
     RefitFlag = cms.bool( True )
 )
 
+# These customizations will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(GlobalMuonRefitter, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -68,3 +68,12 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
 	RefitFlag = cms.bool(True)
         ),
 )
+
+# This customization will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(GlobalTrajectoryBuilderCommon, # FIXME
+    TrackerRecHitBuilder = 'WithTrackAngle',
+    TrackTransformer = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
+    GlbRefitterParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
+)

--- a/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
+++ b/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
@@ -17,3 +17,8 @@ TrackerKinkFinderParametersBlock = cms.PSet(
         Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
     )
 )
+
+# This customization will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(TrackerKinkFinderParametersBlock, TrackerKinkFinderParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle')) # FIXME

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -84,3 +84,7 @@ MuonTrackLoaderForCosmic = cms.PSet(
     )
 )
 
+# These customizations will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(MuonTrackLoaderForGLB, TrackLoaderParameters = dict(TTRHBuilder = 'WithTrackAngle')) # FIXME

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
@@ -50,3 +50,7 @@ trackerDrivenElectronSeeds = cms.EDProducer("GoodSeedProducer",
 )
 
 
+# This customization will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(trackerDrivenElectronSeeds, TTRHBuilder  = 'WithTrackAngle') # FIXME

--- a/RecoPixelVertexing/PixelTriplets/python/PixelTripletLargeTipGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/PixelTripletLargeTipGenerator_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # moving to the block.  Will delete the PSet once transition is done
 PixelTripletLargeTipGenerator = cms.PSet(
@@ -11,4 +12,5 @@ PixelTripletLargeTipGenerator = cms.PSet(
     extraHitRPhitolerance = cms.double(0.032),
     extraHitRZtolerance = cms.double(0.037)
 )
+eras.trackingPhase1.toModify(PixelTripletLargeTipGenerator, maxElement = 0)
 

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -381,7 +381,6 @@ convStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone
     AlgorithmName = cms.string('conversionStep'),
     Fitter = 'convStepFitterSmoother',
     )
-eras.trackingPhase1.toModify(convStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -1,20 +1,26 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
 from RecoTracker.ConversionSeedGenerators.PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi import *
 from RecoTracker.ConversionSeedGenerators.ConversionStep2_cff import *
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-convClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_convClustersBase = _trackClusterRemover.clone(
   maxChi2               = cms.double(30.0),
   trajectories          = cms.InputTag("tobTecStepTracks"),
   pixelClusters         = cms.InputTag("siPixelClusters"),
   stripClusters         = cms.InputTag("siStripClusters"),
   oldClusterRemovalInfo = cms.InputTag("tobTecStepClusters"),
-  trackClassifier       = cms.InputTag('tobTecStep',"QualityMasks"),
   TrackQuality          = cms.string('highPurity'),
 )
+convClusters = _convClustersBase.clone(
+  trackClassifier       = cms.InputTag('tobTecStep',"QualityMasks"),
+)
+eras.trackingPhase1.toReplaceWith(convClusters, _convClustersBase.clone(
+  overrideTrkQuals      = "tobTecStepSelector:tobTecStep",
+))
 
 convLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                 layerList = cms.vstring('BPix1+BPix2', 
@@ -201,13 +207,115 @@ convLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                     skipClusters = cms.InputTag('convClusters'),
                                     )
                                 )
+eras.trackingPhase1.toModify(convLayerPairs,
+    layerList = [
+        'BPix1+BPix2',
 
+        'BPix2+BPix3',
+        'BPix2+FPix1_pos',
+        'BPix2+FPix1_neg',
+        'BPix2+FPix2_pos',
+        'BPix2+FPix2_neg',
+
+        'FPix1_pos+FPix2_pos',
+        'FPix1_neg+FPix2_neg',
+
+        'BPix3+TIB1',
+        'BPix3+TIB2',
+
+        'TIB1+TID1_pos',
+        'TIB1+TID1_neg',
+        'TIB1+TID2_pos',
+        'TIB1+TID2_neg',
+        'TIB1+TIB2',
+        'TIB1+TIB3',
+
+        'TIB2+TID1_pos',
+        'TIB2+TID1_neg',
+        'TIB2+TID2_pos',
+        'TIB2+TID2_neg',
+        'TIB2+TIB3',
+        'TIB2+TIB4',
+
+        'TIB3+TIB4',
+        'TIB3+TOB1',
+        'TIB3+TID1_pos',
+        'TIB3+TID1_neg',
+
+        'TIB4+TOB1',
+        'TIB4+TOB2',
+
+        'TOB1+TOB2',
+        'TOB1+TOB3',
+        'TOB1+TEC1_pos',
+        'TOB1+TEC1_neg',
+
+        'TOB2+TOB3',
+        'TOB2+TOB4',
+        'TOB2+TEC1_pos',
+        'TOB2+TEC1_neg',
+
+        #NB: re-introduce these combinations when large displaced
+        #    tracks, reconstructed only in TOB will be available
+        #    For instance think at the OutIn Ecal Seeded tracks
+        #'TOB3+TOB4',
+        #'TOB3+TOB5',
+        #'TOB3+TEC1_pos',
+        #'TOB3+TEC1_neg',
+        #
+        #'TOB4+TOB5',
+        #'TOB4+TOB6',
+        #
+        #'TOB5+TOB6',
+
+        'TID1_pos+TID2_pos',
+        'TID2_pos+TID3_pos',
+        'TID3_pos+TEC1_pos',
+
+        'TID1_neg+TID2_neg',
+        'TID2_neg+TID3_neg',
+        'TID3_neg+TEC1_neg',
+
+        'TEC1_pos+TEC2_pos',
+        'TEC2_pos+TEC3_pos',
+        'TEC3_pos+TEC4_pos',
+        'TEC4_pos+TEC5_pos',
+        'TEC5_pos+TEC6_pos',
+        'TEC6_pos+TEC7_pos',
+        'TEC7_pos+TEC8_pos',
+
+        'TEC1_neg+TEC2_neg',
+        'TEC2_neg+TEC3_neg',
+        'TEC3_neg+TEC4_neg',
+        'TEC4_neg+TEC5_neg',
+        'TEC5_neg+TEC6_neg',
+        'TEC6_neg+TEC7_neg',
+        'TEC7_neg+TEC8_neg'
+        #other combinations could be added
+    ],
+    BPix = dict(TTRHBuilder = "TTRHBuilderWithoutAngle4PixelPairs"),
+    FPix = dict(TTRHBuilder = "TTRHBuilderWithoutAngle4PixelPairs"),
+    TIB1 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TIB2 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TIB3 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TIB4 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TID1 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TID2 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TID3 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TEC  = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TOB1 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TOB2 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TOB3 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TOB4 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TOB5 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+    TOB6 = dict(clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")),
+)
 
 photonConvTrajSeedFromSingleLeg.TrackRefitter = cms.InputTag('generalTracks')
 photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrimaryVertices')
 #photonConvTrajSeedFromQuadruplets.TrackRefitter = cms.InputTag('generalTracks')
 #photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertices')
-
+eras.trackingPhase1.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag = "pixelVertices")
 
 # TRACKER DATA CONTROL
 
@@ -233,12 +341,17 @@ convStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
-convCkfTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+_convCkfTrajectoryBuilderBase = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('convCkfTrajectoryFilter')),
     minNrOfHitsForRebuild = 3,
     maxCand = 1,
+)
+convCkfTrajectoryBuilder = _convCkfTrajectoryBuilderBase.clone(
     estimator = cms.string('convStepChi2Est')
     )
+eras.trackingPhase1.toReplaceWith(convCkfTrajectoryBuilder, _convCkfTrajectoryBuilderBase.clone(
+    maxCand = 2,
+))
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -268,6 +381,7 @@ convStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone
     AlgorithmName = cms.string('conversionStep'),
     Fitter = 'convStepFitterSmoother',
     )
+eras.trackingPhase1.toModify(convStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 photonConvTrajSeedFromSingleLeg  = cms.EDProducer("PhotonConversionTrajectorySeedProducerFromSingleLeg",
                                                   TrackRefitter        = cms.InputTag('TrackRefitter',''),
@@ -44,3 +45,12 @@ photonConvTrajSeedFromSingleLeg  = cms.EDProducer("PhotonConversionTrajectorySee
                                                       TTRHBuilder = cms.string('WithTrackAngle')
                                                       )
                                                   )
+eras.trackingPhase1.toModify(photonConvTrajSeedFromSingleLeg,
+    ClusterCheckPSet = dict(
+        MaxNumberOfCosmicClusters = 1000000,
+        MaxNumberOfPixelClusters = 100000,
+        cut = 'strip < 1000000 && pixel < 100000 && (strip < 100000 + 20*pixel) && (pixel < 20000 + 0.1*strip)'
+    ),
+    OrderedHitsFactoryPSet = dict(maxElement = 100000),
+    RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.3)),
+)

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoTracker.FinalTrackSelectors.DuplicateTrackMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.DuplicateListMerger_cfi import *
@@ -7,6 +8,9 @@ duplicateTrackCandidates = DuplicateTrackMerger.clone()
 duplicateTrackCandidates.source = cms.InputTag("preDuplicateMergingGeneralTracks")
 duplicateTrackCandidates.useInnermostState  = True
 duplicateTrackCandidates.ttrhBuilderName   = "WithAngleAndTemplate"
+# This customization will be removed once we get the templates for
+# phase1 pixel
+eras.phase1Pixel.toModify(duplicateTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
                                      
 import RecoTracker.TrackProducer.TrackProducer_cfi
 mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
@@ -21,3 +22,29 @@ earlyGeneralTracks.inputClassifiers =["initialStep",
                                       "pixelLessStep",
                                       "tobTecStep"
                                       ]
+
+# For Phase1PU70
+from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
+eras.trackingPhase1.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
+    TrackProducers = ['initialStepTracks',
+                      'highPtTripletStepTracks',
+                      'lowPtQuadStepTracks',
+                      'lowPtTripletStepTracks',
+                      'detachedQuadStepTracks',
+                      'mixedTripletStepTracks',
+                      'pixelPairStepTracks',
+                      'tobTecStepTracks'],
+    hasSelector = [1,1,1,1,1,1,1,1],
+    indivShareFrac = [1.0,0.16,0.095,0.09,0.095,0.095,0.095,0.08],
+    selectedTrackQuals = [cms.InputTag("initialStepSelector","initialStep"),
+                          cms.InputTag("highPtTripletStepSelector","highPtTripletStep"),
+                          cms.InputTag("lowPtQuadStepSelector","lowPtQuadStep"),
+                          cms.InputTag("lowPtTripletStepSelector","lowPtTripletStep"),
+                          cms.InputTag("detachedQuadStep"),
+                          cms.InputTag("mixedTripletStep"),
+                          cms.InputTag("pixelPairStepSelector","pixelPairStep"),
+                          cms.InputTag("tobTecStepSelector","tobTecStep")],
+    setsToMerge = [cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7), pQual=cms.bool(True) ) ],
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False)
+))

--- a/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 
 preDuplicateMergingGeneralTracks = TrackCollectionMerger.clone()
@@ -17,3 +18,28 @@ preDuplicateMergingGeneralTracks.foundHitBonus  = 100.0
 preDuplicateMergingGeneralTracks.lostHitPenalty =   1.0
 
 
+# For Phase1PU70
+from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
+eras.trackingPhase1.toReplaceWith(preDuplicateMergingGeneralTracks, _trackListMerger.clone(
+    TrackProducers = [
+        "earlyGeneralTracks",
+        "muonSeededTracksInOut",
+        "muonSeededTracksOutIn",
+    ],
+    hasSelector = [0,1,1],
+    selectedTrackQuals = [
+        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"), # not used but needed
+        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"),
+        cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
+    ],
+    mvaValueTags = cms.VInputTag(
+        cms.InputTag("earlyGeneralTracks","MVAVals"),
+        cms.InputTag("muonSeededTracksInOutSelector","MVAVals"),
+        cms.InputTag("muonSeededTracksOutInSelector","MVAVals"),
+    ),
+    setsToMerge = [cms.PSet(pQual = cms.bool(True), tLists = cms.vint32(0, 1,2))],
+    FoundHitBonus  = 100.0,
+    LostHitPenalty =   1.0,
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False)
+))

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -1,14 +1,21 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
 initialStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("initialStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("pixelLessStepClusters")
 )
+eras.trackingPhase1.toModify(initialStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepClusters")
+highPtTripletStepSeedClusterMask = seedClusterRemover.clone( # for Phase1PU70
+    trajectories = "highPtTripletStepSeeds",
+    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+)
 pixelPairStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("pixelPairStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
 )
+eras.trackingPhase1.toModify(pixelPairStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepSeedClusterMask")
 mixedTripletStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("mixedTripletStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("pixelPairStepSeedClusterMask")
@@ -33,6 +40,23 @@ tripletElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
     )
 )
+eras.trackingPhase1.toModify(tripletElectronSeedLayers,
+    layerList = [
+        'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+    ],
+    BPix = dict(skipClusters = 'pixelPairStepSeedClusterMask'),
+    FPix = dict(skipClusters = 'pixelPairStepSeedClusterMask')
+)
 
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
@@ -47,6 +71,9 @@ tripletElectronSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.g
     )
 )
 tripletElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('tripletElectronSeedLayers')
+eras.trackingPhase1.toModify(tripletElectronSeeds,
+    OrderedHitsFactoryPSet = dict(maxElement = cms.uint32(0)), # not sure if this has any effect
+)
 
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
 tripletElectronClusterMask = seedClusterRemover.clone(
@@ -126,6 +153,12 @@ newCombinedSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCom
       cms.InputTag('stripPairElectronSeeds')
       )
 )
+eras.trackingPhase1.toModify(newCombinedSeeds, seedCollections = [
+    'initialStepSeeds',
+    'highPtTripletStepSeeds',
+    'pixelPairStepSeeds',
+    'tripletElectronSeeds'
+])
 
 electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
                                  pixelPairStepSeedClusterMask*
@@ -139,4 +172,11 @@ electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
                                  stripPairElectronSeedLayers*
                                  stripPairElectronSeeds*
                                  newCombinedSeeds)
-
+eras.trackingPhase1.toReplaceWith(electronSeedsSeq, cms.Sequence(
+    initialStepSeedClusterMask*
+    highPtTripletStepSeedClusterMask*
+    pixelPairStepSeedClusterMask*
+    tripletElectronSeedLayers*
+    tripletElectronSeeds*
+    newCombinedSeeds
+))

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ### STEP 0 ###
 
@@ -25,6 +26,17 @@ initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globa
     )
     )
 initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+eras.trackingPhase1.toModify(
+    initialStepSeeds,
+    RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+        addRemainingTriplets = cms.bool(False),
+        mergeTriplets = cms.bool(True),
+        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
@@ -32,12 +44,15 @@ initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoP
 
 # building
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.2,
+)
+initialStepTrajectoryFilterBase = _initialStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
+eras.trackingPhase1.toReplaceWith(initialStepTrajectoryFilterBase, _initialStepTrajectoryFilterBase)
 
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 initialStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
@@ -57,6 +72,9 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_c
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
+eras.trackingPhase1.toModify(initialStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
@@ -67,6 +85,7 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
     )
+eras.trackingPhase1.toModify(initialStepTrajectoryBuilder, maxCand = 6)
 
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
@@ -86,6 +105,7 @@ initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.cl
     AlgorithmName = cms.string('initialStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother')
     )
+eras.trackingPhase1.toModify(initialStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 
 #vertices
@@ -125,7 +145,51 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 initialStep = ClassifierMerger.clone()
 initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
 
-
+# For Phase1PU70
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+initialStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'initialStepTracks',
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'initialStepLoose',
+            chi2n_par = 2.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 3,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.8, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.6, 4.0 )
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'initialStepTight',
+            preFilterName = 'initialStepLoose',
+            chi2n_par = 1.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+        maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.35, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'initialStep',
+            preFilterName = 'initialStepTight',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.5, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.25, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+        ),
+    ] #end of vpset
+) #end of clone
 
 # Final sequence
 InitialStep = cms.Sequence(initialStepSeedLayers*
@@ -135,3 +199,6 @@ InitialStep = cms.Sequence(initialStepSeedLayers*
                            firstStepPrimaryVertices*
                            initialStepClassifier1*initialStepClassifier2*initialStepClassifier3*
                            initialStep)
+_InitialStep_Phase1PU70 = InitialStep.copyAndExclude([firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
+_InitialStep_Phase1PU70.replace(initialStep, initialStepSelector)
+eras.trackingPhase1.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -105,7 +105,6 @@ initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.cl
     AlgorithmName = cms.string('initialStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother')
     )
-eras.trackingPhase1.toModify(initialStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 
 #vertices

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -136,7 +136,6 @@ lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     AlgorithmName = cms.string('lowPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother')
     )
-eras.trackingPhase1.toModify(lowPtTripletStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -1,23 +1,44 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-lowPtTripletStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_lowPtTripletStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("detachedTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("detachedTripletStepClusters"),
-    trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+lowPtTripletStepClusters = _lowPtTripletStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
+)
+eras.trackingPhase1.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
+    trajectories                             = "lowPtQuadStepTracks",
+    oldClusterRemovalInfo                    = "lowPtQuadStepClusters",
+    overrideTrkQuals                         = "lowPtQuadStepSelector:lowPtQuadStep",
+))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
 lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 lowPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
 lowPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
+eras.trackingPhase1.toModify(lowPtTripletStepSeedLayers, layerList = [
+    'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+    'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+    'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+    'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+    'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+    'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+    'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+    'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+    'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+    'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+    'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+])
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
@@ -33,6 +54,14 @@ lowPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.
     )
     )
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtTripletStepSeedLayers'
+eras.trackingPhase1.toModify(lowPtTripletStepSeeds,
+    RegionFactoryPSet = dict(
+        RegionPSet = dict(
+            ptMin = 0.35,
+            originRadius = 0.015
+        )
+    ),
+)
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
@@ -40,21 +69,27 @@ lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = 
 
 
 # QUALITY CUTS DURING TRACK BUILDING
-import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
+_lowPtTripletStepStandardTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.075,
+)
+lowPtTripletStepStandardTrajectoryFilter = _lowPtTripletStepStandardTrajectoryFilterBase.clone(
     maxCCCLostHits = 1,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
+eras.trackingPhase1.toReplaceWith(lowPtTripletStepStandardTrajectoryFilter, _lowPtTripletStepStandardTrajectoryFilterBase)
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
 # Composite filter
-lowPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
+lowPtTripletStepTrajectoryFilter = _TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
     filters   = [cms.PSet(refToPSet_ = cms.string('lowPtTripletStepStandardTrajectoryFilter')),
                  # cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))
                 ]
     )
+eras.trackingPhase1.toModify(lowPtTripletStepTrajectoryFilter,
+    filters = lowPtTripletStepTrajectoryFilter.filters + [cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))]
+)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -62,6 +97,9 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
+)
+eras.trackingPhase1.toModify(lowPtTripletStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
 
 # TRACK BUILDING
@@ -98,6 +136,7 @@ lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     AlgorithmName = cms.string('lowPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother')
     )
+eras.trackingPhase1.toModify(lowPtTripletStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
@@ -106,6 +145,7 @@ lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
             allowSharedFirstHit = cms.bool(True)
             )
 lowPtTripletStepTrackCandidates.TrajectoryCleaner = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
+eras.trackingPhase1.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
 
 # Final selection
 
@@ -117,6 +157,51 @@ lowPtTripletStep.src = 'lowPtTripletStepTracks'
 lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
+# For Phase1PU70
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'lowPtTripletStepTracks',
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'lowPtTripletStepLoose',
+            chi2n_par = 2.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.8, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.5, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'lowPtTripletStepTight',
+            preFilterName = 'lowPtTripletStepLoose',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.6, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'lowPtTripletStep',
+            preFilterName = 'lowPtTripletStepTight',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.45, 4.0 ),
+            d0_par2 = ( 0.3, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+        ),
+    ] #end of vpset
+) #end of clone
 
 
 # Final sequence
@@ -126,3 +211,6 @@ LowPtTripletStep = cms.Sequence(lowPtTripletStepClusters*
                                 lowPtTripletStepTrackCandidates*
                                 lowPtTripletStepTracks*
                                 lowPtTripletStep)
+_LowPtTripletStep_Phase1PU70 = LowPtTripletStep.copy()
+_LowPtTripletStep_Phase1PU70.replace(lowPtTripletStep, lowPtTripletStepSelector)
+eras.trackingPhase1.toReplaceWith(LowPtTripletStep, _LowPtTripletStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -259,7 +259,6 @@ mixedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     src = 'mixedTripletStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother')
 )
-eras.trackingPhase1.toModify(mixedTripletStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -140,12 +140,18 @@ muonSeededTracksOutInClassifier.mva.maxLostLayers = [4,3,2]
 
 
 
+muonSeededStepCoreInOut = cms.Sequence(
+    muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut
+)
 muonSeededStepCore = cms.Sequence(
-    muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut +
-    muonSeededSeedsOutIn + muonSeededTrackCandidatesOutIn + muonSeededTracksOutIn 
+    muonSeededStepCoreInOut +
+    muonSeededSeedsOutIn + muonSeededTrackCandidatesOutIn + muonSeededTracksOutIn
+)
+muonSeededStepExtraInOut = cms.Sequence(
+    muonSeededTracksInOutClassifier
 )
 muonSeededStepExtra = cms.Sequence(
-    muonSeededTracksInOutClassifier +
+    muonSeededStepExtraInOut +
     muonSeededTracksOutInClassifier
 )
 
@@ -161,7 +167,10 @@ muonSeededSeedsInOutAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src =
 muonSeededSeedsOutInAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src = cms.InputTag("muonSeededSeedsOutIn"))
 muonSeededTrackCandidatesInOutAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesInOut"))
 muonSeededTrackCandidatesOutInAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesOutIn"))
+muonSeededStepDebugInOut = cms.Sequence(
+    muonSeededSeedsInOutAsTracks + muonSeededTrackCandidatesInOutAsTracks
+)
 muonSeededStepDebug = cms.Sequence(
     muonSeededSeedsOutInAsTracks + muonSeededTrackCandidatesOutInAsTracks +
-    muonSeededSeedsInOutAsTracks + muonSeededTrackCandidatesInOutAsTracks
+    muonSeededStepDebugInOut
 )

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_MuonSeededStep_cff.py
@@ -191,13 +191,18 @@ muonSeededTracksOutInSelector = RecoTracker.FinalTrackSelectors.multiTrackSelect
     ) #end of clone
 
 
-
+muonSeededStepCoreInOut = cms.Sequence(
+    muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut
+)
 muonSeededStepCore = cms.Sequence(
-    muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut +
+    muonSeededStepCoreInOut +
     muonSeededSeedsOutIn + muonSeededTrackCandidatesOutIn + muonSeededTracksOutIn
 )
+muonSeededStepExtraInOut = cms.Sequence(
+    muonSeededTracksInOutSelector
+)
 muonSeededStepExtra = cms.Sequence(
-    muonSeededTracksInOutSelector +
+    muonSeededStepExtraInOut +
     muonSeededTracksOutInSelector
 )
 
@@ -213,7 +218,10 @@ muonSeededSeedsInOutAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src =
 muonSeededSeedsOutInAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src = cms.InputTag("muonSeededSeedsOutIn"))
 muonSeededTrackCandidatesInOutAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesInOut"))
 muonSeededTrackCandidatesOutInAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesOutIn"))
+muonSeededStepDebugInOut = cms.Sequence(
+    muonSeededSeedsInOutAsTracks + muonSeededTrackCandidatesInOutAsTracks
+)
 muonSeededStepDebug = cms.Sequence(
     muonSeededSeedsOutInAsTracks + muonSeededTrackCandidatesOutInAsTracks +
-    muonSeededSeedsInOutAsTracks + muonSeededTrackCandidatesInOutAsTracks
+    muonSeededStepDebugInOut
 )

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -157,7 +157,6 @@ pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
     src = 'pixelPairStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother')
     )
-eras.trackingPhase1.toModify(pixelPairStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -299,7 +299,6 @@ tobTecStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clo
     #Fitter = 'tobTecStepFitterSmoother',
     Fitter = 'tobTecFlexibleKFFittingSmoother',
     )
-eras.trackingPhase1.toModify(tobTecStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 
 

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -1,20 +1,28 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 #######################################################################
 # Very large impact parameter tracking using TOB + TEC ring 5 seeding #
 #######################################################################
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-tobTecStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_tobTecStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("pixelLessStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("pixelLessStepClusters"),
-    trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+tobTecStepClusters = _tobTecStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
+)
+eras.trackingPhase1.toReplaceWith(tobTecStepClusters, _tobTecStepClustersBase.clone(
+    trajectories                             = "pixelPairStepTracks",
+    oldClusterRemovalInfo                    = "pixelPairStepClusters",
+    overrideTrkQuals                         = "pixelPairStepSelector:pixelPairStep",
+))
 
 # TRIPLET SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
@@ -141,25 +149,48 @@ tobTecStepSeedsPair.SeedComparitorPSet = cms.PSet(
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
 tobTecStepSeeds.seedCollections = cms.VInputTag(cms.InputTag('tobTecStepSeedsTripl'),cms.InputTag('tobTecStepSeedsPair'))
+# Phase1PU70
+import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+eras.trackingPhase1.toReplaceWith(tobTecStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
+    OrderedHitsFactoryPSet = dict(SeedingLayers = 'tobTecStepSeedLayers'),
+    RegionFactoryPSet = dict(
+        RegionPSet = dict(
+            ptMin = 1.0,
+            originHalfLength = 15.0,
+            originRadius = 2.0
+        )
+    ),
+    SeedCreatorPSet = dict(OriginTransverseErrorMultiplier = 3.0),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(False),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    ),
+))
+
 
 # QUALITY CUTS DURING TRACK BUILDING (for inwardss and outwards track building steps)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-
-tobTecStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_tobTecStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     maxLostHits = 0,
     minimumNumberOfHits = 5,
-    seedPairPenalty = 1,
     minPt = 0.1,
     minHitsMinPt = 3
     )
+tobTecStepTrajectoryFilter = _tobTecStepTrajectoryFilterBase.clone(
+    seedPairPenalty = 1,
+)
+eras.trackingPhase1.toReplaceWith(tobTecStepTrajectoryFilter, _tobTecStepTrajectoryFilterBase.clone(
+    minimumNumberOfHits = 6,
+))
 
 tobTecStepInOutTrajectoryFilter = tobTecStepTrajectoryFilter.clone(
-    maxLostHits = 0,
     minimumNumberOfHits = 4,
-    seedPairPenalty = 1,
-    minPt = 0.1,
-    minHitsMinPt = 3
-    )
+)
+
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -167,6 +198,10 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingPhase1.toModify(tobTecStepChi2Est,
+    MaxChi2 = 9.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
 
 # TRACK BUILDING
@@ -207,6 +242,7 @@ tobTecStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
     allowSharedFirstHit = cms.bool(True)
     )
 tobTecStepTrackCandidates.TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
+eras.trackingPhase1.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.08)
 
 # TRACK FITTING AND SMOOTHING OPTIONS
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
@@ -217,6 +253,7 @@ tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFi
     Fitter = cms.string('tobTecStepRKFitter'),
     Smoother = cms.string('tobTecStepRKSmoother')
     )
+eras.trackingPhase1.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
 
 tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
     ComponentName = 'tobTecStepFitterSmootherForLoopers',
@@ -229,6 +266,7 @@ tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.
     ComponentName = cms.string('tobTecStepRKFitter'),
     minHits = 7
 )
+eras.trackingPhase1.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
 tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
     ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -239,6 +277,7 @@ tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cf
     errorRescaling = 10.0,
     minHits = 7
 )
+eras.trackingPhase1.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
 tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
     ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -260,6 +299,7 @@ tobTecStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clo
     #Fitter = 'tobTecStepFitterSmoother',
     Fitter = 'tobTecFlexibleKFFittingSmoother',
     )
+eras.trackingPhase1.toModify(tobTecStepTracks, TTRHBuilder = 'WithTrackAngle')
 
 
 
@@ -293,3 +333,101 @@ TobTecStep = cms.Sequence(tobTecStepClusters*
                           tobTecStepClassifier1*tobTecStepClassifier2*
                           tobTecStep)
 
+
+
+### Following are specific for Phase1PU70, they're collected here to
+### not to interfere too much with the default configuration
+# For Phase1
+tobTecStepSeedClusters = _trackClusterRemover.clone(
+    maxChi2                                  = 9.0,
+    trajectories                             = "mixedTripletStepTracks",
+    pixelClusters                            = "siPixelClusters",
+    stripClusters                            = "siStripClusters",
+    oldClusterRemovalInfo                    = "mixedTripletStepClusters",
+    overrideTrkQuals                         = 'mixedTripletStep',
+    TrackQuality                             = 'highPurity',
+    minNumberOfLayersWithMeasBeforeFiltering = 0,
+)
+
+# SEEDING LAYERS
+tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('TOB1+TOB2', 
+        'TOB1+TEC1_pos', 'TOB1+TEC1_neg', 
+        'TEC1_pos+TEC2_pos', 'TEC2_pos+TEC3_pos', 
+        'TEC3_pos+TEC4_pos', 'TEC4_pos+TEC5_pos', 
+        'TEC5_pos+TEC6_pos', 'TEC6_pos+TEC7_pos', 
+        'TEC1_neg+TEC2_neg', 'TEC2_neg+TEC3_neg', 
+        'TEC3_neg+TEC4_neg', 'TEC4_neg+TEC5_neg', 
+        'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'),
+    TOB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('tobTecStepSeedClusters'),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('tobTecStepSeedClusters'),
+        #    untracked bool useSimpleRphiHitsCleaner = false
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        minRing = cms.int32(5),
+        maxRing = cms.int32(5)
+    )
+)
+
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+tobTecStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'tobTecStepTracks',
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'tobTecStepLoose',
+            chi2n_par = 0.25,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.3, 4.0 ),
+            dz_par1 = ( 1.2, 4.0 ),
+            d0_par2 = ( 1.3, 4.0 ),
+            dz_par2 = ( 1.2, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'tobTecStepTight',
+            preFilterName = 'tobTecStepLoose',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            max_minMissHitOutOrIn = 1,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.0, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.0, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'tobTecStep',
+            preFilterName = 'tobTecStepTight',
+            chi2n_par = 0.15,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 6,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            max_minMissHitOutOrIn = 0,
+            d0_par1 = ( 0.9, 4.0 ),
+            dz_par1 = ( 0.8, 4.0 ),
+            d0_par2 = ( 0.9, 4.0 ),
+            dz_par2 = ( 0.8, 4.0 )
+        ),
+    ] #end of vpset
+) #end of clone
+
+eras.trackingPhase1.toReplaceWith(TobTecStep, cms.Sequence(
+    tobTecStepClusters*
+    tobTecStepSeedClusters*
+    tobTecStepSeedLayers*
+    tobTecStepSeeds*
+    tobTecStepTrackCandidates*
+    tobTecStepTracks*
+    tobTecStepSelector
+))

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -10,6 +10,11 @@ from RecoTracker.IterativeTracking.PixelLessStep_cff import *
 from RecoTracker.IterativeTracking.TobTecStep_cff import *
 from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import *
 
+# Phase1PU70 specific iterations
+from RecoTracker.IterativeTracking.Phase1PU70_HighPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase1PU70_LowPtQuadStep_cff import *
+from RecoTracker.IterativeTracking.Phase1PU70_DetachedQuadStep_cff import *
+
 from RecoTracker.FinalTrackSelectors.earlyGeneralTracks_cfi import *
 from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
 from RecoTracker.FinalTrackSelectors.preDuplicateMergingGeneralTracks_cfi import *
@@ -32,3 +37,21 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
                             ConvStep*
                             conversionStepTracks
                             )
+
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase1.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStep +
+    HighPtTripletStep +
+    LowPtQuadStep +
+    LowPtTripletStep +
+    DetachedQuadStep +
+    MixedTripletStep +
+    PixelPairStep +
+    TobTecStep +
+    earlyGeneralTracks +
+    muonSeededStep +
+    preDuplicateMergingGeneralTracks +
+    generalTracksSequence +
+    ConvStep +
+    conversionStepTracks
+))

--- a/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
@@ -21,3 +21,7 @@ inOutSeedsFromTrackerMuons = cms.EDProducer("MuonReSeeder",
     Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
 )
 
+# This customization will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(inOutSeedsFromTrackerMuons, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME

--- a/RecoTracker/TkSeedGenerator/python/GlobalMixedSeeds_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalMixedSeeds_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # initialize magnetic field #########################
 # initialize geometry #####################
@@ -24,4 +25,7 @@ globalMixedSeeds = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProd
        SeedingLayers = cms.InputTag('MixedLayerPairs'),
        maxElement = cms.uint32(1000000)
     )
+)
+eras.trackingPhase1.toModify(globalMixedSeeds,
+    OrderedHitsFactoryPSet = dict(maxElement = 0),
 )

--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromPairsWithVertices_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromPairsWithVertices_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEfromTrackAngle_cfi import *
@@ -25,4 +26,7 @@ globalSeedsFromPairsWithVertices = RecoTracker.TkSeedGenerator.SeedGeneratorFrom
       ComponentName = cms.string('GlobalTrackingRegionWithVerticesProducer')
     )
 )    
+eras.trackingPhase1.toModify(globalSeedsFromPairsWithVertices,
+    OrderedHitsFactoryPSet = dict(maxElement = 0),
+)
 

--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTriplets_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTriplets_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+from Configuration.StandardSequences.Eras import eras
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEfromTrackAngle_cfi import *
 from RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitMatcher_cfi import *
@@ -24,4 +24,7 @@ globalSeedsFromTriplets = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHit
 # arbitrarily large D0 and generally exhibits a smaller fake rate:
 #     GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
     )
+)
+eras.trackingPhase1.toModify(globalSeedsFromTriplets,
+    OrderedHitsFactoryPSet = dict(GeneratorPSet = dict(maxElement = 0)),
 )

--- a/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 SeedFromConsecutiveHitsCreator = cms.PSet(
   ComponentName = cms.string('SeedFromConsecutiveHitsCreator'),
@@ -11,4 +12,8 @@ SeedFromConsecutiveHitsCreator = cms.PSet(
 #  magneticField = cms.string(''),
   TTRHBuilder = cms.string('WithTrackAngle'),
   forceKinematicWithRegionDirection = cms.bool(False)
+)
+eras.trackingPhase1.toModify(SeedFromConsecutiveHitsCreator,
+        magneticField = '',
+        propagator = 'PropagatorWithMaterial'
 )

--- a/RecoTracker/TkSeedGenerator/python/SeedGeneratorFromRegionHitsEDProducer_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedGeneratorFromRegionHitsEDProducer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
 from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import *
@@ -34,4 +35,8 @@ ClusterCheckPSet = cms.PSet(
                  PixelClusterCollectionLabel = cms.InputTag("siPixelClusters"),
                  cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)")
                  ),
+)
+# Disable too many clusters check until we have an updated cut string for phase1
+eras.phase1Pixel.toModify(seedGeneratorFromRegionHitsEDProducer, # FIXME
+    ClusterCheckPSet = dict(doClusterCheck = False)
 )

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
@@ -18,4 +18,20 @@ PixelLayerTriplets.FPix = cms.PSet(
     HitProducer = cms.string('siPixelRecHits'),
 )
 
-
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase1.toModify(PixelLayerTriplets, layerList=[
+    'BPix1+BPix2+BPix3',
+    'BPix2+BPix3+BPix4',
+    'BPix1+BPix3+BPix4',
+    'BPix1+BPix2+BPix4',
+    'BPix2+BPix3+FPix1_pos',
+    'BPix2+BPix3+FPix1_neg',
+    'BPix1+BPix2+FPix1_pos',
+    'BPix1+BPix2+FPix1_neg',
+    'BPix2+FPix1_pos+FPix2_pos',
+    'BPix2+FPix1_neg+FPix2_neg',
+    'BPix1+FPix1_pos+FPix2_pos',
+    'BPix1+FPix1_neg+FPix2_neg',
+    'FPix1_pos+FPix2_pos+FPix3_pos',
+    'FPix1_neg+FPix2_neg+FPix3_neg'
+])

--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -27,5 +27,8 @@ TrackProducer = cms.EDProducer("TrackProducer",
     MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent'),                   
 )
 
-
+# This customization will be removed once we get the templates for
+# phase1 pixel
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(TrackProducer, TTRHBuilder = 'WithTrackAngle') # FIXME
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -441,7 +441,9 @@ def customise_Reco(process,pileup):
     del process.earlyGeneralTracks
     del process.muonSeededStep
     del process.muonSeededStepCore
+    del process.muonSeededStepCoreInOut
     del process.muonSeededStepDebug
+    del process.muonSeededStepDebugInOut
     del process.muonSeededStepDebugDisplaced
     del process.ConvStep
     # add the correct tracking back in

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -483,35 +483,38 @@ def customise_Reco(process,pileup):
     process.PixelCPEGenericESProducer.DoCosmics = False
     # CPE for other steps
     process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
-    # Turn of template use in tracking (iterative steps handled inside their configs)
-    process.duplicateTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
-    process.mergedDuplicateTracks.TTRHBuilder = 'WithTrackAngle'
-    process.ctfWithMaterialTracks.TTRHBuilder = 'WithTrackAngle'
-    process.muonSeededSeedsInOut.TrackerRecHitBuilder=cms.string('WithTrackAngle')
-    process.muonSeededTracksInOut.TTRHBuilder=cms.string('WithTrackAngle')
-    process.muonSeededTracksOutIn.TTRHBuilder=cms.string('WithTrackAngle')
-    process.muons1stStep.TrackerKinkFinderParameters.TrackerRecHitBuilder=cms.string('WithTrackAngle')
-    process.regionalCosmicTracks.TTRHBuilder=cms.string('WithTrackAngle')
-    process.cosmicsVetoTracksRaw.TTRHBuilder=cms.string('WithTrackAngle')
-    process.trackerDrivenElectronSeeds.TTRHBuilder = 'WithTrackAngle'
-    process.globalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
-    process.tevMuons.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.tevMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
-    process.muonSeededTracksOutInDisplaced.TTRHBuilder = 'WithTrackAngle'
-    process.duplicateDisplacedTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
-    process.mergedDuplicateDisplacedTracks.TTRHBuilder = 'WithTrackAngle'
-    process.displacedGlobalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.displacedGlobalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
-    process.glbTrackQual.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalSETMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalSETMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalSETMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
-    process.globalSETMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+
+    if not eras.phase1Pixel.isChosen():
+        # Turn of template use in tracking
+        # Iterations and the following ones are treated in the configs    
+        process.duplicateTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
+        process.mergedDuplicateTracks.TTRHBuilder = 'WithTrackAngle'
+        process.ctfWithMaterialTracks.TTRHBuilder = 'WithTrackAngle'
+        process.muonSeededSeedsInOut.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+        process.muonSeededTracksInOut.TTRHBuilder=cms.string('WithTrackAngle')
+        process.muonSeededTracksOutIn.TTRHBuilder=cms.string('WithTrackAngle')
+        process.regionalCosmicTracks.TTRHBuilder=cms.string('WithTrackAngle')
+        process.cosmicsVetoTracksRaw.TTRHBuilder=cms.string('WithTrackAngle')
+        process.muonSeededTracksOutInDisplaced.TTRHBuilder = 'WithTrackAngle'
+        process.mergedDuplicateDisplacedTracks.TTRHBuilder = 'WithTrackAngle'
+        process.muons1stStep.TrackerKinkFinderParameters.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+        process.trackerDrivenElectronSeeds.TTRHBuilder = 'WithTrackAngle'
+        process.globalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+        process.tevMuons.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.tevMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+        process.duplicateDisplacedTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
+        process.displacedGlobalMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.displacedGlobalMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.displacedGlobalMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
+        process.glbTrackQual.RefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalSETMuons.GLBTrajBuilderParameters.GlbRefitterParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalSETMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalSETMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
+        process.globalSETMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
     # End of pixel template needed section
 
     # Remove, for now, the pre-cluster-splitting clustering step

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -324,136 +324,137 @@ def customise_Reco(process,pileup):
     # Need this line to stop error about missing siPixelDigis.
     process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
 
-    # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
-    process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
-                                                        'BPix2+BPix3+BPix4',
-                                                        'BPix1+BPix3+BPix4',
-                                                        'BPix1+BPix2+BPix4',
-                                                        'BPix2+BPix3+FPix1_pos',
-                                                        'BPix2+BPix3+FPix1_neg',
-                                                        'BPix1+BPix2+FPix1_pos',
-                                                        'BPix1+BPix2+FPix1_neg',
-                                                        'BPix2+FPix1_pos+FPix2_pos',
-                                                        'BPix2+FPix1_neg+FPix2_neg',
-                                                        'BPix1+FPix1_pos+FPix2_pos',
-                                                        'BPix1+FPix1_neg+FPix2_neg',
-                                                        'FPix1_pos+FPix2_pos+FPix3_pos',
-                                                        'FPix1_neg+FPix2_neg+FPix3_neg' )
+    if not eras.trackingPhase1.isChosen():
+        # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
+        process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
+                                                            'BPix2+BPix3+BPix4',
+                                                            'BPix1+BPix3+BPix4',
+                                                            'BPix1+BPix2+BPix4',
+                                                            'BPix2+BPix3+FPix1_pos',
+                                                            'BPix2+BPix3+FPix1_neg',
+                                                            'BPix1+BPix2+FPix1_pos',
+                                                            'BPix1+BPix2+FPix1_neg',
+                                                            'BPix2+FPix1_pos+FPix2_pos',
+                                                            'BPix2+FPix1_neg+FPix2_neg',
+                                                            'BPix1+FPix1_pos+FPix2_pos',
+                                                            'BPix1+FPix1_neg+FPix2_neg',
+                                                            'FPix1_pos+FPix2_pos+FPix3_pos',
+                                                            'FPix1_neg+FPix2_neg+FPix3_neg' )
 
-    # New tracking.  This is really ugly because it redefines globalreco and reconstruction.
-    # It can be removed if change one line in Configuration/StandardSequences/python/Reconstruction_cff.py
-    # from RecoTracker_cff.py to RecoTrackerPhase1PU140_cff.py
-
-    # remove all the tracking first
-    itIndex=process.globalreco_tracking.index(process.trackingGlobalReco)
-    grIndex=process.globalreco.index(process.globalreco_tracking)
-
-    process.globalreco.remove(process.globalreco_tracking)
-    process.globalreco_tracking.remove(process.iterTracking)
-    process.globalreco_tracking.remove(process.electronSeedsSeq)
-    process.reconstruction_fromRECO.remove(process.trackingGlobalReco)
-    process.reconstruction_fromRECO.remove(process.electronSeedsSeq)
-    process.reconstruction_fromRECO.remove(process.initialStepSeedLayers)
-    process.reconstruction_fromRECO.remove(process.initialStepSeeds)
-    process.reconstruction_fromRECO.remove(process.initialStepClassifier1)
-    process.reconstruction_fromRECO.remove(process.initialStepClassifier2)
-    process.reconstruction_fromRECO.remove(process.initialStepClassifier3)
-    process.reconstruction_fromRECO.remove(initialStepTrackCandidates)
-    process.reconstruction_fromRECO.remove(initialStepTracks)
-    process.reconstruction_fromRECO.remove(lowPtTripletStepClusters)
-    process.reconstruction_fromRECO.remove(lowPtTripletStepSeedLayers)
-    process.reconstruction_fromRECO.remove(lowPtTripletStepSeeds)
-    process.reconstruction_fromRECO.remove(lowPtTripletStep)
-    process.reconstruction_fromRECO.remove(lowPtTripletStepTrackCandidates)
-    process.reconstruction_fromRECO.remove(lowPtTripletStepTracks)
-
-    process.reconstruction_fromRECO.remove(mixedTripletStep)
-    process.reconstruction_fromRECO.remove(mixedTripletStepClusters)
-    process.reconstruction_fromRECO.remove(mixedTripletStepSeedLayersA)
-    process.reconstruction_fromRECO.remove(mixedTripletStepSeedLayersB)
-    process.reconstruction_fromRECO.remove(mixedTripletStepSeeds)
-    process.reconstruction_fromRECO.remove(mixedTripletStepSeedsA)
-    process.reconstruction_fromRECO.remove(mixedTripletStepSeedsB)
-    process.reconstruction_fromRECO.remove(mixedTripletStepClassifier1)
-    process.reconstruction_fromRECO.remove(mixedTripletStepClassifier2)
-    process.reconstruction_fromRECO.remove(mixedTripletStepTrackCandidates)
-    process.reconstruction_fromRECO.remove(mixedTripletStepTracks)
-
-    process.reconstruction_fromRECO.remove(pixelPairStepClusters)
-    process.reconstruction_fromRECO.remove(pixelPairStepSeeds)
-    process.reconstruction_fromRECO.remove(pixelPairStepSeedLayers)
-    process.reconstruction_fromRECO.remove(pixelPairStep)
-    process.reconstruction_fromRECO.remove(pixelPairStepTrackCandidates)
-    process.reconstruction_fromRECO.remove(pixelPairStepTracks)
+        # New tracking.  This is really ugly because it redefines globalreco and reconstruction.
+        # It can be removed if change one line in Configuration/StandardSequences/python/Reconstruction_cff.py
+        # from RecoTracker_cff.py to RecoTrackerPhase1PU140_cff.py
     
-    process.reconstruction_fromRECO.remove(tobTecStepClusters)
-    process.reconstruction_fromRECO.remove(tobTecStepSeeds)
-    #process.reconstruction_fromRECO.remove(tobTecStepSeedLayers)
-    process.reconstruction_fromRECO.remove(tobTecStepClassifier1)
-    process.reconstruction_fromRECO.remove(tobTecStepClassifier2)
-    process.reconstruction_fromRECO.remove(tobTecStep)
-    process.reconstruction_fromRECO.remove(tobTecStepTrackCandidates)
-    process.reconstruction_fromRECO.remove(tobTecStepTracks)
+        # remove all the tracking first
+        itIndex=process.globalreco_tracking.index(process.trackingGlobalReco)
+        grIndex=process.globalreco.index(process.globalreco_tracking)
+    
+        process.globalreco.remove(process.globalreco_tracking)
+        process.globalreco_tracking.remove(process.iterTracking)
+        process.globalreco_tracking.remove(process.electronSeedsSeq)
+        process.reconstruction_fromRECO.remove(process.trackingGlobalReco)
+        process.reconstruction_fromRECO.remove(process.electronSeedsSeq)
+        process.reconstruction_fromRECO.remove(process.initialStepSeedLayers)
+        process.reconstruction_fromRECO.remove(process.initialStepSeeds)
+        process.reconstruction_fromRECO.remove(process.initialStepClassifier1)
+        process.reconstruction_fromRECO.remove(process.initialStepClassifier2)
+        process.reconstruction_fromRECO.remove(process.initialStepClassifier3)
+        process.reconstruction_fromRECO.remove(initialStepTrackCandidates)
+        process.reconstruction_fromRECO.remove(initialStepTracks)
+        process.reconstruction_fromRECO.remove(lowPtTripletStepClusters)
+        process.reconstruction_fromRECO.remove(lowPtTripletStepSeedLayers)
+        process.reconstruction_fromRECO.remove(lowPtTripletStepSeeds)
+        process.reconstruction_fromRECO.remove(lowPtTripletStep)
+        process.reconstruction_fromRECO.remove(lowPtTripletStepTrackCandidates)
+        process.reconstruction_fromRECO.remove(lowPtTripletStepTracks)
+    
+        process.reconstruction_fromRECO.remove(mixedTripletStep)
+        process.reconstruction_fromRECO.remove(mixedTripletStepClusters)
+        process.reconstruction_fromRECO.remove(mixedTripletStepSeedLayersA)
+        process.reconstruction_fromRECO.remove(mixedTripletStepSeedLayersB)
+        process.reconstruction_fromRECO.remove(mixedTripletStepSeeds)
+        process.reconstruction_fromRECO.remove(mixedTripletStepSeedsA)
+        process.reconstruction_fromRECO.remove(mixedTripletStepSeedsB)
+        process.reconstruction_fromRECO.remove(mixedTripletStepClassifier1)
+        process.reconstruction_fromRECO.remove(mixedTripletStepClassifier2)
+        process.reconstruction_fromRECO.remove(mixedTripletStepTrackCandidates)
+        process.reconstruction_fromRECO.remove(mixedTripletStepTracks)
+    
+        process.reconstruction_fromRECO.remove(pixelPairStepClusters)
+        process.reconstruction_fromRECO.remove(pixelPairStepSeeds)
+        process.reconstruction_fromRECO.remove(pixelPairStepSeedLayers)
+        process.reconstruction_fromRECO.remove(pixelPairStep)
+        process.reconstruction_fromRECO.remove(pixelPairStepTrackCandidates)
+        process.reconstruction_fromRECO.remove(pixelPairStepTracks)
+        
+        process.reconstruction_fromRECO.remove(tobTecStepClusters)
+        process.reconstruction_fromRECO.remove(tobTecStepSeeds)
+        #process.reconstruction_fromRECO.remove(tobTecStepSeedLayers)
+        process.reconstruction_fromRECO.remove(tobTecStepClassifier1)
+        process.reconstruction_fromRECO.remove(tobTecStepClassifier2)
+        process.reconstruction_fromRECO.remove(tobTecStep)
+        process.reconstruction_fromRECO.remove(tobTecStepTrackCandidates)
+        process.reconstruction_fromRECO.remove(tobTecStepTracks)
+    
+        # Yes, needs to be done twice for InOut...
+        process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
+        process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
+        process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
+        process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
+        process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
+        process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
+        process.reconstruction_fromRECO.remove(process.muonSeededSeedsOutIn)
+        process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesOutIn)
+        process.reconstruction_fromRECO.remove(process.muonSeededTracksOutIn)
+        # Why are these modules in this sequence (isn't iterTracking enough)?
+        process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsInOut)
+        process.muonSeededStepCoreDisplaced.remove(process.muonSeededTrackCandidatesInOut)
+        process.muonSeededStepCoreDisplaced.remove(process.muonSeededTracksInOut)
+        process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsOutIn)
+        process.muonSeededStepExtraDisplaced.remove(process.muonSeededTracksInOutClassifier)
+    
+        process.reconstruction_fromRECO.remove(process.convClusters)
+        process.reconstruction_fromRECO.remove(process.convLayerPairs)
+        process.reconstruction_fromRECO.remove(process.convStepSelector)
+        process.reconstruction_fromRECO.remove(process.convTrackCandidates)
+        process.reconstruction_fromRECO.remove(process.convStepTracks)
+        process.reconstruction_fromRECO.remove(process.photonConvTrajSeedFromSingleLeg)
+    
+        process.reconstruction_fromRECO.remove(process.preDuplicateMergingGeneralTracks)
 
-    # Yes, needs to be done twice for InOut...
-    process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
-    process.reconstruction_fromRECO.remove(process.muonSeededSeedsInOut)
-    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
-    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesInOut)
-    process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
-    process.reconstruction_fromRECO.remove(process.muonSeededTracksInOut)
-    process.reconstruction_fromRECO.remove(process.muonSeededSeedsOutIn)
-    process.reconstruction_fromRECO.remove(process.muonSeededTrackCandidatesOutIn)
-    process.reconstruction_fromRECO.remove(process.muonSeededTracksOutIn)
-    # Why are these modules in this sequence (isn't iterTracking enough)?
-    process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsInOut)
-    process.muonSeededStepCoreDisplaced.remove(process.muonSeededTrackCandidatesInOut)
-    process.muonSeededStepCoreDisplaced.remove(process.muonSeededTracksInOut)
-    process.muonSeededStepCoreDisplaced.remove(process.muonSeededSeedsOutIn)
-    process.muonSeededStepExtraDisplaced.remove(process.muonSeededTracksInOutClassifier)
-
-    process.reconstruction_fromRECO.remove(process.convClusters)
-    process.reconstruction_fromRECO.remove(process.convLayerPairs)
-    process.reconstruction_fromRECO.remove(process.convStepSelector)
-    process.reconstruction_fromRECO.remove(process.convTrackCandidates)
-    process.reconstruction_fromRECO.remove(process.convStepTracks)
-    process.reconstruction_fromRECO.remove(process.photonConvTrajSeedFromSingleLeg)
-
-    process.reconstruction_fromRECO.remove(process.preDuplicateMergingGeneralTracks)
+        del process.iterTracking
+        del process.ckftracks
+        del process.ckftracks_woBH
+        del process.ckftracks_wodEdX
+        del process.ckftracks_plus_pixelless
+        del process.trackingGlobalReco
+        del process.electronSeedsSeq
+        del process.InitialStep
+        del process.LowPtTripletStep
+        del process.PixelPairStep
+        del process.DetachedTripletStep
+        del process.MixedTripletStep
+        del process.PixelLessStep
+        del process.TobTecStep
+        del process.earlyGeneralTracks
+        del process.muonSeededStep
+        del process.muonSeededStepCore
+        del process.muonSeededStepCoreInOut
+        del process.muonSeededStepDebug
+        del process.muonSeededStepDebugInOut
+        del process.muonSeededStepDebugDisplaced
+        del process.ConvStep
+        # add the correct tracking back in
+        process.load("RecoTracker.Configuration.RecoTrackerPhase1PU"+str(nPU)+"_cff")
+    
+        process.globalreco_tracking.insert(itIndex,process.trackingGlobalReco)
+        process.globalreco.insert(grIndex,process.globalreco_tracking)
+        #Note process.reconstruction_fromRECO is broken
+        
+        # End of new tracking configuration which can be removed if new Reconstruction is used.
 
     # Needed to make the loading of recoFromSimDigis_cff below to work
     process.InitialStepPreSplitting.remove(siPixelClusters)
-
-    del process.iterTracking
-    del process.ckftracks
-    del process.ckftracks_woBH
-    del process.ckftracks_wodEdX
-    del process.ckftracks_plus_pixelless
-    del process.trackingGlobalReco
-    del process.electronSeedsSeq
-    del process.InitialStep
-    del process.LowPtTripletStep
-    del process.PixelPairStep
-    del process.DetachedTripletStep
-    del process.MixedTripletStep
-    del process.PixelLessStep
-    del process.TobTecStep
-    del process.earlyGeneralTracks
-    del process.muonSeededStep
-    del process.muonSeededStepCore
-    del process.muonSeededStepCoreInOut
-    del process.muonSeededStepDebug
-    del process.muonSeededStepDebugInOut
-    del process.muonSeededStepDebugDisplaced
-    del process.ConvStep
-    # add the correct tracking back in
-    process.load("RecoTracker.Configuration.RecoTrackerPhase1PU"+str(nPU)+"_cff")
-
-    process.globalreco_tracking.insert(itIndex,process.trackingGlobalReco)
-    process.globalreco.insert(grIndex,process.globalreco_tracking)
-    #Note process.reconstruction_fromRECO is broken
-    
-    # End of new tracking configuration which can be removed if new Reconstruction is used.
 
 
     process.reconstruction.remove(process.castorreco)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -35,7 +35,7 @@ _algos = [
     "muonSeededStepOutIn",
     "duplicateMerge",
 ]
-_algosForPhase1Pixel = [
+_algosForTrackingPhase1 = [
     "generalTracks",
     "initialStep",
     "highPtTripletStep",
@@ -72,7 +72,7 @@ _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
 _seedProducersForFastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
 
 
-_seedProducersForPhase1Pixel = [
+_seedProducersForTrackingPhase1 = [
         "initialStepSeeds",
         "highPtTripletStepSeeds",
         "lowPtQuadStepSeeds",
@@ -106,7 +106,7 @@ _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "muonSeededTracksOutIn"]
 _trackProducersForFastSim = [ x for x in _trackProducers if x not in _removeForFastTrackProducers]
 
-_trackProducersForPhase1Pixel = [
+_trackProducersForTrackingPhase1 = [
     "initialStepTracks",
     "highPtTripletStepTracks",
     "lowPtQuadStepTracks",
@@ -204,18 +204,18 @@ def _addSeedToTrackProducers(seedProducers,modDict):
 
 # Validation iterative steps
 (_selectorsByAlgo, tracksValidationSelectorsByAlgo) = _addSelectorsByAlgo(_algos, globals())
-(_selectorsByAlgo_phase1Pixel, _tracksValidationSelectorsByAlgo_phase1Pixel) = _addSelectorsByAlgo(_algosForPhase1Pixel, globals())
-eras.phase1Pixel.toReplaceWith(tracksValidationSelectorsByAlgo, _tracksValidationSelectorsByAlgo_phase1Pixel)
+(_selectorsByAlgo_trackingPhase1, _tracksValidationSelectorsByAlgo_trackingPhase1) = _addSelectorsByAlgo(_algosForTrackingPhase1, globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgo, _tracksValidationSelectorsByAlgo_trackingPhase1)
 
 # high purity
 (_selectorsByAlgoHp, tracksValidationSelectorsByAlgoHp) = _addSelectorsByHp(_algos,globals())
-(_selectorsByAlgoHp_phase1Pixel, _tracksValidationSelectorsByAlgoHp_phase1Pixel) = _addSelectorsByHp(_algosForPhase1Pixel,globals())
-eras.phase1Pixel.toReplaceWith(tracksValidationSelectorsByAlgoHp, _tracksValidationSelectorsByAlgoHp_phase1Pixel)
+(_selectorsByAlgoHp_trackingPhase1, _tracksValidationSelectorsByAlgoHp_trackingPhase1) = _addSelectorsByHp(_algosForTrackingPhase1, globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgoHp, _tracksValidationSelectorsByAlgoHp_trackingPhase1)
 
 _generalTracksHp = _selectorsByAlgoHp[0]
-_generalTracksHp_phase1Pixel = _selectorsByAlgoHp_phase1Pixel[0]
+_generalTracksHp_trackingPhase1 = _selectorsByAlgoHp_trackingPhase1[0]
 _selectorsByAlgoHp = _selectorsByAlgoHp[1:]
-_selectorsByAlgoHp_phase1Pixel = _selectorsByAlgoHp_phase1Pixel[1:]
+_selectorsByAlgoHp_trackingPhase1 = _selectorsByAlgoHp_trackingPhase1[1:]
 
 # BTV-like selection
 import PhysicsTools.RecoAlgos.btvTracks_cfi as btvTracks_cfi
@@ -273,9 +273,9 @@ generalTracksFromPV = _trackWithVertexRefSelector.clone(
 # and then the selectors
 (_selectorsFromPV, tracksValidationSelectorsFromPV) = _addSelectorsBySrc([_generalTracksHp], "FromPV", "generalTracksFromPV", globals())
 tracksValidationSelectorsFromPV.insert(0, generalTracksFromPV)
-(_selectorsFromPV_phase1Pixel, _tracksValidationSelectorsFromPV_phase1Pixel) = _addSelectorsBySrc([_generalTracksHp_phase1Pixel], "FromPV", "generalTracksFromPV", globals())
-_tracksValidationSelectorsFromPV_phase1Pixel.insert(0, generalTracksFromPV)
-eras.phase1Pixel.toReplaceWith(tracksValidationSelectorsFromPV, _tracksValidationSelectorsFromPV_phase1Pixel)
+(_selectorsFromPV_trackingPhase1, _tracksValidationSelectorsFromPV_trackingPhase1) = _addSelectorsBySrc([_generalTracksHp_trackingPhase1], "FromPV", "generalTracksFromPV", globals())
+_tracksValidationSelectorsFromPV_trackingPhase1.insert(0, generalTracksFromPV)
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsFromPV, _tracksValidationSelectorsFromPV_trackingPhase1)
 
 ## Select conversion TrackingParticles, and define the corresponding associator
 # (do not use associations because the collections of interest are not subsets of each other)
@@ -302,10 +302,12 @@ trackValidator = Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidato
 )
 eras.fastSim.toModify(trackValidator, 
                       dodEdxPlots = False)
-eras.phase1Pixel.toModify(trackValidator,
-                      label = ["generalTracks", _generalTracksHp_phase1Pixel] + _selectorsByAlgo_phase1Pixel + _selectorsByAlgoHp_phase1Pixel +  [
+eras.trackingPhase1.toModify(trackValidator,
+    label = ["generalTracks", _generalTracksHp_trackingPhase1] + _selectorsByAlgo_trackingPhase1 + _selectorsByAlgoHp_trackingPhase1 +  [
         "cutsRecoTracksBtvLike",
-        "cutsRecoTracksAK4PFJets"])
+        "cutsRecoTracksAK4PFJets"
+    ]
+)
 
 # For efficiency of signal TPs vs. signal tracks, and fake rate of
 # signal tracks vs. signal TPs
@@ -319,7 +321,7 @@ trackValidatorFromPV = trackValidator.clone(
     doPlotsOnlyForTruePV = True,
     doPVAssociationPlots = False,
 )
-eras.phase1Pixel.toModify(trackValidatorFromPV, label = ["generalTracksFromPV"]+_selectorsFromPV_phase1Pixel)
+eras.trackingPhase1.toModify(trackValidatorFromPV, label = ["generalTracksFromPV"]+_selectorsFromPV_trackingPhase1)
 
 # For fake rate of signal tracks vs. all TPs, and pileup rate of
 # signal tracks vs. non-signal TPs
@@ -349,7 +351,7 @@ trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi.sig
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.signalOnly = False
-eras.phase1Pixel.toModify(trackValidatorAllTPEffic, label = ["generalTracks", _generalTracksHp_phase1Pixel])
+eras.trackingPhase1.toModify(trackValidatorAllTPEffic, label = ["generalTracks", _generalTracksHp_trackingPhase1])
 
 # For conversions
 trackValidatorConversion = trackValidator.clone(
@@ -431,26 +433,26 @@ eras.fastSim.toModify(tracksValidation, lambda x: x.remove(trackValidatorConvers
 
 # Select by originalAlgo and algoMask
 _selectorsByAlgoAndHp = _selectorsByAlgo+_selectorsByAlgoHp
-_selectorsByAlgoAndHp_phase1Pixel = _selectorsByAlgo_phase1Pixel+_selectorsByAlgoHp_phase1Pixel
+_selectorsByAlgoAndHp_trackingPhase1 = _selectorsByAlgo_trackingPhase1+_selectorsByAlgoHp_trackingPhase1
 (_selectorsByOriginalAlgo, tracksValidationSelectorsByOriginalAlgoStandalone) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp, "ByOriginalAlgo", "originalAlgorithm",globals())
-(_selectorsByOriginalAlgo_phase1Pixel, _tracksValidationSelectorsByOriginalAlgoStandalone_phase1Pixel) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_phase1Pixel, "ByOriginalAlgo", "originalAlgorithm",globals())
-eras.phase1Pixel.toReplaceWith(tracksValidationSelectorsByOriginalAlgoStandalone, _tracksValidationSelectorsByOriginalAlgoStandalone_phase1Pixel)
+(_selectorsByOriginalAlgo_trackingPhase1, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1, "ByOriginalAlgo", "originalAlgorithm",globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByOriginalAlgoStandalone, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1)
 
 (_selectorsByAlgoMask, tracksValidationSelectorsByAlgoMaskStandalone) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp, "ByAlgoMask", "algorithmMaskContains",globals())
-(_selectorsByAlgoMask_phase1Pixel, _tracksValidationSelectorsByAlgoMaskStandalone_phase1Pixel) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_phase1Pixel, "ByAlgoMask", "algorithmMaskContains",globals())
-eras.phase1Pixel.toReplaceWith(tracksValidationSelectorsByAlgoMaskStandalone, _tracksValidationSelectorsByAlgoMaskStandalone_phase1Pixel)
+(_selectorsByAlgoMask_trackingPhase1, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1, "ByAlgoMask", "algorithmMaskContains",globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgoMaskStandalone, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1)
 
 # Select fromPV by iteration
 (_selectorsFromPVStandalone, tracksValidationSelectorsFromPVStandalone) = _addSelectorsBySrc(_selectorsByAlgoAndHp, "FromPV", "generalTracksFromPV",globals())
-(_selectorsFromPVStandalone_phase1Pixel, _tracksValidationSelectorsFromPVStandalone_phase1Pixel) = _addSelectorsBySrc(_selectorsByAlgoAndHp_phase1Pixel, "FromPV", "generalTracksFromPV",globals())
-eras.phase1Pixel.toReplaceWith(tracksValidationSelectorsFromPVStandalone, _tracksValidationSelectorsFromPVStandalone_phase1Pixel)
+(_selectorsFromPVStandalone_trackingPhase1, _tracksValidationSelectorsFromPVStandalone_trackingPhase1) = _addSelectorsBySrc(_selectorsByAlgoAndHp_trackingPhase1, "FromPV", "generalTracksFromPV",globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsFromPVStandalone, _tracksValidationSelectorsFromPVStandalone_trackingPhase1)
 
 # MTV instances
 trackValidatorStandalone = trackValidator.clone( label = trackValidator.label+ _selectorsByOriginalAlgo + _selectorsByAlgoMask)
-eras.phase1Pixel.toModify(trackValidatorStandalone, label = trackValidator.label+ _selectorsByOriginalAlgo_phase1Pixel + _selectorsByAlgoMask_phase1Pixel)
+eras.trackingPhase1.toModify(trackValidatorStandalone, label = trackValidator.label+ _selectorsByOriginalAlgo_trackingPhase1 + _selectorsByAlgoMask_trackingPhase1)
 
 trackValidatorFromPVStandalone = trackValidatorFromPV.clone( label = trackValidatorFromPV.label+_selectorsFromPVStandalone)
-eras.phase1Pixel.toModify(trackValidatorFromPVStandalone, label = trackValidatorFromPV.label+_selectorsFromPVStandalone_phase1Pixel)
+eras.trackingPhase1.toModify(trackValidatorFromPVStandalone, label = trackValidatorFromPV.label+_selectorsFromPVStandalone_trackingPhase1)
 
 trackValidatorFromPVAllTPStandalone = trackValidatorFromPVAllTP.clone(
     label = trackValidatorFromPVStandalone.label.value()
@@ -493,9 +495,9 @@ tracksValidationStandalone = cms.Sequence(
 tracksValidationSelectorsTrackingOnly = tracksValidationSelectors.copyAndExclude([ak4JetTracksAssociatorExplicitAll,cutsRecoTracksAK4PFJets]) # selectors using track information only (i.e. no PF)
 (_seedSelectors, tracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducers, globals())
 (_fastSimSeedSelectors, _fastSimTracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForFastSim, globals())
-(_phase1PixelSeedSelectors, _phase1PixelTracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForPhase1Pixel, globals())
+(_trackingPhase1SeedSelectors, _trackingPhase1TracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForTrackingPhase1, globals())
 eras.fastSim.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _fastSimTracksValidationSeedSelectorsTrackingOnly)
-eras.phase1Pixel.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _phase1PixelTracksValidationSeedSelectorsTrackingOnly)
+eras.trackingPhase1.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _trackingPhase1TracksValidationSeedSelectorsTrackingOnly)
 
 # MTV instances
 trackValidatorTrackingOnly = trackValidatorStandalone.clone(label = [ x for x in trackValidatorStandalone.label if x != "cutsRecoTracksAK4PFJets"] )
@@ -511,7 +513,7 @@ trackValidatorBuildingTrackingOnly = trackValidatorTrackingOnly.clone(
 )
 
 eras.fastSim.toModify(trackValidatorBuildingTrackingOnly, label =  _trackProducersForFastSim )
-eras.phase1Pixel.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForPhase1Pixel)
+eras.trackingPhase1.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForTrackingPhase1)
 
 trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
     dirName = "Tracking/TrackSeeding/",
@@ -519,7 +521,7 @@ trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
     doSeedPlots = True,
 )
 eras.fastSim.toModify(trackValidatorSeedingTrackingOnly, label= _fastSimSeedSelectors)
-eras.phase1Pixel.toModify(trackValidatorSeedingTrackingOnly, label= _phase1PixelSeedSelectors)
+eras.trackingPhase1.toModify(trackValidatorSeedingTrackingOnly, label= _trackingPhase1SeedSelectors)
 
 
 trackValidatorConversionTrackingOnly = trackValidatorConversion.clone(label = [x for x in trackValidatorConversion.label if x not in ["ckfInOutTracksFromConversions", "ckfOutInTracksFromConversions"]])


### PR DESCRIPTION
This PR migrates the iterative tracking customization for 2017 from `phase1TkCustoms` to `trackingPhase1` and `phase1Pixel` eras, as discussed in Feb 17 RECO meeting https://indico.cern.ch/event/489288/session/4/contribution/11/attachments/1230229/1803017/slides_phase1_trk_reco.pdf.

As a first step "displaced muon" configuration is modified to not to import from iterative tracking configurations (imports from there within the same application will just cause headache; but are the tracking internal sequences really needed here at all?).

The TTRHBuilder customization is set to depend on the `phase1Pixel` era since it depends on the detector configuration and is the same for any 2017 tracking configuration. Although it is a temporary customization, I decided to "erafy" it because it is expected to be "fixed" around June (and I hope `phase1TkCustoms.py` is long gone by then). All occurrances of this and other temporary customizations should be found with `git grep "phase1Pixe.*FIXME"`.

Subsequent steps are
- Migrate rest of `phase1TkCustoms.customise_Reco()` to eras
  - There is one issue that needs to solved, it is being discussed in #13381
- Move what is now under `trackingPhase1` era to `trackingPhase1PU70` era, and put the "new phase1 tracking" (from #13149) to under `trackingPhase1` era

Tested in CMSSW_8_1_X_2016-02-23-2300 with `runTheMatrix.py -i all -l limited` for <= 2016 and `-w upgrade -l 10000,10039` for 2017 workflows. No changes are expected in monitored quantities (expanded job configuration files do change for both 2016 and 2017, but are functionally equivalent before and after this PR).

This is purely technical PR, no changes are expected.

@rovere @VinInn 
