### PR TITLE
Made EarlyDeleteHelper thread-safe

### DIFF
--- a/FWCore/Framework/src/EarlyDeleteHelper.cc
+++ b/FWCore/Framework/src/EarlyDeleteHelper.cc
@@ -32,7 +32,7 @@ using namespace edm;
 //
 EarlyDeleteHelper::EarlyDeleteHelper(unsigned int* iBeginIndexItr,
                                      unsigned int* iEndIndexItr,
-                                     std::vector<std::pair<edm::BranchID,unsigned int>>* iBranchCounts):
+                                     std::vector<BranchToCount>* iBranchCounts):
 pBeginIndex_(iBeginIndexItr),
 pEndIndex_(iEndIndexItr),
 pBranchCounts_(iBranchCounts),
@@ -41,10 +41,15 @@ nPathsOn_(0)
 {
 }
 
-// EarlyDeleteHelper::EarlyDeleteHelper(const EarlyDeleteHelper& rhs)
-// {
-//    // do actual copying here;
-// }
+EarlyDeleteHelper::EarlyDeleteHelper(const EarlyDeleteHelper& rhs):
+pBeginIndex_(rhs.pBeginIndex_),
+pEndIndex_(rhs.pEndIndex_),
+pBranchCounts_(rhs.pBranchCounts_),
+pathsLeftToComplete_(rhs.pathsLeftToComplete_.load()),
+nPathsOn_(rhs.nPathsOn_)
+{
+  
+}
 
 //EarlyDeleteHelper::~EarlyDeleteHelper()
 //{
@@ -71,8 +76,8 @@ EarlyDeleteHelper::moduleRan(EventPrincipal const& iEvent) {
   for(auto it = pBeginIndex_; it != pEndIndex_;++it) {
     auto& count = (*pBranchCounts_)[*it];
     assert(count.second>0);
-    --(count.second);
-    if(count.second==0) {
+    auto value = --(count.second);
+    if(value==0) {
       iEvent.deleteProduct(count.first);
     }
   }
@@ -80,9 +85,16 @@ EarlyDeleteHelper::moduleRan(EventPrincipal const& iEvent) {
 
 void 
 EarlyDeleteHelper::pathFinished(EventPrincipal const& iEvent) {
-  if(pathsLeftToComplete_>0 && --pathsLeftToComplete_ == 0) {
-    //we can never reach this module now so declare it as run
-    moduleRan(iEvent);
+  unsigned int value = pathsLeftToComplete_;
+  while(value > 0) {
+    if( pathsLeftToComplete_.compare_exchange_strong(value, value-1)) {
+      //we were the thread that changed the value
+      if( value == 1) {
+        //we can never reach this module now so declare it as run
+        moduleRan(iEvent);
+      }
+      break;
+    }
   }
 }
 

--- a/FWCore/Framework/src/EarlyDeleteHelper.cc
+++ b/FWCore/Framework/src/EarlyDeleteHelper.cc
@@ -75,10 +75,10 @@ EarlyDeleteHelper::moduleRan(EventPrincipal const& iEvent) {
   pathsLeftToComplete_=0;
   for(auto it = pBeginIndex_; it != pEndIndex_;++it) {
     auto& count = (*pBranchCounts_)[*it];
-    assert(count.second>0);
-    auto value = --(count.second);
+    assert(count.count>0);
+    auto value = --(count.count);
     if(value==0) {
-      iEvent.deleteProduct(count.first);
+      iEvent.deleteProduct(count.branch);
     }
   }
 }

--- a/FWCore/Framework/src/EarlyDeleteHelper.h
+++ b/FWCore/Framework/src/EarlyDeleteHelper.h
@@ -30,16 +30,16 @@ namespace edm {
   class EventPrincipal;
   
   struct BranchToCount {
-    edm::BranchID first;
-    std::atomic<unsigned int> second;
+    edm::BranchID const branch;
+    std::atomic<unsigned int> count;
     
     BranchToCount(edm::BranchID id, unsigned int count):
-    first(id),
-    second(count) {}
+    branch(id),
+    count(count) {}
     
     BranchToCount(BranchToCount const& iOther):
-    first(iOther.first),
-    second(iOther.second.load()) {}
+    branch(iOther.branch),
+    count(iOther.count.load()) {}
   };
   
   class EarlyDeleteHelper

--- a/FWCore/Framework/src/EarlyDeleteHelper.h
+++ b/FWCore/Framework/src/EarlyDeleteHelper.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include <vector>
+#include <atomic>
 
 // user include files
 
@@ -28,14 +29,27 @@ namespace edm {
   class BranchID;
   class EventPrincipal;
   
+  struct BranchToCount {
+    edm::BranchID first;
+    std::atomic<unsigned int> second;
+    
+    BranchToCount(edm::BranchID id, unsigned int count):
+    first(id),
+    second(count) {}
+    
+    BranchToCount(BranchToCount const& iOther):
+    first(iOther.first),
+    second(iOther.second.load()) {}
+  };
+  
   class EarlyDeleteHelper
   {
     
   public:
     EarlyDeleteHelper(unsigned int* iBeginIndexItr,
                       unsigned int* iEndIndexItr,
-                      std::vector<std::pair<edm::BranchID,unsigned int>>* iBranchCounts);
-    EarlyDeleteHelper(const EarlyDeleteHelper&) = default;
+                      std::vector<BranchToCount>* iBranchCounts);
+    EarlyDeleteHelper(const EarlyDeleteHelper&);
         EarlyDeleteHelper& operator=(const EarlyDeleteHelper&) = default;
     //virtual ~EarlyDeleteHelper();
     
@@ -59,8 +73,8 @@ namespace edm {
     // ---------- member data --------------------------------
     unsigned int* pBeginIndex_;
     unsigned int* pEndIndex_;
-    std::vector<std::pair<edm::BranchID,unsigned int>>* pBranchCounts_;
-    unsigned int pathsLeftToComplete_;
+    std::vector<BranchToCount>* pBranchCounts_;
+    std::atomic<unsigned int> pathsLeftToComplete_;
     unsigned int nPathsOn_;
     
   };

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -347,7 +347,7 @@ namespace edm {
         if(lastBranchName != branchAndWorker.first) {
           //have to put back the period we removed earlier in order to get the proper name
           BranchID bid(branchAndWorker.first+".");
-          earlyDeleteBranchToCount_.emplace_back(std::make_pair(bid,0U));
+          earlyDeleteBranchToCount_.emplace_back(bid,0U);
           lastBranchName = branchAndWorker.first;
         }
         auto found = alreadySeenWorkers.find(branchAndWorker.second);
@@ -359,9 +359,9 @@ namespace edm {
           size_t index = nextOpenIndex;
           size_t nIndices = reserveSizeForWorker[branchAndWorker.second];
           earlyDeleteHelperToBranchIndicies_[index]=earlyDeleteBranchToCount_.size()-1;
-          earlyDeleteHelpers_.emplace_back(EarlyDeleteHelper(beginAddress+index,
-                                                             beginAddress+index+1,
-                                                             &earlyDeleteBranchToCount_));
+          earlyDeleteHelpers_.emplace_back(beginAddress+index,
+                                           beginAddress+index+1,
+                                           &earlyDeleteBranchToCount_);
           branchAndWorker.second->setEarlyDeleteHelper(&(earlyDeleteHelpers_.back()));
           alreadySeenWorkers.insert(std::make_pair(branchAndWorker.second,&(earlyDeleteHelpers_.back())));
           nextOpenIndex +=nIndices;

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -731,11 +731,11 @@ namespace edm {
   StreamSchedule::resetEarlyDelete() {
     //must be sure we have cleared the count first
     for(auto& count:earlyDeleteBranchToCount_) {
-      count.second = 0;
+      count.count = 0;
     }
     //now reset based on how many helpers use that branch
     for(auto& index: earlyDeleteHelperToBranchIndicies_) {
-      ++(earlyDeleteBranchToCount_[index].second);
+      ++(earlyDeleteBranchToCount_[index].count);
     }
     for(auto& helper: earlyDeleteHelpers_) {
       helper.reset();

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -89,6 +89,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <atomic>
 
 namespace edm {
 
@@ -343,7 +344,7 @@ namespace edm {
     //For each branch that has been marked for early deletion
     // keep track of how many modules are left that read this data but have
     // not yet been run in this event
-    std::vector<std::pair<BranchID,unsigned int>> earlyDeleteBranchToCount_;
+    std::vector<BranchToCount> earlyDeleteBranchToCount_;
     //NOTE the following is effectively internal data for each EarlyDeleteHelper
     // but putting it into one vector makes for better allocation as well as
     // faster iteration when used to reset the earlyDeleteBranchToCount_


### PR DESCRIPTION
Switched to using atomic counters in order to avoid race conditions once we start using more than one thread per event.
