### PR TITLE
Adjusting 1x1 HF output LUTs

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -54,8 +54,9 @@ public:
 
   // Member Variables
   double nominal_gain_;
-  double rctlsb_factor_;
-  double nctlsb_factor_;
+  double lsb_factor_;
+  int rct_factor_;
+  int nct_factor_;
   std::string compressionFile_;
   std::string decompressionFile_;
   std::vector<int> ietal;


### PR DESCRIPTION
Make 1x1 HF output LUTs 4:1 to keep the TP lsb same as for 3x2 (0.5 GeV).
