### PR TITLE
Print deprecation warning if anybody uses phase1TkCustoms without phase1Pixel era

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -7,6 +7,28 @@ from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_pixe
 from Configuration.StandardSequences.Eras import eras
 
 def customise(process):
+    if not eras.phase1Pixel.isChosen():
+        import sys
+        sys.stderr.write("""
+########################################
+#
+# -- Warning! You are using a deprecated customisation function. --
+#
+# It will probably run fine (for now), but the customisations you are getting may be out of date
+# (and will be removed after a short while)
+# You should update your configuration file by
+#   If using cmsDriver:
+#       1) add the option "--era Run2_2017" 
+#   If using a pre-made configuration file:
+#       1) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+#          the process declaration).
+#       2) add "eras.Run2_2017" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_2017)" 
+#
+# There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
+#
+########################################
+""")
+
     if hasattr(process,'DigiToRaw'):
         process=customise_DigiToRaw(process)
     if hasattr(process,'RawToDigi'):


### PR DESCRIPTION
Title says it all. Suggested by @slava77 in https://github.com/cms-sw/cmssw/pull/13477/files#r54273167. I used the message in `postLS1Customs.py` as a template.

Tested in CMSSW_8_1_X_2016-02-23-2300, no changes expected.
