### PR TITLE
Deep const correctness for edm::value_ptr

### DIFF
--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -686,8 +686,8 @@ namespace edm {
         /// Returns the TTree entry of the first event which would be processed in the
         /// current run/lumi if all the events in the run/lumi were processed in the
         /// current processing order. If there are none it returns -1 (invalid).
-        EntryNumber_t firstEventEntryThisRun() const { return impl_->firstEventEntryThisRun(); }
-        EntryNumber_t firstEventEntryThisLumi() const { return impl_->firstEventEntryThisLumi(); }
+        EntryNumber_t firstEventEntryThisRun() { return impl_->firstEventEntryThisRun(); }
+        EntryNumber_t firstEventEntryThisLumi() { return impl_->firstEventEntryThisLumi(); }
 
         // This is intentionally not implemented.
         // It would be difficult to implement for the no sort mode,

--- a/FWCore/ParameterSet/interface/ANDGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ANDGroupDescription.h
@@ -51,15 +51,15 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
-    virtual bool hasNestedContent_() {
+    virtual bool hasNestedContent_() const {
       return true;
     }
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/AllowedLabelsDescription.h
+++ b/FWCore/ParameterSet/interface/AllowedLabelsDescription.h
@@ -73,7 +73,7 @@ namespace edm {
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & helper);
+                                     DocFormatHelper & helper) const;
 
     virtual void validateAllowedLabel_(std::string const& allowedLabel,
                                        ParameterSet & pset,
@@ -106,7 +106,7 @@ namespace edm {
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & helper);
+                                     DocFormatHelper & helper) const;
 
     virtual void validateAllowedLabel_(std::string const& allowedLabel,
                                        ParameterSet & pset,

--- a/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
@@ -29,7 +29,7 @@ namespace edm {
 
     void printNestedContentBase_(std::ostream & os,
                                  bool optional,
-                                 DocFormatHelper & dfh);
+                                 DocFormatHelper & dfh) const;
 
   private:
 
@@ -50,13 +50,13 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
-    virtual bool hasNestedContent_();
+    virtual bool hasNestedContent_() const;
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/EmptyGroupDescription.h
+++ b/FWCore/ParameterSet/interface/EmptyGroupDescription.h
@@ -38,7 +38,7 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/IfExistsDescription.h
+++ b/FWCore/ParameterSet/interface/IfExistsDescription.h
@@ -51,15 +51,15 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
-    virtual bool hasNestedContent_() {
+    virtual bool hasNestedContent_() const {
       return true;
     }
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/ORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ORGroupDescription.h
@@ -51,15 +51,15 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
-    virtual bool hasNestedContent_() {
+    virtual bool hasNestedContent_() const {
       return true;
     }
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/ParameterDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterDescription.h
@@ -170,7 +170,7 @@ namespace edm {
       return pset.existsAs<T>(label(), isTracked());
     }
 
-    virtual bool hasNestedContent_() {
+    virtual bool hasNestedContent_() const {
       if (!hasDefault()) return false;
       return writeParameterValue::hasNestedContent(value_);
     }
@@ -229,13 +229,13 @@ namespace edm {
 
     virtual void printDefault_(std::ostream& os,
                                  bool writeToCfi,
-                                 DocFormatHelper& dfh);
+                                 DocFormatHelper& dfh) const;
 
-    virtual bool hasNestedContent_();
+    virtual bool hasNestedContent_() const;
 
     virtual void printNestedContent_(std::ostream& os,
                                      bool optional,
-                                     DocFormatHelper& dfh);
+                                     DocFormatHelper& dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 
@@ -292,13 +292,13 @@ namespace edm {
 
     virtual void printDefault_(std::ostream& os,
                                bool writeToCfi,
-                               DocFormatHelper& dfh);
+                               DocFormatHelper& dfh) const;
 
-    virtual bool hasNestedContent_();
+    virtual bool hasNestedContent_() const;
 
     virtual void printNestedContent_(std::ostream& os,
                                      bool optional,
-                                     DocFormatHelper& dfh);
+                                     DocFormatHelper& dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
@@ -86,15 +86,15 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
     virtual void printDefault_(std::ostream & os,
                                  bool writeToCfi,
-                                 DocFormatHelper & dfh);
+                                 DocFormatHelper & dfh) const;
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     using ParameterDescriptionNode::exists_;
     virtual bool exists_(ParameterSet const& pset, bool isTracked) const = 0;

--- a/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
@@ -111,15 +111,15 @@ namespace edm {
     void print(std::ostream& os,
                bool optional,
                bool writeToCfi,
-               DocFormatHelper& dfh);
+               DocFormatHelper& dfh) const;
 
-    bool hasNestedContent() {
+    bool hasNestedContent() const {
       return hasNestedContent_();
     }
 
     void printNestedContent(std::ostream& os,
                             bool optional,
-                            DocFormatHelper& dfh);
+                            DocFormatHelper& dfh) const;
 
     // The next three functions are only called by the logical nodes
     // on their subnodes.  When executing these functions, the
@@ -233,15 +233,15 @@ namespace edm {
     virtual void print_(std::ostream&,
                         bool /*optional*/,
                         bool /*writeToCfi*/,
-                        DocFormatHelper&) { }
+                        DocFormatHelper&) const { }
 
-    virtual bool hasNestedContent_() {
+    virtual bool hasNestedContent_() const {
       return false;
     }
 
     virtual void printNestedContent_(std::ostream&,
                                      bool /*optional*/,
-                                     DocFormatHelper&) { }
+                                     DocFormatHelper&) const { }
 
     virtual bool exists_(ParameterSet const& pset) const = 0;
 

--- a/FWCore/ParameterSet/interface/ParameterSwitch.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitch.h
@@ -124,13 +124,13 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh) {
+                        DocFormatHelper & dfh) const {
       printBase(os, optional, writeToCfi, dfh, switch_.label(), switch_.isTracked(), parameterTypeEnumToString(switch_.type()));
     }
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh) {
+                                     DocFormatHelper & dfh) const {
 
       DocFormatHelper new_dfh(dfh);
       printNestedContentBase(os, dfh, new_dfh, switch_.label());

--- a/FWCore/ParameterSet/interface/ParameterSwitchBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitchBase.h
@@ -42,12 +42,12 @@ namespace edm {
                    bool isTracked,
                    std::string const& typeString) const;
 
-    virtual bool hasNestedContent_();
+    virtual bool hasNestedContent_() const;
 
     void printNestedContentBase(std::ostream & os,
                                 DocFormatHelper & dfh,
                                 DocFormatHelper & new_dfh,
-                                std::string const& switchLabel);
+                                std::string const& switchLabel) const;
 
     template <typename T>
     static void printCaseT(std::pair<T, edm::value_ptr<ParameterDescriptionNode> > const& p,

--- a/FWCore/ParameterSet/interface/ParameterWildcard.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcard.h
@@ -86,11 +86,11 @@ namespace edm {
                            std::set<std::string> & validatedLabels,
                            bool optional) const;
 
-    virtual bool hasNestedContent_();
+    virtual bool hasNestedContent_() const;
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & helper);
+                                     DocFormatHelper & helper) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 
@@ -122,11 +122,11 @@ namespace edm {
                            std::set<std::string> & validatedLabels,
                            bool optional) const;
 
-    virtual bool hasNestedContent_();
+    virtual bool hasNestedContent_() const;
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/ParameterWildcardBase.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardBase.h
@@ -57,7 +57,7 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
     virtual bool partiallyExists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/interface/XORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/XORGroupDescription.h
@@ -51,15 +51,15 @@ namespace edm {
     virtual void print_(std::ostream & os,
                         bool optional,
                         bool writeToCfi,
-                        DocFormatHelper & dfh);
+                        DocFormatHelper & dfh) const;
 
-    virtual bool hasNestedContent_() {
+    virtual bool hasNestedContent_() const {
       return true;
     }
 
     virtual void printNestedContent_(std::ostream & os,
                                      bool optional,
-                                     DocFormatHelper & dfh);
+                                     DocFormatHelper & dfh) const;
 
     virtual bool exists_(ParameterSet const& pset) const;
 

--- a/FWCore/ParameterSet/src/ANDGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ANDGroupDescription.cc
@@ -94,7 +94,7 @@ namespace edm {
   print_(std::ostream & os,
          bool optional,
          bool writeToCfi,
-         DocFormatHelper & dfh) {
+         DocFormatHelper & dfh) const {
 
     if (dfh.parent() == DocFormatHelper::AND) {
       dfh.decrementCounter();
@@ -146,7 +146,7 @@ namespace edm {
   ANDGroupDescription::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
 
     if (dfh.parent() == DocFormatHelper::AND) {
       dfh.decrementCounter();

--- a/FWCore/ParameterSet/src/AllowedLabelsDescription.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescription.cc
@@ -51,7 +51,7 @@ namespace edm {
   AllowedLabelsDescription<ParameterSetDescription>::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
 
     printNestedContentBase_(os, optional, dfh);
 
@@ -146,7 +146,7 @@ namespace edm {
   AllowedLabelsDescription<std::vector<ParameterSet> >::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
 
     printNestedContentBase_(os, optional, dfh);
 

--- a/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
@@ -73,7 +73,7 @@ namespace edm {
   print_(std::ostream & os,
          bool optional,
 	 bool writeToCfi,
-         DocFormatHelper & dfh)
+         DocFormatHelper & dfh) const
   {
     if (dfh.pass() == 1) {
 
@@ -116,7 +116,7 @@ namespace edm {
 
   bool
   AllowedLabelsDescriptionBase::
-  hasNestedContent_() {
+  hasNestedContent_() const {
     return true;
   }
 
@@ -125,7 +125,7 @@ namespace edm {
   AllowedLabelsDescriptionBase::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
     printNestedContentBase_(os, optional, dfh);
     if (!dfh.brief()) os << "\n";
   }
@@ -134,7 +134,7 @@ namespace edm {
   AllowedLabelsDescriptionBase::
   printNestedContentBase_(std::ostream & os,
                           bool optional,
-                          DocFormatHelper & dfh) {
+                          DocFormatHelper & dfh) const {
 
     int indentation = dfh.indentation();
     if (dfh.parent() != DocFormatHelper::TOP) {

--- a/FWCore/ParameterSet/src/EmptyGroupDescription.cc
+++ b/FWCore/ParameterSet/src/EmptyGroupDescription.cc
@@ -33,7 +33,7 @@ namespace edm {
   print_(std::ostream& os,
          bool /*optional*/,
          bool /*writeToCfi*/,
-         DocFormatHelper& dfh) {
+         DocFormatHelper& dfh) const {
 
     if(dfh.pass() == 1) {
 

--- a/FWCore/ParameterSet/src/IfExistsDescription.cc
+++ b/FWCore/ParameterSet/src/IfExistsDescription.cc
@@ -109,7 +109,7 @@ namespace edm {
   print_(std::ostream & os,
          bool optional,
          bool writeToCfi,
-         DocFormatHelper & dfh) {
+         DocFormatHelper & dfh) const {
 
     if (dfh.pass() == 1) {
 
@@ -154,7 +154,7 @@ namespace edm {
   IfExistsDescription::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
 
     int indentation = dfh.indentation();
     if (dfh.parent() != DocFormatHelper::TOP) {

--- a/FWCore/ParameterSet/src/ORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ORGroupDescription.cc
@@ -102,7 +102,7 @@ namespace edm {
   print_(std::ostream & os,
          bool optional,
          bool writeToCfi,
-         DocFormatHelper & dfh) {
+         DocFormatHelper & dfh) const {
 
     if (dfh.parent() == DocFormatHelper::OR) {
       dfh.decrementCounter();
@@ -154,7 +154,7 @@ namespace edm {
   ORGroupDescription::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
 
     if (dfh.parent() == DocFormatHelper::OR) {
       dfh.decrementCounter();

--- a/FWCore/ParameterSet/src/ParameterDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterDescription.cc
@@ -83,7 +83,7 @@ namespace edm {
   ParameterDescription<ParameterSetDescription>::
   printDefault_(std::ostream& os,
                   bool writeToCfi,
-                  DocFormatHelper& dfh) {
+                  DocFormatHelper& dfh) const {
     os << "see Section " << dfh.section()
        << "." << dfh.counter();
     if(!writeToCfi) os << " (do not write to cfi)";
@@ -92,7 +92,7 @@ namespace edm {
 
   bool
   ParameterDescription<ParameterSetDescription>::
-  hasNestedContent_() {
+  hasNestedContent_() const {
     return true;
   }
 
@@ -100,7 +100,7 @@ namespace edm {
   ParameterDescription<ParameterSetDescription>::
   printNestedContent_(std::ostream& os,
                       bool /*optional*/,
-                      DocFormatHelper& dfh) {
+                      DocFormatHelper& dfh) const {
     int indentation = dfh.indentation();
     if(dfh.parent() != DocFormatHelper::TOP) {
       indentation -= DocFormatHelper::offsetSectionContent();
@@ -273,7 +273,7 @@ namespace edm {
   ParameterDescription<std::vector<ParameterSet> >::
   printDefault_(std::ostream& os,
                 bool writeToCfi,
-                DocFormatHelper& dfh) {
+                DocFormatHelper& dfh) const {
     os << "see Section " << dfh.section()
        << "." << dfh.counter();
     if(!writeToCfi) os << " (do not write to cfi)";
@@ -283,7 +283,7 @@ namespace edm {
 
   bool
   ParameterDescription<std::vector<ParameterSet> >::
-  hasNestedContent_() {
+  hasNestedContent_() const {
     return true;
   }
 
@@ -291,7 +291,7 @@ namespace edm {
   ParameterDescription<std::vector<ParameterSet> >::
   printNestedContent_(std::ostream& os,
                       bool /*optional*/,
-                      DocFormatHelper& dfh) {
+                      DocFormatHelper& dfh) const {
 
     int indentation = dfh.indentation();
     if(dfh.parent() != DocFormatHelper::TOP) {

--- a/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
@@ -158,7 +158,7 @@ namespace edm {
   print_(std::ostream& os,
          bool optional,
          bool writeToCfi,
-         DocFormatHelper& dfh) {
+         DocFormatHelper& dfh) const {
     if(dfh.pass() == 0) {
       dfh.setAtLeast1(label().size());
       if(isTracked()) {
@@ -228,7 +228,7 @@ namespace edm {
   ParameterDescriptionBase::
   printDefault_(std::ostream& os,
                   bool writeToCfi,
-                  DocFormatHelper& dfh) {
+                  DocFormatHelper& dfh) const {
     if(!dfh.brief()) os << "default: ";
     if(writeToCfi && hasDefault()) {
       if(hasNestedContent()) {
@@ -251,7 +251,7 @@ namespace edm {
   ParameterDescriptionBase::
   printNestedContent_(std::ostream& os,
                       bool /*optional*/,
-                      DocFormatHelper& dfh) {
+                      DocFormatHelper& dfh) const {
     int indentation = dfh.indentation();
     if(dfh.parent() != DocFormatHelper::TOP) {
       indentation -= DocFormatHelper::offsetSectionContent();

--- a/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
@@ -103,7 +103,7 @@ namespace edm {
   ParameterDescriptionNode::print(std::ostream& os,
                                   bool optional,
                                   bool writeToCfi,
-                                  DocFormatHelper& dfh) {
+                                  DocFormatHelper& dfh) const {
     if (hasNestedContent()) {
       dfh.incrementCounter();
     }
@@ -113,7 +113,7 @@ namespace edm {
   void
   ParameterDescriptionNode::printNestedContent(std::ostream& os,
                                                bool optional,
-                                               DocFormatHelper& dfh) {
+                                               DocFormatHelper& dfh) const {
     if (hasNestedContent()) {
       dfh.incrementCounter();
       printNestedContent_(os, optional, dfh);

--- a/FWCore/ParameterSet/src/ParameterSwitchBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSwitchBase.cc
@@ -152,7 +152,7 @@ namespace edm {
 
   bool
   ParameterSwitchBase::
-  hasNestedContent_() {
+  hasNestedContent_() const {
     return true;
   }
 
@@ -161,7 +161,7 @@ namespace edm {
   printNestedContentBase(std::ostream& os,
                          DocFormatHelper& dfh,
                          DocFormatHelper& new_dfh,
-                         std::string const& switchLabel) {
+                         std::string const& switchLabel) const {
 
     int indentation = dfh.indentation();
     if(dfh.parent() != DocFormatHelper::TOP) {

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -78,7 +78,7 @@ namespace edm {
 
   bool
   ParameterWildcard<ParameterSetDescription>::
-  hasNestedContent_() {
+  hasNestedContent_() const {
     if(psetDesc_) return true;
     return false;
   }
@@ -87,7 +87,7 @@ namespace edm {
   ParameterWildcard<ParameterSetDescription>::
   printNestedContent_(std::ostream& os,
                       bool /*optional*/,
-                      DocFormatHelper& dfh) {
+                      DocFormatHelper& dfh) const {
 
     int indentation = dfh.indentation();
     if(dfh.parent() != DocFormatHelper::TOP) {
@@ -197,7 +197,7 @@ namespace edm {
 
   bool
   ParameterWildcard<std::vector<ParameterSet> >::
-  hasNestedContent_() {
+  hasNestedContent_() const {
     if(psetDesc_) return true;
     return false;
   }
@@ -206,7 +206,7 @@ namespace edm {
   ParameterWildcard<std::vector<ParameterSet> >::
   printNestedContent_(std::ostream& os,
                       bool /*optional*/,
-                      DocFormatHelper& dfh) {
+                      DocFormatHelper& dfh) const {
 
     int indentation = dfh.indentation();
     if(dfh.parent() != DocFormatHelper::TOP) {

--- a/FWCore/ParameterSet/src/ParameterWildcardBase.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardBase.cc
@@ -77,7 +77,7 @@ namespace edm {
   print_(std::ostream& os,
          bool optional,
          bool /*writeToCfi*/,
-         DocFormatHelper& dfh) {
+         DocFormatHelper& dfh) const {
     if(dfh.pass() == 0) {
       dfh.setAtLeast1(11U);
       if(isTracked()) {

--- a/FWCore/ParameterSet/src/XORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/XORGroupDescription.cc
@@ -113,7 +113,7 @@ namespace edm {
   print_(std::ostream & os,
          bool optional,
          bool writeToCfi,
-         DocFormatHelper & dfh) {
+         DocFormatHelper & dfh) const {
 
     if (dfh.parent() == DocFormatHelper::XOR) {
       dfh.decrementCounter();
@@ -165,7 +165,7 @@ namespace edm {
   XORGroupDescription::
   printNestedContent_(std::ostream & os,
                       bool optional,
-                      DocFormatHelper & dfh) {
+                      DocFormatHelper & dfh) const {
 
     if (dfh.parent() == DocFormatHelper::XOR) {
       dfh.decrementCounter();

--- a/FWCore/Utilities/interface/atomic_value_ptr.h
+++ b/FWCore/Utilities/interface/atomic_value_ptr.h
@@ -11,7 +11,7 @@
 // describes the functionality of value_ptr.
 //
 // This allows the value of the pointer to be changed atomically.
-// Note that copy/move construction amd copy/move assignment
+// Note that copy/move construction and copy/move assignment
 // are *not* atomic, as an object of type T must be copied or moved.
 // ----------------------------------------------------------------------
 

--- a/FWCore/Utilities/interface/value_ptr.h
+++ b/FWCore/Utilities/interface/value_ptr.h
@@ -34,6 +34,8 @@
 
 #include <algorithm> // for std::swap()
 #include <memory>
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
 
@@ -69,14 +71,14 @@ namespace edm {
 
     value_ptr() : myP(nullptr) { }
     explicit value_ptr(T* p) : myP(p) { }
-    ~value_ptr() { delete myP; }
+    ~value_ptr() { delete myP.get(); }
 
     // --------------------------------------------------
     // Copy constructor/copy assignment:
     // --------------------------------------------------
 
     value_ptr(value_ptr const& orig) :
-      myP(createFrom(orig.myP)) {
+      myP(createFrom(get_underlying_safe(orig.myP))) {
     }
 
     value_ptr& operator=(value_ptr const& orig) {
@@ -94,7 +96,7 @@ namespace edm {
 
     value_ptr& operator=(value_ptr&& orig) {
       if (myP!=orig.myP) {
-        delete myP;
+        delete myP.get();
         myP=orig.myP;
         orig.myP=nullptr;
       } 
@@ -105,8 +107,10 @@ namespace edm {
     // Access mechanisms:
     // --------------------------------------------------
 
-    T& operator*() const { return *myP; }
-    T* operator->() const { return myP; }
+    T const& operator*() const { return *myP; }
+    T& operator*() { return *myP; }
+    T const* operator->() const { return get_underlying_safe(myP); }
+    T* operator->() { return get_underlying_safe(myP); }
 
     // --------------------------------------------------
     // Manipulation:
@@ -191,7 +195,7 @@ namespace edm {
     // Member data:
     // --------------------------------------------------
 
-    T* myP;
+    edm::propagate_const<T*> myP;
 
   }; // value_ptr
 

--- a/IOMC/RandomEngine/src/TRandomAdaptor.h
+++ b/IOMC/RandomEngine/src/TRandomAdaptor.h
@@ -23,45 +23,45 @@ namespace edm {
     virtual ~TRandomAdaptor();
 
     // Returns a pseudo random number in ]0,1[ (i. e., excluding the end points).
-    double flat() { return trand_->Rndm(); }
+    double flat() override { return trand_->Rndm(); }
 
     // Fills an array "vect" of specified size with flat random values.
-    void flatArray(int const size, double* vect) { trand_->RndmArray(size,vect); }
+    void flatArray(int const size, double* vect) override { trand_->RndmArray(size,vect); }
 
     // Sets the state of the algorithm according to seed.
-    void setSeed(long seed, int);
+    void setSeed(long seed, int) override;
 
     // Sets the state of the algorithm according to the zero terminated
     // array of seeds. It is allowed to ignore one or many seeds in this array.
-    void setSeeds(long const* seeds, int);
+    void setSeeds(long const* seeds, int) override;
 
     // Saves the current engine status in the named file
-    void saveStatus(char const filename[] = "TRandom.conf") const { trand_->WriteRandom(filename); }
+    void saveStatus(char const filename[] = "TRandom.conf") const override { trand_->WriteRandom(filename); }
 
     // Reads from named file the the last saved engine status and restores it.
-    void restoreStatus(char const filename[] = "TRandom.conf" ) { trand_->ReadRandom(filename); }
+    void restoreStatus(char const filename[] = "TRandom.conf" ) override { trand_->ReadRandom(filename); }
 
     // Dumps the current engine status on the screen.
-    void showStatus() const { trand_->Dump(); }
+    void showStatus() const override { trand_->Dump(); }
 
     // Returns a float flat ]0,1[
-    operator float() { return (float)(trand_->Rndm()); }
+    operator float() override { return (float)(trand_->Rndm()); }
 
     // Returns an unsigned int (32-bit) flat 
-    operator unsigned int() { return (unsigned int)((trand_->Rndm())*exponent_bit_32()); }
+    operator unsigned int() override { return (unsigned int)((trand_->Rndm())*exponent_bit_32()); }
 
-    virtual std::ostream & put (std::ostream & os) const;
-    virtual std::istream & get (std::istream & is);
+    virtual std::ostream & put(std::ostream & os) const override;
+    virtual std::istream & get(std::istream & is) override;
     std::string beginTag ( ) { return std::string(trand_->GetName())+std::string("-begin"); }
-    virtual std::istream & getState ( std::istream & is );
+    virtual std::istream & getState ( std::istream & is ) override;
 
     // Returns the engine name as a string
-    std::string name() const { return std::string("T")+std::string(trand_->GetName()); }
+    std::string name() const override { return std::string("T")+std::string(trand_->GetName()); }
     static std::string engineName() { return std::string("TRandomAdaptor"); }
 
-    std::vector<unsigned long> put () const;
-    bool get (std::vector<unsigned long> const& v);
-    bool getState (std::vector<unsigned long> const& v) { return get(v); }
+    virtual std::vector<unsigned long> put () const override;
+    bool get (std::vector<unsigned long> const& v) override;
+    bool getState (std::vector<unsigned long> const& v) override { return get(v); }
 
     // In case all else fails, let the user talk directly to the engine
     TRandom3* getRootEngine() { return trand_.operator->(); }
@@ -70,7 +70,7 @@ namespace edm {
 
     void Grumble(std::string const& errortext) const;
 
-    TRandom3Ptr trand_;
+    mutable TRandom3Ptr trand_;
 
   }; // TRandomAdaptor
 


### PR DESCRIPTION
Use the propagage_const template to implement deep const correctness for edm::value_ptr. Make any modifications to users of value_ptr required by this.
I also added missing "override" qualifiers to member functions in the TRandomAdaptor class.
