### PR TITLE
Introduce new tracking sequence for phase1 (2017)

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -61,7 +61,7 @@ globalreco_tracking = cms.Sequence(offlineBeamSpot*
                           vertexreco)
 _globalreco_tracking_Phase1PU70 = globalreco_tracking.copy()
 _globalreco_tracking_Phase1PU70.replace(trackingGlobalReco, recopixelvertexing+trackingGlobalReco)
-eras.trackingPhase1.toReplaceWith(globalreco_tracking, _globalreco_tracking_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(globalreco_tracking, _globalreco_tracking_Phase1PU70)
 
 globalreco = cms.Sequence(globalreco_tracking*
                           hcalGlobalRecoSequence*

--- a/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
+++ b/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
@@ -5,7 +5,7 @@ from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
 caloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbheprereco'))
 ak4CaloJetsForTrk = ak4CaloJets.clone(srcPVs = cms.InputTag('firstStepPrimaryVertices'), src= cms.InputTag('caloTowerForTrk'))
-eras.trackingPhase1.toModify(ak4CaloJetsForTrk,
+eras.trackingPhase1PU70.toModify(ak4CaloJetsForTrk,
     srcPVs = "pixelVertices"
 )
 

--- a/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
+++ b/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
@@ -20,7 +20,7 @@ preDuplicateMergingDisplacedTracks.lostHitPenalty =   1.0
 # that configuration is indended only for tracking comparisons (not
 # for production), it is not worth of the effort to try to fix the
 # situation.
-eras.trackingPhase1.toModify(preDuplicateMergingDisplacedTracks,
+eras.trackingPhase1PU70.toModify(preDuplicateMergingDisplacedTracks,
     trackProducers = [x for x in preDuplicateMergingDisplacedTracks.trackProducers if x != "muonSeededTracksInOut"],
     inputClassifiers = [x for x in preDuplicateMergingDisplacedTracks.inputClassifiers if x != "muonSeededTracksInOutClassifier"],
 )

--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -16,4 +16,4 @@ PixelLayerTripletsPreSplitting = PixelLayerTriplets.clone(
 )
 _recopixelvertexing_Phase1PU70 = recopixelvertexing.copy()
 _recopixelvertexing_Phase1PU70.replace(PixelLayerTriplets, PixelLayerTripletsPreSplitting)
-eras.trackingPhase1.toReplaceWith(recopixelvertexing, _recopixelvertexing_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(recopixelvertexing, _recopixelvertexing_Phase1PU70)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
@@ -35,7 +35,7 @@ PixelTrackReconstructionBlock = cms.PSet (
     )
 )
 
-eras.trackingPhase1.toModify(PixelTrackReconstructionBlock,
+eras.trackingPhase1PU70.toModify(PixelTrackReconstructionBlock,
     SeedMergerPSet = cms.PSet(
         layerList = cms.PSet(refToPSet_ = cms.string('PixelSeedMergerQuadruplets')),
         addRemainingTriplets = cms.bool(False),

--- a/RecoPixelVertexing/PixelTriplets/python/PixelTripletLargeTipGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/PixelTripletLargeTipGenerator_cfi.py
@@ -12,5 +12,5 @@ PixelTripletLargeTipGenerator = cms.PSet(
     extraHitRPhitolerance = cms.double(0.032),
     extraHitRZtolerance = cms.double(0.037)
 )
-eras.trackingPhase1.toModify(PixelTripletLargeTipGenerator, maxElement = 0)
+eras.trackingPhase1PU70.toModify(PixelTripletLargeTipGenerator, maxElement = 0)
 

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -42,7 +42,9 @@ PixelSeedMergerQuadruplets = cms.PSet(
 # InitialStepPreSplitting). The quadruplet merger does not use these
 # hit collections (it uses the hits of the triplets), so this is only
 # to make framework's circular dependency checker happy.
-eras.trackingPhase1PU70.toModify(PixelSeedMergerQuadruplets,
+_forPhase1 = dict(
     BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
     FPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
 )
+eras.trackingPhase1.toModify(PixelSeedMergerQuadruplets, **_forPhase1)
+eras.trackingPhase1PU70.toModify(PixelSeedMergerQuadruplets, **_forPhase1)

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -42,7 +42,7 @@ PixelSeedMergerQuadruplets = cms.PSet(
 # InitialStepPreSplitting). The quadruplet merger does not use these
 # hit collections (it uses the hits of the triplets), so this is only
 # to make framework's circular dependency checker happy.
-eras.trackingPhase1.toModify(PixelSeedMergerQuadruplets,
+eras.trackingPhase1PU70.toModify(PixelSeedMergerQuadruplets,
     BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
     FPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
 )

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -18,7 +18,7 @@ _convClustersBase = _trackClusterRemover.clone(
 convClusters = _convClustersBase.clone(
   trackClassifier       = cms.InputTag('tobTecStep',"QualityMasks"),
 )
-eras.trackingPhase1.toReplaceWith(convClusters, _convClustersBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(convClusters, _convClustersBase.clone(
   overrideTrkQuals      = "tobTecStepSelector:tobTecStep",
 ))
 
@@ -207,7 +207,7 @@ convLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                     skipClusters = cms.InputTag('convClusters'),
                                     )
                                 )
-eras.trackingPhase1.toModify(convLayerPairs,
+eras.trackingPhase1PU70.toModify(convLayerPairs,
     layerList = [
         'BPix1+BPix2',
 
@@ -315,7 +315,7 @@ photonConvTrajSeedFromSingleLeg.TrackRefitter = cms.InputTag('generalTracks')
 photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrimaryVertices')
 #photonConvTrajSeedFromQuadruplets.TrackRefitter = cms.InputTag('generalTracks')
 #photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertices')
-eras.trackingPhase1.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag = "pixelVertices")
+eras.trackingPhase1PU70.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag = "pixelVertices")
 
 # TRACKER DATA CONTROL
 
@@ -349,7 +349,7 @@ _convCkfTrajectoryBuilderBase = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuild
 convCkfTrajectoryBuilder = _convCkfTrajectoryBuilderBase.clone(
     estimator = cms.string('convStepChi2Est')
     )
-eras.trackingPhase1.toReplaceWith(convCkfTrajectoryBuilder, _convCkfTrajectoryBuilderBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(convCkfTrajectoryBuilder, _convCkfTrajectoryBuilderBase.clone(
     maxCand = 2,
 ))
 

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
@@ -45,7 +45,7 @@ photonConvTrajSeedFromSingleLeg  = cms.EDProducer("PhotonConversionTrajectorySee
                                                       TTRHBuilder = cms.string('WithTrackAngle')
                                                       )
                                                   )
-eras.trackingPhase1.toModify(photonConvTrajSeedFromSingleLeg,
+eras.trackingPhase1PU70.toModify(photonConvTrajSeedFromSingleLeg,
     ClusterCheckPSet = dict(
         MaxNumberOfCosmicClusters = 1000000,
         MaxNumberOfPixelClusters = 100000,

--- a/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
@@ -1,5 +1,5 @@
 from Configuration.StandardSequences.Eras import eras
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
-eras.trackingPhase1.toModify(TrackCutClassifier,
+eras.trackingPhase1PU70.toModify(TrackCutClassifier,
     vertices = "pixelVertices"
 )

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -22,6 +22,33 @@ earlyGeneralTracks.inputClassifiers =["initialStep",
                                       "pixelLessStep",
                                       "tobTecStep"
                                       ]
+eras.trackingPhase1.toModify(
+    earlyGeneralTracks,
+    trackProducers = [
+        'initialStepTracks',
+        'highPtTripletStepTracks',
+        'jetCoreRegionalStepTracks',
+        'lowPtQuadStepTracks',
+        'lowPtTripletStepTracks',
+        'detachedQuadStepTracks',
+        #'detachedTripletStepTracks', # FIXME: disabled for now
+        'mixedTripletStepTracks',
+        'pixelLessStepTracks',
+        'tobTecStepTracks'
+    ],
+    inputClassifiers = [
+        "initialStep",
+        "highPtTripletStep",
+        "jetCoreRegionalStep",
+        "lowPtQuadStep",
+        "lowPtTripletStep",
+        "detachedQuadStep",
+        #"detachedTripletStep", # FIXME: disabled for now
+        "mixedTripletStep",
+        "pixelLessStep",
+        "tobTecStep"
+    ],
+)
 
 # For Phase1PU70
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -25,7 +25,7 @@ earlyGeneralTracks.inputClassifiers =["initialStep",
 
 # For Phase1PU70
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
-eras.trackingPhase1.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
+eras.trackingPhase1PU70.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
     TrackProducers = ['initialStepTracks',
                       'highPtTripletStepTracks',
                       'lowPtQuadStepTracks',

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -90,6 +90,6 @@ multiTrackSelector = cms.EDProducer("MultiTrackSelector",
                                tightMTS,
                                highpurityMTS)
  ) 
-eras.trackingPhase1.toModify(multiTrackSelector,
+eras.trackingPhase1PU70.toModify(multiTrackSelector,
     vertices = "pixelVertices"
 )

--- a/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
@@ -20,7 +20,7 @@ preDuplicateMergingGeneralTracks.lostHitPenalty =   1.0
 
 # For Phase1PU70
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
-eras.trackingPhase1.toReplaceWith(preDuplicateMergingGeneralTracks, _trackListMerger.clone(
+eras.trackingPhase1PU70.toReplaceWith(preDuplicateMergingGeneralTracks, _trackListMerger.clone(
     TrackProducers = [
         "earlyGeneralTracks",
         "muonSeededTracksInOut",

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -1,0 +1,291 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+###############################################
+# Low pT and detached tracks from pixel quadruplets
+###############################################
+
+# REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_detachedQuadStepClustersBase = _trackClusterRemover.clone(
+    maxChi2                                  = 9.0,
+    trajectories                             = "highPtTripletStepTracks",
+    pixelClusters                            = "siPixelClusters",
+    stripClusters                            = "siStripClusters",
+    oldClusterRemovalInfo                    = "highPtTripletStepClusters",
+    TrackQuality                             = 'highPurity',
+    minNumberOfLayersWithMeasBeforeFiltering = 0,
+)
+detachedQuadStepClusters = _detachedQuadStepClustersBase.clone(
+    trackClassifier                          = "highPtTripletStep:QualityMasks",
+)
+eras.trackingPhase1PU70.toReplaceWith(detachedQuadStepClusters, _detachedQuadStepClustersBase.clone(
+    trajectories                             = "lowPtTripletStepTracks",
+    oldClusterRemovalInfo                    = "lowPtTripletStepClusters",
+    overrideTrkQuals                         = "lowPtTripletStepSelector:lowPtTripletStep",
+))
+
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+detachedQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    BPix = dict(skipClusters = cms.InputTag('detachedQuadStepClusters')),
+    FPix = dict(skipClusters = cms.InputTag('detachedQuadStepClusters'))
+)
+
+# SEEDS
+from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
+PixelTripletLargeTipGenerator.extraHitRZtolerance = 0.0
+PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock as _RegionPsetFomBeamSpotBlock
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
+detachedQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    OrderedHitsFactoryPSet = dict(
+        SeedingLayers = 'detachedQuadStepSeedLayers',
+        GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
+    ),
+    SeedCreatorPSet = dict(ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'),
+    RegionFactoryPSet = dict(
+        RegionPSet = dict(
+            ptMin = 0.3,
+            originHalfLength = 15.0,
+            originRadius = 1.5
+        )
+    ),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+        addRemainingTriplets = cms.bool(False),
+        mergeTriplets = cms.bool(True),
+        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+eras.trackingPhase1PU70.toModify(detachedQuadStepSeeds,
+    RegionFactoryPSet = dict(
+        RegionPSet = _RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.3,
+            originRadius = 0.5,
+            nSigmaZ = 4.0
+        )
+    )
+)
+
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
+_detachedQuadStepTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.075,
+)
+detachedQuadStepTrajectoryFilterBase = _detachedQuadStepTrajectoryFilterBase.clone(
+    maxCCCLostHits = 2,
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
+)
+eras.trackingPhase1PU70.toReplaceWith(detachedQuadStepTrajectoryFilterBase,
+    _detachedQuadStepTrajectoryFilterBase.clone(
+        maxLostHitsFraction = 1./10.,
+        constantValueForLostHitsFractionFilter = 0.501,
+    )
+)
+detachedQuadStepTrajectoryFilter = _TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
+    filters = [cms.PSet(refToPSet_ = cms.string('detachedQuadStepTrajectoryFilterBase'))]
+)
+eras.trackingPhase1PU70.toModify(detachedQuadStepTrajectoryFilter,
+    filters = detachedQuadStepTrajectoryFilter.filters.value()+[cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))]
+)
+
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+detachedQuadStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = 'detachedQuadStepChi2Est',
+    nSigma = 3.0,
+    MaxChi2 = 9.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
+)
+eras.trackingPhase1PU70.toModify(detachedQuadStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")
+)
+
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = dict(refToPSet_ = 'detachedQuadStepTrajectoryFilter'),
+    maxCand = 3,
+    alwaysUseInvalidHits = True,
+    estimator = 'detachedQuadStepChi2Est',
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7) 
+)
+eras.trackingPhase1PU70.toModify(detachedQuadStepTrajectoryBuilder,
+    maxCand = 2,
+    alwaysUseInvalidHits = False,
+)
+
+# MAKING OF TRACK CANDIDATES
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+detachedQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+    ComponentName = cms.string('detachedQuadStepTrajectoryCleanerBySharedHits'),
+    fractionShared = cms.double(0.13),
+    allowSharedFirstHit = cms.bool(True)
+)
+eras.trackingPhase1PU70.toModify(detachedQuadStepTrajectoryCleanerBySharedHits,
+    fractionShared = 0.095
+)
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = 'detachedQuadStepSeeds',
+    clustersToSkip = cms.InputTag('detachedQuadStepClusters'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'detachedQuadStepTrajectoryBuilder'),
+    TrajectoryCleaner = 'detachedQuadStepTrajectoryCleanerBySharedHits',
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = 'detachedQuadStep',
+    src = 'detachedQuadStepTrackCandidates',
+    Fitter = 'FlexibleKFFittingSmoother',
+)
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+detachedQuadStepClassifier1 = TrackMVAClassifierDetached.clone(
+    src = 'detachedQuadStepTracks',
+    GBRForestLabel = 'MVASelectorIter3_13TeV',
+    qualityCuts = [-0.5,0.0,0.5]
+)
+detachedQuadStepClassifier2 = TrackMVAClassifierPrompt.clone(
+    src = 'detachedQuadStepTracks',
+    GBRForestLabel = 'MVASelectorIter0_13TeV',
+    qualityCuts = [-0.2,0.0,0.4]
+)
+
+# For Phase1PU70
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+detachedQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'detachedQuadStepTracks',
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedQuadStepVtxLoose',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 0.9, 3.0 ),
+            dz_par1 = ( 0.9, 3.0 ),
+            d0_par2 = ( 1.0, 3.0 ),
+            dz_par2 = ( 1.0, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedQuadStepTrkLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 1.3, 4.0 ),
+            dz_par1 = ( 1.3, 4.0 ),
+            d0_par2 = ( 1.3, 4.0 ),
+            dz_par2 = ( 1.3, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedQuadStepVtxTight',
+            preFilterName = 'detachedQuadStepVtxLoose',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.9, 3.0 ),
+            dz_par1 = ( 0.9, 3.0 ),
+            d0_par2 = ( 0.9, 3.0 ),
+            dz_par2 = ( 0.9, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedQuadStepTrkTight',
+            preFilterName = 'detachedQuadStepTrkLoose',
+            chi2n_par = 0.35,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedQuadStepVtx',
+            preFilterName = 'detachedQuadStepVtxTight',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.8, 3.0 ),
+            dz_par1 = ( 0.8, 3.0 ),
+            d0_par2 = ( 0.8, 3.0 ),
+            dz_par2 = ( 0.8, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedQuadStepTrk',
+            preFilterName = 'detachedQuadStepTrkTight',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 0.9, 4.0 ),
+            dz_par1 = ( 0.9, 4.0 ),
+            d0_par2 = ( 0.8, 4.0 ),
+            dz_par2 = ( 0.8, 4.0 )
+        )
+    ]
+) #end of clone
+
+from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+detachedQuadStep = ClassifierMerger.clone()
+detachedQuadStep.inputClassifiers=['detachedQuadStepClassifier1','detachedQuadStepClassifier2']
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+eras.trackingPhase1PU70.toReplaceWith(detachedQuadStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers = [
+        'detachedQuadStepTracks',
+        'detachedQuadStepTracks',
+    ],
+    hasSelector = [1,1],
+    shareFrac = cms.double(0.095),
+    indivShareFrac = [0.095, 0.095],
+    selectedTrackQuals = [
+        cms.InputTag("detachedQuadStepSelector","detachedQuadStepVtx"),
+        cms.InputTag("detachedQuadStepSelector","detachedQuadStepTrk")
+    ],
+    setsToMerge = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
+    writeOnlyTrkQuals = True
+))
+
+DetachedQuadStep = cms.Sequence(detachedQuadStepClusters*
+                                detachedQuadStepSeedLayers*
+                                detachedQuadStepSeeds*
+                                detachedQuadStepTrackCandidates*
+                                detachedQuadStepTracks*
+                                detachedQuadStepClassifier1*detachedQuadStepClassifier2*
+                                detachedQuadStep)
+_DetachedQuadStep_Phase1PU70 = DetachedQuadStep.copyAndExclude([detachedQuadStepClassifier1])
+_DetachedQuadStep_Phase1PU70.replace(detachedQuadStepClassifier2, detachedQuadStepSelector)
+eras.trackingPhase1PU70.toReplaceWith(DetachedQuadStep, _DetachedQuadStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ###############################################
 # Low pT and detached tracks from pixel triplets
@@ -17,12 +18,34 @@ detachedTripletStepClusters = trackClusterRemover.clone(
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+eras.trackingPhase1.toModify(detachedTripletStepClusters,
+    trajectories                             = "detachedQuadStepTracks",
+    oldClusterRemovalInfo                    = "detachedQuadStepClusters",
+    trackClassifier                          = "detachedQuadStep:QualityMasks",
+)
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
 detachedTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 detachedTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
 detachedTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
+eras.trackingPhase1.toModify(detachedTripletStepSeedLayers,
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4',
+        'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+    ]
+)
 
 # SEEDS
 from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -6,7 +6,7 @@ initialStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("initialStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("pixelLessStepClusters")
 )
-eras.trackingPhase1.toModify(initialStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepClusters")
+eras.trackingPhase1PU70.toModify(initialStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepClusters")
 highPtTripletStepSeedClusterMask = seedClusterRemover.clone( # for Phase1PU70
     trajectories = "highPtTripletStepSeeds",
     oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
@@ -15,7 +15,7 @@ pixelPairStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("pixelPairStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
 )
-eras.trackingPhase1.toModify(pixelPairStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepSeedClusterMask")
+eras.trackingPhase1PU70.toModify(pixelPairStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepSeedClusterMask")
 mixedTripletStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("mixedTripletStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("pixelPairStepSeedClusterMask")
@@ -40,7 +40,7 @@ tripletElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
     )
 )
-eras.trackingPhase1.toModify(tripletElectronSeedLayers,
+eras.trackingPhase1PU70.toModify(tripletElectronSeedLayers,
     layerList = [
         'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
         'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
@@ -71,7 +71,7 @@ tripletElectronSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.g
     )
 )
 tripletElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('tripletElectronSeedLayers')
-eras.trackingPhase1.toModify(tripletElectronSeeds,
+eras.trackingPhase1PU70.toModify(tripletElectronSeeds,
     OrderedHitsFactoryPSet = dict(maxElement = cms.uint32(0)), # not sure if this has any effect
 )
 
@@ -153,7 +153,7 @@ newCombinedSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCom
       cms.InputTag('stripPairElectronSeeds')
       )
 )
-eras.trackingPhase1.toModify(newCombinedSeeds, seedCollections = [
+eras.trackingPhase1PU70.toModify(newCombinedSeeds, seedCollections = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',
     'pixelPairStepSeeds',
@@ -172,7 +172,7 @@ electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
                                  stripPairElectronSeedLayers*
                                  stripPairElectronSeeds*
                                  newCombinedSeeds)
-eras.trackingPhase1.toReplaceWith(electronSeedsSeq, cms.Sequence(
+eras.trackingPhase1PU70.toReplaceWith(electronSeedsSeq, cms.Sequence(
     initialStepSeedClusterMask*
     highPtTripletStepSeedClusterMask*
     pixelPairStepSeedClusterMask*

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -16,9 +16,17 @@ pixelPairStepSeedClusterMask = seedClusterRemover.clone(
     oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
 )
 eras.trackingPhase1PU70.toModify(pixelPairStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepSeedClusterMask")
+# This is a pure guess to use lowPtTripletStep for phase1 here instead of the pixelPair in Run2 configuration
+lowPtTripletStepSeedClusterMask = seedClusterRemover.clone(
+    trajectories = cms.InputTag("lowPtTripletStepSeeds"),
+    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+)
 mixedTripletStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("mixedTripletStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("pixelPairStepSeedClusterMask")
+)
+eras.trackingPhase1.toModify(mixedTripletStepSeedClusterMask,
+    oldClusterRemovalInfo = "lowPtTripletStepSeedClusterMask"
 )
 pixelLessStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("pixelLessStepSeeds"),
@@ -40,20 +48,22 @@ tripletElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
     )
 )
+_layerListForPhase1 = [
+    'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+    'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+    'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+    'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+    'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+    'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+    'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+    'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+    'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+    'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+    'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+]
+eras.trackingPhase1.toModify(tripletElectronSeedLayers, layerList = _layerListForPhase1)
 eras.trackingPhase1PU70.toModify(tripletElectronSeedLayers,
-    layerList = [
-        'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
-        'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
-        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
-        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
-        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
-        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
-        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
-        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
-        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
-        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
-        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
-    ],
+    layerList = _layerListForPhase1,
     BPix = dict(skipClusters = 'pixelPairStepSeedClusterMask'),
     FPix = dict(skipClusters = 'pixelPairStepSeedClusterMask')
 )
@@ -97,6 +107,19 @@ pixelPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     HitProducer = cms.string('siPixelRecHits'),
     skipClusters = cms.InputTag('tripletElectronClusterMask')
     )
+)
+eras.trackingPhase1.toModify(pixelPairElectronSeedLayers,
+    layerList = [
+        'BPix1+BPix2', 'BPix1+BPix3', 'BPix1+BPix4',
+        'BPix2+BPix3', 'BPix2+BPix4',
+        'BPix3+BPix4',
+        'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+        'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
+        'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
+        'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg' 
+    ]
 )
 
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
@@ -153,6 +176,15 @@ newCombinedSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCom
       cms.InputTag('stripPairElectronSeeds')
       )
 )
+eras.trackingPhase1.toModify(newCombinedSeeds, seedCollections = [
+    'initialStepSeeds',
+    'highPtTripletStepSeeds',
+    'mixedTripletStepSeeds',
+    'pixelLessStepSeeds',
+    'tripletElectronSeeds',
+    'pixelPairElectronSeeds',
+    'stripPairElectronSeeds'
+])
 eras.trackingPhase1PU70.toModify(newCombinedSeeds, seedCollections = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',
@@ -172,6 +204,9 @@ electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
                                  stripPairElectronSeedLayers*
                                  stripPairElectronSeeds*
                                  newCombinedSeeds)
+_electronSeedsSeq_Phase1 = electronSeedsSeq.copy()
+_electronSeedsSeq_Phase1.replace(pixelPairStepSeedClusterMask, lowPtTripletStepSeedClusterMask)
+eras.trackingPhase1.toReplaceWith(electronSeedsSeq, _electronSeedsSeq_Phase1)
 eras.trackingPhase1PU70.toReplaceWith(electronSeedsSeq, cms.Sequence(
     initialStepSeedClusterMask*
     highPtTripletStepSeedClusterMask*

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -1,106 +1,247 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+### high-pT triplets ###
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-highPtTripletStepClusters = trackClusterRemover.clone(
-    maxChi2          = cms.double(9.0),
-    trajectories     = cms.InputTag("initialStepTracks"),
-    pixelClusters    = cms.InputTag("siPixelClusters"),
-    stripClusters    = cms.InputTag("siStripClusters"),
-    overrideTrkQuals = cms.InputTag('initialStepSelector','initialStep'),
-    TrackQuality     = cms.string('highPurity'),
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_highPtTripletStepClustersBase = _trackClusterRemover.clone(
+    maxChi2                                  = 9.0,
+    trajectories                             = "initialStepTracks",
+    pixelClusters                            = "siPixelClusters",
+    stripClusters                            = "siStripClusters",
+    TrackQuality                             = 'highPurity',
+    minNumberOfLayersWithMeasBeforeFiltering = 0,
 )
+highPtTripletStepClusters = _highPtTripletStepClustersBase.clone(
+    trackClassifier                          = "initialStep:QualityMasks",
+)
+eras.trackingPhase1PU70.toReplaceWith(highPtTripletStepClusters, _highPtTripletStepClustersBase.clone(
+    overrideTrkQuals                         = "initialStepSelector:initialStep",
+))
+
 
 # SEEDING LAYERS
-import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-highPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-highPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('highPtTripletStepClusters')
-highPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('highPtTripletStepClusters')
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi as _PixelLayerTriplets_cfi
+highPtTripletStepSeedLayers = _PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4',
+        'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+    ],
+    BPix = dict(skipClusters = cms.InputTag('highPtTripletStepClusters')),
+    FPix = dict(skipClusters = cms.InputTag('highPtTripletStepClusters'))
+)
 
 # SEEDS
-import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
-highPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
-    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
-    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
-    RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
-    ptMin = 0.6,
-    originRadius = 0.02,
-    nSigmaZ = 4.0
-    )
-    )
-    )
-highPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'highPtTripletStepSeedLayers'
-
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
-import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-highPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
-
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi as _LowPtClusterShapeSeedComparitor_cfi
+highPtTripletStepSeeds = globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.6,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    ),
+    OrderedHitsFactoryPSet = dict(
+        SeedingLayers = 'highPtTripletStepSeedLayers',
+        GeneratorPSet = dict(
+            SeedComparitorPSet = _LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+        )
+    )
+)
+eras.trackingPhase1PU70.toModify(highPtTripletStepSeeds, RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)))
 
 # QUALITY CUTS DURING TRACK BUILDING
-import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-highPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
+_highPtTripletStepTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.2
-    )
+    minPt = 0.2,
+)
+highPtTripletStepTrajectoryFilterBase = _highPtTripletStepTrajectoryFilterBase.clone(
+    maxCCCLostHits = 2,
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
+)
+eras.trackingPhase1PU70.toReplaceWith(highPtTripletStepTrajectoryFilterBase, _highPtTripletStepTrajectoryFilterBase)
+highPtTripletStepTrajectoryFilter = _TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
+    filters = [cms.PSet(refToPSet_ = cms.string('highPtTripletStepTrajectoryFilterBase'))]
+)
 
-import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-highPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('highPtTripletStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0)
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+highPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = 'highPtTripletStepChi2Est',
+    nSigma = 3.0,
+    MaxChi2 = 30.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
+    pTChargeCutThreshold = 15.
+)
+eras.trackingPhase1PU70.toModify(highPtTripletStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")
 )
 
 # TRACK BUILDING
-import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
-highPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('highPtTripletStepTrajectoryFilter')),
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi as _GroupedCkfTrajectoryBuilder_cfi
+highPtTripletStepTrajectoryBuilder = _GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    trajectoryFilter = dict(refToPSet_ = 'highPtTripletStepTrajectoryFilter'),
+    alwaysUseInvalidHits = True,
     maxCand = 3,
-    estimator = cms.string('highPtTripletStepChi2Est')
-    )
+    estimator = 'highPtTripletStepChi2Est',
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7)
+)
+eras.trackingPhase1PU70.toModify(highPtTripletStepTrajectoryBuilder,
+    MeasurementTrackerName = '',
+    maxCand = 4,
+)
 
 # MAKING OF TRACK CANDIDATES
-import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
-highPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('highPtTripletStepSeeds'),
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi as _CkfTrackCandidates_cfi
+highPtTripletStepTrackCandidates = _CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = 'highPtTripletStepSeeds',
     clustersToSkip = cms.InputTag('highPtTripletStepClusters'),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('highPtTripletStepTrajectoryBuilder')),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'highPtTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
-    )
+)
+
+# For Phase1PU70
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits
+highPtTripletStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clone(
+    ComponentName = 'highPtTripletStepTrajectoryCleanerBySharedHits',
+    fractionShared = 0.16,
+    allowSharedFirstHit = True
+)
+eras.trackingPhase1PU70.toModify(highPtTripletStepTrackCandidates, TrajectoryCleaner = 'highPtTripletStepTrajectoryCleanerBySharedHits')
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'highPtTripletStepTrackCandidates',
-    AlgorithmName = cms.string('lowPtTripletStep')
-    )
-
+    AlgorithmName = 'highPtTripletStep',
+    Fitter = 'FlexibleKFFittingSmoother',
+)
 
 # Final selection
+# MVA selection to be enabled after re-training, for time being we go with cut-based selector
+#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+#
+#highPtTripletStepClassifier1 = TrackMVAClassifierPrompt.clone()
+#highPtTripletStepClassifier1.src = 'highPtTripletStepTracks'
+#highPtTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
+#highPtTripletStepClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
+#
+#from RecoTracker.IterativeTracking.Phase1_DetachedTripletStep_cff import detachedTripletStepClassifier1
+#from RecoTracker.IterativeTracking.Phase1_LowPtTripletStep_cff import lowPtTripletStep
+#highPtTripletStepClassifier2 = detachedTripletStepClassifier1.clone()
+#highPtTripletStepClassifier2.src = 'highPtTripletStepTracks'
+#highPtTripletStepClassifier3 = lowPtTripletStep.clone()
+#highPtTripletStepClassifier3.src = 'highPtTripletStepTracks'
+#
+#
+#from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+#highPtTripletStep = ClassifierMerger.clone()
+#highPtTripletStep.inputClassifiers=['highPtTripletStepClassifier1','highPtTripletStepClassifier2','highPtTripletStepClassifier3']
+#highPtTripletStep.inputClassifiers=['highPtTripletStepClassifier1','highPtTripletStepClassifier2','highPtTripletStepClassifier3']
+
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier
+highPtTripletStep = TrackCutClassifier.clone(
+    src = "highPtTripletStepTracks",
+    vertices = "firstStepPrimaryVertices",
+    mva = dict(
+        minPixelHits = [1,1,1],
+        maxChi2 = [9999.,9999.,9999.],
+        maxChi2n = [2.0,1.0,0.7],
+        minLayers = [3,3,3],
+        min3DLayers = [3,3,3],
+        maxLostLayers = [3,2,2],
+        dz_par = dict(
+            dz_par1 = [0.8,0.7,0.7],
+            dz_par2 = [0.6,0.5,0.4],
+            dz_exp = [4,4,4]
+        ),
+        dr_par = dict(
+            dr_par1 = [0.7,0.6,0.5],
+            dr_par2 = [0.4,0.35,0.25],
+            dr_exp = [4,4,4],
+            d0err_par = [0.002,0.002,0.001]
+        )
+    )
+)
+
+# For Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 highPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
-    src='highPtTripletStepTracks',
-    trackSelectors= cms.VPSet(
+    src = 'highPtTripletStepTracks',
+    trackSelectors = [
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'highPtTripletStepLoose',
-            ), #end of pset
+            chi2n_par = 2.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 3,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.8, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.6, 4.0 )
+        ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'highPtTripletStepTight',
             preFilterName = 'highPtTripletStepLoose',
-            ),
+            chi2n_par = 1.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.35, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+        ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'highPtTripletStep',
             preFilterName = 'highPtTripletStepTight',
-            ),
-        ) #end of vpset
-    ) #end of clone
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.5, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.25, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+        ),
+    ]
+) #end of clone
 
 # Final sequence
 HighPtTripletStep = cms.Sequence(highPtTripletStepClusters*
-                                highPtTripletStepSeedLayers*
-                                highPtTripletStepSeeds*
-                                highPtTripletStepTrackCandidates*
-                                highPtTripletStepTracks*
-                                highPtTripletStepSelector)
+                                 highPtTripletStepSeedLayers*
+                                 highPtTripletStepSeeds*
+                                 highPtTripletStepTrackCandidates*
+                                 highPtTripletStepTracks*
+#                                 highPtTripletStepClassifier1*highPtTripletStepClassifier2*highPtTripletStepClassifier3*
+                                 highPtTripletStep)
+_HighPtTripletStep_Phase1PU70 = HighPtTripletStep.copy()
+_HighPtTripletStep_Phase1PU70.replace(highPtTripletStep, highPtTripletStepSelector)
+eras.trackingPhase1PU70.toReplaceWith(HighPtTripletStep, _HighPtTripletStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -157,8 +157,8 @@ InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
 # one place (within Reconstruction_cff) where siPixelClusters
 # module is defined.
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
-eras.trackingPhase1.toReplaceWith(siPixelClusters, _siPixelClusters)
-eras.trackingPhase1.toReplaceWith(InitialStepPreSplitting, cms.Sequence(
+eras.trackingPhase1PU70.toReplaceWith(siPixelClusters, _siPixelClusters)
+eras.trackingPhase1PU70.toReplaceWith(InitialStepPreSplitting, cms.Sequence(
     siPixelClusters +
     siPixelRecHits +
     MeasurementTrackerEvent +

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -27,6 +27,14 @@ initialStepSeedsPreSplitting = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriple
     )
     )
 initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayersPreSplitting'
+eras.trackingPhase1.toModify(initialStepSeedsPreSplitting,
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -26,15 +26,16 @@ initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globa
     )
     )
 initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
-eras.trackingPhase1PU70.toModify(
-    initialStepSeeds,
+_SeedMergerPSet = cms.PSet(
+    layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+    addRemainingTriplets = cms.bool(False),
+    mergeTriplets = cms.bool(True),
+    ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+)
+eras.trackingPhase1.toModify(initialStepSeeds, SeedMergerPSet = _SeedMergerPSet)
+eras.trackingPhase1PU70.toModify(initialStepSeeds,
     RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)),
-    SeedMergerPSet = cms.PSet(
-        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
-        addRemainingTriplets = cms.bool(False),
-        mergeTriplets = cms.bool(True),
-        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
-    )
+    SeedMergerPSet = _SeedMergerPSet
 )
 
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -26,7 +26,7 @@ initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globa
     )
     )
 initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
-eras.trackingPhase1.toModify(
+eras.trackingPhase1PU70.toModify(
     initialStepSeeds,
     RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)),
     SeedMergerPSet = cms.PSet(
@@ -52,7 +52,7 @@ initialStepTrajectoryFilterBase = _initialStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
-eras.trackingPhase1.toReplaceWith(initialStepTrajectoryFilterBase, _initialStepTrajectoryFilterBase)
+eras.trackingPhase1PU70.toReplaceWith(initialStepTrajectoryFilterBase, _initialStepTrajectoryFilterBase)
 
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 initialStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
@@ -72,7 +72,7 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_c
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
-eras.trackingPhase1.toModify(initialStepChi2Est,
+eras.trackingPhase1PU70.toModify(initialStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
 
@@ -85,7 +85,7 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
     )
-eras.trackingPhase1.toModify(initialStepTrajectoryBuilder, maxCand = 6)
+eras.trackingPhase1PU70.toModify(initialStepTrajectoryBuilder, maxCand = 6)
 
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
@@ -200,4 +200,4 @@ InitialStep = cms.Sequence(initialStepSeedLayers*
                            initialStep)
 _InitialStep_Phase1PU70 = InitialStep.copyAndExclude([firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
 _InitialStep_Phase1PU70.replace(initialStep, initialStepSelector)
-eras.trackingPhase1.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # This step runs over all clusters
 
@@ -46,6 +47,20 @@ jetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         HitProducer = cms.string('siPixelRecHits'),
         #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
     )
+)
+eras.trackingPhase1.toModify(jetCoreRegionalStepSeedLayers,
+    layerList = [
+        'BPix1+BPix2', 'BPix1+BPix3', 'BPix1+BPix4',
+        'BPix2+BPix3', 'BPix2+BPix4',
+        'BPix3+BPix4',
+        'BPix1+FPix1_pos', 'BPix1+FPix1_neg',
+        'BPix2+FPix1_pos', 'BPix2+FPix1_neg',
+        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
+        'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg',
+        #'BPix3+TIB1','BPix3+TIB2'
+        'BPix4+TIB1','BPix4+TIB2'
+    ]
 )
 
 # SEEDS

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -1,0 +1,211 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+# NEW CLUSTERS (remove previously used clusters)
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_lowPtQuadStepClustersBase = _trackClusterRemover.clone(
+    maxChi2                                  = 9.0,
+    trajectories                             = "detachedTripletStepTracks",
+    pixelClusters                            = "siPixelClusters",
+    stripClusters                            = "siStripClusters",
+    oldClusterRemovalInfo                    = "detachedTripletStepClusters",
+    TrackQuality                             = 'highPurity',
+    minNumberOfLayersWithMeasBeforeFiltering = 0,
+)
+_lowPtQuadStepClusters = _lowPtQuadStepClustersBase.clone(
+    trackClassifier                          = "detachedTripletStep:QualityMasks",
+)
+# FIXME: detachedTriplet is dropped for time being, but may be enabled later
+lowPtQuadStepClusters = _lowPtQuadStepClusters.clone(
+    trajectories                             = "detachedQuadStepTracks",
+    oldClusterRemovalInfo                    = "detachedQuadStepClusters",
+    trackClassifier                          = "detachedQuadStep:QualityMasks",
+)
+eras.trackingPhase1PU70.toReplaceWith(lowPtQuadStepClusters, _lowPtQuadStepClustersBase.clone(
+    trajectories                             = "highPtTripletStepTracks",
+    oldClusterRemovalInfo                    = "highPtTripletStepClusters",
+    overrideTrkQuals                         = "highPtTripletStepSelector:highPtTripletStep",
+))
+
+
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+lowPtQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    BPix = dict(skipClusters = cms.InputTag('lowPtQuadStepClusters')),
+    FPix = dict(skipClusters = cms.InputTag('lowPtQuadStepClusters'))
+)
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi as _LowPtClusterShapeSeedComparitor_cfi
+lowPtQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.2,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+        )
+    ),
+    OrderedHitsFactoryPSet = dict(
+        SeedingLayers = 'lowPtQuadStepSeedLayers',
+        GeneratorPSet = dict(
+            SeedComparitorPSet = _LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+        )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+
+
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
+_lowPtQuadStepTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.075,
+)
+lowPtQuadStepTrajectoryFilterBase = _lowPtQuadStepTrajectoryFilterBase.clone(
+    maxCCCLostHits = 1,
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
+)
+eras.trackingPhase1PU70.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
+# Composite filter
+lowPtQuadStepTrajectoryFilter = _TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
+    filters = [cms.PSet(refToPSet_ = cms.string('lowPtQuadStepTrajectoryFilterBase'))]
+)
+eras.trackingPhase1PU70.toModify(lowPtQuadStepTrajectoryFilter,
+    filters = lowPtQuadStepTrajectoryFilter.filters.value() + [cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))]
+)
+
+import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
+lowPtQuadStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = 'lowPtQuadStepChi2Est',
+    nSigma = 3.0,
+    MaxChi2 = 9.0,
+    clusterChargeCut = dict(refToPSet_ = ('SiStripClusterChargeCutTiny')),
+)
+eras.trackingPhase1PU70.toModify(lowPtQuadStepChi2Est,
+    MaxChi2 = 25.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = dict(refToPSet_ = 'lowPtQuadStepTrajectoryFilter'),
+    maxCand = 4,
+    estimator = cms.string('lowPtQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7) 
+)
+
+# MAKING OF TRACK CANDIDATES
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits
+lowPtQuadStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clone(
+    ComponentName = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
+    fractionShared = 0.16,
+    allowSharedFirstHit = True
+)
+eras.trackingPhase1PU70.toModify(lowPtQuadStepTrajectoryCleanerBySharedHits, fractionShared = 0.095)
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = 'lowPtQuadStepSeeds',
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'lowPtQuadStepTrajectoryBuilder'),
+    TrajectoryCleaner = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
+    clustersToSkip = cms.InputTag('lowPtQuadStepClusters'),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'lowPtQuadStepTrackCandidates',
+    AlgorithmName = 'lowPtQuadStep',
+    Fitter = 'FlexibleKFFittingSmoother',
+)
+
+
+
+# Final selection
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+lowPtQuadStep =  TrackMVAClassifierPrompt.clone(
+    src = 'lowPtQuadStepTracks',
+    GBRForestLabel = 'MVASelectorIter1_13TeV',
+    qualityCuts = [-0.6,-0.3,-0.1]
+)
+# For Phase1PU70
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+lowPtQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'lowPtQuadStepTracks',
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'lowPtQuadStepLoose',
+            chi2n_par = 2.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.8, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.5, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'lowPtQuadStepTight',
+            preFilterName = 'lowPtQuadStepLoose',
+            chi2n_par = 1.3,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.6, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'lowPtQuadStep',
+            preFilterName = 'lowPtQuadStepTight',
+            chi2n_par = 1.0,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.5, 4.0 ),
+            d0_par2 = ( 0.3, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+        ),
+    ]
+) #end of clone
+
+# Final sequence
+LowPtQuadStep = cms.Sequence(lowPtQuadStepClusters*
+                             lowPtQuadStepSeedLayers*
+                             lowPtQuadStepSeeds*
+                             lowPtQuadStepTrackCandidates*
+                             lowPtQuadStepTracks*
+                             lowPtQuadStep)
+_LowPtQuadStep_Phase1PU70 = LowPtQuadStep.copy()
+_LowPtQuadStep_Phase1PU70.replace(lowPtQuadStep, lowPtQuadStepSelector)
+eras.trackingPhase1PU70.toReplaceWith(LowPtQuadStep, _LowPtQuadStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -15,7 +15,7 @@ _lowPtTripletStepClustersBase = _trackClusterRemover.clone(
 lowPtTripletStepClusters = _lowPtTripletStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
 )
-eras.trackingPhase1.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
     trajectories                             = "lowPtQuadStepTracks",
     oldClusterRemovalInfo                    = "lowPtQuadStepClusters",
     overrideTrkQuals                         = "lowPtQuadStepSelector:lowPtQuadStep",
@@ -26,7 +26,7 @@ import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
 lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 lowPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
 lowPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
-eras.trackingPhase1.toModify(lowPtTripletStepSeedLayers, layerList = [
+eras.trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = [
     'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
     'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
     'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
@@ -54,7 +54,7 @@ lowPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.
     )
     )
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtTripletStepSeedLayers'
-eras.trackingPhase1.toModify(lowPtTripletStepSeeds,
+eras.trackingPhase1PU70.toModify(lowPtTripletStepSeeds,
     RegionFactoryPSet = dict(
         RegionPSet = dict(
             ptMin = 0.35,
@@ -78,7 +78,7 @@ lowPtTripletStepStandardTrajectoryFilter = _lowPtTripletStepStandardTrajectoryFi
     maxCCCLostHits = 1,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
     )
-eras.trackingPhase1.toReplaceWith(lowPtTripletStepStandardTrajectoryFilter, _lowPtTripletStepStandardTrajectoryFilterBase)
+eras.trackingPhase1PU70.toReplaceWith(lowPtTripletStepStandardTrajectoryFilter, _lowPtTripletStepStandardTrajectoryFilterBase)
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
 # Composite filter
@@ -87,7 +87,7 @@ lowPtTripletStepTrajectoryFilter = _TrajectoryFilter_cff.CompositeTrajectoryFilt
                  # cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))
                 ]
     )
-eras.trackingPhase1.toModify(lowPtTripletStepTrajectoryFilter,
+eras.trackingPhase1PU70.toModify(lowPtTripletStepTrajectoryFilter,
     filters = lowPtTripletStepTrajectoryFilter.filters + [cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))]
 )
 
@@ -98,7 +98,7 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
-eras.trackingPhase1.toModify(lowPtTripletStepChi2Est,
+eras.trackingPhase1PU70.toModify(lowPtTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
 
@@ -144,7 +144,7 @@ lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
             allowSharedFirstHit = cms.bool(True)
             )
 lowPtTripletStepTrackCandidates.TrajectoryCleaner = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
-eras.trackingPhase1.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
+eras.trackingPhase1PU70.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
 
 # Final selection
 
@@ -212,4 +212,4 @@ LowPtTripletStep = cms.Sequence(lowPtTripletStepClusters*
                                 lowPtTripletStep)
 _LowPtTripletStep_Phase1PU70 = LowPtTripletStep.copy()
 _LowPtTripletStep_Phase1PU70.replace(lowPtTripletStep, lowPtTripletStepSelector)
-eras.trackingPhase1.toReplaceWith(LowPtTripletStep, _LowPtTripletStep_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(LowPtTripletStep, _LowPtTripletStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -15,6 +15,11 @@ _lowPtTripletStepClustersBase = _trackClusterRemover.clone(
 lowPtTripletStepClusters = _lowPtTripletStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
 )
+eras.trackingPhase1.toModify(lowPtTripletStepClusters,
+    trajectories                             = "lowPtQuadStepTracks",
+    oldClusterRemovalInfo                    = "lowPtQuadStepClusters",
+    trackClassifier                          = "lowPtQuadStep:QualityMasks",
+)
 eras.trackingPhase1PU70.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
     trajectories                             = "lowPtQuadStepTracks",
     oldClusterRemovalInfo                    = "lowPtQuadStepClusters",
@@ -26,7 +31,7 @@ import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
 lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 lowPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
 lowPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
-eras.trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = [
+_layerListForPhase1 = [
     'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
     'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
     'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
@@ -38,7 +43,9 @@ eras.trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = [
     'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
     'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
     'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
-])
+]
+eras.trackingPhase1.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
+eras.trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
@@ -54,6 +61,9 @@ lowPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.
     )
     )
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtTripletStepSeedLayers'
+eras.trackingPhase1.toModify(lowPtTripletStepSeeds, # FIXME: Phase1PU70 value, let's see if we can lower it to Run2 value (0.2)
+    RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.35)),
+)
 eras.trackingPhase1PU70.toModify(lowPtTripletStepSeeds,
     RegionFactoryPSet = dict(
         RegionPSet = dict(
@@ -155,6 +165,33 @@ lowPtTripletStep =  TrackMVAClassifierPrompt.clone()
 lowPtTripletStep.src = 'lowPtTripletStepTracks'
 lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
+
+# For Phase1
+# MVA selection to be enabled after re-training, for time being we go with cut-based selector
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier as _TrackCutClassifier
+eras.trackingPhase1.toReplaceWith(lowPtTripletStep, _TrackCutClassifier.clone(
+    src = "lowPtTripletStepTracks",
+    vertices = "firstStepPrimaryVertices",
+    mva = dict (
+        minPixelHits = [1,1,1],
+        maxChi2 = [9999.,9999.,9999.],
+        maxChi2n = [2.0,0.9,0.5],
+        minLayers = [3,3,3],
+        min3DLayers = [3,3,3],
+        maxLostLayers = [2,2,2],
+        dz_par = dict(
+            dz_par1 = [0.7,0.6,0.45],
+            dz_par2 = [0.5,0.4,0.4],
+            dz_exp = [4,4,4],
+        ),
+        dr_par = dict(
+            dr_par1 = [0.8,0.7,0.6],
+            dr_par2 = [0.5,0.4,0.3],
+            dr_exp = [4,4,4],
+            d0err_par = [0.002,0.002,0.001],
+        ),
+    )
+))
 
 # For Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -27,7 +27,7 @@ _mixedTripletStepClustersBase = _trackClusterRemover.clone(
 mixedTripletStepClusters = _mixedTripletStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('pixelPairStep',"QualityMasks"),
 )
-eras.trackingPhase1.toReplaceWith(mixedTripletStepClusters, _mixedTripletStepClustersBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(mixedTripletStepClusters, _mixedTripletStepClustersBase.clone(
     trajectories                             = "detachedQuadStepTracks",
     oldClusterRemovalInfo                    = "detachedQuadStepClusters",
     overrideTrkQuals                         = "detachedQuadStep",
@@ -61,7 +61,7 @@ mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
 )
-eras.trackingPhase1.toModify(mixedTripletStepSeedLayersA,
+eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersA,
     layerList = [
         'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
         'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
@@ -105,7 +105,7 @@ mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
-eras.trackingPhase1.toModify(
+eras.trackingPhase1PU70.toModify(
     mixedTripletStepSeedsA,
     RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)),
     SeedComparitorPSet = dict(ClusterShapeHitFilterName = 'ClusterShapeHitFilter'),
@@ -125,7 +125,7 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
 )
-eras.trackingPhase1.toModify(mixedTripletStepSeedLayersB,
+eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersB,
     layerList = [
         'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4','BPix1+BPix2+BPix4', 'BPix1+BPix3+BPix4'
     ],
@@ -153,7 +153,7 @@ mixedTripletStepSeedsB.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
-eras.trackingPhase1.toModify(
+eras.trackingPhase1PU70.toModify(
     mixedTripletStepSeedsB,
     RegionFactoryPSet = dict(
         RegionPSet = dict(
@@ -183,7 +183,7 @@ _mixedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Trajec
 mixedTripletStepTrajectoryFilter = _mixedTripletStepTrajectoryFilterBase.clone(
     constantValueForLostHitsFractionFilter = 1.4,
     )
-eras.trackingPhase1.toReplaceWith(mixedTripletStepTrajectoryFilter, _mixedTripletStepTrajectoryFilterBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(mixedTripletStepTrajectoryFilter, _mixedTripletStepTrajectoryFilterBase.clone(
     maxLostHits = 0,
 ))
 
@@ -210,7 +210,7 @@ mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
-eras.trackingPhase1.toModify(mixedTripletStepChi2Est,
+eras.trackingPhase1PU70.toModify(mixedTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
 
@@ -249,7 +249,7 @@ mixedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
             allowSharedFirstHit = cms.bool(True)
             )
 mixedTripletStepTrackCandidates.TrajectoryCleaner = 'mixedTripletStepTrajectoryCleanerBySharedHits'
-eras.trackingPhase1.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.095)
+eras.trackingPhase1PU70.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.095)
 
 
 # TRACK FITTING
@@ -363,7 +363,7 @@ mixedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
 ) #end of clone
 
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
-eras.trackingPhase1.toReplaceWith(mixedTripletStep, _trackListMerger.clone(
+eras.trackingPhase1PU70.toReplaceWith(mixedTripletStep, _trackListMerger.clone(
     TrackProducers = ['mixedTripletStepTracks',
                       'mixedTripletStepTracks'],
     hasSelector = [1,1],
@@ -389,4 +389,4 @@ MixedTripletStep = cms.Sequence(chargeCut2069Clusters*mixedTripletStepClusters*
                                 mixedTripletStep)
 _MixedTripletStep_Phase1PU70 = MixedTripletStep.copyAndExclude([chargeCut2069Clusters, mixedTripletStepClassifier1])
 _MixedTripletStep_Phase1PU70.replace(mixedTripletStepClassifier2, mixedTripletStepSelector)
-eras.trackingPhase1.toReplaceWith(MixedTripletStep, _MixedTripletStep_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(MixedTripletStep, _MixedTripletStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -12,6 +12,7 @@ chargeCut2069Clusters =  cms.EDProducer("ClusterChargeMasker",
     stripClusters = cms.InputTag("siStripClusters"),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
+eras.trackingPhase1.toModify(chargeCut2069Clusters, oldClusterRemovalInfo = "lowPtTripletStepClusters")
 
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
 _mixedTripletStepClustersBase = _trackClusterRemover.clone(
@@ -26,6 +27,10 @@ _mixedTripletStepClustersBase = _trackClusterRemover.clone(
 )
 mixedTripletStepClusters = _mixedTripletStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('pixelPairStep',"QualityMasks"),
+)
+eras.trackingPhase1.toModify(mixedTripletStepClusters,
+    trajectories                             = "lowPtTripletStepTracks",
+    trackClassifier                          = "lowPtTripletStep:QualityMasks",
 )
 eras.trackingPhase1PU70.toReplaceWith(mixedTripletStepClusters, _mixedTripletStepClustersBase.clone(
     trajectories                             = "detachedQuadStepTracks",
@@ -125,6 +130,7 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
 )
+eras.trackingPhase1.toModify(mixedTripletStepSeedLayersB, layerList = ['BPix3+BPix4+TIB1'])
 eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersB,
     layerList = [
         'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4','BPix1+BPix2+BPix4', 'BPix1+BPix3+BPix4'

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -39,7 +39,7 @@ _muonSeededMeasurementEstimatorForInOutBase = _Chi2MeasurementEstimator.clone(
 muonSeededMeasurementEstimatorForInOut = _muonSeededMeasurementEstimatorForInOutBase.clone(
     MaxSagitta = cms.double(-1.)
 )
-eras.trackingPhase1.toReplaceWith(muonSeededMeasurementEstimatorForInOut, _muonSeededMeasurementEstimatorForInOutBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(muonSeededMeasurementEstimatorForInOut, _muonSeededMeasurementEstimatorForInOutBase.clone(
     MaxChi2 = 400
 ))
 _muonSeededMeasurementEstimatorForOutInBase = _Chi2MeasurementEstimator.clone(
@@ -50,7 +50,7 @@ _muonSeededMeasurementEstimatorForOutInBase = _Chi2MeasurementEstimator.clone(
 muonSeededMeasurementEstimatorForOutIn = _muonSeededMeasurementEstimatorForOutInBase.clone(
     MaxSagitta = cms.double(-1.) 
 )
-eras.trackingPhase1.toReplaceWith(muonSeededMeasurementEstimatorForOutIn, _muonSeededMeasurementEstimatorForOutInBase)
+eras.trackingPhase1PU70.toReplaceWith(muonSeededMeasurementEstimatorForOutIn, _muonSeededMeasurementEstimatorForOutInBase)
 
 ###------------- TrajectoryFilter, defining selections on the trajectories while building them ----------------
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
@@ -236,14 +236,14 @@ muonSeededStepCore = cms.Sequence(
 muonSeededStepExtraInOut = cms.Sequence(
     muonSeededTracksInOutClassifier
 )
-eras.trackingPhase1.toReplaceWith(muonSeededStepExtraInOut, cms.Sequence(
+eras.trackingPhase1PU70.toReplaceWith(muonSeededStepExtraInOut, cms.Sequence(
     muonSeededTracksInOutSelector
 ))
 muonSeededStepExtra = cms.Sequence(
     muonSeededStepExtraInOut +
     muonSeededTracksOutInClassifier
 )
-eras.trackingPhase1.toReplaceWith(muonSeededStepExtra, cms.Sequence(
+eras.trackingPhase1PU70.toReplaceWith(muonSeededStepExtra, cms.Sequence(
     muonSeededStepExtraInOut +
     muonSeededTracksOutInSelector
 ))

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -16,7 +16,7 @@ _pixelPairStepClustersBase = _trackClusterRemover.clone(
 pixelPairStepClusters = _pixelPairStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('lowPtTripletStep',"QualityMasks"),
 )
-eras.trackingPhase1.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
     trajectories                             = "mixedTripletStepTracks",
     oldClusterRemovalInfo                    = "mixedTripletStepClusters",
     overrideTrkQuals                         = "mixedTripletStep",
@@ -40,7 +40,7 @@ pixelPairStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('pixelPairStepClusters')
     )
 )
-eras.trackingPhase1.toModify(pixelPairStepSeedLayers,
+eras.trackingPhase1PU70.toModify(pixelPairStepSeedLayers,
     layerList = [
         'BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3',
         'BPix2+BPix4', 'BPix3+BPix4',
@@ -69,7 +69,7 @@ pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache'),
     )
-eras.trackingPhase1.toModify(pixelPairStepSeeds,
+eras.trackingPhase1PU70.toModify(pixelPairStepSeeds,
     RegionFactoryPSet = dict(
         RegionPSet = dict(
             ptMin = 1.2,
@@ -90,7 +90,7 @@ pixelPairStepTrajectoryFilterBase = _pixelPairStepTrajectoryFilterBase.clone(
     seedPairPenalty =0,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
-eras.trackingPhase1.toReplaceWith(pixelPairStepTrajectoryFilterBase, _pixelPairStepTrajectoryFilterBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(pixelPairStepTrajectoryFilterBase, _pixelPairStepTrajectoryFilterBase.clone(
     maxLostHitsFraction = 1./10.,
     constantValueForLostHitsFractionFilter = 0.801,
 ))
@@ -114,7 +114,7 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
-eras.trackingPhase1.toModify(pixelPairStepChi2Est,
+eras.trackingPhase1PU70.toModify(pixelPairStepChi2Est,
     MaxChi2 = 16.0,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
@@ -148,7 +148,7 @@ pixelPairStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clon
     fractionShared = 0.095,
     allowSharedFirstHit = True
 )
-eras.trackingPhase1.toModify(pixelPairStepTrackCandidates, TrajectoryCleaner = 'pixelPairStepTrajectoryCleanerBySharedHits')
+eras.trackingPhase1PU70.toModify(pixelPairStepTrackCandidates, TrajectoryCleaner = 'pixelPairStepTrajectoryCleanerBySharedHits')
 
 
 # TRACK FITTING
@@ -223,4 +223,4 @@ PixelPairStep = cms.Sequence(pixelPairStepClusters*
                          pixelPairStep)
 _PixelPairStep_Phase1PU70 = PixelPairStep.copy()
 _PixelPairStep_Phase1PU70.replace(pixelPairStep, pixelPairStepSelector)
-eras.trackingPhase1.toReplaceWith(PixelPairStep, _PixelPairStep_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(PixelPairStep, _PixelPairStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -18,7 +18,7 @@ _tobTecStepClustersBase = _trackClusterRemover.clone(
 tobTecStepClusters = _tobTecStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
 )
-eras.trackingPhase1.toReplaceWith(tobTecStepClusters, _tobTecStepClustersBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(tobTecStepClusters, _tobTecStepClustersBase.clone(
     trajectories                             = "pixelPairStepTracks",
     oldClusterRemovalInfo                    = "pixelPairStepClusters",
     overrideTrkQuals                         = "pixelPairStepSelector:pixelPairStep",
@@ -151,7 +151,7 @@ tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalComb
 tobTecStepSeeds.seedCollections = cms.VInputTag(cms.InputTag('tobTecStepSeedsTripl'),cms.InputTag('tobTecStepSeedsPair'))
 # Phase1PU70
 import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
-eras.trackingPhase1.toReplaceWith(tobTecStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
+eras.trackingPhase1PU70.toReplaceWith(tobTecStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
     OrderedHitsFactoryPSet = dict(SeedingLayers = 'tobTecStepSeedLayers'),
     RegionFactoryPSet = dict(
         RegionPSet = dict(
@@ -183,7 +183,7 @@ _tobTecStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFi
 tobTecStepTrajectoryFilter = _tobTecStepTrajectoryFilterBase.clone(
     seedPairPenalty = 1,
 )
-eras.trackingPhase1.toReplaceWith(tobTecStepTrajectoryFilter, _tobTecStepTrajectoryFilterBase.clone(
+eras.trackingPhase1PU70.toReplaceWith(tobTecStepTrajectoryFilter, _tobTecStepTrajectoryFilterBase.clone(
     minimumNumberOfHits = 6,
 ))
 
@@ -199,7 +199,7 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
-eras.trackingPhase1.toModify(tobTecStepChi2Est,
+eras.trackingPhase1PU70.toModify(tobTecStepChi2Est,
     MaxChi2 = 9.0,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
@@ -242,7 +242,7 @@ tobTecStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
     allowSharedFirstHit = cms.bool(True)
     )
 tobTecStepTrackCandidates.TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
-eras.trackingPhase1.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.08)
+eras.trackingPhase1PU70.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.08)
 
 # TRACK FITTING AND SMOOTHING OPTIONS
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
@@ -253,7 +253,7 @@ tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFi
     Fitter = cms.string('tobTecStepRKFitter'),
     Smoother = cms.string('tobTecStepRKSmoother')
     )
-eras.trackingPhase1.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
+eras.trackingPhase1PU70.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
 
 tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
     ComponentName = 'tobTecStepFitterSmootherForLoopers',
@@ -266,7 +266,7 @@ tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.
     ComponentName = cms.string('tobTecStepRKFitter'),
     minHits = 7
 )
-eras.trackingPhase1.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
+eras.trackingPhase1PU70.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
 tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
     ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -277,7 +277,7 @@ tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cf
     errorRescaling = 10.0,
     minHits = 7
 )
-eras.trackingPhase1.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
+eras.trackingPhase1PU70.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
 tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
     ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -336,7 +336,7 @@ TobTecStep = cms.Sequence(tobTecStepClusters*
 
 ### Following are specific for Phase1PU70, they're collected here to
 ### not to interfere too much with the default configuration
-# For Phase1
+# For Phase1PU70
 tobTecStepSeedClusters = _trackClusterRemover.clone(
     maxChi2                                  = 9.0,
     trajectories                             = "mixedTripletStepTracks",
@@ -421,7 +421,7 @@ tobTecStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.mult
     ] #end of vpset
 ) #end of clone
 
-eras.trackingPhase1.toReplaceWith(TobTecStep, cms.Sequence(
+eras.trackingPhase1PU70.toReplaceWith(TobTecStep, cms.Sequence(
     tobTecStepClusters*
     tobTecStepSeedClusters*
     tobTecStepSeedLayers*

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -39,7 +39,7 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
                             )
 
 from Configuration.StandardSequences.Eras import eras
-eras.trackingPhase1.toReplaceWith(iterTracking, cms.Sequence(
+eras.trackingPhase1PU70.toReplaceWith(iterTracking, cms.Sequence(
     InitialStepPreSplitting +
     InitialStep +
     HighPtTripletStep +

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -10,10 +10,10 @@ from RecoTracker.IterativeTracking.PixelLessStep_cff import *
 from RecoTracker.IterativeTracking.TobTecStep_cff import *
 from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import *
 
-# Phase1PU70 specific iterations
-from RecoTracker.IterativeTracking.Phase1PU70_HighPtTripletStep_cff import *
-from RecoTracker.IterativeTracking.Phase1PU70_LowPtQuadStep_cff import *
-from RecoTracker.IterativeTracking.Phase1PU70_DetachedQuadStep_cff import *
+# Phase1 specific iterations
+from RecoTracker.IterativeTracking.HighPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.DetachedQuadStep_cff import *
+from RecoTracker.IterativeTracking.LowPtQuadStep_cff import *
 
 from RecoTracker.FinalTrackSelectors.earlyGeneralTracks_cfi import *
 from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
@@ -39,6 +39,25 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
                             )
 
 from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase1.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStepPreSplitting +
+    InitialStep +
+    HighPtTripletStep +
+    DetachedQuadStep +
+    #DetachedTripletStep + # FIXME: dropped for time being, but it may be enabled on the course of further tuning
+    LowPtQuadStep +
+    LowPtTripletStep +
+    MixedTripletStep +
+    PixelLessStep +
+    TobTecStep +
+    JetCoreRegionalStep +
+    earlyGeneralTracks +
+    muonSeededStep +
+    preDuplicateMergingGeneralTracks +
+    generalTracksSequence +
+    ConvStep +
+    conversionStepTracks
+))
 eras.trackingPhase1PU70.toReplaceWith(iterTracking, cms.Sequence(
     InitialStepPreSplitting +
     InitialStep +

--- a/RecoTracker/TkSeedGenerator/python/GlobalMixedSeeds_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalMixedSeeds_cff.py
@@ -26,6 +26,6 @@ globalMixedSeeds = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProd
        maxElement = cms.uint32(1000000)
     )
 )
-eras.trackingPhase1.toModify(globalMixedSeeds,
+eras.trackingPhase1PU70.toModify(globalMixedSeeds,
     OrderedHitsFactoryPSet = dict(maxElement = 0),
 )

--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromPairsWithVertices_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromPairsWithVertices_cff.py
@@ -26,7 +26,7 @@ globalSeedsFromPairsWithVertices = RecoTracker.TkSeedGenerator.SeedGeneratorFrom
       ComponentName = cms.string('GlobalTrackingRegionWithVerticesProducer')
     )
 )    
-eras.trackingPhase1.toModify(globalSeedsFromPairsWithVertices,
+eras.trackingPhase1PU70.toModify(globalSeedsFromPairsWithVertices,
     OrderedHitsFactoryPSet = dict(maxElement = 0),
 )
 

--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTriplets_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTriplets_cff.py
@@ -25,6 +25,6 @@ globalSeedsFromTriplets = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHit
 #     GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
     )
 )
-eras.trackingPhase1.toModify(globalSeedsFromTriplets,
+eras.trackingPhase1PU70.toModify(globalSeedsFromTriplets,
     OrderedHitsFactoryPSet = dict(GeneratorPSet = dict(maxElement = 0)),
 )

--- a/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
@@ -13,7 +13,7 @@ SeedFromConsecutiveHitsCreator = cms.PSet(
   TTRHBuilder = cms.string('WithTrackAngle'),
   forceKinematicWithRegionDirection = cms.bool(False)
 )
-eras.trackingPhase1.toModify(SeedFromConsecutiveHitsCreator,
+eras.trackingPhase1PU70.toModify(SeedFromConsecutiveHitsCreator,
         magneticField = '',
         propagator = 'PropagatorWithMaterial'
 )

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
@@ -19,7 +19,7 @@ PixelLayerTriplets.FPix = cms.PSet(
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.trackingPhase1.toModify(PixelLayerTriplets, layerList=[
+eras.trackingPhase1PU70.toModify(PixelLayerTriplets, layerList=[
     'BPix1+BPix2+BPix3',
     'BPix2+BPix3+BPix4',
     'BPix1+BPix3+BPix4',

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
@@ -19,7 +19,7 @@ PixelLayerTriplets.FPix = cms.PSet(
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.trackingPhase1PU70.toModify(PixelLayerTriplets, layerList=[
+_layersForPhase1 = [
     'BPix1+BPix2+BPix3',
     'BPix2+BPix3+BPix4',
     'BPix1+BPix3+BPix4',
@@ -34,4 +34,6 @@ eras.trackingPhase1PU70.toModify(PixelLayerTriplets, layerList=[
     'BPix1+FPix1_neg+FPix2_neg',
     'FPix1_pos+FPix2_pos+FPix3_pos',
     'FPix1_neg+FPix2_neg+FPix3_neg'
-])
+]
+eras.trackingPhase1.toModify(PixelLayerTriplets, layerList=_layersForPhase1)
+eras.trackingPhase1PU70.toModify(PixelLayerTriplets, layerList=_layersForPhase1)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -35,7 +35,7 @@ _algos = [
     "muonSeededStepOutIn",
     "duplicateMerge",
 ]
-_algosForTrackingPhase1 = [
+_algosForTrackingPhase1PU70 = [
     "generalTracks",
     "initialStep",
     "highPtTripletStep",
@@ -72,7 +72,7 @@ _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
 _seedProducersForFastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
 
 
-_seedProducersForTrackingPhase1 = [
+_seedProducersForTrackingPhase1PU70 = [
         "initialStepSeeds",
         "highPtTripletStepSeeds",
         "lowPtQuadStepSeeds",
@@ -106,7 +106,7 @@ _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "muonSeededTracksOutIn"]
 _trackProducersForFastSim = [ x for x in _trackProducers if x not in _removeForFastTrackProducers]
 
-_trackProducersForTrackingPhase1 = [
+_trackProducersForTrackingPhase1PU70 = [
     "initialStepTracks",
     "highPtTripletStepTracks",
     "lowPtQuadStepTracks",
@@ -204,18 +204,18 @@ def _addSeedToTrackProducers(seedProducers,modDict):
 
 # Validation iterative steps
 (_selectorsByAlgo, tracksValidationSelectorsByAlgo) = _addSelectorsByAlgo(_algos, globals())
-(_selectorsByAlgo_trackingPhase1, _tracksValidationSelectorsByAlgo_trackingPhase1) = _addSelectorsByAlgo(_algosForTrackingPhase1, globals())
-eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgo, _tracksValidationSelectorsByAlgo_trackingPhase1)
+(_selectorsByAlgo_trackingPhase1PU70, _tracksValidationSelectorsByAlgo_trackingPhase1PU70) = _addSelectorsByAlgo(_algosForTrackingPhase1PU70, globals())
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByAlgo, _tracksValidationSelectorsByAlgo_trackingPhase1PU70)
 
 # high purity
 (_selectorsByAlgoHp, tracksValidationSelectorsByAlgoHp) = _addSelectorsByHp(_algos,globals())
-(_selectorsByAlgoHp_trackingPhase1, _tracksValidationSelectorsByAlgoHp_trackingPhase1) = _addSelectorsByHp(_algosForTrackingPhase1, globals())
-eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgoHp, _tracksValidationSelectorsByAlgoHp_trackingPhase1)
+(_selectorsByAlgoHp_trackingPhase1PU70, _tracksValidationSelectorsByAlgoHp_trackingPhase1PU70) = _addSelectorsByHp(_algosForTrackingPhase1PU70, globals())
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByAlgoHp, _tracksValidationSelectorsByAlgoHp_trackingPhase1PU70)
 
 _generalTracksHp = _selectorsByAlgoHp[0]
-_generalTracksHp_trackingPhase1 = _selectorsByAlgoHp_trackingPhase1[0]
+_generalTracksHp_trackingPhase1PU70 = _selectorsByAlgoHp_trackingPhase1PU70[0]
 _selectorsByAlgoHp = _selectorsByAlgoHp[1:]
-_selectorsByAlgoHp_trackingPhase1 = _selectorsByAlgoHp_trackingPhase1[1:]
+_selectorsByAlgoHp_trackingPhase1PU70 = _selectorsByAlgoHp_trackingPhase1PU70[1:]
 
 # BTV-like selection
 import PhysicsTools.RecoAlgos.btvTracks_cfi as btvTracks_cfi
@@ -263,9 +263,9 @@ generalTracksFromPV = _trackWithVertexRefSelector.clone(
 # and then the selectors
 (_selectorsFromPV, tracksValidationSelectorsFromPV) = _addSelectorsBySrc([_generalTracksHp], "FromPV", "generalTracksFromPV", globals())
 tracksValidationSelectorsFromPV.insert(0, generalTracksFromPV)
-(_selectorsFromPV_trackingPhase1, _tracksValidationSelectorsFromPV_trackingPhase1) = _addSelectorsBySrc([_generalTracksHp_trackingPhase1], "FromPV", "generalTracksFromPV", globals())
-_tracksValidationSelectorsFromPV_trackingPhase1.insert(0, generalTracksFromPV)
-eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsFromPV, _tracksValidationSelectorsFromPV_trackingPhase1)
+(_selectorsFromPV_trackingPhase1PU70, _tracksValidationSelectorsFromPV_trackingPhase1PU70) = _addSelectorsBySrc([_generalTracksHp_trackingPhase1PU70], "FromPV", "generalTracksFromPV", globals())
+_tracksValidationSelectorsFromPV_trackingPhase1PU70.insert(0, generalTracksFromPV)
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsFromPV, _tracksValidationSelectorsFromPV_trackingPhase1PU70)
 
 ## Select conversion TrackingParticles, and define the corresponding associator
 trackingParticlesConversion = _trackingParticleConversionRefSelector.clone()
@@ -295,8 +295,8 @@ trackValidator = Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidato
 )
 eras.fastSim.toModify(trackValidator, 
                       dodEdxPlots = False)
-eras.trackingPhase1.toModify(trackValidator,
-    label = ["generalTracks", _generalTracksHp_trackingPhase1] + _selectorsByAlgo_trackingPhase1 + _selectorsByAlgoHp_trackingPhase1 +  [
+eras.trackingPhase1PU70.toModify(trackValidator,
+    label = ["generalTracks", _generalTracksHp_trackingPhase1PU70] + _selectorsByAlgo_trackingPhase1PU70 + _selectorsByAlgoHp_trackingPhase1PU70 +  [
         "cutsRecoTracksBtvLike",
         "cutsRecoTracksAK4PFJets"
     ]
@@ -315,7 +315,7 @@ trackValidatorFromPV = trackValidator.clone(
     doPlotsOnlyForTruePV = True,
     doPVAssociationPlots = False,
 )
-eras.trackingPhase1.toModify(trackValidatorFromPV, label = ["generalTracksFromPV"]+_selectorsFromPV_trackingPhase1)
+eras.trackingPhase1PU70.toModify(trackValidatorFromPV, label = ["generalTracksFromPV"]+_selectorsFromPV_trackingPhase1PU70)
 
 # For fake rate of signal tracks vs. all TPs, and pileup rate of
 # signal tracks vs. non-signal TPs
@@ -347,7 +347,7 @@ trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi.sig
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.signalOnly = False
-eras.trackingPhase1.toModify(trackValidatorAllTPEffic, label = ["generalTracks", _generalTracksHp_trackingPhase1])
+eras.trackingPhase1PU70.toModify(trackValidatorAllTPEffic, label = ["generalTracks", _generalTracksHp_trackingPhase1PU70])
 
 # For conversions
 trackValidatorConversion = trackValidator.clone(
@@ -426,26 +426,26 @@ eras.fastSim.toReplaceWith(tracksValidation, tracksValidation.copyAndExclude([tr
 
 # Select by originalAlgo and algoMask
 _selectorsByAlgoAndHp = _selectorsByAlgo+_selectorsByAlgoHp
-_selectorsByAlgoAndHp_trackingPhase1 = _selectorsByAlgo_trackingPhase1+_selectorsByAlgoHp_trackingPhase1
+_selectorsByAlgoAndHp_trackingPhase1PU70 = _selectorsByAlgo_trackingPhase1PU70+_selectorsByAlgoHp_trackingPhase1PU70
 (_selectorsByOriginalAlgo, tracksValidationSelectorsByOriginalAlgoStandalone) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp, "ByOriginalAlgo", "originalAlgorithm",globals())
-(_selectorsByOriginalAlgo_trackingPhase1, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1, "ByOriginalAlgo", "originalAlgorithm",globals())
-eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByOriginalAlgoStandalone, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1)
+(_selectorsByOriginalAlgo_trackingPhase1PU70, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1PU70) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1PU70, "ByOriginalAlgo", "originalAlgorithm",globals())
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByOriginalAlgoStandalone, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1PU70)
 
 (_selectorsByAlgoMask, tracksValidationSelectorsByAlgoMaskStandalone) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp, "ByAlgoMask", "algorithmMaskContains",globals())
-(_selectorsByAlgoMask_trackingPhase1, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1, "ByAlgoMask", "algorithmMaskContains",globals())
-eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgoMaskStandalone, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1)
+(_selectorsByAlgoMask_trackingPhase1PU70, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1PU70) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1PU70, "ByAlgoMask", "algorithmMaskContains",globals())
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByAlgoMaskStandalone, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1PU70)
 
 # Select fromPV by iteration
 (_selectorsFromPVStandalone, tracksValidationSelectorsFromPVStandalone) = _addSelectorsBySrc(_selectorsByAlgoAndHp, "FromPV", "generalTracksFromPV",globals())
-(_selectorsFromPVStandalone_trackingPhase1, _tracksValidationSelectorsFromPVStandalone_trackingPhase1) = _addSelectorsBySrc(_selectorsByAlgoAndHp_trackingPhase1, "FromPV", "generalTracksFromPV",globals())
-eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsFromPVStandalone, _tracksValidationSelectorsFromPVStandalone_trackingPhase1)
+(_selectorsFromPVStandalone_trackingPhase1PU70, _tracksValidationSelectorsFromPVStandalone_trackingPhase1PU70) = _addSelectorsBySrc(_selectorsByAlgoAndHp_trackingPhase1PU70, "FromPV", "generalTracksFromPV",globals())
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsFromPVStandalone, _tracksValidationSelectorsFromPVStandalone_trackingPhase1PU70)
 
 # MTV instances
 trackValidatorStandalone = trackValidator.clone( label = trackValidator.label+ _selectorsByOriginalAlgo + _selectorsByAlgoMask)
-eras.trackingPhase1.toModify(trackValidatorStandalone, label = trackValidator.label+ _selectorsByOriginalAlgo_trackingPhase1 + _selectorsByAlgoMask_trackingPhase1)
+eras.trackingPhase1PU70.toModify(trackValidatorStandalone, label = trackValidator.label+ _selectorsByOriginalAlgo_trackingPhase1PU70 + _selectorsByAlgoMask_trackingPhase1PU70)
 
 trackValidatorFromPVStandalone = trackValidatorFromPV.clone( label = trackValidatorFromPV.label+_selectorsFromPVStandalone)
-eras.trackingPhase1.toModify(trackValidatorFromPVStandalone, label = trackValidatorFromPV.label+_selectorsFromPVStandalone_trackingPhase1)
+eras.trackingPhase1PU70.toModify(trackValidatorFromPVStandalone, label = trackValidatorFromPV.label+_selectorsFromPVStandalone_trackingPhase1PU70)
 
 trackValidatorFromPVAllTPStandalone = trackValidatorFromPVAllTP.clone(
     label = trackValidatorFromPVStandalone.label.value()
@@ -489,9 +489,9 @@ tracksValidationStandalone = cms.Sequence(
 tracksValidationSelectorsTrackingOnly = tracksValidationSelectors.copyAndExclude([ak4JetTracksAssociatorExplicitAll,cutsRecoTracksAK4PFJets]) # selectors using track information only (i.e. no PF)
 (_seedSelectors, tracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducers, globals())
 (_fastSimSeedSelectors, _fastSimTracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForFastSim, globals())
-(_trackingPhase1SeedSelectors, _trackingPhase1TracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForTrackingPhase1, globals())
+(_trackingPhase1PU70SeedSelectors, _trackingPhase1PU70TracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForTrackingPhase1PU70, globals())
 eras.fastSim.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _fastSimTracksValidationSeedSelectorsTrackingOnly)
-eras.trackingPhase1.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _trackingPhase1TracksValidationSeedSelectorsTrackingOnly)
+eras.trackingPhase1PU70.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _trackingPhase1PU70TracksValidationSeedSelectorsTrackingOnly)
 
 # MTV instances
 trackValidatorTrackingOnly = trackValidatorStandalone.clone(label = [ x for x in trackValidatorStandalone.label if x != "cutsRecoTracksAK4PFJets"] )
@@ -507,7 +507,7 @@ trackValidatorBuildingTrackingOnly = trackValidatorTrackingOnly.clone(
 )
 
 eras.fastSim.toModify(trackValidatorBuildingTrackingOnly, label =  _trackProducersForFastSim )
-eras.trackingPhase1.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForTrackingPhase1)
+eras.trackingPhase1PU70.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForTrackingPhase1PU70)
 
 trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
     dirName = "Tracking/TrackSeeding/",
@@ -515,7 +515,7 @@ trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
     doSeedPlots = True,
 )
 eras.fastSim.toModify(trackValidatorSeedingTrackingOnly, label= _fastSimSeedSelectors)
-eras.trackingPhase1.toModify(trackValidatorSeedingTrackingOnly, label= _trackingPhase1SeedSelectors)
+eras.trackingPhase1PU70.toModify(trackValidatorSeedingTrackingOnly, label= _trackingPhase1PU70SeedSelectors)
 
 
 trackValidatorConversionTrackingOnly = trackValidatorConversion.clone(label = [x for x in trackValidatorConversion.label if x not in ["ckfInOutTracksFromConversions", "ckfOutInTracksFromConversions"]])

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -35,6 +35,22 @@ _algos = [
     "muonSeededStepOutIn",
     "duplicateMerge",
 ]
+_algosForTrackingPhase1 = [
+    "generalTracks",
+    "initialStep",
+    "highPtTripletStep",
+    "detachedQuadStep",
+    #"detachedTripletStep",
+    "lowPtQuadStep",
+    "lowPtTripletStep",
+    "mixedTripletStep",
+    "pixelLessStep",
+    "tobTecStep",
+    "jetCoreRegionalStep",
+    "muonSeededStepInOut",
+    "muonSeededStepOutIn",
+    "duplicateMerge",
+]
 _algosForTrackingPhase1PU70 = [
     "generalTracks",
     "initialStep",
@@ -47,7 +63,7 @@ _algosForTrackingPhase1PU70 = [
     "tobTecStep",
     "muonSeededStepInOut",
     "muonSeededStepOutIn",
-    ]
+]
 
 _seedProducers = [
     "initialStepSeedsPreSplitting",
@@ -71,20 +87,36 @@ _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "muonSeededSeedsOutIn"]
 _seedProducersForFastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
 
-
+_seedProducersForTrackingPhase1 = [
+    "initialStepSeedsPreSplitting",
+    "initialStepSeeds",
+    "highPtTripletStepSeeds",
+    "detachedQuadStepSeeds",
+    #"detachedTripletStepSeeds",
+    "lowPtQuadStepSeeds",
+    "lowPtTripletStepSeeds",
+    "mixedTripletStepSeedsA",
+    "mixedTripletStepSeedsB",
+    "pixelLessStepSeeds",
+    "tobTecStepSeedsPair",
+    "tobTecStepSeedsTripl",
+    "jetCoreRegionalStepSeeds",
+    "muonSeededSeedsInOut",
+    "muonSeededSeedsOutIn",
+]
 _seedProducersForTrackingPhase1PU70 = [
-        "initialStepSeeds",
-        "highPtTripletStepSeeds",
-        "lowPtQuadStepSeeds",
-        "lowPtTripletStepSeeds",
-        "detachedQuadStepSeeds",
-        "mixedTripletStepSeedsA",
-        "mixedTripletStepSeedsB",
-        "pixelPairStepSeeds",
-        "tobTecStepSeeds",
-        "muonSeededSeedsInOut",
-        "muonSeededSeedsOutIn",
-    ]
+    "initialStepSeeds",
+    "highPtTripletStepSeeds",
+    "lowPtQuadStepSeeds",
+    "lowPtTripletStepSeeds",
+    "detachedQuadStepSeeds",
+    "mixedTripletStepSeedsA",
+    "mixedTripletStepSeedsB",
+    "pixelPairStepSeeds",
+    "tobTecStepSeeds",
+    "muonSeededSeedsInOut",
+    "muonSeededSeedsOutIn",
+]
 
 
 _trackProducers = [
@@ -106,6 +138,21 @@ _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "muonSeededTracksOutIn"]
 _trackProducersForFastSim = [ x for x in _trackProducers if x not in _removeForFastTrackProducers]
 
+_trackProducersForTrackingPhase1 = [
+    "initialStepTracksPreSplitting",
+    "initialStepTracks",
+    "highPtTripletStepTracks",
+    "detachedQuadStepTracks",
+#    "detachedTripletStepTracks",
+    "lowPtQuadStepTracks",
+    "lowPtTripletStepTracks",
+    "mixedTripletStepTracks",
+    "pixelLessStepTracks",
+    "tobTecStepTracks",
+    "jetCoreRegionalStepTracks",
+    "muonSeededTracksInOut",
+    "muonSeededTracksOutIn",
+]
 _trackProducersForTrackingPhase1PU70 = [
     "initialStepTracks",
     "highPtTripletStepTracks",
@@ -204,17 +251,23 @@ def _addSeedToTrackProducers(seedProducers,modDict):
 
 # Validation iterative steps
 (_selectorsByAlgo, tracksValidationSelectorsByAlgo) = _addSelectorsByAlgo(_algos, globals())
+(_selectorsByAlgo_trackingPhase1, _tracksValidationSelectorsByAlgo_trackingPhase1) = _addSelectorsByAlgo(_algosForTrackingPhase1, globals())
 (_selectorsByAlgo_trackingPhase1PU70, _tracksValidationSelectorsByAlgo_trackingPhase1PU70) = _addSelectorsByAlgo(_algosForTrackingPhase1PU70, globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgo, _tracksValidationSelectorsByAlgo_trackingPhase1)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByAlgo, _tracksValidationSelectorsByAlgo_trackingPhase1PU70)
 
 # high purity
 (_selectorsByAlgoHp, tracksValidationSelectorsByAlgoHp) = _addSelectorsByHp(_algos,globals())
+(_selectorsByAlgoHp_trackingPhase1, _tracksValidationSelectorsByAlgoHp_trackingPhase1) = _addSelectorsByHp(_algosForTrackingPhase1, globals())
 (_selectorsByAlgoHp_trackingPhase1PU70, _tracksValidationSelectorsByAlgoHp_trackingPhase1PU70) = _addSelectorsByHp(_algosForTrackingPhase1PU70, globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgoHp, _tracksValidationSelectorsByAlgoHp_trackingPhase1)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByAlgoHp, _tracksValidationSelectorsByAlgoHp_trackingPhase1PU70)
 
 _generalTracksHp = _selectorsByAlgoHp[0]
+_generalTracksHp_trackingPhase1 = _selectorsByAlgoHp_trackingPhase1[0]
 _generalTracksHp_trackingPhase1PU70 = _selectorsByAlgoHp_trackingPhase1PU70[0]
 _selectorsByAlgoHp = _selectorsByAlgoHp[1:]
+_selectorsByAlgoHp_trackingPhase1 = _selectorsByAlgoHp_trackingPhase1[1:]
 _selectorsByAlgoHp_trackingPhase1PU70 = _selectorsByAlgoHp_trackingPhase1PU70[1:]
 
 # BTV-like selection
@@ -262,9 +315,12 @@ generalTracksFromPV = _trackWithVertexRefSelector.clone(
 )
 # and then the selectors
 (_selectorsFromPV, tracksValidationSelectorsFromPV) = _addSelectorsBySrc([_generalTracksHp], "FromPV", "generalTracksFromPV", globals())
-tracksValidationSelectorsFromPV.insert(0, generalTracksFromPV)
+(_selectorsFromPV_trackingPhase1, _tracksValidationSelectorsFromPV_trackingPhase1) = _addSelectorsBySrc([_generalTracksHp_trackingPhase1], "FromPV", "generalTracksFromPV", globals())
 (_selectorsFromPV_trackingPhase1PU70, _tracksValidationSelectorsFromPV_trackingPhase1PU70) = _addSelectorsBySrc([_generalTracksHp_trackingPhase1PU70], "FromPV", "generalTracksFromPV", globals())
+tracksValidationSelectorsFromPV.insert(0, generalTracksFromPV)
+_tracksValidationSelectorsFromPV_trackingPhase1.insert(0, generalTracksFromPV)
 _tracksValidationSelectorsFromPV_trackingPhase1PU70.insert(0, generalTracksFromPV)
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsFromPV, _tracksValidationSelectorsFromPV_trackingPhase1)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsFromPV, _tracksValidationSelectorsFromPV_trackingPhase1PU70)
 
 ## Select conversion TrackingParticles, and define the corresponding associator
@@ -295,6 +351,12 @@ trackValidator = Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidato
 )
 eras.fastSim.toModify(trackValidator, 
                       dodEdxPlots = False)
+eras.trackingPhase1.toModify(trackValidator,
+    label = ["generalTracks", _generalTracksHp_trackingPhase1] + _selectorsByAlgo_trackingPhase1 + _selectorsByAlgoHp_trackingPhase1 +  [
+        "cutsRecoTracksBtvLike",
+        "cutsRecoTracksAK4PFJets"
+    ]
+)
 eras.trackingPhase1PU70.toModify(trackValidator,
     label = ["generalTracks", _generalTracksHp_trackingPhase1PU70] + _selectorsByAlgo_trackingPhase1PU70 + _selectorsByAlgoHp_trackingPhase1PU70 +  [
         "cutsRecoTracksBtvLike",
@@ -315,6 +377,7 @@ trackValidatorFromPV = trackValidator.clone(
     doPlotsOnlyForTruePV = True,
     doPVAssociationPlots = False,
 )
+eras.trackingPhase1.toModify(trackValidatorFromPV, label = ["generalTracksFromPV"]+_selectorsFromPV_trackingPhase1)
 eras.trackingPhase1PU70.toModify(trackValidatorFromPV, label = ["generalTracksFromPV"]+_selectorsFromPV_trackingPhase1PU70)
 
 # For fake rate of signal tracks vs. all TPs, and pileup rate of
@@ -347,6 +410,7 @@ trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi.sig
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.signalOnly = False
+eras.trackingPhase1.toModify(trackValidatorAllTPEffic, label = ["generalTracks", _generalTracksHp_trackingPhase1])
 eras.trackingPhase1PU70.toModify(trackValidatorAllTPEffic, label = ["generalTracks", _generalTracksHp_trackingPhase1PU70])
 
 # For conversions
@@ -426,25 +490,34 @@ eras.fastSim.toReplaceWith(tracksValidation, tracksValidation.copyAndExclude([tr
 
 # Select by originalAlgo and algoMask
 _selectorsByAlgoAndHp = _selectorsByAlgo+_selectorsByAlgoHp
+_selectorsByAlgoAndHp_trackingPhase1 = _selectorsByAlgo_trackingPhase1+_selectorsByAlgoHp_trackingPhase1
 _selectorsByAlgoAndHp_trackingPhase1PU70 = _selectorsByAlgo_trackingPhase1PU70+_selectorsByAlgoHp_trackingPhase1PU70
 (_selectorsByOriginalAlgo, tracksValidationSelectorsByOriginalAlgoStandalone) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp, "ByOriginalAlgo", "originalAlgorithm",globals())
+(_selectorsByOriginalAlgo_trackingPhase1, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1, "ByOriginalAlgo", "originalAlgorithm",globals())
 (_selectorsByOriginalAlgo_trackingPhase1PU70, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1PU70) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1PU70, "ByOriginalAlgo", "originalAlgorithm",globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByOriginalAlgoStandalone, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByOriginalAlgoStandalone, _tracksValidationSelectorsByOriginalAlgoStandalone_trackingPhase1PU70)
 
 (_selectorsByAlgoMask, tracksValidationSelectorsByAlgoMaskStandalone) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp, "ByAlgoMask", "algorithmMaskContains",globals())
+(_selectorsByAlgoMask_trackingPhase1, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1, "ByAlgoMask", "algorithmMaskContains",globals())
 (_selectorsByAlgoMask_trackingPhase1PU70, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1PU70) = _addSelectorsByOriginalAlgoMask(_selectorsByAlgoAndHp_trackingPhase1PU70, "ByAlgoMask", "algorithmMaskContains",globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsByAlgoMaskStandalone, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsByAlgoMaskStandalone, _tracksValidationSelectorsByAlgoMaskStandalone_trackingPhase1PU70)
 
 # Select fromPV by iteration
 (_selectorsFromPVStandalone, tracksValidationSelectorsFromPVStandalone) = _addSelectorsBySrc(_selectorsByAlgoAndHp, "FromPV", "generalTracksFromPV",globals())
+(_selectorsFromPVStandalone_trackingPhase1, _tracksValidationSelectorsFromPVStandalone_trackingPhase1) = _addSelectorsBySrc(_selectorsByAlgoAndHp_trackingPhase1, "FromPV", "generalTracksFromPV",globals())
 (_selectorsFromPVStandalone_trackingPhase1PU70, _tracksValidationSelectorsFromPVStandalone_trackingPhase1PU70) = _addSelectorsBySrc(_selectorsByAlgoAndHp_trackingPhase1PU70, "FromPV", "generalTracksFromPV",globals())
+eras.trackingPhase1.toReplaceWith(tracksValidationSelectorsFromPVStandalone, _tracksValidationSelectorsFromPVStandalone_trackingPhase1)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSelectorsFromPVStandalone, _tracksValidationSelectorsFromPVStandalone_trackingPhase1PU70)
 
 # MTV instances
 trackValidatorStandalone = trackValidator.clone( label = trackValidator.label+ _selectorsByOriginalAlgo + _selectorsByAlgoMask)
+eras.trackingPhase1.toModify(trackValidatorStandalone, label = trackValidator.label+ _selectorsByOriginalAlgo_trackingPhase1 + _selectorsByAlgoMask_trackingPhase1)
 eras.trackingPhase1PU70.toModify(trackValidatorStandalone, label = trackValidator.label+ _selectorsByOriginalAlgo_trackingPhase1PU70 + _selectorsByAlgoMask_trackingPhase1PU70)
 
 trackValidatorFromPVStandalone = trackValidatorFromPV.clone( label = trackValidatorFromPV.label+_selectorsFromPVStandalone)
+eras.trackingPhase1.toModify(trackValidatorFromPVStandalone, label = trackValidatorFromPV.label+_selectorsFromPVStandalone_trackingPhase1)
 eras.trackingPhase1PU70.toModify(trackValidatorFromPVStandalone, label = trackValidatorFromPV.label+_selectorsFromPVStandalone_trackingPhase1PU70)
 
 trackValidatorFromPVAllTPStandalone = trackValidatorFromPVAllTP.clone(
@@ -489,8 +562,10 @@ tracksValidationStandalone = cms.Sequence(
 tracksValidationSelectorsTrackingOnly = tracksValidationSelectors.copyAndExclude([ak4JetTracksAssociatorExplicitAll,cutsRecoTracksAK4PFJets]) # selectors using track information only (i.e. no PF)
 (_seedSelectors, tracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducers, globals())
 (_fastSimSeedSelectors, _fastSimTracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForFastSim, globals())
+(_trackingPhase1SeedSelectors, _trackingPhase1TracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForTrackingPhase1, globals())
 (_trackingPhase1PU70SeedSelectors, _trackingPhase1PU70TracksValidationSeedSelectorsTrackingOnly) = _addSeedToTrackProducers(_seedProducersForTrackingPhase1PU70, globals())
 eras.fastSim.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _fastSimTracksValidationSeedSelectorsTrackingOnly)
+eras.trackingPhase1.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _trackingPhase1TracksValidationSeedSelectorsTrackingOnly)
 eras.trackingPhase1PU70.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _trackingPhase1PU70TracksValidationSeedSelectorsTrackingOnly)
 
 # MTV instances
@@ -507,6 +582,7 @@ trackValidatorBuildingTrackingOnly = trackValidatorTrackingOnly.clone(
 )
 
 eras.fastSim.toModify(trackValidatorBuildingTrackingOnly, label =  _trackProducersForFastSim )
+eras.trackingPhase1.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForTrackingPhase1)
 eras.trackingPhase1PU70.toModify(trackValidatorBuildingTrackingOnly, label = _trackProducersForTrackingPhase1PU70)
 
 trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
@@ -515,6 +591,7 @@ trackValidatorSeedingTrackingOnly = trackValidatorBuildingTrackingOnly.clone(
     doSeedPlots = True,
 )
 eras.fastSim.toModify(trackValidatorSeedingTrackingOnly, label= _fastSimSeedSelectors)
+eras.trackingPhase1.toModify(trackValidatorSeedingTrackingOnly, label= _trackingPhase1SeedSelectors)
 eras.trackingPhase1PU70.toModify(trackValidatorSeedingTrackingOnly, label= _trackingPhase1PU70SeedSelectors)
 
 

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -242,7 +242,7 @@ def _addSeedToTrackProducers(seedProducers,modDict):
         modName = "seedTracks"+seed
         if modName not in modDict:
             mod = _trajectorySeedTracks.clone(src=seed)
-            globals()[modName] = mod
+            modDict[modName] = mod
         else:
             mod = modDict[modName]
         names.append(modName)


### PR DESCRIPTION
This PR replaces the "Phase1PU70" tracking with the one presented in Feb 1 TRK POG meeting https://indico.cern.ch/event/489234/contribution/5/attachments/1220760/1784567/slides_phase1.pdf (and in the closed PR #13149). The "Phase1PU70" tracking can still be run with `Run2_2017_trackingPhase1PU70` era, and there should be no changes in it (i.e. `Run2_2017_trackingPhase1PU70` with this PR should give the same tracks as `Run2_2017` without this PR).

Tested in CMSSW_8_1_X_2016-03-15-1100. There should be no changes in <= 2016 workflows, but in 2017 workflows changes are expected in all(?) track-related variables.

about all track-related will change in 2017 workflows.

@rovere @VinInn 
