### PR TITLE
Fix RectangularEtaPhiTrackingRegion (76X)

### DIFF
--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -327,7 +327,7 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(
         (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::barrel)) {
       const BarrelDetLayer& bl = dynamic_cast<const BarrelDetLayer&>(*detLayer);
       est = estimator(&bl,es);
-    } else if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isBarrel(detLayer->subDetector())) ||
+    } else if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) && GeomDetEnumerators::isEndcap(detLayer->subDetector())) ||
                (!theUseEtaPhi  && detLayer->location() == GeomDetEnumerators::endcap)) {
       const ForwardDetLayer& fl = dynamic_cast<const ForwardDetLayer&>(*detLayer);
       est = estimator(&fl,es);


### PR DESCRIPTION
Backport of #13729. Original description:

> This PR fixes a bug introduced in #11624, where in an `if` statement a pixel barrel was required, but it should have been pixel endcap.

Tested in 7_6_0. In the PR tests there are probably no changes visible because the affected code path does not get run.

@rovere @VinInn
