### PR TITLE
Add accessor to HGCalDDDConstants

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -70,7 +70,10 @@ public:
   std::pair<double,double> waferPosition(int wafer) const;
   int                 wafers() const;
   int                 waferToCopy(int wafer) const {return ((wafer>=0)&&(wafer< (int)(hgpar_->waferCopy_.size()))) ? hgpar_->waferCopy_[wafer] : (int)(hgpar_->waferCopy_.size());}
+  // wafer transverse thickness classification (2 = coarse, 1 = fine)
   int                 waferTypeT(int wafer) const {return ((wafer>=0)&&(wafer<(int)(hgpar_->waferTypeT_.size()))) ? hgpar_->waferTypeT_[wafer] : 0;}
+  // wafer longitudinal thickness classification (1 = 100um, 2 = 200um, 3=300um)
+  int                 waferTypeL(int wafer) const {return ((wafer>=0)&&(wafer<(int)(hgpar_->waferTypeL_.size()))) ? hgpar_->waferTypeL_[wafer] : 0;}
   double              waferZ(int layer, bool reco) const;
 
   HGCalParameters::hgtrap getModule(unsigned int k, bool hexType, bool reco) const;


### PR DESCRIPTION
Add an accessor to provide information about the thickness of the silicon wafer.

An integer is returned with value 1,2,3, corresponding to 100um, 200um, 300um, respectively.
