### PR TITLE
add scenario for handling tracking w/o CCC

### DIFF
--- a/Configuration/DataProcessing/python/Impl/trackingnoccc.py
+++ b/Configuration/DataProcessing/python/Impl/trackingnoccc.py
@@ -10,10 +10,6 @@ import os
 import sys
 
 from Configuration.DataProcessing.Impl.pp import pp
-from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-
-def esproducers_by_type(process, *types):
-    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
 
 class trackingnoccc(pp):
     def __init__(self):

--- a/Configuration/DataProcessing/python/Impl/trackingnoccc.py
+++ b/Configuration/DataProcessing/python/Impl/trackingnoccc.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+_trackingnoccc_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.pp import pp
+from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+
+def esproducers_by_type(process, *types):
+    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
+
+class trackingnoccc(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=':reconstruction_trackingOnly'
+        self.cbSc='pp'
+        self.promptCustoms  += [ 'RecoTracker/Configuration/customiseForRunIInoCCC.customiseForRunIInoCCC' ]
+        self.expressCustoms += [ 'RecoTracker/Configuration/customiseForRunIInoCCC.customiseForRunIInoCCC' ]
+
+    """
+    _trackingnoccc_
+
+    Implement configuration building for data processing for proton
+    collision data taking without CCC in the tracking sequence
+
+    """
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Proton collision data taking prompt reco
+
+        """
+
+#        if not 'skims' in args:
+#            args['skims']=['SiStripAlCaMinBias']
+
+        process = pp.promptReco(self,globalTag,**args)
+
+        return process

--- a/Configuration/DataProcessing/python/Impl/trackingnocccEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/trackingnocccEra_Run2_2016.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+_trackingnocccEra_Run2_2016_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.trackingnoccc import trackingnoccc
+import Configuration.StandardSequences.Eras as eras
+
+class trackingnocccEra_Run2_2016(trackingnoccc):
+    def __init__(self):
+        trackingnoccc.__init__(self)
+        self.recoSeq=':reconstruction_trackingOnly'
+        self.cbSc='pp'
+        self.eras = eras.eras.Run2_2016
+
+    """
+    _trackingnocccEra_Run2_2016_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "trackingnoccc" "trackingnocccEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/RecoTracker/Configuration/python/customiseForRunIInoCCC.py
+++ b/RecoTracker/Configuration/python/customiseForRunIInoCCC.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseForRunIInoCCC(process):
+
+    # overwrite parameters which handles the CCC value            
+    if hasattr(process,'SiStripClusterChargeCutTiny'):
+        setattr(process,'SiStripClusterChargeCutTiny', cms.PSet(value = cms.double( -1.0 ) ) )  #  800.0
+    if hasattr(process,'SiStripClusterChargeCutLoose'):
+        setattr(process,'SiStripClusterChargeCutLoose', cms.PSet(value = cms.double( -1.0 ) ) ) # 1620.0
+    if hasattr(process,'SiStripClusterChargeCutTight'):
+        setattr(process,'SiStripClusterChargeCutTight', cms.PSet(value = cms.double( -1.0 ) ) ) # 1945.0
+        
+
+    return process


### PR DESCRIPTION
I created a new scenario for handling the track reconstruction w/o CCC
this is mainly meant for having the possibility of running the tracking w/o CCC on dedicated streams/PDs in case of need @tier0

hope it is fine

NB:
it should be back ported in 80x, if we want to make use of it in 2016 data processing
please, let me know if I can do a dedicated PR for 80x

NB:
the implementation is closer to a trick, rather than a proper handling of each instances of the cut w/in the reco config,
but I was not able to handle all different instances :(

ps:
thanks to @slava77 and @mmusich for the suggestions !

@rovere @VinInn @mmusich @boudoul @dimattia 
