### PR TITLE
Adapting JSON monitoring to L1 Stage 2 (80X version)

### DIFF
--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -30,12 +30,12 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"          
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"  
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"  
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"  
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
@@ -137,11 +137,10 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
   edm::InputTag triggerResults_;                               // Input tag for TriggerResults 
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults
 
-  edm::InputTag level1Results_;                                 // Input tag for L1 GT Readout Record   
-  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1t_results; // Token for L1 GT Readout Record
+  edm::InputTag level1Results_;                                 // Input tag for L1 Global collection   
+  edm::EDGetTokenT<GlobalAlgBlkBxCollection> m_l1t_results; // Token for L1 Global collection 
 
   //Variables that change at most once per run 
-  HLTPrescaleProvider hltPrescaleProvider_; // To get at HLTConfigProvider
   HLTConfigProvider hltConfig_;         // to get configuration for HLT
   const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu   
   AlgorithmMap algorithmMap;            // L1 algorithm map  

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -26,8 +26,7 @@ TriggerJSONMonitoring::TriggerJSONMonitoring(const edm::ParameterSet& ps) :
   triggerResults_(ps.getParameter<edm::InputTag>("triggerResults")),
   triggerResultsToken_(consumes<edm::TriggerResults>(triggerResults_)),
   level1Results_(ps.getParameter<edm::InputTag>("L1Results")),   
-  m_l1t_results(consumes<L1GlobalTriggerReadoutRecord>(level1Results_)),             
-  hltPrescaleProvider_(ps, consumesCollector(), *this)
+  m_l1t_results(consumes<GlobalAlgBlkBxCollection>(level1Results_))             
 {
 
                                                      
@@ -41,7 +40,7 @@ void
 TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("triggerResults",edm::InputTag("TriggerResults","","HLT"));
-  desc.add<edm::InputTag>("L1Results",edm::InputTag("hltGtDigis"));                
+  desc.add<edm::InputTag>("L1Results",edm::InputTag("hltGtStage2Digis"));                
   descriptions.add("triggerJSONMonitoring", desc);
 }
 
@@ -62,41 +61,42 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     LogDebug("TriggerJSONMonitoring") << "Not Physics, Calibration or Random. experimentType = " << ex << std::endl;
   }   
 
+  //Temporarily removing L1 monitoring while we adapt for Stage 2
   //Get hold of L1TResults 
-  edm::Handle<L1GlobalTriggerReadoutRecord> l1tResults;
-  iEvent.getByToken(m_l1t_results, l1tResults);
+  // edm::Handle<L1GlobalTriggerReadoutRecord> l1tResults;
+  // iEvent.getByToken(m_l1t_results, l1tResults);
 
-  L1GlobalTriggerReadoutRecord L1TResults = * l1tResults.product();
+  // L1GlobalTriggerReadoutRecord L1TResults = * l1tResults.product();
 
-  const std::vector<bool> & algoword = L1TResults.decisionWord();  
-  if (algoword.size() == L1AlgoAccept_.size()){
-    for (unsigned int i = 0; i < algoword.size(); i++){
-      if (algoword[i]){
-	L1AlgoAccept_[i]++;
-	if (ex == 1) L1AlgoAcceptPhysics_[i]++;
-	if (ex == 2) L1AlgoAcceptCalibration_[i]++;
-	if (ex == 3) L1AlgoAcceptRandom_[i]++;
-      }
-    }
-  }
-  else {
-    LogWarning("TriggerJSONMonitoring")<<"L1 Algo Trigger Mask size does not match number of L1 Algo Triggers!";
-  }
+  // const std::vector<bool> & algoword = L1TResults.decisionWord();  
+  // if (algoword.size() == L1AlgoAccept_.size()){
+  //   for (unsigned int i = 0; i < algoword.size(); i++){
+  //     if (algoword[i]){
+  // 	L1AlgoAccept_[i]++;
+  // 	if (ex == 1) L1AlgoAcceptPhysics_[i]++;
+  // 	if (ex == 2) L1AlgoAcceptCalibration_[i]++;
+  // 	if (ex == 3) L1AlgoAcceptRandom_[i]++;
+  //     }
+  //   }
+  // }
+  // else {
+  //   LogWarning("TriggerJSONMonitoring")<<"L1 Algo Trigger Mask size does not match number of L1 Algo Triggers!";
+  // }
 
-  const std::vector<bool> & techword = L1TResults.technicalTriggerWord();
-  if (techword.size() == L1TechAccept_.size()){
-    for (unsigned int i = 0; i < techword.size(); i++){
-      if (techword[i]){
-	L1TechAccept_[i]++;
-	if (ex == 1) L1TechAcceptPhysics_[i]++;
-	if (ex == 2) L1TechAcceptCalibration_[i]++;
-	if (ex == 3) L1TechAcceptRandom_[i]++;
-      }
-    }
-  }
-  else{
-    LogWarning("TriggerJSONMonitoring")<<"L1 Tech Trigger Mask size does not match number of L1 Tech Triggers!";
-  }
+  // const std::vector<bool> & techword = L1TResults.technicalTriggerWord();
+  // if (techword.size() == L1TechAccept_.size()){
+  //   for (unsigned int i = 0; i < techword.size(); i++){
+  //     if (techword[i]){
+  // 	L1TechAccept_[i]++;
+  // 	if (ex == 1) L1TechAcceptPhysics_[i]++;
+  // 	if (ex == 2) L1TechAcceptCalibration_[i]++;
+  // 	if (ex == 3) L1TechAcceptRandom_[i]++;
+  //     }
+  //   }
+  // }
+  // else{
+  //   LogWarning("TriggerJSONMonitoring")<<"L1 Tech Trigger Mask size does not match number of L1 Tech Triggers!";
+  // }
   
   //Get hold of TriggerResults  
   Handle<TriggerResults> HLTR;
@@ -136,8 +136,10 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   }
 
   //Prescale index
-  prescaleIndex_ = hltPrescaleProvider_.prescaleSet(iEvent, iSetup);
-
+  edm::Handle<GlobalAlgBlkBxCollection> l1tResults;
+  if (iEvent.getByToken(m_l1t_results, l1tResults) and not (l1tResults->begin(0) == l1tResults->end(0)))
+    prescaleIndex_ = static_cast<unsigned int>(l1tResults->begin(0)->getPreScColumn());
+  
   //Check that the prescale index hasn't changed inside a lumi section
   unsigned int newLumi = (unsigned int) iEvent.eventAuxiliary().luminosityBlock();
   if (oldLumi == newLumi and prescaleIndex_ != oldPrescaleIndex){
@@ -315,12 +317,9 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
 
   //Initialize hltConfig_     
   bool changed = true;
-  if (hltPrescaleProvider_.init(iRun, iSetup, triggerResults_.process(), changed)){
-    hltConfig_ =  hltPrescaleProvider_.hltConfigProvider();
-    resetRun(changed);
-  }
+  if (hltConfig_.init(iRun, iSetup, triggerResults_.process(), changed)) resetRun(changed);
   else{
-    LogDebug("TriggerJSONMonitoring") << "HLTPrescaleProvider initialization failed!" << std::endl;
+    LogDebug("TriggerJSONMonitoring") << "HLTConfigProvider initialization failed!" << std::endl;
     return;
   }
 


### PR DESCRIPTION
This is the first part of the adaptation for Stage 2. It temporarily removes L1 monitoring until the new database tables are in place and reports the rates of all L1 tech and algo bits to be 0 (as requested by the DAQ group so as not to have to modify their scripts). The L1 physics/calibration/random value is taken from the event just as before. The prescale index and HLT paths and datasets should all be correct.

This PR is identical to #13586 (the latter was submitted to CMSSW_8_0_0_patchX instead of CMSSW_8_0_X).
