### PR TITLE
Opening files from "fileNames" in DAQ input source and a different output merging mode

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -56,6 +56,7 @@ namespace evf{
 
       explicit EvFDaqDirector( const edm::ParameterSet &pset, edm::ActivityRegistry& reg );
       ~EvFDaqDirector();
+      void initRun();
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
       void preallocate(edm::service::SystemBounds const& bounds);
       void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
@@ -64,6 +65,7 @@ namespace evf{
       void preGlobalEndLumi(edm::GlobalContext const& globalContext);
       void preSourceEvent(edm::StreamID const& streamID);
       //std::string &baseDir(){return base_dir_;}
+      void overrideRunNumber(unsigned int run) {run_=run;}
       std::string &baseRunDir(){return run_dir_;}
       std::string &buBaseRunDir(){return bu_run_dir_;}
       std::string &buBaseRunOpenDir(){return bu_run_open_dir_;}

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -75,6 +75,7 @@ namespace evf{
       std::string getRawFilePath(const unsigned int ls, const unsigned int index) const;
       std::string getOpenRawFilePath(const unsigned int ls, const unsigned int index) const;
       std::string getOpenInputJsonFilePath(const unsigned int ls, const unsigned int index) const;
+      std::string getDatFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getOpenDatFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getOpenOutputJsonFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getOutputJsonFilePath(const unsigned int ls, std::string const& stream) const;
@@ -123,6 +124,7 @@ namespace evf{
       void checkTransferSystemPSet(edm::ProcessContext const& pc);
       std::string getStreamDestinations(std::string const& stream) const;
       bool emptyLumisectionMode() const {return emptyLumisectionMode_;}
+      bool microMergeDisabled() const {return microMergeDisabled_;}
 
 
     private:
@@ -148,6 +150,7 @@ namespace evf{
       std::string hltSourceDirectory_;
       unsigned int fuLockPollInterval_;
       bool emptyLumisectionMode_;
+      bool microMergeDisabled_;
 
       std::string hostname_;
       std::string run_string_;

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -51,6 +51,7 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
+
 namespace evf{
 
   class FastMonitoringService : public MicroStateService
@@ -123,6 +124,8 @@ namespace evf{
 
       void preallocate(edm::service::SystemBounds const&);
       void jobFailure();
+      void preBeginJob(edm::PathsAndConsumesOfModulesBase const&,edm::ProcessContext const& pc);
+
       void preModuleBeginJob(edm::ModuleDescription const&);
       void postBeginJob();
       void postEndJob();

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -79,7 +79,7 @@ private:
   //monitoring
   void reportEventsThisLumiInSource(unsigned int lumi,unsigned int events);
 
-  int initFileList(); 
+  long initFileList(); 
   evf::EvFDaqDirector::FileStatus getFile(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint64_t& lockWaitTime);
 
   //variables
@@ -107,9 +107,8 @@ private:
   const bool fileListMode_;
   unsigned int fileListIndex_ = 0;
 
-  const edm::RunNumber_t runNumber_;
-
-  const std::string fuOutputDir_;
+  edm::RunNumber_t runNumber_;
+  std::string fuOutputDir_;
 
   const edm::DaqProvenanceHelper daqProvenanceHelper_;
 

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -79,6 +79,9 @@ private:
   //monitoring
   void reportEventsThisLumiInSource(unsigned int lumi,unsigned int events);
 
+  int initFileList(); 
+  evf::EvFDaqDirector::FileStatus getFile(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint64_t& lockWaitTime);
+
   //variables
   evf::FastMonitoringService* fms_=nullptr;
   evf::EvFDaqDirector* daqDirector_=nullptr;
@@ -98,6 +101,11 @@ private:
   const bool verifyAdler32_;
   const bool verifyChecksum_;
   const bool useL1EventID_;
+  std::vector<std::string> fileNames_;
+  //std::vector<std::string> fileNamesSorted_;
+
+  const bool fileListMode_;
+  unsigned int fileListIndex_ = 0;
 
   const edm::RunNumber_t runNumber_;
 
@@ -207,7 +215,7 @@ struct InputFile {
   std::string fileName_;
   uint32_t fileSize_;
   uint32_t nChunks_;
-  unsigned int nEvents_;
+  int nEvents_;
   unsigned int nProcessed_;
 
   tbb::concurrent_vector<InputChunk*> chunks_;
@@ -217,7 +225,7 @@ struct InputFile {
   unsigned int currentChunk_ = 0;
 
   InputFile(evf::EvFDaqDirector::FileStatus status, unsigned int lumi = 0, std::string const& name = std::string(), 
-      uint32_t fileSize =0, uint32_t nChunks=0, unsigned int nEvents=0, FedRawDataInputSource *parent = nullptr):
+      uint32_t fileSize =0, uint32_t nChunks=0, int nEvents=0, FedRawDataInputSource *parent = nullptr):
     parent_(parent),
     status_(status),
     lumi_(lumi),

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -66,7 +66,7 @@ namespace evf {
     boost::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
     evf::FastMonitoringService *fms_;
     jsoncollector::DataPointDefinition outJsonDef_;
-    unsigned char* outBuf_=0;
+    unsigned char* outBuf_=nullptr;
     bool readAdler32Check_=false;
 
 
@@ -218,6 +218,11 @@ namespace evf {
       readInput+=toRead;
     }
     fclose(src);
+    //free output buffer if micromerge is not done by the module
+    if (edm::Service<evf::EvFDaqDirector>()->microMergeDisabled()) {
+      delete [] outBuf_;
+      outBuf_=nullptr;
+    }
     uint32_t adler32c = (adlerb << 16) | adlera;
     if (adler32c != c_->get_adler32_ini()) {
       throw cms::Exception("RecoEventOutputModuleForFU") << "Checksum mismatch of ini file -: " << openIniFileName
@@ -281,15 +286,17 @@ namespace evf {
     if(processed_.value()!=0) {
 
       //lock
-      FILE *des = edm::Service<evf::EvFDaqDirector>()->maybeCreateAndLockFileHeadForStream(ls.luminosityBlock(),stream_label_);
-
-      std::string deschecksum = edm::Service<evf::EvFDaqDirector>()->getMergedDatChecksumFilePath(ls.luminosityBlock(), stream_label_);
-
       struct stat istat;
-      FILE * cf = NULL;
-      uint32_t mergedAdler32=1;
-      //get adler32 accumulated checksum for the merged file
-      if (!stat(deschecksum.c_str(), &istat)) {
+      if (!edm::Service<evf::EvFDaqDirector>()->microMergeDisabled()) {
+        FILE *des = edm::Service<evf::EvFDaqDirector>()->maybeCreateAndLockFileHeadForStream(ls.luminosityBlock(),stream_label_);
+
+        std::string deschecksum = edm::Service<evf::EvFDaqDirector>()->getMergedDatChecksumFilePath(ls.luminosityBlock(), stream_label_);
+
+        struct stat istat;
+        FILE * cf = NULL;
+        uint32_t mergedAdler32=1;
+        //get adler32 accumulated checksum for the merged file
+        if (!stat(deschecksum.c_str(), &istat)) {
           if (istat.st_size) {
             cf = fopen(deschecksum.c_str(),"r");
             if (!cf) throw cms::Exception("RecoEventOutputModuleForFU") << "Unable to open checksum file -: " << deschecksum.c_str();
@@ -297,15 +304,15 @@ namespace evf {
             fclose(cf);
           }
           else edm::LogWarning("RecoEventOutputModuleForFU") << "Checksum file size is empty -: "<< deschecksum.c_str();
-      }
+        }
 
-      FILE *src = fopen(openDatFilePath_.string().c_str(),"r");
+        FILE *src = fopen(openDatFilePath_.string().c_str(),"r");
 
-      stat(openDatFilePath_.string().c_str(), &istat);
-      off_t readInput=0;
-      uint32_t adlera=1;
-      uint32_t adlerb=0;
-      while (readInput<istat.st_size) {
+        stat(openDatFilePath_.string().c_str(), &istat);
+        off_t readInput=0;
+        uint32_t adlera=1;
+        uint32_t adlerb=0;
+        while (readInput<istat.st_size) {
           size_t toRead=  readInput+1024*1024 < istat.st_size ? 1024*1024 : istat.st_size-readInput;
           fread(outBuf_,toRead,1,src);
           fwrite(outBuf_,toRead,1,des);
@@ -313,38 +320,38 @@ namespace evf {
             cms::Adler32((const char*)outBuf_,toRead,adlera,adlerb);
           readInput+=toRead;
           filesize+=toRead;
-      }
+        }
 
-      //if(des != 0 && src !=0){
-      //	while((b=fgetc(src))!= EOF){
-      //	  fputc((unsigned char)b,des);
-      //    filesize++;
-      //	}
-      //}
+        //write new string representation of the checksum value
+        cf = fopen(deschecksum.c_str(),"w");
+        if (!cf) throw cms::Exception("RecoEventOutputModuleForFU") << "Unable to open or rewind checksum file for writing -:" << deschecksum.c_str();
 
-      //write new string representation of the checksum value
-      cf = fopen(deschecksum.c_str(),"w");
-      if (!cf) throw cms::Exception("RecoEventOutputModuleForFU") << "Unable to open or rewind checksum file for writing -:" << deschecksum.c_str();
+        //write adler32 combine to checksum file 
+        mergedAdler32 = adler32_combine(mergedAdler32,fileAdler32_.value(),filesize);
 
-      //write adler32 combine to checksum file 
-      mergedAdler32 = adler32_combine(mergedAdler32,fileAdler32_.value(),filesize);
+        fprintf(cf,"%u",mergedAdler32);
+        fclose(cf);
 
-      fprintf(cf,"%u",mergedAdler32);
-      fclose(cf);
+        edm::Service<evf::EvFDaqDirector>()->unlockAndCloseMergeStream();
+        fclose(src);
 
-      edm::Service<evf::EvFDaqDirector>()->unlockAndCloseMergeStream();
-      fclose(src);
+        if (readAdler32Check_ && ((adlerb << 16) | adlera) != fileAdler32_.value()) {
 
-      if (readAdler32Check_ && ((adlerb << 16) | adlera) != fileAdler32_.value()) {
-
-        throw cms::Exception("RecoEventOutputModuleForFU") << "Adler32 checksum mismatch after reading file -: " 
+          throw cms::Exception("RecoEventOutputModuleForFU") << "Adler32 checksum mismatch after reading file -: " 
                                                            << openDatFilePath_.string() <<" in LS " << ls.luminosityBlock() << std::endl;
+        }
       }
-
+      else  { //no micromerge by HLT
+        stat(openDatFilePath_.string().c_str(), &istat);
+        filesize = istat.st_size;
+        boost::filesystem::rename(openDatFilePath_.string().c_str(), edm::Service<evf::EvFDaqDirector>()->getDatFilePath(ls.luminosityBlock(),stream_label_));
+      }
     } else {
-      //return if not in empty lumisectio mode
-      if (!edm::Service<evf::EvFDaqDirector>()->emptyLumisectionMode())
+      //return if not in empty lumisection mode
+      if (!edm::Service<evf::EvFDaqDirector>()->emptyLumisectionMode()) {
+        remove(openDatFilePath_.string().c_str());
         return;
+      }
       filelist_ = "";
       fileAdler32_.value()=-1;
     }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -287,6 +287,7 @@ namespace evf {
     desc.addUntracked<std::string>("selectedTransferMode","")->setComment("Selected transfer mode (choice in Lvl0 propagated as Python parameter");
     desc.addUntracked<unsigned int>("fuLockPollInterval",2000)->setComment("Lock polling interval in microseconds for the input directory file lock");
     desc.addUntracked<bool>("emptyLumisectionMode",false)->setComment("Enables writing stream output metadata even when no events are processed in a lumisection");
+    desc.addUntracked<bool>("microMergeDisabled",false)->setComment("Disabled micro-merging by the Output Module, so it is later done by hltd service");
     desc.setAllowAnything();
     descriptions.add("EvFDaqDirector", desc);
   }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -52,6 +52,7 @@ namespace evf {
     hltSourceDirectory_(pset.getUntrackedParameter<std::string>("hltSourceDirectory","")),
     fuLockPollInterval_(pset.getUntrackedParameter<unsigned int>("fuLockPollInterval",2000)),
     emptyLumisectionMode_(pset.getUntrackedParameter<bool>("emptyLumisectionMode",false)),
+    microMergeDisabled_(pset.getUntrackedParameter<bool>("microMergeDisabled",false)),
     hostname_(""),
     bu_readlock_fd_(-1),
     bu_writelock_fd_(-1),
@@ -101,17 +102,23 @@ namespace evf {
     if (fuLockPollIntervalPtr) {
       try {
         fuLockPollInterval_=boost::lexical_cast<unsigned int>(std::string(fuLockPollIntervalPtr));
-        edm::LogInfo("Setting fu lock poll interval by environment string: ") << fuLockPollInterval_ << " us";
+        edm::LogInfo("EvFDaqDirector") << "Setting fu lock poll interval by environment string: " << fuLockPollInterval_ << " us";
       }
       catch( boost::bad_lexical_cast const& ) {
-        edm::LogWarning("Bad lexical cast in parsing: ") << std::string(fuLockPollIntervalPtr); 
+        edm::LogWarning("EvFDaqDirector") << "Bad lexical cast in parsing: " << std::string(fuLockPollIntervalPtr);
       }
     }
 
     char * emptyLumiModePtr = getenv("FFF_EMPTYLSMODE");
     if (emptyLumiModePtr) {
         emptyLumisectionMode_ = true;
-        edm::LogInfo("Setting empty lumisection mode");
+        edm::LogInfo("EvFDaqDirector") << "Setting empty lumisection mode";
+    }
+
+    char * microMergeDisabledPtr = getenv("FFF_MICROMERGEDISABLED");
+    if (microMergeDisabledPtr) {
+        microMergeDisabled_ = true;
+        edm::LogInfo("EvFDaqDirector") << "Disabling dat file micro-merge by the HLT process (delegated to the hlt daemon)";
     }
   }
 
@@ -374,6 +381,10 @@ namespace evf {
 
   std::string EvFDaqDirector::getOpenInputJsonFilePath(const unsigned int ls, const unsigned int index) const {
     return bu_run_dir_ + "/open/" + fffnaming::inputJsonFileName(run_,ls,index);
+  }
+
+  std::string EvFDaqDirector::getDatFilePath(const unsigned int ls, std::string const& stream) const {
+    return run_dir_ + "/" + fffnaming::streamerDataFileNameWithPid(run_,ls,stream);
   }
 
   std::string EvFDaqDirector::getOpenDatFilePath(const unsigned int ls, std::string const& stream) const {

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -52,6 +52,7 @@ namespace evf{
     reg.watchPreallocate(this, &FastMonitoringService::preallocate);//receiving information on number of threads
     reg.watchJobFailure(this,&FastMonitoringService::jobFailure);//global
 
+    reg.watchPreBeginJob(this,&FastMonitoringService::preBeginJob);
     reg.watchPreModuleBeginJob(this,&FastMonitoringService::preModuleBeginJob);//global
     reg.watchPostBeginJob(this,&FastMonitoringService::postBeginJob);
     reg.watchPostEndJob(this,&FastMonitoringService::postEndJob);
@@ -141,6 +142,16 @@ namespace evf{
 
   void FastMonitoringService::preallocate(edm::service::SystemBounds const & bounds)
   {
+    nStreams_=bounds.maxNumberOfStreams();
+    nThreads_=bounds.maxNumberOfThreads();
+    //this should already be >=1
+    if (nStreams_==0) nStreams_=1;
+    if (nThreads_==0) nThreads_=1;
+  }
+
+  void FastMonitoringService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&,
+                                          edm::ProcessContext const& pc)
+  {
 
     // FIND RUN DIRECTORY
     // The run dir should be set via the configuration of EvFDaqDirector
@@ -187,13 +198,6 @@ namespace evf{
     LogDebug("FastMonitoringService") << "Initializing FastMonitor with microstate def path -: "
 			                  << microstateDefPath_;
 			                  //<< encPath_.current_ + 1 << " " << encModule_.current_ + 1
-
-    nStreams_=bounds.maxNumberOfStreams();
-    nThreads_=bounds.maxNumberOfThreads();
-
-    //this should already be >=1
-    if (nStreams_==0) nStreams_=1;
-    if (nThreads_==0) nThreads_=1;
 
     /*
      * initialize the fast monitor with:

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -217,6 +217,8 @@ void FedRawDataInputSource::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.addUntracked<bool> ("verifyAdler32", true)->setComment("Verify event Adler32 checksum with FRDv3 or v4");
   desc.addUntracked<bool> ("verifyChecksum", true)->setComment("Verify event CRC-32C checksum of FRDv5 or higher");
   desc.addUntracked<bool> ("useL1EventID", false)->setComment("Use L1 event ID from FED header if true or from TCDS FED if false");
+  desc.addUntracked<bool> ("fileListMode", false)->setComment("Use fileNames parameter to directly specify raw files to open");
+  desc.addUntracked<std::vector<std::string>> ("fileNames", std::vector<std::string>())->setComment("file list used when fileListMode is enabled");
   desc.setAllowAnything();
   descriptions.add("source", desc);
 }


### PR DESCRIPTION
Changes:
- special mode for FedRawDataInputSource where "fileNames" vstring parameter can be provided. Another parameter, "fileLIstMode" (boolean), can enable this behavior. Initialization order of services and modules is reorganized to allow setting run number from file names found by source.
- option to disable reading back and merging output files at the end of lumisection (output module). In this case it is done by HLTD script when copying to BU output. This reduces used disk IO by 50% in HLT machines. (HLTD detects the change automatically.)
- fix for a lumisection variable which was being re-initialized in a loop instead of before (source)
- throw exception if "stat" returns -1, i.e. fails to find a file (source)
