### PR TITLE
Remove unneeded selector

### DIFF
--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -29,12 +29,6 @@ namespace edm {
 
     class NamedEventSelector {
     public:
-      NamedEventSelector(std::string const& n, EventSelector const& s) :
-	inputTag_("TriggerResults", "", n),
-        token_(),
-	eventSelector_(s)
-      { }
-
       NamedEventSelector(std::string const& n, EventSelector const& s, ConsumesCollector&& iC) :
 	inputTag_("TriggerResults", "", n),
         token_(iC.consumes<TriggerResults>(inputTag_)),
@@ -65,7 +59,7 @@ namespace edm {
       typedef std::vector<NamedEventSelector>     selectors_t;
       typedef std::pair<std::string, std::string> parsed_path_spec_t;
 
-      void setupDefault(std::vector<std::string> const& triggernames);
+      void setupDefault();
 
       void setup(std::vector<parsed_path_spec_t> const& path_specs,
 		 std::vector<std::string> const& triggernames,
@@ -76,6 +70,7 @@ namespace edm {
 
     private:
       selectors_t selectors_;
+      bool wantAllEvents_;
     };
 
     /** Handles the final initialization of the TriggerResutsBasedEventSelector

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -91,7 +91,7 @@ namespace edm
       // is empty, we are to write all events. We have no need for any
       // EventSelectors.
       if(iPSet.empty()) {
-        oSelector.setupDefault(iAllTriggerNames);
+        oSelector.setupDefault();
         return true;
       }
 
@@ -99,7 +99,7 @@ namespace edm
       iPSet.getParameter<std::vector<std::string> >("SelectEvents");
 
       if(path_specs.empty()) {
-        oSelector.setupDefault(iAllTriggerNames);
+        oSelector.setupDefault();
         return true;
       }
 
@@ -117,18 +117,13 @@ namespace edm
     // typedef detail::NamedEventSelector NES;
 
     TriggerResultsBasedEventSelector::TriggerResultsBasedEventSelector() :
-      selectors_()
+      selectors_(),
+      wantAllEvents_(false)
     { }
 
     void
-    TriggerResultsBasedEventSelector::setupDefault(std::vector<std::string> const& triggernames) {
-      // Set up one NamedEventSelector, with default configuration
-      // Since wantAllEvents will be true, wantEvent() will not be called,
-      // and therefore TriggerResults will not be consumed.
-      std::vector<std::string> paths;
-      EventSelector es(paths, triggernames);
-      selectors_.emplace_back("", es);
-      //selectors_.push_back(NES("", EventSelector("",triggernames)));
+    TriggerResultsBasedEventSelector::setupDefault() {
+      wantAllEvents_ = true;
     }
 
     void
@@ -165,6 +160,9 @@ namespace edm
 
     bool
     TriggerResultsBasedEventSelector::wantEvent(EventForOutput const& ev) {
+      if(wantAllEvents_) {
+        return true;
+      }
       for(auto& selector : selectors_) {
         Handle<TriggerResults> handle;
         ev.getByToken<TriggerResults>(selector.token(), handle);


### PR DESCRIPTION
Minor internal framework improvement.
The current code uses a default event selector when there is no event selection, i.e. all events are selected. However, output modules were recently modified to enforce the consumes interface.
This required a new NamedEventSelector constructor to enforce the consumes interface. However, the default event selector does not consume anything, so the prior constructor was needed just for it.
Chris Jones commented that this old constructor should be removed if no longer needed.
This PR removes the default selector, and replaces it with a simple bool wantAllEvents_ flag, thereby simplifying the code.
