### PR TITLE
Allowing empty user text in tag log entries

### DIFF
--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -204,9 +204,12 @@ namespace cond {
 	m_session->iovSchema().iovTable().insertMany( m_data->tag, m_data->iovBuffer );
 	std::stringstream msg;
         msg << m_data->iovBuffer.size() << " iov(s) inserted.";
-	if( m_session->iovSchema().tagLogTable().exists() )
+	if( m_session->iovSchema().tagLogTable().exists() ){
+	  std::string lt = logText;
+	  if( lt.empty() ) lt = "-";
 	  m_session->iovSchema().tagLogTable().insert(  m_data->tag,  operationTime, cond::getUserName(), cond::getHostName(), cond::getCommand(), 
-							msg.str(),logText );
+							msg.str(),lt );
+	}
 	m_data->iovBuffer.clear();
 	ret = true;
       }


### PR DESCRIPTION
This fix is required by the Oracle storage, where empty strings are treated as NULL. Empty string from the user text will be converted into "-".

Only affecting direct wrinting into Oracle => O2Os
