### PR TITLE
Global Tag updates for 81x: introducing new L1 uGT stage-II menu and MC updates for Digi-Reco 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,11 +20,11 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v8',
+    'run1_data'         :   '80X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v8',
+    'run2_data'         :   '80X_dataRun2_v9',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,7 +30,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v3',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v4',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,15 +10,15 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v7',
+    'run2_design'       :   '80X_mcRun2_design_v8',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v7',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v7',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v8',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v6',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v6',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v7',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing
@@ -34,7 +34,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v5',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,15 +10,15 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v6',
+    'run2_design'       :   '80X_mcRun2_design_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v6',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v6',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v7',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v4',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v6',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing
@@ -26,15 +26,15 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '80X_dataRun2_relval_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v6',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v6',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v6',
+    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v4',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,15 +10,15 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v8',
+    'run2_design'       :   '80X_mcRun2_design_v9',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v8',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v9',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v8',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v9',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v7',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v8',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v7',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v8',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -969,7 +969,7 @@ steps['RECODR2_50ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_r
 steps['RECODR2_25ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--customise':'Configuration/DataProcessing/RecoTLR.customiseDataRun2Common_25ns',},dataReco])
 
 
-steps['RECODR2AlCaEle']=merge([{'--scenario':'pp','--conditions':'auto:run2_data','--customise':'Configuration/DataProcessing/RecoTLR.customisePromptRun2',},dataRecoAlCaCalo])
+steps['RECODR2AlCaEle']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--customise':'Configuration/DataProcessing/RecoTLR.customisePromptRun2',},dataRecoAlCaCalo])
 
 steps['RECODSplit']=steps['RECOD'] # finer job splitting  
 steps['RECOSKIMALCA']=merge([{'--inputCommands':'"keep *","drop *_*_*_RECO"'
@@ -1085,7 +1085,7 @@ steps['RECODreHLTAlCaCalo']=merge([{'--hltProcess':'reHLT','--conditions':'auto:
 
 steps['RECODR2_25nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_25ns']])
 steps['RECODR2_50nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_50ns']])
-steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data'},steps['RECODR2AlCaEle']])
+steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2AlCaEle']])
 
 steps['RECO']=merge([step3Defaults])
 steps['RECOAlCaCalo']=merge([step3DefaultsAlCaCalo])


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v9) as [80X_mcRun2_design_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v9/80X_mcRun2_design_v6): 
  - updated ES ChannelStatus start 2016 : (2x32) sensors dead
  - updated ES pedestal/noise 137216 channels with (2x32) sensors out : ADC mean = 1300, RMS = 3.
  - updated Hcal channel quality for MC (copy from the last approved condition on Fev/2016)
  - updated Hcal QIE data post LS1 
  - added first L1T stage-2 uGT menu
  - updated SiPixel Dynamic inefficiency for 2016 (based on 2015 measurements)
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v8) as [80X_mcRun2cosmics_startup_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v8/80X_mcRun2cosmics_startup_peak_v4): 
  - updated ES ChannelStatus start 2016 : (2x32) sensors dead
  - updated ES pedestal/noise 137216 channels with (2x32) sensors out : ADC mean = 1300, RMS = 3.
  - updated Hcal channel quality for MC (copy from the last approved condition on Fev/2016)
  - updated Hcal QIE data post LS1 
  - added first L1T stage-2 uGT menu
  - updated HLT JEC to payloads with L2/L3 residuals to allow integrtation of new paths in menu
  - updated SiPixel Dynamic inefficiency for 2016 (based on 2015 measurements)
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v9) as [80X_mcRun2_asymptotic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v9/80X_mcRun2_asymptotic_v6): 
  - updated ES ChannelStatus start 2016 : (2x32) sensors dead
  - updated ES pedestal/noise 137216 channels with (2x32) sensors out : ADC mean = 1300, RMS = 3.
  - updated Hcal channel quality for MC (copy from the last approved condition on Fev/2016)
  - updated Hcal QIE data post LS1 
  - added first L1T stage-2 uGT menu
  - updated non-zero muon DT alignment uncertainties defined by the comparison of asymptotic and ideal MC geometries (quadratic sum of RMS and mean shifts on homogeneous sets of chambers).
  - updated non-zero muon CSC alignment uncertainties defined by the comparison of asymptotic and ideal MC geometries (quadratic sum of RMS and mean shifts on homogeneous sets of chambers).
  - updated Ecal laser transparency: as start 2016 + 15/fb prediction
  - updated Ecal noise: 2015 + 15/fb prediction
  - updated Ecal tuning of the thresholds of the zero-suppression (ZS tag), to safely run with a PU up to ~ 40-50.
  - updated Ecal tuning of the thresholds of the selective-readout (TPG tag), to safely run with a PU up to ~ 40-50.
  - updated SiStrip bad channels payload for 2016 MC campaigns. Computed using Run 260627. This considers optimistic scenario where the active channels have been defined using Fed Cabling payload.
  - updated SiPixel Dynamic inefficiency for 2016 (based on 2015 measurements)
- **RunII Startup scenario** : [80X_mcRun2_startup_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v8) as [80X_mcRun2_startup_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v9/80X_mcRun2_startup_v6): 
  - updated ES ChannelStatus start 2016 : (2x32) sensors dead
  - updated ES pedestal/noise 137216 channels with (2x32) sensors out : ADC mean = 1300, RMS = 3.
  - updated Hcal channel quality for MC (copy from the last approved condition on Fev/2016)
  - updated Hcal QIE data post LS1 
  - added first L1T stage-2 uGT menu
  - updated SiPixel Dynamic inefficiency for 2016 (based on 2015 measurements)
- **RunII Heavy Ions scenario** : [80X_mcRun2_HeavyIon_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v7) as [80X_mcRun2_HeavyIon_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_HeavyIon_v7/80X_mcRun2_HeavyIon_v5): 
  - updated Hcal QIEData mc tag to reflect situation in data (2016)
  - updated ES ChannelStatus start 2016 : (2x32) sensors dead
  - updated ES pedestal/noise 137216 channels with (2x32) sensors out : ADC mean = 1300, RMS = 3.
  - updated Hcal channel quality for MC (copy from the last approved condition on Fev/2016)
  - updated Hcal QIE data post LS1 
  - added first Heavy Ions L1T stage-2 uGT menu
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v9) as [80X_dataRun2_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v9/80X_dataRun2_v8): 
  - updated AlCaReco trigger bit to allow new SiStripAfterAbortGap AlcaRecos in the matrix
  - updared CSC Xtalk payload to fix the incorrect values for ME-2/1/03.
  - introducing "all-uTCA" HBHE Electronics Map 
  - adding Stage2 uGT L1T menu
- **RunII HLTHI processing** : [80X_dataRun2_HLTHI_frozen_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v7) as [80X_dataRun2_HLTHI_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLTHI_frozen_v7/80X_dataRun2_HLTHI_frozen_v6): 
  - introducing HI Stage-II L1T menu for Release validation
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v4) as [80X_dataRun2_HLT_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v4/80X_dataRun2_HLT_relval_v3): 
  - introducing Stage-II L1T menu for Release validation
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v8) as [80X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v8/80X_dataRun2_HLT_frozen_v6): 
  - better name for O2O tag for Stage 2 L1T menu.
- **RunII Offline relval processing** : [80X_dataRun2_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v4) as [80X_dataRun2_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v4/80X_dataRun2_relval_v3): 
  - updated AlCaReco trigger bit to allow new SiStripAfterAbortGap AlcaRecos in the matrix
  - updared CSC Xtalk payload to fix the incorrect values for ME-2/1/03.
  - introducing "all-uTCA" HBHE Electronics Map 
  - adding Stage2 uGT L1T menu
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v6) as [80X_upgrade2017_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v6/80X_upgrade2017_design_v4): 
  - updated Hcal QIE data post LS1 
  - added Pixel Dynamic inefficiency for phase-I
