### PR TITLE
Hcal tb2006 update

### DIFF
--- a/SimG4CMS/EcalTestBeam/interface/EcalTBMCInfoProducer.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBMCInfoProducer.h
@@ -5,8 +5,6 @@
  *
  *
 */
-
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -22,13 +20,9 @@
 
 #include "Math/GenVector/Rotation3D.h"
 
-#include <iostream>
-#include <fstream>
-#include <vector>
-
-class EcalTBMCInfoProducer: public edm::stream::EDProducer{
-  
- public:
+class EcalTBMCInfoProducer: public edm::stream::EDProducer<>
+{  
+public:
   
   /// Constructor
   explicit EcalTBMCInfoProducer(const edm::ParameterSet& ps);
@@ -57,7 +51,7 @@ private:
 
   ROOT::Math::Rotation3D * fromCMStoTB;
 
-  std::string GenVtxLabel;
+  edm::EDGetTokenT<edm::HepMCProduct> GenVtxToken;
 };
 
 #endif

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBMCInfoProducer.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBMCInfoProducer.h
@@ -7,7 +7,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,12 +26,12 @@
 #include <fstream>
 #include <vector>
 
-class EcalTBMCInfoProducer: public edm::EDProducer{
+class EcalTBMCInfoProducer: public edm::stream::EDProducer{
   
  public:
   
   /// Constructor
-  EcalTBMCInfoProducer(const edm::ParameterSet& ps);
+  explicit EcalTBMCInfoProducer(const edm::ParameterSet& ps);
   
   /// Destructor
   virtual ~EcalTBMCInfoProducer();
@@ -39,13 +39,6 @@ class EcalTBMCInfoProducer: public edm::EDProducer{
   /// Produce digis out of raw data
   void produce(edm::Event & event, const edm::EventSetup& eventSetup);
   
-  // BeginJob
-  //void beginJob();
-  
-  // EndJob
-  //void endJob(void);
-  
-
 private:
 
   double beamEta;

--- a/SimG4CMS/EcalTestBeam/interface/FakeTBEventHeaderProducer.h
+++ b/SimG4CMS/EcalTestBeam/interface/FakeTBEventHeaderProducer.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,30 +23,22 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBEventHeader.h"
 #include "Geometry/EcalTestBeam/interface/EcalTBHodoscopeGeometry.h"
 
-class FakeTBEventHeaderProducer: public edm::EDProducer{
-
-  
- public:
+class FakeTBEventHeaderProducer: public edm::stream::EDProducer <>
+{  
+public:
   
   /// Constructor
-  FakeTBEventHeaderProducer(const edm::ParameterSet& ps);
+  explicit FakeTBEventHeaderProducer(const edm::ParameterSet& ps);
   
   /// Destructor
   virtual ~FakeTBEventHeaderProducer();
   
   /// Produce digis out of raw data
-  void produce(edm::Event & event, const edm::EventSetup& eventSetup);
+  void produce(edm::Event & event, const edm::EventSetup& eventSetup) override;
   
-  // BeginJob
-  //void beginJob();
-  
-  // EndJob
-  //void endJob(void);
-  
-
 private:
 
-  std::string ecalTBInfoLabel_;
+  edm::EDGetTokenT<PEcalTBInfo> ecalTBInfo_;
 
 };
 

--- a/SimG4CMS/EcalTestBeam/interface/FakeTBHodoscopeRawInfoProducer.h
+++ b/SimG4CMS/EcalTestBeam/interface/FakeTBHodoscopeRawInfoProducer.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,32 +24,24 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRawInfo.h"
 #include "Geometry/EcalTestBeam/interface/EcalTBHodoscopeGeometry.h"
 
-class FakeTBHodoscopeRawInfoProducer: public edm::EDProducer{
-
-  
- public:
+class FakeTBHodoscopeRawInfoProducer: public edm::stream::EDProducer<>
+{
+public:
   
   /// Constructor
-  FakeTBHodoscopeRawInfoProducer(const edm::ParameterSet& ps);
+  explicit FakeTBHodoscopeRawInfoProducer(const edm::ParameterSet& ps);
   
   /// Destructor
   virtual ~FakeTBHodoscopeRawInfoProducer();
   
   /// Produce digis out of raw data
-  void produce(edm::Event & event, const edm::EventSetup& eventSetup);
+  void produce(edm::Event & event, const edm::EventSetup& eventSetup) override;
   
-  // BeginJob
-  //void beginJob();
-  
-  // EndJob
-  //void endJob(void);
-  
-
 private:
 
   EcalTBHodoscopeGeometry * theTBHodoGeom_;
 
-  std::string ecalTBInfoLabel_;
+  edm::EDGetTokenT<PEcalTBInfo> ecalTBInfo_;
 
 };
 

--- a/SimG4CMS/EcalTestBeam/interface/TBHodoActiveVolumeRawInfoProducer.h
+++ b/SimG4CMS/EcalTestBeam/interface/TBHodoActiveVolumeRawInfoProducer.h
@@ -6,8 +6,7 @@
  *
  */
 
-
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,24 +23,25 @@
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 
-class TBHodoActiveVolumeRawInfoProducer: public edm::EDProducer{
+class TBHodoActiveVolumeRawInfoProducer: public edm::stream::EDProducer<>
+{
 
-  
- public:
+public:
   
   /// Constructor
-  TBHodoActiveVolumeRawInfoProducer(const edm::ParameterSet& ps);
+  explicit TBHodoActiveVolumeRawInfoProducer(const edm::ParameterSet& ps);
   
   /// Destructor
   virtual ~TBHodoActiveVolumeRawInfoProducer();
   
   /// Produce digis out of raw data
-  void produce(edm::Event & event, const edm::EventSetup& eventSetup);
+  void produce(edm::Event & event, const edm::EventSetup& eventSetup) override;
   
 private:
 
   double myThreshold;
 
+  edm::EDGetTokenT<edm::PCaloHitContainer> m_EcalToken;
   EcalTBHodoscopeGeometry * theTBHodoGeom_;
 };
 

--- a/SimG4CMS/EcalTestBeam/plugins/EcalTBMCInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/EcalTBMCInfoProducer.cc
@@ -12,6 +12,10 @@
 
 #include "DataFormats/Math/interface/Point3D.h"
 
+#include <iostream>
+#include <fstream>
+#include <vector>
+
 using namespace std;
 using namespace cms;
 
@@ -20,7 +24,7 @@ EcalTBMCInfoProducer::EcalTBMCInfoProducer(const edm::ParameterSet& ps) {
   produces<PEcalTBInfo>();
 
   edm::FileInPath CrystalMapFile = ps.getParameter<edm::FileInPath>("CrystalMapFile");
-  GenVtxLabel = ps.getUntrackedParameter<string>("moduleLabelVtx","source");
+  GenVtxToken = consumes<edm::HepMCProduct>(edm::InputTag("moduleLabelVtx","source"));
   double fMinEta = ps.getParameter<double>("MinEta");
   double fMaxEta = ps.getParameter<double>("MaxEta");
   double fMinPhi = ps.getParameter<double>("MinPhi");
@@ -100,7 +104,7 @@ EcalTBMCInfoProducer::~EcalTBMCInfoProducer() {
   delete theTestMap;
 }
 
- void EcalTBMCInfoProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
+void EcalTBMCInfoProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
 {
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(event.streamID());
@@ -120,7 +124,7 @@ EcalTBMCInfoProducer::~EcalTBMCInfoProducer() {
   partXhodo = partYhodo = 0.;
 
   edm::Handle<edm::HepMCProduct> GenEvt;
-  event.getByLabel(GenVtxLabel,GenEvt);
+  event.getByToken(GenVtxToken,GenEvt);
 
   const HepMC::GenEvent* Evt = GenEvt->GetEvent() ;
   HepMC::GenEvent::vertex_const_iterator Vtx = Evt->vertices_begin();

--- a/SimG4CMS/EcalTestBeam/plugins/FakeTBEventHeaderProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/FakeTBEventHeaderProducer.cc
@@ -10,35 +10,32 @@
 using namespace cms;
 using namespace std;
 
-
 FakeTBEventHeaderProducer::FakeTBEventHeaderProducer(const edm::ParameterSet& ps) {
+  ecalTBInfo_ = consumes<PEcalTBInfo>(edm::InputTag("EcalTBInfoLabel","SimEcalTBG4Object"));
   produces<EcalTBEventHeader>();
-  ecalTBInfoLabel_ = ps.getUntrackedParameter<string>("EcalTBInfoLabel","SimEcalTBG4Object");
-
 }
-
  
 FakeTBEventHeaderProducer::~FakeTBEventHeaderProducer() 
 {
 }
 
- void FakeTBEventHeaderProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
+void FakeTBEventHeaderProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
 {
   auto_ptr<EcalTBEventHeader> product(new EcalTBEventHeader());
 
   // get the vertex information from the event
 
-  const PEcalTBInfo* theEcalTBInfo=0;
+  const PEcalTBInfo* theEcalTBInfo = nullptr;
   edm::Handle<PEcalTBInfo> EcalTBInfo;
-  event.getByLabel(ecalTBInfoLabel_,EcalTBInfo);
+  event.getByToken(ecalTBInfo_,EcalTBInfo);
   if (EcalTBInfo.isValid()){
     theEcalTBInfo = EcalTBInfo.product(); 
   } else {
-    edm::LogError("FakeTBEventHeaderProducer") << "Error! can't get the product " << ecalTBInfoLabel_.c_str() ;
+    edm::LogError("FakeTBEventHeaderProducer") << "Error! can't get the product PEcalTBInfo";
   }
   
   if (!theEcalTBInfo)
-    return;
+    { return; }
   
   // 64 bits event ID in CMSSW converted to EcalTBEventHeader ID
   int evtid = (int)event.id().event();

--- a/SimG4CMS/EcalTestBeam/plugins/FakeTBHodoscopeRawInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/FakeTBHodoscopeRawInfoProducer.cc
@@ -9,32 +9,28 @@
 using namespace cms;
 using namespace std;
 
-
 FakeTBHodoscopeRawInfoProducer::FakeTBHodoscopeRawInfoProducer(const edm::ParameterSet& ps) {
   
+  ecalTBInfo_ = consumes<PEcalTBInfo>(edm::InputTag("EcalTBInfoLabel","SimEcalTBG4Object"));
   produces<EcalTBHodoscopeRawInfo>();
 
-  ecalTBInfoLabel_ = ps.getUntrackedParameter<string>("EcalTBInfoLabel","SimEcalTBG4Object");
-
   theTBHodoGeom_ = new EcalTBHodoscopeGeometry();
-
 }
 
- 
 FakeTBHodoscopeRawInfoProducer::~FakeTBHodoscopeRawInfoProducer() {
 
   delete theTBHodoGeom_;
 
 }
 
- void FakeTBHodoscopeRawInfoProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
+void FakeTBHodoscopeRawInfoProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
 {
   auto_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
 
   // get the vertex information from the event
 
   edm::Handle<PEcalTBInfo> theEcalTBInfo;
-  event.getByLabel(ecalTBInfoLabel_,theEcalTBInfo);
+  event.getByToken(ecalTBInfo_,theEcalTBInfo);
 
   double partXhodo = theEcalTBInfo->evXbeam();
   double partYhodo = theEcalTBInfo->evYbeam();

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06Analysis.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06Analysis.h
@@ -23,7 +23,7 @@
   
 class HcalTB06Histo;
 
-class HcalTB06Analysis : public edm::one::EDAnalyzer<edm::one::SharedResources>
+class HcalTB06Analysis : public edm::one::EDAnalyzer<>
 {
 public:
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06Analysis.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06Analysis.h
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 
 #include <memory>
 #include <vector>
@@ -38,15 +39,22 @@ private:
   HcalTB06Analysis(const HcalTB06Analysis&) = delete; 
   const HcalTB06Analysis& operator=(const HcalTB06Analysis&) = delete;
 
-  int         count;
-  edm::InputTag m_EcalTag;
-  edm::InputTag m_HcalTag;
+  edm::EDGetTokenT<edm::PCaloHitContainer> m_EcalToken;
+  edm::EDGetTokenT<edm::PCaloHitContainer> m_HcalToken;
   bool        m_ECAL;
+
+  int         count;
+  int         m_idxetaEcal;
+  int         m_idxphiEcal;
+  int         m_idxetaHcal;
+  int         m_idxphiHcal;
 
   double      m_eta;
   double      m_phi;
   double      m_ener;
+  double      m_timeLimit;
   double      m_widthEcal;
+  double      m_widthHcal;
   double      m_factEcal;
   double      m_factHcal;
   std::vector<int> m_PDG;

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06Histo.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06Histo.h
@@ -43,9 +43,11 @@ private:
 
   // ---------- Private Data members -----------------------
   bool                  verbose;
+  double                ebeam;
 
   TH1D                  *iniE,  *iEta,  *iPhi;
   TH1D                  *edepS, *edecS, *edhcS;
+  TH1D                  *edepN, *edecN, *edhcN;
   TH2D                  *edehS;
 };
  

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
@@ -111,7 +111,6 @@ void HcalTB06Analysis::endJob()
 
 void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
 {
-  G4cout << "New Event# " << count << G4endl;
   ++count;
 
   //Beam Information
@@ -139,12 +138,6 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
     ne = EcalHits->size();
     for (unsigned int i=0; i<ne; ++i) {
       EBDetId ecalid((*EcalHits)[i].id());
-      G4cout << "Ecal hit E= " << (*EcalHits)[i].energy()
-	     << "  id= " << (*EcalHits)[i].id()
-	     << "  time= " << (*EcalHits)[i].time()
-	     << "  ieta= " << ecalid.ieta() 
-	     << "  iphi= " << ecalid.iphi()
-	     << G4endl;
       if(std::abs(m_idxetaEcal - ecalid.ieta()) <= 3 &&
       	 std::abs(m_idxphiEcal - ecalid.iphi()) <= 3 &&
 	 (*EcalHits)[i].time() < m_timeLimit) {
@@ -160,13 +153,6 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
     nh = HcalHits->size();
     for (unsigned int i=0; i<nh; ++i) {
       HcalDetId hcalid((*HcalHits)[i].id());
-      G4cout << "Hcal hit E= " << (*HcalHits)[i].energy()
-	     << "  id= " << (*HcalHits)[i].id()
-	     << "  depth= " << (*HcalHits)[i].depth()
-	     << "  time= " << (*HcalHits)[i].time() 
-	     << "  ieta= " << hcalid.ieta() 
-	     << "  iphi= " << hcalid.iphi()
-	     << G4endl;
       if(std::abs(m_idxetaHcal - hcalid.ieta()) <= 1 &&
       	 std::abs(m_idxphiHcal - hcalid.iphi()) <= 1 &&
 	 (*HcalHits)[i].time() < m_timeLimit) {
@@ -179,11 +165,6 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
     ehcals *= m_factHcal;
   }
   double etots = eecals + ehcals;
-  std::cout  << "HcalTB06Analysis:: Etot(MeV)= " << etots 
-	     << "   E(Ecal)= " << eecals 
-	     << "   E(Hcal)= " << ehcals
-	     << "  Nhits(ECAL)= " << ne 
-	     << "  Nhits(HCAL)= " << nh << std::endl;
   LogDebug("HcalTBSim") << "HcalTB06Analysis:: Etot(MeV)= " << etots 
 			<< "   E(Ecal)= " << eecals 
 			<< "   E(Hcal)= " << ehcals

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
@@ -15,8 +15,9 @@
 #include "SimG4CMS/HcalTestBeam/interface/HcalTB06Histo.h"
 
 // to retreive hits
-#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 #include "SimG4CMS/Calo/interface/CaloG4Hit.h"
 #include "SimG4CMS/Calo/interface/CaloG4HitCollection.h"
@@ -41,32 +42,54 @@
 //
 
 HcalTB06Analysis::HcalTB06Analysis(const edm::ParameterSet &p)
-  : count(0), m_EcalTag(edm::InputTag("g4SimHits","EcalHitsEB")), 
-    m_HcalTag(edm::InputTag("g4SimHits","HcalHits"))
+  : count(0)
 {
   m_ECAL = p.getParameter<bool>("ECAL");
   if(m_ECAL) {
-    consumes<edm::PCaloHitContainer>(m_EcalTag);
+    m_EcalToken = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","EcalHitsEB"));
   }
-  consumes<edm::PCaloHitContainer>(m_HcalTag);
+  m_HcalToken = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","HcalHits"));
   m_eta = p.getParameter<double>("MinEta");
   m_phi = p.getParameter<double>("MinPhi");
   m_ener= p.getParameter<double>("MinE");
   m_PDG = p.getParameter<std::vector<int> >("PartID");
 
+  double minEta  = p.getParameter<double>("MinEta");
+  double maxEta  = p.getParameter<double>("MaxEta");
+  double minPhi  = p.getParameter<double>("MinPhi");
+  double maxPhi  = p.getParameter<double>("MaxPhi");
+  double beamEta = (maxEta+minEta)*0.5;
+  double beamPhi = (maxPhi+minPhi)*0.5;
+  if (beamPhi < 0) { beamPhi += twopi; }
+
+  m_idxetaEcal = 13;
+  m_idxphiEcal = 13;
+
+  m_idxetaHcal   = (int)(beamEta/0.087) + 1;
+  m_idxphiHcal   = (int)(beamPhi/0.087) + 6;
+  if(m_idxphiHcal > 72) { m_idxphiHcal -= 73; }
+
   edm::ParameterSet ptb = p.getParameter<edm::ParameterSet>("TestBeamAnalysis");
+  m_timeLimit = ptb.getParameter<double>("TimeLimit");
   m_widthEcal = ptb.getParameter<double>("EcalWidth");
+  m_widthHcal = ptb.getParameter<double>("HcalWidth");
   m_factEcal  = ptb.getParameter<double>("EcalFactor");
   m_factHcal  = ptb.getParameter<double>("HcalFactor");
 
   edm::LogInfo("HcalTB06Analysis") 
     << "Beam parameters: E(GeV)= " << m_ener
     << " pdgID= " << m_PDG[0]
-    << "  eta= " << m_eta
-    << "  phi= " << m_phi
+    << "\n eta= " << m_eta 
+    << "  idx_etaEcal= " << m_idxetaEcal 
+    << "  idx_etaHcal= " << m_idxetaHcal 
+    << "  phi= " << m_phi 
+    << "  idx_phiEcal= " << m_idxphiEcal
+    << "  idx_phiHcal= " << m_idxphiHcal
     << "\n        EcalFactor= " << m_factEcal
     << "  EcalWidth= " << m_widthEcal << " GeV" 
-    << "\n        HcalFactor= " << m_factHcal;
+    << "\n        HcalFactor= " << m_factHcal
+    << "  HcalWidth= " << m_widthHcal << " GeV"
+    << "\n        TimeLimit=  " << m_timeLimit << " ns";
   m_histo = new HcalTB06Histo(ptb);
 } 
    
@@ -88,6 +111,7 @@ void HcalTB06Analysis::endJob()
 
 void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
 {
+  G4cout << "New Event# " << count << G4endl;
   ++count;
 
   //Beam Information
@@ -98,10 +122,10 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
 
   const std::vector<PCaloHit>* EcalHits = nullptr;
   if(m_ECAL) { 
-    evt.getByLabel(m_EcalTag, Ecal); 
+    evt.getByToken(m_EcalToken, Ecal); 
     EcalHits = Ecal.product();
   }
-  evt.getByLabel(m_HcalTag, Hcal);
+  evt.getByToken(m_HcalToken, Hcal);
   const std::vector<PCaloHit>* HcalHits = Hcal.product();
 
   // Total Energy
@@ -114,7 +138,18 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
   if(EcalHits) {  
     ne = EcalHits->size();
     for (unsigned int i=0; i<ne; ++i) {
-      eecals += (*EcalHits)[i].energy();
+      EBDetId ecalid((*EcalHits)[i].id());
+      G4cout << "Ecal hit E= " << (*EcalHits)[i].energy()
+	     << "  id= " << (*EcalHits)[i].id()
+	     << "  time= " << (*EcalHits)[i].time()
+	     << "  ieta= " << ecalid.ieta() 
+	     << "  iphi= " << ecalid.iphi()
+	     << G4endl;
+      if(std::abs(m_idxetaEcal - ecalid.ieta()) <= 3 &&
+      	 std::abs(m_idxphiEcal - ecalid.iphi()) <= 3 &&
+	 (*EcalHits)[i].time() < m_timeLimit) {
+	eecals += (*EcalHits)[i].energy();
+      }
     }
     if(m_widthEcal > 0.0) {
       eecals += G4RandGauss::shoot(0.0,m_widthEcal);
@@ -124,15 +159,35 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
   if(HcalHits) {
     nh = HcalHits->size();
     for (unsigned int i=0; i<nh; ++i) {
-      ehcals += (*HcalHits)[i].energy();
+      HcalDetId hcalid((*HcalHits)[i].id());
+      G4cout << "Hcal hit E= " << (*HcalHits)[i].energy()
+	     << "  id= " << (*HcalHits)[i].id()
+	     << "  depth= " << (*HcalHits)[i].depth()
+	     << "  time= " << (*HcalHits)[i].time() 
+	     << "  ieta= " << hcalid.ieta() 
+	     << "  iphi= " << hcalid.iphi()
+	     << G4endl;
+      if(std::abs(m_idxetaHcal - hcalid.ieta()) <= 1 &&
+      	 std::abs(m_idxphiHcal - hcalid.iphi()) <= 1 &&
+	 (*HcalHits)[i].time() < m_timeLimit) {
+	ehcals += (*HcalHits)[i].energy();
+      }
+    }
+    if(m_widthHcal > 0.0) {
+      eecals += G4RandGauss::shoot(0.0,m_widthHcal);
     }
     ehcals *= m_factHcal;
   }
   double etots = eecals + ehcals;
+  std::cout  << "HcalTB06Analysis:: Etot(MeV)= " << etots 
+	     << "   E(Ecal)= " << eecals 
+	     << "   E(Hcal)= " << ehcals
+	     << "  Nhits(ECAL)= " << ne 
+	     << "  Nhits(HCAL)= " << nh << std::endl;
   LogDebug("HcalTBSim") << "HcalTB06Analysis:: Etot(MeV)= " << etots 
 			<< "   E(Ecal)= " << eecals 
 			<< "   E(Hcal)= " << ehcals
 			<< "  Nhits(ECAL)= " << ne 
 			<< "  Nhits(HCAL)= " << nh;
-  m_histo->fillEdep(etots, eecals, ehcals);
+  m_histo->fillEdep(etots, eecals, ehcals); 
 }

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
@@ -138,6 +138,7 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
     ne = EcalHits->size();
     for (unsigned int i=0; i<ne; ++i) {
       EBDetId ecalid((*EcalHits)[i].id());
+      // 7x7 crystal selection
       if(std::abs(m_idxetaEcal - ecalid.ieta()) <= 3 &&
       	 std::abs(m_idxphiEcal - ecalid.iphi()) <= 3 &&
 	 (*EcalHits)[i].time() < m_timeLimit) {
@@ -153,6 +154,7 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
     nh = HcalHits->size();
     for (unsigned int i=0; i<nh; ++i) {
       HcalDetId hcalid((*HcalHits)[i].id());
+      // 3x3 towers selection
       if(std::abs(m_idxetaHcal - hcalid.ieta()) <= 1 &&
       	 std::abs(m_idxphiHcal - hcalid.iphi()) <= 1 &&
 	 (*HcalHits)[i].time() < m_timeLimit) {

--- a/SimG4CMS/HcalTestBeam/python/TB2006Analysis_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TB2006Analysis_cfi.py
@@ -66,7 +66,10 @@ def testbeam2006(process):
             Verbose = cms.untracked.bool(False),
             ETtotMax = cms.untracked.double(400.),
             EHCalMax = cms.untracked.double(400.),
-            EcalWidth  = cms.double(0.1),
+            beamEnergy = cms.untracked.double(50.),
+            TimeLimit  = cms.double(500.),
+            EcalWidth  = cms.double(0.362),
+            HcalWidth  = cms.double(0.640),
             EcalFactor = cms.double(1.),
             HcalFactor = cms.double(100.)
         )

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06Histo.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06Histo.cc
@@ -22,12 +22,13 @@
  
 //
 // constructors and destructor
-HcalTB06Histo::HcalTB06Histo(const edm::ParameterSet& ps) :
-  iniE(0),  iEta(0), iPhi(0), edepS(0), edecS(0), edhcS(0), edehS(0) {
+HcalTB06Histo::HcalTB06Histo(const edm::ParameterSet& ps) 
+{
 
   verbose    = ps.getUntrackedParameter<bool>("Verbose", false);
   double em1 = ps.getUntrackedParameter<double>("ETtotMax", 400.);
   double em2 = ps.getUntrackedParameter<double>("EHCalMax", 4.0);
+  ebeam = 50.;
 
   // Book histograms
   edm::Service<TFileService> tfile;
@@ -41,6 +42,9 @@ HcalTB06Histo::HcalTB06Histo(const edm::ParameterSet& ps) :
   edepS= tfile->make<TH1D>("edepS", "Energy deposit == Total",4000, 0., em1);
   edecS= tfile->make<TH1D>("edecS", "Energy deposit == ECal ",4000, 0., em1);
   edhcS= tfile->make<TH1D>("edhcS", "Energy deposit == HCal ",4000, 0., em2);
+  edepN= tfile->make<TH1D>("edepN", "Etot/Ebeam   ", 200, -2.5, 2.5);
+  edecN= tfile->make<TH1D>("edecN", "Eecal/Ebeam  ", 200, -2.5, 2.5);
+  edhcN= tfile->make<TH1D>("edhcN", "Ehcal/Ebeam  ", 200, -2.5, 2.5);
   edehS= tfile->make<TH2D>("edehS", "Hcal vs Ecal", 100,0.,em1, 100, 0.,em2);
 }
  
@@ -54,6 +58,7 @@ void HcalTB06Histo::fillPrimary(double energy, double eta, double phi) {
 
   LogDebug("HcalTBSim") << "HcalTB06Histo::fillPrimary: Energy " 
 			<< energy << " Eta " << eta << " Phi " << phi;
+  ebeam = energy;
   iniE->Fill(energy);
   iEta->Fill(eta);
   iPhi->Fill(phi);
@@ -66,5 +71,8 @@ void HcalTB06Histo::fillEdep(double etots, double eecals, double ehcals) {
   edepS->Fill(etots);
   edecS->Fill(eecals);
   edhcS->Fill(ehcals);
+  edepN->Fill(etots/ebeam);
+  edecN->Fill(eecals/ebeam);
+  edhcN->Fill(ehcals/ebeam);
   edehS->Fill(eecals, ehcals);
 }

--- a/SimG4CMS/HcalTestBeam/test/python/anal_tb06_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/anal_tb06_cfg.py
@@ -29,11 +29,12 @@ process.testbeam.MinE = process.common_beam_parameters.MinE
 process.testbeam.MaxE = process.common_beam_parameters.MaxE
 process.testbeam.PartID = process.common_beam_parameters.PartID
 
-process.testbeam.TestBeamAnalysis.EcalWidth = cms.double(0.1)
+process.testbeam.TestBeamAnalysis.TimeLimit  = cms.double(500.)
+process.testbeam.TestBeamAnalysis.EcalFactor = cms.double(1.)
 process.testbeam.TestBeamAnalysis.HcalFactor = cms.double(100.)
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(5000)
 )
 
 #process.Timing = cms.Service("Timing")

--- a/SimG4CMS/HcalTestBeam/test/python/anal_tb06_noEcal_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/anal_tb06_noEcal_cfg.py
@@ -30,14 +30,13 @@ process.testbeam.MaxE = process.common_beam_parameters.MaxE
 process.testbeam.PartID = process.common_beam_parameters.PartID
 process.testbeam.ECAL = cms.bool(False)
 
-process.testbeam.TestBeamAnalysis.EcalWidth = cms.double(0.1)
+process.testbeam.TestBeamAnalysis.TimeLimit  = cms.double(500.)
+process.testbeam.TestBeamAnalysis.EcalFactor = cms.double(1.)
 process.testbeam.TestBeamAnalysis.HcalFactor = cms.double(100.)
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(5000)
 )
-
-#process.Timing = cms.Service("Timing")
 
 process.g4SimHits.Physics.type = 'SimG4Core/Physics/QGSP_FTFP_BERT_EML'
 


### PR DESCRIPTION
Analysis of Hcal TB is updated: more configuration parameters; selection of 7x7 for Ecal and and 3x3 for Hcal; noise added.
Cleanup Ecal TB sub-package: use consumes and getByToken; producers moved to plugin sub-directory.
