### PR TITLE
Adding new detectors - integration of RomanPot detectors for CTPPS project

### DIFF
--- a/DataFormats/DetId/interface/DetId.h
+++ b/DataFormats/DetId/interface/DetId.h
@@ -21,7 +21,7 @@ public:
   static const int kSubdetOffset       = 25;
 
 
-  enum Detector { Tracker=1,Muon=2,Ecal=3,Hcal=4,Calo=5,Forward=6 };
+  enum Detector { Tracker=1,Muon=2,Ecal=3,Hcal=4,Calo=5,Forward=6,Totem=7,CTPPS=8 };
   /// Create an empty or null id (also for persistence)
   DetId()  : id_(0) { }
   /// Create an id from a raw number

--- a/DataFormats/DetId/interface/DetId.h
+++ b/DataFormats/DetId/interface/DetId.h
@@ -21,7 +21,7 @@ public:
   static const int kSubdetOffset       = 25;
 
 
-  enum Detector { Tracker=1,Muon=2,Ecal=3,Hcal=4,Calo=5,Forward=6,Totem=7,CTPPS=8 };
+  enum Detector { Tracker=1,Muon=2,Ecal=3,Hcal=4,Calo=5,Forward=6,VeryForward=7 };
   /// Create an empty or null id (also for persistence)
   DetId()  : id_(0) { }
   /// Create an id from a raw number


### PR DESCRIPTION
Integration of RomanPot (RP) detectors for CTPPS.
DetId=7 refers to the standard sequence of Totem RP + Si Strips sensors.
These detectors are required in the early runs of CTPPS (2016 start of run).
DetId=8 refers to the baseline setup of CTPPS with new 3D pixel sensors (operative end of 2016)
and Timing sensors (operative mid 2016) installed in a new Roman Pot. 

The reason to have two DetId is to avoid possible clashes
