### PR TITLE
Fix a small bug in an online DQM input source

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -43,7 +43,13 @@ DQMStreamerReader::DQMStreamerReader(edm::ParameterSet const& pset,
   reset_();
 }
 
-DQMStreamerReader::~DQMStreamerReader() { closeFile_("destructor"); }
+DQMStreamerReader::~DQMStreamerReader() {
+  // Sometimes(?) the destructor called after service registry was already destructed
+  // and closeFile_ throws away no ServiceRegistry found exception...
+  //
+  // Normally, this file should be closed before this destructor is called.
+  //closeFile_("destructor");
+}
 
 void DQMStreamerReader::reset_() {
   // We have to load at least a single header,


### PR DESCRIPTION
DQMStreamerReader would throw a "no ServiceRegistry has been set for this thread" exception if prematurely destructed and hide the real cause for this premature destruction.
