### PR TITLE
Fix all [-Wheader-guard] warnings

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.h
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.h
@@ -1,5 +1,5 @@
 #ifndef SelectedElectronFEDListProducer_h
-#define SelectedFEDListProducer_h
+#define SelectedElectronFEDListProducer_h
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 // egamma objects
@@ -167,4 +167,4 @@ template<typename TEle, typename TCand>
 
 };
 
-#endif
+#endif // SelectedElectronFEDListProducer_h

--- a/CondCore/CondDB/interface/PayloadReader.h
+++ b/CondCore/CondDB/interface/PayloadReader.h
@@ -1,5 +1,5 @@
 #ifndef CondCore_CondDB_PayloadReader_h
-#define CondCore_CondDB_PyloadReader_h
+#define CondCore_CondDB_PayloadReader_h
 //
 // Package:     CondDB
 // Class  :     PayloadReader
@@ -71,4 +71,4 @@ namespace cond {
 
   }
 }
-#endif
+#endif // CondCore_CondDB_PayloadReader_h

--- a/CondFormats/DataRecord/interface/CSCIdentifierRcd.h
+++ b/CondFormats/DataRecord/interface/CSCIdentifierRcd.h
@@ -1,6 +1,6 @@
-#ifndef CSCINDENTIFIERSRCD_H
+#ifndef CSCIDENTIFIERRCD_H
 #define CSCIDENTIFIERRCD_H
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 class CSCIdentifierRcd : public edm::eventsetup::EventSetupRecordImplementation<CSCIdentifierRcd> {};
-#endif
+#endif // CSCIDENTIFIERRCD_H

--- a/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
+++ b/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
@@ -8,7 +8,7 @@
 */
 
 #ifndef PIXELVTXMONITOR_H
-#define PIXELVTXMONITORH
+#define PIXELVTXMONITOR_H
 
 #include <string>
 #include <vector>
@@ -68,7 +68,7 @@ private:
   std::map<std::string, PixelMEs> histoMap_;
 };
 
-#endif
+#endif // PIXELVTXMONITOR_H
 
 // Local Variables:
 // show-trailing-whitespace: t

--- a/DQM/RCTMonitor/interface/RCTMonitor.h
+++ b/DQM/RCTMonitor/interface/RCTMonitor.h
@@ -1,6 +1,5 @@
-
 #ifndef RCTMonitor_RCTMonitor_H
-#define RCTMOnitor_RCTMonitor_H
+#define RCTMonitor_RCTMonitor_H
 
 // -*- C++ -*-
 //
@@ -154,4 +153,4 @@ class RCTMonitor : public DQMEDAnalyzer {
   edm::EDGetTokenT<L1CaloEmCollection> m_rctSourceToken_;
 };
 
-#endif
+#endif // RCTMonitor_RCTMonitor_H

--- a/DQM/SiStripCommissioningSources/interface/PedestalsTask.h
+++ b/DQM/SiStripCommissioningSources/interface/PedestalsTask.h
@@ -1,4 +1,4 @@
-#ifndef DQM_SiStripCommissioningSources_PedsAndNoiseTask_h
+#ifndef DQM_SiStripCommissioningSources_PedestalsTask_h
 #define DQM_SiStripCommissioningSources_PedestalsTask_h
 
 #include "DQM/SiStripCommissioningSources/interface/CommissioningTask.h"

--- a/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
@@ -1,5 +1,5 @@
 #ifndef _DQMOFFLINE_HCAL_HCALRECHITSDQMCLIENT_H_
-#define _DQMOFFLINE_HCAL_HCALRECHITDQMSCLIENT_H_
+#define _DQMOFFLINE_HCAL_HCALRECHITSDQMCLIENT_H_
 
 // -*- C++ -*-
 //
@@ -58,4 +58,4 @@ class HcalRecHitsDQMClient : public DQMEDHarvester {
 
 };
  
-#endif
+#endif // _DQMOFFLINE_HCAL_HCALRECHITSDQMCLIENT_H_

--- a/DQMServices/Components/plugins/DQMLumiMonitor.h
+++ b/DQMServices/Components/plugins/DQMLumiMonitor.h
@@ -8,7 +8,7 @@
 */
 
 #ifndef DQMLUMIMONITOR_H
-#define DQMLUMIMONITORH
+#define DQMLUMIMONITOR_H
 
 #include <string>
 #include <vector>
@@ -65,4 +65,4 @@ private:
   unsigned long long m_cacheID_;
 };
 
-#endif
+#endif // DQMLUMIMONITOR_H

--- a/DQMServices/Diagnostic/interface/DQMHistoryPopConHandler.h
+++ b/DQMServices/Diagnostic/interface/DQMHistoryPopConHandler.h
@@ -1,4 +1,4 @@
-#ifndef SISTRIPPOPCON_DB_HANDLE_H
+#ifndef DQMHISTORYPOPCON_DB_HANDLER_H
 #define DQMHISTORYPOPCON_DB_HANDLER_H
 
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/FWCore/MessageLogger/interface/LoggedErrorsSummary.h
+++ b/FWCore/MessageLogger/interface/LoggedErrorsSummary.h
@@ -1,5 +1,5 @@
-#ifndef MessageLogger_LoggedErrorsSummaryy_h
-#define MessageLogger_LoggedErrorsSummaryEntry_h
+#ifndef MessageLogger_LoggedErrorsSummary_h
+#define MessageLogger_LoggedErrorsSummary_h
 
 // ----------------------------------------------------------------------
 //
@@ -57,5 +57,5 @@ std::vector<ErrorSummaryEntry> LoggedErrorsOnlySummary(unsigned int iStreamID); 
 }        // end of namespace edm
 
 
-#endif  // MessageLogger_ErrorSummaryEntry_h
+#endif  // MessageLogger_LoggedErrorsSummary_h
 

--- a/FastSimulation/MaterialEffects/interface/PairProductionSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/PairProductionSimulator.h
@@ -1,5 +1,5 @@
 #ifndef PAIRPRODUCTIONSIMULATOR_H
-#define FPAIRPRODUCTIONSIMULATOR_H
+#define PAIRPRODUCTIONSIMULATOR_H
 
 #include "FastSimulation/MaterialEffects/interface/MaterialEffectsSimulator.h"
 
@@ -42,4 +42,4 @@ class PairProductionSimulator : public MaterialEffectsSimulator
   /// A universal angular distribution - still from GEANT.
   double gbteth(double ener,double partm,double efrac, RandomEngineAndDistribution const*);
 };
-#endif
+#endif // PAIRPRODUCTIONSIMULATOR

--- a/Fireworks/ParticleFlow/plugins/FWPFPatJetLegoProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFPatJetLegoProxyBuilder.h
@@ -1,4 +1,4 @@
-#ifndef _FWPFAPATJETLEGOPROXYBUILDER_H_
+#ifndef _FWPFPATJETLEGOPROXYBUILDER_H_
 #define _FWPFPATJETLEGOPROXYBUILDER_H_
 
 // -*- C++ -*-
@@ -51,5 +51,5 @@ class FWPFPatJetLegoProxyBuilder : public FWSimpleProxyBuilderTemplate<T>
    // --------------------- Member Functions --------------------------
 
 };
-#endif
+#endif // FWPFPATJETLEGOPROXYBUILDER
 //=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_

--- a/GeneratorInterface/PartonShowerVeto/interface/JetMatchingAlpgen.h
+++ b/GeneratorInterface/PartonShowerVeto/interface/JetMatchingAlpgen.h
@@ -1,6 +1,5 @@
-#ifndef GeneratorInterface_PartonShowerVeto_JetMatchingMadggraph_h
-#define GeneratorInterface_PartonShowerVeto_JetMatchingMadgraph_h
-
+#ifndef GeneratorInterface_PartonShowerVeto_JetMatchingAlpgen_h
+#define GeneratorInterface_PartonShowerVeto_JetMatchingAlpgen_h
 
 #include "GeneratorInterface/PartonShowerVeto/interface/JetMatching.h"
 #include "GeneratorInterface/AlpgenInterface/interface/AlpgenHeader.h"

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingHook.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingHook.h
@@ -1,4 +1,4 @@
-#ifndef gen_JetMatchinhHook_h
+#ifndef gen_JetMatchingHook_h
 #define gen_JetMatchingHook_h
 
 #include "Pythia8/Pythia.h"
@@ -78,6 +78,4 @@ protected:
  
 };
 
-#endif
-
-
+#endif // gen_JetMatchingHook_h

--- a/Geometry/ForwardGeometry/interface/ZdcGeometry.h
+++ b/Geometry/ForwardGeometry/interface/ZdcGeometry.h
@@ -1,5 +1,5 @@
 #ifndef Geometry_ForwardGeometry_ZdcGeometry_h
-#define Geometry_ForwardGeometry_ZDcGeometry_h
+#define Geometry_ForwardGeometry_ZdcGeometry_h
 
 #include "CondFormats/AlignmentRecord/interface/ZDCAlignmentRcd.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
@@ -77,5 +77,5 @@ class ZdcGeometry : public CaloSubdetectorGeometry
 };
 
 
-#endif
+#endif // Geometry_ForwardGeometry_ZdcGeometry_h
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h
@@ -1,5 +1,5 @@
 #ifndef Geometry_TrackerNumberingBuilder_CmsDetConstruction_H
-#define Geometry_TrackerNumberingBuilderCmsDetConstruction_H
+#define Geometry_TrackerNumberingBuilder_CmsDetConstruction_H
 #include<string>
 #include<vector>
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.h"
@@ -15,6 +15,4 @@ class CmsDetConstruction : public CmsTrackerLevelBuilder {
   void buildSmallDetsforStack(DDFilteredView& , GeometricDet* , std::string);
 };
 
-
-
-#endif
+#endif // Geometry_TrackerNumberingBuilder_CmsDetConstruction_H

--- a/HLTrigger/special/interface/HLTHFAsymmetryFilter.h
+++ b/HLTrigger/special/interface/HLTHFAsymmetryFilter.h
@@ -1,5 +1,5 @@
 #ifndef _HLTHFAsymmetryFilter_H
-#define _HLTHFAsymetryFilter_H
+#define _HLTHFAsymmetryFilter_H
 
 
 ///////////////////////////////////////////////////////
@@ -65,4 +65,4 @@ class HLTHFAsymmetryFilter : public edm::EDFilter {
 
 };
 
-#endif
+#endif // _HLTHFAsymmetryFilter_H

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTCrate.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTCrate.h
@@ -1,5 +1,5 @@
 #ifndef L1RCTCrate_h
-#define L1RCTCRate_h
+#define L1RCTCrate_h
 
 #include <vector>
 #include "L1Trigger/RegionalCaloTrigger/interface/L1RCTReceiverCard.h"
@@ -111,4 +111,4 @@ class L1RCTCrate {
 
   //L1RCTJetCaptureCard jetCaptureCard;
 };
-#endif
+#endif // L1RCTCrate_h

--- a/PhysicsTools/JetMCUtils/interface/CandMCTag.h
+++ b/PhysicsTools/JetMCUtils/interface/CandMCTag.h
@@ -1,4 +1,4 @@
-#ifndef CandMCTag_H
+#ifndef CandMCTag_h
 #define CandMCTag_h
 
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -12,4 +12,4 @@ namespace CandMCTagUtils {
   bool isLightParton(const reco::Candidate &c);
 
 }
-#endif
+#endif // CandMCTag_h

--- a/PhysicsTools/JetMCUtils/interface/JetMCTag.h
+++ b/PhysicsTools/JetMCUtils/interface/JetMCTag.h
@@ -1,4 +1,4 @@
-#ifndef JetMCTag_H
+#ifndef JetMCTag_h
 #define JetMCTag_h
 
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -13,4 +13,4 @@ namespace JetMCTagUtils {
   std::string genTauDecayMode(const reco::CompositePtrCandidate &c);
 
 }
-#endif
+#endif // JetMCTag_h

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/interface/EcalDeadChannelRecoveryAlgos.h
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/interface/EcalDeadChannelRecoveryAlgos.h
@@ -1,5 +1,5 @@
 #ifndef RecoLocalCalo_EcalDeadChannelRecoveryAlgos_EcalDeadChannelRecoveryAlgos_HH
-#define RecoLocalCalo_EcalDeadChannelRecoveryAlgos_ECalDeadChannelRecoveryAlgos_HH
+#define RecoLocalCalo_EcalDeadChannelRecoveryAlgos_EcalDeadChannelRecoveryAlgos_HH
 
 // Reconstruction Classes
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
@@ -19,4 +19,4 @@ template <typename DetIdT> class EcalDeadChannelRecoveryAlgos {
  private:
   EcalDeadChannelRecoveryNN<DetIdT> nn;
 };
-#endif
+#endif // RecoLocalCalo_EcalDeadChannelRecoveryAlgos_EcalDeadChannelRecoveryAlgos_HH

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -1,4 +1,4 @@
-#ifndef RecoLocalMuon_DTLinearDrifFromDBtAlgo_H
+#ifndef RecoLocalMuon_DTLinearDriftFromDBAlgo_H
 #define RecoLocalMuon_DTLinearDriftFromDBAlgo_H
 
 /** \class DTLinearDriftFromDBAlgo
@@ -111,6 +111,4 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
   // Switch on/off the verbosity
   const bool debug;
 };
-#endif
-
-
+#endif // RecoLocalMuon_DTLinearDriftFromDBAlgo_H

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaHeavyObjectCache.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaHeavyObjectCache.h
@@ -1,5 +1,5 @@
 #ifndef __RecoParticleFlow_PFProducer_pfEGHelpersHeavyObjectCache_h__
-#define __RecoEgamma_GsfElectronAlgos_pfEGHelpersHeavyObjectCache_h__
+#define __RecoParticleFlow_PFProducer_pfEGHelpersHeavyObjectCache_h__
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
@@ -22,4 +22,4 @@ namespace pfEGHelpers {
   };
 }
 
-#endif
+#endif // __RecoParticleFlow_PFProducer_pfEGHelpersHeavyObjectCache_h__

--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
@@ -1,5 +1,5 @@
 #ifndef RecoLocalTracker_ESProducers_MultiRecHitCollectorESProducer_h
-#define RecoLocalTracker_ESProducers_ESProducers_MultiRecHitCollectorESProducer_h
+#define RecoLocalTracker_ESProducers_MultiRecHitCollectorESProducer_h
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -32,8 +32,4 @@ class  MultiRecHitCollectorESProducer: public edm::ESProducer{
 };
 
 
-#endif
-
-
-
-
+#endif // RecoLocalTracker_ESProducers_MultiRecHitCollectorESProducer_h

--- a/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
@@ -1,5 +1,5 @@
 #ifndef RecoLocalTracker_ESProducers_SiTrackerMultiRecHitUpdatorESProducer_h
-#define RecoLocalTracker_ESProducers_ESProducers_SiTrackerMultiRecHitUpdatorESProducer_h
+#define RecoLocalTracker_ESProducers_SiTrackerMultiRecHitUpdatorESProducer_h
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,8 +19,4 @@ class  SiTrackerMultiRecHitUpdatorESProducer: public edm::ESProducer{
 };
 
 
-#endif
-
-
-
-
+#endif // RecoLocalTracker_ESProducers_SiTrackerMultiRecHitUpdatorESProducer_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingEMDigiWorker_h
+#ifndef SimDataMixingEMDigiWorker_h
 #define SimDataMixingEMDigiWorker_h
 
 /** \class DataMixingEMDigiWorker
@@ -110,4 +110,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingEMDigiWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingEMWorker_h
+#ifndef SimDataMixingEMWorker_h
 #define SimDataMixingEMWorker_h
 
 /** \class DataMixingEMWorker
@@ -99,4 +99,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingEMWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEcalDigiWorkerProd.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingEcalDigiWorkerProd_h
+#ifndef SimDataMixingEcalDigiWorkerProd_h
 #define SimDataMixingEcalDigiWorkerProd_h
 
 /** \class DataMixingEcalDigiWorkerProd
@@ -99,4 +99,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingEcalDigiWorkerProd_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingGeneralTrackWorker_h
+#ifndef SimDataMixingGeneralTrackWorker_h
 #define SimDataMixingGeneralTrackWorker_h
 
 /** \class DataMixingGeneralTrackWorker
@@ -72,4 +72,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingGeneralTrackWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingHcalDigiWorker_h
+#ifndef SimDataMixingHcalDigiWorker_h
 #define SimDataMixingHcalDigiWorker_h
 
 /** \class DataMixingHcalDigiWorker
@@ -110,4 +110,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingHcalDigiWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingHcalDigiWorkerProd_h
+#ifndef SimDataMixingHcalDigiWorkerProd_h
 #define SimDataMixingHcalDigiWorkerProd_h
 
 /** \class DataMixingHcalDigiWorkerProd
@@ -97,4 +97,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingHcalDigiWorkerProd_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingHcalWorker_h
+#ifndef SimDataMixingHcalWorker_h
 #define SimDataMixingHcalWorker_h
 
 /** \class DataMixingHcalWorker
@@ -97,4 +97,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingHcalWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingMuonWorker_h
+#ifndef SimDataMixingMuonWorker_h
 #define SimDataMixingMuonWorker_h
 
 /** \class DataMixingMuonWorker
@@ -109,4 +109,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingMuonWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingPileupCopy_h
+#ifndef SimDataMixingPileupCopy_h
 #define SimDataMixingPileupCopy_h
 
 /** \class DataMixingPileupCopy
@@ -76,4 +76,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingPileupCopy_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.h
@@ -1,5 +1,5 @@
-#ifndef DataMixingSiPixelMCDigiWorker_h
-#define DataMixingSiPixelMCDigiWorker_h
+#ifndef SimDataMixingSiPixelMCDigiWorker_h
+#define SimDataMixingSiPixelMCDigiWorker_h
 
 /** \class DataMixingSiPixelMCDigiWorker
  *
@@ -165,4 +165,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingSiPixelMCDigiWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingSiPixelWorker_h
+#ifndef SimDataMixingSiPixelWorker_h
 #define SimDataMixingSiPixelWorker_h
 
 /** \class DataMixingSiPixelWorker
@@ -77,4 +77,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingSiPixelWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingSiStripMCDigiWorker_h
+#ifndef SimDataMixingSiStripMCDigiWorker_h
 #define SimDataMixingSiStripMCDigiWorker_h
 
 /** \class DataMixingSiStripMCDigiWorker
@@ -148,4 +148,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingSiStripMCDigiWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingSiStripRawWorker_h
+#ifndef SimDataMixingSiStripRawWorker_h
 #define SimDataMixingSiStripRawWorker_h
 
 /** \class DataMixingSiStripRawWorker
@@ -82,4 +82,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingSiStripRawWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingSiStripWorker_h
+#ifndef SimDataMixingSiStripWorker_h
 #define SimDataMixingSiStripWorker_h
 
 /** \class DataMixingSiStripWorker
@@ -85,4 +85,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingSiStripWorker_h

--- a/SimGeneral/DataMixingModule/plugins/DataMixingTrackingParticleWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingTrackingParticleWorker.h
@@ -1,4 +1,4 @@
-#ifndef DataMixingTrackingParticleWorker_h
+#ifndef SimDataMixingTrackingParticleWorker_h
 #define SimDataMixingTrackingParticleWorker_h
 
 /** \class DataMixingTrackingParticleWorker
@@ -120,4 +120,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimDataMixingTrackingParticleWorker_h

--- a/SimGeneral/DataMixingModule/plugins/EcalNoiseStorage.h
+++ b/SimGeneral/DataMixingModule/plugins/EcalNoiseStorage.h
@@ -1,4 +1,4 @@
-#ifndef EcalNoiseStorage_h
+#ifndef SimEcalNoiseStorage_h
 #define SimEcalNoiseStorage_h
 
 /** \class EcalNoiseStorage
@@ -52,4 +52,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimEcalNoiseStorage_h

--- a/SimGeneral/DataMixingModule/plugins/HcalNoiseStorage.h
+++ b/SimGeneral/DataMixingModule/plugins/HcalNoiseStorage.h
@@ -1,4 +1,4 @@
-#ifndef HcalNoiseStorage_h
+#ifndef SimHcalNoiseStorage_h
 #define SimHcalNoiseStorage_h
 
 /** \class HcalNoiseStorage
@@ -55,4 +55,4 @@ namespace edm
     };
 }//edm
 
-#endif
+#endif // SimHcalNoiseStorage_h

--- a/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
+++ b/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
@@ -1,4 +1,4 @@
-#ifndef Validaiton_RPCRecHits_RPCPointVsRecHit_h
+#ifndef Validation_RPCRecHits_RPCPointVsRecHit_h
 #define Validation_RPCRecHits_RPCPointVsRecHit_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -32,4 +32,4 @@ private:
   RPCValidHistograms h_;
 };
 
-#endif
+#endif // Validation_RPCRecHits_RPCPointVsRecHit_h

--- a/Validation/RPCRecHits/interface/RPCRecHitValid.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValid.h
@@ -1,5 +1,5 @@
 #ifndef Validation_RPCRecHits_RPCRecHitValid_h
-#define Validaiton_RPCRecHits_RPCRecHitValid_h
+#define Validation_RPCRecHits_RPCRecHitValid_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -75,4 +75,4 @@ private:
   std::map<int, int> detIdToIndexMapBarrel_, detIdToIndexMapEndcap_;
 };
 
-#endif
+#endif // Validation_RPCRecHits_RPCRecHitValid_h

--- a/Validation/RPCRecHits/interface/RPCRecHitValidClient.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValidClient.h
@@ -1,5 +1,5 @@
 #ifndef Validation_RPCRecHits_RPCRecHitValidClient_h
-#define Validaiton_RPCRecHits_RPCRecHitValidClient_h
+#define Validation_RPCRecHits_RPCRecHitValidClient_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
@@ -27,4 +27,4 @@ private:
   std::string subDir_;
 };
 
-#endif
+#endif // Validation_RPCRecHits_RPCRecHitValidClient_h


### PR DESCRIPTION
The patch fixes 138 warnings of the following format:

```
warning: '<..>' is used as a header guard here,
followed by #define of a different macro [-Wheader-guard]
```

Tested with Clang 3.8.0.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
