### PR TITLE
Revert "updating  TrackerGeometry in Geometry/TrackerGeometryBuilder to accom…"

### DIFF
--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -311,12 +311,9 @@ float TrackerGeometry::getDetectorThickness(DetId detid) const {
 }
 
 TrackerGeometry::ModuleType TrackerGeometry::moduleType(const std::string& name) const {
-  if ( name.find("Pixel") != std::string::npos ){
-    if ( name.find("BarrelActive") != std::string::npos) return ModuleType::Ph1PXB;
-    else if ( name.find("ForwardSensor") != std::string::npos) return ModuleType::Ph1PXF;
-    else if ( name.find("BModule") != std::string::npos && name.find("InnerPixelActive") != std::string::npos ) return ModuleType::Ph2PXB;
-    else if ( name.find("EModule") != std::string::npos && name.find("InnerPixelActive") != std::string::npos ) return ModuleType::Ph2PXF;
-  } else if ( name.find("TIB") != std::string::npos) {
+  if ( name.find("PixelBarrel") != std::string::npos) return ModuleType::Ph1PXB;
+  else if (name.find("PixelForward") != std::string::npos) return ModuleType::Ph1PXF;
+  else if ( name.find("TIB") != std::string::npos) {
     if ( name.find("0") != std::string::npos) return ModuleType::IB1;
     else return ModuleType::IB2;
   } else if ( name.find("TOB") != std::string::npos) {

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -105,8 +105,7 @@ namespace cms
     rndEngine_ = &(rng->getEngine(lumi.index()));
 
     iSetup.get<IdealMagneticFieldRecord>().get(pSetup_);
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-
+    iSetup.get<IdealGeometryRecord>().get(tTopoHand);
     
     if (theTkDigiGeomWatcher.check(iSetup)) {
       iSetup.get<TrackerDigiGeometryRecord>().get(geometryType_, pDD_);
@@ -224,10 +223,10 @@ namespace cms
     TrackerGeometry::ModuleType mType = pDD_->getDetectorType(detId);    
     switch(mType){
 
-    case TrackerGeometry::ModuleType::Ph2PXB:
+    case TrackerGeometry::ModuleType::Ph1PXB:
       algotype = AlgorithmType::InnerPixel;
       break;
-    case TrackerGeometry::ModuleType::Ph2PXF:
+    case TrackerGeometry::ModuleType::Ph1PXF:
       algotype = AlgorithmType::InnerPixel;
       break;
     case TrackerGeometry::ModuleType::Ph2PSP:


### PR DESCRIPTION
Reverts cms-sw/cmssw#13706

The PR I am reverting is using new names for the phase2 digitizer which are not yet defined in the Geometry (for Tracker Phase2), therefore I'm reverting this PR as long as the new names in the Tracker Phase2 Geometry are not defined, 
