### PR TITLE
Migrate remaining 2017 reco customizations to era

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
@@ -58,6 +59,10 @@ globalreco_tracking = cms.Sequence(offlineBeamSpot*
                           standalonemuontracking*
                           trackingGlobalReco*
                           vertexreco)
+_globalreco_tracking_Phase1PU70 = globalreco_tracking.copy()
+_globalreco_tracking_Phase1PU70.replace(trackingGlobalReco, recopixelvertexing+trackingGlobalReco)
+eras.trackingPhase1.toReplaceWith(globalreco_tracking, _globalreco_tracking_Phase1PU70)
+
 globalreco = cms.Sequence(globalreco_tracking*
                           hcalGlobalRecoSequence*
                           particleFlowCluster*
@@ -117,6 +122,9 @@ noTrackingAndDependent.append(siPixelClusters)
 noTrackingAndDependent.append(clusterSummaryProducer)
 noTrackingAndDependent.append(siPixelRecHitsPreSplitting)
 noTrackingAndDependent.append(MeasurementTrackerEventPreSplitting)
+noTrackingAndDependent.append(PixelLayerTriplets)
+noTrackingAndDependent.append(pixelTracks)
+noTrackingAndDependent.append(pixelVertices)
 modulesToRemove.append(dt1DRecHits)
 modulesToRemove.append(dt1DCosmicRecHits)
 modulesToRemove.append(csc2DRecHits)

--- a/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
+++ b/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
@@ -1,9 +1,13 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
 caloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbheprereco'))
 ak4CaloJetsForTrk = ak4CaloJets.clone(srcPVs = cms.InputTag('firstStepPrimaryVertices'), src= cms.InputTag('caloTowerForTrk'))
+eras.trackingPhase1.toModify(ak4CaloJetsForTrk,
+    srcPVs = "pixelVertices"
+)
 
 caloJetsForTrk = cms.Sequence(caloTowerForTrk*ak4CaloJetsForTrk)
 

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
@@ -3,25 +3,5 @@ import FWCore.ParameterSet.Config as cms
 
 #
 from CondTools.SiPixel.SiPixelGainCalibrationService_cfi import *
-siPixelClustersPreSplitting = cms.EDProducer("SiPixelClusterProducer",
-    SiPixelGainCalibrationServiceParameters,
-    src = cms.InputTag("siPixelDigis"),
-    ChannelThreshold = cms.int32(1000),
-    MissCalibrate = cms.untracked.bool(True),
-    SplitClusters = cms.bool(False),
-    VCaltoElectronGain = cms.int32(65),
-    VCaltoElectronOffset = cms.int32(-414),
-    # **************************************
-    # ****  payLoadType Options         ****
-    # ****  HLT - column granularity    ****
-    # ****  Offline - gain:col/ped:pix  ****
-    # **************************************
-    payloadType = cms.string('Offline'),
-    SeedThreshold = cms.int32(1000),
-    ClusterThreshold = cms.double(4000.0),
-    # **************************************
-    maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
-)
-
-
-
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+siPixelClustersPreSplitting = _siPixelClusters.clone()

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -24,3 +24,9 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
 )
 
 
+# This customization will be removed once we have phase1 pixel digis
+from Configuration.StandardSequences.Eras import eras
+eras.phase1Pixel.toModify(siPixelClusters, # FIXME
+    src = 'simSiPixelDigis',
+    MissCalibrate = False
+)

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -23,7 +23,7 @@ mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.Tra
 
 
 #for displaced global muons
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 duplicateDisplacedTrackClassifier = TrackCutClassifier.clone()
 duplicateDisplacedTrackClassifier.src='mergedDuplicateDisplacedTracks'
 duplicateDisplacedTrackClassifier.mva.minPixelHits = [0,0,0]

--- a/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
+++ b/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 
 preDuplicateMergingDisplacedTracks = TrackCollectionMerger.clone()
@@ -14,3 +15,12 @@ preDuplicateMergingDisplacedTracks.inputClassifiers =[
 preDuplicateMergingDisplacedTracks.foundHitBonus  = 100.0
 preDuplicateMergingDisplacedTracks.lostHitPenalty =   1.0
 
+# For Phase1PU70 tracking, take out muonSeededTracksInOut because the
+# cut-selector module is technically incompatible with this one. Since
+# that configuration is indended only for tracking comparisons (not
+# for production), it is not worth of the effort to try to fix the
+# situation.
+eras.trackingPhase1.toModify(preDuplicateMergingDisplacedTracks,
+    trackProducers = [x for x in preDuplicateMergingDisplacedTracks.trackProducers if x != "muonSeededTracksInOut"],
+    inputClassifiers = [x for x in preDuplicateMergingDisplacedTracks.inputClassifiers if x != "muonSeededTracksInOutClassifier"],
+)

--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 #
@@ -8,3 +9,11 @@ from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
 recopixelvertexing = cms.Sequence(PixelLayerTriplets*pixelTracks*pixelVertices)
 
+# For Phase1PU70
+PixelLayerTripletsPreSplitting = PixelLayerTriplets.clone(
+    BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+    FPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+)
+_recopixelvertexing_Phase1PU70 = recopixelvertexing.copy()
+_recopixelvertexing_Phase1PU70.replace(PixelLayerTriplets, PixelLayerTripletsPreSplitting)
+eras.trackingPhase1.toReplaceWith(recopixelvertexing, _recopixelvertexing_Phase1PU70)

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
@@ -1,7 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ClusterShapeHitFilterESProducer = cms.ESProducer("ClusterShapeHitFilterESProducer",
                                                         ComponentName = cms.string('ClusterShapeHitFilter'),
                                                         PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
                                                         clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
                                                         )
+eras.phase1Pixel.toModify(ClusterShapeHitFilterESProducer,
+    PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par'
+)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoPixelVertexing.PixelTrackFitting.PixelFitterByHelixProjections_cfi import *
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
@@ -34,3 +35,16 @@ PixelTrackReconstructionBlock = cms.PSet (
     )
 )
 
+eras.trackingPhase1.toModify(PixelTrackReconstructionBlock,
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string('PixelSeedMergerQuadruplets')),
+        addRemainingTriplets = cms.bool(False),
+        mergeTriplets = cms.bool(True),
+        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    ),
+    FilterPSet = dict(
+        chi2 = 50.0,
+        tipMax = 0.05
+    ),
+    RegionFactoryPSet = dict(RegionPSet = dict(originRadius =  0.02))
+)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
@@ -46,5 +46,9 @@ eras.trackingPhase1.toModify(PixelTrackReconstructionBlock,
         chi2 = 50.0,
         tipMax = 0.05
     ),
-    RegionFactoryPSet = dict(RegionPSet = dict(originRadius =  0.02))
+    RegionFactoryPSet = dict(RegionPSet = dict(originRadius =  0.02)),
+    OrderedHitsFactoryPSet = dict(
+        SeedingLayers = "PixelLayerTripletsPreSplitting",
+        GeneratorPSet = dict(SeedComparitorPSet = dict(clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"))
+    ),
 )

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -1,5 +1,6 @@
 
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # creating quadruplet SeedingLayerSets for the merger;
 PixelSeedMergerQuadruplets = cms.PSet(
@@ -36,3 +37,12 @@ PixelSeedMergerQuadruplets = cms.PSet(
   TEC = cms.PSet(  )
 )
 
+# Needed to have pixelTracks to not to look like depending
+# siPixelRecHits (that is inserted in reco sequences in
+# InitialStepPreSplitting). The quadruplet merger does not use these
+# hit collections (it uses the hits of the triplets), so this is only
+# to make framework's circular dependency checker happy.
+eras.trackingPhase1.toModify(PixelSeedMergerQuadruplets,
+    BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+    FPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+)

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -26,12 +26,12 @@ PixelSeedMergerQuadruplets = cms.PSet(
   ),
 
   BPix = cms.PSet( 
-    TTRHBuilder = cms.string( "TTRHBuilderPixelOnly" ),
-    HitProducer = cms.string( "hltSiPixelRecHits" ),
+    TTRHBuilder = cms.string( "PixelTTRHBuilderWithoutAngle" ),
+    HitProducer = cms.string( "siPixelRecHits" ),
   ),
   FPix = cms.PSet( 
-    TTRHBuilder = cms.string( "TTRHBuilderPixelOnly" ),
-    HitProducer = cms.string( "hltSiPixelRecHits" ),
+    TTRHBuilder = cms.string( "PixelTTRHBuilderWithoutAngle" ),
+    HitProducer = cms.string( "siPixelRecHits" ),
   ),
   TEC = cms.PSet(  )
 )

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -17,7 +17,7 @@ mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduce
 mergedDuplicateTracks.src = cms.InputTag("duplicateTrackCandidates","candidates")
 mergedDuplicateTracks.Fitter='RKFittingSmoother' # no outlier rejection!
 
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 duplicateTrackClassifier = TrackCutClassifier.clone()
 duplicateTrackClassifier.src='mergedDuplicateTracks'
 duplicateTrackClassifier.mva.minPixelHits = [0,0,0]

--- a/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
@@ -1,0 +1,5 @@
+from Configuration.StandardSequences.Eras import eras
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+eras.trackingPhase1.toModify(TrackCutClassifier,
+    vertices = "pixelVertices"
+)

--- a/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
@@ -1,4 +1,4 @@
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 looseMTS = cms.PSet(
     preFilterName=cms.string(''),
@@ -89,3 +90,6 @@ multiTrackSelector = cms.EDProducer("MultiTrackSelector",
                                tightMTS,
                                highpurityMTS)
  ) 
+eras.trackingPhase1.toModify(multiTrackSelector,
+    vertices = "pixelVertices"
+)

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ### STEP 0 ###
 
@@ -141,3 +142,25 @@ InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
                                        MeasurementTrackerEvent*
                                        siPixelClusterShapeCache)
 
+# Although InitialStepPreSplitting is not really part of Phase1PU70
+# tracking, we use it to get siPixelClusters and siPixelRecHits
+# collections for non-splitted pixel clusters. All modules before
+# iterTracking sequence use siPixelClustersPreSplitting and
+# siPixelRecHitsPreSplitting for that purpose.
+#
+# If siPixelClusters would be defined in
+# RecoLocalTracker.Configuration.RecoLocalTracker_cff, we would have a
+# situation where
+# - Phase1PU70 has siPixelClusters defined in RecoLocalTracker_cff
+# - everything else has siPixelClusters defined here
+# and this leads to a mess. The way it is done here we have only
+# one place (within Reconstruction_cff) where siPixelClusters
+# module is defined.
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+eras.trackingPhase1.toReplaceWith(siPixelClusters, _siPixelClusters)
+eras.trackingPhase1.toReplaceWith(InitialStepPreSplitting, cms.Sequence(
+    siPixelClusters +
+    siPixelRecHits +
+    MeasurementTrackerEvent +
+    siPixelClusterShapeCache
+))

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -148,7 +148,7 @@ from RecoTracker.IterativeTracking.InitialStep_cff import initialStepClassifier1
 #jetCoreRegionalStep.inputClassifiers=['jetCoreRegionalStepClassifier1','jetCoreRegionalStepClassifier2']
 
 
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 jetCoreRegionalStep = TrackCutClassifier.clone()
 jetCoreRegionalStep.src='jetCoreRegionalStepTracks'
 jetCoreRegionalStep.mva.minPixelHits = [1,1,1]

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -126,7 +126,7 @@ muonSeededTracksInOut = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduce
 
 
 # Final Classifier
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 muonSeededTracksInOutClassifier = TrackCutClassifier.clone()
 muonSeededTracksInOutClassifier.src='muonSeededTracksInOut'
 muonSeededTracksInOutClassifier.mva.minPixelHits = [0,0,0]

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -73,7 +73,8 @@ eras.trackingPhase1.toModify(pixelPairStepSeeds,
     RegionFactoryPSet = dict(
         RegionPSet = dict(
             ptMin = 1.2,
-            useMultipleScattering = False
+            useMultipleScattering = False,
+            VertexCollection = "pixelVertices",
         )
     ),
 )

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -40,6 +40,7 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
 
 from Configuration.StandardSequences.Eras import eras
 eras.trackingPhase1.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStepPreSplitting +
     InitialStep +
     HighPtTripletStep +
     LowPtQuadStep +

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 MeasurementTrackerEvent = cms.EDProducer("MeasurementTrackerEventProducer",
     measurementTracker = cms.string(''),
@@ -12,6 +13,10 @@ MeasurementTrackerEvent = cms.EDProducer("MeasurementTrackerEventProducer",
     inactivePixelDetectorLabels = cms.VInputTag(cms.InputTag('siPixelDigis')),
     inactiveStripDetectorLabels = cms.VInputTag(cms.InputTag('siStripDigis')),
     switchOffPixelsIfEmpty = cms.bool(True), # let's keep it like this, for cosmics                                    
+)
+# This customization will be removed once we have phase1 pixel digis
+eras.phase1Pixel.toModify(MeasurementTrackerEvent, # FIXME
+    inactivePixelDetectorLabels = []
 )
 
 MeasurementTrackerEventPreSplitting = MeasurementTrackerEvent.clone(

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -471,8 +471,7 @@ def customise_Reco(process,pileup):
         
         # End of new tracking configuration which can be removed if new Reconstruction is used.
 
-    # Needed to make the loading of recoFromSimDigis_cff below to work
-    process.InitialStepPreSplitting.remove(siPixelClusters)
+        process.InitialStepPreSplitting.remove(siPixelClusters)
 
     process.reconstruction.remove(process.castorreco)
     process.reconstruction.remove(process.CastorTowerReco)
@@ -483,7 +482,8 @@ def customise_Reco(process,pileup):
     process.reconstruction.remove(process.ak7CastorJetID)
 
     # Need these until pixel templates are used
-    process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
+    if not eras.phase1Pixel.isChosen():
+        process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
     # CPE for other steps
     process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
 
@@ -518,20 +518,19 @@ def customise_Reco(process,pileup):
         process.globalSETMuons.GLBTrajBuilderParameters.TrackTransformer.TrackerRecHitBuilder = 'WithTrackAngle'
         process.globalSETMuons.GLBTrajBuilderParameters.TrackerRecHitBuilder = 'WithTrackAngle'
         process.globalSETMuons.TrackLoaderParameters.TTRHBuilder = 'WithTrackAngle'
-    # End of pixel template needed section
 
-    # Remove, for now, the pre-cluster-splitting clustering step
-    # To be enabled later together with or after the jet core step is enabled
-    # This snippet must be after the loading of recoFromSimDigis_cff
-    process.pixeltrackerlocalreco = cms.Sequence(
-        process.siPixelClusters +
-        process.siPixelRecHits
-    )
-    process.clusterSummaryProducer.pixelClusters = "siPixelClusters"
-    process.globalreco_tracking.replace(process.MeasurementTrackerEventPreSplitting, process.MeasurementTrackerEvent)
-    process.globalreco_tracking.replace(process.siPixelClusterShapeCachePreSplitting, process.siPixelClusterShapeCache)
 
-    if not eras.phase1Pixel.isChosen():
+        # Remove the pre-cluster-splitting clustering step
+        # To be enabled later together with or after the jet core step is enabled
+        # This snippet must be after the loading of recoFromSimDigis_cff
+        process.pixeltrackerlocalreco = cms.Sequence(
+            process.siPixelClusters +
+            process.siPixelRecHits
+        )
+        process.clusterSummaryProducer.pixelClusters = "siPixelClusters"
+        process.globalreco_tracking.replace(process.MeasurementTrackerEventPreSplitting, process.MeasurementTrackerEvent)
+        process.globalreco_tracking.replace(process.siPixelClusterShapeCachePreSplitting, process.siPixelClusterShapeCache)
+
         # Enable, for now, pixel tracks and vertices
         # To be removed later together with the cluster splitting
         process.globalreco_tracking.replace(process.standalonemuontracking,

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -337,12 +337,12 @@ def customise_Reco(process,pileup):
     nPU=70
     if pileup>100: nPU=140
     
-    #use with latest pixel geometry
-    process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
-    # Need this line to stop error about missing siPixelDigis.
-    process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
-
     if not eras.phase1Pixel.isChosen():
+        #use with latest pixel geometry
+        process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
+        # Need this line to stop error about missing siPixelDigis.
+        process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
+
         # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
         process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
                                                             'BPix2+BPix3+BPix4',

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -568,10 +568,10 @@ def customise_Reco(process,pileup):
     #process.templates.LoadTemplatesFromDB = cms.bool(False)
     #process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
 
-    # This probably breaks badly the "displaced muon" reconstruction,
-    # but let's do it for now, until the upgrade tracking sequences
-    # are modernized
-    process.preDuplicateMergingDisplacedTracks.inputClassifiers.remove("muonSeededTracksInOutClassifier")
-    process.preDuplicateMergingDisplacedTracks.trackProducers.remove("muonSeededTracksInOut")
+        # This probably breaks badly the "displaced muon" reconstruction,
+        # but let's do it for now, until the upgrade tracking sequences
+        # are modernized
+        process.preDuplicateMergingDisplacedTracks.inputClassifiers.remove("muonSeededTracksInOutClassifier")
+        process.preDuplicateMergingDisplacedTracks.trackProducers.remove("muonSeededTracksInOut")
 
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -553,16 +553,16 @@ def customise_Reco(process,pileup):
         process.muonSeededTracksOutInDisplacedClassifier.vertices = "pixelVertices"
         process.duplicateDisplacedTrackClassifier.vertices = "pixelVertices"
 
-    # Make pixelTracks use quadruplets
-    process.pixelTracks.SeedMergerPSet = cms.PSet(
-        layerList = cms.PSet(refToPSet_ = cms.string('PixelSeedMergerQuadruplets')),
-        addRemainingTriplets = cms.bool(False),
-        mergeTriplets = cms.bool(True),
-        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
-        )
-    process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
-    process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
-    process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
+        # Make pixelTracks use quadruplets
+        process.pixelTracks.SeedMergerPSet = cms.PSet(
+            layerList = cms.PSet(refToPSet_ = cms.string('PixelSeedMergerQuadruplets')),
+            addRemainingTriplets = cms.bool(False),
+            mergeTriplets = cms.bool(True),
+            ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+            )
+        process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
+        process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
+        process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
 
     # use defaults d.k. 2/16
     #process.templates.DoLorentz=False

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -474,7 +474,6 @@ def customise_Reco(process,pileup):
     # Needed to make the loading of recoFromSimDigis_cff below to work
     process.InitialStepPreSplitting.remove(siPixelClusters)
 
-
     process.reconstruction.remove(process.castorreco)
     process.reconstruction.remove(process.CastorTowerReco)
     process.reconstruction.remove(process.ak5CastorJets)
@@ -483,13 +482,6 @@ def customise_Reco(process,pileup):
     #process.reconstruction.remove(process.ak7BasicJets)
     process.reconstruction.remove(process.ak7CastorJetID)
 
-    #the quadruplet merger configuration     
-    process.load("RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff")
-    process.PixelSeedMergerQuadruplets.BPix.TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
-    process.PixelSeedMergerQuadruplets.BPix.HitProducer = cms.string("siPixelRecHits" )
-    process.PixelSeedMergerQuadruplets.FPix.TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
-    process.PixelSeedMergerQuadruplets.FPix.HitProducer = cms.string("siPixelRecHits" )    
-    
     # Need these until pixel templates are used
     process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
     # CPE for other steps

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -342,7 +342,7 @@ def customise_Reco(process,pileup):
     # Need this line to stop error about missing siPixelDigis.
     process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
 
-    if not eras.trackingPhase1.isChosen():
+    if not eras.phase1Pixel.isChosen():
         # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
         process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
                                                             'BPix2+BPix3+BPix4',

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -484,10 +484,7 @@ def customise_Reco(process,pileup):
     # Need these until pixel templates are used
     if not eras.phase1Pixel.isChosen():
         process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
-    # CPE for other steps
-    process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
 
-    if not eras.phase1Pixel.isChosen():
         # Turn of template use in tracking
         # Iterations and the following ones are treated in the configs    
         process.duplicateTrackCandidates.ttrhBuilderName = 'WithTrackAngle'
@@ -562,11 +559,6 @@ def customise_Reco(process,pileup):
         process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
         process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
         process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
-
-    # use defaults d.k. 2/16
-    #process.templates.DoLorentz=False
-    #process.templates.LoadTemplatesFromDB = cms.bool(False)
-    #process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
 
         # This probably breaks badly the "displaced muon" reconstruction,
         # but let's do it for now, until the upgrade tracking sequences

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -473,16 +473,15 @@ def customise_Reco(process,pileup):
 
         process.InitialStepPreSplitting.remove(siPixelClusters)
 
-    process.reconstruction.remove(process.castorreco)
-    process.reconstruction.remove(process.CastorTowerReco)
-    process.reconstruction.remove(process.ak5CastorJets)
-    process.reconstruction.remove(process.ak5CastorJetID)
-    process.reconstruction.remove(process.ak7CastorJets)
-    #process.reconstruction.remove(process.ak7BasicJets)
-    process.reconstruction.remove(process.ak7CastorJetID)
+        process.reconstruction.remove(process.castorreco)
+        process.reconstruction.remove(process.CastorTowerReco)
+        process.reconstruction.remove(process.ak5CastorJets)
+        process.reconstruction.remove(process.ak5CastorJetID)
+        process.reconstruction.remove(process.ak7CastorJets)
+        #process.reconstruction.remove(process.ak7BasicJets)
+        process.reconstruction.remove(process.ak7CastorJetID)
 
-    # Need these until pixel templates are used
-    if not eras.phase1Pixel.isChosen():
+        # Need these until pixel templates are used
         process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
 
         # Turn of template use in tracking

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -531,26 +531,27 @@ def customise_Reco(process,pileup):
     process.globalreco_tracking.replace(process.MeasurementTrackerEventPreSplitting, process.MeasurementTrackerEvent)
     process.globalreco_tracking.replace(process.siPixelClusterShapeCachePreSplitting, process.siPixelClusterShapeCache)
 
-    # Enable, for now, pixel tracks and vertices
-    # To be removed later together with the cluster splitting
-    process.globalreco_tracking.replace(process.standalonemuontracking,
-                                        process.standalonemuontracking+process.recopixelvertexing)
-    process.initialStepSelector.vertices = "pixelVertices"
-    process.highPtTripletStepSelector.vertices = "pixelVertices"
-    process.lowPtQuadStepSelector.vertices = "pixelVertices"
-    process.lowPtTripletStepSelector.vertices = "pixelVertices"
-    process.detachedQuadStepSelector.vertices = "pixelVertices"
-    process.mixedTripletStepSelector.vertices = "pixelVertices"
-    process.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = "pixelVertices"
-    process.pixelPairStepSelector.vertices = "pixelVertices"
-    process.tobTecStepSelector.vertices = "pixelVertices"
-    process.muonSeededTracksInOutSelector.vertices = "pixelVertices"
-    process.muonSeededTracksOutInSelector.vertices = "pixelVertices"
-    process.duplicateTrackClassifier.vertices = "pixelVertices"
-    process.convStepSelector.vertices = "pixelVertices"
-    process.ak4CaloJetsForTrk.srcPVs = "pixelVertices"
-    process.muonSeededTracksOutInDisplacedClassifier.vertices = "pixelVertices"
-    process.duplicateDisplacedTrackClassifier.vertices = "pixelVertices"
+    if not eras.phase1Pixel.isChosen():
+        # Enable, for now, pixel tracks and vertices
+        # To be removed later together with the cluster splitting
+        process.globalreco_tracking.replace(process.standalonemuontracking,
+                                            process.standalonemuontracking+process.recopixelvertexing)
+        process.initialStepSelector.vertices = "pixelVertices"
+        process.highPtTripletStepSelector.vertices = "pixelVertices"
+        process.lowPtQuadStepSelector.vertices = "pixelVertices"
+        process.lowPtTripletStepSelector.vertices = "pixelVertices"
+        process.detachedQuadStepSelector.vertices = "pixelVertices"
+        process.mixedTripletStepSelector.vertices = "pixelVertices"
+        process.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = "pixelVertices"
+        process.pixelPairStepSelector.vertices = "pixelVertices"
+        process.tobTecStepSelector.vertices = "pixelVertices"
+        process.muonSeededTracksInOutSelector.vertices = "pixelVertices"
+        process.muonSeededTracksOutInSelector.vertices = "pixelVertices"
+        process.duplicateTrackClassifier.vertices = "pixelVertices"
+        process.convStepSelector.vertices = "pixelVertices"
+        process.ak4CaloJetsForTrk.srcPVs = "pixelVertices"
+        process.muonSeededTracksOutInDisplacedClassifier.vertices = "pixelVertices"
+        process.duplicateDisplacedTrackClassifier.vertices = "pixelVertices"
 
     # Make pixelTracks use quadruplets
     process.pixelTracks.SeedMergerPSet = cms.PSet(


### PR DESCRIPTION
This PR completes the migration of 2017 reconstruction customizations from `phase1TkCustoms` to `phase1Pixel`/`trackingPhase1` eras that was started in #13477. The produced configurations before and after this PR are not exactly the same. Functionally they are, with the exception that with this PR the castor reconstruction modules are run (following #13591).

The only non-straightforward part was the treatment of non-splitted `siPixelClusters` for the `Phase1PU70` tracking. The issue was discussed in #13381 and in March 3 RECO meeting https://indico.cern.ch/event/505422/contribution/5/attachments/1237476/1817746/slides_trk_phase1_era.pdf, and the impelemented way is to use both `siPixelClustersPreSplitting` and `siPixelClusters` for non-splitted clusters for `Phase1PU70`.

Next step is to switch the default 2017 tracking to the one in #13149 (`Phase1PU70` will be left as a reference that can be switched on with `Run2_2017_trackingPhase1PU70` era).

Tested in CMSSW_8_1_X_2016-03-08-2300 (`runTheMatrix.py -i all -l limited,25202.0,10024.0,10224.0`), no changes expected in monitored quantities.

@rovere @VinInn 
