### PR TITLE
Extend Calo objects to record intermediate steps in calculation

### DIFF
--- a/DataFormats/L1Trigger/interface/EGamma.h
+++ b/DataFormats/L1Trigger/interface/EGamma.h
@@ -18,14 +18,16 @@ namespace l1t {
 
   public:
     EGamma(){}
+
+    // ctor from base allowed, but note that extended variables will be set to zero:
+    EGamma(const L1Candidate& rhs):L1Candidate(rhs){ clear_extended(); } 
+
     EGamma( const LorentzVector& p4,
 	    int pt=0,
 	    int eta=0,
 	    int phi=0,
 	    int qual=0,
 	    int iso=0);
-    EGamma(const L1Candidate& rhs):L1Candidate(rhs){} //this is okay given that EGamma currently has no additional data members
-                                                      //but need to add a check for rhs being an EGamma if this changes
 
     EGamma( const PolarLorentzVector& p4,
 	    int pt=0,
@@ -36,13 +38,33 @@ namespace l1t {
 
     ~EGamma();
 
+    void setTowerIEta(short int ieta);  // ieta of seed tower
+    void setTowerIPhi(short int iphi);  // iphi of seed tower
+    void setRawEt(short int pt);        // raw (uncalibrated) cluster sum
+    void setIsoEt(short int iso);       // raw isolation sum - cluster sum
+    void setFootprintEt(short int fp);  // raw footprint
+    void setNTT(short int ntt);         // n towers above threshold
+    void setShape(short int s);         // cluster shape variable
+
+    short int towerIEta();
+    short int towerIPhi();
+    short int rawEt();
+    short int isoEt();
+    short int footprintEt();
+    short int nTT();
+    short int shape();
 
   private:
 
-    // additional hardware quantities common to L1 global jet
-    // there are currently none
-
-
+    // additional hardware quantities common to L1 global EG
+    void clear_extended();
+    short int towerIEta_;
+    short int towerIPhi_;
+    short int rawEt_;
+    short int isoEt_;
+    short int footprintEt_;
+    short int nTT_;
+    short int shape_;
 
   };
 

--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -28,13 +28,33 @@ namespace l1t {
        int phi=0,
        int qual=0);
 
-
   ~Jet();
+
+                  
+  void setTowerIEta(short int ieta);  // ieta of seed tower                   
+  void setTowerIPhi(short int iphi);  // iphi of seed tower                   
+  void setRawEt(short int et);    // raw (uncalibrated) cluster sum
+  void setSeedEt(short int et);
+  void setPUEt(short int et);
+  void setPUDonutEt(int i, short int et);
+
+  short int towerIEta();
+  short int towerIPhi();
+  short int rawEt();
+  short int seedEt();
+  short int puEt();
+  short int puDonutEt(int i);
 
   private:
 
   // additional hardware quantities common to L1 global jet
-  // there are currently none
+  void clear_extended();
+  short int towerIEta_;
+  short int towerIPhi_;
+  short int rawEt_;
+  short int seedEt_;
+  short int puEt_;
+  short int puDonutEt_[4];
 
   };
 

--- a/DataFormats/L1Trigger/interface/Tau.h
+++ b/DataFormats/L1Trigger/interface/Tau.h
@@ -33,11 +33,33 @@ namespace l1t {
 
     ~Tau();
 
+    void setTowerIEta(short int ieta);  // ieta of seed tower
+    void setTowerIPhi(short int iphi);  // iphi of seed tower
+    void setRawEt(short int et);    // raw (uncalibrated) cluster sum
+    void setIsoEt(short int et);    // raw isolation sum - cluster sum
+    void setNTT(short int ntt);     // n towers above threshold
+    void setHasEM(bool hasEM);
+    void setIsMerged(bool isMerged);
+
+    short int towerIEta();
+    short int towerIPhi();
+    short int rawEt();
+    short int isoEt();
+    short int nTT();
+    bool hasEM();
+    bool isMerged();
+
   private:
 
-    // additional hardware quantities common to L1 global jet
-    // there are currently none
-
+    // additional hardware quantities common to L1 global tau
+    void clear_extended();
+    short int towerIEta_;
+    short int towerIPhi_;
+    short int rawEt_;
+    short int isoEt_;
+    short int nTT_;
+    bool hasEM_;
+    bool isMerged_;
 
   };
 

--- a/DataFormats/L1Trigger/src/EGamma.cc
+++ b/DataFormats/L1Trigger/src/EGamma.cc
@@ -1,7 +1,18 @@
 
 #include "DataFormats/L1Trigger/interface/EGamma.h"
+using namespace l1t;
 
-l1t::EGamma::EGamma( const LorentzVector& p4,
+void EGamma::clear_extended(){
+  towerIEta_ = 0;
+  towerIPhi_ = 0;
+  rawEt_ = 0;
+  isoEt_ = 0;
+  footprintEt_ = 0;
+  nTT_ = 0;
+  shape_ = 0;
+}
+
+EGamma::EGamma( const LorentzVector& p4,
 		     int pt,
 		     int eta,
 		     int phi,
@@ -9,10 +20,10 @@ l1t::EGamma::EGamma( const LorentzVector& p4,
 		     int iso )
   : L1Candidate(p4, pt, eta, phi, qual, iso)
 {
-
+  clear_extended();
 }
 
-l1t::EGamma::EGamma( const PolarLorentzVector& p4,
+EGamma::EGamma( const PolarLorentzVector& p4,
 		     int pt,
 		     int eta,
 		     int phi,
@@ -20,10 +31,66 @@ l1t::EGamma::EGamma( const PolarLorentzVector& p4,
 		     int iso )
   : L1Candidate(p4, pt, eta, phi, qual, iso)
 {
+  clear_extended();
+}
+
+EGamma::~EGamma()
+{
 
 }
 
-l1t::EGamma::~EGamma()
-{
+void EGamma::setTowerIEta(short int ieta) {
+  towerIEta_ = ieta;
+}
 
+void EGamma::setTowerIPhi(short int iphi) {
+  towerIPhi_ = iphi;
+}
+
+void EGamma::setRawEt(short int et) {
+  rawEt_ = et;
+}
+
+void EGamma::setIsoEt(short int et) {
+  isoEt_ = et;
+}
+
+void EGamma::setFootprintEt(short int et) {
+  footprintEt_ = et;
+}
+
+void EGamma::setNTT(short int ntt) {
+  nTT_ = ntt;
+}
+
+void EGamma::setShape(short int s) {
+  shape_ = s;
+}
+
+short int EGamma::towerIEta() {
+  return towerIEta_;
+}
+
+short int EGamma::towerIPhi() {
+  return towerIPhi_;
+}
+
+short int EGamma::rawEt() {
+  return rawEt_;
+}
+
+short int EGamma::isoEt() {
+  return isoEt_;
+}
+
+short int EGamma::footprintEt() {
+  return footprintEt_;
+}
+
+short int EGamma::nTT() {
+  return nTT_;
+}
+
+short int EGamma::shape() {
+  return shape_;
 }

--- a/DataFormats/L1Trigger/src/Jet.cc
+++ b/DataFormats/L1Trigger/src/Jet.cc
@@ -1,27 +1,85 @@
-
 #include "DataFormats/L1Trigger/interface/Jet.h"
+using namespace l1t;
 
-l1t::Jet::Jet( const LorentzVector& p4,
+void Jet::clear_extended(){
+  towerIEta_ = 0;
+  towerIPhi_ = 0;
+  rawEt_ = 0;
+  seedEt_ = 0;
+  puEt_ = 0;
+  puDonutEt_[0] = puDonutEt_[1] = puDonutEt_[2] = puDonutEt_[3] = 0;
+}
+
+Jet::Jet( const LorentzVector& p4,
 	       int pt,
 	       int eta,
 	       int phi,
 	       int qual )
   : L1Candidate(p4, pt, eta, phi, qual, 0)
 {
-
+  clear_extended();
 }
 
-l1t::Jet::Jet( const PolarLorentzVector& p4,
+Jet::Jet( const PolarLorentzVector& p4,
 	       int pt,
 	       int eta,
 	       int phi,
 	       int qual )
   : L1Candidate(p4, pt, eta, phi, qual, 0)
 {
+  clear_extended();
+}
+
+Jet::~Jet()
+{
 
 }
 
-l1t::Jet::~Jet()
-{
+void Jet::setTowerIEta(short int ieta) {
+  towerIEta_ = ieta;
+}
 
+void Jet::setTowerIPhi(short int iphi) {
+  towerIPhi_ = iphi;
+}
+
+void Jet::setSeedEt(short int et) {
+  seedEt_ = et;
+}
+
+void Jet::setRawEt(short int et) {
+  rawEt_ = et;
+}
+
+void Jet::setPUEt(short int et) {
+  puEt_ = et;
+}
+
+void Jet::setPUDonutEt(int i, short int et) {
+  if (i>=0 && i<4) puDonutEt_[i] = et;
+}
+
+short int Jet::towerIEta() {
+  return towerIEta_;
+}
+
+short int Jet::towerIPhi() {
+  return towerIPhi_;
+}
+
+short int Jet::seedEt() {
+  return seedEt_;
+}
+
+short int Jet::rawEt() {
+  return rawEt_;
+}
+
+short int Jet::puEt() {
+  return puEt_;
+}
+
+short int Jet::puDonutEt(int i) {
+  if (i>=0 && i<4) return puDonutEt_[i];
+  else return 0;
 }

--- a/DataFormats/L1Trigger/src/Tau.cc
+++ b/DataFormats/L1Trigger/src/Tau.cc
@@ -1,7 +1,18 @@
 
 #include "DataFormats/L1Trigger/interface/Tau.h"
+using namespace l1t;
 
-l1t::Tau::Tau( const LorentzVector& p4,
+void Tau::clear_extended(){
+  towerIEta_ = 0;
+  towerIPhi_ = 0;
+  rawEt_ = 0;
+  isoEt_ = 0;
+  nTT_ = 0;
+  hasEM_ = false;
+  isMerged_ = false;
+}
+
+Tau::Tau( const LorentzVector& p4,
 	       int pt,
 	       int eta,
 	       int phi,
@@ -9,10 +20,10 @@ l1t::Tau::Tau( const LorentzVector& p4,
 	       int iso )
   : L1Candidate(p4, pt, eta, phi, qual,iso)
 {
-
+  clear_extended();
 }
 
-l1t::Tau::Tau( const PolarLorentzVector& p4,
+Tau::Tau( const PolarLorentzVector& p4,
 	       int pt,
 	       int eta,
 	       int phi,
@@ -20,10 +31,67 @@ l1t::Tau::Tau( const PolarLorentzVector& p4,
 	       int iso )
   : L1Candidate(p4, pt, eta, phi, qual,iso)
 {
-
+  clear_extended();
 }
 
-l1t::Tau::~Tau()
+Tau::~Tau()
 {
 
 }
+
+void Tau::setTowerIEta(short int ieta) {
+  towerIEta_ = ieta;
+}
+
+void Tau::setTowerIPhi(short int iphi) {
+  towerIPhi_ = iphi;
+}
+
+void Tau::setRawEt(short int et) { 
+  rawEt_ = et;
+}
+
+void Tau::setIsoEt(short int et) {
+  isoEt_ = et;
+}
+
+void Tau::setNTT(short int ntt) {
+  nTT_ = ntt;
+}
+
+void Tau::setHasEM(bool hasEM) {
+  hasEM_ = hasEM;
+}
+
+void Tau::setIsMerged(bool isMerged) {
+  isMerged_ = isMerged;
+}
+
+short int Tau::towerIEta() {
+  return towerIEta_;
+}
+
+short int Tau::towerIPhi() {
+  return towerIPhi_;
+}
+
+short int Tau::rawEt() {
+  return rawEt_;
+}
+
+short int Tau::isoEt() {
+  return isoEt_;
+}
+
+short int Tau::nTT() {
+  return nTT_;
+}
+
+bool Tau::hasEM() {
+  return hasEM_;
+}
+
+bool Tau::isMerged() {
+  return isMerged_;
+}
+

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -13,7 +13,8 @@
   <class name="l1t::L1CandidateVectorRef"/>
   <class name="edm::Wrapper<l1t::L1CandidateVectorRef>"/>
 
-  <class name="l1t::Jet" ClassVersion="12">
+  <class name="l1t::Jet" ClassVersion="13">
+   <version ClassVersion="13" checksum="3915457337"/>
    <version ClassVersion="12" checksum="380555501"/>
    <version ClassVersion="11" checksum="1836963461"/>
    <version ClassVersion="10" checksum="4108627301"/>
@@ -28,7 +29,8 @@
   <class name="edm::Wrapper<l1t::JetVectorRef>"/>
 
 
-  <class name="l1t::EGamma" ClassVersion="12">
+  <class name="l1t::EGamma" ClassVersion="13">
+   <version ClassVersion="13" checksum="2044674704"/>
    <version ClassVersion="12" checksum="1332125006"/>
    <version ClassVersion="11" checksum="2788532966"/>
    <version ClassVersion="10" checksum="130849840"/>
@@ -57,7 +59,8 @@
   <class name="l1t::EtSumVectorRef"/>
   <class name="edm::Wrapper<l1t::EtSumVectorRef>"/>
 
-  <class name="l1t::Tau" ClassVersion="12">
+  <class name="l1t::Tau" ClassVersion="13">
+   <version ClassVersion="13" checksum="3236083459"/>
    <version ClassVersion="12" checksum="1992693786"/>
    <version ClassVersion="11" checksum="3449101746"/>
    <version ClassVersion="10" checksum="3214350964"/>


### PR DESCRIPTION
Adds (not yet exercised) variables to L1 calo output objects, which will allow for future recording of intermediate HW values during the calculation of each object.
