### PR TITLE
Add missing <vector> header

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -1,6 +1,8 @@
 #ifndef SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
 #define SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
 
+#include <vector>
+
 /** \class GenLumiInfoProduct
  *
  */


### PR DESCRIPTION
The are 32 errors reported by GCC (6.0.0, r233941) due to missing
<vector> header:

```
SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h:153:8: error: 'vector' in namespace 'std' does not name a template type
SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h:23:14: error: 'vector' in namespace 'std' does not name a template type
SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h:28:34: error: 'vector' in namespace 'std' does not name a template type
SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h:28:40: error: expected ',' or '...' before '<' token
SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h:28:68: error: 'internalProcesses_' was not declared in this scope
SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h:28:89: error: 'processes' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:100:28: error: 'const class GenLumiInfoProduct' has no member named 'internalProcesses_'
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:100:3: error: class 'GenLumiInfoProduct' does not have any field named 'internalProcesses_'
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:112:47: error: 'getProcessInfos' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:120:37: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:121:20: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:124:25: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:126:17: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:129:3: error: 'internalProcesses_' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:35:3: error: 'vector' is not a member of 'std'
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:35:46: error: expected primary-expression before '>' token
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:35:48: error: 'lhsVector' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:35:64: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:36:3: error: 'vector' is not a member of 'std'
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:36:46: error: expected primary-expression before '>' token
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:36:48: error: 'rhsVector' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:36:64: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:63:3: error: 'vector' is not a member of 'std'
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:63:46: error: expected primary-expression before '>' token
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:63:48: error: 'lhsVector' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:63:64: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:64:3: error: 'vector' is not a member of 'std'
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:64:46: error: expected primary-expression before '>' token
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:64:48: error: 'rhsVector' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:64:64: error: 'const class GenLumiInfoProduct' has no member named 'getProcessInfos'; did you mean 'setProcessInfo'?
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:88:3: error: 'internalProcesses_' was not declared in this scope
SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc:95:3: error: 'internalProcesses_' was not declared in this scope
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
