### PR TITLE
FastSim: never run DQM in endPath for FastSim

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1937,7 +1937,8 @@ class ConfigBuilder(object):
 			self.renameHLTprocessInSequence(sequence)
 
 		# if both HLT and DQM are run in the same process, schedule [HLT]DQM in an EndPath
-		if 'HLT' in self.stepMap.keys():
+	        # not for fastsim
+		if 'HLT' in self.stepMap.keys() and not self._options.fast:
 			# need to put [HLT]DQM in an EndPath, to access the HLT trigger results
 			setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
 		else:


### PR DESCRIPTION
In FastSim workflows (and only in FastSim workflows),
the DQM path contains Filters.
When run in an endPath the outcome of Filters is ignored,
while proper running of the DQM path depends on the outcome of the Filters.

(This has caused crashes in runTheMatrix, since FastSim started running the DQM sequence)
