### PR TITLE
Misc cleanup for GCC 6 (missing header, integer overflow, wrong address usage, ..)

### DIFF
--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -10,6 +10,7 @@
 #include "CommonTools/Utils/interface/FormulaEvaluator.h"
 
 #include <algorithm>
+#include <cmath>
 
 class testFormulaEvaluator : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testFormulaEvaluator);
@@ -26,7 +27,7 @@ public:
 
 namespace {
   bool compare(double iLHS, double iRHS) {
-    return std::abs(iLHS-iRHS)< 1E-6*std::abs(iLHS);
+    return std::fabs(iLHS-iRHS)< 1E-6*std::fabs(iLHS);
   }
 }
 

--- a/DataFormats/Math/test/Similarity_t.cpp
+++ b/DataFormats/Math/test/Similarity_t.cpp
@@ -2,6 +2,7 @@
 #include "Math/SMatrix.h"
 #include <cmath>
 #include <cstddef>
+#include <random>
 
 typedef unsigned int IndexType;
 //typedef unsigned long long IndexType;

--- a/DataFormats/Math/test/testAtan2.cpp
+++ b/DataFormats/Math/test/testAtan2.cpp
@@ -145,21 +145,15 @@ void testIntPhi() {
 
   std::cout << "pi,  pi2,  pi4, p34 " << maxint << ' ' << pi2 << ' ' << pi4 << ' ' << pi34 << ' ' << pi2+pi4  << '\n';
   std::cout << "Maximum value for int: " << std::numeric_limits<int>::max() << '\n';
-  std::cout << "Maximum value for int+2: " << std::numeric_limits<int>::max()+2 << '\n';
   std::cout << "Maximum value for int+1 as LL: " << (long long)(std::numeric_limits<int>::max())+1LL << std::endl;
 
   std::cout << "Maximum value for short: " << std::numeric_limits<short>::max() << '\n';
-  std::cout << "Maximum value for short+2: " << short(std::numeric_limits<short>::max()+short(2)) << '\n';
   std::cout << "Maximum value for short+1 as int: " << (int)(std::numeric_limits<short>::max())+1 << std::endl;
-
 
   auto d = float(M_PI) -std::nextafter(float(M_PI),0.f);
   std::cout << "abs res at pi for float " << d << ' ' << phi2int(d) << std::endl;
   std::cout << "abs res at for int " << int2dphi(1) << std::endl;
   std::cout << "abs res at for short " << short2phi(1) << std::endl;
-
-
-  assert(-std::numeric_limits<int>::max() == (std::numeric_limits<int>::max()+2));
 
   assert(phiLess(0.f,2.f));
   assert(phiLess(6.f,0.f));

--- a/DataFormats/SiStripCommon/src/SiStripDetKey.cc
+++ b/DataFormats/SiStripCommon/src/SiStripDetKey.cc
@@ -103,14 +103,12 @@ SiStripDetKey::SiStripDetKey( const SiStripKey& input ) :
   apvWithinPair_(sistrip::invalid_)
 {
   const SiStripDetKey& det_key = dynamic_cast<const SiStripDetKey&>(input);
-  if ( (&det_key) ) {
-    key(det_key.key());
-    path(det_key.path());
-    granularity(det_key.granularity());
-    partition_ = det_key.partition();
-    apvPairNumber_ = det_key.apvPairNumber();
-    apvWithinPair_ = det_key.apvWithinPair();
-  }
+  key(det_key.key());
+  path(det_key.path());
+  granularity(det_key.granularity());
+  partition_ = det_key.partition();
+  apvPairNumber_ = det_key.apvPairNumber();
+  apvWithinPair_ = det_key.apvWithinPair();
 }
 
 // -----------------------------------------------------------------------------
@@ -123,19 +121,14 @@ SiStripDetKey::SiStripDetKey( const SiStripKey& input,
   apvWithinPair_(0)
 {
   const SiStripDetKey& det_key = dynamic_cast<const SiStripDetKey&>(input);
-  if ( (&det_key) ) {
-
-    if ( gran == sistrip::PARTITION ) {
-      partition_ = det_key.partition(); 
-    }
-
-    initFromValue();
-    initFromKey();
-    initFromPath();
-    initGranularity();
-    
+  if ( gran == sistrip::PARTITION ) {
+    partition_ = det_key.partition(); 
   }
 
+  initFromValue();
+  initFromKey();
+  initFromPath();
+  initGranularity();
 }
 
 // -----------------------------------------------------------------------------
@@ -151,7 +144,6 @@ SiStripDetKey::SiStripDetKey() :
 // 
 bool SiStripDetKey::isEqual( const SiStripKey& key ) const {
   const SiStripDetKey& input = dynamic_cast<const SiStripDetKey&>(key);
-  if ( !(&input) ) { return false; }
   if ( partition_ == input.partition() &&
        apvPairNumber_ == input.apvPairNumber() &&
        apvWithinPair_ == input.apvWithinPair() ) {
@@ -163,7 +155,6 @@ bool SiStripDetKey::isEqual( const SiStripKey& key ) const {
 // 
 bool SiStripDetKey::isConsistent( const SiStripKey& key ) const {
   const SiStripDetKey& input = dynamic_cast<const SiStripDetKey&>(key);
-  if ( !(&input) ) { return false; }
   if ( isEqual(input) ) { return false; }
   else if ( ( partition_ == 0 || input.partition() == 0 ) &&
             ( apvPairNumber_ == 0 || input.apvPairNumber() == 0 ) &&

--- a/DataFormats/SiStripCommon/src/SiStripFecKey.cc
+++ b/DataFormats/SiStripCommon/src/SiStripFecKey.cc
@@ -101,18 +101,16 @@ SiStripFecKey::SiStripFecKey( const SiStripKey& input ) :
   i2cAddr_(sistrip::invalid_)
 {
   const SiStripFecKey& fec_key = dynamic_cast<const SiStripFecKey&>(input);
-  if ( (&fec_key) ) {
-    key(fec_key.key());
-    path(fec_key.path());
-    granularity(fec_key.granularity());
-    fecCrate_ = fec_key.fecCrate(); 
-    fecSlot_ = fec_key.fecSlot();
-    fecRing_ = fec_key.fecRing(); 
-    ccuAddr_ = fec_key.ccuAddr();
-    ccuChan_ = fec_key.ccuChan(); 
-    lldChan_ = fec_key.lldChan();
-    i2cAddr_ = fec_key.i2cAddr();
-  }
+  key(fec_key.key());
+  path(fec_key.path());
+  granularity(fec_key.granularity());
+  fecCrate_ = fec_key.fecCrate(); 
+  fecSlot_ = fec_key.fecSlot();
+  fecRing_ = fec_key.fecRing(); 
+  ccuAddr_ = fec_key.ccuAddr();
+  ccuChan_ = fec_key.ccuChan(); 
+  lldChan_ = fec_key.lldChan();
+  i2cAddr_ = fec_key.i2cAddr();
 }
 
 // -----------------------------------------------------------------------------
@@ -129,52 +127,47 @@ SiStripFecKey::SiStripFecKey( const SiStripKey& input,
   i2cAddr_(0)
 {
   const SiStripFecKey& fec_key = dynamic_cast<const SiStripFecKey&>(input);
-  if ( (&fec_key) ) {
-    
-    if ( gran == sistrip::FEC_CRATE || gran == sistrip::FEC_SLOT ||
-	 gran == sistrip::FEC_RING || gran == sistrip::CCU_ADDR ||
-	 gran == sistrip::CCU_CHAN || gran == sistrip::LLD_CHAN ||
-	 gran == sistrip::APV ) {
-      fecCrate_ = fec_key.fecCrate(); 
-    }
-
-    if ( gran == sistrip::FEC_SLOT || gran == sistrip::FEC_RING ||
-	 gran == sistrip::CCU_ADDR || gran == sistrip::CCU_CHAN ||
-	 gran == sistrip::LLD_CHAN || gran == sistrip::APV ) {
-      fecSlot_ = fec_key.fecSlot();
-    }
-
-    if ( gran == sistrip::FEC_RING || gran == sistrip::CCU_ADDR ||
-	 gran == sistrip::CCU_CHAN || gran == sistrip::LLD_CHAN ||
-	 gran == sistrip::APV ) {
-      fecRing_ = fec_key.fecRing(); 
-    }
-
-    if ( gran == sistrip::CCU_ADDR || gran == sistrip::CCU_CHAN ||
-	 gran == sistrip::LLD_CHAN || gran == sistrip::APV ) {
-      ccuAddr_ = fec_key.ccuAddr();
-    }
-
-    if ( gran == sistrip::CCU_CHAN || gran == sistrip::LLD_CHAN ||
-	 gran == sistrip::APV ) {
-      ccuChan_ = fec_key.ccuChan(); 
-    }
-
-    if ( gran == sistrip::LLD_CHAN || gran == sistrip::APV ) {
-      lldChan_ = fec_key.lldChan();
-    }
-
-    if ( gran == sistrip::APV ) {
-      i2cAddr_ = fec_key.i2cAddr();
-    }
-
-    initFromValue();
-    initFromKey();
-    initFromPath();
-    initGranularity();
-    
+  if ( gran == sistrip::FEC_CRATE || gran == sistrip::FEC_SLOT ||
+       gran == sistrip::FEC_RING || gran == sistrip::CCU_ADDR ||
+       gran == sistrip::CCU_CHAN || gran == sistrip::LLD_CHAN ||
+       gran == sistrip::APV ) {
+    fecCrate_ = fec_key.fecCrate(); 
   }
 
+  if ( gran == sistrip::FEC_SLOT || gran == sistrip::FEC_RING ||
+       gran == sistrip::CCU_ADDR || gran == sistrip::CCU_CHAN ||
+       gran == sistrip::LLD_CHAN || gran == sistrip::APV ) {
+    fecSlot_ = fec_key.fecSlot();
+  }
+
+  if ( gran == sistrip::FEC_RING || gran == sistrip::CCU_ADDR ||
+       gran == sistrip::CCU_CHAN || gran == sistrip::LLD_CHAN ||
+       gran == sistrip::APV ) {
+    fecRing_ = fec_key.fecRing(); 
+  }
+
+  if ( gran == sistrip::CCU_ADDR || gran == sistrip::CCU_CHAN ||
+       gran == sistrip::LLD_CHAN || gran == sistrip::APV ) {
+    ccuAddr_ = fec_key.ccuAddr();
+  }
+
+  if ( gran == sistrip::CCU_CHAN || gran == sistrip::LLD_CHAN ||
+       gran == sistrip::APV ) {
+    ccuChan_ = fec_key.ccuChan(); 
+  }
+
+  if ( gran == sistrip::LLD_CHAN || gran == sistrip::APV ) {
+    lldChan_ = fec_key.lldChan();
+  }
+
+  if ( gran == sistrip::APV ) {
+    i2cAddr_ = fec_key.i2cAddr();
+  }
+
+  initFromValue();
+  initFromKey();
+  initFromPath();
+  initGranularity();
 }
 
 // -----------------------------------------------------------------------------
@@ -248,7 +241,6 @@ bool SiStripFecKey::firstApvOfPair( const uint16_t& i2c_addr ) {
 // 
 bool SiStripFecKey::isEqual( const SiStripKey& key ) const {
   const SiStripFecKey& input = dynamic_cast<const SiStripFecKey&>(key);
-  if ( !(&input) ) { return false; }
   if ( fecCrate_ == input.fecCrate() &&
        fecSlot_ == input.fecSlot() &&
        fecRing_ == input.fecRing() &&
@@ -264,7 +256,6 @@ bool SiStripFecKey::isEqual( const SiStripKey& key ) const {
 // 
 bool SiStripFecKey::isConsistent( const SiStripKey& key ) const {
   const SiStripFecKey& input = dynamic_cast<const SiStripFecKey&>(key);
-  if ( !(&input) ) { return false; }
   if ( isEqual(input) ) { return true; }
   else if ( ( fecCrate_ == 0 || input.fecCrate() == 0 ) &&
 	    ( fecSlot_ == 0 || input.fecSlot() == 0 ) &&

--- a/DataFormats/SiStripCommon/src/SiStripFedKey.cc
+++ b/DataFormats/SiStripCommon/src/SiStripFedKey.cc
@@ -82,15 +82,13 @@ SiStripFedKey::SiStripFedKey( const SiStripKey& input ) :
   fedApv_(sistrip::invalid_)
 {
   const SiStripFedKey& fed_key = dynamic_cast<const SiStripFedKey&>(input);
-  if ( (&fed_key) ) {
-    key(fed_key.key());
-    path(fed_key.path());
-    granularity(fed_key.granularity());
-    fedId_ = fed_key.fedId(); 
-    feUnit_ = fed_key.feUnit(); 
-    feChan_ = fed_key.feChan();
-    fedApv_ = fed_key.fedApv();
-  }
+  key(fed_key.key());
+  path(fed_key.path());
+  granularity(fed_key.granularity());
+  fedId_ = fed_key.fedId(); 
+  feUnit_ = fed_key.feUnit(); 
+  feChan_ = fed_key.feChan();
+  fedApv_ = fed_key.fedApv();
 }
 
 // -----------------------------------------------------------------------------
@@ -148,7 +146,6 @@ uint32_t SiStripFedKey::fedIndex( const uint16_t& fed_id,
 // 
 bool SiStripFedKey::isEqual( const SiStripKey& key ) const {
   const SiStripFedKey& input = dynamic_cast<const SiStripFedKey&>(key);
-  if ( !(&input) ) { return false; }
   if ( fedId_ == input.fedId() &&
        feUnit_ == input.feUnit() &&
        feChan_ == input.feChan() &&
@@ -161,7 +158,6 @@ bool SiStripFedKey::isEqual( const SiStripKey& key ) const {
 // 
 bool SiStripFedKey::isConsistent( const SiStripKey& key ) const {
   const SiStripFedKey& input = dynamic_cast<const SiStripFedKey&>(key);
-  if ( !(&input) ) { return false; }
   if ( isEqual(input) ) { return true; }
   else if ( ( fedId_ == 0 || input.fedId() == 0 ) &&
 	    ( feUnit_ == 0 || input.feUnit() == 0 ) &&

--- a/DataFormats/SiStripCommon/src/SiStripHistoTitle.cc
+++ b/DataFormats/SiStripCommon/src/SiStripHistoTitle.cc
@@ -30,11 +30,9 @@ SiStripHistoTitle::SiStripHistoTitle( const sistrip::HistoType& histo_type,
   } else {
     keyType_ = sistrip::UNKNOWN_KEY;
   }
-  if ( &key_object ) {
-    keyValue_ = key_object.key();
-    granularity_ = key_object.granularity();
-    channel_ = key_object.channel();
-  }
+  keyValue_ = key_object.key();
+  granularity_ = key_object.granularity();
+  channel_ = key_object.channel();
   setTitle();
 }
 

--- a/DataFormats/SiStripCommon/src/SiStripKey.cc
+++ b/DataFormats/SiStripCommon/src/SiStripKey.cc
@@ -54,7 +54,6 @@ SiStripKey::SiStripKey() :
 // -----------------------------------------------------------------------------
 // 
 bool SiStripKey::isEqual( const SiStripKey& input ) const {
-  if ( !(&input) ) { return false; }
   if ( key_ == input.key() &&
        path_ == input.path() &&
        granularity_ == input.granularity() &&

--- a/EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h
@@ -149,8 +149,6 @@ private:
   bool orbit0Set_;
   int bx_;
   int l1a_;
-  int l1amin_;
-  int l1amax_;
   int simpleTrigType_;
   int detailedTrigType_;
   //  PGHisto histo_;

--- a/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
@@ -147,8 +147,6 @@ EcalDumpRaw::EcalDumpRaw(const edm::ParameterSet& ps):
   orbit0Set_(false),
   bx_(-1),
   l1a_(-1),
-  l1amin_(numeric_limits<int>::max()),
-  l1amax_(-numeric_limits<int>::min()),
   simpleTrigType_(-1),
   detailedTrigType_(-1),
   //  histo_("hist.root", "RECREATE"),
@@ -439,10 +437,6 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
     cerr << "DCC ID discrepancy in detailed trigger type "
          << " of " << toNth(iEvent_) << " event." << endl;
   }
-
-  if(l1a_>0 && l1a_< l1amin_) l1amin_ = l1a_;
-  if(l1a_>l1amax_) l1amax_ = l1a_;
-
 
 #endif
 


### PR DESCRIPTION
The following contains various small cleanup to get packages compiling with GCC 6.0.0. Note that majority to them were reported by Clang for a long time. I guess, the most interesting part is `DataFormats/Math/test/testAtan2.cpp` because it's obviously gonna force integer overflow, but that is undefined behaviour in C++. This patch currently suggests to remove the offending lines.

Commit messages might contain more information.
