### PR TITLE
Improve exception message for missing produces call

### DIFF
--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -225,17 +225,26 @@ namespace edm {
     ProductHolderIndexHelper const& productHolderIndexHelper = principal_.productLookup();
     ProductHolderIndex index = productHolderIndexHelper.index(PRODUCT_TYPE, type, md_.moduleLabel().c_str(),productInstanceName.c_str(), md_.processName().c_str());
     if(index == ProductHolderIndexInvalid) {
+      std::ostringstream str;
+      for(auto branchDescription: principal_.productRegistry().allBranchDescriptions()) {
+        if (branchDescription->moduleLabel() == md_.moduleLabel() and branchDescription->processName() == md_.processName()) {
+          str << *branchDescription<< "-----\n";
+        }
+      }
       throw edm::Exception(edm::errors::InsertFailure)
-	<< "Illegal attempt to 'put' an unregistered product.\n"
-	<< "No product is registered for\n"
-	<< "  product friendly class name: '" << type.friendlyClassName() << "'\n"
-  << "  module label:                '" << md_.moduleLabel() << "'\n"
-	<< "  product instance name:       '" << productInstanceName << "'\n"
-  << "  process name:                '" << md_.processName() << "'\n"
+      << "Illegal attempt to 'put' an unregistered product.\n"
+      << "No product is registered for\n"
+      << "  product friendly class name: '" << type.friendlyClassName() << "'\n"
+      << "  module label:                '" << md_.moduleLabel() << "'\n"
+      << "  product instance name:       '" << productInstanceName << "'\n"
+      << "  process name:                '" << md_.processName() << "'\n"
 
-	<< "The ProductRegistry contains:\n"
-	<< principal_.productRegistry()
-	<< '\n';
+      << "The following data products are registered for production by "<<md_.moduleLabel()<<":\n"
+      << str.str()
+      << '\n'
+      << "To correct the problem:\n"
+      "   1) make sure the proper 'produce' call is being made in the module's constructor,\n"
+      "   2) if 'produce' exists and uses a product instance name make sure that same name is used during the 'put' call.";
     }
     ProductHolderBase const*  phb = principal_.getProductHolderByIndex(index);
     assert(phb != nullptr);


### PR DESCRIPTION
The previous exception message given when a module was missing a produces call printed the entire contents of the ProductRegistry. The new message only prints those entries which the module has registered and gives two ways to potentially fix the problem.
