### PR TITLE
Remove duplicated functions in Provenance.h

### DIFF
--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -40,9 +40,7 @@ namespace edm {
     StableProvenance const& stable() const {return stableProvenance_;}
     StableProvenance& stable() {return stableProvenance_;}
 
-    BranchDescription const& product() const {return branchDescription();}
     BranchDescription const& branchDescription() const {return stable().branchDescription();}
-    BranchDescription const& constBranchDescription() const {return branchDescription();}
     std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return stable().constBranchDescriptionPtr();}
 
     ProductProvenance const* productProvenance() const;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -767,7 +767,7 @@ namespace edm {
       if(productResolver->singleProduct() && productResolver->provenanceAvailable() && !productResolver->branchDescription().isAlias()) {
         // We do not attempt to get the event/lumi/run status from the provenance,
         // because the per event provenance may have been dropped.
-        if(productResolver->provenance()->product().present()) {
+        if(productResolver->provenance()->branchDescription().present()) {
            provenances.push_back(productResolver->provenance());
         }
       }

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -324,7 +324,7 @@ namespace edmtest {
       e.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 11);
 
-      edm::BranchID const& originalBranchID = h_thing.provenance()->constBranchDescription().originalBranchID();
+      edm::BranchID const& originalBranchID = h_thing.provenance()->branchDescription().originalBranchID();
       bool foundOriginalInRegistry = false;
       edm::Service<edm::ConstProductRegistry> reg;
       // Loop over provenance of products in registry.
@@ -403,7 +403,7 @@ namespace edmtest {
       run.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 100001);
 
-      edm::BranchID const& originalBranchID = h_thing.provenance()->constBranchDescription().originalBranchID();
+      edm::BranchID const& originalBranchID = h_thing.provenance()->branchDescription().originalBranchID();
       bool foundOriginalInRegistry = false;
       edm::Service<edm::ConstProductRegistry> reg;
       // Loop over provenance of products in registry.
@@ -472,7 +472,7 @@ namespace edmtest {
       lumi.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 1001);
 
-      edm::BranchID const& originalBranchID = h_thing.provenance()->constBranchDescription().originalBranchID();
+      edm::BranchID const& originalBranchID = h_thing.provenance()->branchDescription().originalBranchID();
       bool foundOriginalInRegistry = false;
       edm::Service<edm::ConstProductRegistry> reg;
       // Loop over provenance of products in registry.

--- a/FWCore/Modules/src/AsciiOutputModule.cc
+++ b/FWCore/Modules/src/AsciiOutputModule.cc
@@ -61,9 +61,8 @@ namespace edm {
     // Write out non-EDProduct contents...
 
     // ... list of process-names
-    for (ProcessHistory::const_iterator it = e.processHistory().begin(), itEnd = e.processHistory().end();
-        it != itEnd; ++it) {
-      LogAbsolute("AsciiOut") << it->processName() << " ";
+    for (auto const& process : e.processHistory()) {
+      LogAbsolute("AsciiOut") << process.processName() << " ";
     }
 
     // ... collision id
@@ -73,13 +72,10 @@ namespace edm {
 
     std::vector<Provenance const*> provs;
     e.getAllProvenance(provs);
-    for(std::vector<Provenance const*>::const_iterator i = provs.begin(),
-         iEnd = provs.end();
-         i != iEnd;
-         ++i) {
-      BranchDescription const& desc = (*i)->product();
+    for(auto const& prov : provs) {
+      BranchDescription const& desc = prov->branchDescription();
       if (selected(desc)) {
-        LogAbsolute("AsciiOut") << **i << '\n';
+        LogAbsolute("AsciiOut") << *prov << '\n';
       }
     }
   }

--- a/HLTrigger/btau/src/HLTJetTag.cc
+++ b/HLTrigger/btau/src/HLTJetTag.cc
@@ -100,7 +100,7 @@ HLTJetTag<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger
   if (not dependent.isNull() and not dependent.hasCache()) {
     // only an empty AssociationVector can have a invalid dependent collection
     edm::Provenance const & dependent_provenance = event.getProvenance(dependent.id());
-    if (dependent_provenance.constBranchDescription().dropped())
+    if (dependent_provenance.branchDescription().dropped())
       // FIXME the error message should be made prettier
       throw edm::Exception(edm::errors::ProductNotFound) << "Product " << handle.provenance()->branchName() << " requires product " << dependent_provenance.branchName() << ", which has been dropped";
   }

--- a/HLTrigger/btau/src/HLTJetTagWithMatching.cc
+++ b/HLTrigger/btau/src/HLTJetTagWithMatching.cc
@@ -116,7 +116,7 @@ HLTJetTagWithMatching<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
   if (not dependent.isNull() and not dependent.hasCache()) {
     // only an empty AssociationVector can have a invalid dependent collection
     edm::Provenance const & dependent_provenance = event.getProvenance(dependent.id());
-    if (dependent_provenance.constBranchDescription().dropped())
+    if (dependent_provenance.branchDescription().dropped())
       // FIXME the error message should be made prettier
       throw edm::Exception(edm::errors::ProductNotFound) << "Product " << handle.provenance()->branchName() << " requires product " << dependent_provenance.branchName() << ", which has been dropped";
   }

--- a/IOPool/Input/test/ProductInfo.h
+++ b/IOPool/Input/test/ProductInfo.h
@@ -30,7 +30,7 @@ class ProductInfo {
 
 ProductInfo::ProductInfo(const edm::Provenance &prov, TBranch & branch, edm::EDGetToken const& token) :
     m_tag(prov.moduleLabel(), prov.productInstanceName(), prov.processName()),
-    m_type(prov.product().unwrappedTypeID()),
+    m_type(prov.branchDescription().unwrappedTypeID()),
     m_token(token),
     m_size(0)
 {

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -777,7 +777,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event& iEvent)
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->product()).moduleLabel() == "generatorSmeared")
+    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -787,7 +787,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event& iEvent)
     validHepMCevt = false;
   } else {
     eventout += "\n          Using HepMCProduct: ";
-    eventout += (HepMCEvt.provenance()->product()).moduleLabel();
+    eventout += (HepMCEvt.provenance()->branchDescription()).moduleLabel();
   }
   if (validHepMCevt) {
     const HepMC::GenEvent* MCEvt = HepMCEvt->GetEvent();

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -760,7 +760,7 @@ void GlobalHitsProdHist::fillG4MC(edm::Event& iEvent)
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->product()).moduleLabel() == "generatorSmeared")
+    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -770,7 +770,7 @@ void GlobalHitsProdHist::fillG4MC(edm::Event& iEvent)
     return;
   } else {
     eventout += "\n          Using HepMCProduct: ";
-    eventout += (HepMCEvt.provenance()->product()).moduleLabel();
+    eventout += (HepMCEvt.provenance()->branchDescription()).moduleLabel();
   }
   const HepMC::GenEvent* MCEvt = HepMCEvt->GetEvent();
   nRawGenPart = MCEvt->particles_size();

--- a/Validation/GlobalHits/src/GlobalHitsProdHistStripper.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHistStripper.cc
@@ -169,23 +169,23 @@ void GlobalHitsProdHistStripper::endRun(const edm::Run& iRun,
     /*
     std::cout << "Extracting histogram: " << std::endl
 	      << "       Module       : "
-	      << (histogram1D.provenance()->product()).moduleLabel()
+	      << (histogram1D.provenance()->branchDescription()).moduleLabel()
 	      << std::endl
 	      << "       ProductID    : "
-	      << (histogram1D.provenance()->product()).productID().id()
+	      << (histogram1D.provenance()->branchDescription()).productID().id()
 	      << std::endl
 	      << "       ClassName    : "
-	      << (histogram1D.provenance()->product()).className()
+	      << (histogram1D.provenance()->branchDescription()).className()
 	      << std::endl
 	      << "       InstanceName : "
-	      << (histogram1D.provenance()->product()).productInstanceName()
+	      << (histogram1D.provenance()->branchDescription()).productInstanceName()
 	      << std::endl
 	      << "       BranchName   : "
-	      << (histogram1D.provenance()->product()).branchName()
+	      << (histogram1D.provenance()->branchDescription()).branchName()
 	      << std::endl;
     */
 
-    if ((histogram1D.provenance()->product()).moduleLabel()
+    if ((histogram1D.provenance()->branchDescription()).moduleLabel()
 	!= "globalhitsprodhist") continue;
    
     std::string histname = histogram1D->GetName();

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -290,7 +290,7 @@ void GlobalHitsProducer::fillG4MC(edm::Event& iEvent)
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->product()).moduleLabel() == "generatorSmeared")
+    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -300,7 +300,7 @@ void GlobalHitsProducer::fillG4MC(edm::Event& iEvent)
     return;
   } else {
     eventout += "\n          Using HepMCProduct: ";
-    eventout += (HepMCEvt.provenance()->product()).moduleLabel();
+    eventout += (HepMCEvt.provenance()->branchDescription()).moduleLabel();
   }
   const HepMC::GenEvent* MCEvt = HepMCEvt->GetEvent();
   nRawGenPart = MCEvt->particles_size();


### PR DESCRIPTION
For historical reasons, the class "Provenance" has three different member functions that are identical except for the function name. This PR removes two of them, constBranchDescription() and product(), and replaces calls to them with calls to the existing identical function, branchDescription().
It also replaces two iterator loops with two C++11 range based for loops in a file that was modified anyway. This PR should not cause any functional changes whatever.
