### PR TITLE
Add missing <cmath> header and remove <string.h> header

### DIFF
--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -7,10 +7,10 @@
 #include "FWCore/Utilities/src/Guid.h"
 
 #include <string>
+#include <cmath>
 
 #include <unistd.h>
 #include <fcntl.h>
-#include <string.h>
 
 #include <openssl/x509.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
The following errors are reported by GCC (6.0.0, r233941):

```
Utilities/StorageFactory/src/StatisticsSenderService.cc:82:191: error: 'sqrt' was not declared in this scope
Utilities/StorageFactory/src/StatisticsSenderService.cc:90:191: error: 'sqrt' was not declared in this scope
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
