### PR TITLE
CondDBSetup deprecated : moving to CondDB.CondDB_cfi 

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from SimCalorimetry.HcalSimProducers.hcalSimParameters_cfi import *
-from CondCore.DBCommon.CondDBSetup_cfi import *
+from CondCore.CondDB.CondDB_cfi import *
 from Geometry.HcalEventSetup.HcalRelabel_cfi import HcalReLabel
 
 # make a block so other modules, such as the data mixing module, can


### PR DESCRIPTION
This change is removing the warning message seen when running GENSIM step in standard workflows defined in runthematrix .

I simply replaced  CondCore.DBCommon.CondDBSetup_cfi  by CondCore.CondDB.CondDB_cfi as recommended by the ALCADB group 

However the deprecated files:
CondCore/DBCommon/python/CondDBSetup_cfi.py  
CondCore/DBCommon/python/CondDBCommon_cfi.py

are still spread 'everywhere' in cmssw , generating the warning messages in many other configurations including many of the StandardSequences .
Maybe a central migration can be foreseen ? 
@ggovi  FYI
