### PR TITLE
FastSim: Bug fix 80X: fix layer definition hltPixelPairSeeds

### DIFF
--- a/FastSimulation/Tracking/python/hltElectronGsfTracks_cff.py
+++ b/FastSimulation/Tracking/python/hltElectronGsfTracks_cff.py
@@ -1,14 +1,14 @@
-from FastSimulation.EgammaElectronAlgos.electronGSGsfTrackCandidates_cff import *
+from FastSimulation.Tracking.electronCkfTrackCandidates_cff import *
 import TrackingTools.GsfTracking.GsfElectronFit_cfi
 
-hltEgammaCkfTrackCandidatesForGSF = electronGSGsfTrackCandidates.clone()
+hltEgammaCkfTrackCandidatesForGSF = electronCkfTrackCandidates.clone()
 hltEgammaCkfTrackCandidatesForGSF.src = "hltEgammaElectronPixelSeeds"
 hltEgammaGsfTracks = TrackingTools.GsfTracking.GsfElectronFit_cfi.GsfGlobalElectronTest.clone()
 hltEgammaGsfTracks.src = 'hltEgammaCkfTrackCandidatesForGSF'
 hltEgammaGsfTracks.TTRHBuilder = 'WithoutRefit'
 hltEgammaGsfTracks.TrajectoryInEvent = True
 
-hltEgammaCkfTrackCandidatesForGSFUnseeded = electronGSGsfTrackCandidates.clone()
+hltEgammaCkfTrackCandidatesForGSFUnseeded = electronCkfTrackCandidates.clone()
 hltEgammaCkfTrackCandidatesForGSFUnseeded.src = "hltEgammaElectronPixelSeedsUnseeded"
 hltEgammaGsfTracksUnseeded = hltEgammaGsfTracks.clone()
 hltEgammaGsfTracksUnseeded.src =  'hltEgammaCkfTrackCandidatesForGSFUnseeded'

--- a/FastSimulation/Tracking/python/hltElectronGsfTracks_cff.py
+++ b/FastSimulation/Tracking/python/hltElectronGsfTracks_cff.py
@@ -1,14 +1,14 @@
-from FastSimulation.Tracking.electronCkfTrackCandidates_cff import *
+from FastSimulation.EgammaElectronAlgos.electronGSGsfTrackCandidates_cff import *
 import TrackingTools.GsfTracking.GsfElectronFit_cfi
 
-hltEgammaCkfTrackCandidatesForGSF = electronCkfTrackCandidates.clone()
+hltEgammaCkfTrackCandidatesForGSF = electronGSGsfTrackCandidates.clone()
 hltEgammaCkfTrackCandidatesForGSF.src = "hltEgammaElectronPixelSeeds"
 hltEgammaGsfTracks = TrackingTools.GsfTracking.GsfElectronFit_cfi.GsfGlobalElectronTest.clone()
 hltEgammaGsfTracks.src = 'hltEgammaCkfTrackCandidatesForGSF'
 hltEgammaGsfTracks.TTRHBuilder = 'WithoutRefit'
 hltEgammaGsfTracks.TrajectoryInEvent = True
 
-hltEgammaCkfTrackCandidatesForGSFUnseeded = electronCkfTrackCandidates.clone()
+hltEgammaCkfTrackCandidatesForGSFUnseeded = electronGSGsfTrackCandidates.clone()
 hltEgammaCkfTrackCandidatesForGSFUnseeded.src = "hltEgammaElectronPixelSeedsUnseeded"
 hltEgammaGsfTracksUnseeded = hltEgammaGsfTracks.clone()
 hltEgammaGsfTracksUnseeded.src =  'hltEgammaCkfTrackCandidatesForGSFUnseeded'

--- a/FastSimulation/Tracking/python/hltSeeds_cff.py
+++ b/FastSimulation/Tracking/python/hltSeeds_cff.py
@@ -13,17 +13,9 @@ hltPixelTripletSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajec
 # pixel pair seeds
 # todo: import layerlist 
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
+import RecoTracker.TkSeedingLayers.MixedLayerPairs_cfi
 hltPixelPairSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    layerList = cms.vstring(
-        'BPix1+BPix2'
-        'BPix1+FPix1_pos',
-        'BPix1+FPix1_neg',
-        'BPix2+FPix1_pos',
-        'BPix2+FPix1_neg',
-        
-        'FPix1_pos+FPix2_pos',
-        'FPix1_neg+FPix2_neg',
-        ),
+    layerList = RecoTracker.TkSeedingLayers.MixedLayerPairs_cfi.MixedLayerPairs.layerList,
     skipSeedFinderSelector = cms.untracked.bool(True),
     RegionFactoryPSet = FastSimulation.Tracking.InitialStep_cff.initialStepSeeds.RegionFactoryPSet.clone()
     )


### PR DESCRIPTION
Fix on top of 
#13438

Backport of 
#13501

Electron electron HLT functions again in FastSim!
Tested in 800pre6, because later releases have general issues with L1 trigger.

![image](https://cloud.githubusercontent.com/assets/5065551/13426266/a269acba-dfac-11e5-903c-429c108029b3.png)
