### PR TITLE
Enable Partial Sim/Reco Geometry Dump

### DIFF
--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -56,6 +56,9 @@ private:
   boost::shared_ptr<FWRecoGeometry>          m_fwGeometry;
   
   unsigned int m_current;
+  bool m_tracker;
+  bool m_muon;
+  bool m_calo;
 };
 
 #endif // GEOMETRY_FWRECO_GEOMETRY_ES_PRODUCER_H

--- a/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
@@ -79,6 +79,10 @@ private:
    boost::shared_ptr<FWTGeoRecoGeometry> m_fwGeometry;
 
    TGeoMedium* m_dummyMedium;
+
+   bool m_tracker;
+   bool m_muon;
+   bool m_calo;
 };
 
 #endif // GEOMETRY_FWTGEORECO_GEOMETRY_ES_PRODUCER_H

--- a/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
@@ -3,7 +3,7 @@ import sys
 import FWCore.ParameterSet.VarParsing as VarParsing
 from FWCore.Utilities.Enumerate import Enumerate
 
-varType = Enumerate ("Run1 2015 2017 2019 PhaseIPixel 2023Muon SLHC SLHCDB")
+varType = Enumerate ("Run1 2015 2017 2019 PhaseIPixel 2023 2023Muon GEMDev MaPSA SLHC")
 
 def help():
    print "Usage: cmsRun dumpFWRecoGeometry_cfg.py  tag=TAG "
@@ -15,103 +15,108 @@ def help():
    print "       dump in TGeo format to borwse it geomtery viewer"
    print "       import this will in Fireworks with option --sim-geom-file"
    print ""
+   print "   tracker=bool"
+   print "       include Tracker subdetectors"
+   print ""
+   print "   muon=bool"
+   print "       include Muon subdetectors"
+   print ""
+   print "   calo=bool"
+   print "       include Calo subdetectors"
+   print ""
    print ""
    exit(1);
 
 def recoGeoLoad(score):
     print "Loading configuration for tag ", options.tag ,"...\n"
-    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
     if score == "Run1":
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['mc']
+       process.GlobalTag.globaltag = autoCond['run1_mc']
        process.load("Configuration.StandardSequences.GeometryDB_cff")
-       process.load("Configuration.StandardSequences.Reconstruction_cff")
 
     elif score == "2015":
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['mc']
-       process.load("Configuration.Geometry.GeometryExtended2015Reco_cff");
+       process.GlobalTag.globaltag = autoCond['run2_mc']
+       process.load("Configuration.StandardSequences.GeometryDB_cff")
 
     elif score == "2017":
-       from Configuration.AlCa.GlobalTag import GlobalTag
-       process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2017', '')
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.autoCond import autoCond
+       process.GlobalTag.globaltag = autoCond['upgrade2017']
        process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
        # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
        #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2017 
        #process.load("SLHCUpgradeSimulations.Configuration.combinedCustoms.cust_2017")
-      # process = cust_2017(process)
+       #process = cust_2017(process)
 
     elif  score == "2019":
-      from Configuration.AlCa.GlobalTag import GlobalTag
-      process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
-      process.load('Configuration.Geometry.GeometryExtended2019Reco_cff')
-      #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2019
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.autoCond import autoCond
+       process.GlobalTag.globaltag = autoCond['upgrade2019']
+       ## NOTE: There is no PTrackerParameters Rcd in this GT yet
+       process.load('Geometry.TrackerGeometryBuilder.trackerParameters_cfi')
+       process.load('Configuration.Geometry.GeometryExtended2019Reco_cff')
+       ## NOTE: There are no Muon alignement records in the GT yet
+       process.DTGeometryESModule.applyAlignment = cms.bool(False)
+       process.CSCGeometryESModule.applyAlignment = cms.bool(False)
 
-    elif score ==  "PhaseIPixel":
-      from Configuration.AlCa.GlobalTag import GlobalTag
-      process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
-      process.load('Configuration.Geometry.GeometryExtendedPhaseIPixelReco_cff')
+    elif score == "PhaseIPixel":
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.GlobalTag import GlobalTag
+       process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
+       process.load('Configuration.Geometry.GeometryExtendedPhaseIPixelReco_cff')
 
     elif  score == "2023":
-      from Configuration.AlCa.autoCond import autoCond
-      process.GlobalTag.globaltag = autoCond['mc']
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.autoCond import autoCond
+       process.GlobalTag.globaltag = autoCond['mc']
       #from Configuration.AlCa.GlobalTag import GlobalTag
       #process.GlobalTag = GlobalTag(process.GlobalTag, 'PH2_1K_FB_V6::All', '')
-      process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
+       process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
       #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2019
       #process = cust_2019(process)
       
-    elif  score == "2023Dev":
-      from Configuration.AlCa.autoCond import autoCond
-      process.GlobalTag.globaltag = autoCond['mc']
-      #from Configuration.AlCa.GlobalTag import GlobalTag                                                            
-      #process.GlobalTag = GlobalTag(process.GlobalTag, 'PH2_1K_FB_V6::All', '')                                     
-      process.load('Configuration.Geometry.GeometryExtended2023DevReco_cff')
-      #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2019                                    
-      #process = cust_2019(process)
-
     elif  score == "2023Muon":
-      from Configuration.AlCa.autoCond import autoCond
-      process.GlobalTag.globaltag = autoCond['mc']
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.autoCond import autoCond
+       process.GlobalTag.globaltag = autoCond['mc']
       #from Configuration.AlCa.GlobalTag import GlobalTag
       #process.GlobalTag = GlobalTag(process.GlobalTag, 'PH2_1K_FB_V6::All', '')
-      process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
+       process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
       # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
       #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023Muon
       #call to customisation function cust_2023Muon imported from SLHCUpgradeSimulations.Configuration.combinedCustoms
       #process = cust_2023Muon(process)
 
     elif  score == "GEMDev":
-      from Configuration.AlCa.autoCond import autoCond
-      process.GlobalTag.globaltag = autoCond['mc']
-      process.load('Configuration.Geometry.GeometryExtended2015MuonGEMDevReco_cff')
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.autoCond import autoCond
+       process.GlobalTag.globaltag = autoCond['mc']
+       process.load('Configuration.Geometry.GeometryExtended2015MuonGEMDevReco_cff')
 
-    elif score == "SLHCDB": # orig dumpFWRecoSLHCGeometry_cfg.py
-      process.GlobalTag.globaltag = 'DESIGN42_V17::All'
-      process.load("Configuration.StandardSequences.GeometryDB_cff")
-      process.load("Configuration.StandardSequences.Reconstruction_cff")
+    elif score == "MaPSA":
+       process.load('Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff')
+       process.load('Geometry.TrackerCommonData.mapsaGeometryXML_cfi')
+       process.load('Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi')
+       process.load('Geometry.TrackerNumberingBuilder.trackerTopology_cfi')
+       process.load('Geometry.TrackerGeometryBuilder.trackerParameters_cfi')
+       process.load('Geometry.TrackerGeometryBuilder.trackerGeometry_cfi')
+       process.trackerGeometry.applyAlignment = cms.bool(False)
+       process.load('RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi')
 
-      process.GlobalTag.toGet = cms.VPSet(
-        cms.PSet(record = cms.string("GeometryFileRcd"),
-                 tag = cms.string("XMLFILE_Geometry_428SLHCYV0_Phase1_R30F12_HCal_Ideal_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_COND_42X_GEOMETRY")
-                 ),
-        cms.PSet(record = cms.string('IdealGeometryRecord'),
-                 tag = cms.string('TKRECO_Geometry_428SLHCYV0'),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_COND_42X_GEOMETRY")),
-        cms.PSet(record = cms.string('PGeometricDetExtraRcd'),
-                 tag = cms.string('TKExtra_Geometry_428SLHCYV0'),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_COND_42X_GEOMETRY")),
-                 )
+       process.load('Geometry.CommonDetUnit.bareGlobalTrackingGeometry_cfi')
 
-    elif score == varType.valueForKey("SLHC"): # orig dumpFWRecoGeometrySLHC_cfg.py
-      from Configuration.AlCa.autoCond import autoCond
-      process.GlobalTag.globaltag = autoCond['mc']
-      process.load("Configuration.Geometry.GeometrySLHCSimIdeal_cff")
-      process.load("Configuration.Geometry.GeometrySLHCReco_cff")
-      process.load("Configuration.StandardSequences.Reconstruction_cff")
-      process.trackerSLHCGeometry.applyAlignment = False
+    elif score == "SLHC": # orig dumpFWRecoGeometrySLHC_cfg.py
+       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+       from Configuration.AlCa.autoCond import autoCond
+       process.GlobalTag.globaltag = autoCond['mc']
+       process.load("Configuration.Geometry.GeometrySLHCSimIdeal_cff")
+       process.load("Configuration.Geometry.GeometrySLHCReco_cff")
+       process.load("Configuration.StandardSequences.Reconstruction_cff")
+       process.trackerSLHCGeometry.applyAlignment = False
 
     else:
       help()
@@ -137,6 +142,23 @@ options.register ('tgeo',
                   VarParsing.VarParsing.varType.bool,
                   "write geometry in TGeo format")
 
+options.register ('tracker',
+                  True, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "write Tracker geometry")
+
+options.register ('muon',
+                  True, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "write Muon geometry")
+
+options.register ('calo',
+                  True, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "write Calo geometry")
 
 options.register ('out',
                   defaultOutputFileName, # default value
@@ -160,7 +182,10 @@ recoGeoLoad(options.tag)
 if ( options.tgeo == True):
     if (options.out == defaultOutputFileName ):
         options.out = "cmsTGeoRecoGeom-" +  str(options.tag) + ".root"
-    process.add_(cms.ESProducer("FWTGeoRecoGeometryESProducer"))
+    process.add_(cms.ESProducer("FWTGeoRecoGeometryESProducer",
+                 Tracker = cms.untracked.bool(options.tracker),
+                 Muon = cms.untracked.bool(options.muon),
+                 Calo = cms.untracked.bool(options.calo)))
     process.dump = cms.EDAnalyzer("DumpFWTGeoRecoGeometry",
                               tagInfo = cms.untracked.string(options.tag),
                        outputFileName = cms.untracked.string(options.out)
@@ -168,7 +193,10 @@ if ( options.tgeo == True):
 else:
     if (options.out == defaultOutputFileName ):
         options.out = "cmsRecoGeom-" +  str(options.tag) + ".root"
-    process.add_(cms.ESProducer("FWRecoGeometryESProducer"))
+    process.add_(cms.ESProducer("FWRecoGeometryESProducer",
+                 Tracker = cms.untracked.bool(options.tracker),
+                 Muon = cms.untracked.bool(options.muon),
+                 Calo = cms.untracked.bool(options.calo)))
     process.dump = cms.EDAnalyzer("DumpFWRecoGeometry",
                               level   = cms.untracked.int32(1),
                               tagInfo = cms.untracked.string(options.tag),

--- a/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
@@ -3,7 +3,7 @@ import sys
 import FWCore.ParameterSet.VarParsing as VarParsing
 from FWCore.Utilities.Enumerate import Enumerate
 
-varType = Enumerate ("Run1 Ideal2015 Ideal2015dev 2015 2015dev 2019 PhaseIPixel Phase1_R34F16 Phase2Tk  2023Muon SLHC DB SLHCDB")
+varType = Enumerate ("Run1 Ideal2015 Ideal2015dev 2015 2015dev 2019 PhaseIPixel Phase1_R34F16 Phase2Tk  2023Muon MaPSA CRack PhaseIIFlatTracker SLHC DB SLHCDB")
 
 def help():
    print "Usage: cmsRun dumpSimGeometry_cfg.py  tag=TAG "
@@ -51,6 +51,15 @@ def simGeoLoad(score):
 
     elif score == "2023":
        process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
+
+    elif score == "MaPSA":
+       process.load('Geometry.TrackerCommonData.mapsaGeometryXML_cfi')
+
+    elif score == "CRack":
+       process.load('Geometry.TrackerCommonData.crackGeometryXML_cfi')
+
+    elif score == "PhaseIIFlatTracker":
+       process.load('Geometry.TrackerCommonData.phaseIIFlatTrackerGeometryXML_cfi')
                 
     elif score == "DB":
         process.load("Configuration.StandardSequences.GeometryDB_cff")

--- a/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
@@ -18,6 +18,7 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -63,9 +64,13 @@
 namespace {
 typedef std::map< const float*, TGeoVolume*> CaloVolMap;
 }
-FWTGeoRecoGeometryESProducer::FWTGeoRecoGeometryESProducer( const edm::ParameterSet& /*pset*/ ):
-m_dummyMedium(0)
+FWTGeoRecoGeometryESProducer::FWTGeoRecoGeometryESProducer( const edm::ParameterSet& pset )
+  : m_dummyMedium(0)
 {
+  m_tracker = pset.getUntrackedParameter<bool>( "Tracker", true );
+  m_muon = pset.getUntrackedParameter<bool>( "Muon", true );
+  m_calo = pset.getUntrackedParameter<bool>( "Calo", true );
+  
   setWhatProduced( this );
 }
 
@@ -262,8 +267,9 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
   
    DetId detId( DetId::Tracker, 0 );
    m_trackerGeom = (const TrackerGeometry*) m_geomRecord->slaveGeometry( detId );
-  
-   record.getRecord<CaloGeometryRecord>().get( m_caloGeom );
+
+   if( m_calo )
+     record.getRecord<CaloGeometryRecord>().get( m_caloGeom );
 
    TGeoManager* geom = new TGeoManager( "cmsGeo", "CMS Detector" );
    if( 0 == gGeoIdentity )
@@ -277,10 +283,8 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
    TGeoMaterial *vacuum = new TGeoMaterial( "Vacuum", 0 ,0 ,0 );
    m_dummyMedium = new TGeoMedium( "reco", 0, vacuum);
 
-
    TGeoVolume *top = geom->MakeBox( "CMS", m_dummyMedium, 270., 270., 120. );
   
-
    if( 0 == top )
    {
       return boost::shared_ptr<FWTGeoRecoGeometry>();
@@ -289,25 +293,35 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
    // ROOT chokes unless colors are assigned
    top->SetVisibility( kFALSE );
    top->SetLineColor( kBlue );
+
+   if( m_tracker )
+   {
+     addPixelBarrelGeometry();
+     addPixelForwardGeometry();
+
+     addTIBGeometry();
+     addTIDGeometry();
+     addTOBGeometry();
+     addTECGeometry();
+   }
    
-   addPixelBarrelGeometry();
-   addPixelForwardGeometry();
+   if( m_muon )
+   {
+     addDTGeometry();
 
-   addTIBGeometry();
-   addTIDGeometry();
-   addTOBGeometry();
-   addTECGeometry();
-   addDTGeometry();
+     addCSCGeometry();
+     addRPCGeometry();
+     addME0Geometry();
+     addGEMGeometry();
+   }
 
-   addCSCGeometry();
-   addRPCGeometry();
-   addME0Geometry();
-   addGEMGeometry();
-
-   addEcalCaloGeometry();   
-   addHcalCaloGeometryBarrel();
-   addHcalCaloGeometryEndcap();
-
+   if( m_calo )
+   {  
+     addEcalCaloGeometry();   
+     addHcalCaloGeometryBarrel();
+     addHcalCaloGeometryEndcap();
+   }
+   
    geom->CloseGeometry();
 
    geom->DefaultColors();


### PR DESCRIPTION
- Allow partial sim/reco geometry dump in TGeo and root formats. Useul for testbeam tests
- Add flags for Muon, Calo and Tracker dumps
- Ceanup obsolete geometry dump
- Add testbeam geometries
- Use appropriate conditions
