### PR TITLE
Update miniAOD AK8 userFloat content. Add PUPPI substructure. Remove CMSTT. (80X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -15,11 +15,12 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
-        'keep *_cmsTopTaggerMap_*_*',
+        #'keep *_cmsTopTaggerMap_*_*',
         #'keep *_slimmedJetsAK8PFCHSSoftDropSubjets_*_*',
         #'keep *_slimmedJetsCMSTopTagCHSSubjets_*_*',
         'keep *_slimmedJetsAK8PFCHSSoftDropPacked_SubJets_*',
-        'keep *_slimmedJetsCMSTopTagCHSPacked_SubJets_*',
+        'keep *_slimmedJetsAK8PFPuppiSoftDropPacked_SubJets_*',
+        #'keep *_slimmedJetsCMSTopTagCHSPacked_SubJets_*',
         #'keep *_packedPatJetsAK8_*_*',
         ## add extra METs
         

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -15,14 +15,8 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
-        #'keep *_cmsTopTaggerMap_*_*',
-        #'keep *_slimmedJetsAK8PFCHSSoftDropSubjets_*_*',
-        #'keep *_slimmedJetsCMSTopTagCHSSubjets_*_*',
         'keep *_slimmedJetsAK8PFCHSSoftDropPacked_SubJets_*',
         'keep *_slimmedJetsAK8PFPuppiSoftDropPacked_SubJets_*',
-        #'keep *_slimmedJetsCMSTopTagCHSPacked_SubJets_*',
-        #'keep *_packedPatJetsAK8_*_*',
-        ## add extra METs
         
         'keep recoPhotonCores_reducedEgamma_*_*',
         'keep recoGsfElectronCores_reducedEgamma_*_*',
@@ -41,7 +35,6 @@ MicroEventContent = cms.PSet(
 
         'keep *_bunchSpacingProducer_*_*',
 
-        #'keep double_fixedGridRho*__*',
         'keep double_fixedGridRhoAll__*',
         'keep double_fixedGridRhoFastjetAll__*',
         'keep double_fixedGridRhoFastjetAllCalo__*',
@@ -61,8 +54,7 @@ MicroEventContent = cms.PSet(
         'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
         'keep recoCSCHaloData_CSCHaloData_*_*',
-        'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
-        'keep *_caTopTagInfosPAT_*_*'
+        'keep recoBeamHaloSummary_BeamHaloSummary_*_*'
     )
 )
 MicroEventContentMC = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -34,14 +34,12 @@ def applySubstructure( process ) :
     )
 
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsPuppiSoftDrop #ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed,
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsPuppiSoftDrop 
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
     process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
-    #process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
-    #process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
-    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass']  #,'ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
+    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass'] 
     process.patJetsAK8.addTagInfos = cms.bool(True)
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -40,7 +40,7 @@ def applySubstructure( process ) :
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
     process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass'] 
-    process.patJetsAK8.addTagInfos = cms.bool(True)
+    process.patJetsAK8.addTagInfos = cms.bool(False)
 
 
 
@@ -86,7 +86,7 @@ def applySubstructure( process ) :
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsPuppi_groomingValueMaps_cfi")
     process.patJetsAK8Puppi.userData.userFloats.src += ['ak8PFJetsPuppiSoftDropMass']
-    process.patJetsAK8Puppi.addTagInfos = cms.bool(True)
+    process.patJetsAK8Puppi.addTagInfos = cms.bool(False)
 
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -34,14 +34,14 @@ def applySubstructure( process ) :
     )
 
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed, ak8PFJetsPuppiSoftDrop
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsPuppiSoftDrop #ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed,
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
     process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
-    process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
-    process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
+    #process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
+    #process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
     process.ak8PFJetsPuppiSoftDrop = ak8PFJetsPuppiSoftDrop.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
-    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass','ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
+    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass']  #,'ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
     process.patJetsAK8.addTagInfos = cms.bool(True)
 
 
@@ -155,7 +155,7 @@ def applySubstructure( process ) :
         fatJets=cms.InputTag('ak8PFJetsCHS'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsCHSSoftDrop') # needed for subjet flavor clustering
     )
-    #process.selectedPatJetsAK8PFCHSSoftDrop.cut = cms.string("pt > 170")
+    process.selectedPatJetsAK8PFCHSSoftDrop.cut = cms.string("pt > 170")
     
     process.slimmedJetsAK8PFCHSSoftDropSubjets = cms.EDProducer("PATJetSlimmer",
         src = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropSubjets"),
@@ -205,7 +205,7 @@ def applySubstructure( process ) :
         fatJets=cms.InputTag('ak8PFJetsPuppi'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsPuppiSoftDrop') # needed for subjet flavor clustering
     )
-    #process.selectedPatJetsAK8PFPuppiSoftDrop.cut = cms.string("pt > 170")
+    process.selectedPatJetsAK8PFPuppiSoftDrop.cut = cms.string("pt > 170")
     
     process.slimmedJetsAK8PFPuppiSoftDropSubjets = cms.EDProducer("PATJetSlimmer",
         src = cms.InputTag("selectedPatJetsAK8PFPuppiSoftDropSubjets"),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -245,6 +245,19 @@ def miniAOD_customizeCommon(process):
     process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
 
+
+    process.load('RecoJets.JetProducers.ak8PFJetsPuppi_cfi')
+
+    process.ak8PFJetsPuppi.doAreaFastjet = True # even for standard ak8PFJets this is overwritten in RecoJets/Configuration/python/RecoPFJets_cff
+
+    from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
+    process.ak8PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
+        j2tParametersVX,
+        jets = cms.InputTag("ak8PFJetsPuppi")
+    )
+
+
+    
     ## puppi met
     from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppies
     makePuppies( process );

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -244,19 +244,6 @@ def miniAOD_customizeCommon(process):
     process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")    
     process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
-
-
-    process.load('RecoJets.JetProducers.ak8PFJetsPuppi_cfi')
-
-    process.ak8PFJetsPuppi.doAreaFastjet = True # even for standard ak8PFJets this is overwritten in RecoJets/Configuration/python/RecoPFJets_cff
-
-    from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
-    process.ak8PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
-        j2tParametersVX,
-        jets = cms.InputTag("ak8PFJetsPuppi")
-    )
-
-
     
     ## puppi met
     from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppies

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -21,6 +21,7 @@ from RecoJets.JetProducers.ca8PFJetsCHS_groomingValueMaps_cfi import ca8PFJetsCH
 from CommonTools.PileupAlgos.Puppi_cff import puppi
 from CommonTools.PileupAlgos.softKiller_cfi import softKiller
 from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
+from RecoJets.JetProducers.ak8PFJetsPuppi_cfi import ak8PFJetsPuppi
 from RecoJets.JetProducers.ak4PFJetsSK_cfi import ak4PFJetsSK
 
 sisCone7PFJets = sisCone5PFJets.clone( rParam = 0.7 )
@@ -40,6 +41,7 @@ ak5PFJets.doAreaFastjet = True
 ak5PFJetsTrimmed.doAreaFastjet = True
 ak7PFJets.doAreaFastjet = True
 ak8PFJets.doAreaFastjet = True
+ak8PFJetsPuppi.doAreaFastjet = True
 ak4PFJetsSK.doAreaFastjet = True
 
 kt6PFJetsCentralChargedPileUp = kt6PFJets.clone(
@@ -139,6 +141,11 @@ ak8PFJetsCHSSoftDrop = ak5PFJetsCHSSoftDrop.clone(
     jetPtMin = 100.0,
     R0 = 0.8
     )
+
+ak8PFJetsPuppiSoftDrop = ak8PFJetsCHSSoftDrop.clone(
+    src = cms.InputTag("puppi")
+    )
+
 
 
 ca8PFJetsCHS = ak8PFJetsCHS.clone(

--- a/RecoJets/JetProducers/python/ak8PFJetsPuppi_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsPuppi_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoJets.JetProducers.PFJetParameters_cfi import *
+from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
+from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
+
+ak8PFJetsPuppi = ak4PFJetsPuppi.clone(
+    rParam = 0.8    
+    )
+

--- a/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
@@ -10,9 +10,3 @@ ak8PFJetsPuppiSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          value = cms.string('mass')  
                         )
 
-ak8PFJetsPuppiSoftDropMassFromCHS = cms.EDProducer("RecoJetDeltaRValueMapProducer",
-                                         src = cms.InputTag("ak8PFJetsCHS"),
-                                         matched = cms.InputTag("ak8PFJetsPuppiSoftDrop"),                                         
-                                         distMax = cms.double(0.8),
-                                         value = cms.string('mass')  
-                        )

--- a/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsPuppi_groomingValueMaps_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+
+# Delta-R matching value maps
+
+ak8PFJetsPuppiSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+                                         src = cms.InputTag("ak8PFJetsPuppi"),
+                                         matched = cms.InputTag("ak8PFJetsPuppiSoftDrop"),                                         
+                                         distMax = cms.double(0.8),
+                                         value = cms.string('mass')  
+                        )
+
+ak8PFJetsPuppiSoftDropMassFromCHS = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+                                         src = cms.InputTag("ak8PFJetsCHS"),
+                                         matched = cms.InputTag("ak8PFJetsPuppiSoftDrop"),                                         
+                                         distMax = cms.double(0.8),
+                                         value = cms.string('mass')  
+                        )


### PR DESCRIPTION
Backport of #13793 

We have the following proposal for the AK8chs jet MiniAOD userfloat content in 80X/81X:
- Remove unused run 1 taggers (CMS Top tagger)
- Add PUPPI based taggers (PUPPI soft drop + PUPPI Nsubjettiness ) for matched AK8 PUPPI jets
- In order to save space, add only PUPPI subjets and userfloats for matched PUPPI jet 4-vector and substructure variables.

Size/timing estimates are given in the slides linked here.
https://indico.cern.ch/event/510570/contribution/7/attachments/1246782/1836484/160321_-_Jet_substructure_MiniAOD_content.pptx.pdf

Cheers,
@rappoccio @ahinzmann @jdolen
