### PR TITLE
Multi-IOV weak mode constraints

### DIFF
--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -81,6 +81,11 @@ public:
   /// or if all branches of components end with such components (i.e. 'consistent').
   bool firstCompsWithParams(Alignables &paramComps) const;
 
+  /// Steps down hierarchy to the lowest level of components with AlignmentParameters
+  /// and adds them to argument. True either if no such components are found
+  /// or if all branches of components end with such components (i.e. 'consistent').
+  bool lastCompsWithParams(Alignables& paramComps) const;
+
   /// Return pointer to container alignable (if any)
   Alignable* mother() const { return theMother; }
 

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -78,6 +78,35 @@ bool Alignable::firstCompsWithParams(Alignables &paramComps) const
 }
 
 //__________________________________________________________________________________________________
+bool Alignable::lastCompsWithParams(Alignables& paramComps) const
+{
+  bool isConsistent = true;
+  bool hasAliComp = false;
+  bool first = true;
+  const Alignables comps(this->components());
+  for (const auto& iComp: comps) {
+    const auto nCompsBefore = paramComps.size();
+    isConsistent = iComp->lastCompsWithParams(paramComps);
+    if (paramComps.size() == nCompsBefore) {
+      if (iComp->alignmentParameters()) {
+	paramComps.push_back(iComp);
+	if (!first && !hasAliComp) isConsistent = false;
+	hasAliComp = true;
+      }
+    } else {
+      if (hasAliComp) {
+	isConsistent = false;
+      }
+      if (!first && !hasAliComp) isConsistent = false;
+      hasAliComp = true;
+    }
+    first = false;
+  }
+
+  return isConsistent;
+}
+
+//__________________________________________________________________________________________________
 void Alignable::setAlignmentParameters( AlignmentParameters* dap )
 {
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -714,19 +714,15 @@ void PedeSteerer::buildSubSteer(AlignableTracker *aliTracker, AlignableMuon *ali
     //prepare the output files
     //Get the data structure in which the configuration data are stored.
     //The relation between the ostream* and the corresponding file name needs to be filled
-    std::list<GeometryConstraintConfigData>* ConstraintsConfigContainer = GeometryConstraints.getConfigData();
+    auto& ConstraintsConfigContainer = GeometryConstraints.getConfigData();
     
     //loop over all configured constraints
-    for(std::list<GeometryConstraintConfigData>::iterator it = ConstraintsConfigContainer->begin();
-        it != ConstraintsConfigContainer->end(); it++) {
+    for(auto& it: ConstraintsConfigContainer) {
       //each level has its own constraint which means the output is stored in a separate file
-      for(std::vector<std::pair<Alignable*, std::string> >::const_iterator ilevelsFilename = it->levelsFilenames_.begin();
-          ilevelsFilename != it->levelsFilenames_.end(); ilevelsFilename++) {
-        it->mapFileName_.insert(
-                                std::pair<std::string, std::ofstream*>
-                                (ilevelsFilename->second,this->createSteerFile(ilevelsFilename->second,true))
-                                );
-        
+      for(const auto& ilevelsFilename: it.levelsFilenames_) {
+        it.mapFileName_.insert(std::make_pair
+			       (ilevelsFilename.second,this->createSteerFile(ilevelsFilename.second,true))
+			       );
       }
     }
     

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -3,9 +3,6 @@
  *
  *  \author    : Joerg Behr
  *  date       : February 2013
- *  $Revision: 1.14 $
- *  $Date: 2013/06/18 15:47:55 $
- *  (last update by $Author: jbehr $)
  */
 
 #include "Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h"
@@ -16,8 +13,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Alignment/CommonAlignment/interface/Alignable.h"
-#include <boost/cstdint.hpp> 
-#include <boost/assign/list_of.hpp>
+#include <boost/cstdint.hpp>
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h"
@@ -34,11 +30,11 @@
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 #include "Alignment/CommonAlignment/interface/AlignableExtras.h"
 // GF doubts the need of these includes from include checker campaign:
-#include <FWCore/Framework/interface/EventSetup.h> 
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h> 
-#include <Geometry/CommonDetUnit/interface/GeomDetType.h> 
-#include <DataFormats/GeometrySurface/interface/LocalError.h> 
-#include <Geometry/DTGeometry/interface/DTLayer.h> 
+#include <FWCore/Framework/interface/EventSetup.h>
+#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDetType.h>
+#include <DataFormats/GeometrySurface/interface/LocalError.h>
+#include <Geometry/DTGeometry/interface/DTLayer.h>
 // end of doubt
 
 #include <DataFormats/GeometryVector/interface/GlobalPoint.h>
@@ -58,11 +54,11 @@
 
 
 
-GeometryConstraintConfigData::GeometryConstraintConfigData(const std::vector<double> co,
-                                                           const std::string c,
-                                                           const std::vector<std::pair<Alignable*,std::string> > &alisFile,
+GeometryConstraintConfigData::GeometryConstraintConfigData(const std::vector<double>& co,
+                                                           const std::string& c,
+                                                           const std::vector<std::pair<Alignable*,std::string> >& alisFile,
                                                            const int sd,
-                                                           const std::vector<Alignable*> ex
+                                                           const std::vector<Alignable*>& ex
                                                            ) :
   coefficients_(co),
   constraintName_(c),
@@ -84,44 +80,41 @@ PedeSteererWeakModeConstraints::PedeSteererWeakModeConstraints(AlignableTracker 
 {
   unsigned int psetnr = 0;
   std::set<std::string> steerFilePrefixContainer;
-  for(std::vector<edm::ParameterSet>::const_iterator pset = myConfig_.begin();
-      pset != myConfig_.end();
-      ++pset) {
-    this->verifyParameterNames((*pset),psetnr);
+  for(const auto& pset: myConfig_) {
+    this->verifyParameterNames(pset, psetnr);
     psetnr++;
- 
-    const std::vector<double> coefficients = pset->getParameter<std::vector<double> > ("coefficients");
-    const std::vector<unsigned int> dm = pset->exists("deadmodules") ?
-      pset->getParameter<std::vector<unsigned int> >("deadmodules") : std::vector<unsigned int>();
-    std::string name = pset->getParameter<std::string> ("constraint");
+
+    const auto coefficients = pset.getParameter<std::vector<double> > ("coefficients");
+    const auto dm = pset.exists("deadmodules") ?
+      pset.getParameter<std::vector<unsigned int> >("deadmodules") : std::vector<unsigned int>();
+    std::string name = pset.getParameter<std::string> ("constraint");
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
 
     std::stringstream defaultsteerfileprefix;
     defaultsteerfileprefix << "autosteerFilePrefix_" << name << "_" << psetnr;
 
-    std::string steerFilePrefix = pset->exists("steerFilePrefix") ?
-      pset->getParameter<std::string> ("steerFilePrefix") : defaultsteerfileprefix.str();
+    const auto steerFilePrefix = pset.exists("steerFilePrefix") ?
+      pset.getParameter<std::string> ("steerFilePrefix") : defaultsteerfileprefix.str();
 
-                
-    AlignmentParameterSelector selector(aliTracker, NULL, NULL);
+    AlignmentParameterSelector selector(aliTracker, nullptr, nullptr);
     selector.clear();
-    selector.addSelections(pset->getParameter<edm::ParameterSet> ("levels"));
-        
-    const std::vector<Alignable*> &alis = selector.selectedAlignables();
-        
-    AlignmentParameterSelector selector_excludedalignables(aliTracker, NULL, NULL);
+    selector.addSelections(pset.getParameter<edm::ParameterSet> ("levels"));
+
+    const auto& alis = selector.selectedAlignables();
+
+    AlignmentParameterSelector selector_excludedalignables(aliTracker, nullptr, nullptr);
     selector_excludedalignables.clear();
-    if(pset->exists("excludedAlignables")) {
-      selector_excludedalignables.addSelections(pset->getParameter<edm::ParameterSet> ("excludedAlignables"));
+    if(pset.exists("excludedAlignables")) {
+      selector_excludedalignables.addSelections(pset.getParameter<edm::ParameterSet> ("excludedAlignables"));
     }
-    const std::vector<Alignable*> &excluded_alis = selector_excludedalignables.selectedAlignables();
+    const auto& excluded_alis = selector_excludedalignables.selectedAlignables();
       
-    const std::vector<std::pair<Alignable*, std::string> > levelsFilenames = this->makeLevelsFilenames(steerFilePrefixContainer,
-                                                                                                       alis,
-                                                                                                       steerFilePrefix);
+    const auto levelsFilenames = this->makeLevelsFilenames(steerFilePrefixContainer,
+							   alis,
+							   steerFilePrefix);
     //check that the name of the deformation is known and that the number 
     //of provided parameter is right.
-    int sysdeformation = this->verifyDeformationName(name,coefficients);
+    auto sysdeformation = this->verifyDeformationName(name,coefficients);
       
     //Add the configuration data for this constraint to the container of config data
     ConstraintsConfigContainer_.push_back(GeometryConstraintConfigData(coefficients,
@@ -132,9 +125,7 @@ PedeSteererWeakModeConstraints::PedeSteererWeakModeConstraints(AlignableTracker 
     if(deadmodules_.size() == 0) { //fill the list of dead modules only once
       edm::LogInfo("Alignment") << "@SUB=PedeSteererWeakModeConstraints"
                                 << "Load list of dead modules (size = " << dm.size()<< ").";
-      for(std::vector<unsigned int>::const_iterator it = dm.begin(); it != dm.end(); it++) {
-        deadmodules_.push_back((*it));
-      }
+      for(const auto& it: dm) deadmodules_.push_back(it);
     }
       
   }
@@ -143,18 +134,15 @@ PedeSteererWeakModeConstraints::PedeSteererWeakModeConstraints(AlignableTracker 
 //_________________________________________________________________________
 std::pair<align::GlobalPoint, align::GlobalPoint> PedeSteererWeakModeConstraints::getDoubleSensorPosition(const Alignable *ali) const
 {
-  const TwoBowedSurfacesAlignmentParameters *aliPar = 
+  const auto aliPar =
     dynamic_cast<TwoBowedSurfacesAlignmentParameters*>(ali->alignmentParameters());
   if(aliPar) {
-    const double ySplit = aliPar->ySplit();
-    //const double halfWidth   = 0.5 * ali->surface().width();
-    const double halfLength  = 0.5 * ali->surface().length();
-    //const double halfLength1 = 0.5 * (halfLength + ySplit);
-    //const double halfLength2 = 0.5 * (halfLength - ySplit);
-    const double yM1 = 0.5 * (ySplit - halfLength); // y_mean of surface 1
-    const double yM2 = yM1 + halfLength;            // y_mean of surface 2
-    const align::GlobalPoint pos_sensor0(ali->surface().toGlobal(align::LocalPoint(0.,yM1,0.)));
-    const align::GlobalPoint pos_sensor1(ali->surface().toGlobal(align::LocalPoint(0.,yM2,0.)));
+    const auto ySplit = aliPar->ySplit();
+    const auto halfLength  = 0.5 * ali->surface().length();
+    const auto yM1 = 0.5 * (ySplit - halfLength); // y_mean of surface 1
+    const auto yM2 = yM1 + halfLength;            // y_mean of surface 2
+    const auto pos_sensor0(ali->surface().toGlobal(align::LocalPoint(0.,yM1,0.)));
+    const auto pos_sensor1(ali->surface().toGlobal(align::LocalPoint(0.,yM2,0.)));
     return std::make_pair(pos_sensor0, pos_sensor1);
   } else {
     throw cms::Exception("Alignment")
@@ -165,77 +153,73 @@ std::pair<align::GlobalPoint, align::GlobalPoint> PedeSteererWeakModeConstraints
 }
 
 //_________________________________________________________________________
-unsigned int PedeSteererWeakModeConstraints::createAlignablesDataStructure() 
+unsigned int PedeSteererWeakModeConstraints::createAlignablesDataStructure()
 {
   unsigned int nConstraints = 0;
-  for(std::list<GeometryConstraintConfigData>::iterator iC = ConstraintsConfigContainer_.begin();
-      iC != ConstraintsConfigContainer_.end(); ++iC) {
+  for(auto& iC:ConstraintsConfigContainer_) {
     //loop over all HLS for which the constraint is to be determined
-    for(std::vector<std::pair<Alignable*,std::string> >::const_iterator iHLS = iC->levelsFilenames_.begin();
-        iHLS != iC->levelsFilenames_.end(); ++iHLS) {
+    for(const auto& iHLS: iC.levelsFilenames_) {
       //determine next active sub-alignables for iHLS
       std::vector<Alignable*> aliDaughts;
-      if (!(*iHLS).first->firstCompsWithParams(aliDaughts)) {
+      if (!iHLS.first->firstCompsWithParams(aliDaughts)) {
         edm::LogWarning("Alignment") << "@SUB=PedeSteererWeakModeConstraints::createAlignablesDataStructure"
                                      << "Some but not all daughters of "
-                                     << AlignableObjectId::idToString((*iHLS).first->alignableObjectId())
+                                     << AlignableObjectId::idToString(iHLS.first->alignableObjectId())
                                      << " with params!";
       }
       ++nConstraints;
-  
+
       std::list<Alignable*> usedinconstraint;
-      for (std::vector<Alignable*>::const_iterator iD = aliDaughts.begin();
-           iD != aliDaughts.end(); ++iD) {
+      for (const auto& iD: aliDaughts) {
         bool isNOTdead = true;
-        for(std::list<unsigned int>::const_iterator iDeadmodules = deadmodules_.begin();
-            iDeadmodules != deadmodules_.end(); iDeadmodules++) {
-          if( ((*iD)->alignableObjectId() == align::AlignableDetUnit 
-               || (*iD)->alignableObjectId() == align::AlignableDet)
-              && (*iD)->geomDetId().rawId() == (*iDeadmodules)) {
+        for(const auto& iDeadmodules: deadmodules_) {
+          if( (iD->alignableObjectId() == align::AlignableDetUnit
+               || iD->alignableObjectId() == align::AlignableDet)
+              && iD->geomDetId().rawId() == iDeadmodules) {
             isNOTdead = false;
             break;
           }
         }
         //check if the module is excluded
-        for(std::vector<Alignable*>::const_iterator iEx = iC->excludedAlignables_.begin();
-            iEx != iC->excludedAlignables_.end(); iEx++) {
-          if((*iD)->id() == (*iEx)->id() &&  (*iD)->alignableObjectId() == (*iEx)->alignableObjectId() ) {
-            //if((*iD)->geomDetId().rawId() == (*iEx)->geomDetId().rawId()) {
+        for(std::vector<Alignable*>::const_iterator iEx = iC.excludedAlignables_.begin();
+            iEx != iC.excludedAlignables_.end(); iEx++) {
+          if(iD->id() == (*iEx)->id() &&  iD->alignableObjectId() == (*iEx)->alignableObjectId() ) {
+            //if(iD->geomDetId().rawId() == (*iEx)->geomDetId().rawId()) {
             isNOTdead = false;
             break;
           }
         }
-        const bool issubcomponent = this->checkMother((*iD),(*iHLS).first);
+        const bool issubcomponent = this->checkMother(iD,iHLS.first);
         if(issubcomponent) {
           if(isNOTdead) {
-            usedinconstraint.push_back((*iD));
+            usedinconstraint.push_back(iD);
           }
         } else {
           //sanity check
           throw cms::Exception("Alignment")
-            << "[PedeSteererWeakModeConstraints::createAlignablesDataStructure]" 
+            << "[PedeSteererWeakModeConstraints::createAlignablesDataStructure]"
             << " Sanity check failed. Alignable defined as active sub-component, "
-            << " but in fact its not a daugther of " << AlignableObjectId::idToString((*iHLS).first->alignableObjectId());
+            << " but in fact its not a daugther of " << AlignableObjectId::idToString(iHLS.first->alignableObjectId());
         }
       }
 
       if( usedinconstraint.size() > 0){
-        (*iC).HLSsubdets_.push_back(std::make_pair((*iHLS).first, usedinconstraint));
+        iC.HLSsubdets_.push_back(std::make_pair(iHLS.first, usedinconstraint));
       } else {
         edm::LogInfo("Alignment") << "@SUB=PedeSteererWeakModeConstraints"
-                                  << "No sub-components for " 
-                                  << AlignableObjectId::idToString((*iHLS).first->alignableObjectId())
-                                  << "at (" << (*iHLS).first->globalPosition().x() << ","<< (*iHLS).first->globalPosition().y() << "," << (*iHLS).first->globalPosition().z() << ") "
+                                  << "No sub-components for "
+                                  << AlignableObjectId::idToString(iHLS.first->alignableObjectId())
+                                  << "at (" << iHLS.first->globalPosition().x() << ","<< iHLS.first->globalPosition().y() << "," << iHLS.first->globalPosition().z() << ") "
                                   << "selected. Skip constraint";
       }
       if(aliDaughts.size() == 0) {
         edm::LogWarning("Alignment") << "@SUB=PedeSteererWeakModeConstraints::createAlignablesDataStructure"
                                      << "No active sub-alignables found for "
-                                     << AlignableObjectId::idToString((*iHLS).first->alignableObjectId())
-                                     << " at (" << (*iHLS).first->globalPosition().x() << ","<< (*iHLS).first->globalPosition().y() << "," << (*iHLS).first->globalPosition().z() << ").";
+                                     << AlignableObjectId::idToString(iHLS.first->alignableObjectId())
+                                     << " at (" << iHLS.first->globalPosition().x() << ","<< iHLS.first->globalPosition().y() << "," << iHLS.first->globalPosition().z() << ").";
       }
-         
-       
+
+
     }
   }
   return nConstraints;
@@ -245,39 +229,31 @@ unsigned int PedeSteererWeakModeConstraints::createAlignablesDataStructure()
 double PedeSteererWeakModeConstraints::getX(const int sysdeformation, const align::GlobalPoint &pos, const double phase) const
 {
   double x = 0.0;
-  
+
   const double r = TMath::Sqrt(pos.x() * pos.x() + pos.y() * pos.y());
-  
+
   switch(sysdeformation) {
   case SystematicDeformations::kTwist:
-    x = pos.z();
-    break;
   case SystematicDeformations::kZexpansion:
     x = pos.z();
     break;
   case SystematicDeformations::kSagitta:
-    x = r; 
-    break;
   case SystematicDeformations::kRadial:
-    x = r; 
-    break;
   case SystematicDeformations::kTelescope:
-    x = r; 
-    break;
   case SystematicDeformations::kLayerRotation:
-    x = r; 
+    x = r;
     break;
   case SystematicDeformations::kBowing:
-    x = pos.z() * pos.z(); //TMath::Abs(pos.z()); 
+    x = pos.z() * pos.z(); //TMath::Abs(pos.z());
     break;
   case SystematicDeformations::kElliptical:
-    x = r * TMath::Cos(2.0 * pos.phi() + phase); 
+    x = r * TMath::Cos(2.0 * pos.phi() + phase);
     break;
   case SystematicDeformations::kSkew:
-    x = TMath::Cos(pos.phi() + phase); 
+    x = TMath::Cos(pos.phi() + phase);
     break;
   };
-  
+
   return x;
 }
 
@@ -297,45 +273,45 @@ double PedeSteererWeakModeConstraints::getCoefficient(const int sysdeformation,
       << "[PedeSteererWeakModeConstraints::getCoefficient]" << " iParameter has to be in the range [0,2] but"
       << " it is equal to " << iParameter << ".";
   }
-  
+
 
   //global vectors pointing in u,v,w direction
-  const std::vector<double> vec_u = boost::assign::list_of(pos.x() - gUDirection.x())(pos.y() - gUDirection.y())(pos.z() - gUDirection.z());
-  const std::vector<double> vec_v = boost::assign::list_of(pos.x() - gVDirection.x())(pos.y() - gVDirection.y())(pos.z() - gVDirection.z());
-  const std::vector<double> vec_w = boost::assign::list_of(pos.x() - gWDirection.x())(pos.y() - gWDirection.y())(pos.z() - gWDirection.z());
+  const std::vector<double> vec_u = {pos.x() - gUDirection.x(), pos.y() - gUDirection.y(), pos.z() - gUDirection.z()};
+  const std::vector<double> vec_v = {pos.x() - gVDirection.x(), pos.y() - gVDirection.y(), pos.z() - gVDirection.z()};
+  const std::vector<double> vec_w = {pos.x() - gWDirection.x(), pos.y() - gWDirection.y(), pos.z() - gWDirection.z()};
 
   //FIXME: how to make inner vectors const?
-  const std::vector<std::vector<double> > global_vecs = boost::assign::list_of(vec_u)(vec_v)(vec_w);
+  const std::vector<std::vector<double> > global_vecs = {vec_u, vec_v, vec_w};
 
-  const double n = TMath::Sqrt( global_vecs.at(iParameter).at(0) * global_vecs.at(iParameter).at(0) 
-                                + global_vecs.at(iParameter).at(1) * global_vecs.at(iParameter).at(1) 
+  const double n = TMath::Sqrt( global_vecs.at(iParameter).at(0) * global_vecs.at(iParameter).at(0)
+                                + global_vecs.at(iParameter).at(1) * global_vecs.at(iParameter).at(1)
                                 + global_vecs.at(iParameter).at(2) * global_vecs.at(iParameter).at(2) );
   const double r = TMath::Sqrt( pos.x() * pos.x() + pos.y() * pos.y() );
-  
+
   const double phase = this->getPhase(constraintparameters);
   //const double radial_direction[3] = {TMath::Sin(phase), TMath::Cos(phase), 0.0};
-  const std::vector<double> radial_direction = boost::assign::list_of(TMath::Sin(phase))(TMath::Cos(phase))(0.0);
+  const std::vector<double> radial_direction = {TMath::Sin(phase), TMath::Cos(phase), 0.0};
   //is equal to unity by construction ...
   const double norm_radial_direction =  TMath::Sqrt(radial_direction.at(0) * radial_direction.at(0)
-                                                    + radial_direction.at(1) * radial_direction.at(1) 
+                                                    + radial_direction.at(1) * radial_direction.at(1)
                                                     + radial_direction.at(2) * radial_direction.at(2));
-  
+
   //const double phi_direction[3] = { -1.0 * pos.y(), pos.x(), 0.0};
-  const std::vector<double> phi_direction = boost::assign::list_of(-1.0 * pos.y())(pos.x())(0.0);
+  const std::vector<double> phi_direction = {-1.0 * pos.y(), pos.x(), 0.0};
   const double norm_phi_direction = TMath::Sqrt(phi_direction.at(0) * phi_direction.at(0)
-                                                + phi_direction.at(1) * phi_direction.at(1) 
+                                                + phi_direction.at(1) * phi_direction.at(1)
                                                 + phi_direction.at(2) * phi_direction.at(2));
-  
+
   //const double z_direction[3] = {0.0, 0.0, 1.0};
-  static const std::vector<double> z_direction = boost::assign::list_of(0.0)(0.0)(1.0);
+  static const std::vector<double> z_direction = {0.0, 0.0, 1.0};
   const double norm_z_direction = TMath::Sqrt(z_direction.at(0)*z_direction.at(0)
-                                              + z_direction.at(1)*z_direction.at(1) 
+                                              + z_direction.at(1)*z_direction.at(1)
                                               + z_direction.at(2)*z_direction.at(2));
 
   //unit vector pointing from the origin to the module position in the transverse plane
-  const std::vector<double> rDirection = boost::assign::list_of(pos.x())(pos.y())(0.0);
+  const std::vector<double> rDirection = {pos.x(), pos.y(), 0.0};
   const double norm_rDirection =  TMath::Sqrt(rDirection.at(0) * rDirection.at(0)
-                                              + rDirection.at(1) * rDirection.at(1) 
+                                              + rDirection.at(1) * rDirection.at(1)
                                               + rDirection.at(2) * rDirection.at(2));
 
   double coeff = 0.0;
@@ -343,33 +319,39 @@ double PedeSteererWeakModeConstraints::getCoefficient(const int sysdeformation,
   double normalisation_factor = 1.0;
 
   //see https://indico.cern.ch/getFile.py/access?contribId=15&sessionId=1&resId=0&materialId=slides&confId=127126
-  if(sysdeformation == SystematicDeformations::kTwist 
-     || sysdeformation == SystematicDeformations::kLayerRotation) {
-    dot_product = phi_direction.at(0) * global_vecs.at(iParameter).at(0) 
+  switch(sysdeformation) {
+  case SystematicDeformations::kTwist:
+  case SystematicDeformations::kLayerRotation:
+    dot_product = phi_direction.at(0) * global_vecs.at(iParameter).at(0)
       + phi_direction.at(1) * global_vecs.at(iParameter).at(1)
       + phi_direction.at(2) * global_vecs.at(iParameter).at(2);
     normalisation_factor = r * n * norm_phi_direction;
-  } else if(sysdeformation == SystematicDeformations::kZexpansion 
-            || sysdeformation == SystematicDeformations::kTelescope 
-            || sysdeformation == SystematicDeformations::kSkew) {
-    dot_product = global_vecs.at(iParameter).at(0) * z_direction.at(0) 
-      + global_vecs.at(iParameter).at(1) * z_direction.at(1) 
+    break;
+  case SystematicDeformations::kZexpansion :
+  case SystematicDeformations::kTelescope:
+  case SystematicDeformations::kSkew:
+    dot_product = global_vecs.at(iParameter).at(0) * z_direction.at(0)
+      + global_vecs.at(iParameter).at(1) * z_direction.at(1)
       + global_vecs.at(iParameter).at(2) * z_direction.at(2);
     normalisation_factor = ( n * norm_z_direction);
-  } else if(sysdeformation == SystematicDeformations::kRadial 
-            || sysdeformation == SystematicDeformations::kBowing 
-            || sysdeformation == SystematicDeformations::kElliptical) {
-    dot_product = global_vecs.at(iParameter).at(0) * rDirection.at(0) 
-      + global_vecs.at(iParameter).at(1) * rDirection.at(1) 
+    break;
+  case SystematicDeformations::kRadial:
+  case SystematicDeformations::kBowing:
+  case SystematicDeformations::kElliptical:
+    dot_product = global_vecs.at(iParameter).at(0) * rDirection.at(0)
+      + global_vecs.at(iParameter).at(1) * rDirection.at(1)
       + global_vecs.at(iParameter).at(2) * rDirection.at(2);
     normalisation_factor = ( n * norm_rDirection);
-  } else if(sysdeformation == SystematicDeformations::kSagitta) {
-    dot_product = global_vecs.at(iParameter).at(0) * radial_direction.at(0) 
-      + global_vecs.at(iParameter).at(1) * radial_direction.at(1) 
+    break;
+  case SystematicDeformations::kSagitta:
+    dot_product = global_vecs.at(iParameter).at(0) * radial_direction.at(0)
+      + global_vecs.at(iParameter).at(1) * radial_direction.at(1)
       + global_vecs.at(iParameter).at(2) * radial_direction.at(2);
     normalisation_factor = ( n * norm_radial_direction);
+    break;
+  default: break;
   }
-  
+
   if(TMath::Abs(normalisation_factor) > 0.0) {
     coeff = dot_product * ( this->getX(sysdeformation,pos,phase) - x0 ) / normalisation_factor;
   } else {
@@ -386,17 +368,17 @@ bool PedeSteererWeakModeConstraints::checkSelectionShiftParameter(const Alignabl
   bool isselected = false;
   const std::vector<bool> &aliSel= ali->alignmentParameters()->selector();
   //exclude non-shift parameters
-  if((iParameter <= 2) 
+  if((iParameter <= 2)
      || (iParameter >= 9 && iParameter <=11)) {
     if(!aliSel.at(iParameter)) {
       isselected = false;
     } else {
-      AlignmentParameters *params = ali->alignmentParameters();
-      SelectionUserVariables *selVar = dynamic_cast<SelectionUserVariables*>(params->userVariables());
+      auto params = ali->alignmentParameters();
+      auto selVar = dynamic_cast<SelectionUserVariables*>(params->userVariables());
       if (selVar) {
         if(selVar->fullSelection().size() <= (iParameter+1)) {
-          throw cms::Exception("Alignment") 
-            << "[PedeSteererWeakModeConstraints::checkSelectionShiftParameter]" 
+          throw cms::Exception("Alignment")
+            << "[PedeSteererWeakModeConstraints::checkSelectionShiftParameter]"
             << " Can not access selected alignment variables of alignable "
             <<  AlignableObjectId::idToString(ali->alignableObjectId())
             << "at (" << ali->globalPosition().x() << ","<< ali->globalPosition().y() << "," << ali->globalPosition().z()<< ") "
@@ -417,15 +399,14 @@ bool PedeSteererWeakModeConstraints::checkSelectionShiftParameter(const Alignabl
 void PedeSteererWeakModeConstraints::closeOutputfiles()
 {
    //'delete' output files which means: close them
-  for(std::list<GeometryConstraintConfigData>::iterator it = ConstraintsConfigContainer_.begin();
-      it != ConstraintsConfigContainer_.end(); it++) {
-    for(std::map<std::string, std::ofstream*>::iterator iFile = it->mapFileName_.begin();
-        iFile != it->mapFileName_.end(); iFile++) {
-      if(iFile->second)
-        delete iFile->second;
-      else {
+  for(auto& it: ConstraintsConfigContainer_) {
+    for(auto& iFile:it.mapFileName_) {
+      if(iFile.second) {
+        delete iFile.second;
+        iFile.second = nullptr;
+      } else {
         throw cms::Exception("FileCloseProblem")
-          << "[PedeSteererWeakModeConstraints]" << " can not close file " << iFile->first << ".";
+          << "[PedeSteererWeakModeConstraints]" << " can not close file " << iFile.first << ".";
       }
     }
   }
@@ -433,54 +414,50 @@ void PedeSteererWeakModeConstraints::closeOutputfiles()
 
 //_________________________________________________________________________
 void PedeSteererWeakModeConstraints::writeOutput(const std::list<std::pair<unsigned int,double> > &output,
-                                                 const std::list<GeometryConstraintConfigData>::const_iterator &it, Alignable* iHLS, double sum_xi_x0)
+                                                 const GeometryConstraintConfigData &it, Alignable* iHLS, double sum_xi_x0)
 {
-  
+
   //write output to file
-  std::ofstream* ofile = NULL;
+  std::ofstream* ofile = nullptr;
 
-  for(std::vector<std::pair<Alignable*, std::string> >::const_iterator ilevelsFilename = it->levelsFilenames_.begin();
-      ilevelsFilename != it->levelsFilenames_.end(); ilevelsFilename++) {
-    if((*ilevelsFilename).first->id() == iHLS->id() && (*ilevelsFilename).first->alignableObjectId() == iHLS->alignableObjectId()) {
+  for(const auto& ilevelsFilename: it.levelsFilenames_) {
+    if(ilevelsFilename.first->id() == iHLS->id() &&
+       ilevelsFilename.first->alignableObjectId() == iHLS->alignableObjectId()) {
 
-      std::map<std::string, std::ofstream*>::const_iterator iFile = it->mapFileName_.find((*ilevelsFilename).second);
-      if(iFile != it->mapFileName_.end()) {
-        ofile = (*iFile).second; 
+      const auto iFile = it.mapFileName_.find(ilevelsFilename.second);
+      if(iFile != it.mapFileName_.end()) {
+        ofile = iFile->second;
       }
     }
   }
 
-  if(ofile == NULL) {
+  if(ofile == nullptr) {
     throw cms::Exception("FileFindError")
-      << "[PedeSteererWeakModeConstraints]" << " Can not find output file.";
+      << "[PedeSteererWeakModeConstraints]" << " Cannot find output file.";
   } else {
     if(output.size() > 0) {
-      const double constr = sum_xi_x0 * it->coefficients_.front();
+      const double constr = sum_xi_x0 * it.coefficients_.front();
       (*ofile) << "Constraint " << std::scientific << constr << std::endl;
-      for(std::list<std::pair<unsigned int,double> >::const_iterator ioutput = output.begin();
-          ioutput != output.end(); ioutput++) {
-        (*ofile) << std::fixed << ioutput->first << " " << std::scientific << ioutput->second << std::endl;
+      for(const auto& ioutput: output) {
+        (*ofile) << std::fixed << ioutput.first << " " << std::scientific << ioutput.second << std::endl;
       }
     }
   }
 }
 
 //_________________________________________________________________________
-double PedeSteererWeakModeConstraints::getX0(std::list<std::pair<Alignable*, std::list<Alignable*> > >::iterator &iHLS,
-                                             std::list<GeometryConstraintConfigData>::iterator &it)
+double PedeSteererWeakModeConstraints::getX0(const std::pair<Alignable*, std::list<Alignable*> > &iHLS,
+                                             const GeometryConstraintConfigData &it) const
 {
   double nmodules = 0.0;
-  double x0 =0.0;
+  double x0 = 0.0;
 
-  for(std::list<Alignable*>::iterator iAlignables = iHLS->second.begin();
-      iAlignables != iHLS->second.end(); iAlignables++) {
-        
-    Alignable *ali = (*iAlignables);
+  for(const auto& ali: iHLS.second) {
     align::PositionType pos = ali->globalPosition();
     bool alignableIsFloating = false; //means: true=alignable is able to move in at least one direction
-       
+
     //test whether at least one variable has been selected in the configuration
-    for(unsigned int iParameter = 0; 
+    for(unsigned int iParameter = 0;
         static_cast<int>(iParameter) < ali->alignmentParameters()->size(); iParameter++) {
       if(this->checkSelectionShiftParameter(ali,iParameter) ) {
         alignableIsFloating = true;
@@ -490,7 +467,7 @@ double PedeSteererWeakModeConstraints::getX0(std::list<std::pair<Alignable*, std
           throw cms::Exception("PedeSteererWeakModeConstraints")
             << "@SUB=PedeSteererWeakModeConstraints::ConstructConstraints"
             << " Weak mode constraints are only supported for alignables which have"
-            << " just one label. However, e.g. alignable" 
+            << " just one label. However, e.g. alignable"
             << " " << AlignableObjectId::idToString(ali->alignableObjectId())
             << "at (" << ali->globalPosition().x() << ","<< ali->globalPosition().y() << "," << ali->globalPosition().z()<< "), "
             << " was configured to have >1 label. Remove e.g. IOV-dependence for this (and other) alignables which are used in the constraint.";
@@ -498,15 +475,15 @@ double PedeSteererWeakModeConstraints::getX0(std::list<std::pair<Alignable*, std
         break;
       }
     }
-    //at least one parameter of the alignable can be changed in the alignment 
+    //at least one parameter of the alignable can be changed in the alignment
     if(alignableIsFloating) {
-      const double phase = this->getPhase(it->coefficients_);
+      const auto phase = this->getPhase(it.coefficients_);
       if(ali->alignmentParameters()->type() != AlignmentParametersFactory::kTwoBowedSurfaces ) {
-        x0 += this->getX(it->sysdeformation_,pos,phase);
+        x0 += this->getX(it.sysdeformation_,pos,phase);
         nmodules++;
       } else {
         std::pair<align::GlobalPoint, align::GlobalPoint> sensorpositions = this->getDoubleSensorPosition(ali);
-        x0 += this->getX(it->sysdeformation_,sensorpositions.first,phase) + this->getX(it->sysdeformation_,sensorpositions.second,phase);
+        x0 += this->getX(it.sysdeformation_,sensorpositions.first,phase) + this->getX(it.sysdeformation_,sensorpositions.second,phase);
         nmodules++;
         nmodules++;
       }
@@ -515,8 +492,9 @@ double PedeSteererWeakModeConstraints::getX0(std::list<std::pair<Alignable*, std
   if(nmodules>0) {
     x0 = x0 / nmodules;
   } else {
-    throw cms::Exception("Alignment") << "@SUB=PedeSteererWeakModeConstraints::ConstructConstraints"
-                                      << " Number of selected modules equal to zero. Check configuration!";
+    throw cms::Exception("Alignment")
+      << "@SUB=PedeSteererWeakModeConstraints::ConstructConstraints"
+      << " Number of selected modules equal to zero. Check configuration!";
     x0 = 1.0;
   }
   return x0;
@@ -526,27 +504,25 @@ double PedeSteererWeakModeConstraints::getX0(std::list<std::pair<Alignable*, std
 unsigned int PedeSteererWeakModeConstraints::constructConstraints(const std::vector<Alignable*> &alis)
 {
   //FIXME: split the code of the method into smaller pieces/submethods
-  
-  //create the data structures that store the alignables 
+
+  //create the data structures that store the alignables
   //for which the constraints need to be calculated and
   //their association to high-level structures
-  const unsigned int nConstraints = this->createAlignablesDataStructure();
+  const auto nConstraints = this->createAlignablesDataStructure();
 
   //calculate constraints
   //loop over all constraints
-  for(std::list<GeometryConstraintConfigData>::iterator it = ConstraintsConfigContainer_.begin();
-      it != ConstraintsConfigContainer_.end(); it++) {
-     
+  for(const auto& it: ConstraintsConfigContainer_) {
+
     //loop over all subdets for which constraints are determined
-    for(std::list<std::pair<Alignable*, std::list<Alignable*> > >::iterator iHLS = it->HLSsubdets_.begin();
-        iHLS != it->HLSsubdets_.end(); iHLS++) {
+    for(const auto& iHLS : it.HLSsubdets_) {
       double sum_xi_x0 = 0.0;
       std::list<std::pair<unsigned int,double> > output;
-      
+
       const double x0 = this->getX0(iHLS, it);
-      
-      for(std::list<Alignable*>::const_iterator iAlignables = iHLS->second.begin();
-          iAlignables != iHLS->second.end(); iAlignables++) {
+
+      for(std::list<Alignable*>::const_iterator iAlignables = iHLS.second.begin();
+          iAlignables != iHLS.second.end(); iAlignables++) {
         const Alignable *ali = (*iAlignables);
         const unsigned int aliLabel = myLabels_->alignableLabel(const_cast<Alignable*>(ali));
         const AlignableSurface &surface = ali->surface();
@@ -554,28 +530,28 @@ unsigned int PedeSteererWeakModeConstraints::constructConstraints(const std::vec
         const LocalPoint  lUDirection(1.,0.,0.),
           lVDirection(0.,1.,0.),
           lWDirection(0.,0.,1.);
-        
+
         GlobalPoint gUDirection = surface.toGlobal(lUDirection),
           gVDirection = surface.toGlobal(lVDirection),
           gWDirection = surface.toGlobal(lWDirection);
-        
+
         const bool isDoubleSensor = ali->alignmentParameters()->type() == AlignmentParametersFactory::kTwoBowedSurfaces ? true : false;
-       
-        const std::pair<align::GlobalPoint, align::GlobalPoint> sensorpositions =
+
+        const auto sensorpositions =
           isDoubleSensor ? this->getDoubleSensorPosition(ali) : std::make_pair(ali->globalPosition(), align::PositionType ());
 
-        const align::GlobalPoint &pos_sensor0 = sensorpositions.first;
-        const align::GlobalPoint &pos_sensor1 = sensorpositions.second;
-        const double phase = this->getPhase(it->coefficients_);
-        const double x_sensor0 = this->getX(it->sysdeformation_,pos_sensor0,phase);
-        const double x_sensor1 = isDoubleSensor ? this->getX(it->sysdeformation_,pos_sensor1,phase) : 0.0;
-            
+        const auto& pos_sensor0 = sensorpositions.first;
+        const auto& pos_sensor1 = sensorpositions.second;
+        const auto phase = this->getPhase(it.coefficients_);
+        const auto x_sensor0 = this->getX(it.sysdeformation_,pos_sensor0,phase);
+        const auto x_sensor1 = isDoubleSensor ? this->getX(it.sysdeformation_,pos_sensor1,phase) : 0.0;
+
         sum_xi_x0 += ( x_sensor0 - x0 ) * ( x_sensor0 - x0 );
         if(isDoubleSensor) {
           sum_xi_x0 += ( x_sensor1 - x0 ) * ( x_sensor1 - x0 );
         }
         const int numparameterlimit = ali->alignmentParameters()->size(); //isDoubleSensor ? 18 : 3;
-        
+
         for(int iParameter = 0; iParameter < numparameterlimit; iParameter++) {
           int localindex = 0;
           if(iParameter == 0 || iParameter == 9)
@@ -585,7 +561,7 @@ unsigned int PedeSteererWeakModeConstraints::constructConstraints(const std::vec
           if(iParameter == 2 || iParameter == 11)
             localindex = 2;
 
-          if((iParameter >= 0 && iParameter <= 2) 
+          if((iParameter >= 0 && iParameter <= 2)
              || (iParameter >= 9 && iParameter <=11)) {
           } else {
             continue;
@@ -594,45 +570,45 @@ unsigned int PedeSteererWeakModeConstraints::constructConstraints(const std::vec
             continue;
           }
           //do it for each 'instance' separately? -> IOV-dependence, no
-          const unsigned int paramLabel = myLabels_->parameterLabel(aliLabel, iParameter);
-                  
-          const align::GlobalPoint &pos = (iParameter <= 2) ? pos_sensor0 : pos_sensor1;
+          const auto paramLabel = myLabels_->parameterLabel(aliLabel, iParameter);
+
+          const auto& pos = (iParameter <= 2) ? pos_sensor0 : pos_sensor1;
           //select only u,v,w
-          if(iParameter == 0 || iParameter == 1 || iParameter == 2 
+          if(iParameter == 0 || iParameter == 1 || iParameter == 2
              || iParameter == 9 || iParameter == 10 || iParameter == 11) {
-            const double coeff = this->getCoefficient(it->sysdeformation_, 
-                                                      pos, 
+            const double coeff = this->getCoefficient(it.sysdeformation_,
+                                                      pos,
                                                       gUDirection,
                                                       gVDirection,
                                                       gWDirection,
                                                       localindex,
                                                       x0,
-                                                      it->coefficients_);
+                                                      it.coefficients_);
             if(TMath::Abs(coeff) > 0.0) {
               //nothing
             } else {
               edm::LogWarning("PedeSteererWeakModeConstraints")
                 << "@SUB=PedeSteererWeakModeConstraints::getCoefficient"
-                << "Coefficient of alignable " 
+                << "Coefficient of alignable "
                 <<  AlignableObjectId::idToString(ali->alignableObjectId())
                 << " at (" << ali->globalPosition().x() << ","<< ali->globalPosition().y() << "," << ali->globalPosition().z()<< ") "
-                << " in subdet " << AlignableObjectId::idToString((*iHLS).first->alignableObjectId())
+                << " in subdet " << AlignableObjectId::idToString(iHLS.first->alignableObjectId())
                 << " for parameter " << localindex << " equal to zero. This alignable is used in the constraint"
-                << " '" << it->constraintName_ << "'. The id is: alignable->geomDetId().rawId() = "
+                << " '" << it.constraintName_ << "'. The id is: alignable->geomDetId().rawId() = "
                 << ali->geomDetId().rawId() << ".";
             }
             output.push_back(std::make_pair (paramLabel, coeff));
           }
         }
-        
-        
+
+
       }
 
-      this->writeOutput(output, it, (*iHLS).first, sum_xi_x0);
+      this->writeOutput(output, it, iHLS.first, sum_xi_x0);
     }
   }
   this->closeOutputfiles();
- 
+
   return nConstraints;
 }
 
@@ -642,7 +618,7 @@ bool PedeSteererWeakModeConstraints::checkMother(const Alignable * const lowleve
   if(lowleveldet->id() == HLS->id() && lowleveldet->alignableObjectId() == HLS->alignableObjectId()) {
     return true;
   } else {
-    if(lowleveldet->mother() == NULL) 
+    if(lowleveldet->mother() == nullptr)
       return false;
     else
       return this->checkMother(lowleveldet->mother(),HLS);
@@ -652,12 +628,9 @@ bool PedeSteererWeakModeConstraints::checkMother(const Alignable * const lowleve
 //_________________________________________________________________________
 void PedeSteererWeakModeConstraints::verifyParameterNames(const edm::ParameterSet &pset, unsigned int psetnr) const
 {
-  std::vector<std::string> parameterNames = pset.getParameterNames();
-  for ( std::vector<std::string>::const_iterator iParam = parameterNames.begin(); 
-        iParam != parameterNames.end(); ++iParam) {
-    const std::string name = (*iParam);
-    if(
-       name != "coefficients"
+  const auto parameterNames = pset.getParameterNames();
+  for (const auto& name: parameterNames) {
+    if(name != "coefficients"
        && name != "deadmodules" && name != "constraint"
        && name != "steerFilePrefix" && name != "levels"
        && name != "excludedAlignables"
@@ -670,11 +643,10 @@ void PedeSteererWeakModeConstraints::verifyParameterNames(const edm::ParameterSe
 }
 
 //_________________________________________________________________________
-const std::vector<std::pair<Alignable*, std::string> > PedeSteererWeakModeConstraints::makeLevelsFilenames(
-                                                                                                           std::set<std::string> &steerFilePrefixContainer,
-                                                                                                           const std::vector<Alignable*> &alis,
-                                                                                                           const std::string &steerFilePrefix
-                                                                                                           ) const
+const std::vector<std::pair<Alignable*, std::string> >
+PedeSteererWeakModeConstraints::makeLevelsFilenames(std::set<std::string> &steerFilePrefixContainer,
+                                                    const std::vector<Alignable*> &alis,
+                                                    const std::string &steerFilePrefix) const
 {
   //check whether the prefix is unique
   if(steerFilePrefixContainer.find(steerFilePrefix) != steerFilePrefixContainer.end()) {
@@ -683,15 +655,15 @@ const std::vector<std::pair<Alignable*, std::string> > PedeSteererWeakModeConstr
   } else {
     steerFilePrefixContainer.insert(steerFilePrefix);
   }
-        
+
   std::vector<std::pair<Alignable*, std::string> > levelsFilenames;
-  for(std::vector<Alignable*>::const_iterator it = alis.begin(); it != alis.end(); ++it) {
+  for(const auto& ali: alis) {
     std::stringstream n;
-    n << steerFile_ << "_" << steerFilePrefix //<< "_" << name 
-      << "_" << AlignableObjectId::idToString((*it)->alignableObjectId())
-      << "_" << (*it)->id() << "_" << (*it)->alignableObjectId() << ".txt";
-            
-    levelsFilenames.push_back(std::make_pair((*it),n.str()));
+    n << steerFile_ << "_" << steerFilePrefix //<< "_" << name
+      << "_" << AlignableObjectId::idToString(ali->alignableObjectId())
+      << "_" << ali->id() << "_" << ali->alignableObjectId() << ".txt";
+
+    levelsFilenames.push_back(std::make_pair(ali, n.str()));
   }
   return levelsFilenames;
 }
@@ -720,20 +692,20 @@ int PedeSteererWeakModeConstraints::verifyDeformationName(const std::string &nam
   } else if(name == "elliptical") {
     sysdeformation = SystematicDeformations::kElliptical;
   }
-        
+
   if(sysdeformation == SystematicDeformations::kUnknown) {
     throw cms::Exception("BadConfig")
       << "[PedeSteererWeakModeConstraints]" << " specified configuration option '"
       << name << "' not known.";
   }
-  if((sysdeformation == SystematicDeformations::kSagitta 
-      || sysdeformation == SystematicDeformations::kElliptical 
+  if((sysdeformation == SystematicDeformations::kSagitta
+      || sysdeformation == SystematicDeformations::kElliptical
       || sysdeformation == SystematicDeformations::kSkew) && coefficients.size() != 2) {
     throw cms::Exception("BadConfig")
       << "[PedeSteererWeakModeConstraints]" << " Excactly two parameters using the coefficient"
       << " variable have to be provided for the " << name << " constraint.";
   }
-  if((sysdeformation == SystematicDeformations::kTwist 
+  if((sysdeformation == SystematicDeformations::kTwist
       || sysdeformation == SystematicDeformations::kZexpansion
       || sysdeformation == SystematicDeformations::kTelescope
       || sysdeformation == SystematicDeformations::kLayerRotation
@@ -750,7 +722,7 @@ int PedeSteererWeakModeConstraints::verifyDeformationName(const std::string &nam
   }
   return sysdeformation;
 }
- 
+
 
 //_________________________________________________________________________
 double PedeSteererWeakModeConstraints::getPhase(const std::vector<double> &coefficients) const
@@ -759,7 +731,4 @@ double PedeSteererWeakModeConstraints::getPhase(const std::vector<double> &coeff
 }
 
 //_________________________________________________________________________
-PedeSteererWeakModeConstraints::~PedeSteererWeakModeConstraints()
-{
- 
-}
+PedeSteererWeakModeConstraints::~PedeSteererWeakModeConstraints() = default;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
@@ -8,9 +8,6 @@
  *
  * \author    : Joerg Behr
  * date       : February 2013
- * $Date: 2013/06/18 15:47:55 $
- * $Revision: 1.10 $
- * (last update by $Author: jbehr $)
  */
 
 #include <list>
@@ -36,11 +33,11 @@ class PedeLabelerBase;
 //FIXME: move GeometryConstraintConfigData to PedeSteererWeakModeConstraints?
 class GeometryConstraintConfigData {
  public:
-  GeometryConstraintConfigData(const std::vector<double> co,
-                               const std::string c,
-                               const std::vector<std::pair<Alignable*,std::string> > &alisFile,
+  GeometryConstraintConfigData(const std::vector<double>& co,
+                               const std::string& c,
+                               const std::vector<std::pair<Alignable*,std::string> >& alisFile,
                                const int sd,
-                               const std::vector<Alignable*> ex
+                               const std::vector<Alignable*>& ex
                                );
   const std::vector<double> coefficients_;
   const std::string constraintName_;
@@ -65,7 +62,7 @@ class PedeSteererWeakModeConstraints {
   unsigned int constructConstraints(const std::vector<Alignable*> &alis);
  
   // Returns a references to the container in which the configuration is stored
-  std::list<GeometryConstraintConfigData>* getConfigData() { return &ConstraintsConfigContainer_; }
+  std::list<GeometryConstraintConfigData>& getConfigData() { return ConstraintsConfigContainer_; }
 
  private:
   // Method creates the data structures with the full configuration
@@ -73,7 +70,7 @@ class PedeSteererWeakModeConstraints {
 
   // Write the calculated constraints to the output files
   void writeOutput(const std::list<std::pair<unsigned int,double> > &output,
-                   const std::list<GeometryConstraintConfigData>::const_iterator &it, Alignable* iHLS, double sum_xi_x0);
+                   const GeometryConstraintConfigData &it, Alignable* iHLS, double sum_xi_x0);
 
   // Close the output files
   void closeOutputfiles();
@@ -89,8 +86,8 @@ class PedeSteererWeakModeConstraints {
   // The methods returns x depending on the type of deformation
   double getX(const int sysdeformation, const align::GlobalPoint &pos, const double phase) const;
 
-  double getX0(std::list<std::pair<Alignable*, std::list<Alignable*> > >::iterator &iHLS,
-               std::list<GeometryConstraintConfigData>::iterator &it);
+  double getX0(const std::pair<Alignable*, std::list<Alignable*> > &iHLS,
+               const GeometryConstraintConfigData &it) const;
 
   // Calculates and returns the coefficient for alignment parameter iParameter
   // for an alignable at position pos.

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
@@ -12,11 +12,11 @@
 
 #include <list>
 #include <vector>
-#include <map> 
-#include <set> 
+#include <map>
+#include <set>
 #include <string>
 // forward ofstream:
-#include <iosfwd> 
+#include <iosfwd>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h"
@@ -37,7 +37,8 @@ class GeometryConstraintConfigData {
                                const std::string& c,
                                const std::vector<std::pair<Alignable*,std::string> >& alisFile,
                                const int sd,
-                               const std::vector<Alignable*>& ex
+                               const std::vector<Alignable*>& ex,
+                               const int instance
                                );
   const std::vector<double> coefficients_;
   const std::string constraintName_;
@@ -45,7 +46,8 @@ class GeometryConstraintConfigData {
   const std::vector<Alignable*> excludedAlignables_;
   std::map<std::string, std::ofstream*> mapFileName_;
   std::list<std::pair<Alignable*, std::list<Alignable*> > > HLSsubdets_; //first pointer to HLS object, second list is the list of pointers to the lowest components
-  int sysdeformation_;
+  const int sysdeformation_;
+  const int instance_;
 };
 
 class PedeSteererWeakModeConstraints {
@@ -60,7 +62,7 @@ class PedeSteererWeakModeConstraints {
   //FIXME: split the code of the method into smaller pieces/submethods
   // Main method that configures everything and calculates also the constraints
   unsigned int constructConstraints(const std::vector<Alignable*> &alis);
- 
+
   // Returns a references to the container in which the configuration is stored
   std::list<GeometryConstraintConfigData>& getConfigData() { return ConstraintsConfigContainer_; }
 
@@ -101,7 +103,7 @@ class PedeSteererWeakModeConstraints {
 
   //returns true if iParameter of Alignable is selected in configuration file
   bool checkSelectionShiftParameter(const Alignable *ali, unsigned int iParameter) const;
- 
+
   // Method used to test the provided configuration for unknown parameters
   void verifyParameterNames(const edm::ParameterSet &pset, unsigned int psetnr) const;
 
@@ -114,9 +116,9 @@ class PedeSteererWeakModeConstraints {
 
   // Verify that the name of the configured deformation is known and that the number of coefficients has been correctly configured
   int verifyDeformationName(const std::string &name, const std::vector<double> &coefficients) const;
-  
+
   //list of dead modules which are not used in any constraint
-  std::list<align::ID> deadmodules_; 
+  std::list<align::ID> deadmodules_;
 
   //the data structure that holds all needed informations for the constraint configuration
   std::list<GeometryConstraintConfigData> ConstraintsConfigContainer_;
@@ -140,5 +142,5 @@ class PedeSteererWeakModeConstraints {
     kSkew
   };
 };
- 
+
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
@@ -38,7 +38,8 @@ class GeometryConstraintConfigData {
                                const std::vector<std::pair<Alignable*,std::string> >& alisFile,
                                const int sd,
                                const std::vector<Alignable*>& ex,
-                               const int instance
+                               const int instance,
+			       const bool downToLowestLevel
                                );
   const std::vector<double> coefficients_;
   const std::string constraintName_;
@@ -48,6 +49,7 @@ class GeometryConstraintConfigData {
   std::list<std::pair<Alignable*, std::list<Alignable*> > > HLSsubdets_; //first pointer to HLS object, second list is the list of pointers to the lowest components
   const int sysdeformation_;
   const int instance_;
+  const bool downToLowestLevel_;
 };
 
 class PedeSteererWeakModeConstraints {
@@ -72,7 +74,10 @@ class PedeSteererWeakModeConstraints {
 
   // Write the calculated constraints to the output files
   void writeOutput(const std::list<std::pair<unsigned int,double> > &output,
-                   const GeometryConstraintConfigData &it, Alignable* iHLS, double sum_xi_x0);
+                   const GeometryConstraintConfigData &it, const Alignable* iHLS, double sum_xi_x0);
+
+  // find the out file stream for a given constraint and high-level structure
+  std::ofstream* getFile(const GeometryConstraintConfigData &it, const Alignable* iHLS) const;
 
   // Close the output files
   void closeOutputfiles();


### PR DESCRIPTION
Feature allows to constrain the tracker alignment procedure to avoid the introduction of weak modes.
Includes extension of the existing code to support multi-IOV alignments + clean-up of existing code.

Presented at Tracker Alignment meeting 16 March 2016:
https://indico.cern.ch/event/504824/session/0/contribution/65/attachments/1244395/1831868/talk.pdf
