### PR TITLE
Electron validation 80X histo name modification

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -67,8 +67,8 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi","mean ele momentum / gen momentum vs phi","#phi (rad)","<P/P_{gen}>");
   profileX(iBooker, iGetter, "sigmaIetaIetaVsPt","SigmaIetaIeta vs pt","p_{T} (GeV/c)","SigmaIetaIeta");
-  profileX(iBooker, iGetter, "EoEtruePfVsEg","mean pflow sc energy / true energy vs e/g sc energy","E/E_{gen} (e/g)","<E/E_{gen}> (pflow)") ;
-  profileY(iBooker, iGetter, "EoEtruePfVsEg","mean e/g sc energy / true energy vs pflow sc energy","E/E_{gen} (pflow)","<E/E_{gen}> (eg)") ;
+  profileX(iBooker, iGetter, "EoEtruePfVsEg","mean mustache SC/true energy vs final SC/true energy","E_{final SC}/E_{gen}","E_{mustache}/E_{gen}") ;
+  profileY(iBooker, iGetter, "EoEtruePfVsEg","mean mustache SC/true energy vs final SC/true energy","E_{final SC}/E_{gen}","E_{mustache}/E_{gen}") ;
   profileX(iBooker, iGetter, "EtaMnEtaTrueVsEta","mean ele eta - gen eta vs eta","#eta","<#eta_{rec} - #eta_{gen}>");
   profileX(iBooker, iGetter, "EtaMnEtaTrueVsPhi","mean ele eta - gen eta vs phi","#phi (rad)","<#eta_{rec} - #eta_{gen}>");
   profileX(iBooker, iGetter, "PhiMnPhiTrueVsEta","mean ele phi - gen phi vs eta","#eta","<#phi_{rec} - #phi_{gen}> (rad)");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -765,7 +765,7 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_E5x5 = bookH1withSumw2(iBooker, "E5x5","ele supercluster energy in 5x5",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
   h1_scl_E5x5_barrel = bookH1withSumw2(iBooker, "E5x5_barrel","ele supercluster energy in 5x5 barrel",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
   h1_scl_E5x5_endcaps = bookH1withSumw2(iBooker, "E5x5_endcaps","ele supercluster energy in 5x5 endcaps",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
-  h2_scl_EoEtruePfVsEg = bookH2(iBooker, "EoEtruePfVsEg","ele supercluster energy / gen energy pflow vs eg",75,-0.1,1.4, 75, -0.1, 1.4,"E/E_{gen} (e/g)","E/E_{gen} (pflow)") ;
+  h2_scl_EoEtruePfVsEg = bookH2(iBooker, "EoEtruePfVsEg","mean mustache SC/true energy vs final SC/true energy",75,-0.1,1.4, 75, -0.1, 1.4,"E_{final SC}/E_{gen}","E_{mustache}/E_{gen}") ;
   h1_scl_bcl_EtotoEtrue = bookH1withSumw2(iBooker, "bcl_EtotoEtrue","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_barrel = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_endcaps = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
@@ -1426,9 +1426,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_PoPtrueVsEta->Fill( bestGsfElectron.eta(), bestGsfElectron.p()/mcIter->p());
     h2_ele_PoPtrueVsPhi->Fill( bestGsfElectron.phi(), bestGsfElectron.p()/mcIter->p());
     h2_ele_PoPtrueVsPt->Fill( bestGsfElectron.py(), bestGsfElectron.p()/mcIter->p());
-    if (passMiniAODSelection) { // Pt > 5.
+//    if (passMiniAODSelection) { // Pt > 5.
         h2_ele_sigmaIetaIetaVsPt->Fill( bestGsfElectron.pt(), bestGsfElectron.scSigmaIEtaIEta());
-    }
+//    }
     if (bestGsfElectron.isEB()) h1_ele_PoPtrue_barrel->Fill( bestGsfElectron.p()/mcIter->p());
     if (bestGsfElectron.isEE()) h1_ele_PoPtrue_endcaps->Fill( bestGsfElectron.p()/mcIter->p());
     if (bestGsfElectron.isEB() && bestGsfElectron.classification() == GsfElectron::GOLDEN) h1_ele_PoPtrue_golden_barrel->Fill( bestGsfElectron.p()/mcIter->p());

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -173,7 +173,7 @@ int electronCompare()
     file_ref = TFile::Open(CMP_BLUE_FILE) ;
     if (file_ref!=0)
      {
-      std::cout<<"open "<<CMP_BLUE_FILE<<std::endl ;
+      std::cout<<"open ref : "<<CMP_BLUE_FILE<<std::endl ;
       if (file_ref->cd(internal_path)==kTRUE)
        {
         std::cerr<<"cd "<<internal_path<<std::endl ;
@@ -203,7 +203,7 @@ int electronCompare()
     file_new = TFile::Open(CMP_RED_FILE) ;
     if (file_new!=0)
      {
-      std::cout<<"open "<<CMP_RED_FILE<<std::endl ;
+      std::cout<<"open new : "<<CMP_RED_FILE<<std::endl ;
       if (file_new->cd(internal_path)==kTRUE)
        {
         std::cerr<<"cd "<<internal_path<<std::endl ;
@@ -426,10 +426,23 @@ int electronCompare()
     // search histo_ref
     if ( file_ref != 0 )
      {
+      TString histo_reduced_path = histo_path.c_str();
+//      std::cout << "histo path : " << histo_reduced_path << std::endl;
       if (file_ref_dir.IsNull())
        { histo_full_path = histo_name ; /*std::cout << "file_ref_dir.IsNull()" << std::endl ;*/ }
       else
-       { histo_full_path = file_ref_dir ; histo_full_path += histo_path.c_str() ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ }
+       { 
+        if (histo_reduced_path.BeginsWith("ElectronMcSignalValidatorMiniAOD"))
+        { 
+            histo_reduced_path.Remove(25,7); /*std::cout << "OK !!" << histo_reduced_path << std::endl;*/ 
+            histo_full_path = file_ref_dir ; histo_full_path += histo_reduced_path ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ }
+        else 
+        {
+            histo_full_path = file_ref_dir ; histo_full_path += histo_path.c_str() ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ 
+        }
+       }
+      std::cout << "histo ref : " << histo_full_path << std::endl;
+ 
    // WARNING
    // the line below have to be unmasked if the reference release is prior to 740pre8 and for Pt1000
    // before 740pre8 : DQMData/Run 1/EgammaV/Run summary/ ElectronMcSignalValidator/ histo name (same as Pt35, Pt10, ....)
@@ -462,6 +475,7 @@ int electronCompare()
 
     // search histo_new
     histo_full_path = file_new_dir ; histo_full_path += histo_path.c_str() ;
+    std::cout <<  "histo new : " << histo_full_path << std::endl;
     histo_new = (TH1 *)file_new->Get(histo_full_path) ;
 
     // special treatments


### PR DESCRIPTION
An histo name modification was made in files ElectronMcSignalPostValidator.cc (lines 70-71) and ElectronMcSignalValidator.cc (line 768). Title and legend axis were modified.

A small modification about miniAOD cut over 5Gev is removed (lines 1429 & 1431) in the ElectronMcSignalValidator.cc file. 

Small modification are made in the electronCompare.C file (lines 428 to 450) in order to take correctly into account miniAOD vs RECO in the web page validation.

Tests about PR are made and passed : 
[PR_batch-20160315.txt](https://github.com/cms-sw/cmssw/files/173993/PR_batch-20160315.txt)

@beaudett @matteosan1 @fcouderc
