### PR TITLE
add QIE10 product to DataMixingModule (one-line fix)

### DIFF
--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -131,7 +131,7 @@ namespace edm
 
       produces<HBHEUpgradeDigiCollection>("HBHEUpgradeDigiCollection");
       produces<HFUpgradeDigiCollection>("HFUpgradeDigiCollection");
-
+      produces<QIE10DigiCollection>("HFQIE10DigiCollection");
 
       if(MergeHcalDigisProd_) {
 	//        edm::ConsumesCollector iC(consumesCollector());


### PR DESCRIPTION
@davidlange6 @lveldere - This should fix the problem you observed with premixing. I ran 250202.0 with the fix and step2 finished successfully.

At some point we'll need actual premixing functionality for QIE10 (and QIE11), but that is a task for another day.
