### PR TITLE
Changed the struct Count to avoid thread safety warnings

### DIFF
--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -13,6 +13,7 @@
 
 namespace {
   struct Count {
+    Count() {}
 #ifdef SISTRIP_COUNT
     // note: this code is not thread safe, counts will be inaccurate if run with multiple threads
     double ncall=0;

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -30,15 +30,17 @@ namespace {
       std::cout << "strips  " << nstr/ndep << " " << std::sqrt(nstr2*ndep -nstr*nstr)/ndep << std::endl;
       std::cout << "vaules  " << ncv << " " << maxv << " " << nval/ncv << " " << std::sqrt(nval2*ncv -nval*nval)/ncv << std::endl;
     }
-#else
-    void dep(double) {}
-    void str(double) {}
-    void val(double) {}
-    void zero() {}    
-#endif
   };
-  
  Count count;
+#else
+    void dep(double) const {}
+    void str(double) const {}
+    void val(double) const {}
+    void zero() const {}    
+ };
+ const Count count;
+#endif
+  
 }
 
 


### PR DESCRIPTION
Changed struct Count in SiTrivialInduceChargeOnStrips
so that it is const during normal compilation.

Avoids thread safety warnings in the Static analyzers
