### PR TITLE
Add missing headers (GCC 6.0.0)

### DIFF
--- a/HLTrigger/JetMET/src/AlphaT.cc
+++ b/HLTrigger/JetMET/src/AlphaT.cc
@@ -1,3 +1,5 @@
+#include <numeric>
+#include <cmath>
 #include "HLTrigger/JetMET/interface/AlphaT.h"
 
 double AlphaT::value_(std::vector<bool> * jet_sign) const {
@@ -47,5 +49,5 @@ double AlphaT::value_(std::vector<bool> * jet_sign) const {
     }
   }
   // Alpha_T
-  return (0.5 * (sum_et - min_delta_sum_et) / sqrt( sum_et*sum_et - (sum_px*sum_px+sum_py*sum_py) ));  
+  return (0.5 * (sum_et - min_delta_sum_et) / std::sqrt( sum_et*sum_et - (sum_px*sum_px+sum_py*sum_py) ));
 }


### PR DESCRIPTION
The following errors are reported by GCC (6.0.0, r233941):

```
HLTrigger/JetMET/src/AlphaT.cc:21:25: error: 'accumulate' is not a member of 'std'
HLTrigger/JetMET/src/AlphaT.cc:22:25: error: 'accumulate' is not a member of 'std'
HLTrigger/JetMET/src/AlphaT.cc:23:25: error: 'accumulate' is not a member of 'std'
HLTrigger/JetMET/src/AlphaT.cc:39:43: error: call of overloaded 'abs(double&)' is ambiguous
HLTrigger/JetMET/src/AlphaT.cc:50:99: error: 'sqrt' was not declared in this scope
```

Patch adds missing headers and adds `std::` where needed.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
