### PR TITLE
 delete loaded cleanPatJets after the temporary load if it was not around already (same as #13681 )

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1409,10 +1409,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 photonCollection = cms.InputTag("cleanedPatPhotons"+postfix)
 
         #jet cleaning
+        have_cleanPatJets = hasattr(process, "cleanPatJets")
         process.load("PhysicsTools.PatAlgos.cleaningLayer1.jetCleaner_cfi")
         cleanPatJetProducer = getattr(process, "cleanPatJets").clone( 
                      src = jetCollection
             )
+        #do not leave it hanging
+        if not have_cleanPatJets:
+            del process.cleanPatJets
         cleanPatJetProducer.checkOverlaps.muons.src = muonCollection
         cleanPatJetProducer.checkOverlaps.electrons.src = electronCollection
         if isValidInputTag(photonCollection) and autoJetCleaning != "LepClean":


### PR DESCRIPTION
[copy-paste from 13681 )

On a technical side, this cleans up the temporary module loaded to the process only for the purpose of cloning it.

On a practical side, this also recovers back 500MB of extra memory triggered by PATStringCutObjectSelector due to jetCleaning loaded in #13372 / #13115 .

The default cleaner has a non-trivial cleaning selector in tkIsoElectrons and is never used in miniAOD workflow, while the derived cleaners loaded by jetCleaning have trivial selectors only (which do not use much memory).

[it looks like there are enough different context line that this PR is independent from #13372 / #13115 . ]

A better solution for PATStringCutObjectSelector memory use will need a more targeted instantiation selector functions (instead of all possible pat objects).
