### PR TITLE
Fix "withTopo" issue

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -60,7 +60,7 @@ HcalTextCalibrations::HcalTextCalibrations ( const edm::ParameterSet& iConfig )
       findingRecord <HcalQIETypesRcd> ();
     }
     else if (objectName == "ChannelQuality") {
-      setWhatProduced (this, &HcalTextCalibrations::produceChannelQuality);
+      setWhatProduced (this, &HcalTextCalibrations::produceChannelQuality, edm::es::Label("withTopo"));
       findingRecord <HcalChannelQualityRcd> ();
     }
     else if (objectName == "ZSThresholds") {


### PR DESCRIPTION
A simple fix to an error that happens when we try to create SQLite files for Channel Quality tags.
