### PR TITLE
Enable castor digis for 2017

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -26,9 +26,8 @@ ecalPacker.labelEBSRFlags = "simEcalDigis:ebSrFlags"
 ecalPacker.labelEESRFlags = "simEcalDigis:eeSrFlags"
 
 
-if eras.phase1Pixel.isChosen() :
-    DigiToRaw.remove(siPixelRawData)
-    DigiToRaw.remove(castorRawData)
+# Remove siPixelRawData until we have phase1 pixel digis
+eras.phase1Pixel.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
 
 if eras.fastSim.isChosen() :
     for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -79,9 +79,8 @@ muonRPCDigis.InputLabel = 'rawDataCollector'
 castorDigis.InputLabel = 'rawDataCollector'
 
 
-if eras.phase1Pixel.isChosen() :
-    RawToDigi.remove(siPixelDigis)
-    RawToDigi.remove(castorDigis)
+# Remove siPixelDigis until we have phase1 pixel digis
+eras.phase1Pixel.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([siPixelDigis])) # FIXME
 
 
 


### PR DESCRIPTION
Apparently the `castorRawData` and `castorDigis` technically work in 2017 workflows, so I see no reason to remove them. On the same go I removed the use of `phase1Pixel.isChosen()` in these files. I leave the enabling of the reconstruction (i.e. removing these https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py#L490) to later PR in order to not to possibly interfere with #13477 (if this PR gets integrated quickly I'll do it in the followup of #13477).

Tested in CMSSW_8_1_X_2016-02-29-2300.
