### PR TITLE
Add missing <numeric> include for std::accumulate

### DIFF
--- a/RecoJets/JetProducers/plugins/QjetsAdder.cc
+++ b/RecoJets/JetProducers/plugins/QjetsAdder.cc
@@ -1,3 +1,5 @@
+#include <numeric>
+
 #include "RecoJets/JetProducers/interface/QjetsAdder.h"
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/ClusterSequence.hh"

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -9,6 +9,7 @@
 #include <TF1.h>
 #include <map>
 #include <algorithm>
+#include <numeric>
 
 using namespace std;
 

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -30,6 +30,7 @@
 #include <TVector2.h>
 #include <iomanip>
 #include <algorithm>
+#include <numeric>
 #include <TMath.h>
 #include "TMVA/MethodBDT.h"
 


### PR DESCRIPTION
The following errors are reported by GCC (6.0.0, r233941):

```
RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc:553:20: error: 'accumulate' is not a member of 'std'
RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc:2055:30: error: 'accumulate' is not a member of 'std'
RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc:2308:22: error: 'accumulate' is not a member of 'std'
RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc:2310:22: error: 'accumulate' is not a member of 'std'

RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc:392:15: error: 'accumulate' is not a member of 'std'
RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc:393:15: error: 'accumulate' is not a member of 'std'
RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc:419:15: error: 'accumulate' is not a member of 'std'
RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc:420:15: error: 'accumulate' is not a member of 'std'

RecoJets/JetProducers/plugins/QjetsAdder.cc:77:19: error: 'accumulate' is not a member of 'std'
```

Patch add the missing <numeric> include.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
