### PR TITLE
fix memory leak in EcalClusterLazyToolsBase::eseffsirir

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -78,7 +78,7 @@ class EcalClusterLazyToolsBase {
   
   edm::EDGetTokenT<EcalRecHitCollection> ebRHToken_, eeRHToken_, esRHToken_;
 
-  std::unique_ptr<CaloSubdetectorTopology> ecalPS_topology_;
+  std::shared_ptr<CaloSubdetectorTopology> ecalPS_topology_;
 
   //const EcalIntercalibConstantMap& icalMap;
   edm::ESHandle<EcalIntercalibConstants> ical;

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -78,6 +78,8 @@ class EcalClusterLazyToolsBase {
   
   edm::EDGetTokenT<EcalRecHitCollection> ebRHToken_, eeRHToken_, esRHToken_;
 
+  std::unique_ptr<CaloSubdetectorTopology> ecalPS_topology_;
+
   //const EcalIntercalibConstantMap& icalMap;
   edm::ESHandle<EcalIntercalibConstants> ical;
   EcalIntercalibConstantMap        icalMap;

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -50,7 +50,7 @@ class EcalClusterLazyToolsBase {
   // mapping for preshower rechits
   std::map<DetId, EcalRecHit> rechits_map_;
   // get Preshower hit array
-  std::vector<float> getESHits(double X, double Y, double Z, const std::map<DetId, EcalRecHit>& rechits_map, const CaloGeometry* geometry, CaloSubdetectorTopology *topology_p, int row=0, int plane=1);
+  std::vector<float> getESHits(double X, double Y, double Z, const std::map<DetId, EcalRecHit>& rechits_map, const CaloGeometry* geometry, CaloSubdetectorTopology const *topology_p, int row=0, int plane=1);
   // get Preshower hit shape
   float getESShape(const std::vector<float>& ESHits0);
   // get Preshower effective sigmaRR
@@ -78,7 +78,7 @@ class EcalClusterLazyToolsBase {
   
   edm::EDGetTokenT<EcalRecHitCollection> ebRHToken_, eeRHToken_, esRHToken_;
 
-  std::shared_ptr<CaloSubdetectorTopology> ecalPS_topology_;
+  std::shared_ptr<CaloSubdetectorTopology const> ecalPS_topology_;
 
   //const EcalIntercalibConstantMap& icalMap;
   edm::ESHandle<EcalIntercalibConstants> ical;

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -301,7 +301,7 @@ float EcalClusterLazyToolsBase::eseffsiyiy(const reco::SuperCluster &cluster)
 }
 
 // get Preshower Rechits
-std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, double Z, const std::map<DetId, EcalRecHit>& _rechits_map, const CaloGeometry* geometry, CaloSubdetectorTopology *topology_p, int row, int plane) 
+std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, double Z, const std::map<DetId, EcalRecHit>& _rechits_map, const CaloGeometry* geometry, CaloSubdetectorTopology const *topology_p, int row, int plane) 
 {
   std::map<DetId, EcalRecHit> rechits_map = _rechits_map;
   std::vector<float> esHits;

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -265,6 +265,8 @@ float EcalClusterLazyToolsBase::eseffsirir(const reco::SuperCluster &cluster)
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
 
+  delete topology_p;
+
   return sqrt(phoESShapeIXIX*phoESShapeIXIX + phoESShapeIYIY*phoESShapeIYIY);
 }
 

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -59,6 +59,14 @@ void EcalClusterLazyToolsBase::getGeometry( const edm::EventSetup &es ) {
         edm::ESHandle<CaloGeometry> pGeometry;
         es.get<CaloGeometryRecord>().get(pGeometry);
         geometry_ = pGeometry.product();
+
+        const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+        if (geometryES) {
+          ecalPS_topology_.reset(new EcalPreshowerTopology(geometry_));
+        } else {
+          ecalPS_topology_.reset();
+          edm::LogWarning("subdetector geometry not available") << "EcalPreshower geometry is missing" << std::endl;
+        }
 }
 
 void EcalClusterLazyToolsBase::getTopology( const edm::EventSetup &es ) {
@@ -256,12 +264,8 @@ float EcalClusterLazyToolsBase::eseffsirir(const reco::SuperCluster &cluster)
 {
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
-  const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  std::unique_ptr<CaloSubdetectorTopology> topology_p;
-  if (geometryES) topology_p.reset(new EcalPreshowerTopology(geometry_));
-
-  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 1);
-  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 2);
+  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
+  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
 
@@ -273,11 +277,7 @@ float EcalClusterLazyToolsBase::eseffsixix(const reco::SuperCluster &cluster)
 {
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
-  const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  std::unique_ptr<CaloSubdetectorTopology> topology_p;
-  if (geometryES) topology_p.reset(new EcalPreshowerTopology(geometry_));
-
-  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 1);
+  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
 
   return phoESShapeIXIX;
@@ -288,11 +288,7 @@ float EcalClusterLazyToolsBase::eseffsiyiy(const reco::SuperCluster &cluster)
 {
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
-  const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  std::unique_ptr<CaloSubdetectorTopology> topology_p;
-  if (geometryES) topology_p.reset(new EcalPreshowerTopology(geometry_));
-
-  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 2);
+  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
 
   return phoESShapeIYIY;

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -257,15 +257,13 @@ float EcalClusterLazyToolsBase::eseffsirir(const reco::SuperCluster &cluster)
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
   const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_p = 0;
-  if (geometryES) topology_p = new EcalPreshowerTopology(geometry_);
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
+  if (geometryES) topology_p.reset(new EcalPreshowerTopology(geometry_));
 
-  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p, 0, 1);
-  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p, 0, 2);
+  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 1);
+  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 2);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
-
-  delete topology_p;
 
   return sqrt(phoESShapeIXIX*phoESShapeIXIX + phoESShapeIYIY*phoESShapeIYIY);
 }

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -264,6 +264,8 @@ float EcalClusterLazyToolsBase::eseffsirir(const reco::SuperCluster &cluster)
 {
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
+  if (!ecalPS_topology_) return 0.;
+
   std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
   std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
@@ -277,6 +279,8 @@ float EcalClusterLazyToolsBase::eseffsixix(const reco::SuperCluster &cluster)
 {
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
+  if (!ecalPS_topology_) return 0.;
+
   std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
 
@@ -287,6 +291,8 @@ float EcalClusterLazyToolsBase::eseffsixix(const reco::SuperCluster &cluster)
 float EcalClusterLazyToolsBase::eseffsiyiy(const reco::SuperCluster &cluster)
 {
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
+
+  if (!ecalPS_topology_) return 0.;
 
   std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -274,10 +274,10 @@ float EcalClusterLazyToolsBase::eseffsixix(const reco::SuperCluster &cluster)
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
   const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_p = 0;
-  if (geometryES) topology_p = new EcalPreshowerTopology(geometry_);
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
+  if (geometryES) topology_p.reset(new EcalPreshowerTopology(geometry_));
 
-  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p, 0, 1);
+  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 1);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
 
   return phoESShapeIXIX;
@@ -289,10 +289,10 @@ float EcalClusterLazyToolsBase::eseffsiyiy(const reco::SuperCluster &cluster)
   if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
 
   const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_p = 0;
-  if (geometryES) topology_p = new EcalPreshowerTopology(geometry_);
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
+  if (geometryES) topology_p.reset(new EcalPreshowerTopology(geometry_));
 
-  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p, 0, 2);
+  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, topology_p.get(), 0, 2);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
 
   return phoESShapeIYIY;


### PR DESCRIPTION
I just came across this memory leak.

Also I'm wondering if `geometryES` in this function is needed at all (only `geometry_` is used). But I'm not familiar with this code, maybe the call of `getSubdetectorGeometry()` is important.
