### PR TITLE
Add missing <cassert> header

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
@@ -5,6 +5,7 @@
 #include "CLHEP/Random/RandFlat.h"
 
 #include <cmath>
+#include <cassert>
 
 using std::vector;
 //345678911234567892123456789312345678941234567895123456789612345678971234567898


### PR DESCRIPTION
The following errors are reported by GCC (6.0.0, r233941):

```
SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc:105:18: error: 'assert' was not declared in this scope
SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc:15:24: error: 'assert' was not declared in this scope
```

Patch adds the missing header.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
