### PR TITLE
Added customizations to run pp reco on peripheral HI events

### DIFF
--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -80,39 +80,43 @@ def addHIIsolationProducer(process):
     # modify cluster limits to run pp reconstruction on peripheral PbPb
 def modifyClusterLimits(process):
 
-    process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.initialStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.lowPtTripletStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.globalSeedsFromTriplets.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.detachedTripletStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.mixedTripletStepSeedsA.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.mixedTripletStepSeedsB.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.globalMixedSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.pixelLessStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.globalPixelLessSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.globalPixelSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.pixelPairStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.globalSeedsFromPairsWithVertices.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.tobTecStepSeedsPair.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.tobTecStepSeedsTripl.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.pixelPairElectronSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.regionalCosmicTrackerSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.stripPairElectronSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.photonConvTrajSeedFromQuadruplets.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-    process.tripletElectronSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    hiClusterCut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+
+    process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = hiClusterCut
+    process.initialStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.lowPtTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.globalSeedsFromTriplets.ClusterCheckPSet.cut = hiClusterCut
+    process.detachedTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.mixedTripletStepSeedsA.ClusterCheckPSet.cut = hiClusterCut
+    process.mixedTripletStepSeedsB.ClusterCheckPSet.cut = hiClusterCut
+    process.globalMixedSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.pixelLessStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.globalPixelLessSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.globalPixelSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.pixelPairStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.globalSeedsFromPairsWithVertices.ClusterCheckPSet.cut = hiClusterCut
+    process.tobTecStepSeedsPair.ClusterCheckPSet.cut = hiClusterCut
+    process.tobTecStepSeedsTripl.ClusterCheckPSet.cut = hiClusterCut
+    process.pixelPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.regionalCosmicTrackerSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.stripPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    process.photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.cut = hiClusterCut
+    process.photonConvTrajSeedFromQuadruplets.ClusterCheckPSet.cut = hiClusterCut
+    process.tripletElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+
+    maxElement = cms.uint32(1000000)
     
-    process.initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
-    process.tobTecStepSeedsPair.OrderedHitsFactoryPSet.maxElement = cms.uint32(1000000)
-    process.pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(1000000)
-    process.jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(1000000)
+    process.initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    process.tobTecStepSeedsPair.OrderedHitsFactoryPSet.maxElement = maxElement
+    process.pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
+    process.jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
 
     return process
 

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -82,41 +82,43 @@ def modifyClusterLimits(process):
 
     hiClusterCut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
 
-    process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = hiClusterCut
-    process.initialStepSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.lowPtTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.globalSeedsFromTriplets.ClusterCheckPSet.cut = hiClusterCut
-    process.detachedTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.mixedTripletStepSeedsA.ClusterCheckPSet.cut = hiClusterCut
-    process.mixedTripletStepSeedsB.ClusterCheckPSet.cut = hiClusterCut
-    process.globalMixedSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.pixelLessStepSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.globalPixelLessSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.globalPixelSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.pixelPairStepSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.globalSeedsFromPairsWithVertices.ClusterCheckPSet.cut = hiClusterCut
-    process.tobTecStepSeedsPair.ClusterCheckPSet.cut = hiClusterCut
-    process.tobTecStepSeedsTripl.ClusterCheckPSet.cut = hiClusterCut
-    process.pixelPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.regionalCosmicTrackerSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.stripPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
-    process.photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.cut = hiClusterCut
-    process.photonConvTrajSeedFromQuadruplets.ClusterCheckPSet.cut = hiClusterCut
-    process.tripletElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'initialStepSeedsPreSplitting'): process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'initialStepSeeds'): process.initialStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'lowPtTripletStepSeeds'): process.lowPtTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalSeedsFromTriplets'): process.globalSeedsFromTriplets.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'detachedTripletStepSeeds'): process.detachedTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'mixedTripletStepSeedsA'): process.mixedTripletStepSeedsA.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'mixedTripletStepSeedsB'): process.mixedTripletStepSeedsB.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalMixedSeeds'): process.globalMixedSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'pixelLessStepSeeds'): process.pixelLessStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalPixelLessSeeds'): process.globalPixelLessSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalPixelSeeds'): process.globalPixelSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'pixelPairStepSeeds'): process.pixelPairStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalSeedsFromPairsWithVertices'): process.globalSeedsFromPairsWithVertices.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'tobTecStepSeedsPair'): process.tobTecStepSeedsPair.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'tobTecStepSeedsTripl'): process.tobTecStepSeedsTripl.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'pixelPairElectronSeeds'): process.pixelPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'regionalCosmicTrackerSeeds'): process.regionalCosmicTrackerSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'stripPairElectronSeeds'): process.stripPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'photonConvTrajSeedFromSingleLeg'): process.photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'photonConvTrajSeedFromQuadruplets'): process.photonConvTrajSeedFromQuadruplets.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'tripletElectronSeeds'): process.tripletElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'jetCoreRegionalStepSeeds'): process.jetCoreRegionalStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+
 
     maxElement = cms.uint32(1000000)
     
-    process.initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
-    process.tobTecStepSeedsPair.OrderedHitsFactoryPSet.maxElement = maxElement
-    process.pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
-    process.jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
+    if hasattr(process,'initialStepSeedsPreSplitting'): process.initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'initialStepSeeds'): process.initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'lowPtTripletStepSeeds'): process.lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'mixedTripletStepSeedsA'): process.mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'mixedTripletStepSeedsB'): process.mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'detachedTripletStepSeeds'): process.detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'pixelLessStepSeeds'): process.pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'tobTecStepSeedsTripl'): process.tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'tobTecStepSeedsPair'): process.tobTecStepSeedsPair.OrderedHitsFactoryPSet.maxElement = maxElement
+    if hasattr(process,'pixelPairStepSeeds'): process.pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
+    if hasattr(process,'jetCoreRegionalStepSeeds'): process.jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
 
     return process
 

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -75,3 +75,60 @@ def addHIIsolationProducer(process):
     process.reconstruction *= process.photonIsolationHISequencePP
     
     return process
+
+# Customize process to run HI-style photon isolation in the pp RECO sequences                                                                                                        
+def modifyClusterLimits(process):
+
+    process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.initialStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.lowPtTripletStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.globalSeedsFromTriplets.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.detachedTripletStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.mixedTripletStepSeedsA.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.mixedTripletStepSeedsB.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.globalMixedSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.pixelLessStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.globalPixelLessSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.globalPixelSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.pixelPairStepSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.globalSeedsFromPairsWithVertices.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.tobTecStepSeedsPair.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.tobTecStepSeedsTripl.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.pixelPairElectronSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.regionalCosmicTrackerSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.stripPairElectronSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.photonConvTrajSeedFromQuadruplets.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    process.tripletElectronSeeds.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+    
+    process.initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(1000000)
+    process.tobTecStepSeedsPair.OrderedHitsFactoryPSet.maxElement = cms.uint32(1000000)
+    process.pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(1000000)
+    process.jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(1000000)
+
+    return process
+
+def storeCaloTowersAOD(process):
+
+    process.load('Configuration.EventContent.EventContent_cff')
+    
+    # extend AOD content
+    process.AODoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+
+    return process
+
+def storeCaloTowersAODSIM(process):
+
+    process.load('Configuration.EventContent.EventContent_cff')
+    
+    # extend AOD content
+    process.AODSIMoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+
+    return process

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -76,7 +76,8 @@ def addHIIsolationProducer(process):
     
     return process
 
-# Customize process to run HI-style photon isolation in the pp RECO sequences                                                                                                        
+
+    # modify cluster limits to run pp reconstruction on peripheral PbPb
 def modifyClusterLimits(process):
 
     process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
@@ -115,20 +116,26 @@ def modifyClusterLimits(process):
 
     return process
 
+
+# Add caloTowers to AOD event content
 def storeCaloTowersAOD(process):
 
     process.load('Configuration.EventContent.EventContent_cff')
     
     # extend AOD content
-    process.AODoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+    if hasattr(process,'AODoutput'):
+        process.AODoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+
+    if hasattr(process,'AODSIMoutput'):
+        process.AODSIMoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
 
     return process
 
-def storeCaloTowersAODSIM(process):
+def customisePPwithHI(process):
 
-    process.load('Configuration.EventContent.EventContent_cff')
-    
-    # extend AOD content
-    process.AODSIMoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+    process=addHIIsolationProducer(process)
+    process=modifyClusterLimits(process)
+    process=storeCaloTowersAOD(process)
 
     return process
+


### PR DESCRIPTION
Same as #13603 
Modifies number of cluster limits in tracking and allows us to store calotowers.
