### PR TITLE
Bugfix in the BoostedDoubleSV tagger (81X)

### DIFF
--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -360,7 +360,7 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
               tau1_flightDistance2dSig =svTagInfo.flightDistance(vtx,true).significance();
               tau1_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx),currentAxes[0]);
             }
-            etaRelToTauAxis(vertex, currentAxes[1], tau1_trackEtaRels);
+            etaRelToTauAxis(vertex, currentAxes[0], tau1_trackEtaRels);
             tau1_nSecondaryVertices += 1.;
     }
 


### PR DESCRIPTION
Bugfix for the BoostedDoubleSV tagger. The bug is expected to manifest itself in extremely rare instances where a jet has only one constituent. The fix has no impact on RECO (since the tagger is not run there) but could impact MiniAOD in those rare instances.
