### PR TITLE
Adjusting 1x1 HF output LUTs

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -19,7 +19,7 @@ using namespace std;
 CaloTPGTranscoderULUT::CaloTPGTranscoderULUT(const std::string& compressionFile,
                                              const std::string& decompressionFile)
                                                 : theTopology(0),
-                                                  nominal_gain_(0.), rctlsb_factor_(0.), nctlsb_factor_(0),
+                                                  nominal_gain_(0.), lsb_factor_(0.), rct_factor_(0), nct_factor_(0),
                                                   compressionFile_(compressionFile),
                                                   decompressionFile_(decompressionFile)
 {
@@ -40,12 +40,14 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
     }
 
     std::array<unsigned int, OUTPUT_LUT_SIZE> analyticalLUT;
-    std::array<unsigned int, OUTPUT_LUT_SIZE> identityLUT;
+    std::array<unsigned int, OUTPUT_LUT_SIZE> linearRctLUT;
+    std::array<unsigned int, OUTPUT_LUT_SIZE> linearNctLUT;
 
     // Compute compression LUT
     for (unsigned int i=0; i < OUTPUT_LUT_SIZE; i++) {
 	analyticalLUT[i] = (unsigned int)(sqrt(14.94*log(1.+i/14.94)*i) + 0.5);
-	identityLUT[i] = min(i, TPGMAX - 1);
+	linearRctLUT[i] = min(i/rct_factor_, TPGMAX - 1);
+	linearNctLUT[i] = min(i/nct_factor_, TPGMAX - 1);
     }
  
     std::vector<DetId> allChannels = lutMetadata.getAllChannels();
@@ -78,7 +80,8 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 
 	for (unsigned int i = 0; i < threshold; ++i) outputLUT_[index].push_back(0);
 	for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i){
-	    LUT value =  isHBHE ? analyticalLUT[i] : identityLUT[i];
+	    LUT value =  isHBHE ? analyticalLUT[i] : 
+			 (version==0?linearRctLUT[i]:linearNctLUT[i]);
 	    outputLUT_[index].push_back(value);
         }
 
@@ -90,21 +93,30 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	double cosh_ieta   = fabs(cosh((eta_low + eta_high)/2.));
 	double granularity =  meta->getLutGranularity(); 
 
-	double factor = isHBHE ?  
-			(nominal_gain_ / cosh_ieta * granularity) : 
-			(version==0 ? rctlsb_factor_ : nctlsb_factor_);
-
-        LUT tpg = outputLUT_[index][0];
-        int low = 0;
-        for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
-	    if (outputLUT_[index][i] != tpg){
-               unsigned int mid = (low + i)/2; 
-               hcaluncomp_[index][tpg] = (tpg == 0 ? low : factor * mid);
-               low = i;
-               tpg = outputLUT_[index][i];
-            }
-        }
-        hcaluncomp_[index][tpg] = factor * low;
+	if(isHBHE){
+	    double factor = nominal_gain_ / cosh_ieta * granularity;
+	    LUT tpg = outputLUT_[index][0];
+	    int low = 0;
+	    for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
+		if (outputLUT_[index][i] != tpg){
+		   unsigned int mid = (low + i)/2; 
+		   hcaluncomp_[index][tpg] = (tpg == 0 ? low : factor * mid);
+		   low = i;
+		   tpg = outputLUT_[index][i];
+		}
+	    }
+	    hcaluncomp_[index][tpg] = factor * low;
+	}
+	else{
+	    LUT tpg = outputLUT_[index][0];
+	    hcaluncomp_[index][tpg]=0;
+	    for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
+		if (outputLUT_[index][i] != tpg){
+		   tpg = outputLUT_[index][i];
+		   hcaluncomp_[index][tpg] = lsb_factor_ * i / (version==0?rct_factor_:nct_factor_);
+		}
+	    }
+	}
     }
 }
 
@@ -211,9 +223,10 @@ void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTo
 {
     theTopology	    = lutMetadata.topo();
     nominal_gain_   = lutMetadata.getNominalGain();
+    lsb_factor_	    = lutMetadata.getRctLsb();
 
-    rctlsb_factor_  = HcaluLUTTPGCoder::lsb_*(1<<rctScaleShift);
-    nctlsb_factor_  = HcaluLUTTPGCoder::lsb_*(1<<nctScaleShift);
+    rct_factor_  = lsb_factor_/(HcaluLUTTPGCoder::lsb_*(1<<rctScaleShift));
+    nct_factor_  = lsb_factor_/(HcaluLUTTPGCoder::lsb_*(1<<nctScaleShift));
 
     if (compressionFile_.empty() && decompressionFile_.empty()) {
 	loadHCALCompress(lutMetadata,theTrigTowerGeometry);

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -56,8 +56,8 @@ public:
   // Member Variables
   double nominal_gain_;
   double lsb_factor_;
-  int rct_factor_;
-  int nct_factor_;
+  double rct_factor_;
+  double nct_factor_;
   std::string compressionFile_;
   std::string decompressionFile_;
   std::vector<int> ietal;
@@ -65,6 +65,7 @@ public:
   std::vector<int> ZS;
   std::vector<int> LUTfactor;
 
+  unsigned int size;
   std::vector<std::vector<LUT> > outputLUT_;
   std::vector<RCTdecompression> hcaluncomp_;
 };

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -55,8 +55,9 @@ public:
 
   // Member Variables
   double nominal_gain_;
-  double rctlsb_factor_;
-  double nctlsb_factor_;
+  double lsb_factor_;
+  int rct_factor_;
+  int nct_factor_;
   std::string compressionFile_;
   std::string decompressionFile_;
   std::vector<int> ietal;


### PR DESCRIPTION
Make 1x1 HF output LUTs 4:1 to keep the TP lsb same as for 3x2 (0.5 GeV). 
