### PR TITLE
Update miniAOD AK8 userFloat content. Add PUPPI substructure. Remove CMSTT.

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -15,11 +15,12 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
-        'keep *_cmsTopTaggerMap_*_*',
+        #'keep *_cmsTopTaggerMap_*_*',
         #'keep *_slimmedJetsAK8PFCHSSoftDropSubjets_*_*',
         #'keep *_slimmedJetsCMSTopTagCHSSubjets_*_*',
         'keep *_slimmedJetsAK8PFCHSSoftDropPacked_SubJets_*',
-        'keep *_slimmedJetsCMSTopTagCHSPacked_SubJets_*',
+        'keep *_slimmedJetsAK8PFPuppiSoftDropPacked_SubJets_*',
+        #'keep *_slimmedJetsCMSTopTagCHSPacked_SubJets_*',
         #'keep *_packedPatJetsAK8_*_*',
         ## add extra METs
         

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -15,15 +15,9 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
-        #'keep *_cmsTopTaggerMap_*_*',
-        #'keep *_slimmedJetsAK8PFCHSSoftDropSubjets_*_*',
-        #'keep *_slimmedJetsCMSTopTagCHSSubjets_*_*',
         'keep *_slimmedJetsAK8PFCHSSoftDropPacked_SubJets_*',
         'keep *_slimmedJetsAK8PFPuppiSoftDropPacked_SubJets_*',
-        #'keep *_slimmedJetsCMSTopTagCHSPacked_SubJets_*',
-        #'keep *_packedPatJetsAK8_*_*',
-        ## add extra METs
-        
+
         'keep recoPhotonCores_reducedEgamma_*_*',
         'keep recoGsfElectronCores_reducedEgamma_*_*',
         'keep recoConversions_reducedEgamma_*_*',
@@ -41,7 +35,6 @@ MicroEventContent = cms.PSet(
 
         'keep *_bunchSpacingProducer_*_*',
 
-        #'keep double_fixedGridRho*__*',
         'keep double_fixedGridRhoAll__*',
         'keep double_fixedGridRhoFastjetAll__*',
         'keep double_fixedGridRhoFastjetAllCalo__*',
@@ -61,8 +54,7 @@ MicroEventContent = cms.PSet(
         'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
         'keep recoCSCHaloData_CSCHaloData_*_*',
-        'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
-        'keep *_caTopTagInfosPAT_*_*'
+        'keep recoBeamHaloSummary_BeamHaloSummary_*_*'
     )
 )
 MicroEventContentMC = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -86,7 +86,7 @@ def applySubstructure( process ) :
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsPuppi_groomingValueMaps_cfi")
     process.patJetsAK8Puppi.userData.userFloats.src += ['ak8PFJetsPuppiSoftDropMass']
-    process.patJetsAK8Puppi.addTagInfos = cms.bool(True)
+    process.patJetsAK8Puppi.addTagInfos = cms.bool(False)
 
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -34,14 +34,12 @@ def applySubstructure( process ) :
     )
 
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsPuppiSoftDrop #ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed,
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsPuppiSoftDrop 
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
     process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
-    #process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
-    #process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
-    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass']  #,'ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
+    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass']  
     process.patJetsAK8.addTagInfos = cms.bool(True)
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -4,15 +4,6 @@ def applySubstructure( process ) :
 
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 
-    # add CMS top tagger
-    from RecoJets.JetProducers.caTopTaggers_cff import caTopTagInfos
-    process.caTopTagInfos = caTopTagInfos.clone()
-    process.caTopTagInfosPAT = cms.EDProducer("RecoJetDeltaRTagInfoValueMapProducer",
-                                    src = cms.InputTag("ak8PFJetsCHS"),
-                                    matched = cms.InputTag("cmsTopTagPFJetsCHS"),
-                                    matchedTagInfos = cms.InputTag("caTopTagInfos"),
-                                    distMax = cms.double(0.8)
-    )
 
     from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import patJets as patJetsDefault
 
@@ -30,16 +21,15 @@ def applySubstructure( process ) :
 
 
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed 
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed, ak8PFJetsPuppiSoftDrop
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
     process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
     process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
     process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
+    process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
-    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass','ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
-
-    # Add AK8 top tagging variables
-    process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("caTopTagInfosPAT"))
+    process.load("RecoJets.JetProducers.ak8PFJetsPuppi_groomingValueMaps_cfi")
+    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass','ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass','ak8PFJetsPuppiSoftDropMassFromCHS']
     process.patJetsAK8.addTagInfos = cms.bool(True)
 
 
@@ -98,36 +88,39 @@ def applySubstructure( process ) :
         jetSrc=cms.InputTag("selectedPatJetsAK8PFCHSSoftDrop"),
         subjetSrc=cms.InputTag("slimmedJetsAK8PFCHSSoftDropSubjets")
     )
-    
-    addJetCollection(
-        process,
-        labelName = 'CMSTopTagCHS',
-        jetSource = cms.InputTag('cmsTopTagPFJetsCHS'),
-        jetCorrections = ('AK8PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-        btagDiscriminators = ['None'],
-        genJetCollection = cms.InputTag('slimmedGenJetsAK8'), 
-        getJetMCFlavour = False #
-        )
-    process.selectedPatJetsCMSTopTagCHS.cut = cms.string("pt > 200")
 
+    
+    
+
+    ## PATify pruned fat jets
     addJetCollection(
         process,
-        labelName = 'CMSTopTagCHSSubjets',
-        jetSource = cms.InputTag('cmsTopTagPFJetsCHS','caTopSubJets'),
-        algo = 'AK',  # needed for subjet flavor clustering
-        rParam = 0.8, # needed for subjet flavor clustering        
+        labelName = 'AK8PFPuppiSoftDrop',
+        jetSource = cms.InputTag('ak8PFJetsPuppiSoftDrop'),
+        btagDiscriminators = ['None'],
+        jetCorrections = ('AK8PFPuppi', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+        getJetMCFlavour = False # jet flavor disabled
+    )
+    
+    ## PATify soft drop subjets
+    addJetCollection(
+        process,
+        labelName = 'AK8PFPuppiSoftDropSubjets',
+        jetSource = cms.InputTag('ak8PFJetsPuppiSoftDrop','SubJets'),
+        algo = 'ak',  # needed for subjet flavor clustering
+        rParam = 0.8, # needed for subjet flavor clustering
         btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfCombinedInclusiveSecondaryVertexV2BJetTags'],
-        jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
-        genJetCollection = cms.InputTag('slimmedGenJets'), # Using ak4GenJets for matching which is not entirely appropriate
+        jetCorrections = ('AK4PFPuppi', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
         explicitJTA = True,  # needed for subjet b tagging
         svClustering = True, # needed for subjet b tagging
-        fatJets=cms.InputTag('ak8PFJetsCHS'),             # needed for subjet flavor clustering
-        groomedFatJets=cms.InputTag('cmsTopTagPFJetsCHS') # needed for subjet flavor clustering
-
-        )
-
-    process.slimmedJetsCMSTopTagCHSSubjets = cms.EDProducer("PATJetSlimmer",
-        src = cms.InputTag("selectedPatJetsCMSTopTagCHSSubjets"),
+        genJetCollection = cms.InputTag('slimmedGenJets'), 
+        fatJets=cms.InputTag('ak8PFJetsPuppi'),             # needed for subjet flavor clustering
+        groomedFatJets=cms.InputTag('ak8PFJetsPuppiSoftDrop') # needed for subjet flavor clustering
+    )
+    process.selectedPatJetsAK8PFPuppiSoftDrop.cut = cms.string("pt > 170")
+    
+    process.slimmedJetsAK8PFPuppiSoftDropSubjets = cms.EDProducer("PATJetSlimmer",
+        src = cms.InputTag("selectedPatJetsAK8PFPuppiSoftDropSubjets"),
         packedPFCandidates = cms.InputTag("packedPFCandidates"),
         dropJetVars = cms.string("1"),
         dropDaughters = cms.string("0"),
@@ -138,14 +131,15 @@ def applySubstructure( process ) :
         modifyJets = cms.bool(True),
         modifierConfig = cms.PSet( modifications = cms.VPSet() )
     )
+
     
     ## Establish references between PATified fat jets and subjets using the BoostedJetMerger
-    process.slimmedJetsCMSTopTagCHSPacked = cms.EDProducer("BoostedJetMerger",
-        jetSrc=cms.InputTag("selectedPatJetsCMSTopTagCHS"),
-        subjetSrc=cms.InputTag("slimmedJetsCMSTopTagCHSSubjets")
+    process.slimmedJetsAK8PFPuppiSoftDropPacked = cms.EDProducer("BoostedJetMerger",
+        jetSrc=cms.InputTag("selectedPatJetsAK8PFPuppiSoftDrop"),
+        subjetSrc=cms.InputTag("slimmedJetsAK8PFPuppiSoftDropSubjets")
     )
 
-
+    
     process.packedPatJetsAK8 = cms.EDProducer("JetSubstructurePacker",
             jetSrc = cms.InputTag("selectedPatJetsAK8"),
             distMax = cms.double(0.8),
@@ -155,11 +149,11 @@ def applySubstructure( process ) :
                 #       The CMSTopTag subjets are derived from CA8 jets later matched to AK8 jets and could in principle
                 #       contain extra constituents not clustered inside AK8 jets.
                 cms.InputTag("slimmedJetsAK8PFCHSSoftDropPacked"),
-                cms.InputTag("slimmedJetsCMSTopTagCHSPacked")
+                cms.InputTag("slimmedJetsAK8PFPuppiSoftDropPacked")
             ),
             algoLabels = cms.vstring(
                 'SoftDrop',
-                'CMSTopTag'
+                'SoftDropPuppi'
                 ),
             fixDaughters = cms.bool(True),
             packedPFCandidates = cms.InputTag("packedPFCandidates"),

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -40,7 +40,7 @@ def applySubstructure( process ) :
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
     process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass']  
-    process.patJetsAK8.addTagInfos = cms.bool(True)
+    process.patJetsAK8.addTagInfos = cms.bool(False)
 
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -34,14 +34,14 @@ def applySubstructure( process ) :
     )
 
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed, ak8PFJetsPuppiSoftDrop
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsPuppiSoftDrop #ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed,
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
     process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
-    process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
-    process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
+    #process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
+    #process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
-    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass','ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
+    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass']  #,'ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
     process.patJetsAK8.addTagInfos = cms.bool(True)
 
 
@@ -155,7 +155,7 @@ def applySubstructure( process ) :
         fatJets=cms.InputTag('ak8PFJetsCHS'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsCHSSoftDrop') # needed for subjet flavor clustering
     )
-    #process.selectedPatJetsAK8PFCHSSoftDrop.cut = cms.string("pt > 170")
+    process.selectedPatJetsAK8PFCHSSoftDrop.cut = cms.string("pt > 170")
     
     process.slimmedJetsAK8PFCHSSoftDropSubjets = cms.EDProducer("PATJetSlimmer",
         src = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropSubjets"),
@@ -205,7 +205,7 @@ def applySubstructure( process ) :
         fatJets=cms.InputTag('ak8PFJetsPuppi'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsPuppiSoftDrop') # needed for subjet flavor clustering
     )
-    #process.selectedPatJetsAK8PFPuppiSoftDrop.cut = cms.string("pt > 170")
+    process.selectedPatJetsAK8PFPuppiSoftDrop.cut = cms.string("pt > 170")
     
     process.slimmedJetsAK8PFPuppiSoftDropSubjets = cms.EDProducer("PATJetSlimmer",
         src = cms.InputTag("selectedPatJetsAK8PFPuppiSoftDropSubjets"),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -246,19 +246,6 @@ def miniAOD_customizeCommon(process):
     process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")    
     process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
-
-
-    process.load('RecoJets.JetProducers.ak8PFJetsPuppi_cfi')
-
-    process.ak8PFJetsPuppi.doAreaFastjet = True # even for standard ak8PFJets this is overwritten in RecoJets/Configuration/python/RecoPFJets_cff
-
-    from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
-    process.ak8PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
-        j2tParametersVX,
-        jets = cms.InputTag("ak8PFJetsPuppi")
-    )
-
-
     
     ## puppi met
     from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppies

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -247,6 +247,19 @@ def miniAOD_customizeCommon(process):
     process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
 
+
+    process.load('RecoJets.JetProducers.ak8PFJetsPuppi_cfi')
+
+    process.ak8PFJetsPuppi.doAreaFastjet = True # even for standard ak8PFJets this is overwritten in RecoJets/Configuration/python/RecoPFJets_cff
+
+    from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
+    process.ak8PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
+        j2tParametersVX,
+        jets = cms.InputTag("ak8PFJetsPuppi")
+    )
+
+
+    
     ## puppi met
     from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppies
     makePuppies( process );

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -21,6 +21,7 @@ from RecoJets.JetProducers.ca8PFJetsCHS_groomingValueMaps_cfi import ca8PFJetsCH
 from CommonTools.PileupAlgos.Puppi_cff import puppi
 from CommonTools.PileupAlgos.softKiller_cfi import softKiller
 from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
+from RecoJets.JetProducers.ak8PFJetsPuppi_cfi import ak8PFJetsPuppi
 from RecoJets.JetProducers.ak4PFJetsSK_cfi import ak4PFJetsSK
 
 sisCone7PFJets = sisCone5PFJets.clone( rParam = 0.7 )
@@ -40,6 +41,7 @@ ak5PFJets.doAreaFastjet = True
 ak5PFJetsTrimmed.doAreaFastjet = True
 ak7PFJets.doAreaFastjet = True
 ak8PFJets.doAreaFastjet = True
+ak8PFJetsPuppi.doAreaFastjet = True
 ak4PFJetsSK.doAreaFastjet = True
 
 kt6PFJetsCentralChargedPileUp = kt6PFJets.clone(
@@ -139,6 +141,11 @@ ak8PFJetsCHSSoftDrop = ak5PFJetsCHSSoftDrop.clone(
     jetPtMin = 100.0,
     R0 = 0.8
     )
+
+ak8PFJetsPuppiSoftDrop = ak8PFJetsCHSSoftDrop.clone(
+    src = cms.InputTag("puppi")
+    )
+
 
 
 ca8PFJetsCHS = ak8PFJetsCHS.clone(

--- a/RecoJets/JetProducers/python/ak8PFJetsPuppi_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsPuppi_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoJets.JetProducers.PFJetParameters_cfi import *
+from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
+from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
+
+ak8PFJetsPuppi = ak4PFJetsPuppi.clone(
+    rParam = 0.8    
+    )
+

--- a/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
@@ -10,9 +10,3 @@ ak8PFJetsPuppiSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          value = cms.string('mass')  
                         )
 
-ak8PFJetsPuppiSoftDropMassFromCHS = cms.EDProducer("RecoJetDeltaRValueMapProducer",
-                                         src = cms.InputTag("ak8PFJetsCHS"),
-                                         matched = cms.InputTag("ak8PFJetsPuppiSoftDrop"),                                         
-                                         distMax = cms.double(0.8),
-                                         value = cms.string('mass')  
-                        )

--- a/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+
+# Delta-R matching value maps
+
+ak8PFJetsPuppiSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+                                         src = cms.InputTag("ak8PFJetsPuppi"),
+                                         matched = cms.InputTag("ak8PFJetsPuppiSoftDrop"),                                         
+                                         distMax = cms.double(0.8),
+                                         value = cms.string('mass')  
+                        )
+
+ak8PFJetsPuppiSoftDropMassFromCHS = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+                                         src = cms.InputTag("ak8PFJetsCHS"),
+                                         matched = cms.InputTag("ak8PFJetsPuppiSoftDrop"),                                         
+                                         distMax = cms.double(0.8),
+                                         value = cms.string('mass')  
+                        )


### PR DESCRIPTION
We have the following proposal for the AK8chs jet MiniAOD userfloat content in 80X/81X:
- Remove unused run 1 taggers (CMS Top tagger)
- Add PUPPI based taggers (PUPPI soft drop + PUPPI Nsubjettiness ) for matched AK8 PUPPI jets
- In order to save space, add only PUPPI subjets and userfloats for matched PUPPI jet 4-vector and substructure variables.

Size/timing estimates are given in the slides linked here.
https://indico.cern.ch/event/510570/contribution/7/attachments/1246782/1836484/160321_-_Jet_substructure_MiniAOD_content.pptx.pdf

Cheers,
@rappoccio @ahinzmann @jdolen
