### PR TITLE
FastSim: disable btag DQM cause it depends on product not available in FastSim

### DIFF
--- a/FastSimulation/Configuration/python/DQMOfflineMC_cff.py
+++ b/FastSimulation/Configuration/python/DQMOfflineMC_cff.py
@@ -8,11 +8,9 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.RecoB.PrimaryVertexMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
-from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from Validation.RecoTau.DQMSequences_cfi import *
 
 DQMOfflinePrePOG = cms.Sequence(
-    bTagPlotsDATA *	
     pvMonitor *
     dqmPhysics *
     produceDenoms *


### PR DESCRIPTION
fixes crashes in FastSim workflows in CMSSW_8_1_X_2016-02-26-0800
