### PR TITLE
cleanup unnamed sequences in TrackingDQMSourceTier0*

### DIFF
--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -58,7 +58,7 @@ trackSelector = cms.EDFilter('TrackSelector',
 highPurityPtRange0to1 = trackSelector.clone()
 highPurityPtRange0to1.cut = cms.string("quality('highPurity') & pt >= 0 & pt < 1 ")
 
-sequenceName    ['highPurityPtRange0to1'] = cms.Sequence(highPurityPtRange0to1)
+sequenceName    ['highPurityPtRange0to1'] = highPurityPtRange0to1
 mainfolderName  ['highPurityPtRange0to1'] = 'Tracking/TrackParameters/highPurityTracks/pt_0to1'
 vertexfolderName['highPurityPtRange0to1'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_0to1'
 trackPtN        ['highPurityPtRange0to1'] = cms.int32(10)
@@ -85,7 +85,7 @@ doEffFromHitPattern                 ['highPurityPtRange0to1'] = cms.bool(False)
 highPurityPtRange1to10 = trackSelector.clone()
 highPurityPtRange1to10.cut = cms.string("quality('highPurity') & pt >= 1 & pt < 10 ")
 
-sequenceName    ['highPurityPtRange1to10'] = cms.Sequence( highPurityPtRange1to10 )
+sequenceName    ['highPurityPtRange1to10'] = highPurityPtRange1to10 
 mainfolderName  ['highPurityPtRange1to10'] = 'Tracking/TrackParameters/highPurityTracks/pt_1to10'
 vertexfolderName['highPurityPtRange1to10'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_1to10'
 trackPtN        ['highPurityPtRange1to10'] = cms.int32(10)
@@ -111,7 +111,7 @@ doEffFromHitPattern                 ['highPurityPtRange1to10'] = cms.bool(True)
 highPurityPt10 = trackSelector.clone()
 highPurityPt10.cut = cms.string("quality('highPurity') & pt >= 10")
 
-sequenceName    ['highPurityPt10'] = cms.Sequence( highPurityPt10 )
+sequenceName    ['highPurityPt10'] = highPurityPt10 
 mainfolderName  ['highPurityPt10'] = 'Tracking/TrackParameters/highPurityTracks/pt_10'
 vertexfolderName['highPurityPt10'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_10'
 trackPtN        ['highPurityPt10'] = cms.int32(100)
@@ -139,7 +139,7 @@ doEffFromHitPattern                 ['highPurityPt10'] = cms.bool(True)
 highPurityPt1 = trackSelector.clone()
 highPurityPt1.cut = cms.string("quality('highPurity') & pt >= 1")
 
-sequenceName    ['highPurityPt1'] = cms.Sequence(highPurityPt1)
+sequenceName    ['highPurityPt1'] = highPurityPt1
 mainfolderName  ['highPurityPt1'] = 'Tracking/TrackParameters/highPurityTracks/pt_1'
 vertexfolderName['highPurityPt1'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_1'
 trackPtN        ['highPurityPt1'] = cms.int32(100)

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -167,15 +167,15 @@ for tracks in selectedTracks :
     if tracks != 'generalTracks':
         TrackingDQMSourceTier0 += sequenceName[tracks]
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
-    TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0 += locals()[label]
 # seeding monitoring
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
-    TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0 += locals()[label]
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
-    TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0 += locals()[label]
 TrackingDQMSourceTier0 += dqmInfoTracking
 
 
@@ -187,15 +187,15 @@ for tracks in selectedTracks :
     if tracks != 'generalTracks':
         TrackingDQMSourceTier0Common+=sequenceName[tracks]
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
-    TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0Common += locals()[label]
 # seeding monitoring
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
-    TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0Common += locals()[label]
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
-    TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0Common += locals()[label]
 TrackingDQMSourceTier0Common += dqmInfoTracking
 
 TrackingDQMSourceTier0MinBias = cms.Sequence()
@@ -208,14 +208,14 @@ for tracks in selectedTracks :
     if tracks != 'generalTracks':
         TrackingDQMSourceTier0MinBias += sequenceName[tracks]
     label = 'TrackerCollisionSelectedTrackMonMB' + str(tracks)
-    TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0MinBias += locals()[label]
 # seeding monitoring
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
-    TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0MinBias += locals()[label]
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonMB'
-    TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
+    TrackingDQMSourceTier0MinBias += locals()[label]
 TrackingDQMSourceTier0MinBias += dqmInfoTracking
 


### PR DESCRIPTION
use labeled objects directly; do not wrap them in unnamed sequences

this is a result of trying to run RECO+DQM step with --repacked flag in the cmsDriver as a part of tests to run pp scenario on HI inputs.
Prior to the fix, the cmsDriver was failing with `RuntimeError: module has no label. ...`
