### PR TITLE
FEDid-wheel mapping fixed for +1 and +2

### DIFF
--- a/EventFilter/L1TXRawToDigi/python/twinMuxStage2Digis_cfi.py
+++ b/EventFilter/L1TXRawToDigi/python/twinMuxStage2Digis_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 twinMuxStage2Digis = cms.EDProducer("L1TTwinMuxRawToDigi",
                                DTTM7_FED_Source = cms.InputTag("rawDataCollector"),
-                               feds     = cms.untracked.vint32( 1395,           1391,           1390,           1394,           1393           ),
+                               feds     = cms.untracked.vint32( 1395,           1391,           1390,           1393,           1394           ),
                                wheels   = cms.untracked.vint32( -2,             -1,             0,              +1,             +2             ),
                                # Sector = '1' to '12' in HEX ('1' -> 'C'); 'F' if the AmcId is not associated to any Sector
                                # AmcId                         (  123456789...)


### PR DESCRIPTION
backport of PR13742

https://github.com/cms-sw/cmssw/pull/13742
