### PR TITLE
EMTF DQM Module

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -52,7 +52,9 @@ process.gctDigis.numberOfGctSamplesToUnpack = cms.uint32(5)
 
 process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
 
-process.stage2UnpackPath = cms.Path(process.caloStage2Digis+process.gmtStage2Digis)
+process.stage2UnpackPath = cms.Path(process.caloStage2Digis +
+                                    process.gmtStage2Digis +
+                                    process.emtfStage2Digis)
 
 process.l1tMonitorPath = cms.Path(process.l1tStage2online)
 

--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -1,0 +1,43 @@
+#ifndef DQM_L1TMonitor_L1TStage2EMTF_h
+#define DQM_L1TMonitor_L1TStage2EMTF_h
+
+#include "DataFormats/L1TMuon/interface/EMTFOutput.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+class L1TStage2EMTF : public DQMEDAnalyzer {
+
+ public:
+
+  L1TStage2EMTF(const edm::ParameterSet& ps);
+  virtual ~L1TStage2EMTF();
+
+ protected:
+
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+ private:
+
+  edm::EDGetTokenT<l1t::EMTFOutputCollection> emtfToken;
+  std::string monitorDir;
+  bool verbose;
+ 
+  MonitorElement* emtfnTracks;
+  MonitorElement* emtfTrackBX;
+  MonitorElement* emtfTrackPt;
+  MonitorElement* emtfTrackEta;
+  MonitorElement* emtfTrackPhi;
+  MonitorElement* emtfTrackPhiFull;
+  MonitorElement* emtfTrackOccupancy;
+};
+
+#endif

--- a/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tStage2Emtf = cms.EDAnalyzer(
+    'L1TStage2EMTF',
+    emtfSource = cms.InputTag('emtfStage2Digis'),
+    monitorDir = cms.untracked.string('L1T2016/L1TStage2EMTF'), 
+    verbose = cms.untracked.bool(False),
+)
+

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -10,7 +10,7 @@ from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
 from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import *
 
 l1tStage2online = cms.Sequence(
-    l1tStage2CaloLayer2+
-    l1tStage2mGMT+
+    l1tStage2CaloLayer2 +
+    l1tStage2mGMT +
     l1tStage2Emtf
     )

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -2,12 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitor.L1TStage2CaloLayer2_cfi import *
 from DQM.L1TMonitor.L1TStage2mGMT_cfi import *
+from DQM.L1TMonitor.L1TStage2EMTF_cfi import *
 
 
 from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import *
 from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
+from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import *
 
 l1tStage2online = cms.Sequence(
     l1tStage2CaloLayer2+
-    l1tStage2mGMT
+    l1tStage2mGMT+
+    l1tStage2Emtf
     )

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -1,0 +1,61 @@
+#include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
+
+
+L1TStage2EMTF::L1TStage2EMTF(const edm::ParameterSet& ps) 
+    : emtfToken(consumes<l1t::EMTFOutputCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
+      monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
+      verbose(ps.getUntrackedParameter<bool>("verbose", false)) {}
+
+L1TStage2EMTF::~L1TStage2EMTF() {}
+
+void L1TStage2EMTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
+
+void L1TStage2EMTF::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
+
+void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+
+  ibooker.setCurrentFolder(monitorDir);
+
+  emtfnTracks = ibooker.book1D("emtfnTracks", "Number of EMTF Tracks per Event", 4, 0, 4);
+  
+  emtfTrackPt = ibooker.book1D("emtfTrackPt", "EMTF Track p_{T}", 512, 0, 512);
+  emtfTrackPt->setAxisTitle("Track p_{T} [GeV]", 1);
+
+  emtfTrackEta = ibooker.book1D("emtfTrackEta", "EMTF Track #eta", 460, -230, 230);
+  emtfTrackEta->setAxisTitle("Track #eta", 1);
+
+  emtfTrackPhi = ibooker.book1D("emtfTrackPhi", "EMTF Track #phi", 116, -16, 100);
+  emtfTrackPhi->setAxisTitle("Track #phi", 1);
+
+  emtfTrackPhiFull = ibooker.book1D("emtfTrackPhiFull", "EMTF Full Precision Track #phi", 4096, 0, 4096);
+  emtfTrackPhiFull->setAxisTitle("Full Precision Track #phi", 1);
+
+  emtfTrackBX = ibooker.book1D("emtfTrackBX", "EMTF Track Bunch Crossings", 4, 0, 4);
+  emtfTrackBX->setAxisTitle("Track BX", 1);
+}
+
+void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
+
+  if (verbose) edm::LogInfo("L1TStage2EMTF") << "L1TStage2EMTF: analyze..." << std::endl;
+
+  int nTracks = 0;
+
+  edm::Handle<l1t::EMTFOutputCollection> EMTF;
+  e.getByToken(emtfToken, EMTF);
+ 
+  for (std::vector<l1t::EMTFOutput>::const_iterator itEMTF = EMTF->begin(); itEMTF != EMTF->end(); ++itEMTF) {
+
+    l1t::emtf::SPCollection SP = itEMTF->GetSPCollection();
+
+    for (std::vector<l1t::emtf::SP>::const_iterator itSP = SP.begin(); itSP != SP.end(); ++itSP) {
+      emtfTrackBX->Fill(itSP->BX());
+      emtfTrackPt->Fill(itSP->Pt());
+      emtfTrackEta->Fill(itSP->Eta_GMT());
+      emtfTrackPhi->Fill(itSP->Phi_GMT());
+      emtfTrackPhiFull->Fill(itSP->Phi_full());
+      nTracks++;
+    }
+  }
+  emtfnTracks->Fill(nTracks);
+}
+

--- a/DQM/L1TMonitor/src/SealModule.cc
+++ b/DQM/L1TMonitor/src/SealModule.cc
@@ -35,6 +35,9 @@ DEFINE_FWK_MODULE(L1TStage2mGMT);
 #include <DQM/L1TMonitor/interface/L1TStage2BMTF.h>
 DEFINE_FWK_MODULE(L1TStage2BMTF);
 
+#include <DQM/L1TMonitor/interface/L1TStage2EMTF.h>
+DEFINE_FWK_MODULE(L1TStage2EMTF);
+
 #include <DQM/L1TMonitor/interface/L1TGCT.h>
 DEFINE_FWK_MODULE(L1TGCT);
 

--- a/DataFormats/L1TMuon/interface/EMTFOutput.h
+++ b/DataFormats/L1TMuon/interface/EMTFOutput.h
@@ -50,27 +50,27 @@ namespace l1t {
     void set_AMC13Trailer(emtf::AMC13Trailer bits)  { AMC13Trailer = bits; hasAMC13Trailer = true; };
     void set_dataword(uint64_t bits)                { dataword = bits;               };
     
-    bool HasAMC13Header()                   { return hasAMC13Header;  };
-    bool HasMTF7Header()                    { return hasMTF7Header;   };
-    bool HasEventHeader()                   { return hasEventHeader;  };
-    bool HasCounters()                      { return hasCounters;     };
-    int  NumSP()                            { return numSP;           };
-    int  NumRPC()                           { return numRPC;          };
-    int  NumME()                            { return numME;           };
-    bool HasAMC13Trailer()                  { return hasAMC13Trailer; };
-    bool HasMTF7Trailer()                   { return hasMTF7Trailer;  };
-    bool HasEventTrailer()                  { return hasEventTrailer; };
-    emtf::AMC13Header GetAMC13Header()      { return AMC13Header;   };
-    emtf::MTF7Header GetMTF7Header()        { return MTF7Header;    };
-    emtf::EventHeader GetEventHeader()      { return EventHeader;   };
-    emtf::Counters GetCounters()            { return Counters;      };
-    emtf::MECollection GetMECollection()    { return MECollection;  };
-    emtf::RPCCollection GetRPCCollection()  { return RPCCollection; };
-    emtf::SPCollection GetSPCollection()    { return SPCollection;  };
-    emtf::EventTrailer GetEventTrailer()    { return EventTrailer;  };
-    emtf::MTF7Trailer GetMTF7Trailer()      { return MTF7Trailer;   };
-    emtf::AMC13Trailer GetAMC13Trailer()    { return AMC13Trailer;  };
-    const uint64_t Dataword() const     { return dataword; };
+    const bool HasAMC13Header()                  const { return hasAMC13Header;  };
+    const bool HasMTF7Header()                   const { return hasMTF7Header;   };
+    const bool HasEventHeader()                  const { return hasEventHeader;  };
+    const bool HasCounters()                     const { return hasCounters;     };
+    const int  NumSP()                           const { return numSP;           };
+    const int  NumRPC()                          const { return numRPC;          };
+    const int  NumME()                           const { return numME;           };
+    const bool HasAMC13Trailer()                 const { return hasAMC13Trailer; };
+    const bool HasMTF7Trailer()                  const { return hasMTF7Trailer;  };
+    const bool HasEventTrailer()                 const { return hasEventTrailer; };
+    const emtf::AMC13Header GetAMC13Header()     const { return AMC13Header;     };
+    const emtf::MTF7Header GetMTF7Header()       const { return MTF7Header;      };
+    const emtf::EventHeader GetEventHeader()     const { return EventHeader;     };
+    const emtf::Counters GetCounters()           const { return Counters;        };
+    const emtf::MECollection GetMECollection()   const { return MECollection;    };
+    const emtf::RPCCollection GetRPCCollection() const { return RPCCollection;   };
+    const emtf::SPCollection GetSPCollection()   const { return SPCollection;    };
+    const emtf::EventTrailer GetEventTrailer()   const { return EventTrailer;    };
+    const emtf::MTF7Trailer GetMTF7Trailer()     const { return MTF7Trailer;     };
+    const emtf::AMC13Trailer GetAMC13Trailer()   const { return AMC13Trailer;    };
+    const uint64_t Dataword()                    const { return dataword;        };
     
   private:
     bool hasAMC13Header; 

--- a/EventFilter/L1TRawToDigi/python/emtfStage2Digis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/emtfStage2Digis_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+emtfStage2Digis = cms.EDProducer(
+    "L1TRawToDigi",
+    Setup = cms.string("stage2::EMTFSetup"),
+    InputLabel = cms.InputTag("rawDataCollector"),
+    FedIds = cms.vint32(1384, 1385),
+    FWId = cms.uint32(0),                           ## Need to implement properly - AWB 23.02.16
+    debug = cms.untracked.bool(False),
+    MTF7 = cms.untracked.bool(True)
+)
+


### PR DESCRIPTION
#### EMTF DQM Module
- L1TStage2EMTF.h
- L1TStage2EMTF.cc
- L1TStage2EMTF_cfi.py

This module was written following the naming convention set forth by Jing Yu and Esmaeel and currently monitors basic hardware values stored in the EMTFOutputCollection.
#### EMTF Unpacker

emtfStage2Digis_cfi.py
EMTFOutput.h

The file EMTFOutput.h was modified with permission from Andrew to fix some method declarations. The python configuration file was provided by Andrew, with some naming changes to follow convention.
#### Testing

This module was compiled and tested within CMSSW_8_0_0_pre6. The input files used were the following from MWGR2:
- 'root://eoscms//store/express/Commissioning2016/ExpressCosmics/FEVT/Express-v1/000/264/593/00000/E8F68B40-0ED2-E511-90DB-02163E0145B3.root'
- 'root://eoscms//store/express/Commissioning2016/ExpressCosmics/FEVT/Express-v1/000/264/593/00000/EA333C9D-2BD2-E511-AF4D-02163E0138BE.root'
- 'root://eoscms//store/express/Commissioning2016/ExpressCosmics/FEVT/Express-v1/000/264/593/00000/EC0A64B5-21D2-E511-B525-02163E0136D0.root'
- 'root://eoscms//store/express/Commissioning2016/ExpressCosmics/FEVT/Express-v1/000/264/593/00000/EC871D40-1AD2-E511-96AF-02163E0133C2.root'
