### PR TITLE
Fix binning in ZS filter SRTask plots

### DIFF
--- a/DQM/EcalMonitorTasks/python/SelectiveReadoutTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/SelectiveReadoutTask_cfi.py
@@ -19,7 +19,7 @@ ecalSelectiveReadoutTask = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             xaxis = cms.untracked.PSet(
                 high = cms.untracked.double(60.0),
-                nbins = cms.untracked.int32(100),
+                nbins = cms.untracked.int32(120),
                 low = cms.untracked.double(-60.0),
                 title = cms.untracked.string('ADC counts*4')
             ),
@@ -73,7 +73,7 @@ ecalSelectiveReadoutTask = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             xaxis = cms.untracked.PSet(
                 high = cms.untracked.double(60.0),
-                nbins = cms.untracked.int32(100),
+                nbins = cms.untracked.int32(120),
                 low = cms.untracked.double(-60.0),
                 title = cms.untracked.string('ADC counts*4')
             ),


### PR DESCRIPTION
- Fix binning in high/low interest ZS filter output plots in Selective Readout Task so that 1 bin = 1 ADC count*4
