### PR TITLE
locally named load of FEVT in hotlineSkims (same as #13746)

### DIFF
--- a/Calibration/Hotline/python/hotlineSkims_Output_cff.py
+++ b/Calibration/Hotline/python/hotlineSkims_Output_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import copy
 
-from Configuration.EventContent.EventContent_cff import FEVTEventContent
+from Configuration.EventContent.EventContent_cff import FEVTEventContent as _FEVTEventContent
 
 OutALCARECOHotline_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
@@ -27,7 +27,7 @@ OutALCARECOHotline_noDrop = cms.PSet(
             "pathHotlineSkimCondMET",
         ),
     ),
-    outputCommands = copy.deepcopy(FEVTEventContent.outputCommands)
+    outputCommands = copy.deepcopy(_FEVTEventContent.outputCommands)
 )
 
 while 'drop *' in OutALCARECOHotline_noDrop.outputCommands: OutALCARECOHotline_noDrop.outputCommands.remove('drop *')


### PR DESCRIPTION
This appears to clear the problem with incorrect FEVTEventContent loaded in the Express processing reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1428/1/1/1.html

Checked with Configuration/DataProcessing configuration dumps:
- express cosmics: FEVT goes back to the cosmics content (nothing else changes)
- prompt comsics:  unchanged
- prompt and express pp is unchanged
