### PR TITLE
Filter to select HLT paths corresponding to peripheral HI events

### DIFF
--- a/RecoHI/Configuration/python/peripheralHLTFilter_cff.py
+++ b/RecoHI/Configuration/python/peripheralHLTFilter_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltPerhiphHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltPerhiphHI.HLTPaths = ["HLT_HISinglePhoton*_Eta*_Cent50_100_*","HLT_HISinglePhoton*_Eta*_Cent30_100_*","HLT_HIFullTrack*_L1Centrality30100_*","HLT_HIPuAK4CaloJet*_Eta5p1_Cent50_100_v*","HLT_HIPuAK4CaloJet*_Eta5p1_Cent30_100_v*","HLT_HIDmesonHITrackingGlobal_Dpt*_Cent50_100_v*","HLT_HIDmesonHITrackingGlobal_Dpt*_Cent30_100_v*","HLT_HIL1Centralityext30100MinimumumBiasHF*","HLT_HIL1Centralityext50100MinimumumBiasHF*","HLT_HIQ2*005_Centrality3050_v*","HLT_HIQ2*005_Centrality5070_v*","HLT_HICastor*","HLT_HIL1Castor*","HLT_HIUPC*"]
+hltPerhiphHI.throw = False
+hltPerhiphHI.andOr = True
+
+peripheralHLTFilterSequence = cms.Sequence( hltPerhiphHI )

--- a/RecoHI/Configuration/python/peripheralHLTFilter_cff.py
+++ b/RecoHI/Configuration/python/peripheralHLTFilter_cff.py
@@ -2,7 +2,20 @@ import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltPerhiphHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltPerhiphHI.HLTPaths = ["HLT_HISinglePhoton*_Eta*_Cent50_100_*","HLT_HISinglePhoton*_Eta*_Cent30_100_*","HLT_HIFullTrack*_L1Centrality30100_*","HLT_HIPuAK4CaloJet*_Eta5p1_Cent50_100_v*","HLT_HIPuAK4CaloJet*_Eta5p1_Cent30_100_v*","HLT_HIDmesonHITrackingGlobal_Dpt*_Cent50_100_v*","HLT_HIDmesonHITrackingGlobal_Dpt*_Cent30_100_v*","HLT_HIL1Centralityext30100MinimumumBiasHF*","HLT_HIL1Centralityext50100MinimumumBiasHF*","HLT_HIQ2*005_Centrality3050_v*","HLT_HIQ2*005_Centrality5070_v*","HLT_HICastor*","HLT_HIL1Castor*","HLT_HIUPC*"]
+hltPerhiphHI.HLTPaths = ["HLT_HISinglePhoton*_Eta*_Cent50_100_*",
+                         "HLT_HISinglePhoton*_Eta*_Cent30_100_*",
+                         "HLT_HIFullTrack*_L1Centrality30100_*",
+                         "HLT_HIPuAK4CaloJet*_Eta5p1_Cent50_100_v*",
+                         "HLT_HIPuAK4CaloJet*_Eta5p1_Cent30_100_v*",
+                         "HLT_HIDmesonHITrackingGlobal_Dpt*_Cent50_100_v*",
+                         "HLT_HIDmesonHITrackingGlobal_Dpt*_Cent30_100_v*",
+                         "HLT_HIL1Centralityext30100MinimumumBiasHF*",
+                         "HLT_HIL1Centralityext50100MinimumumBiasHF*",
+                         "HLT_HIQ2*005_Centrality3050_v*",
+                         "HLT_HIQ2*005_Centrality5070_v*",
+                         "HLT_HICastor*",
+                         "HLT_HIL1Castor*",
+                         "HLT_HIUPC*"]
 hltPerhiphHI.throw = False
 hltPerhiphHI.andOr = True
 


### PR DESCRIPTION
For a reprocessing of peripheral PbPb events with pp reco.

Tested with:
cmsDriver.py step3 --process ppRECO --repacked --conditions 75X_dataRun2_PromptHI_v3 -s FILTER:RecoHI/Configuration/peripheralHLTFilter_cff.peripheralHLTFilterSequence,RAW2DIGI,L1Reco,RECO --datatier AOD --customise Configuration/DataProcessing/RecoTLR.customiseDataRun2Common_50nsRunsAfter253000 --customise RecoHI/Configuration/customise_PPwithHI.customisePPwithHI --data --scenario pp --eventcontent AOD --no_exec
