### PR TITLE
Fix SLHC parameter for Run-2 emulation (80X only)

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -13,13 +13,15 @@ class Eras (object):
         self.run2_HI_specific = cms.Modifier()
         self.run2_HF_2016 = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
-        self.stage2L1Trigger = cms.Modifier()
-        self.phase1Pixel = cms.Modifier()
         # Implementation note: When this was first started, stage1L1Trigger wasn't in all
         # of the eras. Now that it is, it could in theory be dropped if all changes are
         # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to
         # "run2_common" over the whole python tree). In practice, I don't think it's worth
         # it, and this also gives the flexibilty to take it out easily.
+        self.stage2L1Trigger = cms.Modifier()
+        self.phase1Pixel = cms.Modifier()
+        self.muonTrigger2017 = cms.Modifier()
+        # Implementation note: muonTrigger2017 enables the L1CSC SLHC algorithm for high-PU running
 
         # Phase 2 sub-eras for stable features
         self.phase2_common = cms.Modifier()
@@ -48,7 +50,7 @@ class Eras (object):
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
         # Future Run 2 scenarios.
         self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger, self.run2_HF_2016 )
-        self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel )
+        self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.muonTrigger2017 )
         # Scenarios further afield.
         # Phase2 is everything for the 2023 (2026?) detector that works so far in this release.
         self.Phase2 = cms.ModifierChain( self.phase2_common, self.phase2_tracker, self.phase2_hgc, self.phase2_muon )

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -11,7 +11,7 @@ def _modifyCscTriggerPrimitiveDigisForRun2( object ) :
     """
     object.debugParameters = True
     object.checkBadChambers = False
-    object.commonParam.isSLHC = True
+    object.commonParam.isSLHC = False
     object.commonParam.smartME1aME1b = True
     object.commonParam.gangedME1a = False
     object.alctParam07.alctNarrowMaskForR1 = True

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -29,7 +29,7 @@ def _modifyCscTriggerPrimitiveDigisForRun2_2017( object ) :
     """
     object.debugParameters = True
     object.checkBadChambers = False
-    object.commonParam.isSLHC = False
+    object.commonParam.isSLHC = True
     object.commonParam.smartME1aME1b = True
     object.commonParam.gangedME1a = False
     object.alctParam07.alctNarrowMaskForR1 = True

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -608,7 +608,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 #
 from Configuration.StandardSequences.Eras import eras
 eras.run2_common.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2 )
-eras.Run2_2017.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )
+eras.muonTrigger2017.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )
 eras.phase2_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )
 eras.phase2_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2GE11 )
 eras.phase2dev_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -23,6 +23,24 @@ def _modifyCscTriggerPrimitiveDigisForRun2( object ) :
     object.tmbParam.matchTrigWindowSize = 3
 
 
+def _modifyCscTriggerPrimitiveDigisForRun2_2017( object ) :
+    """
+    Modifies cscTriggerPrimitiveDigis for Run 2 2017
+    """
+    object.debugParameters = True
+    object.checkBadChambers = False
+    object.commonParam.isSLHC = False
+    object.commonParam.smartME1aME1b = True
+    object.commonParam.gangedME1a = False
+    object.alctParam07.alctNarrowMaskForR1 = True
+    object.alctParam07.alctGhostCancellationBxDepth = cms.int32(1)
+    object.alctParam07.alctGhostCancellationSideQuality = cms.bool(True)
+    object.alctParam07.alctPretrigDeadtime = cms.uint32(4)
+    object.clctParam07.clctPidThreshPretrig = 4
+    object.clctParam07.clctMinSeparation = 5
+    object.tmbParam.matchTrigWindowSize = 3
+
+
 def _modifyCscTriggerPrimitiveDigisForRun2GE11( object ) :
     """
     Modifies cscTriggerPrimitiveDigis for Run 2 + GEMs
@@ -590,3 +608,8 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 #
 from Configuration.StandardSequences.Eras import eras
 eras.run2_common.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2 )
+eras.Run2_2017.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )
+eras.phase2_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )
+eras.phase2_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2GE11 )
+eras.phase2dev_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2_2017 )
+eras.phase2dev_muon.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2GE11 )

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -52,6 +52,7 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
 
   // special configuration parameters for ME11 treatment
   edm::ParameterSet commonParams = conf.getParameter<edm::ParameterSet>("commonParam");
+  isSLHC = commonParams.getParameter<bool>("isSLHC");
   smartME1aME1b = commonParams.getParameter<bool>("smartME1aME1b");
   disableME1a = commonParams.getParameter<bool>("disableME1a");
   disableME42 = commonParams.getParameter<bool>("disableME42");
@@ -90,13 +91,13 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
             int ring = CSCTriggerNumbering::ringFromTriggerLabels(stat, cham);
             // When the motherboard is instantiated, it instantiates ALCT
             // and CLCT processors.
-            if (stat==1 && ring==1 && smartME1aME1b && !runME11ILT_)
+            if (stat==1 && ring==1 && isSLHC && smartME1aME1b && !runME11ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME11(endc, stat, sect, subs, cham, conf) );
-            else if (stat==1 && ring==1 && smartME1aME1b && runME11ILT_)
+            else if (stat==1 && ring==1 && isSLHC && smartME1aME1b && runME11ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME11GEM(endc, stat, sect, subs, cham, conf) );
-            else if (stat==2 && ring==1 && runME21ILT_)
+            else if (stat==2 && ring==1 && isSLHC && runME21ILT_)
 	      tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME21GEM(endc, stat, sect, subs, cham, conf) );
-            else if ((stat==3 || stat==4) && ring==1 && runME3141ILT_)
+            else if ((stat==3 || stat==4) && ring==1 && isSLHC && runME3141ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME3141RPC(endc, stat, sect, subs, cham, conf) );
             else
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboard(endc, stat, sect, subs, cham, conf) );
@@ -205,7 +206,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
 
             // running upgraded ME1/1 TMBs
-            if (stat==1 && ring==1 && smartME1aME1b && !runME11ILT_)
+            if (stat==1 && ring==1 && isSLHC && smartME1aME1b && !runME11ILT_)
             {
               CSCMotherboardME11* tmb11 = static_cast<CSCMotherboardME11*>(tmb);
  
@@ -317,7 +318,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             } // upgraded TMB
 
 	    // running upgraded ME1/1 TMBs with GEMs
-            else if (stat==1 && ring==1 && smartME1aME1b && runME11ILT_)
+            else if (stat==1 && ring==1 && isSLHC && smartME1aME1b && runME11ILT_)
 	    {
 	      CSCMotherboardME11GEM* tmb11GEM = static_cast<CSCMotherboardME11GEM*>(tmb);
 	      
@@ -443,7 +444,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 	    } 
 
             // running upgraded ME2/1 TMBs
-            else if (stat==2 && ring==1 && runME21ILT_)
+            else if (stat==2 && ring==1 && isSLHC && runME21ILT_)
 	    {
 	      CSCMotherboardME21GEM* tmb21GEM = static_cast<CSCMotherboardME21GEM*>(tmb);
 	      tmb21GEM->setCSCGeometry(csc_g);
@@ -505,7 +506,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 	      }
 	    }
 	    // running upgraded ME3/1-ME4/1 TMBs
-            else if ((stat==3 or stat==4) && ring==1 && runME3141ILT_)
+            else if ((stat==3 or stat==4) && ring==1 && isSLHC && runME3141ILT_)
 	    {
 	      CSCMotherboardME3141RPC* tmb3141RPC = static_cast<CSCMotherboardME3141RPC*>(tmb);
 	      tmb3141RPC->setCSCGeometry(csc_g);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
@@ -91,6 +91,9 @@ class CSCTriggerPrimitivesBuilder
   /// a flag whether to skip chambers from the bad chambers map
   bool checkBadChambers_;
 
+  /** SLHC: master switch. */
+  bool isSLHC;
+
   /** SLHC: special configuration parameters for ME11 treatment. */
   bool smartME1aME1b, disableME1a;
 


### PR DESCRIPTION
This should fix #13243. This PR is not be ported to 81X. There is already a dedicated version #13364 
