### PR TITLE
Protect default PAT jet configuration (81X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-patJets = cms.EDProducer("PATJetProducer",
+_patJets = cms.EDProducer("PATJetProducer",
     # input
     jetSource = cms.InputTag("ak4PFJetsCHS"),
     # add user data
@@ -89,4 +89,4 @@ patJets = cms.EDProducer("PATJetProducer",
     resolutions     = cms.PSet()
 )
 
-
+patJets = _patJets.clone()

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -14,7 +14,7 @@ def applySubstructure( process ) :
                                     distMax = cms.double(0.8)
     )
 
-    from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import patJets as patJetsDefault
+    from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import _patJets as patJetsDefault
 
     #add AK8
     addJetCollection(process, labelName = 'AK8',

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -235,8 +235,6 @@ def miniAOD_customizeCommon(process):
     
     process.patJetGenJetMatchPuppi.matched = 'slimmedGenJets'
     
-    process.patJetsPuppi.userData.userFloats.src = cms.VInputTag(cms.InputTag(""))
-    process.patJetsPuppi.userData.userInts.src = cms.VInputTag(cms.InputTag(""))
     process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
 
     process.selectedPatJetsPuppi.cut = cms.string("pt > 15")

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -544,7 +544,7 @@ class AddJetCollection(ConfigToolBase):
         if _algo=='':
             unsupportedJetAlgorithm(self)
         ## add new patJets to process (keep instance for later further modifications)
-        from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import patJets
+        from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import _patJets as patJets
         if 'patJets'+_labelName+postfix in knownModules :
             _newPatJets=getattr(process, 'patJets'+_labelName+postfix)
             _newPatJets.jetSource=jetSource


### PR DESCRIPTION
This PR addresses the problem reported in https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3631.html by protecting the default PAT jet configuration from being modified inadvertently.

**Update (Mar. 10, 2016):** Rebased to CMSSW_8_1_X_2016-03-10-1100 with

``` python
process.patJetsPuppi.userData.userInts.src = cms.VInputTag(cms.InputTag(""))
```

(introduced in #13642 but now redundant) removed from `PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py`.
