### PR TITLE
Adjust Muon Quality to 12

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonQualityAdjuster.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonQualityAdjuster.cc
@@ -120,7 +120,7 @@ L1TMuonQualityAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     filteredBMTFMuons->setBXRange(bmtfMuons->getFirstBX(), bmtfMuons->getLastBX());
     for (int bx = bmtfMuons->getFirstBX(); bx <= bmtfMuons->getLastBX(); ++bx) {
       for (auto mu = bmtfMuons->begin(bx); mu != bmtfMuons->end(bx); ++mu) {
-	int newqual = 1;
+	int newqual = 12;
 	l1t::RegionalMuonCand newMu((*mu));      
 	newMu.setHwQual(newqual);
 	filteredBMTFMuons->push_back(bx+m_bmtfBxOffset, newMu);      
@@ -135,7 +135,7 @@ L1TMuonQualityAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     for (int bx = emtfMuons->getFirstBX(); bx <= emtfMuons->getLastBX(); ++bx) {
       for (auto mu = emtfMuons->begin(bx); mu != emtfMuons->end(bx); ++mu) {
 	int newqual = 0;
-	if (mu->hwQual() == 11 || mu->hwQual() > 12) newqual=1;
+	if (mu->hwQual() == 11 || mu->hwQual() > 12) newqual=12;
 	l1t::RegionalMuonCand newMu((*mu));
 	newMu.setHwQual(newqual);
 	filteredEMTFMuons->push_back(bx, newMu);
@@ -150,7 +150,7 @@ L1TMuonQualityAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     for (int bx = omtfMuons->getFirstBX(); bx <= omtfMuons->getLastBX(); ++bx) {
       for (auto mu = omtfMuons->begin(bx); mu != omtfMuons->end(bx); ++mu) {
 	int newqual = 0;
-	if (mu->hwQual() > 0) newqual = 1;
+	if (mu->hwQual() > 0) newqual = 12;
 	l1t::RegionalMuonCand newMu((*mu));
 	newMu.setHwQual(newqual);
 	filteredOMTFMuons->push_back(bx, newMu);


### PR DESCRIPTION
While the treatment of L1T Muon firmware is being finalized, a fictitious Muon Quality adjuster was introduced to provide usable qualities (0 or 1) while the emulators remain synced with the actual firmware (unusable for studies in present state).

This change has the muon quality adjuster set passing muons qualty to 0x1100 = 12, so that uGT algorithms which expect muon quality in the two MSBs can be used with muon quality adjuster.
