### PR TITLE
 add missing initialization in CaloCluster (same as #13506 )

### DIFF
--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -60,7 +60,7 @@ namespace reco {
      /// constructor from values 
      CaloCluster( double energy,  
  		 const math::XYZPoint& position ) : 
-       energy_ (energy), correctedEnergy_(-1.0), position_ (position),algoID_( undefined ), flags_(0) {} 
+    energy_ (energy), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), position_ (position),algoID_( undefined ), flags_(0) {} 
 
 
     CaloCluster( double energy,
@@ -68,7 +68,7 @@ namespace reco {
 		 const CaloID& caloID,
                  const AlgoID& algoID,
                  uint32_t flags = 0) :
-      energy_ (energy), correctedEnergy_(-1.0), position_ (position), 
+    energy_ (energy), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), position_ (position), 
       caloID_(caloID), algoID_(algoID) {
       flags_=flags&flagsMask_;
     }
@@ -80,7 +80,7 @@ namespace reco {
                  const AlgoId algoId,
 		 const DetId seedId = DetId(0),
                  uint32_t flags = 0) :
-      energy_ (energy), correctedEnergy_(-1.0), position_ (position), caloID_(caloID), 
+    energy_ (energy), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), position_ (position), caloID_(caloID), 
       hitsAndFractions_(usedHitsAndFractions), algoID_(algoId),seedId_(seedId){
       flags_=flags&flagsMask_;
     }
@@ -93,7 +93,7 @@ namespace reco {
                  const std::vector<DetId > &usedHits,
                  const AlgoId algoId,
                  uint32_t flags = 0) :
-      energy_(energy), correctedEnergy_(-1.0), position_ (position),  algoID_(algoId)
+    energy_(energy), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), position_ (position),  algoID_(algoId)
        {
           hitsAndFractions_.reserve(usedHits.size());
           for(size_t i = 0; i < usedHits.size(); i++) hitsAndFractions_.push_back(std::pair< DetId, float > ( usedHits[i],1.));


### PR DESCRIPTION
add missing correctedEnergyUncertainty_ initialization in a few constructors

Some of the CaloCluster (or classes deriving from it) collections do not use the correctedEnergy* data members, in some cases the correctedEnergyUncertainty_ was never initialized. This generated occasional random numbers in the saved products and can also trigger fake differences in event size comparisons.

after the fix all values are now appropriately set to 1 (the plot isn't showing it directly, but it shows that there is a range of values in the old/baseline version)
![all_sign674vsorig_runhi2011wf140p53c_log10max1e-5 recocaloclusters_multi5x5superclusters_multi5x5endcapbasicclusters_rereco_obj_correctedenergyuncertainty](https://cloud.githubusercontent.com/assets/4676718/13365971/1493b52e-dc8d-11e5-9a8c-beb7414b7352.png)
