### PR TITLE
Cleaning TkMaps code and adding Strip Merged Bad Channels

### DIFF
--- a/CalibTracker/Records/interface/SiStripDependentRecords.h
+++ b/CalibTracker/Records/interface/SiStripDependentRecords.h
@@ -9,6 +9,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
+#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
 
 class SiStripFecCablingRcd : public edm::eventsetup::DependentRecordImplementation<SiStripFecCablingRcd,
   boost::mpl::vector<SiStripFedCablingRcd> > {};
@@ -23,7 +24,6 @@ class SiStripRegionCablingRcd : public edm::eventsetup::DependentRecordImplement
 class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, boost::mpl::vector<SiStripApvGainRcd, SiStripApvGain2Rcd, SiStripApvGain3Rcd> > {};
 class SiStripGainSimRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainSimRcd, boost::mpl::vector<SiStripApvGainSimRcd> > {};
 
-class SiStripQualityRcd : public edm::eventsetup::DependentRecordImplementation<SiStripQualityRcd, boost::mpl::vector<SiStripBadModuleRcd, SiStripBadFiberRcd, SiStripBadChannelRcd, SiStripBadStripRcd, SiStripDetCablingRcd, SiStripDCSStatusRcd, SiStripDetVOffRcd, RunInfoRcd> > {};
 
 class SiStripDelayRcd : public edm::eventsetup::DependentRecordImplementation<SiStripDelayRcd, boost::mpl::vector<SiStripBaseDelayRcd> > {};
 
@@ -36,6 +36,10 @@ class SiStripHashedDetIdRcd : public edm::eventsetup::DependentRecordImplementat
 class SiStripNoisesDepRcd : public edm::eventsetup::DependentRecordImplementation<SiStripNoisesDepRcd, boost::mpl::vector<SiStripNoisesRcd,IdealGeometryRecord> > {};
 
 class SiStripBadModuleDepRcd : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleDepRcd, boost::mpl::vector<SiStripBadModuleRcd,IdealGeometryRecord> > {};
+
+class SiStripBadModuleFedErrRcd : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleFedErrRcd, boost::mpl::vector<SiStripFedCablingRcd> > {};
+
+class SiStripQualityRcd : public edm::eventsetup::DependentRecordImplementation<SiStripQualityRcd, boost::mpl::vector<SiStripBadModuleRcd, SiStripBadFiberRcd, SiStripBadChannelRcd, SiStripBadStripRcd, SiStripDetCablingRcd, SiStripDCSStatusRcd, SiStripDetVOffRcd, RunInfoRcd, SiStripBadModuleFedErrRcd > > {};
 
 #endif 
 

--- a/CalibTracker/Records/src/SiStripDependentRecords.cc
+++ b/CalibTracker/Records/src/SiStripDependentRecords.cc
@@ -16,3 +16,4 @@ EVENTSETUP_RECORD_REG(SiStripBackPlaneCorrectionDepRcd);
 EVENTSETUP_RECORD_REG(SiStripHashedDetIdRcd);
 EVENTSETUP_RECORD_REG(SiStripNoisesDepRcd);
 EVENTSETUP_RECORD_REG(SiStripBadModuleDepRcd);
+EVENTSETUP_RECORD_REG(SiStripBadModuleFedErrRcd);

--- a/CalibTracker/SiStripESProducers/BuildFile.xml
+++ b/CalibTracker/SiStripESProducers/BuildFile.xml
@@ -10,7 +10,9 @@
 <use   name="CondFormats/RunInfo"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
+<use   name="DQMServices/Core"/>
 <use   name="boost"/>
+<use   name="classlib"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CalibTracker/SiStripESProducers/README.md
+++ b/CalibTracker/SiStripESProducers/README.md
@@ -1,0 +1,27 @@
+### SiStrip fake ESSource to create SiStrip Bad channels from FED errors
+
+A new SiStrip fake source has been added to create Bad Components from the list of Fed detected errors. This
+is done using a histogram from DQM output where FedId vs APVId is plotted for detected channels.
+
+The tool inclides following components
+
+ - `SiStripBadModuleFedErrService`: the service defined in `CalibTracker/SiStripESProducers` package which 
+   accesses the specific histogram from the DQM root file (to be specified in the configuration) and creates
+   `SiStripBadStrip` object checking detected `FedChannel` and `FedId` and using `SiStripFedCabling` information.
+
+    - corresponding configuration is `CalibTracker/SiStripESProducers/python/services/SiStripBadModuleFedErrService_cfi.py`
+
+ - `SiStripBadModuleFedErrRcd` : the record defined in `CalibTracker/Records` package in `SiStripDependentRecords.h`
+    and `SiStripDependentRecords.cc`. This is a dependent record and depends on `SiStripFedCablingRcd'. This record
+    is filled with `SiStripBadStrip` object.
+
+ - `SiStripBadModuleFedErrFakeESSource` : the actual fake source is defined in the package `CalibTracker/SiStripESProducers` 
+   in `plugins/fake` area from the  template 'SiStripTemplateFakeESSource' in `modules.cc`. The record `SiStripBadModuleFedErrRcd`
+   is filled with the object `SiStripBadStrip`
+
+    - corresponding configuration file is `CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleFedErrFakeESSource_cfi.py`
+
+
+ - An overall configuration file can be found in `CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py` which merges
+   SiStrip Bad channels from PLC, `RunInfo` and SiStripBadModuleFedErrFakeESSource in `SiStripQualityEsProducer` and finally
+   listed by the `SiStripQualityStatistics` module.

--- a/CalibTracker/SiStripESProducers/interface/SiStripBadModuleFedErrService.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripBadModuleFedErrService.h
@@ -1,0 +1,49 @@
+#ifndef SiStripESSources_SiStripBadModuleFedErrService_h
+#define SiStripESSources_SiStripBadModuleFedErrService_h
+// -*- C++ -*-
+//
+//
+#include <string>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondTools/SiStrip/interface/SiStripDepCondObjBuilderBase.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+class MonitorElement;
+class SiStripQuality;
+
+class SiStripBadModuleFedErrService : public SiStripDepCondObjBuilderBase<SiStripBadStrip, SiStripFedCabling> {
+
+public:
+
+  explicit SiStripBadModuleFedErrService(const edm::ParameterSet&,const edm::ActivityRegistry&);
+  ~SiStripBadModuleFedErrService();
+
+  /// Used to fill the logDB
+  void getMetaDataString(std::stringstream& ss);
+
+  /// Check is the transfer is needed
+  virtual bool checkForCompatibility(std::string ss);
+
+  void getObj(SiStripBadStrip* & obj, const SiStripFedCabling * cabling){obj = readBadComponentsFromFed(cabling);}
+  uint32_t getRunNumber() const;
+
+private:
+
+
+  SiStripBadStrip* readBadComponentsFromFed(const SiStripFedCabling* cabling);
+  bool openRequestedFile();
+  void getFedBadChannelList(MonitorElement* me, std::vector<std::pair<uint16_t, uint16_t>>& list);
+  float getProcessedEvents();
+
+  DQMStore* dqmStore_;
+
+  edm::ParameterSet iConfig_;
+  bool notAlreadyRead_;
+};
+#endif

--- a/CalibTracker/SiStripESProducers/plugins/fake/modules.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/modules.cc
@@ -62,6 +62,11 @@ DEFINE_FWK_EVENTSETUP_SOURCE(SiStripNoisesFakeESSource);
 typedef SiStripTemplateDepFakeESSource< SiStripBadStrip, SiStripBadModuleDepRcd, SiStripBadModuleGenerator,IdealGeometryRecord,TrackerTopology > SiStripBadModuleConfigurableFakeESSource;
 DEFINE_FWK_EVENTSETUP_SOURCE(SiStripBadModuleConfigurableFakeESSource);
 
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "CalibTracker/SiStripESProducers/interface/SiStripBadModuleFedErrService.h"
+typedef SiStripTemplateDepFakeESSource< SiStripBadStrip, SiStripBadModuleFedErrRcd, SiStripBadModuleFedErrService, SiStripFedCablingRcd, SiStripFedCabling > SiStripBadModuleFedErrFakeESSource;
+DEFINE_FWK_EVENTSETUP_SOURCE(SiStripBadModuleFedErrFakeESSource);
+
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
 #include "CalibTracker/SiStripESProducers/interface/SiStripLorentzAngleGenerator.h"
 typedef SiStripTemplateDepFakeESSource< SiStripLorentzAngle, SiStripLorentzAngleDepRcd, SiStripLorentzAngleGenerator,IdealGeometryRecord,TrackerTopology > SiStripLorentzAngleFakeESSource;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -67,6 +67,9 @@ boost::shared_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStri
     if (recordName=="SiStripBadModuleRcd"){
       iRecord.getRecord<SiStripBadModuleRcd>().get(tagName,obj); 
       quality->add( obj.product() );
+    } else if (recordName=="SiStripBadModuleFedErrRcd"){
+      iRecord.getRecord<SiStripBadModuleFedErrRcd>().get(tagName,obj); 
+      quality->add( obj.product() );
     } else if (recordName=="SiStripBadFiberRcd"){
       iRecord.getRecord<SiStripBadFiberRcd>().get(tagName,obj); 
       quality->add( obj.product() );    

--- a/CalibTracker/SiStripESProducers/plugins/services/modules.cc
+++ b/CalibTracker/SiStripESProducers/plugins/services/modules.cc
@@ -40,3 +40,7 @@ DEFINE_FWK_SERVICE(SiStripBaseDelayGenerator);
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "CalibTracker/SiStripESProducers/interface/SiStripConfObjectGenerator.h"
 DEFINE_FWK_SERVICE(SiStripConfObjectGenerator);
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "CalibTracker/SiStripESProducers/interface/SiStripBadModuleFedErrService.h"
+DEFINE_FWK_SERVICE(SiStripBadModuleFedErrService);

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleFedErrFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleFedErrFakeESSource_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from CalibTracker.SiStripESProducers.services.SiStripBadModuleFedErrService_cfi import *
+
+siStripBadModuleFedErrFakeESSource = cms.ESSource("SiStripBadModuleFedErrFakeESSource",
+                                                   appendToDataLabel = cms.string('')
+                                                 )

--- a/CalibTracker/SiStripESProducers/python/services/SiStripBadModuleFedErrService_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/services/SiStripBadModuleFedErrService_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+siStripBadModuleFedErrService = cms.Service("SiStripBadModuleFedErrService",
+                                       appendToDataLabel = cms.string(''),
+                                       ReadFromFile = cms.bool(True),  
+                                       FileName = cms.string('DQM.root'),
+                                       BadStripCutoff = cms.double(0.8)
+                                       )
+
+
+
+

--- a/CalibTracker/SiStripESProducers/src/SiStripBadModuleFedErrService.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripBadModuleFedErrService.cc
@@ -1,0 +1,168 @@
+
+#include "CalibTracker/SiStripESProducers/interface/SiStripBadModuleFedErrService.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+
+#include "boost/cstdint.hpp"
+#include "boost/lexical_cast.hpp"
+
+#include <cctype>
+#include <time.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+SiStripBadModuleFedErrService::SiStripBadModuleFedErrService(const edm::ParameterSet& iConfig,const edm::ActivityRegistry& aReg):
+  SiStripDepCondObjBuilderBase<SiStripBadStrip,SiStripFedCabling>::SiStripDepCondObjBuilderBase(iConfig),
+  iConfig_(iConfig)
+{
+  edm::LogInfo("SiStripBadModuleFedErrService") <<  "[SiStripBadModuleFedErrService::SiStripBadModuleFedErrService]";
+}
+
+SiStripBadModuleFedErrService::~SiStripBadModuleFedErrService()
+{
+  edm::LogInfo("SiStripBadModuleFedErrService") <<  "[SiStripBadModuleFedErrService::~SiStripBadModuleFedErrService]";
+}
+
+void SiStripBadModuleFedErrService::getMetaDataString(std::stringstream& ss)
+{
+  ss << "Run " << getRunNumber() << std::endl;
+  obj_->printSummary(ss);
+}
+
+bool SiStripBadModuleFedErrService::checkForCompatibility(std::string ss)
+{
+  std::stringstream localString;
+  getMetaDataString(localString);
+  if( ss == localString.str() ) return false;
+
+  return true;
+}
+
+SiStripBadStrip* SiStripBadModuleFedErrService::readBadComponentsFromFed(const SiStripFedCabling *  cabling) {
+
+  
+  SiStripQuality* obj_  = new SiStripQuality();
+
+  bool readFlag = iConfig_.getParameter<bool>("ReadFromFile");
+  dqmStore_ = edm::Service<DQMStore>().operator->();
+
+  
+  if (readFlag && !openRequestedFile()) return obj_;
+  
+  dqmStore_->cd();
+  
+  std::string dname = "SiStrip/ReadoutView";
+  std::string hpath = dname;
+  hpath += "/FedIdVsApvId";
+  if (dqmStore_->dirExists(dname)) {    
+    MonitorElement* me = dqmStore_->get(hpath);
+    if (me) {
+      std::vector<std::pair<uint16_t, uint16_t>> channelList;
+      getFedBadChannelList(me, channelList); 
+      uint16_t fId_last = 9999;
+      uint16_t fChan_last = 9999;
+      std::map< uint32_t , std::set<int> > detectorMap;
+      for (std::vector<std::pair<uint16_t, uint16_t>>::iterator it = channelList.begin(); it != channelList.end(); it++) {
+	uint16_t fId = it->first;        
+
+	uint16_t fChan = it->second/2;
+        if (fId == fId_last && fChan == fChan_last) continue;
+
+	FedChannelConnection channel = cabling->fedConnection(fId, fChan);
+	const uint32_t detId =  channel.detId(); 
+	const uint16_t ipair = channel.apvPairNumber();
+        detectorMap[detId].insert(ipair);
+      }
+      for (std::map< uint32_t , std::set<int> >::iterator im =  detectorMap.begin(); im != detectorMap.end(); im++) {
+        const uint32_t detId = im->first;
+	std::set<int> pairs = im->second;		
+        SiStripQuality::InputVector theSiStripVector;	  
+	unsigned short firstBadStrip = 0;
+	unsigned short fNconsecutiveBadStrips = 0;
+	unsigned int theBadStripRange;
+        int last_pair = -1;
+	for (std::set<int>::iterator ip = pairs.begin(); ip != pairs.end(); ip++) {
+          if (last_pair == -1) {
+	    firstBadStrip = (*ip) * 128 * 2;
+	    fNconsecutiveBadStrips = 128*2;
+	  } else if ((*ip) - last_pair  > 1) {
+	    theBadStripRange = obj_->encode(firstBadStrip,fNconsecutiveBadStrips);       
+	    theSiStripVector.push_back(theBadStripRange);
+	    firstBadStrip = (*ip) * 128 * 2;
+	    fNconsecutiveBadStrips = 128*2;
+	  } else { 
+	    fNconsecutiveBadStrips += 128*2;
+	  }
+          last_pair = (*ip);
+	}
+	theBadStripRange = obj_->encode(firstBadStrip,fNconsecutiveBadStrips);       
+	theSiStripVector.push_back(theBadStripRange);
+	
+	edm::LogInfo("SiStripBadModuleFedErrService") << " SiStripBadModuleFedErrService::readBadComponentsFromFed " 
+						      << " detid " << detId 
+						      << " firstBadStrip " << firstBadStrip 
+						      << " NconsecutiveBadStrips " << fNconsecutiveBadStrips 
+						      << " packed integer " << std::hex << theBadStripRange  << std::dec; 
+	SiStripBadStrip::Range range(theSiStripVector.begin(),theSiStripVector.end());
+	if ( !obj_->put(detId,range) ) {
+	  edm::LogError("SiStripBadModuleFedErrService")<<"[SiStripBadModuleFedErrService::readBadComponentsFromFed] detid already exists"<<std::endl; 
+	} 
+      }
+      obj_->cleanUp();
+    }
+  }
+  return obj_;
+}
+
+
+bool SiStripBadModuleFedErrService::openRequestedFile() {
+  
+  std::string fileName = iConfig_.getParameter<std::string>("FileName");
+    
+  edm::LogInfo("SiStripBadModuleFedErrService") <<  "[SiStripBadModuleFedErrService::openRequestedFile] Accessing root File" << fileName;
+
+  if (!dqmStore_->load(fileName, DQMStore::OpenRunDirs::StripRunDirs, true) ) {
+    edm::LogError("SiStripBadModuleFedErrService")<<"[SiStripBadModuleFedErrService::openRequestedFile] Requested file " << fileName << "Can not be opened!! ";
+    return false;
+  } else return true;
+}
+ 
+uint32_t SiStripBadModuleFedErrService::getRunNumber() const {
+  edm::LogInfo("SiStripBadModuleFedErrService") <<  "[SiStripBadModuleFedErrService::getRunNumber] " << iConfig_.getParameter<uint32_t>("RunNumber");
+  return iConfig_.getParameter<uint32_t>("RunNumber");
+}
+void SiStripBadModuleFedErrService::getFedBadChannelList(MonitorElement* me, std::vector<std::pair<uint16_t,uint16_t> >& list) {
+  float cutoff = iConfig_.getParameter<double>("BadStripCutoff");
+  if (me->kind() == MonitorElement::DQM_KIND_TH2F) {
+    TH2F* th2 = me->getTH2F();
+    float entries = getProcessedEvents();
+    if (!entries) entries = th2->GetBinContent(th2->GetMaximumBin()); 
+    for (uint16_t i = 1; i < th2->GetNbinsY()+1; i++) { 
+      for (uint16_t j = 1; j < th2->GetNbinsX()+1; j++) { 
+        if (th2->GetBinContent(j,i) > cutoff * entries) {
+	  edm::LogInfo("SiStripBadModuleFedErrService") << " [SiStripBadModuleFedErrService::getFedBadChannelList] :: FedId & Channel " << th2->GetYaxis()->GetBinLowEdge(i) <<   "  " << th2->GetXaxis()->GetBinLowEdge(j);
+          list.push_back(std::pair<uint16_t, uint16_t>(th2->GetYaxis()->GetBinLowEdge(i), th2->GetXaxis()->GetBinLowEdge(j)));  
+	}
+      }
+    }
+  }
+}
+float SiStripBadModuleFedErrService::getProcessedEvents() {
+
+  dqmStore_->cd();
+  
+  std::string dname = "SiStrip/ReadoutView";
+  std::string hpath = dname;
+  hpath += "/nTotalBadActiveChannels";
+  if (dqmStore_->dirExists(dname)) {
+    MonitorElement* me = dqmStore_->get(hpath);
+    if (me) return (me->getEntries());
+  } 
+  return 0; 
+}

--- a/CalibTracker/SiStripESProducers/test/fedBadChannelFromNoiseRun_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/fedBadChannelFromNoiseRun_cfg.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("fedBadChannelFromNoiseRun")
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    destinations = cms.untracked.vstring('cout')
+)
+process.load('Configuration.Geometry.GeometryIdeal_cff')
+process.load("Configuration.Geometry.GeometryReco_cff")
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:com10', '')
+
+
+process.source = cms.Source("EmptyIOVSource",
+    firstValue = cms.uint64(258714),
+    lastValue = cms.uint64(258714),
+    timetype = cms.string('runnumber'),
+    interval = cms.uint64(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleFedErrFakeESSource_cfi")
+process.siStripBadModuleFedErrFakeESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+process.SiStripBadModuleFedErrService.ReadFromFile = cms.bool(False)
+
+process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel'))
+#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string(''))
+)
+process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+
+#### Add these lines to produce a tracker map
+process.load("DQMServices.Core.DQMStore_cfg")
+process.TkDetMap = cms.Service("TkDetMap")
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+####
+
+process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
+    dataLabel = cms.untracked.string('')
+)
+
+
+process.p = cms.Path(process.stat)
+

--- a/CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("BadChannelMerge")
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    destinations = cms.untracked.vstring('cout')
+)
+process.load('Configuration.Geometry.GeometryIdeal_cff')
+process.load("Configuration.Geometry.GeometryReco_cff")
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:com10', '')
+
+
+process.source = cms.Source("EmptyIOVSource",
+    firstValue = cms.uint64(258714),
+    lastValue = cms.uint64(258714),
+    timetype = cms.string('runnumber'),
+    interval = cms.uint64(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleFedErrFakeESSource_cfi")
+process.siStripBadModuleFedErrFakeESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+process.SiStripBadModuleFedErrService.FileName = cms.string('/afs/cern.ch/user/d/dutta/work/public/BadChannel/DQM_V0001_R000260576__ZeroBias__Run2015D-PromptReco-v4__DQMIO.root')
+
+process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),
+        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')),
+        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string(''))
+)
+process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+
+#### Add these lines to produce a tracker map
+process.load("DQMServices.Core.DQMStore_cfg")
+process.TkDetMap = cms.Service("TkDetMap")
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+####
+
+process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
+    dataLabel = cms.untracked.string('')
+)
+
+
+process.p = cms.Path(process.stat)
+

--- a/DQM/SiStripMonitorClient/data/index_template_TKMap.html
+++ b/DQM/SiStripMonitorClient/data/index_template_TKMap.html
@@ -24,22 +24,27 @@
       <LI><A href="QTestAlarm.png">Modules which are BAD from quality tests</a> (<A href="QTestAlarm_fed.png">FED view</a>, <A href="fedmap.html">interactive</a>) (<A href="QTestAlarm_psu.png">PSU view</a>, <A href="psumap.html">interactive</a>)
       <LI><A href="QualityTest_runRunNumber.txt">List of Modules which are BAD from quality tests</a> 
       (<A href="QualityTestOBSOLETE_runRunNumber.txt">obsolete version</a>)
-      <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a>
-      <LI><A href="TopModulesList.log">List of the modules with the highest values</a> 
+     <!-- <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a> -->
       <LI><A href="FractionOfBadChannels.png">FED errors per modules</a>
       <LI><A href="NumberOfDigi.png">Number of digis per module</a>
       <LI><A href="NumberOfCluster.png">Number of clusters per module</a>
       <LI><A href="NApvShots.png">Number of APV shots per module</a>
-      <LI><A href="MedianChargeApvShots.png">Median charge for Apv Shots per module</a>
+      <!-- <LI><A href="MedianChargeApvShots.png">Median charge for Apv Shots per module</a> -->
       <LI><A href="NumberOfOnTrackCluster.png">Number of clusters on-track per module</a>
       <LI><A href="NumberOfOfffTrackCluster.png">Number of clusters off-track per module</a> (<A href="NumberOfOfffTrackCluster_autoscale.png">automatic scale</a>)
+      <LI><A href="NumberInactiveHits.png">Number of Inactive hits per module</a>
+      <LI><A href="NumberMissingHits.png">Number of Missing hits per module</a>
+      <LI><A href="NumberValidHits.png">Number of Valid hits per module</a>
       <LI><A href="StoNCorrOnTrack.png">Mean value for S/N for on-track cluster corrected for the angle</a>
+      <LI><A href="ChargePerCMfromTrack.png">Mean value for Cluster Charge per cm from Track</a>
+      <LI><A href="MergedBadComponents_runRunNumber.txt"> Merged Bad components (PCL + FED Err + Cabling)</a>
+      <LI><A href="TopModulesList.log">List of the modules with the highest values</a> 
       <LI><A href="PCLBadComponents.png">Fraction of bad components per module found by the prompt calibration loop</a>
       <LI><A href="PCLBadComponents_Run_RunNumber.png">Type of bad components per module found by the prompt calibration loop</a>
       <LI><A href="PCLBadComponents.log">List of bad components found by the prompt calibration loop</a>
-      <LI><A href="Certification_run_RunNumber.png">Certification per LS - plot</a>
+      <!-- <LI><A href="Certification_run_RunNumber.png">Certification per LS - plot</a>
       <LI><A href="Certification_run_RunNumber.txt">Certification per LS - text</a>
-      <LI><A href="Certification_BS_run_RunNumber.txt">Validation for Beam Spot - Only for PromptReco - FOR EXPERT</a>
+      <LI><A href="Certification_BS_run_RunNumber.txt">Validation for Beam Spot - Only for PromptReco - FOR EXPERT</a> -->
      </UL>
     </TD>
    </TR>

--- a/DQM/SiStripMonitorClient/data/index_template_TKMap_cosmics.html
+++ b/DQM/SiStripMonitorClient/data/index_template_TKMap_cosmics.html
@@ -24,16 +24,21 @@
       <LI><A href="QTestAlarm.png">Modules which are BAD from quality tests</a> (<A href="QTestAlarm_fed.png">FED view</a>, <A href="fedmap.html">interactive</a>) (<A href="QTestAlarm_psu.png">PSU view</a>, <A href="psumap.html">interactive</a>)
       <LI><A href="QualityTest_runRunNumber.txt">List of Modules which are BAD from quality tests</a>
        (<A href="QualityTestOBSOLETE_runRunNumber.txt">obsolete version</a>)
-     <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a>
-      <LI><A href="TopModulesList.log">List of the modules with the highest values</a> 
+     <!-- <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a> -->
       <LI><A href="FractionOfBadChannels.png">FED errors per module</a>
       <LI><A href="NumberOfDigi.png">Number of digis per module</a>
       <LI><A href="NumberOfCluster.png">Number of clusters per module</a>
       <LI><A href="NApvShots.png">Number of APV shots per module</a>
-      <LI><A href="MedianChargeApvShots.png">Median charge for Apv Shots per module</a>
+      <!-- <LI><A href="MedianChargeApvShots.png">Median charge for Apv Shots per module</a> -->
       <LI><A href="NumberOfOnTrackCluster.png">Number of clusters on-track per module</a>
       <LI><A href="NumberOfOfffTrackCluster.png">Number of clusters off-track per module</a> (<A href="NumberOfOfffTrackCluster_autoscale.png">automatic scale</a>)
+      <LI><A href="NumberInactiveHits.png">Number of Inactive hits per module</a>
+      <LI><A href="NumberMissingHits.png">Number of Missing hits per module</a>
+      <LI><A href="NumberValidHits.png">Number of Valid hits per module</a>
       <LI><A href="StoNCorrOnTrack.png">Mean value for S/N for on-track cluster corrected for the angle</a>
+      <LI><A href="ChargePerCMfromTrack.png">Mean value for Cluster Charge per cm from Track</a>
+      <LI><A href="MergedBadComponents_runRunNumber.txt"> Merged Bad components (PCL + FED Err + Cabling)</a>
+      <LI><A href="TopModulesList.log">List of the modules with the highest values</a> 
       <LI><A href="PCLBadComponents.png">Fraction of bad components per module found by the prompt calibration loop</a>
       <LI><A href="PCLBadComponents_Run_RunNumber.png">Type of bad components per module found by the prompt calibration loop</a>
       <LI><A href="PCLBadComponents.log">List of bad components found by the prompt calibration loop</a>

--- a/DQM/SiStripMonitorClient/scripts/TkMap_script_automatic_DB.sh1
+++ b/DQM/SiStripMonitorClient/scripts/TkMap_script_automatic_DB.sh1
@@ -18,7 +18,7 @@ do
 
     if [ "$Run_numb" == "$1" ]; then continue; fi
 
-    #2016 - Commissioning period
+#2016 - Commissioning period                                                                                                                               
     if [ $Run_numb -gt 264200 ]; then
 
         DataLocalDir='Data2016'
@@ -27,7 +27,6 @@ do
 
     #Run2015A
     if [ $Run_numb -gt 246907 ]; then
-
         DataLocalDir='Data2015'
         DataOfflineDir='Run2015'
     else
@@ -167,17 +166,6 @@ do
     echo " Creating the list of bad modules "
     
     listbadmodule ${file_path}/$dqmFileName PCLBadComponents.log
-   if [ "$thisDataset" != "StreamExpress" ] ; then
-       sefile=QualityTest_run${Run_numb}.txt
-
-       if [ "$thisDataset" == "Cosmics" ]; then
-           python ../../DQM/SiStripMonitorClient/scripts/findBadModT9.py -p $sefile -s /data/users/event_display/${DataLocalDir}/Cosmics/${nnn}/${Run_numb}/StreamExpressCosmics/${sefile}
-       else
-
-           python ../../DQM/SiStripMonitorClient/scripts/findBadModT9.py -p $sefile -s /data/users/event_display/${DataLocalDir}/Beam/${nnn}/${Run_numb}/StreamExpress/${sefile}
-
-       fi
-   fi
 
 #    mv QualityTest*txt $Run_numb/$thisDataset
 
@@ -217,7 +205,9 @@ do
 # dest=FinalTest
 
 ## create merged list of BadComponent from (PCL, RunInfo and FED Errors)
+
     cmsRun ${CMSSW_BASE}/src/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py globalTag=${GLOBALTAG} runNumber=${Run_numb} dqmFile=${file_path}/$dqmFileName
+
     mv MergedBadComponents.log MergedBadComponents_run${Run_numb}.txt
 
     rm -f *.xml

--- a/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py
+++ b/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py
@@ -1,0 +1,86 @@
+import FWCore.ParameterSet.Config as cms
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("BadChannelMerge")
+
+#prepare options
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                                    "DONOTEXIST::All",
+                                    VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                                    VarParsing.VarParsing.varType.string,          # string, int, or float
+                                    "GlobalTag")
+options.register ('dqmFile',
+                                    "",
+                                    VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                                    VarParsing.VarParsing.varType.string,          # string, int, or float
+                                    "DQM root file")
+options.register ('runNumber',
+                                    1,
+                                    VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                                    VarParsing.VarParsing.varType.int,          # string, int, or float
+                                    "run number")
+options.parseArguments()
+
+
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations = cms.untracked.vstring('cout','cerr','MergedBadComponents'), #Reader, cout
+    categories = cms.untracked.vstring('SiStripQualityStatistics'),
+
+    debugModules = cms.untracked.vstring('siStripDigis', 
+                                         'siStripClusters', 
+                                         'siStripZeroSuppression', 
+                                         'SiStripClusterizer',
+                                         'siStripOfflineAnalyser'),
+    cerr = cms.untracked.PSet(threshold = cms.untracked.string('ERROR')
+                              ),
+    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO'),
+                                default = cms.untracked.PSet(limit=cms.untracked.int32(0))
+                              ),
+    MergedBadComponents = cms.untracked.PSet(threshold = cms.untracked.string('INFO'),
+                                default = cms.untracked.PSet(limit=cms.untracked.int32(0)),
+                                SiStripQualityStatistics = cms.untracked.PSet(limit=cms.untracked.int32(100000))
+                                )
+                                    
+)
+process.load('Configuration.Geometry.GeometryIdeal_cff')
+process.load("Configuration.Geometry.GeometryReco_cff")
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+process.source = cms.Source("EmptyIOVSource",
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    timetype = cms.string('runnumber'),
+    interval = cms.uint64(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleFedErrFakeESSource_cfi")
+process.siStripBadModuleFedErrFakeESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+process.SiStripBadModuleFedErrService.FileName = cms.string(options.dqmFile)
+
+process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),
+       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')),
+       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string(''))
+)
+process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+
+process.load("DQMServices.Core.DQMStore_cfg")
+
+process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
+    dataLabel = cms.untracked.string('')
+)
+
+
+process.p = cms.Path(process.stat)
+


### PR DESCRIPTION
Modify the code to have merged SiStrip bad channels from PCL, FED errors and RunInfo. Modified and cleaned TlMap creation script. These tools are used Offline by the Tracker shifters, nothing is modified in standard Strip DQM workflow
