### PR TITLE
Added L1TStage2uGT DQM module

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -54,7 +54,8 @@ process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
 
 process.stage2UnpackPath = cms.Path(process.caloStage2Digis +
                                     process.gmtStage2Digis +
-                                    process.emtfStage2Digis
+                                    process.emtfStage2Digis +
+                                    process.gtStage2Digis
                                     )
 
 process.l1tMonitorPath = cms.Path(process.l1tStage2online)
@@ -97,6 +98,7 @@ process.siPixelDigis.InputLabel = cms.InputTag("rawDataCollector")
 process.siStripDigis.ProductLabel = cms.InputTag("rawDataCollector")
 process.bxTiming.FedSource = cms.untracked.InputTag("rawDataCollector")
 process.l1s.fedRawData = cms.InputTag("rawDataCollector")
+process.gtStage2Digis.InputLabel = cms.InputTag("rawDataCollector")
     
 if (process.runType.getRunType() == process.runType.hi_run):
     process.castorDigis.InputLabel = cms.InputTag("rawDataRepacker")

--- a/DQM/L1TMonitor/BuildFile.xml
+++ b/DQM/L1TMonitor/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="DQMServices/Components"/>
 <use   name="DQMServices/ClientConfig"/>
 <use   name="DataFormats/L1Trigger"/>
+<use   name="DataFormats/L1TGlobal"/>
 <use   name="DataFormats/LTCDigi"/>
 <use   name="DataFormats/CSCDigi"/>
 <use   name="DataFormats/L1CSCTrackFinder"/>

--- a/DQM/L1TMonitor/interface/L1TStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGT.h
@@ -1,0 +1,79 @@
+#ifndef L1TSTAGE2UGT_H
+#define L1TSTAGE2UGT_H
+
+/**
+ * \class L1TStage2uGT
+ *
+ * Description: DQM for L1 Micro Global Trigger.
+ *
+ * \author Mateusz Zarucki 2016
+ * \author J. Berryhill, I. Mikulec
+ * \author Vasile Mihai Ghete - HEPHY Vienna
+ *
+ */
+
+// System include files
+#include <memory>
+#include <vector>
+
+// User include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/typedefs.h"
+
+// L1 trigger include files
+//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+
+// DQM include files
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+//
+// Class declaration
+//
+
+class L1TStage2uGT: public DQMEDAnalyzer {
+
+public:
+   L1TStage2uGT(const edm::ParameterSet& ps); // constructor
+   virtual ~L1TStage2uGT(); // destructor
+
+protected:
+   virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+   virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
+   virtual void analyze(const edm::Event&, const edm::EventSetup&);
+   virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&); // end section
+
+private:
+   
+   // Input parameters
+   edm::EDGetTokenT<GlobalAlgBlkBxCollection> l1tStage2uGtSource_; // input tag for L1 uGT DAQ readout record
+  
+   bool verbose_; // verbosity switch
+   
+   std::string histFolder_; // histogram folder for L1 uGT plots
+   
+   // Booking of histograms for the module
+   MonitorElement* algoBits_;
+   MonitorElement* algoBits_corr_;
+   MonitorElement* algoBits_bx_global_;
+   MonitorElement* algoBits_bx_inEvt_;
+   MonitorElement* algoBits_lumi_;
+  
+   MonitorElement* prescaleFactorSet_;
+ 
+};
+
+#endif

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -3,13 +3,16 @@ import FWCore.ParameterSet.Config as cms
 from DQM.L1TMonitor.L1TStage2CaloLayer2_cfi import *
 from DQM.L1TMonitor.L1TStage2mGMT_cfi import *
 from DQM.L1TMonitor.L1TStage2EMTF_cfi import *
+from DQM.L1TMonitor.L1TStage2uGT_cfi import *
 
 from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import *
 from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
 from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import *
+from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
 
 l1tStage2online = cms.Sequence(
     l1tStage2CaloLayer2 +
     l1tStage2mGMT +
-    l1tStage2Emtf
+    l1tStage2Emtf +
+    l1tStage2uGt
     )

--- a/DQM/L1TMonitor/python/L1TStage2uGT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGT_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tStage2uGt = cms.EDAnalyzer("L1TStage2uGT",
+    l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),    
+    verbose = cms.untracked.bool(False)
+)

--- a/DQM/L1TMonitor/src/L1TStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGT.cc
@@ -1,0 +1,122 @@
+/**
+ * \class L1TStage2uGT
+ *
+ * Description: DQM for L1 Micro Global Trigger.
+ *
+ * \author Mateusz Zarucki 2016
+ * \author J. Berryhill, I. Mikulec
+ * \author Vasile Mihai Ghete - HEPHY Vienna
+ *
+ */
+
+#include "DQM/L1TMonitor/interface/L1TStage2uGT.h"
+
+// Constructor
+L1TStage2uGT::L1TStage2uGT(const edm::ParameterSet& params):
+   l1tStage2uGtSource_(consumes<GlobalAlgBlkBxCollection>(params.getParameter<edm::InputTag>("l1tStage2uGtSource"))),
+   verbose_(params.getUntrackedParameter<bool>("verbose", false))
+{
+   histFolder_ = params.getUntrackedParameter<std::string> ("HistFolder", "L1T2016/L1TStage2uGT");
+}
+
+// Destructor
+L1TStage2uGT::~L1TStage2uGT() {
+   // empty
+}
+
+void L1TStage2uGT::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& evtSetup) {
+   // empty 
+}
+
+void L1TStage2uGT::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& evtSetup) { 
+   // empty
+}
+
+void L1TStage2uGT::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const& evtSetup) {
+   
+   // Book histograms
+   const int numLS = 1000;
+   const double numLS_d = static_cast<double>(numLS);
+   const int numAlgs = 512; // FIXME: Take number of algorithms from EventSetup
+   const double numAlgs_d = static_cast<double>(numAlgs)-0.5;
+
+   ibooker.setCurrentFolder(histFolder_);
+    
+   algoBits_ = ibooker.book1D("algoBits", "uGT: Algorithm Trigger Bits", numAlgs, -0.5, numAlgs_d);
+   algoBits_->setAxisTitle("Algorithm Trigger Bits", 1);
+   
+   algoBits_corr_ = ibooker.book2D("algoBits_corr","uGT: Algorithm Trigger Bit Correlation", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_corr_->setAxisTitle("Algorithm Trigger Bits", 1);
+   algoBits_corr_->setAxisTitle("Algorithm Trigger Bits", 2);
+   
+   algoBits_bx_global_ = ibooker.book2D("algoBits_bx_global", "uGT: Algorithm Trigger Bits vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
+   algoBits_bx_global_->setAxisTitle("Algorithm Trigger Bits", 2);
+   
+   algoBits_bx_inEvt_ = ibooker.book2D("algoBits_bx_inEvt", "uGT: Algorithm Trigger Bits vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
+   algoBits_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits", 2);
+   
+   algoBits_lumi_ = ibooker.book2D("algoBits_lumi","uGT: Algorithm Trigger Bits vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_lumi_->setAxisTitle("Luminosity Segment", 1);
+   algoBits_lumi_->setAxisTitle("Algorithm Trigger Bits", 2);
+ 
+   prescaleFactorSet_ = ibooker.book2D("prescaleFactorSet", "uGT: Index of Prescale Factor Set vs. LS", numLS, 0., numLS_d, 25, 0., 25.);
+   prescaleFactorSet_->setAxisTitle("Luminosity Segment", 1);
+   prescaleFactorSet_->setAxisTitle("Prescale Factor Set Index", 2);
+}
+
+void L1TStage2uGT::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
+   // FIXME: Remove duplicate definition of numAlgs 
+   const int numAlgs = 512;
+  
+   if (verbose_) {
+      edm::LogInfo("L1TStage2uGT") << "L1TStage2uGT DQM: Analyzing.." << std::endl;
+   }
+   
+   // Get standard event parameters 
+   int lumi = evt.luminosityBlock();
+   int bx = evt.bunchCrossing();
+      
+   // Open uGT readout record
+   edm::Handle<GlobalAlgBlkBxCollection> uGtAlgs;
+   evt.getByToken(l1tStage2uGtSource_, uGtAlgs);
+   
+   if (!uGtAlgs.isValid()) {
+      edm::LogInfo("L1TStage2uGT") << "Cannot find uGT readout record.";
+      return;
+   }
+   
+   // Get uGT algo bit statistics
+   else {
+      //algoBits_->Fill(-1.); // fill underflow to normalize // FIXME: needed? 
+      for (int ibx=uGtAlgs->getFirstBX(); ibx <= uGtAlgs->getLastBX(); ++ibx) {
+         for (auto itr = uGtAlgs->begin(ibx); itr != uGtAlgs->end(ibx); ++itr) { // FIXME: redundant loop over 1-dim vector?
+            
+            // Fills prescale factor set histogram
+            prescaleFactorSet_->Fill(lumi, itr->getPreScColumn());
+             
+            // Fills algorithm bits histograms
+            for(int algoBit = 0; algoBit < numAlgs; ++algoBit) {
+               if(itr->getAlgoDecisionFinal(algoBit)) {
+                  algoBits_->Fill(algoBit);
+                  algoBits_lumi_->Fill(lumi, algoBit);
+                  algoBits_bx_global_->Fill(bx, algoBit);
+                  algoBits_bx_inEvt_->Fill(ibx, algoBit); // FIXME: or itr->getbxInEventNr()/getbxNr()?
+                  
+                  for(int algoBit2 = 0; algoBit2 < numAlgs; ++algoBit2) {
+                     if(itr->getAlgoDecisionFinal(algoBit2)) {
+                        algoBits_corr_->Fill(algoBit, algoBit2);
+                     }
+                  }
+               }  
+            }
+         }
+      }
+   }
+}
+
+// End section
+void L1TStage2uGT::endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& evtSetup) {
+   // empty
+}

--- a/DQM/L1TMonitor/src/SealModule.cc
+++ b/DQM/L1TMonitor/src/SealModule.cc
@@ -38,6 +38,9 @@ DEFINE_FWK_MODULE(L1TStage2BMTF);
 #include <DQM/L1TMonitor/interface/L1TStage2EMTF.h>
 DEFINE_FWK_MODULE(L1TStage2EMTF);
 
+#include <DQM/L1TMonitor/interface/L1TStage2uGT.h>
+DEFINE_FWK_MODULE(L1TStage2uGT);
+
 #include <DQM/L1TMonitor/interface/L1TGCT.h>
 DEFINE_FWK_MODULE(L1TGCT);
 


### PR DESCRIPTION
## **uGT DQM Module**

Data Quality Monitoring module for the L1 Micro Global Trigger (uGT):
- _L1TStage2uGT.h_
- _L1TStage2uGT.cc_
- _L1TStage2uGT_cfi.py_

The EDAnalyzer module takes the readout record from the **gtStage2Digis** unpacker as input, to produce DQM plots. The _DataFormats/L1TGlobal_ package was included to access the necessary methods used on the readout record. The module was added to the L1TStage2 monitoring sequence in the _L1TStage2_cff.py_ configuration file fragment, following the standard workflow for the L1T2016 DQM. 

The module was tested on 2016 MWGR2 and MWGR3 data.
