### PR TITLE
Picosecond stepping for HGC and FastTimer SDs

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -381,11 +381,15 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
          Verbosity = cms.untracked.int32(0)
     ),
     FastTimerSD = cms.PSet(
-        Verbosity = cms.untracked.int32(0)
+        Verbosity = cms.untracked.int32(0),
+        TimeSliceUnit    = cms.double(0.001), #stepping = 1 ps (for timing)
+        IgnoreTrackID    = cms.bool(False),
+        EminHit          = cms.double(0.0),
+        CheckID          = cms.untracked.bool(True),
     ),
     HGCSD = cms.PSet(
         Verbosity        = cms.untracked.int32(0),
-        TimeSliceUnit    = cms.double(1),
+        TimeSliceUnit    = cms.double(0.001), #stepping = 1 ps (for timing)
         IgnoreTrackID    = cms.bool(False),
         EminHit          = cms.double(0.0),
         CheckID          = cms.untracked.bool(True),


### PR DESCRIPTION
Allows reconstruction of timing-related quantities when picosecond accuracy is needed.
- In busy events this comes with a ~50% memory penalty due to additional SimHits.
