### PR TITLE
Add PU id working points to MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -154,6 +154,7 @@ def miniAOD_customizeCommon(process):
     ## PU JetID
     process.load("RecoJets.JetProducers.PileupJetID_cfi")
     process.patJets.userData.userFloats.src = [ cms.InputTag("pileupJetId:fullDiscriminant"), ]
+    process.patJets.userData.userInts.src = [ cms.InputTag("pileupJetId:fullId"), ]
 
     ## CaloJets
     process.caloJetMap = cms.EDProducer("RecoJetDeltaRValueMapProducer",
@@ -250,6 +251,7 @@ def miniAOD_customizeCommon(process):
     process.patJetGenJetMatchPuppi.matched = 'slimmedGenJets'
     
     process.patJetsPuppi.userData.userFloats.src = cms.VInputTag(cms.InputTag(""))
+    process.patJetsPuppi.userData.userInts.src = cms.VInputTag(cms.InputTag(""))
     process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
 
     process.selectedPatJetsPuppi.cut = cms.string("pt > 20")


### PR DESCRIPTION
Add one user int containing 3 bits for loose, medium and tight working points of the PU jet ID to MiniAOD slimmedJets.

Could conflict with #13605. Code would be cleaner if this one is updated after #13605 is merged.

Made sure that
PhysicsTools/PatAlgos/test/patMiniAOD_standard_cfg.py 
adds the desired userInt and is accessible.
