### PR TITLE
Me0 digitizer constand phi smearing 800

### DIFF
--- a/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
@@ -24,19 +24,19 @@ public:
   ~ME0PreRecoGaussianModel();
 
   void simulateSignal(const ME0EtaPartition*, const edm::PSimHitContainer&, CLHEP::HepRandomEngine*) override;
-
   void simulateNoise(const ME0EtaPartition*, CLHEP::HepRandomEngine*) override;
-
+  double correctSigmaU(const ME0EtaPartition*, double);
   void setup() {}
 
 private:
   double sigma_t;
   double sigma_u;
   double sigma_v;
+  bool gaussianSmearing_;
+  double constPhiSmearing_;
   bool corr;
   bool etaproj;
   bool digitizeOnlyMuons_;
-  bool gaussianSmearing_;
   double averageEfficiency_;
   // bool simulateIntrinsicNoise_; // not implemented
   // double averageNoiseRate_;     // not implemented

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -7,6 +7,7 @@ simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
     timeResolution = cms.double(0.001), # in ns
     phiResolution = cms.double(0.05),   # in cm average resolution along local x in case of no correlation
     etaResolution = cms.double(1.),     # in cm average resolution along local y in case of no correlation
+    constantPhiSpatialResolution = cms.bool(False),
     useCorrelation = cms.bool(False),
     useEtaProjectiveGEO = cms.bool(False),
     averageEfficiency = cms.double(0.98),


### PR DESCRIPTION
Make configuration file of ME0Digitizer configurable such that one can choose between constant phi smearing in local coordinates (e.g. 500um everywhere) or constant phi smearing in radians 0.019\* (=3.3E-4 rad) everywhere.

at R=62cm, a smearing of 500um corresponds to 0.046\* = 8.1E-4 rad
at R=150cm, a smearing of 500um corresponds to 0.019\* = 3.3E-4 rad

Port of #13397 to 81X. Corresponding SLHCDEV PR is #13396.
