### PR TITLE
cMVAv2 negative/positive configuration files (76X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -70,6 +70,7 @@ supportedBtagDiscr = {
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'combinedMVAV2BJetTags'                                 : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexNegativeTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'positiveCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexPositiveTagInfos', 'inclusiveSecondaryVertexFinderPositiveTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
@@ -126,6 +127,7 @@ supportedBtagDiscr = {
   , 'pfNegativeCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedMVAV2BJetTags'                               : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexNegativeTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfPositiveCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexPositiveTagInfos', 'pfInclusiveSecondaryVertexFinderPositiveTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedSecondaryVertexSoftLeptonBJetTags'           : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags'   : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfBoostedDoubleSecondaryVertexAK8BJetTags'             : ['pfImpactParameterTagInfosAK8', 'pfInclusiveSecondaryVertexFinderTagInfosAK8']

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -69,7 +69,7 @@ supportedBtagDiscr = {
   , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'combinedMVAV2BJetTags'                                 : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  , 'negativeCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'negativeCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexNegativeTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
@@ -125,7 +125,7 @@ supportedBtagDiscr = {
   , 'pfPositiveCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedMVAV2BJetTags'                               : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  , 'pfNegativeCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfNegativeCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexNegativeTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedSecondaryVertexSoftLeptonBJetTags'           : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags'   : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfBoostedDoubleSecondaryVertexAK8BJetTags'             : ['pfImpactParameterTagInfosAK8', 'pfInclusiveSecondaryVertexFinderTagInfosAK8']

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -69,6 +69,7 @@ supportedBtagDiscr = {
   , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'combinedMVAV2BJetTags'                                 : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'negativeCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
@@ -124,6 +125,7 @@ supportedBtagDiscr = {
   , 'pfPositiveCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedMVAV2BJetTags'                               : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfNegativeCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedSecondaryVertexSoftLeptonBJetTags'           : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags'   : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfBoostedDoubleSecondaryVertexAK8BJetTags'             : ['pfImpactParameterTagInfosAK8', 'pfInclusiveSecondaryVertexFinderTagInfosAK8']

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -70,7 +70,7 @@ supportedBtagDiscr = {
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'combinedMVAV2BJetTags'                                 : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexNegativeTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  , 'positiveCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexPositiveTagInfos', 'inclusiveSecondaryVertexFinderPositiveTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'positiveCombinedMVAV2BJetTags'                         : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
@@ -127,7 +127,7 @@ supportedBtagDiscr = {
   , 'pfNegativeCombinedMVABJetTags'                         : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedMVAV2BJetTags'                               : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexNegativeTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  , 'pfPositiveCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexPositiveTagInfos', 'pfInclusiveSecondaryVertexFinderPositiveTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'pfPositiveCombinedMVAV2BJetTags'                       : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfCombinedSecondaryVertexSoftLeptonBJetTags'           : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfNegativeCombinedSecondaryVertexSoftLeptonBJetTags'   : ['pfImpactParameterTagInfos', 'pfInclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'pfBoostedDoubleSecondaryVertexAK8BJetTags'             : ['pfImpactParameterTagInfosAK8', 'pfInclusiveSecondaryVertexFinderTagInfosAK8']

--- a/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateCombinedMVAV2Computer_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 candidateCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
 	jetTagComputers = cms.vstring(
-		'candidateNegativeOnlyJetProbabilityComputer',
-		'candidateNegativeOnlyJetBProbabilityComputer',
-		'candidateNegativeCombinedSecondaryVertexV2Computer',
-		'negativeSoftPFMuonComputer',
-		'negativeSoftPFElectronComputer'
+		'candidateJetProbabilityComputer',
+		'candidateJetBProbabilityComputer',
+		'candidateCombinedSecondaryVertexV2Computer',
+		'softPFMuonComputer',
+		'softPFElectronComputer'
 	),
 	mvaName = cms.string("bdt"),
 	variables = cms.vstring(

--- a/RecoBTag/Combined/python/candidateNegativeCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateNegativeCombinedMVAV2Computer_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 candidateNegativeCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
 	jetTagComputers = cms.vstring(
-		'candidateJetProbabilityComputer',
-		'candidateJetBProbabilityComputer',
-		'candidateCombinedSecondaryVertexV2Computer',
-		'softPFMuonComputer',
-		'softPFElectronComputer'
+		'candidateNegativeOnlyJetProbabilityComputer',
+		'candidateNegativeOnlyJetBProbabilityComputer',
+		'candidateNegativeCombinedSecondaryVertexV2Computer',
+		'negativeSoftPFMuonComputer',
+		'negativeSoftPFElectronComputer'
 	),
 	mvaName = cms.string("bdt"),
 	variables = cms.vstring(

--- a/RecoBTag/Combined/python/candidateNegativeCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidateNegativeCombinedMVAV2Computer_cfi.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-candidateCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+candidateNegativeCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
 	jetTagComputers = cms.vstring(
-		'candidateNegativeOnlyJetProbabilityComputer',
-		'candidateNegativeOnlyJetBProbabilityComputer',
-		'candidateNegativeCombinedSecondaryVertexV2Computer',
-		'negativeSoftPFMuonComputer',
-		'negativeSoftPFElectronComputer'
+		'candidateJetProbabilityComputer',
+		'candidateJetBProbabilityComputer',
+		'candidateCombinedSecondaryVertexV2Computer',
+		'softPFMuonComputer',
+		'softPFElectronComputer'
 	),
 	mvaName = cms.string("bdt"),
 	variables = cms.vstring(

--- a/RecoBTag/Combined/python/candidatePositiveCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/candidatePositiveCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+candidatePositiveCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'candidatePositiveOnlyJetProbabilityComputer',
+		'candidatePositiveOnlyJetBProbabilityComputer',
+		'candidatePositiveCombinedSecondaryVertexV2Computer',
+		'negativeSoftPFMuonComputer',
+		'negativeSoftPFElectronComputer'
+	),
+	mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+		["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+	useCondDB = cms.bool(True),
+	gbrForestLabel = cms.string("btag_CombinedMVAv2_BDT"),
+	useGBRForest = cms.bool(True),
+	useAdaBoost = cms.bool(False),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/python/combinedMVA_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_cff.py
@@ -17,6 +17,10 @@ from RecoBTag.Combined.pfPositiveCombinedMVABJetTags_cfi import *
 
 #combined MVA V2
 from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.negativeCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.combinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.negativeCombinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidateNegativeCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.pfCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.pfNegativeCombinedMVAV2BJetTags_cfi import *

--- a/RecoBTag/Combined/python/combinedMVA_cff.py
+++ b/RecoBTag/Combined/python/combinedMVA_cff.py
@@ -18,9 +18,13 @@ from RecoBTag.Combined.pfPositiveCombinedMVABJetTags_cfi import *
 #combined MVA V2
 from RecoBTag.Combined.combinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.negativeCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.positiveCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.combinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.negativeCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.positiveCombinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.candidateCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.candidateNegativeCombinedMVAV2Computer_cfi import *
+from RecoBTag.Combined.candidatePositiveCombinedMVAV2Computer_cfi import *
 from RecoBTag.Combined.pfCombinedMVAV2BJetTags_cfi import *
 from RecoBTag.Combined.pfNegativeCombinedMVAV2BJetTags_cfi import *
+from RecoBTag.Combined.pfPositiveCombinedMVAV2BJetTags_cfi import *

--- a/RecoBTag/Combined/python/negativeCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/negativeCombinedMVAV2BJetTags_cfi.py
@@ -4,8 +4,8 @@ negativeCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('negativeCombinedMVAV2Computer'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
-		cms.InputTag("secondaryVertexTagInfos"),
-		cms.InputTag("inclusiveSecondaryVertexFinderTagInfos"),
+		cms.InputTag("secondaryVertexNegativeTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderNegativeTagInfos"),
 		cms.InputTag("softPFMuonsTagInfos"),
 		cms.InputTag("softPFElectronsTagInfos")
 	)

--- a/RecoBTag/Combined/python/negativeCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/negativeCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+negativeCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('negativeCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/negativeCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/negativeCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+negativeCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'negativeOnlyJetProbabilityComputer',
+		'negativeOnlyJetBProbabilityComputer',
+		'negativeCombinedSecondaryVertexV2Computer',
+		'negativeSoftPFMuonComputer',
+		'negativeSoftPFElectronComputer'
+	),
+    mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+        ["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+    useCondDB = cms.bool(False),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(True),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/python/pfNegativeCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfNegativeCombinedMVAV2BJetTags_cfi.py
@@ -4,8 +4,8 @@ pfNegativeCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('candidateNegativeCombinedMVAV2Computer'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("pfImpactParameterTagInfos"),
-		cms.InputTag("pfSecondaryVertexTagInfos"),
-		cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfos"),
+		cms.InputTag("pfSecondaryVertexNegativeTagInfos"),
+		cms.InputTag("pfInclusiveSecondaryVertexFinderNegativeTagInfos"),
 		cms.InputTag("softPFMuonsTagInfos"),
 		cms.InputTag("softPFElectronsTagInfos")
 	)

--- a/RecoBTag/Combined/python/pfNegativeCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfNegativeCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+pfNegativeCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('candidateNegativeCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("pfImpactParameterTagInfos"),
+		cms.InputTag("pfSecondaryVertexTagInfos"),
+		cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/pfPositiveCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfPositiveCombinedMVAV2BJetTags_cfi.py
@@ -4,8 +4,8 @@ pfPositiveCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('candidatePositiveCombinedMVAV2Computer'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("pfImpactParameterTagInfos"),
-		cms.InputTag("pfSecondaryVertexPositiveTagInfos"),
-		cms.InputTag("pfInclusiveSecondaryVertexFinderPositiveTagInfos"),
+		cms.InputTag("pfSecondaryVertexTagInfos"),
+		cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfos"),
 		cms.InputTag("softPFMuonsTagInfos"),
 		cms.InputTag("softPFElectronsTagInfos")
 	)

--- a/RecoBTag/Combined/python/pfPositiveCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfPositiveCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+pfPositiveCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('candidatePositiveCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("pfImpactParameterTagInfos"),
+		cms.InputTag("pfSecondaryVertexPositiveTagInfos"),
+		cms.InputTag("pfInclusiveSecondaryVertexFinderPositiveTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/positiveCombinedMVAV2BJetTags_cfi.py
+++ b/RecoBTag/Combined/python/positiveCombinedMVAV2BJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+positiveCombinedMVAV2BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('positiveCombinedMVAV2Computer'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexPositiveTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderPositiveTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)

--- a/RecoBTag/Combined/python/positiveCombinedMVAV2Computer_cfi.py
+++ b/RecoBTag/Combined/python/positiveCombinedMVAV2Computer_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+positiveCombinedMVAV2Computer = cms.ESProducer("CombinedMVAV2JetTagESProducer",
+	jetTagComputers = cms.vstring(
+		'positiveOnlyJetProbabilityComputer',
+		'positiveOnlyJetBProbabilityComputer',
+		'positiveCombinedSecondaryVertexV2Computer',
+		'positiveSoftPFMuonComputer',
+		'positiveSoftPFElectronComputer'
+	),
+    mvaName = cms.string("bdt"),
+	variables = cms.vstring(
+        ["Jet_CSV", "Jet_CSVIVF", "Jet_JP", "Jet_JBP", "Jet_SoftMu", "Jet_SoftEl"]
+	),
+	spectators = cms.vstring([]),
+    useCondDB = cms.bool(False),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(True),
+	weightFile = cms.FileInPath('RecoBTag/Combined/data/CombinedMVAV2_13_07_2015.weights.xml.gz')
+)

--- a/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
+++ b/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
@@ -99,6 +99,13 @@ float CombinedMVAV2JetTagComputer::discriminator(const JetTagComputer::TagInfoHe
   inputs["Jet_CSVIVF"]   = (*(computers[2]))( TagInfoHelper(ivfTagInfos) );
   inputs["Jet_SoftMu"]   = (*(computers[3]))( TagInfoHelper(smTagInfos) );
   inputs["Jet_SoftEl"]   = (*(computers[4]))( TagInfoHelper(seTagInfos) );
+  std::cout << "JP=" << inputs["Jet_JP"]
+    << " JBP=" << inputs["Jet_JBP"]
+    << " CSV=" << inputs["Jet_CSV"]
+    << " CSVIVF=" << inputs["Jet_CSVIVF"]
+    << " SoftMu=" << inputs["Jet_SoftMu"]
+    << " SoftEl=" << inputs["Jet_SoftEl"]
+    << std::endl;
 //  inputs["Jet_pt"]       = 0.0;
 //  inputs["Jet_eta"]      = 0.0;
 //  inputs["Jet_flavour"]  = 0.0;

--- a/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
+++ b/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
@@ -99,13 +99,13 @@ float CombinedMVAV2JetTagComputer::discriminator(const JetTagComputer::TagInfoHe
   inputs["Jet_CSVIVF"]   = (*(computers[2]))( TagInfoHelper(ivfTagInfos) );
   inputs["Jet_SoftMu"]   = (*(computers[3]))( TagInfoHelper(smTagInfos) );
   inputs["Jet_SoftEl"]   = (*(computers[4]))( TagInfoHelper(seTagInfos) );
-  std::cout << "JP=" << inputs["Jet_JP"]
-    << " JBP=" << inputs["Jet_JBP"]
-    << " CSV=" << inputs["Jet_CSV"]
-    << " CSVIVF=" << inputs["Jet_CSVIVF"]
-    << " SoftMu=" << inputs["Jet_SoftMu"]
-    << " SoftEl=" << inputs["Jet_SoftEl"]
-    << std::endl;
+  //std::cout << "JP=" << inputs["Jet_JP"]
+  //  << " JBP=" << inputs["Jet_JBP"]
+  //  << " CSV=" << inputs["Jet_CSV"]
+  //  << " CSVIVF=" << inputs["Jet_CSVIVF"]
+  //  << " SoftMu=" << inputs["Jet_SoftMu"]
+  //  << " SoftEl=" << inputs["Jet_SoftEl"]
+  //  << std::endl;
 //  inputs["Jet_pt"]       = 0.0;
 //  inputs["Jet_eta"]      = 0.0;
 //  inputs["Jet_flavour"]  = 0.0;


### PR DESCRIPTION
Adds configuration files for negative and positive cMVAv2 b-tagger needed for scale factor measurements. Does not affect reco sequences or event content.

Backport of #13014.
