### PR TITLE
Quadruplet seeding by propagating triplet to 4th layer

### DIFF
--- a/Calibration/IsolatedParticles/python/isoTrack_cff.py
+++ b/Calibration/IsolatedParticles/python/isoTrack_cff.py
@@ -30,7 +30,10 @@ hltHITPixelTracksHB = cms.EDProducer("PixelTrackProducer",
             beamSpot = cms.InputTag( "hltOnlineBeamSpot" )
             )
         ),
-                                     CleanerPSet = cms.PSet(  ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ) ),
+                                     CleanerPSet = cms.PSet(
+                                         ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ),
+                                         useQuadrupletAlgo = cms.bool(False)
+                                     ),
                                      OrderedHitsFactoryPSet = cms.PSet( 
         ComponentName = cms.string( "StandardHitTripletGenerator" ),
         SeedingLayers = cms.string( "hltESPPixelLayerTripletsHITHB" ),
@@ -74,7 +77,10 @@ hltHITPixelTracksHE = cms.EDProducer("PixelTrackProducer",
             ptMin = cms.double( 0.35 )
             )
         ),
-                                     CleanerPSet = cms.PSet(  ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ) ),
+                                     CleanerPSet = cms.PSet(
+                                         ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ),
+                                         useQuadrupletAlgo = cms.bool(False)
+                                     ),
                                      OrderedHitsFactoryPSet = cms.PSet( 
         ComponentName = cms.string( "StandardHitTripletGenerator" ),
         GeneratorPSet = cms.PSet( 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -20,11 +20,21 @@ def esproducers_by_type(process, *types):
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+# Add quadruplet-specific pixel track duplicate cleaning mode (PR #13753)
+def customiseFor13753(process):
+    for producer in producers_by_type(process, "PixelTrackProducer"):
+        if producer.CleanerPSet.ComponentName.value() == "PixelTrackCleanerBySharedHits" and not hasattr(producer.CleanerPSet, "useQuadrupletAlgo"):
+            producer.CleanerPSet.useQuadrupletAlgo = cms.bool(False)
+    return process
+
 #
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     import os
     cmsswVersion = os.environ['CMSSW_VERSION']
+
+    if cmsswVersion >= "CMSSW_8_1":
+        process = customiseFor13753(process)
 
     if cmsswVersion >= "CMSSW_8_0":
 #       process = customiseFor12718(process)

--- a/RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
@@ -41,6 +41,7 @@ hiPixel3ProtoTracks = cms.EDProducer( "PixelTrackProducer",
 	
     # Cleaner
     CleanerPSet = cms.PSet(  
-      ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ) 
+      ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ),
+      useQuadrupletAlgo = cms.bool(False),
     )
 )

--- a/RecoMuon/L3MuonProducer/test/newL3.py
+++ b/RecoMuon/L3MuonProducer/test/newL3.py
@@ -73,7 +73,10 @@ def addL3ToHLT(process):
 	        beamSpot = cms.InputTag( "hltOnlineBeamSpot" )
 	      )
 	    ),
-	    CleanerPSet = cms.PSet(  ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ) ),
+	    CleanerPSet = cms.PSet(
+              ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ),
+              useQuadrupletAlgo = cms.bool(False)
+            ),
 	    OrderedHitsFactoryPSet = cms.PSet(
 	      ComponentName = cms.string( "StandardHitTripletGenerator" ),
 	      GeneratorPSet = cms.PSet(
@@ -457,7 +460,10 @@ def addL3ToHLT(process):
 	        beamSpot = cms.InputTag( "hltOnlineBeamSpot" )
 	      )
 	    ),
-	    CleanerPSet = cms.PSet(  ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ) ),
+	    CleanerPSet = cms.PSet(
+              ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ),
+              useQuadrupletAlgo = cms.bool(False)
+            ),
 	    OrderedHitsFactoryPSet = cms.PSet(
 	      ComponentName = cms.string( "StandardHitTripletGenerator" ),
 	      GeneratorPSet = cms.PSet(
@@ -512,7 +518,10 @@ def addL3ToHLT(process):
 	      fixImpactParameter = cms.double( 0.0 )
 	    ),
 	    RegionFactoryPSet = IterMasterMuonTrackingRegionBuilder,
-	    CleanerPSet = cms.PSet(  ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ) ),
+	    CleanerPSet = cms.PSet(
+              ComponentName = cms.string( "PixelTrackCleanerBySharedHits" ),
+              useQuadrupletAlgo = cms.bool(False)
+            ),
 	    OrderedHitsFactoryPSet = cms.PSet(
 	      ComponentName = cms.string( "StandardHitTripletGenerator" ),
 	      GeneratorPSet = cms.PSet(

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -31,7 +31,7 @@ class   PixelTripletLowPtGenerator :
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
-                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
  private:

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -77,7 +77,7 @@ void PixelTripletLowPtGenerator::hitTriplets(
     OrderedHitTriplets & result,
     const edm::Event & ev,
     const edm::EventSetup& es,
-    SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+    const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
     const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 {
 

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
@@ -24,7 +24,8 @@ public:
   typedef pixeltrackfitting::TracksWithRecHits TracksWithRecHits;
   virtual TracksWithRecHits cleanTracks(const TracksWithRecHits & tracksWithRecHits, const TrackerTopology *tTopo);
 
-
+private:
+  const bool useQuadrupletAlgo_;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
@@ -30,7 +30,8 @@ PixelTrackReconstructionBlock = cms.PSet (
         )
     ),
     CleanerPSet = cms.PSet(
-        ComponentName = cms.string('PixelTrackCleanerBySharedHits')
+        ComponentName = cms.string('PixelTrackCleanerBySharedHits'),
+        useQuadrupletAlgo = cms.bool(False),
     )
 )
 

--- a/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h
@@ -1,0 +1,38 @@
+#ifndef HitQuadrupletGenerator_H
+#define HitQuadrupletGenerator_H
+
+/** abstract interface for generators of hit triplets pairs
+ *  compatible with a TrackingRegion.
+ */
+
+#include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitSeeds.h"
+
+#include "FWCore/Utilities/interface/RunningAverage.h"
+
+class TrackingRegion;
+namespace edm { class Event; class EventSetup; }
+#include <vector>
+
+class HitQuadrupletGenerator : public OrderedHitsGenerator {
+public:
+
+  HitQuadrupletGenerator(unsigned int size=500);
+
+  virtual ~HitQuadrupletGenerator() { }
+
+  virtual const OrderedHitSeeds & run(
+    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es) final;
+
+  virtual void hitQuadruplets( const TrackingRegion& reg, OrderedHitSeeds& prs,
+      const edm::Event & ev,  const edm::EventSetup& es) = 0;
+
+  virtual void clear() final;
+
+private:
+  OrderedHitSeeds theQuadruplets;
+  edm::RunningAverage localRA;
+};
+
+
+#endif

--- a/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h
@@ -1,0 +1,37 @@
+#ifndef RecoPixelVertexing_PixelTriplets_HitQuadrupletGeneratorFromTripletAndLayers_h
+#define RecoPixelVertexing_PixelTriplets_HitQuadrupletGeneratorFromTripletAndLayers_h
+
+/** A HitQuadrupletGenerator from HitTripletGenerator and vector of
+    Layers. The HitTripletGenerator provides a set of hit triplets.
+    For each triplet the search for compatible hit(s) is done among
+    provided Layers
+ */
+
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitSeeds.h"
+#include <vector>
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+
+class HitTripletGeneratorFromPairAndLayers;
+
+class HitQuadrupletGeneratorFromTripletAndLayers {
+
+public:
+  typedef LayerHitMapCache  LayerCacheType;
+
+  HitQuadrupletGeneratorFromTripletAndLayers();
+  virtual ~HitQuadrupletGeneratorFromTripletAndLayers();
+
+  void init( std::unique_ptr<HitTripletGeneratorFromPairAndLayers>&& tripletGenerator, LayerCacheType* layerCache);
+
+  virtual void hitQuadruplets( const TrackingRegion& region, OrderedHitSeeds& result,
+                               const edm::Event& ev, const edm::EventSetup& es,
+                               SeedingLayerSetsHits::SeedingLayerSet tripletLayers,
+                               const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers) = 0;
+
+protected:
+  std::unique_ptr<HitTripletGeneratorFromPairAndLayers> theTripletGenerator;
+  LayerCacheType *theLayerCache;
+};
+#endif
+

--- a/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h
@@ -26,7 +26,7 @@ public:
 
   virtual void hitQuadruplets( const TrackingRegion& region, OrderedHitSeeds& result,
                                const edm::Event& ev, const edm::EventSetup& es,
-                               SeedingLayerSetsHits::SeedingLayerSet tripletLayers,
+                               const SeedingLayerSetsHits::SeedingLayerSet& tripletLayers,
                                const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers) = 0;
 
 protected:

--- a/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayersFactory.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayersFactory.h
@@ -1,0 +1,12 @@
+#ifndef PixelTriplets_HitQuadrupletGeneratorFromTripletAndLayersFactory_H
+#define PixelTriplets_HitQuadrupletGeneratorFromTripletAndLayersFactory_H
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+
+namespace edm {class ParameterSet; class ConsumesCollector;}
+
+typedef edmplugin::PluginFactory<HitQuadrupletGeneratorFromTripletAndLayers *(const edm::ParameterSet &, edm::ConsumesCollector&)>
+	HitQuadrupletGeneratorFromTripletAndLayersFactory;
+
+#endif

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h
@@ -31,7 +31,7 @@ public:
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
-                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) = 0;
 protected:
   std::unique_ptr<HitPairGeneratorFromLayerPair> thePairGenerator;

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="RecoTracker/TkTrackingRegions"/>
 <use   name="RecoPixelVertexing/PixelTriplets"/>
 <use   name="RecoTracker/TkSeedingLayers"/>
+<use   name="RecoPixelVertexing/PixelTrackFitting"/>
 <library   file="*.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitQuadrupletGenerator.cc
@@ -1,0 +1,50 @@
+#include "CombinedHitQuadrupletGenerator.h"
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayersFactory.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayersFactory.h"
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "LayerQuadruplets.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+
+using namespace std;
+using namespace ctfseeding;
+
+CombinedHitQuadrupletGenerator::CombinedHitQuadrupletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC):
+  theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers")))
+{
+  edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
+  std::string       generatorName = generatorPSet.getParameter<std::string>("ComponentName");
+  edm::ParameterSet tripletGeneratorPSet = cfg.getParameter<edm::ParameterSet>("TripletGeneratorPSet");
+  std::string tripletGeneratorName = tripletGeneratorPSet.getParameter<std::string>("ComponentName");
+
+  std::unique_ptr<HitTripletGeneratorFromPairAndLayers> tripletGenerator(HitTripletGeneratorFromPairAndLayersFactory::get()->create(tripletGeneratorName, tripletGeneratorPSet, iC));
+  // Some CPU wasted here because same pairs are generated multiple times
+  tripletGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
+
+  theGenerator.reset(HitQuadrupletGeneratorFromTripletAndLayersFactory::get()->create(generatorName, generatorPSet, iC));
+  theGenerator->init(std::move(tripletGenerator), &theLayerCache);
+}
+
+CombinedHitQuadrupletGenerator::~CombinedHitQuadrupletGenerator() {}
+
+void CombinedHitQuadrupletGenerator::hitQuadruplets(
+   const TrackingRegion& region, OrderedHitSeeds & result,
+   const edm::Event& ev, const edm::EventSetup& es)
+{
+  edm::Handle<SeedingLayerSetsHits> hlayers;
+  ev.getByToken(theSeedingLayerToken, hlayers);
+  const SeedingLayerSetsHits& layers = *hlayers;
+  if(layers.numberOfLayersInSet() != 4)
+    throw cms::Exception("Configuration") << "CombinedHitQuadrupletsGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 4, got " << layers.numberOfLayersInSet();
+
+  std::vector<LayerQuadruplets::LayerSetAndLayers> quadlayers = LayerQuadruplets::layers(layers);
+  for(const auto& tripletAndLayers: quadlayers) {
+    theGenerator->hitQuadruplets(region, result, ev, es, tripletAndLayers.first, tripletAndLayers.second);
+  }
+  theLayerCache.clear();
+}

--- a/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitQuadrupletGenerator.h
@@ -1,0 +1,44 @@
+#ifndef CombinedHitQuadrupletGenerator_H
+#define CombinedHitQuadrupletGenerator_H
+
+/** A HitQuadrupletGenerator consisting of a set of
+ *  quadruplet generators of type HitQuadrupletGeneratorFromPairAndLayers
+ *  initialised from provided layers in the form of PixelLayerQuadruplets
+ */
+
+#include <vector>
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+
+class TrackingRegion;
+class HitQuadrupletGeneratorFromTripletAndLayers;
+class SeedingLayerSetsHits;
+
+namespace edm { class Event; }
+namespace edm { class EventSetup; }
+
+class CombinedHitQuadrupletGenerator : public HitQuadrupletGenerator {
+public:
+  typedef LayerHitMapCache  LayerCacheType;
+
+public:
+
+  CombinedHitQuadrupletGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
+
+  virtual ~CombinedHitQuadrupletGenerator();
+
+  /// from base class
+  virtual void hitQuadruplets( const TrackingRegion& reg, OrderedHitSeeds & triplets,
+      const edm::Event & ev,  const edm::EventSetup& es);
+
+private:
+  edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
+
+  LayerCacheType            theLayerCache;
+
+  std::unique_ptr<HitQuadrupletGeneratorFromTripletAndLayers> theGenerator;
+};
+#endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/LayerQuadruplets.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/LayerQuadruplets.cc
@@ -1,0 +1,30 @@
+#include "LayerQuadruplets.h"
+
+namespace LayerQuadruplets {
+std::vector<LayerSetAndLayers> layers(const SeedingLayerSetsHits& sets) {
+  std::vector<LayerSetAndLayers> result;
+  if(sets.numberOfLayersInSet() != 4)
+    return result;
+
+  for(LayerSet set: sets) {
+    bool added = false;
+
+    for(auto ir = result.begin(); ir < result.end(); ++ir) {
+      const LayerSet & resTriplet = ir->first;
+      if(resTriplet[0].index() == set[0].index() &&
+         resTriplet[1].index() == set[1].index() &&
+         resTriplet[2].index() == set[2].index()) {
+        std::vector<Layer>& fourths = ir->second;
+        fourths.push_back( set[3] );
+        added = true;
+        break;
+      }
+    }
+    if (!added) {
+      LayerSetAndLayers ltl = std::make_pair(set, std::vector<Layer>(1, set[3]) );
+      result.push_back(ltl);
+    }
+  }
+  return result;
+}
+}

--- a/RecoPixelVertexing/PixelTriplets/plugins/LayerQuadruplets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/LayerQuadruplets.h
@@ -1,0 +1,23 @@
+#ifndef LayerQuadruplets_H
+#define LayerQuadruplets_H
+
+/** A class grouping pixel layers in triplets and associating a vector
+    of layers to each layer pair. The layer triplet is used to generate
+    hit triplets and the associated vector of layers to generate
+    a fourth hit confirming layer triplet
+ */
+
+#include <vector>
+#include <tuple>
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
+namespace LayerQuadruplets {
+  using Layer = SeedingLayerSetsHits::SeedingLayer;
+  using LayerSet = SeedingLayerSetsHits::SeedingLayerSet;
+  using LayerSetAndLayers = std::pair<LayerSet, std::vector<Layer> >;
+
+  std::vector<LayerSetAndLayers> layers(const SeedingLayerSetsHits& sets);
+};
+
+#endif
+

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
@@ -63,7 +63,7 @@ void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, Orde
   declareDynArray(KDTreeLinkerAlgo<unsigned int>, size, hitTree);
   float rzError[size]; //save maximum errors
 
-  ThirdHitRZPrediction<PixelRecoLineRZ> preds[size];
+  declareDynArray(ThirdHitRZPrediction<PixelRecoLineRZ>, size, preds);
 
   // Build KDtrees
   for(size_t il=0; il!=size; ++il) {
@@ -109,8 +109,7 @@ void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, Orde
 
     const double curvature = predictionRPhi.curvature(ThirdHitPredictionFromCircle::Vector2D(gp1.x(), gp1.y()));
 
-    constexpr float nSigmaRZ = std::sqrt(12.f);
-
+    constexpr float nSigmaRZ = 3.46410161514f; // std::sqrt(12.f); // ...and continue as before
 
     SeedingHitSet::ConstRecHitPointer selectedHit = nullptr;
     float selectedChi2 = std::numeric_limits<float>::max();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
@@ -1,0 +1,235 @@
+#include "PixelQuadrupletGenerator.h"
+#include "ThirdHitRZPrediction.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoLineRZ.h"
+
+#include "RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h"
+#include "RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h"
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+
+#include "RecoPixelVertexing/PixelTrackFitting/src/RZLine.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+
+#include "CommonTools/Utils/interface/DynArray.h"
+
+#include "FWCore/Utilities/interface/isFinite.h"
+
+typedef PixelRecoRange<float> Range;
+
+PixelQuadrupletGenerator::PixelQuadrupletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC):
+  extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")), //extra window in ThirdHitRZPrediction range
+  extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
+  maxChi2(cfg.getParameter<double>("maxChi2")),
+  keepTriplets(cfg.getParameter<bool>("keepTriplets"))
+{
+  if(cfg.exists("SeedComparitorPSet")) {
+    edm::ParameterSet comparitorPSet =
+      cfg.getParameter<edm::ParameterSet>("SeedComparitorPSet");
+    std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
+    if(comparitorName != "none") {
+      theComparitor.reset(SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC));
+    }
+  }
+}
+
+PixelQuadrupletGenerator::~PixelQuadrupletGenerator() {}
+
+
+void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, OrderedHitSeeds& result,
+                                              const edm::Event& ev, const edm::EventSetup& es,
+                                              SeedingLayerSetsHits::SeedingLayerSet tripletLayers,
+                                              const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers)
+{
+  if (theComparitor) theComparitor->init(ev, es);
+
+  OrderedHitTriplets triplets;
+  theTripletGenerator->hitTriplets(region, triplets, ev, es,
+                                   tripletLayers, // pair generator picks the correct two layers from these
+                                   std::vector<SeedingLayerSetsHits::SeedingLayer>{tripletLayers[2]});
+  if(triplets.empty()) return;
+
+  const size_t size = fourthLayers.size();
+
+  const RecHitsSortedInPhi *fourthHitMap[size];
+  typedef RecHitsSortedInPhi::Hit Hit;
+
+  using NodeInfo = KDTreeNodeInfo<unsigned int>;
+  std::vector<NodeInfo > layerTree; // re-used throughout
+  std::vector<unsigned int> foundNodes; // re-used thoughout
+
+  declareDynArray(KDTreeLinkerAlgo<unsigned int>, size, hitTree);
+  float rzError[size]; //save maximum errors
+
+  ThirdHitRZPrediction<PixelRecoLineRZ> preds[size];
+
+  // Build KDtrees
+  for(size_t il=0; il!=size; ++il) {
+    fourthHitMap[il] = &(*theLayerCache)(fourthLayers[il], region, ev, es);
+    auto const& hits = *fourthHitMap[il];
+
+    ThirdHitRZPrediction<PixelRecoLineRZ> & pred = preds[il];
+    pred.initLayer(fourthLayers[il].detLayer());
+    pred.initTolerance(extraHitRZtolerance);
+
+    layerTree.clear();
+    float maxphi = Geom::ftwoPi(), minphi = -maxphi; // increase to cater for any range
+    float minv=999999.0, maxv= -999999.0; // Initialise to extreme values in case no hits
+    float maxErr=0.0f;
+    for (unsigned int i=0; i!=hits.size(); ++i) {
+      auto angle = hits.phi(i);
+      auto v =  hits.gv(i);
+      //use (phi,r) for endcaps rather than (phi,z)
+      minv = std::min(minv,v);  maxv = std::max(maxv,v);
+      float myerr = hits.dv[i];
+      maxErr = std::max(maxErr,myerr);
+      layerTree.emplace_back(i, angle, v); // save it
+      if (angle < 0)  // wrap all points in phi
+	{ layerTree.emplace_back(i, angle+Geom::ftwoPi(), v);}
+      else
+	{ layerTree.emplace_back(i, angle-Geom::ftwoPi(), v);}
+    }
+    KDTreeBox phiZ(minphi, maxphi, minv-0.01f, maxv+0.01f);  // declare our bounds
+    //add fudge factors in case only one hit and also for floating-point inaccuracy
+    hitTree[il].build(layerTree, phiZ); // make KDtree
+    rzError[il] = maxErr; // save error
+  }
+
+
+  // Loop over triplets
+  for(const auto& triplet: triplets) {
+    GlobalPoint gp0 = triplet.inner()->globalPosition();
+    GlobalPoint gp1 = triplet.middle()->globalPosition();
+    GlobalPoint gp2 = triplet.outer()->globalPosition();
+
+    PixelRecoLineRZ line(gp0, gp2);
+    ThirdHitPredictionFromCircle predictionRPhi(gp0, gp2, extraHitRPhitolerance);
+
+    const double curvature = predictionRPhi.curvature(ThirdHitPredictionFromCircle::Vector2D(gp1.x(), gp1.y()));
+
+    constexpr float nSigmaRZ = std::sqrt(12.f);
+
+
+    SeedingHitSet::ConstRecHitPointer selectedHit = nullptr;
+    float selectedChi2 = std::numeric_limits<float>::max();
+    unsigned nLayersWithManyHits = 0;
+
+    auto isBarrel = [](const unsigned id) -> bool {
+      return id == PixelSubdetector::PixelBarrel;
+    };
+
+    std::vector<GlobalPoint> gps(4);
+    std::vector<GlobalError> ges(4);
+    std::vector<bool> barrels(4);
+    gps[0] = triplet.inner()->globalPosition();
+    ges[0] = triplet.inner()->globalPositionError();
+    barrels[0] = isBarrel(triplet.inner()->geographicalId().subdetId());
+
+    gps[1] = triplet.middle()->globalPosition();
+    ges[1] = triplet.middle()->globalPositionError();
+    barrels[1] = isBarrel(triplet.middle()->geographicalId().subdetId());
+
+    gps[2] = triplet.outer()->globalPosition();
+    ges[2] = triplet.outer()->globalPositionError();
+    barrels[2] = isBarrel(triplet.outer()->geographicalId().subdetId());
+
+    for(size_t il=0; il!=size; ++il) {
+      if(hitTree[il].empty()) continue; // Don't bother if no hits
+
+      auto const& hits = *fourthHitMap[il];
+      const DetLayer *layer = fourthLayers[il].detLayer();
+      bool barrelLayer = layer->isBarrel();
+
+      auto& predictionRZ = preds[il];
+      predictionRZ.initPropagator(&line);
+      Range rzRange = predictionRZ(); // z in barrel, r in endcap
+
+      // construct search box and search
+      Range phiRange;
+      if(barrelLayer) {
+        auto radius = static_cast<const BarrelDetLayer *>(layer)->specificSurface().radius();
+        double phi = predictionRPhi.phi(curvature, radius);
+        //double tol = extraHitRPhitolerance/radius;
+        const double tol = 0.15;
+        phiRange = Range(phi-tol, phi+tol);
+      }
+      else {
+        double phi1 = predictionRPhi.phi(curvature, rzRange.min());
+        double phi2 = predictionRPhi.phi(curvature, rzRange.max());
+        const double tol = 0.15;
+        phiRange = Range(std::min(phi1, phi2)-tol, std::max(phi1, phi2)+tol);
+      }
+
+      KDTreeBox phiZ(phiRange.min(), phiRange.max(),
+                     rzRange.min()-nSigmaRZ*rzError[il],
+                     rzRange.max()+nSigmaRZ*rzError[il]);
+
+      foundNodes.clear();
+      hitTree[il].search(phiZ, foundNodes);
+
+      if(foundNodes.empty()) {
+        continue;
+      }
+
+      std::vector<std::tuple<unsigned int, float> > passedQualityCuts; // hit index, chi2
+      constexpr unsigned kHitIndex = 0;
+      constexpr unsigned kChi2 = 1;
+      for(auto hitIndex: foundNodes) {
+        const auto& hit = hits.theHits[hitIndex].hit();
+
+        // Reject comparitor. For now, because of technical
+        // limitations, pass three hits to the comparitor
+        if(theComparitor) {
+          SeedingHitSet tmpTriplet(triplet.inner(), triplet.outer(), hit);
+          if(!theComparitor->compatible(tmpTriplet, region)) {
+            continue;
+          }
+        }
+
+        gps[3] = hit->globalPosition();
+        ges[3] = hit->globalPositionError();
+        barrels[3] = isBarrel(hit->geographicalId().subdetId());
+
+        RZLine rzLine(gps, ges, barrels);
+        float  cottheta, intercept, covss, covii, covsi;
+        rzLine.fit(cottheta, intercept, covss, covii, covsi);
+        float chi2 = rzLine.chi2(cottheta, intercept);
+        if(edm::isNotFinite(chi2) || chi2 > maxChi2) {
+          continue;
+        }
+
+        passedQualityCuts.push_back(std::make_tuple(hitIndex, chi2));
+      }
+
+      if(passedQualityCuts.empty()) {
+        continue;
+      }
+
+      if(passedQualityCuts.size() == 1) {
+        unsigned index = std::get<kHitIndex>(passedQualityCuts[0]);
+        const auto& hit = hits.theHits[index].hit();
+        float chi2 = std::get<kChi2>(passedQualityCuts[0]);
+
+        if(chi2 < selectedChi2) {
+          selectedHit = hit;
+          selectedChi2 = chi2;
+        }
+      }
+      else {
+        ++nLayersWithManyHits;
+      }
+    }
+
+    if(nLayersWithManyHits == 0) {
+      if(selectedHit) {
+        SeedingHitSet quadruplet(triplet.inner(), triplet.middle(), triplet.outer(), selectedHit);
+        result.push_back(quadruplet);
+      }
+    }
+    else if(keepTriplets) {
+      result.push_back(triplet);
+    }
+  }
+}

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
@@ -40,7 +40,7 @@ PixelQuadrupletGenerator::~PixelQuadrupletGenerator() {}
 
 void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, OrderedHitSeeds& result,
                                               const edm::Event& ev, const edm::EventSetup& es,
-                                              SeedingLayerSetsHits::SeedingLayerSet tripletLayers,
+                                              const SeedingLayerSetsHits::SeedingLayerSet& tripletLayers,
                                               const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers)
 {
   if (theComparitor) theComparitor->init(ev, es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
@@ -1,0 +1,38 @@
+#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+#include "CombinedHitQuadrupletGenerator.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingLayer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h"
+
+#include <utility>
+#include <vector>
+
+class SeedComparitor;
+
+class PixelQuadrupletGenerator : public HitQuadrupletGeneratorFromTripletAndLayers {
+
+typedef CombinedHitQuadrupletGenerator::LayerCacheType       LayerCacheType;
+
+public:
+  PixelQuadrupletGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
+
+  virtual ~PixelQuadrupletGenerator();
+
+  virtual void hitQuadruplets( const TrackingRegion& region, OrderedHitSeeds& result,
+                               const edm::Event & ev, const edm::EventSetup& es,
+                               SeedingLayerSetsHits::SeedingLayerSet tripletLayers,
+                               const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers) override;
+
+private:
+  std::unique_ptr<SeedComparitor> theComparitor;
+
+  const double extraHitRZtolerance;
+  const double extraHitRPhitolerance;
+  const double maxChi2;
+  const bool keepTriplets;
+};
+
+
+

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
@@ -22,7 +22,7 @@ public:
 
   virtual void hitQuadruplets( const TrackingRegion& region, OrderedHitSeeds& result,
                                const edm::Event & ev, const edm::EventSetup& es,
-                               SeedingLayerSetsHits::SeedingLayerSet tripletLayers,
+                               const SeedingLayerSetsHits::SeedingLayerSet& tripletLayers,
                                const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers) override;
 
 private:

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -57,7 +57,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 					   OrderedHitTriplets & result,
 					   const edm::Event & ev,
 					   const edm::EventSetup& es,
-					   SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+					   const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
 					   const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -28,7 +28,7 @@ public:
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
-                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -74,7 +74,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 						OrderedHitTriplets & result,
 						const edm::Event & ev,
 						const edm::EventSetup& es,
-						SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+						const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
 						const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 { 
   edm::ESHandle<TrackerGeometry> tracker;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
@@ -27,7 +27,7 @@ public:
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
-                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -37,7 +37,7 @@ void PixelTripletNoTipGenerator::hitTriplets(
     OrderedHitTriplets & result,
     const edm::Event & ev,
     const edm::EventSetup& es,
-    SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+    const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
     const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.h
@@ -19,7 +19,7 @@ public:
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
-                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:

--- a/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
@@ -18,3 +18,10 @@ DEFINE_EDM_PLUGIN(HitTripletGeneratorFromPairAndLayersFactory,PixelTripletNoTipG
 #include "CombinedHitTripletGenerator.h"
 DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedHitTripletGenerator, "StandardHitTripletGenerator");
 
+#include "CombinedHitQuadrupletGenerator.h"
+DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedHitQuadrupletGenerator, "CombinedHitQuadrupletGenerator");
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayersFactory.h"
+#include "PixelQuadrupletGenerator.h"
+DEFINE_EDM_PLUGIN(HitQuadrupletGeneratorFromTripletAndLayersFactory, PixelQuadrupletGenerator, "PixelQuadrupletGenerator");

--- a/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGenerator.cc
@@ -1,0 +1,20 @@
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h"
+
+HitQuadrupletGenerator::HitQuadrupletGenerator(unsigned int nSize): localRA(nSize) {}
+
+const OrderedHitSeeds & HitQuadrupletGenerator::run(
+    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
+{
+  assert(theQuadruplets.size()==0);assert(theQuadruplets.capacity()==0);
+  theQuadruplets.reserve(localRA.upper());
+  hitQuadruplets(region, theQuadruplets, ev, es);
+  localRA.update(theQuadruplets.size());
+  theQuadruplets.shrink_to_fit();
+  return theQuadruplets;
+}
+
+void HitQuadrupletGenerator::clear()
+{
+  theQuadruplets.clear(); theQuadruplets.shrink_to_fit();
+}
+

--- a/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGeneratorFromTripletAndLayers.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGeneratorFromTripletAndLayers.cc
@@ -1,0 +1,13 @@
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+
+HitQuadrupletGeneratorFromTripletAndLayers::HitQuadrupletGeneratorFromTripletAndLayers():
+  theLayerCache(nullptr)
+{}
+
+HitQuadrupletGeneratorFromTripletAndLayers::~HitQuadrupletGeneratorFromTripletAndLayers() {}
+
+void HitQuadrupletGeneratorFromTripletAndLayers::init(std::unique_ptr<HitTripletGeneratorFromPairAndLayers>&& tripletGenerator, LayerCacheType *layerCache) {
+  theTripletGenerator = std::move(tripletGenerator);
+  theLayerCache = layerCache;
+}

--- a/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGeneratorFromTripletAndLayersFactory.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGeneratorFromTripletAndLayersFactory.cc
@@ -1,0 +1,6 @@
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayersFactory.h"
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+
+EDM_REGISTER_PLUGINFACTORY(HitQuadrupletGeneratorFromTripletAndLayersFactory,"HitQuadrupletGeneratorFromTripletAndLayersFactory");
+

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsByPropagation.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsByPropagation.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseForQuadrupletsByPropagation(process):
+    for module in process._Process__producers.values():
+        if not hasattr(module, "SeedMergerPSet"):
+            continue
+
+        # Adjust seeding layers
+        seedingLayersName = module.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
+        seedingLayersModule = getattr(process, seedingLayersName)
+        seedingLayersModule.layerList = process.PixelSeedMergerQuadruplets.layerList.value()
+
+        # Configure seed generator / pixel track producer
+        del module.SeedMergerPSet
+        triplets = module.OrderedHitsFactoryPSet.clone()
+        module.OrderedHitsFactoryPSet = cms.PSet(
+            ComponentName = cms.string("CombinedHitQuadrupletGenerator"),
+            GeneratorPSet = cms.PSet(
+                ComponentName = cms.string("PixelQuadrupletGenerator"),
+                extraHitRZtolerance = triplets.GeneratorPSet.extraHitRZtolerance,
+                extraHitRPhitolerance = triplets.GeneratorPSet.extraHitRPhitolerance,
+                maxChi2 = cms.double(50),
+                keepTriplets = cms.bool(True)
+            ),
+            TripletGeneratorPSet = triplets.GeneratorPSet,
+            SeedingLayers = cms.InputTag(seedingLayersName),
+        )
+        if hasattr(triplets.GeneratorPSet, "SeedComparitorPSet"):
+            module.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = triplets.GeneratorPSet.SeedComparitorPSet
+
+        if module.type_() == "PixelTrackProducer":
+            module.CleanerPSet.useQuadrupletAlgo = cms.bool(True)
+
+    return process


### PR DESCRIPTION
This PR adds code for the first prototype of quadruplet seeding by "propagating triplet to 4th layer and searching for compatible hits", discussed in TRK POG meetings March 14 https://indico.cern.ch/event/508493/contribution/3/attachments/1242946/1828945/slides.pdf and Feb 23 2015 https://indico.cern.ch/event/361404/contribution/3/attachments/719405/987513/slides.pdf. The algorithm is disabled by default, but a customize `--customise RecoTracker/Configuration/customiseForQuadrupletsByPropagation.customiseForQuadrupletsByPropagation` switching all triplet-merging cases to propagation in PixelTrackProducer and in seeding.

Although being still work in progress and disabled by default, integrating the code eases its maintenance and testing by other people.

Tested in 8_0_1_pre1, no changes expected in standard workflows.

I have here two sets of MTV plots (with 1000 TTbar+PU events in CMSSW_8_1_X_2016-03-15-1100)
- IB vs. this PR with customization https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_X_newquad_Phase1PU70/
- IB + #13736 vs.  this PR with customization https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_X_newquad_Phase1New/

@rovere @VinInn 
