### PR TITLE
Do not use constexpr with std::log in C++14 for ICC

### DIFF
--- a/TrackingTools/GsfTracking/src/GsfBetheHeitlerUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfBetheHeitlerUpdator.cc
@@ -20,7 +20,7 @@ namespace {
   /// Second moment of the Bethe-Heitler distribution (in z=E/E0)
   inline float BetheHeitlerVariance (const float rl)
   {
-#if __clang__
+#if defined(__clang__) || defined(__INTEL_COMPILER)
     const
 #else
     constexpr


### PR DESCRIPTION
C++14 standard prohibits library implementation to mark random C++
standard library functions as being `constexpr`. That's why this isn't
working with Clang and ICC in general.

It's a bit of gray area here. GCC most likely will lower  `std::log` to
`__builtin_log_*` intrinsic which are not covered by C++14 standard.
Thus it's `__builtin_log_*` which is `constexpr`, thus making it work
under C++14.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
