### PR TITLE
Principal::getForOutput now always retrieves the product

### DIFF
--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -95,7 +95,7 @@ namespace edm {
     
     EDProductGetter const* prodGetter() const {return this;}
 
-    OutputHandle getForOutput(BranchID const& bid, bool getProd, ModuleCallingContext const* mcc) const;
+    OutputHandle getForOutput(BranchID const& bid, ModuleCallingContext const* mcc) const;
 
     // Return a BasicHandle to the product which:
     //   1. matches the given label, instance, and process

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -89,10 +89,10 @@ namespace edm {
                       ModuleCallingContext const*);
 
      void insertAncestors(ProductProvenance const& iGetParents,
-                          EventPrincipal const& principal,
+                          ProductProvenanceRetriever const* iMapper,
                           bool produced,
-                          std::set<StoredProductProvenance>& oToFill,
-                          ModuleCallingContext const*);
+                          std::set<BranchID> const& producedBranches,
+                          std::set<StoredProductProvenance>& oToFill);
 
     bool insertProductProvenance(const ProductProvenance&,
                                  std::set<StoredProductProvenance>& oToInsert);

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -143,7 +143,7 @@ namespace edm {
       BranchDescription const& desc = **i;
       BranchID const& id = desc.branchID();
 
-      OutputHandle const oh = eventPrincipal.getForOutput(id, true, mcc);
+      OutputHandle const oh = eventPrincipal.getForOutput(id, mcc);
       if(!oh.productProvenance()) {
         // No product with this ID was put in the event.
         // Create and write the provenance.


### PR DESCRIPTION
The method Principal::getForOutput now always retrieves the product. If only the provenance is needed one should call ProductProvenanceRetriever directly.
This change is needed as a step towards allowing more than one thread per event.
