### PR TITLE
Change LogWarning to LogTrace

### DIFF
--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -375,7 +375,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
         if(emulDecision != initDecision) {
 
-          edm::LogWarning("HLTL1TSeed") 
+          LogTrace("HLTL1TSeed") 
           << "L1T decision (emulated vs. unpacked initial) is not the same:"
           << "\n\tbit = " << std::setw(3) << bit 
           << std::setw(40) << objMaps[imap].algoName() 


### PR DESCRIPTION
Shut up the HLTL1TSeeding module complaining about disagreement between emulated and unpacked
decisions.  This is a must when we run HLT.
