### PR TITLE
Implmementation of the statistics split for the Gain Calibration workflow.

### DIFF
--- a/CalibTracker/Configuration/python/produceCalibrationTree_cfg.py
+++ b/CalibTracker/Configuration/python/produceCalibrationTree_cfg.py
@@ -5,7 +5,7 @@ process.load('CalibTracker.Configuration.setupCalibrationTree_cff')
 process.load('Configuration.StandardSequences.Geometry_cff')
 process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'GR09_R_V1::All'
+process.GlobalTag.globaltag = '76X_dataRun2_v15'
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
@@ -14,20 +14,40 @@ process.add_( cms.Service( "TFileService",
                            closeFileFast = cms.untracked.bool(True)  ) )
 
 process.load('CalibTracker.SiStripCommon.theBigNtuple_cfi')
-process.TkCalPath = cms.Path( process.theBigNtuple * process.TkCalFullSequence     )
-process.TkPathDigi = cms.Path (process.theBigNtupleDigi)
-process.endPath = cms.EndPath(process.bigShallowTree)
+process.TkCalPath_AB   = cms.Path( process.theBigNtuple * process.TkCalSeq_AllBunch     )
+process.TkCalPath_AB0T = cms.Path( process.theBigNtuple * process.TkCalSeq_AllBunch0T   )
+process.TkCalPath_IB   = cms.Path( process.theBigNtuple * process.TkCalSeq_IsoBunch     )
+process.TkCalPath_IB0T = cms.Path( process.theBigNtuple * process.TkCalSeq_IsoBunch0T   )
+process.TkPathDigi     = cms.Path (process.theBigNtupleDigi)
+process.endPath        = cms.EndPath(process.bigShallowTree)
 
-#process.schedule = cms.Schedule( process.TkCalPath )
+process.schedule = cms.Schedule( process.TkCalPath_AB, process.TkCalPath_AB0T, process.TkCalPath_IB, process.TkCalPath_IB0T )
 
 
 #following ignored by CRAB
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 process.source = cms.Source (
     "PoolSource",
-    #from run = 123596, dataset = /MinimumBias/BeamCommissioning09-SD_AllMinBias-skim_GR09_P_V7_v1/RAW-RECO 
-    fileNames=cms.untracked.vstring('/store/data/BeamCommissioning09/MinimumBias/RAW-RECO/Dec9thReReco_BSCNOBEAMHALO-v1/0000/5A8A4A57-22E5-DE11-81B0-0026189438B5.root',
-                                    '/store/data/BeamCommissioning09/MinimumBias/RAW-RECO/Dec9thReReco_BSCNOBEAMHALO-v1/0000/1A202DCE-1DE5-DE11-A176-002618943985.root'
+    fileNames=cms.untracked.vstring(
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60002/9A39175A-8BAC-E511-B537-00261894393C.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60003/F632A9B7-F9A8-E511-AB7B-001E67398390.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/3A69DC8F-3BAA-E511-B41E-3417EBE645E2.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/48FF6A16-CCAB-E511-A8C4-0025905A612C.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/6401E5E5-F4AC-E511-8FBA-0CC47A4C8F0A.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/6A9970CA-39AA-E511-8859-0CC47A4DED1A.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/6EA49B98-DEAC-E511-A459-0025905A60E0.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/80756625-3DAA-E511-92BA-001D09FDD6AB.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/927C387E-B5AC-E511-87C5-0CC47A78A478.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/969B7185-01AD-E511-86C4-0CC47A78A3EE.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/9E36132E-19AD-E511-AD43-0CC47A4D760C.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/A6870647-39AA-E511-8754-549F358EB748.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/C243CE41-3AAA-E511-ACCE-A0369F7FC544.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/C412AC3F-4AAC-E511-9881-0025905A6068.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/D8B72B94-3AAC-E511-B81D-0025905A6066.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/F6363144-3AAA-E511-A708-002590D0B016.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/F88F1B6D-3FAA-E511-8ADA-A0369F7F9EDC.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60006/FAD08497-DEAC-E511-9CB5-0CC47A4D762E.root',
+      '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalZeroBias-16Dec2015-v1/60007/CC5DD2C0-65AA-E511-8A92-549F35AC7E56.root'
                                     ),
     secondaryFileNames = cms.untracked.vstring())
 

--- a/CalibTracker/Configuration/python/setupCalibrationTree_cff.py
+++ b/CalibTracker/Configuration/python/setupCalibrationTree_cff.py
@@ -5,13 +5,18 @@ from CalibTracker.SiStripLorentzAngle.ntuple_cff import *
 from CalibTracker.SiStripChannelGain.ntuple_cff import *
 from CalibTracker.SiStripHitEfficiency.SiStripHitEff_cff import *
 
-shallowTrackClusters.Tracks = "CalibrationTracksRefit"
-shallowTrackClusters.Clusters = 'CalibrationTracks'
-shallowClusters.Clusters = 'CalibrationTracks'
-shallowGainCalibration.Tracks = "CalibrationTracksRefit"
-anEff.combinatorialTracks = "CalibrationTracksRefit"
-anEff.trajectories = "CalibrationTracksRefit"
+shallowTrackClusters.Tracks             = 'CalibrationTracksRefit'
+shallowTrackClusters.Clusters           = 'CalibrationTracks'
+shallowClusters.Clusters                = 'CalibrationTracks'
+shallowGainCalibration.Tracks           = 'CalibrationTracksRefit'
+anEff.combinatorialTracks               = 'CalibrationTracksRefit'
+anEff.trajectories                      = 'CalibrationTracksRefit'
 
 #Schedule
 #TkCalFullSequence = cms.Sequence( trackFilterRefit + LorentzAngleNtuple + hiteff + OfflineGainNtuple)
-TkCalFullSequence = cms.Sequence(MeasurementTrackerEvent + trackFilterRefit + OfflineGainNtuple + hiteff)
+TkCalSeq_AllBunch   = cms.Sequence(MeasurementTrackerEvent + trackFilterRefit + OfflineGainNtuple_AllBunch + hiteff)
+TkCalSeq_AllBunch0T = cms.Sequence(MeasurementTrackerEvent + trackFilterRefit + OfflineGainNtuple_AllBunch0T + hiteff)
+TkCalSeq_IsoBunch   = cms.Sequence(MeasurementTrackerEvent + trackFilterRefit + OfflineGainNtuple_IsoBunch + hiteff)
+TkCalSeq_IsoBunch0T = cms.Sequence(MeasurementTrackerEvent + trackFilterRefit + OfflineGainNtuple_IsoBunch0T + hiteff)
+
+

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -76,6 +76,8 @@
 
 #include <ext/hash_map>
 
+
+
 using namespace edm;
 using namespace reco;
 using namespace std;
@@ -127,6 +129,8 @@ private:
 	virtual void algoEndJob        () override;
 	virtual void algoAnalyze       (const edm::Event &, const edm::EventSetup &) override;
 
+        int  statCollectionFromMode(const char* tag) const;
+        void bookDQMHistos(const char* dqm_dir, const char* tag);
 	void merge(TH2* A, TH2* B); //needed to add histograms with different number of bins
 	void algoAnalyzeTheTree();
 	void algoComputeMPVandGain();
@@ -150,7 +154,6 @@ private:
 
 	TFileService *tfs;
 	DQMStore* dbe;
-	bool         harvestingMode;
 	double       MinNrEntries;
 	double       MaxMPVError;
 	double       MaxChi2OverNDF;
@@ -161,6 +164,7 @@ private:
 	unsigned int MaxNrStrips;
 	unsigned int MinTrackHits;
 	double       MaxTrackChiOverNdf;
+        int          MaxTrackingIteration;
 	bool         AllowSaturation;
 	bool         FirstSetOfConstants;
 	bool         Validation;
@@ -169,6 +173,9 @@ private:
 
 	bool         saveSummary;
 	bool         useCalibration;
+        bool         m_harvestingMode;
+        bool         m_splitDQMstat;
+        string       m_calibrationMode;
 	string       m_calibrationPath;
 
 	double tagCondition_NClusters;
@@ -178,16 +185,21 @@ private:
 	std::string  OutputGains;
 	vector<string> VInputFiles;
 
-	MonitorElement*        Charge_Vs_Index;
-	MonitorElement*        Charge_Vs_Index_Absolute;
-	MonitorElement*        Charge_Vs_PathlengthTIB;
-	MonitorElement*        Charge_Vs_PathlengthTOB;
-	MonitorElement*        Charge_Vs_PathlengthTIDP;
-	MonitorElement*        Charge_Vs_PathlengthTIDM;
-	MonitorElement*        Charge_Vs_PathlengthTECP1;
-	MonitorElement*        Charge_Vs_PathlengthTECP2;
-	MonitorElement*        Charge_Vs_PathlengthTECM1;
-	MonitorElement*        Charge_Vs_PathlengthTECM2;
+        enum statistic_type {None=-1, AllBunch, AllBunch0T, IsoBunch, IsoBunch0T, HLTAllBunch, HLTAllBunch0T, HLTIsoBunch,
+                             HLTIsoBunch0T, HTALLBunch, HTTAllBunch0T, HTTIsoBunch, HTTIsoBunch0T, Harvest};
+
+        std::vector<string>    dqm_tag_;
+
+        std::vector<MonitorElement*>  Charge_Vs_Index;
+        //std::vector<MonitorElement*>  Charge_Vs_Index_Absolute;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTIB;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTOB;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTIDP;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTIDM;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTECP1;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTECP2;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM1;
+        std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM2;
 
 	unsigned int NEvent;    
 	unsigned int NTrack;
@@ -201,33 +213,38 @@ private:
 	unsigned int BAD;
 	unsigned int MASKED;
 
-	//data members for processing
-	unsigned int                 eventnumber    = 0;
-	unsigned int                 runnumber      = 0;
-	const std::vector<bool>*           TrigTech       = 0;  edm::EDGetTokenT<std::vector<bool>        	 > TrigTech_token_;
+	//Data members for processing
 
-	const std::vector<double>*         trackchi2ndof  = 0;  edm::EDGetTokenT<std::vector<double>      	 > trackchi2ndof_token_;
-	const std::vector<float>*          trackp         = 0;  edm::EDGetTokenT<std::vector<float>       	 > trackp_token_;
-	const std::vector<float>*          trackpt        = 0;  edm::EDGetTokenT<std::vector<float>       	 > trackpt_token_;
-	const std::vector<double>*         tracketa       = 0;  edm::EDGetTokenT<std::vector<double>      	 > tracketa_token_;
-	const std::vector<double>*         trackphi       = 0;  edm::EDGetTokenT<std::vector<double>      	 > trackphi_token_;
-	const std::vector<unsigned int>*   trackhitsvalid = 0;  edm::EDGetTokenT<std::vector<unsigned int>	 > trackhitsvalid_token_;
+	//Event data
+	unsigned int                       eventnumber    =0;
+	unsigned int                       runnumber      =0;
+	const std::vector<bool>*           TrigTech       =0;  edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
 
-	const std::vector<int>*            trackindex     = 0;  edm::EDGetTokenT<std::vector<int>         	 > trackindex_token_;
-	const std::vector<unsigned int>*   rawid          = 0;  edm::EDGetTokenT<std::vector<unsigned int>	 > rawid_token_;
-	const std::vector<double>*         localdirx      = 0;  edm::EDGetTokenT<std::vector<double>       	 > localdirx_token_;
-	const std::vector<double>*         localdiry      = 0;  edm::EDGetTokenT<std::vector<double>       	 > localdiry_token_;
-	const std::vector<double>*         localdirz      = 0;  edm::EDGetTokenT<std::vector<double>       	 > localdirz_token_;
-	const std::vector<unsigned short>* firststrip     = 0;  edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
-	const std::vector<unsigned short>* nstrips        = 0;  edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
-	const std::vector<bool>*           saturation     = 0;  edm::EDGetTokenT<std::vector<bool>        	 > saturation_token_;
-	const std::vector<bool>*           overlapping    = 0;  edm::EDGetTokenT<std::vector<bool>        	 > overlapping_token_;
-	const std::vector<bool>*           farfromedge    = 0;  edm::EDGetTokenT<std::vector<bool>        	 > farfromedge_token_;
-	const std::vector<unsigned int>*   charge         = 0;  edm::EDGetTokenT<std::vector<unsigned int>	 > charge_token_;
-	const std::vector<double>*         path           = 0;  edm::EDGetTokenT<std::vector<double>       	 > path_token_;
-	const std::vector<double>*         chargeoverpath = 0;  edm::EDGetTokenT<std::vector<double>       	 > chargeoverpath_token_;
-	const std::vector<unsigned char>*  amplitude      = 0;  edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
-	const std::vector<double>*         gainused       = 0;  edm::EDGetTokenT<std::vector<double>         > gainused_token_;
+        // Track data
+	const std::vector<double>*         trackchi2ndof  =0;  edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
+	const std::vector<float>*          trackp         =0;  edm::EDGetTokenT<std::vector<float>          > trackp_token_;
+	const std::vector<float>*          trackpt        =0;  edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
+	const std::vector<double>*         tracketa       =0;  edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
+	const std::vector<double>*         trackphi       =0;  edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
+	const std::vector<unsigned int>*   trackhitsvalid =0;  edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
+        const std::vector<int>*            trackalgo      =0;  edm::EDGetTokenT<std::vector<int>   >          trackalgo_token_;
+
+        // CalibTree data
+	const std::vector<int>*            trackindex     =0;  edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
+	const std::vector<unsigned int>*   rawid          =0;  edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
+	const std::vector<double>*         localdirx      =0;  edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
+	const std::vector<double>*         localdiry      =0;  edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
+	const std::vector<double>*         localdirz      =0;  edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
+	const std::vector<unsigned short>* firststrip     =0;  edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
+	const std::vector<unsigned short>* nstrips        =0;  edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
+	const std::vector<bool>*           saturation     =0;  edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
+	const std::vector<bool>*           overlapping    =0;  edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
+	const std::vector<bool>*           farfromedge    =0;  edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
+	const std::vector<unsigned int>*   charge         =0;  edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
+	const std::vector<double>*         path           =0;  edm::EDGetTokenT<std::vector<double>         > path_token_;
+	const std::vector<double>*         chargeoverpath =0;  edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
+	const std::vector<unsigned char>*  amplitude      =0;  edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
+	const std::vector<double>*         gainused       =0;  edm::EDGetTokenT<std::vector<double>         > gainused_token_;
 
 	string EventPrefix_; //("");
 	string EventSuffix_; //("");
@@ -235,7 +252,6 @@ private:
 	string TrackSuffix_; //("");
 	string CalibPrefix_; //("GainCalibration");
 	string CalibSuffix_; //("");
-	string tree_path_;
 
 private :
 	class isEqual{
@@ -246,6 +262,20 @@ private :
 	std::vector<stAPVGain*> APVsCollOrdered;
 	__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual > APVsColl;
 };
+
+inline int
+SiStripGainFromCalibTree::statCollectionFromMode(const char* tag) const
+{
+    std::vector<string>::const_iterator it=dqm_tag_.begin();
+    while(it!=dqm_tag_.end()) {
+        if(*it==std::string(tag)) return it-dqm_tag_.begin();
+        it++;
+    }
+
+    if (std::string(tag)=="") return 0;  // return AllBunch calibration mode for backward compatibility
+
+    return None;
+}
 
 void SiStripGainFromCalibTree::merge(TH2* A, TH2* B){
 	if(A->GetNbinsX() ==  B->GetNbinsX()){
@@ -262,60 +292,96 @@ void SiStripGainFromCalibTree::merge(TH2* A, TH2* B){
 
 SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iConfig) : ConditionDBWriter<SiStripApvGain>(iConfig)
 {
-	Charge_Vs_Index     = NULL;//make sure this is initialized to NULL 
-	OutputGains         = iConfig.getParameter<std::string>("OutputGains");
+	OutputGains             = iConfig.getParameter<std::string>("OutputGains");
 
-	AlgoMode            = iConfig.getUntrackedParameter<std::string>("AlgoMode", "CalibTree");
-	MinNrEntries        = iConfig.getUntrackedParameter<double>  ("minNrEntries"       ,  20);
-	MaxMPVError         = iConfig.getUntrackedParameter<double>  ("maxMPVError"        ,  500.0);
-	MaxChi2OverNDF      = iConfig.getUntrackedParameter<double>  ("maxChi2OverNDF"     ,  5.0);
-	MinTrackMomentum    = iConfig.getUntrackedParameter<double>  ("minTrackMomentum"   ,  3.0);
-	MaxTrackMomentum    = iConfig.getUntrackedParameter<double>  ("maxTrackMomentum"   ,  99999.0);
-	MinTrackEta         = iConfig.getUntrackedParameter<double>  ("minTrackEta"        , -5.0);
-	MaxTrackEta         = iConfig.getUntrackedParameter<double>  ("maxTrackEta"        ,  5.0);
-	MaxNrStrips         = iConfig.getUntrackedParameter<unsigned>("maxNrStrips"        ,  2);
-	MinTrackHits        = iConfig.getUntrackedParameter<unsigned>("MinTrackHits"       ,  8);
-	MaxTrackChiOverNdf  = iConfig.getUntrackedParameter<double>  ("MaxTrackChiOverNdf" ,  3);
-	AllowSaturation     = iConfig.getUntrackedParameter<bool>    ("AllowSaturation"    ,  false);
-	FirstSetOfConstants = iConfig.getUntrackedParameter<bool>    ("FirstSetOfConstants",  true);
-	Validation          = iConfig.getUntrackedParameter<bool>    ("Validation"         ,  false);
-	OldGainRemoving     = iConfig.getUntrackedParameter<bool>    ("OldGainRemoving"    ,  false);
+	AlgoMode                = iConfig.getUntrackedParameter<std::string>("AlgoMode", "CalibTree");
+	MinNrEntries            = iConfig.getUntrackedParameter<double>  ("minNrEntries"         ,  20);
+	MaxMPVError             = iConfig.getUntrackedParameter<double>  ("maxMPVError"          ,  500.0);
+	MaxChi2OverNDF          = iConfig.getUntrackedParameter<double>  ("maxChi2OverNDF"       ,  5.0);
+	MinTrackMomentum        = iConfig.getUntrackedParameter<double>  ("minTrackMomentum"     ,  3.0);
+	MaxTrackMomentum        = iConfig.getUntrackedParameter<double>  ("maxTrackMomentum"     ,  99999.0);
+	MinTrackEta             = iConfig.getUntrackedParameter<double>  ("minTrackEta"          , -5.0);
+	MaxTrackEta             = iConfig.getUntrackedParameter<double>  ("maxTrackEta"          ,  5.0);
+	MaxNrStrips             = iConfig.getUntrackedParameter<unsigned>("maxNrStrips"          ,  2);
+	MinTrackHits            = iConfig.getUntrackedParameter<unsigned>("MinTrackHits"         ,  8);
+	MaxTrackChiOverNdf      = iConfig.getUntrackedParameter<double>  ("MaxTrackChiOverNdf"   ,  3);
+        MaxTrackingIteration    = iConfig.getUntrackedParameter<int>     ("MaxTrackingIteration" ,  7);
+	AllowSaturation         = iConfig.getUntrackedParameter<bool>    ("AllowSaturation"      ,  false);
+	FirstSetOfConstants     = iConfig.getUntrackedParameter<bool>    ("FirstSetOfConstants"  ,  true);
+	Validation              = iConfig.getUntrackedParameter<bool>    ("Validation"           ,  false);
+	OldGainRemoving         = iConfig.getUntrackedParameter<bool>    ("OldGainRemoving"      ,  false);
 
-	CalibrationLevel    = iConfig.getUntrackedParameter<int>     ("CalibrationLevel"   ,  0);
-	VInputFiles         = iConfig.getUntrackedParameter<vector<string> >  ("InputFiles");
+	CalibrationLevel        = iConfig.getUntrackedParameter<int>     ("CalibrationLevel"   ,  0);
+	VInputFiles             = iConfig.getUntrackedParameter<vector<string> >  ("InputFiles");
 
 
-	useCalibration      = iConfig.getUntrackedParameter<bool>    ("UseCalibration"     , false);
-	m_calibrationPath   = iConfig.getUntrackedParameter<string>  ("calibrationPath");
-	harvestingMode      = iConfig.getUntrackedParameter<bool>    ("harvestingMode"     , false);
+	useCalibration          = iConfig.getUntrackedParameter<bool>    ("UseCalibration"     , false);
+        m_harvestingMode        = iConfig.getUntrackedParameter<bool>    ("harvestingMode"     , false);
+        m_splitDQMstat          = iConfig.getUntrackedParameter<bool>    ("splitDQMstat"       , false);
+        m_calibrationMode       = iConfig.getUntrackedParameter<string>  ("calibrationMode"    , "AllBunch");
+	m_calibrationPath       = iConfig.getUntrackedParameter<string>  ("calibrationPath");
 
-	tagCondition_NClusters  = iConfig.getUntrackedParameter<double>    ("NClustersForTagProd"     , 2E8);
-	tagCondition_GoodFrac   = iConfig.getUntrackedParameter<double>    ("GoodFracForTagProd"     , 0.95);
+	tagCondition_NClusters  = iConfig.getUntrackedParameter<double>  ("NClustersForTagProd"     , 2E8);
+	tagCondition_GoodFrac   = iConfig.getUntrackedParameter<double>  ("GoodFracForTagProd"     , 0.95);
 
-	saveSummary          = iConfig.getUntrackedParameter<bool>    ("saveSummary"     , false);
-	tree_path_ = iConfig.getUntrackedParameter<string>  ("treePath");
+	saveSummary             = iConfig.getUntrackedParameter<bool>    ("saveSummary"     , false);
+
+
+        // Gather DQM Service
 	dbe = edm::Service<DQMStore>().operator->();
 	dbe->setVerbose(10);
 
+        //Set the monitoring element tag and store
+        dqm_tag_.clear();
+        dqm_tag_.push_back( "AllBunch" );      // statistic collection  == AllBunch
+        dqm_tag_.push_back( "AllBunch0T" );    // statistic collection  == AllBunch0T
+        dqm_tag_.push_back( "IsoBunch" );      // statistic collection  == FirstBunch
+        dqm_tag_.push_back( "IsoBunch0T" );    // statistic collection  == FirstBunch0T
+        dqm_tag_.push_back( "HLTAllBunch" );   // statistic collection  == HLTAllBunch
+        dqm_tag_.push_back( "HLTAllBunch0T" ); // statistic collection  == HLTAllBunch0T
+        dqm_tag_.push_back( "HLTIsoBunch" );   // statistic collection  == HLTFirstBunch
+        dqm_tag_.push_back( "HLTIsoBunch0T" ); // statistic collection  == HLTFirstBunch0T
+        dqm_tag_.push_back( "HTTAllBunch" );   // statistic collection  == HTTAllBunch
+        dqm_tag_.push_back( "HTTAllBunch0T" ); // statistic collection  == HTTAllBunch0T
+        dqm_tag_.push_back( "HTTIsoBunch" );   // statistic collection  == HTTFirstBunch
+        dqm_tag_.push_back( "HTTIsoBunch0T" ); // statistic collection  == HTTFirstBunch0T
+        dqm_tag_.push_back( "Harvest" );       // statistic collection  == Harvest
+
+        Charge_Vs_Index.insert( Charge_Vs_Index.begin(), dqm_tag_.size(), 0);
+        //Charge_Vs_Index_Absolute.insert( Charge_Vs_Index_Absolute.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTIB.insert( Charge_Vs_PathlengthTIB.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTOB.insert( Charge_Vs_PathlengthTOB.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTIDP.insert( Charge_Vs_PathlengthTIDP.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTIDM.insert( Charge_Vs_PathlengthTIDM.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTECP1.insert( Charge_Vs_PathlengthTECP1.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTECP2.insert( Charge_Vs_PathlengthTECP2.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTECM1.insert( Charge_Vs_PathlengthTECM1.begin(), dqm_tag_.size(), 0);
+        Charge_Vs_PathlengthTECM2.insert( Charge_Vs_PathlengthTECM2.begin(), dqm_tag_.size(), 0);
+
+        
+
+
+        // configure token for gathering the ntuple variables 
 	edm::ParameterSet swhallowgain_pset = iConfig.getUntrackedParameter<edm::ParameterSet>("gain");
+
 	string label = swhallowgain_pset.getUntrackedParameter<string>("label");
 	CalibPrefix_ = swhallowgain_pset.getUntrackedParameter<string>("prefix");
 	CalibSuffix_ = swhallowgain_pset.getUntrackedParameter<string>("suffix");
 
-	trackindex_token_		  = consumes<std::vector<int>         	 >(edm::InputTag(label, CalibPrefix_ + "trackindex"    + CalibSuffix_)); 
-	rawid_token_				  = consumes<std::vector<unsigned int>	 >(edm::InputTag(label, CalibPrefix_ + "rawid"         + CalibSuffix_)); 
-	localdirx_token_		  = consumes<std::vector<double>       	 >(edm::InputTag(label, CalibPrefix_ + "localdirx"     + CalibSuffix_)); 
-	localdiry_token_		  = consumes<std::vector<double>       	 >(edm::InputTag(label, CalibPrefix_ + "localdiry"     + CalibSuffix_)); 
-	localdirz_token_		  = consumes<std::vector<double>       	 >(edm::InputTag(label, CalibPrefix_ + "localdirz"     + CalibSuffix_)); 
-	firststrip_token_		  = consumes<std::vector<unsigned short> >(edm::InputTag(label, CalibPrefix_ + "firststrip"    + CalibSuffix_)); 
-	nstrips_token_			  = consumes<std::vector<unsigned short> >(edm::InputTag(label, CalibPrefix_ + "nstrips"       + CalibSuffix_)); 
-	saturation_token_		  = consumes<std::vector<bool>        	 >(edm::InputTag(label, CalibPrefix_ + "saturation"    + CalibSuffix_)); 
-	overlapping_token_	  = consumes<std::vector<bool>        	 >(edm::InputTag(label, CalibPrefix_ + "overlapping"   + CalibSuffix_)); 
-	farfromedge_token_	  = consumes<std::vector<bool>        	 >(edm::InputTag(label, CalibPrefix_ + "farfromedge"   + CalibSuffix_)); 
-	charge_token_				  = consumes<std::vector<unsigned int>	 >(edm::InputTag(label, CalibPrefix_ + "charge"        + CalibSuffix_)); 
-	path_token_					  = consumes<std::vector<double>       	 >(edm::InputTag(label, CalibPrefix_ + "path"          + CalibSuffix_)); 
-	chargeoverpath_token_ = consumes<std::vector<double>       	 >(edm::InputTag(label, CalibPrefix_ + "chargeoverpath"+ CalibSuffix_)); 
-	amplitude_token_		  = consumes<std::vector<unsigned char>  >(edm::InputTag(label, CalibPrefix_ + "amplitude"     + CalibSuffix_)); 
+	trackindex_token_     = consumes<std::vector<int>            >(edm::InputTag(label, CalibPrefix_ + "trackindex"    + CalibSuffix_)); 
+	rawid_token_          = consumes<std::vector<unsigned int>   >(edm::InputTag(label, CalibPrefix_ + "rawid"         + CalibSuffix_)); 
+	localdirx_token_      = consumes<std::vector<double>         >(edm::InputTag(label, CalibPrefix_ + "localdirx"     + CalibSuffix_)); 
+	localdiry_token_      = consumes<std::vector<double>         >(edm::InputTag(label, CalibPrefix_ + "localdiry"     + CalibSuffix_)); 
+	localdirz_token_      = consumes<std::vector<double>         >(edm::InputTag(label, CalibPrefix_ + "localdirz"     + CalibSuffix_)); 
+	firststrip_token_     = consumes<std::vector<unsigned short> >(edm::InputTag(label, CalibPrefix_ + "firststrip"    + CalibSuffix_)); 
+	nstrips_token_        = consumes<std::vector<unsigned short> >(edm::InputTag(label, CalibPrefix_ + "nstrips"       + CalibSuffix_)); 
+	saturation_token_     = consumes<std::vector<bool>           >(edm::InputTag(label, CalibPrefix_ + "saturation"    + CalibSuffix_)); 
+	overlapping_token_    = consumes<std::vector<bool>           >(edm::InputTag(label, CalibPrefix_ + "overlapping"   + CalibSuffix_)); 
+	farfromedge_token_    = consumes<std::vector<bool>           >(edm::InputTag(label, CalibPrefix_ + "farfromedge"   + CalibSuffix_)); 
+	charge_token_         = consumes<std::vector<unsigned int>   >(edm::InputTag(label, CalibPrefix_ + "charge"        + CalibSuffix_)); 
+	path_token_           = consumes<std::vector<double>         >(edm::InputTag(label, CalibPrefix_ + "path"          + CalibSuffix_)); 
+	chargeoverpath_token_ = consumes<std::vector<double>         >(edm::InputTag(label, CalibPrefix_ + "chargeoverpath"+ CalibSuffix_)); 
+	amplitude_token_      = consumes<std::vector<unsigned char>  >(edm::InputTag(label, CalibPrefix_ + "amplitude"     + CalibSuffix_)); 
 	gainused_token_       = consumes<std::vector<double>         >(edm::InputTag(label, CalibPrefix_ + "gainused"      + CalibSuffix_)); 
 
 	edm::ParameterSet evtinfo_pset = iConfig.getUntrackedParameter<edm::ParameterSet>("evtinfo");
@@ -330,36 +396,69 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
 	TrackSuffix_ = track_pset.getUntrackedParameter<string>("suffix");
 
 	trackchi2ndof_token_  = consumes<std::vector<double>      	 >(edm::InputTag(label, TrackPrefix_ + "chi2ndof"  + TrackSuffix_)); 
-	trackp_token_				  = consumes<std::vector<float>       	 >(edm::InputTag(label, TrackPrefix_ + "momentum"  + TrackSuffix_)); 
-	trackpt_token_			  = consumes<std::vector<float>       	 >(edm::InputTag(label, TrackPrefix_ + "pt"        + TrackSuffix_)); 
-	tracketa_token_			  = consumes<std::vector<double>      	 >(edm::InputTag(label, TrackPrefix_ + "eta"       + TrackSuffix_)); 
-	trackphi_token_			  = consumes<std::vector<double>      	 >(edm::InputTag(label, TrackPrefix_ + "phi"       + TrackSuffix_)); 
+	trackp_token_	      = consumes<std::vector<float>       	 >(edm::InputTag(label, TrackPrefix_ + "momentum"  + TrackSuffix_)); 
+	trackpt_token_	      = consumes<std::vector<float>       	 >(edm::InputTag(label, TrackPrefix_ + "pt"        + TrackSuffix_)); 
+	tracketa_token_	      = consumes<std::vector<double>      	 >(edm::InputTag(label, TrackPrefix_ + "eta"       + TrackSuffix_)); 
+	trackphi_token_	      = consumes<std::vector<double>      	 >(edm::InputTag(label, TrackPrefix_ + "phi"       + TrackSuffix_)); 
 	trackhitsvalid_token_ = consumes<std::vector<unsigned int>	 >(edm::InputTag(label, TrackPrefix_ + "hitsvalid" + TrackSuffix_)); 
+        trackalgo_token_      = consumes<std::vector<int>                >(edm::InputTag(label, TrackPrefix_ + "algo"      + TrackSuffix_));
 }
 
+void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* tag)
+{
+    edm::LogInfo("SiStripGainFromCalibTree") << "Setting " << dqm_dir << "in DQM and booking histograms for tag "
+                                             << tag << std::endl;
+
+    dbe->setCurrentFolder(dqm_dir);
+
+    std::string stag(tag);
+    if(stag.size()!=0 && stag[0]!='_') stag.insert(0,1,'_');
+
+    std::string cvi      = std::string("Charge_Vs_Index") + stag;
+    //std::string cviA     = std::string("Charge_Vs_Index_Absolute")  + stag;
+    std::string cvpTIB   = std::string("Charge_Vs_PathlengthTIB")   + stag;
+    std::string cvpTOB   = std::string("Charge_Vs_PathlengthTOB")   + stag;
+    std::string cvpTIDP  = std::string("Charge_Vs_PathlengthTIDP")  + stag;
+    std::string cvpTIDM  = std::string("Charge_Vs_PathlengthTIDM")  + stag;
+    std::string cvpTECP1 = std::string("Charge_Vs_PathlengthTECP1") + stag;
+    std::string cvpTECP2 = std::string("Charge_Vs_PathlengthTECP2") + stag;
+    std::string cvpTECM1 = std::string("Charge_Vs_PathlengthTECM1") + stag;
+    std::string cvpTECM2 = std::string("Charge_Vs_PathlengthTECM2") + stag;
+
+    int elepos = statCollectionFromMode(tag);
+
+    Charge_Vs_Index[elepos]           = dbe->book2D(cvi.c_str()     , cvi.c_str()     , 88625, 0   , 88624,2000,0,4000);
+    //Charge_Vs_Index_Absolute[elepos]  = dbe->book2D(cviA.c_str()    , cviA.c_str()    , 88625, 0   , 88624,1000,0,4000);
+    Charge_Vs_PathlengthTIB[elepos]   = dbe->book2D(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTOB[elepos]   = dbe->book2D(cvpTOB.c_str()  , cvpTOB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTIDP[elepos]  = dbe->book2D(cvpTIDP.c_str() , cvpTIDP.c_str() , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTIDM[elepos]  = dbe->book2D(cvpTIDM.c_str() , cvpTIDM.c_str() , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECP1[elepos] = dbe->book2D(cvpTECP1.c_str(), cvpTECP1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECP2[elepos] = dbe->book2D(cvpTECP2.c_str(), cvpTECP2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECM1[elepos] = dbe->book2D(cvpTECM1.c_str(), cvpTECM1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECM2[elepos] = dbe->book2D(cvpTECM2.c_str(), cvpTECM2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
+}
 
 void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 {
-	dbe->setCurrentFolder("AlCaReco/SiStripGains/");
-	if(AlgoMode != "PCL" or harvestingMode)dbe->setCurrentFolder("AlCaReco/SiStripGainsHarvesting/");
+        edm::LogInfo("SiStripGainFromCalibTree") << "AlgoMode        : " << AlgoMode          << "\n"
+                                                 << "CalibrationMode : " << m_calibrationMode << "\n"
+                                                 << "HarvestingMode  : " << m_harvestingMode  << std::endl;
+        //Setup DQM histograms
+	if(AlgoMode != "PCL" or m_harvestingMode) {
+            const char * dqm_dir = "AlCaReco/SiStripGainsHarvesting/";
+            if (m_harvestingMode) this->bookDQMHistos( dqm_dir, dqm_tag_[Harvest].c_str() );
+            else this->bookDQMHistos( dqm_dir, dqm_tag_[statCollectionFromMode(m_calibrationMode.c_str())].c_str() );
+        } else {
+            std::string dqm_dir = "AlCaReco/SiStripGains" + ((m_splitDQMstat)? m_calibrationMode:"") + "/";
+            this->bookDQMHistos( dqm_dir.c_str(), dqm_tag_[statCollectionFromMode(m_calibrationMode.c_str())].c_str() );
+        }
 
-	Charge_Vs_Index           = dbe->book2D("Charge_Vs_Index"          , "Charge_Vs_Index"          , 88625, 0   , 88624,2000,0,4000);
-	Charge_Vs_Index_Absolute  = dbe->book2D("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 88625, 0   , 88624,1000,0,4000);
-//   Charge_Vs_Index           = dbe->book2D("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
-//   Charge_Vs_Index_Absolute  = dbe->book2D("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
-	Charge_Vs_PathlengthTIB   = dbe->book2D("Charge_Vs_PathlengthTIB"  , "Charge_Vs_PathlengthTIB"  , 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTOB   = dbe->book2D("Charge_Vs_PathlengthTOB"  , "Charge_Vs_PathlengthTOB"  , 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTIDP  = dbe->book2D("Charge_Vs_PathlengthTIDP" , "Charge_Vs_PathlengthTIDP" , 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTIDM  = dbe->book2D("Charge_Vs_PathlengthTIDM" , "Charge_Vs_PathlengthTIDM" , 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTECP1 = dbe->book2D("Charge_Vs_PathlengthTECP1", "Charge_Vs_PathlengthTECP1", 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTECP2 = dbe->book2D("Charge_Vs_PathlengthTECP2", "Charge_Vs_PathlengthTECP2", 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTECM1 = dbe->book2D("Charge_Vs_PathlengthTECM1", "Charge_Vs_PathlengthTECM1", 20   , 0.3 , 1.3  , 250,0,2000);
-	Charge_Vs_PathlengthTECM2 = dbe->book2D("Charge_Vs_PathlengthTECM2", "Charge_Vs_PathlengthTECM2", 20   , 0.3 , 1.3  , 250,0,2000);
 
 	edm::ESHandle<TrackerGeometry> tkGeom;
 	iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
 	auto const & Det = tkGeom->dets();
-
+ 
 	NPixelDets = 0;
 	NStripAPVs = 0;
 	unsigned int Index=0;
@@ -504,60 +603,148 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
 }
 
 void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventSetup& iSetup){
-	if(AlgoMode == "PCL" && !harvestingMode)return;//nothing to do in that case
+	if(AlgoMode == "PCL" && !m_harvestingMode) return;//nothing to do in that case
 
-	if(AlgoMode == "PCL" and harvestingMode){
-		// Load the 2D histograms from the DQM objects
-		// When running in AlCaHarvesting mode the histos are already booked and should be just retrieved from
-		// DQMStore so that they can be used in the fit
-     
-//     edm::LogInfo("SiStripGainFromCalibTree")<< "Harvesting " << (dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index"))->getTH2F()->GetEntries() << " more clusters\n";
+	if(AlgoMode == "PCL" and m_harvestingMode){
+            // Load the 2D histograms from the DQM objects
+            // When running in AlCaHarvesting mode the histos are already booked and should be just retrieved from
+            // DQMStore so that they can be used in the fit
+             
+            edm::LogInfo("SiStripGainFromCalibTree") << "Starting harvesting statistics" << std::endl;
 
-		merge(Charge_Vs_Index           ->getTH2F(), (dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index"))->getTH2F() );
-//     Charge_Vs_Index           ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index"))->getTH2F());
-		merge(Charge_Vs_Index_Absolute  ->getTH2F(), (dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index_Absolute"))->getTH2F() );     
-//     Charge_Vs_Index_Absolute  ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index_Absolute"))->getTH2F());
-		Charge_Vs_PathlengthTIB   ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTIB"))->getTH2F());
-		Charge_Vs_PathlengthTOB   ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTOB"))->getTH2F());
-		Charge_Vs_PathlengthTIDP  ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTIDP"))->getTH2F());
-		Charge_Vs_PathlengthTIDM  ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTIDM"))->getTH2F());
-		Charge_Vs_PathlengthTECP1 ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECP1"))->getTH2F());
-		Charge_Vs_PathlengthTECP2 ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECP2"))->getTH2F());
-		Charge_Vs_PathlengthTECM1 ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECM1"))->getTH2F());
-		Charge_Vs_PathlengthTECM2 ->getTH2F()->Add((dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECM2"))->getTH2F());
+            // check the required tag before adding histograms
+            int elepos = statCollectionFromMode(m_calibrationMode.c_str());
+            if (elepos!=Harvest) {
+
+                //collect statistics from DQM into the related monitored elements
+                std::string stag = m_calibrationMode;
+                if(stag.size()!=0 && stag[0]!='_') stag.insert(0,1,'_');
+ 
+                 
+                if (elepos==-1) {
+                    //implememt backward compatibility
+                    elepos=0;
+                    stag="";
+                }
+
+                std::string DQM_dir = "AlCaReco/SiStripGains" + ((m_splitDQMstat)? m_calibrationMode:"");
+
+                std::string cvi      = DQM_dir + std::string("/Charge_Vs_Index") + stag;
+                //std::string cviA     = DQM_dir + std::string("/Charge_Vs_Index_Absolute")  + stag;
+                std::string cvpTIB   = DQM_dir + std::string("/Charge_Vs_PathlengthTIB")   + stag;
+                std::string cvpTOB   = DQM_dir + std::string("/Charge_Vs_PathlengthTOB")   + stag;
+                std::string cvpTIDP  = DQM_dir + std::string("/Charge_Vs_PathlengthTIDP")  + stag;
+                std::string cvpTIDM  = DQM_dir + std::string("/Charge_Vs_PathlengthTIDM")  + stag;
+                std::string cvpTECP1 = DQM_dir + std::string("/Charge_Vs_PathlengthTECP1") + stag;
+                std::string cvpTECP2 = DQM_dir + std::string("/Charge_Vs_PathlengthTECP2") + stag;
+                std::string cvpTECM1 = DQM_dir + std::string("/Charge_Vs_PathlengthTECM1") + stag;
+                std::string cvpTECM2 = DQM_dir + std::string("/Charge_Vs_PathlengthTECM2") + stag;
+
+                Charge_Vs_Index[elepos]           = dbe->get(cvi.c_str());
+                //Charge_Vs_Index_Absolute[elepos]  = dbe->get(cviA.c_str());
+                Charge_Vs_PathlengthTIB[elepos]   = dbe->get(cvpTIB.c_str());
+                Charge_Vs_PathlengthTOB[elepos]   = dbe->get(cvpTOB.c_str());
+                Charge_Vs_PathlengthTIDP[elepos]  = dbe->get(cvpTIDP.c_str());
+                Charge_Vs_PathlengthTIDM[elepos]  = dbe->get(cvpTIDM.c_str());
+                Charge_Vs_PathlengthTECP1[elepos] = dbe->get(cvpTECP1.c_str());
+                Charge_Vs_PathlengthTECP2[elepos] = dbe->get(cvpTECP2.c_str());
+                Charge_Vs_PathlengthTECM1[elepos] = dbe->get(cvpTECM1.c_str());
+                Charge_Vs_PathlengthTECM2[elepos] = dbe->get(cvpTECM2.c_str());
+
+                if (Charge_Vs_Index[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvi.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else {
+                    merge( (Charge_Vs_Index[Harvest])->getTH2F(), (Charge_Vs_Index[elepos])->getTH2F() );
+                    edm::LogInfo("SiStripGainFromCalibTree") << "Harvesting " 
+                                << (Charge_Vs_Index[elepos])->getTH2F()->GetEntries() << " more clusters" << std::endl;
+                }
+
+                //if (Charge_Vs_Index_Absolute[elepos]==0) {
+                //    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cviA.c_str()
+                //                                              << ", statistics will not be summed!" << std::endl;
+                //} else merge( (Charge_Vs_Index_Absolute[Harvest])->getTH2F(), (Charge_Vs_Index_Absolute[elepos])->getTH2F() );
+
+                if (Charge_Vs_PathlengthTIB[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTIB.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTIB[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTIB[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTOB[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTOB.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTOB[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTOB[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTIDP[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTIDP.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTIDP[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTIDP[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTIDM[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTIDM.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTIDM[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTIDM[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTECP1[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTECP1.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTECP1[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTECP1[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTECP2[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTECP2.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTECP2[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTECP2[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTECM1[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTECM1.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTECM1[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTECM1[elepos])->getTH2F());
+
+                if (Charge_Vs_PathlengthTECM2[elepos]==0) {
+                    edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << cvpTECM2.c_str()
+                                                              << ", statistics will not be summed!" << std::endl;
+                } else (Charge_Vs_PathlengthTECM2[Harvest])->getTH2F()->Add((Charge_Vs_PathlengthTECM2[elepos])->getTH2F());
+            }
 	}
 }
+
 void 
 SiStripGainFromCalibTree::algoEndJob() {
-	if(AlgoMode == "PCL" && !harvestingMode)return;//nothing to do in that case
+	if(AlgoMode == "PCL" && !m_harvestingMode) return;//nothing to do in that case
 
 	if(AlgoMode == "CalibTree"){
+                edm::LogInfo("SiStripGainFromCalibTree") << "Analyzing calibration tree" << std::endl;
 		// Loop on calibTrees to fill the 2D histograms
 		algoAnalyzeTheTree();
-	}else if(harvestingMode){
-		NClusterStrip = Charge_Vs_Index->getTH2F()->Integral(0,NStripAPVs+1, 0, 99999 );
-		NClusterPixel = Charge_Vs_Index->getTH2F()->Integral(NStripAPVs+2, NStripAPVs+NPixelDets+2, 0, 99999 );
+	}else if(m_harvestingMode){
+		NClusterStrip = (Charge_Vs_Index[Harvest])->getTH2F()->Integral(0,NStripAPVs+1, 0, 99999 );
+		NClusterPixel = (Charge_Vs_Index[Harvest])->getTH2F()->Integral(NStripAPVs+2, NStripAPVs+NPixelDets+2, 0, 99999 );
 	}
 
 	// Now that we have the full statistics we can extract the information of the 2D histograms
 	algoComputeMPVandGain();
    
 	if(AlgoMode != "PCL" or saveSummary){
-		//also save the 2D monitor elements to this file as TH2D tfs
-		tfs = edm::Service<TFileService>().operator->();
-		tfs->make<TH2F> (*Charge_Vs_Index->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_Index_Absolute->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTIB->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTOB->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTIDP->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTIDM->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTECP1->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTECP2->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTECM1->getTH2F());
-		tfs->make<TH2F> (*Charge_Vs_PathlengthTECM2->getTH2F());
+            edm::LogInfo("SiStripGainFromCalibTree") << "Saving summary into root file" << std::endl;
 
+            //also save the 2D monitor elements to this file as TH2D tfs
+            tfs = edm::Service<TFileService>().operator->();
 
-		storeOnTree(tfs);
+            //save only the statistics for the calibrationTag 
+            int elepos = statCollectionFromMode(m_calibrationMode.c_str());
+
+            if( Charge_Vs_Index[elepos]!=0 )           tfs->make<TH2F> ( *(Charge_Vs_Index[elepos])->getTH2F() );
+            //if( Charge_Vs_Index_Absolute[elepos]!=0 )  tfs->make<TH2F> ( *(Charge_Vs_Index_Absolute[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTIB[elepos]!=0 )   tfs->make<TH2F> ( *(Charge_Vs_PathlengthTIB[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTOB[elepos]!=0 )   tfs->make<TH2F> ( *(Charge_Vs_PathlengthTOB[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTIDP[elepos]!=0 )  tfs->make<TH2F> ( *(Charge_Vs_PathlengthTIDP[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTIDM[elepos]!=0 )  tfs->make<TH2F> ( *(Charge_Vs_PathlengthTIDM[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTECP1[elepos]!=0 ) tfs->make<TH2F> ( *(Charge_Vs_PathlengthTECP1[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTECP2[elepos]!=0 ) tfs->make<TH2F> ( *(Charge_Vs_PathlengthTECP2[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTECM1[elepos]!=0 ) tfs->make<TH2F> ( *(Charge_Vs_PathlengthTECM1[elepos])->getTH2F() );
+            if( Charge_Vs_PathlengthTECM2[elepos]!=0 ) tfs->make<TH2F> ( *(Charge_Vs_PathlengthTECM2[elepos])->getTH2F() );
+
+            storeOnTree(tfs);
 	}
 }
 
@@ -598,23 +785,29 @@ bool SiStripGainFromCalibTree::IsGoodLandauFit(double* FitResults){
 
 void SiStripGainFromCalibTree::processEvent() {
 
+        edm::LogInfo("SiStripGainFromCalibTree") << "Processing run " << runnumber << " and event " << eventnumber << std::endl;
+
 	if(runnumber<SRun)SRun=runnumber;
 	if(runnumber>ERun)ERun=runnumber;
 
 	NEvent++;
 	NTrack+=(*trackp).size();
 
+        int elepos = statCollectionFromMode(m_calibrationMode.c_str());
+
 	unsigned int FirstAmplitude=0;
 	for(unsigned int i=0;i<(*chargeoverpath).size();i++){
 		FirstAmplitude+=(*nstrips)[i];
 		int    TI = (*trackindex)[i];
+
 		//printf("%i - %i - %i %i %i\n", (int)(*rawid)[i], (int)(*firststrip)[i]/128, (int)(*farfromedge)[i], (int)(*overlapping)[i], (int)(*saturation )[i] );
-		if((*tracketa      )[TI]  < MinTrackEta        )continue;
-		if((*tracketa      )[TI]  > MaxTrackEta        )continue;
-		if((*trackp        )[TI]  < MinTrackMomentum   )continue;
-		if((*trackp        )[TI]  > MaxTrackMomentum   )continue;
-		if((*trackhitsvalid)[TI]  < MinTrackHits       )continue;
-		if((*trackchi2ndof )[TI]  > MaxTrackChiOverNdf )continue;
+		if((*tracketa      )[TI]  < MinTrackEta          )continue;
+		if((*tracketa      )[TI]  > MaxTrackEta          )continue;
+		if((*trackp        )[TI]  < MinTrackMomentum     )continue;
+		if((*trackp        )[TI]  > MaxTrackMomentum     )continue;
+		if((*trackhitsvalid)[TI]  < MinTrackHits         )continue;
+		if((*trackchi2ndof )[TI]  > MaxTrackChiOverNdf   )continue;
+                if((*trackalgo     )[TI]  > MaxTrackingIteration )continue;
 
 		stAPVGain* APV = APVsColl[((*rawid)[i]<<4) | ((*firststrip)[i]/128)];   //works for both strip and pixel thanks to firstStrip encoding for pixel in the calibTree
 
@@ -668,23 +861,23 @@ void SiStripGainFromCalibTree::processEvent() {
 			if(Validation)     {ClusterChargeOverPath/=(*gainused)[i];}
 			if(OldGainRemoving){ClusterChargeOverPath*=(*gainused)[i];}
 		}
-		Charge_Vs_Index_Absolute->Fill(APV->Index,Charge);   
-		Charge_Vs_Index         ->Fill(APV->Index,ClusterChargeOverPath);
+		//(Charge_Vs_Index_Absolute[elepos])->Fill(APV->Index,Charge);   
+		(Charge_Vs_Index[elepos])         ->Fill(APV->Index,ClusterChargeOverPath);
 
-		if(APV->SubDet==StripSubdetector::TIB){ Charge_Vs_PathlengthTIB  ->Fill((*path)[i],Charge); 
-		}else if(APV->SubDet==StripSubdetector::TOB){ Charge_Vs_PathlengthTOB  ->Fill((*path)[i],Charge);
+		if(APV->SubDet==StripSubdetector::TIB){ (Charge_Vs_PathlengthTIB[elepos])  ->Fill((*path)[i],Charge); 
+		}else if(APV->SubDet==StripSubdetector::TOB){ (Charge_Vs_PathlengthTOB[elepos])  ->Fill((*path)[i],Charge);
 		}else if(APV->SubDet==StripSubdetector::TID){
-			if(APV->Eta<0){			  Charge_Vs_PathlengthTIDM ->Fill((*path)[i],Charge);
-			}else if(APV->Eta>0){                      Charge_Vs_PathlengthTIDP ->Fill((*path)[i],Charge);
+			if(APV->Eta<0){			  (Charge_Vs_PathlengthTIDM[elepos]) ->Fill((*path)[i],Charge);
+			}else if(APV->Eta>0){                      (Charge_Vs_PathlengthTIDP[elepos]) ->Fill((*path)[i],Charge);
 			}
 		}else if(APV->SubDet==StripSubdetector::TEC){
 			if(APV->Eta<0){
-				if(APV->Thickness<0.04){          Charge_Vs_PathlengthTECM1->Fill((*path)[i],Charge);
-				}else if(APV->Thickness>0.04){          Charge_Vs_PathlengthTECM2->Fill((*path)[i],Charge);
+				if(APV->Thickness<0.04){          (Charge_Vs_PathlengthTECM1[elepos])->Fill((*path)[i],Charge);
+				}else if(APV->Thickness>0.04){          (Charge_Vs_PathlengthTECM2[elepos])->Fill((*path)[i],Charge);
 				}
 			}else if(APV->Eta>0){
-				if(APV->Thickness<0.04){          Charge_Vs_PathlengthTECP1->Fill((*path)[i],Charge);
-				}else if(APV->Thickness>0.04){          Charge_Vs_PathlengthTECP2->Fill((*path)[i],Charge);
+				if(APV->Thickness<0.04){          (Charge_Vs_PathlengthTECP1[elepos])->Fill((*path)[i],Charge);
+				}else if(APV->Thickness>0.04){          (Charge_Vs_PathlengthTECP2[elepos])->Fill((*path)[i],Charge);
 				}
 			}
 		}
@@ -697,7 +890,8 @@ void SiStripGainFromCalibTree::algoAnalyzeTheTree()
 	for(unsigned int i=0;i<VInputFiles.size();i++){
 		printf("Openning file %3i/%3i --> %s\n",i+1, (int)VInputFiles.size(), (char*)(VInputFiles[i].c_str())); fflush(stdout);
 		TFile *tfile = TFile::Open(VInputFiles[i].c_str());
-		TTree* tree  = dynamic_cast<TTree*> (tfile->Get(tree_path_.c_str()));
+                TString tree_path = TString::Format("gainCalibrationTree%s/tree",m_calibrationMode.c_str());
+		TTree* tree  = dynamic_cast<TTree*> (tfile->Get(tree_path.Data()));
 
 		tree->SetBranchAddress((EventPrefix_ + "event"          + EventSuffix_).c_str(), &eventnumber   , NULL);
 		tree->SetBranchAddress((EventPrefix_ + "run"            + EventSuffix_).c_str(), &runnumber     , NULL);
@@ -709,6 +903,7 @@ void SiStripGainFromCalibTree::algoAnalyzeTheTree()
 		tree->SetBranchAddress((TrackPrefix_ + "eta"            + TrackSuffix_).c_str(), &tracketa      , NULL);
 		tree->SetBranchAddress((TrackPrefix_ + "phi"            + TrackSuffix_).c_str(), &trackphi      , NULL);
 		tree->SetBranchAddress((TrackPrefix_ + "hitsvalid"      + TrackSuffix_).c_str(), &trackhitsvalid, NULL);
+                tree->SetBranchAddress((TrackPrefix_ + "algo"           + TrackSuffix_).c_str(), &trackalgo     , NULL);
 
 		tree->SetBranchAddress((CalibPrefix_ + "trackindex"     + CalibSuffix_).c_str(), &trackindex    , NULL);
 		tree->SetBranchAddress((CalibPrefix_ + "rawid"          + CalibSuffix_).c_str(), &rawid         , NULL);
@@ -748,7 +943,17 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
 	double FitResults[6];
 	double MPVmean = 300;
 
-	TH2F *chvsidx = Charge_Vs_Index->getTH2F();
+        int elepos = statCollectionFromMode(m_calibrationMode.c_str());
+
+        if ( Charge_Vs_Index[elepos]==0 ) {
+            edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not execute algoComputeMPVandGain method because "
+                                                      << m_calibrationMode.c_str() << " statistics cannot be retrieved.\n"
+                                                      << "Please check if input contains " 
+                                                      << m_calibrationMode.c_str() << " data." << std::endl;
+            return;
+        }
+
+        TH2F *chvsidx = (Charge_Vs_Index[elepos])->getTH2F();
 
 
 	printf("Progressing Bar              :0%%       20%%       40%%       60%%       80%%       100%%\n");
@@ -883,6 +1088,8 @@ void SiStripGainFromCalibTree::storeOnTree(TFileService* tfs)
 	fprintf(Gains,"Number of Pixel Dets = %lu\n",static_cast<unsigned long>(NPixelDets));
 	fprintf(Gains,"GoodFits = %i BadFits = %i ratio = %f%%   (MASKED=%i)\n",GOOD,BAD,(100.0*GOOD)/(GOOD+BAD), MASKED);
 
+        int elepos = statCollectionFromMode(m_calibrationMode.c_str());
+
 	for(unsigned int a=0;a<APVsCollOrdered.size();a++){
 		stAPVGain* APV = APVsCollOrdered[a];
 		if(APV==NULL)continue;
@@ -890,7 +1097,7 @@ void SiStripGainFromCalibTree::storeOnTree(TFileService* tfs)
 		fprintf(Gains,"%i | %i | PreviousGain = %7.5f(tick) x %7.5f(particle) NewGain (particle) = %7.5f (#clusters=%8.0f)\n", APV->DetId,APV->APVId,APV->PreviousGainTick, APV->PreviousGain,APV->Gain, APV->NEntries);
 
 		tree_Index      = APV->Index;
-		tree_Bin        = Charge_Vs_Index->getTH2F()->GetXaxis()->FindBin(APV->Index);
+		tree_Bin        = (Charge_Vs_Index[elepos])->getTH2F()->GetXaxis()->FindBin(APV->Index);
 		tree_DetId      = APV->DetId;
 		tree_APVId      = APV->APVId;
 		tree_SubDet     = APV->SubDet;
@@ -928,22 +1135,38 @@ void SiStripGainFromCalibTree::storeOnTree(TFileService* tfs)
 
 bool SiStripGainFromCalibTree::produceTagFilter(){
   
-	// The goal of this function is to check wether or not there is enough statistics to produce a meaningful tag for the DB or not 
-  if(Charge_Vs_Index->getTH2F()->Integral(0,NStripAPVs+1, 0, 99999 ) < tagCondition_NClusters) {
-    edm::LogWarning("SiStripGainFromCalibTree")<< "produceTagFilter -> Return false: Statistics is too low : " << Charge_Vs_Index->getTH2F()->Integral() << endl;
-    return false;
-  }
-  if((1.0 * GOOD) / (GOOD+BAD) < tagCondition_GoodFrac) {
-    edm::LogWarning("SiStripGainFromCalibTree")<< "produceTagFilter ->  Return false: ratio of GOOD/TOTAL is too low: " << (1.0 * GOOD) / (GOOD+BAD) << endl;
-    return false;
-  }
-  return true; 
+    // The goal of this function is to check wether or not there is enough statistics
+    // to produce a meaningful tag for the DB
+    int elepos     = statCollectionFromMode(m_calibrationMode.c_str());
+    if( Charge_Vs_Index[elepos]==0 ) {
+        edm::LogError("SiStripGainFromCalibTree") << "produceTagFilter -> Return false: could not retrieve the "
+                                                  << m_calibrationMode.c_str() << " statistics.\n"
+                                                  << "Please check if input contains " 
+                                                  << m_calibrationMode.c_str() << " data." << std::endl;
+        return false; 
+    }
+
+
+    float integral = (Charge_Vs_Index[elepos])->getTH2F()->Integral();
+    if( (Charge_Vs_Index[elepos])->getTH2F()->Integral(0,NStripAPVs+1, 0, 99999 ) < tagCondition_NClusters) {
+        edm::LogWarning("SiStripGainFromCalibTree") 
+                                     << "calibrationMode  -> " << m_calibrationMode << "\n"
+                                     << "produceTagFilter -> Return false: Statistics is too low : " << integral << endl;
+        return false;
+    }
+    if((1.0 * GOOD) / (GOOD+BAD) < tagCondition_GoodFrac) {
+        edm::LogWarning("SiStripGainFromCalibTree")
+              << "calibrationMode  -> " << m_calibrationMode << "\n"
+              << "produceTagFilter ->  Return false: ratio of GOOD/TOTAL is too low: " << (1.0 * GOOD) / (GOOD+BAD) << endl;
+        return false;
+    }
+    return true; 
 }
 
 SiStripApvGain* SiStripGainFromCalibTree::getNewObject() 
 {
 	SiStripApvGain* obj = new SiStripApvGain();
-	if(!harvestingMode) return obj;
+	if(!m_harvestingMode) return obj;
 
 	if(!produceTagFilter()){
 		edm::LogWarning("SiStripGainFromCalibTree")<< "getNewObject -> will not produce a paylaod because produceTagFilter returned false " << endl;       
@@ -1006,7 +1229,7 @@ void
 SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   // in AlCaHarvesting mode we just need to run the logic in the endJob step
-  if(harvestingMode) return;
+  if(m_harvestingMode) return;
   
 	if(AlgoMode=="CalibTree")return;
 
@@ -1035,6 +1258,8 @@ SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::Event
 	auto handle23 = connect(amplitude     , amplitude_token_     , iEvent);
 	auto handle24 = connect(gainused      , gainused_token_      , iEvent);
 
+        auto handle25 = connect(trackalgo     , trackalgo_token_     , iEvent);
+     
 	processEvent();
 }
 

--- a/CalibTracker/SiStripChannelGain/python/ntuple_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/ntuple_cff.py
@@ -3,6 +3,17 @@ import FWCore.ParameterSet.Config as cms
 from CalibTracker.SiStripCommon.ShallowEventDataProducer_cfi import *
 from CalibTracker.SiStripCommon.ShallowTracksProducer_cfi import *
 from CalibTracker.SiStripCommon.ShallowGainCalibration_cfi import *
+from CalibTracker.SiStripCommon.SiStripBFieldFilter_cfi import *
+
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import *
+IsolatedBunch = triggerResultsFilter.clone(
+#                     triggerConditions = cms.vstring("HLT_ZeroBias_*"),
+                      triggerConditions = cms.vstring("HLT_ZeroBias_IsolatedBunches_*"),
+                      hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                      l1tResults = cms.InputTag( "" ),
+                      throw = cms.bool(False)
+                   )
+
 
 OfflineChannelGainOutputCommands =  [
                                      'keep *_shallowEventRun_*_*',
@@ -12,14 +23,53 @@ OfflineChannelGainOutputCommands =  [
                                      'keep *_shallowTracks_tracketa_*',
                                      'keep *_shallowTracks_trackphi_*',
                                      'keep *_shallowTracks_trackhitsvalid_*',
+                                     'keep *_shallowTracks_trackalgo_*',
                                      'keep *_shallowGainCalibration_*_*'
                                     ]
 
-gainCalibrationTree = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
-gainCalibrationTree.outputCommands += OfflineChannelGainOutputCommands
+gainCalibrationTreeIsoBunch   = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
+gainCalibrationTreeIsoBunch.outputCommands += OfflineChannelGainOutputCommands
 
-OfflineGainNtuple = cms.Sequence( (shallowEventRun+
-                        shallowTracks +
-                        shallowGainCalibration) *
-                        gainCalibrationTree
-                       )
+gainCalibrationTreeIsoBunch0T = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
+gainCalibrationTreeIsoBunch0T.outputCommands += OfflineChannelGainOutputCommands
+
+gainCalibrationTreeAllBunch = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
+gainCalibrationTreeAllBunch.outputCommands += OfflineChannelGainOutputCommands
+
+gainCalibrationTreeAllBunch0T = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
+gainCalibrationTreeAllBunch0T.outputCommands += OfflineChannelGainOutputCommands
+
+
+OfflineGainNtuple_AllBunch = cms.Sequence( siStripBFieldOnFilter + 
+                                          (shallowEventRun +
+                                           shallowTracks +
+                                           shallowGainCalibration) *
+                                          gainCalibrationTreeAllBunch
+                                         )
+
+OfflineGainNtuple_AllBunch0T = cms.Sequence( siStripBFieldOffFilter + 
+                                            (shallowEventRun +
+                                             shallowTracks +
+                                             shallowGainCalibration) *
+                                            gainCalibrationTreeAllBunch0T
+                                           )
+
+OfflineGainNtuple_IsoBunch = cms.Sequence( siStripBFieldOnFilter + IsolatedBunch +
+                                          (shallowEventRun +
+                                           shallowTracks +
+                                           shallowGainCalibration) *
+                                          gainCalibrationTreeIsoBunch
+                                         )
+
+OfflineGainNtuple_IsoBunch0T = cms.Sequence( siStripBFieldOffFilter + IsolatedBunch +
+                                            (shallowEventRun +
+                                             shallowTracks +
+                                             shallowGainCalibration) *
+                                            gainCalibrationTreeIsoBunch0T
+                                           )
+
+#OfflineGainNtuple = cms.Sequence( (shallowEventRun+
+#                        shallowTracks +
+#                        shallowGainCalibration) *
+#                        gainCalibrationTree
+#                       )

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/Gains_Compute_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/Gains_Compute_cfg.py
@@ -34,11 +34,13 @@ process.load("CalibTracker.SiStripChannelGain.computeGain_cff")
 process.SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
 process.SiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 process.SiStripCalib.saveSummary         = cms.untracked.bool(True)
+process.SiStripCalib.calibrationMode     = cms.untracked.string( 'XXX_CALMODE_XXX' )
 
 
 if(XXX_PCL_XXX):
    process.SiStripCalib.AlgoMode = cms.untracked.string('PCL')
    process.SiStripCalib.harvestingMode = cms.untracked.bool(True)
+   process.SiStripCalib.splitDQMstat   = cms.untracked.bool(True)
    process.source = cms.Source("PoolSource",
        secondaryFileNames = cms.untracked.vstring(),
        fileNames = calibTreeList,
@@ -79,18 +81,31 @@ if(XXX_PCL_XXX):
    process.dqmSaver.convention = 'Offline'
    process.dqmSaver.workflow = '/Express/PCLTest/ALCAPROMPT'
 
-   process.EDMtoMEConvert = cms.EDAnalyzer("EDMtoMEConverter",
-       Frequency = cms.untracked.int32(50),
-       Name = cms.untracked.string('EDMtoMEConverter'),
-       Verbosity = cms.untracked.int32(0),
-       convertOnEndLumi = cms.untracked.bool(True),
-       convertOnEndRun = cms.untracked.bool(True),
-       lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterLumi"),
-       runInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterRun")
-   )
+   from DQMServices.Components.EDMtoMEConverter_cfi import *
 
-   process.p = cms.Path(process.EDMtoMEConvert * process.SiStripCalib * process.dqmSaver) 
+   process.EDMtoMEConvertSiStripGainsAllBunch = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsAllBunch.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsAllBunch.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch","MEtoEDMConverterRun")
 
+   process.EDMtoMEConvertSiStripGainsAllBunch0T = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsAllBunch0T.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch0T","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsAllBunch0T.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch0T","MEtoEDMConverterRun")
+
+   process.EDMtoMEConvertSiStripGainsIsoBunch = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsIsoBunch.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsIsoBunch.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch","MEtoEDMConverterRun")
+
+   process.EDMtoMEConvertSiStripGainsIsoBunch0T = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsIsoBunch0T.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch0T","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsIsoBunch0T.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch0T","MEtoEDMConverterRun")
+
+
+   ConvertersSiStripGains = cms.Sequence( process.EDMtoMEConvertSiStripGainsAllBunch +
+                                          process.EDMtoMEConvertSiStripGainsAllBunch0T +
+                                          process.EDMtoMEConvertSiStripGainsIsoBunch +
+                                          process.EDMtoMEConvertSiStripGainsIsoBunch0T)
+
+   process.p = cms.Path( ConvertersSiStripGains * process.SiStripCalib * process.dqmSaver)
 
 else:
    process.p = cms.Path(process.SiStripCalib)

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/PlotMacro.C
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/PlotMacro.C
@@ -7,6 +7,7 @@
 #include "TMath.h"
 #include "TLegend.h"
 #include "TGraph.h"
+#include "TString.h"
 #include "TH1.h"
 #include "TH2.h"
 #include "TH3.h"
@@ -33,20 +34,21 @@ using namespace edm;
 
 
 
-void PlotMacro_Core(string input, string moduleName, string output, string TextToPrint);
+void PlotMacro_Core(string input, string moduleName, string modeName, string output, string TextToPrint);
 TF1*  getLandau(TH1* InputHisto, double* FitResults, double LowRange=50, double HighRange=5400);
 TH1D* ChargeToMPV(TH2* InputHisto, string Name, bool DivideByX);
 
 
 
-void PlotMacro(string TextToPrint_="CMS Preliminary 2015"){
+void PlotMacro(string modeName="IsoBunch", string TextToPrint_="CMS Preliminary 2015"){
    system("mkdir Pictures");
-   PlotMacro_Core("file:Gains_Tree.root"     , "SiStripCalib/"          , "Pictures/Gains"     , TextToPrint_ + "  -  Particle Gain");
-   PlotMacro_Core("file:Validation_Tree.root", "SiStripCalibValidation/", "Pictures/Validation", TextToPrint_ + "  -  Gain Validation");
+   printf("Plotting histograms for %s calibration", modeName.c_str());   
+   PlotMacro_Core("file:Gains_Tree.root"     , "SiStripCalib/"          , modeName, "Pictures/Gains"     , TextToPrint_ + "  -  Particle Gain");
+   PlotMacro_Core("file:Validation_Tree.root", "SiStripCalibValidation/", modeName, "Pictures/Validation", TextToPrint_ + "  -  Gain Validation");
 }
 
 
-void PlotMacro_Core(string input, string moduleName, string output, string TextToPrint)
+void PlotMacro_Core(string input, string moduleName, string modeName, string output, string TextToPrint)
 {
    FILE* pFile;
    TCanvas* c1;
@@ -79,6 +81,8 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
    TFile* f1     = new TFile(input.c_str());
    TTree *t1     = (TTree*)GetObjectFromPath(f1,moduleName+"APVGain");
 
+   if(t1==0) return;
+
    t1->SetBranchAddress("Index"             ,&tree_Index      );
    t1->SetBranchAddress("DetId"             ,&tree_DetId      );
    t1->SetBranchAddress("APVId"             ,&tree_APVId      );
@@ -102,20 +106,19 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
    t1->SetBranchAddress("NEntries"          ,&tree_NEntries   );
    t1->SetBranchAddress("isMasked"          ,&tree_isMasked   );
 
+   TH2D* ChargeDistrib  = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_Index_"+modeName);
+   //TH2D* ChargeDistribA = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_Index_Absolute_"+modeName);
 
-   TH2D* ChargeDistrib  = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_Index");
-   TH2D* ChargeDistribA = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_Index_Absolute");
-
-   TH2D* Charge_Vs_PathlengthTIB   = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTIB");
-   TH2D* Charge_Vs_PathlengthTOB   = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTOB");
-   TH2D* Charge_Vs_PathlengthTIDP  = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTIDP");
-   TH2D* Charge_Vs_PathlengthTIDM  = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTIDM");
+   TH2D* Charge_Vs_PathlengthTIB   = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTIB_"+modeName);
+   TH2D* Charge_Vs_PathlengthTOB   = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTOB_"+modeName);
+   TH2D* Charge_Vs_PathlengthTIDP  = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTIDP_"+modeName);
+   TH2D* Charge_Vs_PathlengthTIDM  = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTIDM_"+modeName);
    TH2D* Charge_Vs_PathlengthTID   = (TH2D*)Charge_Vs_PathlengthTIDP->Clone("Charge_Vs_PathlengthTID");
          Charge_Vs_PathlengthTID      ->Add(Charge_Vs_PathlengthTIDM);
-   TH2D* Charge_Vs_PathlengthTECP1 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECP1");
-   TH2D* Charge_Vs_PathlengthTECP2 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECP2");
-   TH2D* Charge_Vs_PathlengthTECM1 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECM1");
-   TH2D* Charge_Vs_PathlengthTECM2 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECM2");
+   TH2D* Charge_Vs_PathlengthTECP1 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECP1_"+modeName);
+   TH2D* Charge_Vs_PathlengthTECP2 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECP2_"+modeName);
+   TH2D* Charge_Vs_PathlengthTECM1 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECM1_"+modeName);
+   TH2D* Charge_Vs_PathlengthTECM2 = (TH2D*)GetObjectFromPath(f1,moduleName+"Charge_Vs_PathlengthTECM2_"+modeName);
    TH2D* Charge_Vs_PathlengthTECP  = (TH2D*)Charge_Vs_PathlengthTECP1->Clone("Charge_Vs_PathlengthTECP");
          Charge_Vs_PathlengthTECP     ->Add(Charge_Vs_PathlengthTECP2);
    TH2D* Charge_Vs_PathlengthTECM  = (TH2D*)Charge_Vs_PathlengthTECM1->Clone("Charge_Vs_PathlengthTECM");
@@ -219,7 +222,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
    TH1D* ChargeTECP2    = new TH1D("ChargeTECP2"   ,"ChargeTECP2"   ,               2000, 0,4000);
    TH1D* ChargeTECM1    = new TH1D("ChargeTECM1"   ,"ChargeTECM1"   ,               2000, 0,4000);
    TH1D* ChargeTECM2    = new TH1D("ChargeTECM2"   ,"ChargeTECM2"   ,               2000, 0,4000);
-
+/*
    TH1D* ChargeAbsPIB   = new TH1D("ChargeAbsPIB"  ,"ChargeAbsPIB"  ,               1000, 0,4000);
    TH1D* ChargeAbsPIE   = new TH1D("ChargeAbsPIE"  ,"ChargeAbsPIE"  ,               1000, 0,4000);
    TH1D* ChargeAbsTIB   = new TH1D("ChargeAbsTIB"  ,"ChargeAbsTIB"  ,               1000, 0,4000);
@@ -236,7 +239,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
    TH1D* ChargeAbsTECP2 = new TH1D("ChargeAbsTECP2","ChargeAbsTECP2",               1000, 0,4000);
    TH1D* ChargeAbsTECM1 = new TH1D("ChargeAbsTECM1","ChargeAbsTECM1",               1000, 0,4000);
    TH1D* ChargeAbsTECM2 = new TH1D("ChargeAbsTECM2","ChargeAbsTECM2",               1000, 0,4000);
-
+*/
    TH1D* DiffWRTPrevGainPIB      = new TH1D("DiffWRTPrevGainPIB"     ,"DiffWRTPrevGainPIB"     ,               250, 0,2);
    TH1D* DiffWRTPrevGainPIE      = new TH1D("DiffWRTPrevGainPIE"     ,"DiffWRTPrevGainPIE"     ,               250, 0,2);
    TH1D* DiffWRTPrevGainTIB      = new TH1D("DiffWRTPrevGainTIB"     ,"DiffWRTPrevGainTIB"     ,               250, 0,2);
@@ -260,7 +263,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
 
       int bin = ChargeDistrib->GetXaxis()->FindBin(tree_Index);
       TH1D* Proj         = ChargeDistrib ->ProjectionY("proj" ,bin, bin);
-      TH1D* ProjAbsolute = ChargeDistribA->ProjectionY("projA",bin, bin);
+      //TH1D* ProjAbsolute = ChargeDistribA->ProjectionY("projA",bin, bin);
 
       if(tree_SubDet>=3 && tree_FitMPV<0      ) NoMPV         ->Fill(tree_z ,tree_R);
       if(tree_SubDet>=3 && tree_FitMPV>=0){
@@ -321,7 +324,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
       if(tree_SubDet==6 && tree_Eta<0 && tree_Thickness>0.04) ChargeTECM2 ->Add(Proj,1);
       if(tree_SubDet==6 && tree_Eta>0 && tree_Thickness<0.04) ChargeTECP1 ->Add(Proj,1);
       if(tree_SubDet==6 && tree_Eta>0 && tree_Thickness>0.04) ChargeTECP2 ->Add(Proj,1);
-
+/*
       if(tree_SubDet==1                       ) ChargeAbsPIB  ->Add(ProjAbsolute,1);
       if(tree_SubDet==2                       ) ChargeAbsPIE  ->Add(ProjAbsolute,1);
       if(tree_SubDet==3                       ) ChargeAbsTIB  ->Add(ProjAbsolute,1);
@@ -338,7 +341,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
       if(tree_SubDet==6 && tree_Eta<0 && tree_Thickness>0.04) ChargeAbsTECM2 ->Add(ProjAbsolute,1);
       if(tree_SubDet==6 && tree_Eta>0 && tree_Thickness<0.04) ChargeAbsTECP1 ->Add(ProjAbsolute,1);
       if(tree_SubDet==6 && tree_Eta>0 && tree_Thickness>0.04) ChargeAbsTECP2 ->Add(ProjAbsolute,1);
-
+*/
       if(tree_SubDet==1                       ) DiffWRTPrevGainPIB  ->Fill(tree_Gain/tree_PrevGain);
       if(tree_SubDet==2                       ) DiffWRTPrevGainPIE  ->Fill(tree_Gain/tree_PrevGain);
       if(tree_SubDet==3                       ) DiffWRTPrevGainTIB  ->Fill(tree_Gain/tree_PrevGain);
@@ -357,7 +360,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
 
 
       delete Proj;
-      delete ProjAbsolute;
+      //delete ProjAbsolute;
    }printf("\n");
 
 
@@ -820,7 +823,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
     DrawPreliminary(TextToPrint);
     SaveCanvas(c1,output,"ChargeTIDSide");
     delete c1;
-
+/*
     c1 = new TCanvas("c1","c1,",600,600);          legend.clear();
     Histos[0] = ChargeAbsPIB;                      legend.push_back("PIB");
     Histos[1] = ChargeAbsPIE;                      legend.push_back("PIE");
@@ -872,7 +875,7 @@ void PlotMacro_Core(string input, string moduleName, string output, string TextT
     DrawPreliminary(TextToPrint);
     SaveCanvas(c1,output,"ChargeAbsTIDSide");
     delete c1;
-
+*/
 
     c1 = new TCanvas("c1","c1,",600,600);          legend.clear();
     Histos[0] = MPV_Vs_PathlengthThin;             legend.push_back("320 #mum");

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/Validation_Compute_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/Validation_Compute_cfg.py
@@ -34,11 +34,13 @@ process.load("CalibTracker.SiStripChannelGain.computeGain_cff")
 process.SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
 process.SiStripCalibValidation.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 process.SiStripCalibValidation.saveSummary         = cms.untracked.bool(True)
+process.SiStripCalibValidation.calibrationMode     = cms.untracked.string( 'XXX_CALMODE_XXX' )
 
 
 if(XXX_PCL_XXX):
    process.SiStripCalibValidation.AlgoMode = cms.untracked.string('PCL')
    process.SiStripCalibValidation.harvestingMode = cms.untracked.bool(True)
+   process.SiStripCalibValidation.splitDQMstat   = cms.untracked.bool(True)
    process.source = cms.Source("PoolSource",
        secondaryFileNames = cms.untracked.vstring(),
        fileNames = calibTreeList,
@@ -64,17 +66,33 @@ if(XXX_PCL_XXX):
    process.dqmSaver.convention = 'Offline'
    process.dqmSaver.workflow = '/Express/PCLTest/ALCAPROMPT'
 
-   process.EDMtoMEConvert = cms.EDAnalyzer("EDMtoMEConverter",
-       Frequency = cms.untracked.int32(50),
-       Name = cms.untracked.string('EDMtoMEConverter'),
-       Verbosity = cms.untracked.int32(0),
-       convertOnEndLumi = cms.untracked.bool(True),
-       convertOnEndRun = cms.untracked.bool(True),
-       lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterLumi"),
-       runInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterRun")
-   )
+   from DQMServices.Components.EDMtoMEConverter_cfi import *
 
-   process.p = cms.Path(process.EDMtoMEConvert * process.SiStripCalibValidation * process.dqmSaver) 
+   process.EDMtoMEConvertSiStripGainsAllBunch = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsAllBunch.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsAllBunch.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch","MEtoEDMConverterRun")
+
+   process.EDMtoMEConvertSiStripGainsAllBunch0T = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsAllBunch0T.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch0T","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsAllBunch0T.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch0T","MEtoEDMConverterRun")
+
+   process.EDMtoMEConvertSiStripGainsIsoBunch = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsIsoBunch.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsIsoBunch.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch","MEtoEDMConverterRun")
+
+   process.EDMtoMEConvertSiStripGainsIsoBunch0T = EDMtoMEConverter.clone()
+   process.EDMtoMEConvertSiStripGainsIsoBunch0T.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch0T","MEtoEDMConverterLumi")
+   process.EDMtoMEConvertSiStripGainsIsoBunch0T.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch0T","MEtoEDMConverterRun")
+
+
+
+   ConvertersSiStripGains = cms.Sequence( process.EDMtoMEConvertSiStripGainsAllBunch +
+                                          process.EDMtoMEConvertSiStripGainsAllBunch0T +
+                                          process.EDMtoMEConvertSiStripGainsIsoBunch +
+                                          process.EDMtoMEConvertSiStripGainsIsoBunch0T)
+
+   process.p = cms.Path( ConvertersSiStripGains * process.SiStripCalibValidation * process.dqmSaver)
+
 else:
    process.p = cms.Path(process.SiStripCalibValidation)
 

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree.py
@@ -9,10 +9,10 @@ import urllib
 import string
 import optparse
 
-def numberOfEvents(file):
+def numberOfEvents(file,mode):
 	rootfile = ROOT.TFile.Open(file,'read')
 	tree = ROOT.TTree()
-	rootfile.GetObject("gainCalibrationTree/tree",tree)
+	rootfile.GetObject("gainCalibrationTree%s/tree"%mode,tree)
         NEntries = tree.GetEntries()
         rootfile.Close()
         print file +' --> '+str(NEntries)
@@ -21,6 +21,7 @@ def numberOfEvents(file):
 
 PCLDATASET = '/StreamExpress/Run2015C-PromptCalibProdSiStripGains-Express-v1/ALCAPROMPT' #used if usePCL==True
 CALIBTREEPATH = '/store/group/dpg_tracker_strip/comm_tracker/Strip/Calibration/calibrationtree/GR15' #used if usePCL==False
+#CALIBTREEPATH = '/store/caf/user/dimattia/CALIB'
 #CALIBTREEPATH = "/castor/cern.ch/user/m/mgalanti/calibrationtree/GR12"
 #CALIBTREEPATH = "/castor/cern.ch/user/m/mgalanti/calibrationtree/GR11"
 
@@ -35,15 +36,17 @@ parser.add_option('-f', '--firstRun'   ,    dest='firstRun'           , help='fi
 parser.add_option('-l', '--lastRun'    ,    dest='lastRun'            , help='last run to process (-1 --> automatic)'   , default='-1')
 parser.add_option('-P', '--publish'    ,    dest='publish'            , help='publish the results'                      , default='True')
 parser.add_option('-p', '--pcl'        ,    dest='usePCL'             , help='use PCL output instead of calibTree'      , default='True')
+parser.add_option('-m', '--mode'       ,    dest='calMode'            , help='select the statistics type'      , default='')
 (opt, args) = parser.parse_args()
 
 scriptDir = os.getcwd()
-globaltag = "74X_dataRun2_Express_v0" # "GR_E_V49" #"GR_P_V53" V56
+globaltag = "auto:run2_data" # "GR_E_V49" #"GR_P_V53" V56
 firstRun = int(opt.firstRun)
 lastRun  = int(opt.lastRun)
+calMode  = str(opt.calMode)
 MC=""
 publish = (opt.publish=='True')
-mail = "loic.quertenmont@gmail.com"
+mail = "dimattia@cern.ch"
 automatic = True;
 usePCL = (opt.usePCL=='True')
 maxNEvents = 2000000
@@ -55,6 +58,7 @@ print "firstRun = " +str(firstRun)
 print "lastRun  = " +str(lastRun)
 print "publish  = " +str(publish)
 print "usePCL   = " +str(usePCL)
+print "calMode  = " + calMode
 
 
 
@@ -113,23 +117,29 @@ if(usePCL==True):
       print("Current number of events to process is " + str(NTotalEvents))
       if(automatic==True and NTotalEvents >= maxNEvents):break;
 else:
-   print("Get the list of calibTree from castor (cmsLs" + CALIBTREEPATH + ")")
-   calibTreeInfo = commands.getstatusoutput("cmsLs "+CALIBTREEPATH)[1].split('\n');
-   calibTreeInfo.sort()
-   print("Check the number of events available");
-   for info in calibTreeInfo:
+   print("Get the list of calibTree from castor (eos ls " + CALIBTREEPATH + ")")
+   calibTreeInfo = commands.getstatusoutput("/afs/cern.ch/project/eos/installation/0.3.84-aquamarine/bin/eos.select ls -l "+CALIBTREEPATH)[1].split('\n');
+
+   # collect the list of runs and file size
+   # calibTreeInfo.split()[8] - file name
+   # calibTreeInfo.split()[4] - file size
+   info_list = [(i.split()[8],
+                 int( i.split()[8].replace("calibTree_","").replace(".root","").split('_')[0] ),
+                 int( i.split()[4] )/1048576 ) for i in calibTreeInfo]
+   info_list.sort( key=lambda tup: tup[1] )
+
+   print("Check the number of events available")
+   for info in info_list:
       if(len(info)<1):continue;
-      subParts = info.split();        
-      size = int(subParts[1])/1048576;
+      size = info[2]
       if(size < 10): continue	#skip file<10MB
-      runS = subParts[4].replace(CALIBTREEPATH+'/',"").replace("calibTree_","").replace(".root","")
-      run = int(runS.split('_')[0])
+      run = info[1]
       if(run<firstRun or run in runsToVeto):continue
       if(lastRun>0 and run>lastRun):continue
-      NEvents = numberOfEvents("root://eoscms//eos/cms"+subParts[4]);	
+      NEvents = numberOfEvents("root://eoscms//eos/cms"+CALIBTREEPATH+'/'+info[0],calMode);	
       if(NEvents<=3000):continue #only keep runs with at least 3K events
       if(FileList==""):firstRun=run;
-      FileList += 'calibTreeList.extend(["root://eoscms//eos/cms'+subParts[4]+'"]) #' + str(size).rjust(6)+'MB  NEvents='+str(NEvents/1000).rjust(8)+'K\n'
+      FileList += 'calibTreeList.extend(["root://eoscms//eos/cms'+CALIBTREEPATH+'/'+info[0]+'"]) #' + str(size).rjust(6)+'MB  NEvents='+str(NEvents/1000).rjust(8)+'K\n'
       NTotalEvents += NEvents;
       print("Current number of events to process is " + str(NTotalEvents))
       if(automatic==True and NTotalEvents >= maxNEvents):break;
@@ -138,12 +148,13 @@ else:
 if(lastRun<=0):lastRun = run
 
 print "RunRange=[" + str(firstRun) + "," + str(lastRun) + "] --> NEvents=" + str(NTotalEvents/1000)+"K"
-if(automatic==True and NTotalEvents<500000):	#ask at least 500K events to perform the calibration
+if(automatic==True and NTotalEvents<1000000):	#ask at least 1M events to perform the calibration
 	print 'Not Enough events to run the calibration'
         os.system('echo "Gain calibration postponed" | mail -s "Gain calibration postponed ('+str(firstRun)+' to '+str(lastRun)+') NEvents=' + str(NTotalEvents/1000)+'K" ' + mail)
 	exit(0);
 
-name = "Run_"+str(firstRun)+"_to_"+str(lastRun); 
+name = "Run_"+str(firstRun)+"_to_"+str(lastRun)
+if len(calMode)>0:  name = name+"_"+calMode
 if(usePCL==True):   name = name+"_PCL"
 else:               name = name+"_CalibTree"
 
@@ -162,8 +173,9 @@ os.system("sed -i 's|XXX_FIRSTRUN_XXX|"+str(firstRun)+"|g' "+newDirectory+"/*_cf
 os.system("sed -i 's|XXX_LASTRUN_XXX|"+str(lastRun)+"|g' "+newDirectory+"/*_cfg.py")
 os.system("sed -i 's|XXX_GT_XXX|"+globaltag+"|g' "+newDirectory+"/*_cfg.py")
 os.system("sed -i 's|XXX_PCL_XXX|"+str(usePCL)+"|g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's|XXX_CALMODE_XXX|"+calMode+"|g' "+newDirectory+"/*_cfg.py")
 os.chdir(newDirectory);
-if(os.system("sh sequence.sh \"" + name + "\" \"CMS Preliminary  -  Run " + str(firstRun) + " to " + str(lastRun) + "\"")!=0):
+if(os.system("sh sequence.sh \"" + name + "\" \"" + calMode + "\" \"CMS Preliminary  -  Run " + str(firstRun) + " to " + str(lastRun) + "\"")!=0):
 	os.system('echo "Gain calibration failed" | mail -s "Gain calibration failed ('+name+')" ' + mail)        
 else:
 	if(publish==True):os.system("sh sequence.sh " + name);

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/sequence.sh
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/sequence.sh
@@ -47,8 +47,9 @@ if [ "$#" != '1' ]; then
    if [ "$#" == '0' ]; then
       sh PlotMacro.sh
    fi
-   if [ "$#" == '2' ]; then
-      sh PlotMacro.sh "\"$2\""
+
+   if [ "$#" == '3' ]; then
+      sh PlotMacro.sh "\"$2\"" "\"$3\""
    fi
 else
    WORKDIR=$PWD

--- a/CalibTracker/SiStripChannelGain/test/PCL/step3_ALCA.py
+++ b/CalibTracker/SiStripChannelGain/test/PCL/step3_ALCA.py
@@ -20,24 +20,38 @@ process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 #process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
-#process.ALCARECOCalibrationTracks.src = cms.InputTag("ALCARECOSiStripCalMinBias")
-process.ALCARECOCalibrationTracks.src = cms.InputTag("generalTracks")
+process.ALCARECOCalibrationTracks.src = cms.InputTag("ALCARECOSiStripCalMinBias")
+#process.ALCARECOCalibrationTracks.src = cms.InputTag("generalTracks")    #for 2012 data
 
-#process.ALCARECOCalMinBiasFilterForSiStripGains.HLTPaths = cms.vstring('pathALCARECOSiStripCalMinBias')
-process.ALCARECOCalMinBiasFilterForSiStripGains.HLTPaths = cms.vstring('*')
+process.ALCARECOCalMinBiasFilterForSiStripGains.HLTPaths = cms.vstring('pathALCARECOSiStripCalMinBias')
+#process.ALCARECOCalMinBiasFilterForSiStripGains.HLTPaths = cms.vstring('*')     #for 2012 data
 
 
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(-1)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-         '/store/relval/CMSSW_7_5_0_pre4/RelValMinBias_13/GEN-SIM-RECO/MCRUN2_75_V1-v1/00000/0ECACE0E-EBF5-E411-9B86-0025905A6136.root')
+      "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60007/869EE593-1FAB-E511-AF99-0025905A60B4.root",
+      "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/0C35C6BF-D3AA-E511-9BC9-0CC47A4C8E16.root",
+      "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/38B847F9-05AA-E511-AB78-00259074AE82.root",
+      "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/D0BAD20B-09AB-E511-B073-0026189438F6.root",
+      "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/DEFA8704-CCAA-E511-8203-0CC47A4D7634.root",
+      "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/FE24690A-2DAA-E511-A96A-00259074AE3E.root"
+    )
 )
+
+# Uncomment to turn on verbosity output
+#process.load("FWCore.MessageLogger.MessageLogger_cfi")
+#process.MessageLogger.threshold = cms.untracked.string('INFO')
+#process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+#process.MessageLogger.debugModules = cms.untracked.vstring("*")
+#process.MessageLogger.destinations = cms.untracked.vstring('cout')
+#process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
 
 process.options = cms.untracked.PSet(
 
@@ -54,13 +68,11 @@ process.configurationMetadata = cms.untracked.PSet(
 
 
 # Additional output definition
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGains_Output_cff import *
+
 process.ALCARECOStreamPromptCalibProdSiStripGains = cms.OutputModule("PoolOutputModule",
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')
-    ),
-    outputCommands = cms.untracked.vstring('drop *', 
-        'keep *_alcaBeamSpotProducer_*_*', 
-        'keep *_MEtoEDMConvertSiStripGains_*_*'),
+    SelectEvents   = OutALCARECOPromptCalibProdSiStripGains.SelectEvents,
+    outputCommands = OutALCARECOPromptCalibProdSiStripGains.outputCommands,
     fileName = cms.untracked.string('PromptCalibProdSiStripGains.root'),
     dataset = cms.untracked.PSet(
         filterName = cms.untracked.string('PromptCalibProdSiStripGains'),
@@ -71,12 +83,18 @@ process.ALCARECOStreamPromptCalibProdSiStripGains = cms.OutputModule("PoolOutput
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'MCRUN2_75_V1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '80X_dataRun2_v1', '')# '76X_dataRun2_v15', '')
 
 # Path and EndPath definitions
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath = cms.EndPath(process.ALCARECOStreamPromptCalibProdSiStripGains)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.pathALCARECOPromptCalibProdSiStripGains,process.endjob_step,process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath)
+process.schedule = cms.Schedule(process.pathALCARECOPromptCalibProdSiStripGainsAB,
+                                process.pathALCARECOPromptCalibProdSiStripGainsAB0T,
+                                process.pathALCARECOPromptCalibProdSiStripGainsIB,
+                                process.pathALCARECOPromptCalibProdSiStripGainsIB0T,
+                                #process.pathALCARECOPromptCalibProdSiStripGainsMEtoEDM,
+                                process.endjob_step,
+                                process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath)
 

--- a/CalibTracker/SiStripChannelGain/test/PCL/step4_ALCAHARVEST.py
+++ b/CalibTracker/SiStripChannelGain/test/PCL/step4_ALCAHARVEST.py
@@ -52,7 +52,7 @@ process.configurationMetadata = cms.untracked.PSet(
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGains_dbOutput)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGains_metadata)
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'MCRUN2_75_V1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '80X_dataRun2_v1', '')# '76X_dataRun2_v15', '')
 
 # Path and EndPath definitions
 process.BeamSpotByRun = cms.Path(process.ALCAHARVESTBeamSpotByRun)
@@ -68,6 +68,7 @@ process.TFileService = cms.Service("TFileService",
 # Schedule definition
 process.schedule = cms.Schedule(process.SiStripGains,process.ALCAHARVESTDQMSaveAndMetadataWriter)
 
+process.alcaSiStripGainsHarvester.calibrationMode = cms.untracked.string("IsoBunch")
 
 
 

--- a/CalibTracker/SiStripCommon/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/plugins/BuildFile.xml
@@ -6,6 +6,8 @@
 <use   name="CalibTracker/SiStripCommon"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="CondFormats/L1TObjects"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="CondFormats/RunInfo"/>
 <library   file="*.cc" name="CalibTrackerSiStripCommonPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
@@ -1,0 +1,51 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
+
+//
+// -- Class Deleration
+//
+
+class SiStripBFieldFilter : public edm::EDFilter {
+  public:
+  SiStripBFieldFilter( const edm::ParameterSet & );
+  ~SiStripBFieldFilter();
+
+  private:
+  double MagFieldCurrentTh_;   /*!<  Threshold for the Magnet current. */
+  bool   HIpassFilter_;        /*!<  Swith for HI/Low filter. */
+
+  bool filter( edm::Event &, edm::EventSetup const& ) override;
+};
+
+//
+// -- Constructor
+//
+SiStripBFieldFilter::SiStripBFieldFilter( const edm::ParameterSet & pset ) {
+    MagFieldCurrentTh_ = pset.getUntrackedParameter<double>  ("MagFieldCurrentTh",  2000.);
+    HIpassFilter_      = pset.getUntrackedParameter<bool>    ("HIpassFilter"   ,  true);
+}
+
+//
+// -- Destructor
+//
+SiStripBFieldFilter::~SiStripBFieldFilter() {
+}
+
+bool SiStripBFieldFilter::filter( edm::Event & evt, edm::EventSetup const& es) {
+
+  edm::ESHandle<RunInfo> runInfo;
+  es.get<RunInfoRcd>().get(runInfo);
+
+  double average_current = runInfo.product()->m_avg_current;
+
+  return ( (HIpassFilter_)? average_current > MagFieldCurrentTh_ : average_current < MagFieldCurrentTh_);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiStripBFieldFilter);

--- a/CalibTracker/SiStripCommon/python/SiStripBFieldFilter_cfi.py
+++ b/CalibTracker/SiStripCommon/python/SiStripBFieldFilter_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+siStripBFieldOnFilter  = cms.EDFilter("SiStripBFieldFilter")
+
+siStripBFieldOffFilter = cms.EDFilter("SiStripBFieldFilter",
+                                      HIpassFilter = cms.untracked.bool(False)
+                                     )

--- a/CalibTracker/SiStripCommon/test/MakeCalibrationTrees/produceCalibrationTree_template_cfg.py
+++ b/CalibTracker/SiStripCommon/test/MakeCalibrationTrees/produceCalibrationTree_template_cfg.py
@@ -1,4 +1,70 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing.VarParsing()
+
+options.register('conditionGT',
+                 "76X_dataRun2_v15",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "condition global tag for the job (\"76X_dataRun2_v15\" is default)")
+
+options.register('conditionOverwrite',
+                 "",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "configuration to overwrite the condition into the GT (\"\" is default)")
+
+options.register('inputCollection',
+                 "ALCARECOSiStripCalMinBias",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "collections to be used for input (\"ALCARECOSiStripCalMinBias\" is default)")
+
+options.register('outputFile',
+                 "calibTreeTest.root",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "name for the output root file (\"calibTreeTest.root\" is default)")
+
+options.register('inputFiles',
+                 "/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60007/869EE593-1FAB-E511-AF99-0025905A60B4.root",
+#                  '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/0C35C6BF-D3AA-E511-9BC9-0CC47A4C8E16.root',
+#                  '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/38B847F9-05AA-E511-AB78-00259074AE82.root',
+#                  '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/D0BAD20B-09AB-E511-B073-0026189438F6.root',
+#                  '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/DEFA8704-CCAA-E511-8203-0CC47A4D7634.root',
+#                  '/store/data/Run2015D/ZeroBias/ALCARECO/SiStripCalMinBias-16Dec2015-v1/60009/FE24690A-2DAA-E511-A96A-00259074AE3E.root',
+                 VarParsing.VarParsing.multiplicity.list,
+                 VarParsing.VarParsing.varType.string,
+                 "file to process")
+
+options.register('maxEvents',
+                 -1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "number of events to process (\"-1\" for all)")
+
+
+
+
+# To use the prompt reco dataset please use 'generalTracks' as inputCollection
+# To use the cosmic reco dataset please use 'ctfWithMaterialTracksP5' as inputCollection
+
+
+
+options.parseArguments()
+
+print "conditionGT       : ", options.conditionGT
+print "conditionOverwrite: ", options.conditionOverwrite
+print "inputCollection   : ", options.inputCollection
+print "maxEvents         : ", options.maxEvents
+print "outputFile        : ", options.outputFile
+print "inputFiles        : ", options.inputFiles
+
+
 
 process = cms.Process('CALIB')
 process.load('CalibTracker.Configuration.setupCalibrationTree_cff')
@@ -6,37 +72,37 @@ process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cf
 process.load('Configuration.Geometry.GeometryExtended2015Reco_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
-#process.GlobalTag.globaltag = 'GR_P_V27::All' #2011
-#process.GlobalTag.globaltag = 'GR_P_V32::All'  #2012AB #first run in 2012 is 190450
-#process.GlobalTag.globaltag = 'GR_P_V40::All' #2012  
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'GLOBALTAG', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, options.conditionGT, options.conditionOverwrite)
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
 process.add_( cms.Service( "TFileService",
-                           fileName = cms.string( 'OUTFILE' ),
+                           fileName = cms.string( options.outputFile ),
                            closeFileFast = cms.untracked.bool(True)  ) )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+#process.source = cms.Source (
+#    "PoolSource",
+#    fileNames = cms.untracked.vstring(options.inputFiles)
+#    )
+
+#import runs
 process.source = cms.Source (
-    "PoolSource",
-    fileNames = cms.untracked.vstring(FILES)
+  "PoolSource",
+  fileNames = cms.untracked.vstring( options.inputFiles )
     )
+
 
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 process.MessageLogger.cerr.FwkReport.reportEvery = 10000
 
-# Definition of the track collection module label
-# To use the prompt reco dataset uncomment the following two lines
-#process.CalibrationTracks.src = 'generalTracks'
-#process.shallowTracks.Tracks  = 'generalTracks'
-# To use the SiStripCalMinBias AlCaReco dataset uncomment the following two lines
-process.CalibrationTracks.src = 'ALCARECOSiStripCalMinBias'
-process.shallowTracks.Tracks  = 'ALCARECOSiStripCalMinBias'
-# To use the cosmic reco dataset uncomment the following two lines
-#process.CalibrationTracks.src = 'ctfWithMaterialTracksP5'
-#process.shallowTracks.Tracks  = 'ctfWithMaterialTracksP5'
+#definition of input collection
+process.CalibrationTracks.src = 'ALCARECOSiStripCalMinBias' #cms.InputTag( options.inputCollection )
+process.shallowTracks.Tracks  = 'ALCARECOSiStripCalMinBias' #cms.InputTag( options.inputCollection )
+#process.shallowGainCalibrationAllBunch   = 'ALCARECOSiStripCalMinBias' #cms.InputTag( options.inputCollection )
+#process.shallowGainCalibrationAllBunch0T = 'ALCARECOSiStripCalMinBias' #cms.InputTag( options.inputCollection )
+
 
 # BSCNoBeamHalo selection (Not to use for Cosmic Runs) --- OUTDATED!!!
 ## process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
@@ -47,26 +113,17 @@ process.shallowTracks.Tracks  = 'ALCARECOSiStripCalMinBias'
 ## process.L1T1.L1SeedsLogicalExpression = cms.string('(40 OR 41) AND NOT (36 OR 37 OR 38 OR 39)')
 
 #process.TkCalPath = cms.Path(process.L1T1*process.TkCalFullSequence)
-process.TkCalPath = cms.Path(process.TkCalFullSequence)
+process.TkCalPath_AllBunch   = cms.Path(process.TkCalSeq_AllBunch)
+process.TkCalPath_AllBunch0T = cms.Path(process.TkCalSeq_AllBunch0T)
+process.TkCalPath_IsoBunch   = cms.Path(process.TkCalSeq_IsoBunch)
+process.TkCalPath_IsoBunch0T = cms.Path(process.TkCalSeq_IsoBunch0T)
 
 
-#uncomment to OVERWRITE Gain condition in GT
-#process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-#    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-#    DBParameters = cms.PSet(
-#        messageLevel = cms.untracked.int32(2),
-#        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-#    ),
-#    timetype = cms.string('runnumber'),
-#    toGet = cms.VPSet(cms.PSet(
-#        record = cms.string('SiStripApvGainRcd'),
-#        tag = cms.string('SiStripGainFromParticles')
-#    )),
-#    connect = cms.string('sqlite_file:Gains_Sqlite.db')
-#)
-#process.es_prefer_gainpayload = cms.ESPrefer("PoolDBESSource")
-
-
+process.schedule = cms.Schedule( process.TkCalPath_AllBunch, 
+                                 process.TkCalPath_AllBunch0T,
+                                 process.TkCalPath_IsoBunch,
+                                 process.TkCalPath_IsoBunch0T
+                               )
 
 
 process.options = cms.untracked.PSet(

--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -25,6 +25,7 @@
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
+#include "DataFormats/DetId/interface/DetIdCollection.h"
 
 
 #include "TROOT.h"
@@ -56,6 +57,12 @@ class HitEff : public edm::EDAnalyzer {
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
         // ----------member data ---------------------------
+
+  const edm::EDGetTokenT< reco::TrackCollection > combinatorialTracks_token_;
+  const edm::EDGetTokenT< std::vector<Trajectory> > trajectories_token_;
+  const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;
+  const edm::EDGetTokenT<DetIdCollection> digis_token_;
+  const edm::EDGetTokenT<MeasurementTrackerEvent> trackerEvent_token_;
 
   edm::ParameterSet conf_;
   

--- a/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
+++ b/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
@@ -10,7 +10,10 @@ anEff = cms.EDAnalyzer("HitEff",
                        #trajectories = cms.InputTag("ctfWithMaterialTracksP5"),
                        #trajectories   =   cms.InputTag("TrackRefitterP5"),
                        #trajectories = cms.InputTag("CalibrationTracksRefit")
-                       trajectories = cms.InputTag("generalTracks")
+                       trajectories        = cms.InputTag("generalTracks"),
+                       siStripClusters     = cms.InputTag("siStripClusters"),
+                       siStripDigis        = cms.InputTag("siStripDigis"),
+                       trackerEvent        = cms.InputTag("MeasurementTrackerEvent")
                        )
 
 hiteff = cms.Sequence( anEff )

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -42,7 +42,7 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "DataFormats/TrackReco/interface/DeDxData.h"
-#include "DataFormats/DetId/interface/DetIdCollection.h"
+//#include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
@@ -72,6 +72,11 @@
 
 using namespace std;
 HitEff::HitEff(const edm::ParameterSet& conf) : 
+  combinatorialTracks_token_( consumes< reco::TrackCollection >(conf.getParameter<edm::InputTag>("combinatorialTracks")) ),
+  trajectories_token_( consumes< std::vector<Trajectory> >(conf.getParameter<edm::InputTag>("trajectories")) ),
+  clusters_token_( consumes< edmNew::DetSetVector<SiStripCluster> >(conf.getParameter<edm::InputTag>("siStripClusters")) ),
+  digis_token_( consumes< DetIdCollection >(conf.getParameter<edm::InputTag>("siStripDigis")) ),
+  trackerEvent_token_( consumes< MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("trackerEvent")) ),
   conf_(conf)
 {
   layers =conf_.getParameter<int>("Layer");
@@ -151,17 +156,18 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 
   //CombinatoriaTrack
   edm::Handle<reco::TrackCollection> trackCollectionCKF;
-  edm::InputTag TkTagCKF = conf_.getParameter<edm::InputTag>("combinatorialTracks");
-  e.getByLabel(TkTagCKF,trackCollectionCKF);
+  //edm::InputTag TkTagCKF = conf_.getParameter<edm::InputTag>("combinatorialTracks");
+  e.getByToken(combinatorialTracks_token_,trackCollectionCKF);
   
   edm::Handle<std::vector<Trajectory> > TrajectoryCollectionCKF;
-  edm::InputTag TkTrajCKF = conf_.getParameter<edm::InputTag>("trajectories");
-  e.getByLabel(TkTrajCKF,TrajectoryCollectionCKF);
+  //edm::InputTag TkTrajCKF = conf_.getParameter<edm::InputTag>("trajectories");
+  e.getByToken(trajectories_token_,TrajectoryCollectionCKF);
   
   // Clusters
   // get the SiStripClusters from the event
   edm::Handle< edmNew::DetSetVector<SiStripCluster> > theClusters;
-  e.getByLabel("siStripClusters", theClusters);
+  //e.getByLabel("siStripClusters", theClusters);
+  e.getByToken(clusters_token_, theClusters);
 
   //get tracker geometry
   edm::ESHandle<TrackerGeometry> tracker;
@@ -190,13 +196,15 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 
   // get the list of module IDs with FED-detected errors
   edm::Handle< DetIdCollection > fedErrorIds;
-  e.getByLabel("siStripDigis", fedErrorIds );
+  //e.getByLabel("siStripDigis", fedErrorIds );
+  e.getByToken(digis_token_, fedErrorIds );
 
   ESHandle<MeasurementTracker> measurementTrackerHandle;
   es.get<CkfComponentsRecord>().get(measurementTrackerHandle);
 
   edm::Handle<MeasurementTrackerEvent> measurementTrackerEvent;
-  e.getByLabel("MeasurementTrackerEvent", measurementTrackerEvent);
+  //e.getByLabel("MeasurementTrackerEvent", measurementTrackerEvent);
+  e.getByToken(trackerEvent_token_,measurementTrackerEvent);
 
   edm::ESHandle<Chi2MeasurementEstimatorBase> est;
   es.get<TrackingComponentsRecord>().get("Chi2",est);

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
@@ -5,11 +5,20 @@ import FWCore.ParameterSet.Config as cms
 
 OutALCARECOPromptCalibProdSiStripGains_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')
+        SelectEvents = cms.vstring(
+                           'pathALCARECOPromptCalibProdSiStripGainsIB',
+                           'pathALCARECOPromptCalibProdSiStripGainsIB0T',
+                           'pathALCARECOPromptCalibProdSiStripGainsAB',
+                           'pathALCARECOPromptCalibProdSiStripGainsAB0T',
+                                  )
     ),
     outputCommands = cms.untracked.vstring(
         'keep *_alcaBeamSpotProducer_*_*',
-        'keep *_MEtoEDMConvertSiStripGains_*_*')
+        'keep *_MEtoEDMConvertSiStripGains_*_*',
+        'keep *_MEtoEDMConvertSiStripGainsAllBunch_*_*',
+        'keep *_MEtoEDMConvertSiStripGainsAllBunch0T_*_*',
+        'keep *_MEtoEDMConvertSiStripGainsIsoBunch_*_*',
+        'keep *_MEtoEDMConvertSiStripGainsIsoBunch0T_*_*')
 )
 
 import copy

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -217,7 +217,7 @@ MEtoEDMConvertSiStripGainsIsoBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
 
 # the actual sequence
 seqALCARECOPromptCalibProdSiStripGainsAllBunch = cms.Sequence(
-   ALCARECOCalMinBiasFilterForSiStripGains * ZeroBiasGC * siStripBFieldOnFilter *
+   ALCARECOCalMinBiasFilterForSiStripGains * siStripBFieldOnFilter *
    ALCARECOTrackFilterRefit *
    ALCARECOShallowSequence *
    ALCARECOSiStripCalibAllBunch *
@@ -225,7 +225,7 @@ seqALCARECOPromptCalibProdSiStripGainsAllBunch = cms.Sequence(
 )
 
 seqALCARECOPromptCalibProdSiStripGainsAllBunch0T = cms.Sequence(
-   ALCARECOCalMinBiasFilterForSiStripGains * ZeroBiasGC * siStripBFieldOffFilter *
+   ALCARECOCalMinBiasFilterForSiStripGains * siStripBFieldOffFilter *
    ALCARECOTrackFilterRefit *
    ALCARECOShallowSequence *
    ALCARECOSiStripCalibAllBunch0T *

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # ------------------------------------------------------------------------------
 # configure a filter to run only on the events selected by TkAlMinBias AlcaReco
 import copy
+from CalibTracker.SiStripCommon.SiStripBFieldFilter_cfi import *
 from HLTrigger.HLTfilters.hltHighLevel_cfi import *
 ALCARECOCalMinBiasFilterForSiStripGains = copy.deepcopy(hltHighLevel)
 ALCARECOCalMinBiasFilterForSiStripGains.HLTPaths = ['pathALCARECOSiStripCalMinBias']
@@ -11,7 +12,50 @@ ALCARECOCalMinBiasFilterForSiStripGains.TriggerResultsTag = cms.InputTag("Trigge
 #process.TkAlMinBiasFilterForBS.eventSetupPathsKey = 'pathALCARECOTkAlMinBias:RECO'
 #ALCARECODtCalibHLTFilter.andOr = True ## choose logical OR between Triggerbits
 
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import *
+ZeroBiasGC                 = triggerResultsFilter.clone(
+                                triggerConditions = cms.vstring("HLT_ZeroBias_v*"),
+                                hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                l1tResults = cms.InputTag( "" ),
+                                throw = cms.bool(False)
+                             )
 
+ZeroBiasIsolatedBunchGC    = triggerResultsFilter.clone(
+                                triggerConditions = cms.vstring("HLT_ZeroBias_IsolatedBunches_*"),
+                                hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                l1tResults = cms.InputTag( "" ),
+                                throw = cms.bool(False)
+                             )
+
+HLTPhysicsGC               = triggerResultsFilter.clone(
+                                triggerConditions = cms.vstring("HLT_Physics_v*"),
+                                hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                l1tResults = cms.InputTag( "" ),
+                                throw = cms.bool(False)
+                             )
+
+HLTPhysicsIsolatedBunchGC  = triggerResultsFilter.clone(
+                                triggerConditions = cms.vstring("HLT_Physics_IsolatedBunches_*"),
+                                hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                l1tResults = cms.InputTag( "" ),
+                                throw = cms.bool(False)
+                             )
+
+#from L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff import *
+#from HLTrigger.HLTfilters.hltLevel1GTSeed_cfi import hltLevel1GTSeed
+#HTTFilter = hltLevel1GTSeed.clone(  
+#              #L1SeedsLogicalExpression = cms.string("L1_HTT125 OR L1_HTT150 OR L1_HTT175" ),
+#              L1SeedsLogicalExpression = cms.string("L1_HTT125 OR L1_HTT150"),
+#              #saveTags = cms.bool( True ),
+#              #L1MuonCollectionTag = cms.InputTag( "hltL1extraParticles" ),
+#              #L1UseL1TriggerObjectMaps = cms.bool( True ),
+#              #L1UseAliasesForSeeding = cms.bool( True ),
+#              #L1GtReadoutRecordTag = cms.InputTag( "hltGtDigis" ),
+#              #L1CollectionsTag = cms.InputTag( "hltL1extraParticles" ),
+#              #L1NrBxInEvent = cms.int32( 3 ),
+#              L1GtObjectMapTag = cms.InputTag( "hltL1GtObjectMap" ),
+#              #L1TechTriggerSeeding = cms.bool( False )
+#            )
 # ------------------------------------------------------------------------------
 
 
@@ -73,20 +117,36 @@ ALCARECOShallowSequence = cms.Sequence(ALCARECOShallowEventRun*ALCARECOShallowTr
 # This is the module actually doing the calibration
 
 from CalibTracker.SiStripChannelGain.computeGain_cff import SiStripCalib
-ALCARECOSiStripCalib = SiStripCalib.clone()
-ALCARECOSiStripCalib.AlgoMode = cms.untracked.string('PCL')
-ALCARECOSiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
-ALCARECOSiStripCalib.harvestingMode    = cms.untracked.bool(False)
-ALCARECOSiStripCalib.doStoreOnDB         = cms.bool(False)
-ALCARECOSiStripCalib.gain.label    = cms.untracked.string('ALCARECOShallowGainCalibration')
-ALCARECOSiStripCalib.evtinfo.label = cms.untracked.string('ALCARECOShallowEventRun')
-ALCARECOSiStripCalib.tracks.label  = cms.untracked.string('ALCARECOShallowTracks')
+ALCARECOSiStripCalibAllBunch = SiStripCalib.clone()
+ALCARECOSiStripCalibAllBunch.AlgoMode            = cms.untracked.string('PCL')
+ALCARECOSiStripCalibAllBunch.Tracks              = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit')
+ALCARECOSiStripCalibAllBunch.FirstSetOfConstants = cms.untracked.bool(False)
+ALCARECOSiStripCalibAllBunch.harvestingMode      = cms.untracked.bool(False)
+ALCARECOSiStripCalibAllBunch.splitDQMstat        = cms.untracked.bool(True)
+ALCARECOSiStripCalibAllBunch.calibrationMode     = cms.untracked.string('AllBunch')
+ALCARECOSiStripCalibAllBunch.doStoreOnDB         = cms.bool(False)
+ALCARECOSiStripCalibAllBunch.gain.label          = cms.untracked.string('ALCARECOShallowGainCalibration')
+ALCARECOSiStripCalibAllBunch.evtinfo.label       = cms.untracked.string('ALCARECOShallowEventRun')
+ALCARECOSiStripCalibAllBunch.tracks.label        = cms.untracked.string('ALCARECOShallowTracks')
 
 
+ALCARECOSiStripCalibAllBunch0T = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('AllBunch0T'))
+ALCARECOSiStripCalibIsoBunch   = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('IsoBunch'))
+ALCARECOSiStripCalibIsoBunch0T = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('IsoBunch0T'))
+
+#ALCARECOSiStripCalibHLTAllBunch   = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HLTAllBunch'))
+#ALCARECOSiStripCalibHLTAllBunch0T = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HLTAllBunch0T'))
+#ALCARECOSiStripCalibHLTIsoBunch   = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HLTIsoBunch'))
+#ALCARECOSiStripCalibHLTIsoBunch0T = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HLTIsoBunch0T'))
+
+#ALCARECOSiStripCalibHTTAllBunch   = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HTTAllBunch'))
+#ALCARECOSiStripCalibHTTAllBunch0T = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HTTAllBunch0T'))
+#ALCARECOSiStripCalibHTTIsoBunch   = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HTTIsoBunch'))
+#ALCARECOSiStripCalibHTTIsoBunch0T = ALCARECOSiStripCalibAllBunch.clone(calibrationMode=cms.untracked.string('HTTIsoBunch0T'))
 # ------------------------------------------------------------------------------
 MEtoEDMConvertSiStripGains = cms.EDProducer("MEtoEDMConverter",
                                             Name = cms.untracked.string('MEtoEDMConverter'),
-                                            Verbosity = cms.untracked.int32(0), # 0 provides no output
+                                            Verbosity = cms.untracked.int32(2), # 0 provides no output
                                             # 1 provides basic output
                                             # 2 provide more detailed output
                                             Frequency = cms.untracked.int32(50),
@@ -94,18 +154,160 @@ MEtoEDMConvertSiStripGains = cms.EDProducer("MEtoEDMConverter",
                                             deleteAfterCopy = cms.untracked.bool(False)
 )
 
+seqALCARECOPromptCalibProdSiStripGainsMEtoEDM = cms.Sequence( MEtoEDMConvertSiStripGains )
 
+MEtoEDMConvertSiStripGainsAllBunch = cms.EDProducer("MEtoEDMConverter",
+                                            Name = cms.untracked.string('MEtoEDMConverter'),
+                                            Verbosity = cms.untracked.int32(2), # 0 provides no output
+                                            # 1 provides basic output
+                                            # 2 provide more detailed output
+                                            Frequency = cms.untracked.int32(50),
+                                            MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsAllBunch'),
+                                            deleteAfterCopy = cms.untracked.bool(True)
+)
+
+MEtoEDMConvertSiStripGainsAllBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
+                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsAllBunch0T')
+                                                                               )
+
+MEtoEDMConvertSiStripGainsIsoBunch   = MEtoEDMConvertSiStripGainsAllBunch.clone(
+                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsIsoBunch')
+                                                                               )
+
+MEtoEDMConvertSiStripGainsIsoBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
+                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsIsoBunch0T')
+                                                                               )
+
+
+#MEtoEDMConvertSiStripGainsHLTAllBunch   = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHLTAllBunch')
+#                                                                               )
+
+#MEtoEDMConvertSiStripGainsHLTAllBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHLTAllBunch0T')
+#                                                                               )
+
+#MEtoEDMConvertSiStripGainsHLTIsoBunch   = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHLTIsoBunch')
+#                                                                               )
+
+#MEtoEDMConvertSiStripGainsHLTIsoBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHLTIsoBunch0T')
+#                                                                               )
+
+
+#MEtoEDMConvertSiStripGainsHTTAllBunch   = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHTTAllBunch')
+#                                                                               )
+
+#MEtoEDMConvertSiStripGainsHTTAllBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHTTAllBunch0T')
+#                                                                               )
+
+#MEtoEDMConvertSiStripGainsHTTIsoBunch   = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHTTIsoBunch')
+#                                                                               )
+
+#MEtoEDMConvertSiStripGainsHTTIsoBunch0T = MEtoEDMConvertSiStripGainsAllBunch.clone(
+#                                             MEPathToSave = cms.untracked.string('AlCaReco/SiStripGainsHTTIsoBunch0T')
+#                                                                               )
 
 
 
 
 # the actual sequence
-seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(
-   ALCARECOCalMinBiasFilterForSiStripGains *
+seqALCARECOPromptCalibProdSiStripGainsAllBunch = cms.Sequence(
+   ALCARECOCalMinBiasFilterForSiStripGains * ZeroBiasGC * siStripBFieldOnFilter *
    ALCARECOTrackFilterRefit *
    ALCARECOShallowSequence *
-   ALCARECOSiStripCalib *
-   MEtoEDMConvertSiStripGains
+   ALCARECOSiStripCalibAllBunch *
+   MEtoEDMConvertSiStripGainsAllBunch
 )
 
+seqALCARECOPromptCalibProdSiStripGainsAllBunch0T = cms.Sequence(
+   ALCARECOCalMinBiasFilterForSiStripGains * ZeroBiasGC * siStripBFieldOffFilter *
+   ALCARECOTrackFilterRefit *
+   ALCARECOShallowSequence *
+   ALCARECOSiStripCalibAllBunch0T *
+   MEtoEDMConvertSiStripGainsAllBunch0T
+)
 
+seqALCARECOPromptCalibProdSiStripGainsIsoBunch = cms.Sequence(
+   ALCARECOCalMinBiasFilterForSiStripGains * ZeroBiasIsolatedBunchGC * siStripBFieldOnFilter *
+   ALCARECOTrackFilterRefit *
+   ALCARECOShallowSequence *
+   ALCARECOSiStripCalibIsoBunch *
+   MEtoEDMConvertSiStripGainsIsoBunch
+)
+
+seqALCARECOPromptCalibProdSiStripGainsIsoBunch0T = cms.Sequence(
+   ALCARECOCalMinBiasFilterForSiStripGains * ZeroBiasIsolatedBunchGC * siStripBFieldOffFilter *
+   ALCARECOTrackFilterRefit *
+   ALCARECOShallowSequence *
+   ALCARECOSiStripCalibIsoBunch0T *
+   MEtoEDMConvertSiStripGainsIsoBunch0T
+)
+
+#seqALCARECOPromptCalibProdSiStripGainsHLTAllBunch = cms.Sequence(
+#  ALCARECOCalMinBiasFilterForSiStripGains * HLTPhysicsGC * siStripBFieldOnFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHLTAllBunch *
+#   MEtoEDMConvertSiStripGainsHLTAllBunch
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHLTAllBunch0T = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HLTPhysicsGC * siStripBFieldOffFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHLTAllBunch0T *
+#   MEtoEDMConvertSiStripGainsHLTAllBunch0T
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHLTIsoBunch = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HLTPhysicsIsolatedBunchGC * siStripBFieldOnFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHLTIsoBunch *
+#   MEtoEDMConvertSiStripGainsHLTIsoBunch
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHLTIsoBunch0T = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HLTPhysicsIsolatedBunchGC * siStripBFieldOffFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHLTIsoBunch0T *
+#   MEtoEDMConvertSiStripGainsHLTIsoBunch0T
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHTTAllBunch = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HTTFilter * ZeroBiasGC * siStripBFieldOnFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHTTAllBunch *
+#   MEtoEDMConvertSiStripGainsHTTAllBunch
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHTTAllBunch0T = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HTTFilter * ZeroBiasGC * siStripBFieldOffFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHTTAllBunch0T *
+#   MEtoEDMConvertSiStripGainsHTTAllBunch0T
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHTTIsoBunch = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HTTFilter * ZeroBiasIsolatedBunchGC * siStripBFieldOnFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHTTIsoBunch *
+#   MEtoEDMConvertSiStripGainsHTTIsoBunch
+#)
+
+#seqALCARECOPromptCalibProdSiStripGainsHTTIsoBunch0T = cms.Sequence(
+#   ALCARECOCalMinBiasFilterForSiStripGains * HTTFilter * ZeroBiasIsolatedBunchGC * siStripBFieldOffFilter *
+#   ALCARECOTrackFilterRefit *
+#   ALCARECOShallowSequence *
+#   ALCARECOSiStripCalibHTTIsoBunch0T *
+#   MEtoEDMConvertSiStripGainsHTTIsoBunch0T
+#)

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
@@ -7,7 +7,28 @@ EDMtoMEConvertSiStripGains = EDMtoMEConverter.clone()
 EDMtoMEConvertSiStripGains.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterLumi")
 EDMtoMEConvertSiStripGains.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterRun")
 
+EDMtoMEConvertSiStripGainsAllBunch = EDMtoMEConverter.clone()
+EDMtoMEConvertSiStripGainsAllBunch.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch","MEtoEDMConverterLumi")
+EDMtoMEConvertSiStripGainsAllBunch.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch","MEtoEDMConverterRun")
+
+EDMtoMEConvertSiStripGainsAllBunch0T = EDMtoMEConverter.clone()
+EDMtoMEConvertSiStripGainsAllBunch0T.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch0T","MEtoEDMConverterLumi")
+EDMtoMEConvertSiStripGainsAllBunch0T.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAllBunch0T","MEtoEDMConverterRun")
+
+EDMtoMEConvertSiStripGainsIsoBunch = EDMtoMEConverter.clone()
+EDMtoMEConvertSiStripGainsIsoBunch.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch","MEtoEDMConverterLumi")
+EDMtoMEConvertSiStripGainsIsoBunch.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch","MEtoEDMConverterRun")
+
+EDMtoMEConvertSiStripGainsIsoBunch0T = EDMtoMEConverter.clone()
+EDMtoMEConvertSiStripGainsIsoBunch0T.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch0T","MEtoEDMConverterLumi")
+EDMtoMEConvertSiStripGainsIsoBunch0T.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsIsoBunch0T","MEtoEDMConverterRun")
+
+
+
 DQMStore = cms.Service("DQMStore")
 
-ALCAHARVESTSiStripGains = cms.Sequence(EDMtoMEConvertSiStripGains + alcaSiStripGainsHarvester)
-
+ALCAHARVESTSiStripGains = cms.Sequence( EDMtoMEConvertSiStripGainsAllBunch + 
+                                        EDMtoMEConvertSiStripGainsAllBunch0T +
+                                        EDMtoMEConvertSiStripGainsIsoBunch +
+                                        EDMtoMEConvertSiStripGainsIsoBunch0T +
+                                        EDMtoMEConvertSiStripGains + alcaSiStripGainsHarvester)

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
@@ -2,8 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 
 from CalibTracker.SiStripChannelGain.computeGain_cff import SiStripCalib as alcaSiStripGainsHarvester
-alcaSiStripGainsHarvester.AlgoMode = cms.untracked.string('PCL')
-alcaSiStripGainsHarvester.Tracks   = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit')
+alcaSiStripGainsHarvester.AlgoMode            = cms.untracked.string('PCL')
+alcaSiStripGainsHarvester.Tracks              = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit')
 alcaSiStripGainsHarvester.FirstSetOfConstants = cms.untracked.bool(False)
+alcaSiStripGainsHarvester.splitDQMstat        = cms.untracked.bool(True)
 alcaSiStripGainsHarvester.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
-alcaSiStripGainsHarvester.harvestingMode    = cms.untracked.bool(True)
+alcaSiStripGainsHarvester.harvestingMode      = cms.untracked.bool(True)

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -189,7 +189,11 @@ pathALCARECOMuAlGlobalCosmicsInCollisions = cms.Path(seqALCARECOMuAlGlobalCosmic
 pathALCARECOMuAlGlobalCosmics = cms.Path(seqALCARECOMuAlGlobalCosmics*ALCARECOMuAlGlobalCosmicsDQM)
 pathALCARECOPromptCalibProd = cms.Path(seqALCARECOPromptCalibProd)
 pathALCARECOPromptCalibProdSiStrip = cms.Path(seqALCARECOPromptCalibProdSiStrip)
-pathALCARECOPromptCalibProdSiStripGains = cms.Path(seqALCARECOPromptCalibProdSiStripGains)
+pathALCARECOPromptCalibProdSiStripGainsAB      = cms.Path(seqALCARECOPromptCalibProdSiStripGainsAllBunch)
+pathALCARECOPromptCalibProdSiStripGainsAB0T    = cms.Path(seqALCARECOPromptCalibProdSiStripGainsAllBunch0T)
+pathALCARECOPromptCalibProdSiStripGainsIB      = cms.Path(seqALCARECOPromptCalibProdSiStripGainsIsoBunch)
+pathALCARECOPromptCalibProdSiStripGainsIB0T    = cms.Path(seqALCARECOPromptCalibProdSiStripGainsIsoBunch0T)
+pathALCARECOPromptCalibProdSiStripGainsMEtoEDM = cms.EndPath(seqALCARECOPromptCalibProdSiStripGainsMEtoEDM)
 pathALCARECOPromptCalibProdSiPixelAli = cms.Path(seqALCARECOPromptCalibProdSiPixelAli)
 pathALCARECOSiStripPCLHistos = cms.Path(seqALCARECOSiStripPCLHistos)
 pathHotlineSkimSingleMuon = cms.Path(seqHotlineSkimSingleMuon)
@@ -621,7 +625,12 @@ ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(
 ALCARECOStreamPromptCalibProdSiStripGains = cms.FilteredStream(
 	responsible = 'Gianluca Cerminara',
 	name = 'PromptCalibProdSiStripGains',
-	paths  = (pathALCARECOPromptCalibProdSiStripGains),
+        paths  = (pathALCARECOPromptCalibProdSiStripGainsAB,
+                  pathALCARECOPromptCalibProdSiStripGainsAB0T,
+                  pathALCARECOPromptCalibProdSiStripGainsIB,
+                  pathALCARECOPromptCalibProdSiStripGainsIB0T,
+                  #pathALCARECOPromptCalibProdSiStripGainsMEtoEDM
+                 ),
 	content = OutALCARECOPromptCalibProdSiStripGains.outputCommands,
 	selectEvents = OutALCARECOPromptCalibProdSiStripGains.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')

--- a/DQMOffline/Trigger/src/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/src/HLTTauRefProducer.cc
@@ -143,6 +143,9 @@ HLTTauRefProducer::doPFTaus(edm::Event& iEvent,const edm::EventSetup& iES)
                       passAll = false;
                       break;
                     }
+                  }else{
+                      passAll = false;
+                      break;
                   }
                 }
                 if(passAll) {

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauReferences_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauReferences_cfi.py
@@ -18,7 +18,7 @@ TauRelvalRefProducer = cms.EDProducer("HLTTauRefProducer",
                                 PFTaus = cms.untracked.PSet(
                                    PFTauDiscriminators = cms.untracked.VInputTag(
                                                     cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),
-                                                    cms.InputTag("hpsPFTauDiscriminationByLooseIsolation")
+                                                    cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits")
                                    ),
                                    doPFTaus = cms.untracked.bool(True),
                                    ptMin = cms.untracked.double(15.0),


### PR DESCRIPTION
Greeting,

this code implement the statistics splitting for the Gain Calibration. The statistics is split according to the magnet status (ON/OFF) and to the HLT selection (mainly from Isolated Bunches and full input from express stream). The code has been integrated in CMSSW_8_0_X_2016-03-04-2300. I successfully run my local test and the full workflow from

runTheMatrix -l 1001.0    
