### PR TITLE
add tracking monitoring on events triggered by HLT_ZeroBias_IsolatedBunches

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -91,6 +91,19 @@ SiStripMonitorTrackMB.hltDBKey = cms.string("Tracker_MB")
 SiStripMonitorTrackMB.errorReplyHlt  = cms.bool( False )
 SiStripMonitorTrackMB.andOrHlt = cms.bool(True) # True:=OR; False:=AND
 
+# Clone for SiStripMonitorTrack for IsolatedBunches ####
+SiStripMonitorTrackIsoBunches = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
+SiStripMonitorTrackIsoBunches.TopFolderName = cms.string('SiStrip/IsolatedBunches')
+SiStripMonitorTrackIsoBunches.TrackProducer = 'generalTracks'
+SiStripMonitorTrackIsoBunches.Mod_On        = False
+SiStripMonitorTrackIsoBunches.andOr         = cms.bool( False )
+SiStripMonitorTrackIsoBunches.dbLabel       = cms.string("SiStripDQMTrigger")
+SiStripMonitorTrackIsoBunches.hltInputTag = cms.InputTag( "TriggerResults::HLT" )
+SiStripMonitorTrackIsoBunches.hltPaths = cms.vstring("HLT_ZeroBias_Isolated*")
+SiStripMonitorTrackIsoBunches.hltDBKey = cms.string("Tracker_MB")
+SiStripMonitorTrackIsoBunches.errorReplyHlt  = cms.bool( False )
+SiStripMonitorTrackIsoBunches.andOrHlt = cms.bool(True) # True:=OR; False:=AND
+
 ### TrackerMonitorTrack defined and used only for MinimumBias ####
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
 MonitorTrackResiduals.trajectoryInput = 'generalTracks'
@@ -140,16 +153,19 @@ from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 SiStripDQMTier0 = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackCommon*MonitorTrackResiduals
+#    *SiStripMonitorTrackIsoBunches ## TEMPORARY
     *dqmInfoSiStrip)
 
 SiStripDQMTier0Common = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
     *SiStripMonitorTrackCommon
+#    *SiStripMonitorTrackIsoBunches ## TEMPORARY
     *dqmInfoSiStrip)
 
 SiStripDQMTier0MinBias = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*MonitorTrackResiduals
+    *SiStripMonitorTrackIsoBunches
     *dqmInfoSiStrip)
 
 

--- a/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfig_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfig_cff.py
@@ -1,8 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 trackingEffFromHitPattern = cms.EDAnalyzer("DQMGenericClient",
-                                           subDirs = cms.untracked.vstring("Tracking/TrackParameters/generalTracks/HitEffFromHitPattern",
-                                                                           "Tracking/TrackParameters/highPurityTracks/pt_1/HitEffFromHitPattern"),
+                                           subDirs = cms.untracked.vstring(
+                                               "Tracking/TrackParameters/generalTracks/IsolatedBunches/HitEffFromHitPattern",
+                                               "Tracking/TrackParameters/highPurityTracks/pt_1/IsolatedBunches/HitEffFromHitPattern",
+                                               "Tracking/TrackParameters/generalTracks/HitEffFromHitPattern",
+                                               "Tracking/TrackParameters/highPurityTracks/pt_1/HitEffFromHitPattern"
+                                           ),
                                            efficiency = cms.vstring(
         "effic_vs_PU_PXB1 'PXB Layer1 Efficiency vs GoodNumVertices' Hits_valid_PXB_Subdet1 Hits_total_PXB_Subdet1",
         "effic_vs_PU_PXB2 'PXB Layer2 Efficiency vs GoodNumVertices' Hits_valid_PXB_Subdet2 Hits_total_PXB_Subdet2",

--- a/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
@@ -10,7 +10,7 @@ LogMessageMonCommon.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29)
 LogMessageMonCommon.andOrDcs      = cms.bool( False )
 LogMessageMonCommon.errorReplyDcs = cms.bool( True )
 
-# Clone for MinBias ###
+# Clone for ZeroBias ###
 LogMessageMonMB = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
 LogMessageMonMB.andOr         = cms.bool( False )
 LogMessageMonMB.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
@@ -19,8 +19,22 @@ LogMessageMonMB.andOrDcs      = cms.bool( False )
 LogMessageMonMB.errorReplyDcs = cms.bool( True )
 LogMessageMonMB.dbLabel       = cms.string("SiStripDQMTrigger")
 LogMessageMonMB.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-LogMessageMonMB.hltPaths      = cms.vstring("HLT_ZeroBias_*")
+LogMessageMonMB.hltPaths      = cms.vstring("HLT_ZeroBias_v*")
 LogMessageMonMB.hltDBKey      = cms.string("Tracker_MB")
 LogMessageMonMB.errorReplyHlt = cms.bool( False )
 LogMessageMonMB.andOrHlt      = cms.bool(True) 
+
+# Clone for ZeroBias_IsolatedBunches ###
+LogMessageMonIsoBunches = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
+LogMessageMonIsoBunches.andOr         = cms.bool( False )
+LogMessageMonIsoBunches.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
+LogMessageMonIsoBunches.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29)
+LogMessageMonIsoBunches.andOrDcs      = cms.bool( False )
+LogMessageMonIsoBunches.errorReplyDcs = cms.bool( True )
+LogMessageMonIsoBunches.dbLabel       = cms.string("SiStripDQMTrigger")
+LogMessageMonIsoBunches.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+LogMessageMonIsoBunches.hltPaths      = cms.vstring("HLT_ZeroBias_Iso*")
+LogMessageMonIsoBunches.hltDBKey      = cms.string("Tracker_MB")
+LogMessageMonIsoBunches.errorReplyHlt = cms.bool( False )
+LogMessageMonIsoBunches.andOrHlt      = cms.bool(True) 
 

--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -163,6 +163,34 @@ doPlotsVsBXlumi                     ['highPurityPt1'] = cms.bool(False)
 doPlotsVsGoodPVtx                   ['highPurityPt1'] = cms.bool(True)
 doEffFromHitPattern                 ['highPurityPt1'] = cms.bool(True)
 
+### AlCaStripAPV
+AlCaStripAPV = trackSelector.clone()
+AlCaStripAPV.cut = cms.string("quality('highPurity') & pt >= 0.8 & p > 2. & numberOfValidHits > 6 & normalizedChi2 < 10")
+
+sequenceName    ['AlCaStripAPV'] = cms.Sequence(AlCaStripAPV)
+mainfolderName  ['AlCaStripAPV'] = 'Tracking/TrackParameters/highPurityTracks/AlCaStripAPV'
+vertexfolderName['AlCaStripAPV'] = 'Tracking/PrimaryVertices/highPurityTracks/AlCaStripAPV'
+trackPtN        ['AlCaStripAPV'] = cms.int32(100)
+trackPtMin      ['AlCaStripAPV'] = cms.double(0.)
+trackPtMax      ['AlCaStripAPV'] = cms.double(100.)
+numCutString    ['AlCaStripAPV'] = cms.string("quality('highPurity') & pt >= 0.8 & p > 2. & numberOfValidHits > 6 & normalizedChi2 < 10") # default: " pt >= 1 & quality('highPurity') "
+denCutString    ['AlCaStripAPV'] = cms.string("") # it is as in the default config (just be sure)
+doPlotsPCA      ['AlCaStripAPV'] = cms.bool(False)
+doGoodTracksPlots                   ['AlCaStripAPV'] = cms.bool(False)
+doTrackerSpecific                   ['AlCaStripAPV'] = cms.bool(False)
+doHitPropertiesPlots                ['AlCaStripAPV'] = cms.bool(True)
+doGeneralPropertiesPlots            ['AlCaStripAPV'] = cms.bool(True)
+doBeamSpotPlots                     ['AlCaStripAPV'] = cms.bool(True)
+doSeedParameterHistos               ['AlCaStripAPV'] = cms.bool(False)
+doRecHitVsPhiVsEtaPerTrack          ['AlCaStripAPV'] = cms.bool(True)
+doGoodTrackRecHitVsPhiVsEtaPerTrack ['AlCaStripAPV'] = cms.bool(False)
+doLayersVsPhiVsEtaPerTrack          ['AlCaStripAPV'] = cms.bool(True)
+doGoodTrackLayersVsPhiVsEtaPerTrack ['AlCaStripAPV'] = cms.bool(False)
+doPUmonitoring                      ['AlCaStripAPV'] = cms.bool(True)
+doPlotsVsBXlumi                     ['AlCaStripAPV'] = cms.bool(False)
+doPlotsVsGoodPVtx                   ['AlCaStripAPV'] = cms.bool(True)
+doEffFromHitPattern                 ['AlCaStripAPV'] = cms.bool(False)
+
 selectedTracks.extend( ['generalTracks'] )
 #selectedTracks.extend( ['highPurityPtRange0to1']  )
 #selectedTracks.extend( ['highPurityPtRange1to10'] )
@@ -170,6 +198,7 @@ selectedTracks.extend( ['generalTracks'] )
 
 selectedTracks.extend( ['highPurityPt1'] )
 selectedTracks.extend( ['highPurityPtRange0to1'] )
+#selectedTracks.extend( ['AlCaStripAPV'] )
 
 #selectedTracks2runSequence=cms.Sequence()
 #for tracks in selectedTracks :

--- a/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
@@ -10,7 +10,7 @@ TrackerCollisionTrackMonCommon.andOrDcs      = cms.bool( False )
 TrackerCollisionTrackMonCommon.errorReplyDcs = cms.bool( True )
 TrackerCollisionTrackMonCommon.setLabel("TrackerCollisionTrackMonCommon")
 
-# Clone for TrackingMonitor for MinBias ###
+# Clone for TrackingMonitor for ZeroBias ###
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
 TrackerCollisionTrackMonMB = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
 TrackerCollisionTrackMonMB.andOr                = cms.bool( False )
@@ -20,10 +20,27 @@ TrackerCollisionTrackMonMB.andOrDcs             = cms.bool( False )
 TrackerCollisionTrackMonMB.errorReplyDcs        = cms.bool( True )
 TrackerCollisionTrackMonMB.dbLabel              = cms.string("SiStripDQMTrigger")
 TrackerCollisionTrackMonMB.hltInputTag          = cms.InputTag( "TriggerResults::HLT" )
-TrackerCollisionTrackMonMB.hltPaths             = cms.vstring("HLT_ZeroBias_*")
+TrackerCollisionTrackMonMB.hltPaths             = cms.vstring("HLT_ZeroBias_v*")
 TrackerCollisionTrackMonMB.hltDBKey             = cms.string("Tracker_MB")
 TrackerCollisionTrackMonMB.errorReplyHlt        = cms.bool( False )
 TrackerCollisionTrackMonMB.andOrHlt             = cms.bool(True)
 TrackerCollisionTrackMonMB.doPrimaryVertexPlots = cms.bool(True)
 TrackerCollisionTrackMonMB.setLabel("TrackerCollisionTrackMonMB")
+
+# Clone for TrackingMonitor for ZeroBias_IsolatedBunches ###
+import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
+TrackerCollisionTrackMonIsoBunches = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
+TrackerCollisionTrackMonIsoBunches.andOr                = cms.bool( False )
+TrackerCollisionTrackMonIsoBunches.dcsInputTag          = cms.InputTag( "scalersRawToDigi" )
+TrackerCollisionTrackMonIsoBunches.dcsPartitions        = cms.vint32 ( 24, 25, 26, 27, 28, 29)
+TrackerCollisionTrackMonIsoBunches.andOrDcs             = cms.bool( False )
+TrackerCollisionTrackMonIsoBunches.errorReplyDcs        = cms.bool( True )
+TrackerCollisionTrackMonIsoBunches.dbLabel              = cms.string("SiStripDQMTrigger")
+TrackerCollisionTrackMonIsoBunches.hltInputTag          = cms.InputTag( "TriggerResults::HLT" )
+TrackerCollisionTrackMonIsoBunches.hltPaths             = cms.vstring("HLT_ZeroBias_Isolated*")
+TrackerCollisionTrackMonIsoBunches.hltDBKey             = cms.string("Tracker_MB")
+TrackerCollisionTrackMonIsoBunches.errorReplyHlt        = cms.bool( False )
+TrackerCollisionTrackMonIsoBunches.andOrHlt             = cms.bool(True)
+TrackerCollisionTrackMonIsoBunches.doPrimaryVertexPlots = cms.bool(True)
+TrackerCollisionTrackMonIsoBunches.setLabel("TrackerCollisionTrackMonIsoBunches")
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -78,6 +78,39 @@ for tracks in selectedTracks :
     locals()[label].doEffFromHitPattern                 = doEffFromHitPattern                 [tracks]
     locals()[label].setLabel(label)
 
+    label = 'TrackerCollisionSelectedTrackMonIsoBunches' + str(tracks)
+    locals()[label] = TrackerCollisionTrackMonIsoBunches.clone()
+    locals()[label].TrackProducer    = cms.InputTag(tracks)
+    locals()[label].FolderName       = cms.string(mainfolderName[tracks]+'/IsolatedBunches')
+    locals()[label].PVFolderName     = cms.string(vertexfolderName[tracks]+'/IsolatedBunches')
+    locals()[label].TrackPtMin       = trackPtMin[tracks]
+    locals()[label].TrackPtBin       = trackPtN[tracks]
+    locals()[label].TrackPtMax       = trackPtMax[tracks]
+    locals()[label].TrackPBin        = trackPtN[tracks]
+    locals()[label].TrackPMin        = trackPtMin[tracks]
+    locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].doDCAPlots       = doPlotsPCA[tracks]
+    locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
+    locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
+    locals()[label].doSIPPlots       = doPlotsPCA[tracks]
+    locals()[label].numCut           = numCutString[tracks]
+    locals()[label].denCut           = denCutString[tracks]
+    locals()[label].doGoodTracksPlots                   = doGoodTracksPlots                   [tracks]
+    locals()[label].doTrackerSpecific                   = doTrackerSpecific                   [tracks]
+    locals()[label].doHitPropertiesPlots                = doHitPropertiesPlots                [tracks]
+    locals()[label].doGeneralPropertiesPlots            = doGeneralPropertiesPlots            [tracks]
+    locals()[label].doBeamSpotPlots                     = doBeamSpotPlots                     [tracks]
+    locals()[label].doSeedParameterHistos               = doSeedParameterHistos               [tracks]
+    locals()[label].doRecHitVsPhiVsEtaPerTrack          = doRecHitVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackRecHitVsPhiVsEtaPerTrack = doGoodTrackRecHitVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doLayersVsPhiVsEtaPerTrack          = doLayersVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackLayersVsPhiVsEtaPerTrack = doGoodTrackLayersVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
+    locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
+    locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doEffFromHitPattern                 = doEffFromHitPattern                 [tracks]
+    locals()[label].setLabel(label)
+
 
 #-------------------------------------------------
 # Tracking Monitor 
@@ -133,6 +166,13 @@ for module in selectedModules :
     locals()[label].categories     = categories[module]
     locals()[label].setLabel(label)
 
+    label = str(module)+'LogMessageMonIsoBunches'
+    locals()[label] = LogMessageMonIsoBunches.clone()
+    locals()[label].pluginsMonName = pluginsMonName[module]
+    locals()[label].modules        = modulesLabel[module]
+    locals()[label].categories     = categories[module]
+    locals()[label].setLabel(label)
+
 
 # dEdx monitor ####
 ### load which dedx
@@ -168,6 +208,9 @@ for tracks in selectedTracks :
         TrackingDQMSourceTier0 += sequenceName[tracks]
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
     TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
+#    # IsolatedBunches
+#    label = 'TrackerCollisionSelectedTrackMonIsoBunches' + str(tracks)
+    TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
 # seeding monitoring
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
@@ -175,6 +218,9 @@ for step in selectedIterTrackingStep :
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
+    TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
+#    # IsolatedBunches
+#    label = str(module)+'LogMessageMonIsoBunches'
     TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
 TrackingDQMSourceTier0 += dqmInfoTracking
 
@@ -188,6 +234,9 @@ for tracks in selectedTracks :
         TrackingDQMSourceTier0Common+=sequenceName[tracks]
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
     TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
+#    # IsolatedBunches
+#    label = 'TrackerCollisionSelectedTrackMonIsoBunches' + str(tracks)
+    TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
 # seeding monitoring
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
@@ -195,6 +244,9 @@ for step in selectedIterTrackingStep :
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
+    TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
+#    # IsolatedBunches
+#    label = str(module)+'LogMessageMonIsoBunches'
     TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
 TrackingDQMSourceTier0Common += dqmInfoTracking
 
@@ -209,6 +261,9 @@ for tracks in selectedTracks :
         TrackingDQMSourceTier0MinBias += sequenceName[tracks]
     label = 'TrackerCollisionSelectedTrackMonMB' + str(tracks)
     TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
+    # IsolatedBunches
+    label = 'TrackerCollisionSelectedTrackMonIsoBunches' + str(tracks)
+    TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
 # seeding monitoring
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
@@ -216,6 +271,9 @@ for step in selectedIterTrackingStep :
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonMB'
+    TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
+    # IsolatedBunches
+    label = str(module)+'LogMessageMonIsoBunches'
     TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
 TrackingDQMSourceTier0MinBias += dqmInfoTracking
 


### PR DESCRIPTION
this PR is meant for adding dedicated plots for monitoring tracking (and strip cluster charge)
using only events triggered by HLT_ZeroBias_IsolatedBunches

the monitoring modules have been added only in the sequence used on the ZeroBias PD

NB: 
as soon as the new HLT menu for 2016 data taking will be available
files:
1. DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
2. DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
3. DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py

have to be updated w/ the final HLT path name
