### PR TITLE
extendedO2O

### DIFF
--- a/CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h
@@ -6,14 +6,14 @@
 #ifndef CondFormatsDataRecord_L1TUtmTriggerMenu_h
 #define CondFormatsDataRecord_L1TUtmTriggerMenu_h
 
-#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-
-class L1TUtmTriggerMenuRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TUtmTriggerMenuRcd> {};
+///#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+///
+///class L1TUtmTriggerMenuRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TUtmTriggerMenuRcd> {};
 
 // Dependent record implmentation:
-//#include "FWCore/Framework/interface/DependentRecordImplementation.h"
-//#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
-//#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmTriggerMenuRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmTriggerMenuRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+class L1TUtmTriggerMenuRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmTriggerMenuRcd, boost::mpl::vector<L1TriggerKeyListExtRcd,L1TriggerKeyExtRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h
+++ b/CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h
@@ -1,0 +1,10 @@
+#ifndef DataRecord_L1TriggerKeyExtRcd_h
+#define DataRecord_L1TriggerKeyExtRcd_h
+
+#include "boost/mpl/vector.hpp"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+class L1TriggerKeyExtRcd : public edm::eventsetup::DependentRecordImplementation<L1TriggerKeyExtRcd, boost::mpl::vector<L1TriggerKeyListExtRcd> > {};
+
+#endif

--- a/CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h
+++ b/CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h
@@ -1,0 +1,8 @@
+#ifndef CondFormats_DataRecord_L1TriggerKeyListExtRcd_h
+#define CondFormats_DataRecord_L1TriggerKeyListExtRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class L1TriggerKeyListExtRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TriggerKeyListExtRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/L1TriggerKeyExtRcd.cc
+++ b/CondFormats/DataRecord/src/L1TriggerKeyExtRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TriggerKeyExtRcd);

--- a/CondFormats/DataRecord/src/L1TriggerKeyListExtRcd.cc
+++ b/CondFormats/DataRecord/src/L1TriggerKeyListExtRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TriggerKeyListExtRcd);

--- a/CondFormats/L1TObjects/interface/L1TriggerKeyExt.h
+++ b/CondFormats/L1TObjects/interface/L1TriggerKeyExt.h
@@ -1,0 +1,110 @@
+#ifndef CondFormats_L1TObjects_L1TriggerKeyExt_h
+#define CondFormats_L1TObjects_L1TriggerKeyExt_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <string>
+#include <map>
+
+/* L1 key used to load all other configuration data from offline db.
+ * This class is just a proxy to the real data. It will contain mapping from data and record
+ * pair to the payload token that could be used to read data. So the use case could be as follows:
+ *   1. User read L1TriggerKey for given Tag and IOV pair.
+ *   2. For each record and type that user whant to load, it ask method get for the payload.
+ *   3. Reads the data with payloads extracted from step 2.
+ *
+ * It is not adviced for user to use this class and direct Pool DB manipulation. One should use
+ * DataReader and DataWriter classes.
+ *
+ * The good point to note is that IOV of all L1 trigger condfiguration is controled bay IOV of L1TriggeKey.
+ * If new configuration has to be created - new L1TriggerKey has to be saved/loaded. More then one key can use
+ * the same paylaod token. This would just mean that data pointed by this payload token has not changed.
+ */
+class L1TriggerKeyExt
+{
+public:
+    typedef std::map<std::string, std::string> RecordToKey;
+
+    enum L1Subsystems
+      {
+	kuGT,
+	kNumberSubsystems
+      } ;
+
+    // Empty strings cannot be stored in the CondDB, so define a null key string.
+    const static std::string kNullKey ;
+
+    const static std::string kEmptyKey ;
+
+    // Constructors
+    L1TriggerKeyExt ()
+      {
+	for( int i = 0 ; i < kNumberSubsystems ; ++i )
+	  {
+	    m_subsystemKeys[ i ] = kNullKey ;
+	  }
+      }
+
+    /* Adds new record and type mapping to payload. If such exists, nothing happens */
+    void add (const std::string & record, const std::string & type, const std::string & key)
+    { m_recordToKey.insert (std::make_pair (record + "@" + type, key.empty() ? kNullKey : key)); }
+
+    void add (const RecordToKey& map)
+    {
+      for( RecordToKey::const_iterator itr = map.begin() ;
+	   itr != map.end() ;
+	   ++itr )
+	{
+	  m_recordToKey.insert( std::make_pair( itr->first, itr->second.empty() ? kNullKey : itr->second ) ) ;
+	}
+    }
+
+    void setTSCKey( const std::string& tscKey )
+    { m_tscKey = tscKey ; }
+
+    void setSubsystemKey( L1Subsystems subsystem, const std::string& key )
+    { m_subsystemKeys[ subsystem ] = key.empty() ? kNullKey : key ; }
+
+    /* Gets payload key for record and type. If no such paylaod exists, emtpy string
+     * is returned.
+     */
+    std::string get (const std::string & record, const std::string & type) const
+    {
+        RecordToKey::const_iterator it = m_recordToKey.find (record + "@" + type);
+        if (it == m_recordToKey.end ())
+            return std::string ();
+        else
+	  return it->second == kNullKey ? kEmptyKey : it->second ;
+    }
+
+    const std::string& tscKey() const
+      { return m_tscKey ; }
+
+    const std::string& subsystemKey( L1Subsystems subsystem ) const
+      { std::map<int,std::string>::const_iterator key = m_subsystemKeys.find( subsystem );
+        return key == m_subsystemKeys.end() || key->second == kNullKey ? kEmptyKey : key->second ; }
+
+    // NB: null keys are represented by kNullKey, not by an empty string
+    const RecordToKey& recordToKeyMap() const
+      { return m_recordToKey ; }
+
+protected:
+    /* Mapping from records and types to tokens.
+     * I as unvable to make type std::map<std::pair<std::string, std::string>, std::string> persistent
+     * so record and type are concatanated with @ sign and resulting string is used as a key.
+     */
+
+  // wsun 03/2008: instead of tokens, store the configuration keys instead.
+/*     typedef std::map<std::string, std::string> RecordsToToken; */
+/*     RecordsToToken recordsToToken; */
+    RecordToKey m_recordToKey;
+
+
+    // wsun 03/2008: add data member for TSC key
+    std::string m_tscKey ;
+    std::map<int,std::string> m_subsystemKeys;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h
+++ b/CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h
@@ -1,0 +1,82 @@
+#ifndef CondFormats_L1TObjects_L1TriggerKeyListExt_h
+#define CondFormats_L1TObjects_L1TriggerKeyListExt_h
+
+// system include files
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <string>
+#include <map>
+
+class L1TriggerKeyListExt
+{
+
+   public:
+      L1TriggerKeyListExt();
+      virtual ~L1TriggerKeyListExt();
+
+      typedef std::map< std::string, std::string > KeyToToken ;
+      typedef std::map< std::string, KeyToToken > RecordToKeyToToken ;
+
+      // ---------- const member functions ---------------------
+
+      // Get payload token for L1TriggerKeyExt
+      std::string token( const std::string& tscKey ) const ;
+
+      // Get payload token for configuration data
+      std::string token( const std::string& recordName,
+			 const std::string& dataType,
+			 const std::string& key ) const ;
+
+      // Get payload token for configuration data
+      std::string token( const std::string& recordType, // "record@type"
+			 const std::string& key ) const ;
+
+      const KeyToToken& tscKeyToTokenMap() const
+	{ return m_tscKeyToToken ; }
+
+      const RecordToKeyToToken& recordTypeToKeyToTokenMap() const
+	{ return m_recordKeyToken ; }
+
+      // Get object key for a given payload token.  In practice, each
+      // record in the CondDB has only one object, so there is no need to
+      // specify the data type.
+      std::string objectKey( const std::string& recordName,
+			     const std::string& payloadToken ) const ;
+
+      // Get TSC key for a given L1TriggerKeyExt payload token
+      std::string tscKey( const std::string& triggerKeyPayloadToken ) const ;
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+      // Store payload token for L1TriggerKey, return true if successful
+      bool addKey( const std::string& tscKey,
+		   const std::string& payloadToken,
+		   bool overwriteKey = false ) ;
+
+      // Store payload token for configuration data, return true if successful
+      bool addKey( const std::string& recordType, // "record@type"
+		   const std::string& key,
+		   const std::string& payloadToken,
+		   bool overwriteKey = false ) ;
+
+   private:
+      //L1TriggerKeyListExt(const L1TriggerKeyListExt&); // stop default
+
+      //const L1TriggerKeyListExt& operator=(const L1TriggerKeyListExt&); // stop default
+
+      // ---------- member data --------------------------------
+
+      // map of TSC key (first) to L1TriggerKeyExt payload token (second)
+      KeyToToken m_tscKeyToToken ;
+
+      // map of subsystem key (second/first) to configuration data payload
+      // token (second/second), keyed by record@type (first)
+      RecordToKeyToToken m_recordKeyToken ;
+
+  COND_SERIALIZABLE;
+};
+
+
+#endif

--- a/CondFormats/L1TObjects/src/L1TriggerKeyExt.cc
+++ b/CondFormats/L1TObjects/src/L1TriggerKeyExt.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+
+const std::string L1TriggerKeyExt::kNullKey = "NULL" ;
+const std::string L1TriggerKeyExt::kEmptyKey = "" ;

--- a/CondFormats/L1TObjects/src/L1TriggerKeyListExt.cc
+++ b/CondFormats/L1TObjects/src/L1TriggerKeyListExt.cc
@@ -1,0 +1,215 @@
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+
+L1TriggerKeyListExt::L1TriggerKeyListExt()
+{
+}
+
+// L1TriggerKeyListExt::L1TriggerKeyListExt(const L1TriggerKeyListExt& rhs)
+// {
+//    // do actual copying here;
+// }
+
+L1TriggerKeyListExt::~L1TriggerKeyListExt()
+{
+}
+
+//
+// assignment operators
+//
+// const L1TriggerKeyListExt& L1TriggerKeyListExt::operator=(const L1TriggerKeyListExt& rhs)
+// {
+//   //An exception safe implementation is
+//   L1TriggerKeyListExt temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
+
+//
+// member functions
+//
+
+bool
+L1TriggerKeyListExt::addKey( const std::string& tscKey,
+			  const std::string& payloadToken,
+			  bool overwriteKey )
+{
+  std::pair< KeyToToken::iterator, bool > result =
+    m_tscKeyToToken.insert( std::make_pair( tscKey, payloadToken ) ) ;
+
+  if( !result.second && overwriteKey )
+    {
+      // Erase previous entry
+      m_tscKeyToToken.erase( result.first ) ;
+
+      // Try again
+      result = m_tscKeyToToken.insert( std::make_pair( tscKey,
+						       payloadToken ) ) ;
+    }
+
+  return result.second ;
+}
+
+bool
+L1TriggerKeyListExt::addKey( const std::string& recordType,
+			  const std::string& key,
+			  const std::string& payloadToken,
+			  bool overwriteKey )
+{
+  RecordToKeyToToken::iterator it = m_recordKeyToken.find( recordType ) ;
+
+  if( it == m_recordKeyToken.end() )
+    {
+      it = m_recordKeyToken.insert( std::make_pair( recordType,
+						    KeyToToken() ) ).first ;
+    } 
+
+  std::pair< KeyToToken::iterator, bool > result =
+    it->second.insert( std::make_pair( key, payloadToken ) ) ;
+
+  if( !result.second && overwriteKey )
+    {
+      // Erase previous entry
+      it->second.erase( result.first ) ;
+
+      // Try again
+      result = it->second.insert( std::make_pair( key, payloadToken ) ) ;
+    }
+
+  return result.second ;
+}
+
+//
+// const member functions
+//
+
+std::string
+L1TriggerKeyListExt::token( const std::string& tscKey ) const
+{
+  KeyToToken::const_iterator it = m_tscKeyToToken.find( tscKey ) ;
+
+  if( it == m_tscKeyToToken.end() )
+    {
+      return std::string() ;
+    }
+  else
+    {
+      return it->second;
+    }
+}
+
+std::string
+L1TriggerKeyListExt::token( const std::string& recordName,
+			 const std::string& dataType,
+			 const std::string& key ) const
+{
+  std::string recordType = recordName + "@" + dataType ;
+  return token( recordType, key ) ;
+}
+
+std::string
+L1TriggerKeyListExt::token( const std::string& recordType,
+			 const std::string& key ) const
+{
+  RecordToKeyToToken::const_iterator it = m_recordKeyToken.find( recordType ) ;
+
+  if( it == m_recordKeyToken.end() )
+    {
+      return std::string() ;
+    } 
+  else
+    {
+      KeyToToken::const_iterator it2 = it->second.find( key ) ;
+
+      if( it2 == it->second.end() )
+	{
+	  return std::string() ;
+	}
+      else
+	{
+	  return it2->second ;
+	}
+    }
+}
+
+// std::string
+// L1TriggerKeyListExt::objectKey( const std::string& recordName,
+// 			     const std::string& dataType,
+// 			     const std::string& payloadToken ) const
+// {
+//   return objectKey( recordName + "@" + dataType,
+// 		    payloadToken ) ;
+// }
+
+// std::string
+// L1TriggerKeyListExt::objectKey( const std::string& recordType,// "record@type"
+// 			     const std::string& payloadToken ) const
+// {
+//   RecordToKeyToToken::const_iterator keyTokenMap =
+//     m_recordKeyToken.find( recordType ) ;
+
+//   if( keyTokenMap != m_recordKeyToken.end() )
+//     {
+//       // Find object key with matching payload token.
+//       KeyToToken::const_iterator iKey = keyTokenMap.second.begin();
+//       KeyToToken::const_iterator eKey = keyTokenMap.second.end() ;
+//       for( ; iKey != eKey ; ++iKey )
+// 	{
+// 	  if( iKey->second == payloadToken )
+// 	    {
+// 	      return iKey->first ;
+// 	    }
+// 	}
+//     }
+
+//   return std::string() ;
+// }
+
+std::string
+L1TriggerKeyListExt::objectKey( const std::string& recordName,
+			     const std::string& payloadToken ) const
+{
+  RecordToKeyToToken::const_iterator iRecordType = m_recordKeyToken.begin() ;
+  for( ; iRecordType != m_recordKeyToken.end() ; ++iRecordType )
+    {
+      // Extract record name from recordType
+      std::string recordInMap( iRecordType->first, 0,
+			       iRecordType->first.find_first_of("@") ) ;
+      if( recordInMap == recordName )
+	{
+	  // Find object key with matching payload token.
+	  KeyToToken::const_iterator iKey = iRecordType->second.begin();
+	  KeyToToken::const_iterator eKey = iRecordType->second.end() ;
+	  for( ; iKey != eKey ; ++iKey )
+	    {
+	      if( iKey->second == payloadToken )
+		{
+		  return iKey->first ;
+		}
+	    }
+	}
+    }
+
+  return std::string() ;
+}
+
+std::string
+L1TriggerKeyListExt::tscKey( const std::string& triggerKeyPayloadToken ) const
+{
+  // Find object key with matching payload token.
+  KeyToToken::const_iterator iKey = m_tscKeyToToken.begin();
+  KeyToToken::const_iterator eKey = m_tscKeyToToken.end() ;
+  for( ; iKey != eKey ; ++iKey )
+    {
+      if( iKey->second == triggerKeyPayloadToken )
+	{
+	  return iKey->first ;
+	}
+    }
+
+  return std::string() ;
+}
+
+//
+// static member functions
+//

--- a/CondFormats/L1TObjects/src/T_EventSetup_L1TriggerKeyExt.cc
+++ b/CondFormats/L1TObjects/src/T_EventSetup_L1TriggerKeyExt.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(L1TriggerKeyExt);

--- a/CondFormats/L1TObjects/src/T_EventSetup_L1TriggerKeyListExt.cc
+++ b/CondFormats/L1TObjects/src/T_EventSetup_L1TriggerKeyListExt.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(L1TriggerKeyListExt);

--- a/CondFormats/L1TObjects/src/classes.h
+++ b/CondFormats/L1TObjects/src/classes.h
@@ -26,6 +26,8 @@
 #include "CondFormats/L1TObjects/interface/L1CaloHcalScale.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKey.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyList.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
 
 #include "CondFormats/L1TObjects/interface/L1GtStableParameters.h"
 #include "CondFormats/L1TObjects/interface/L1GtParameters.h"

--- a/CondFormats/L1TObjects/src/classes_def.xml
+++ b/CondFormats/L1TObjects/src/classes_def.xml
@@ -145,9 +145,16 @@
   <class name="L1TriggerKey">
     <field name="m_recordToKey" mapping="blob" />
   </class>
+  <class name="L1TriggerKeyExt">
+      <field name="m_recordToKey" mapping="blob" />
+  </class>
   <class name="L1TriggerKeyList">
     <field name="m_recordKeyToken" mapping="blob" />
     <field name="m_tscKeyToToken" mapping="blob" />
+  </class>
+  <class name="L1TriggerKeyListExt">
+      <field name="m_recordKeyToken" mapping="blob" />
+      <field name="m_tscKeyToToken" mapping="blob" />
   </class>
   <class name="L1RCTParameters">
     <field name="HoverE_smear_high_" mapping="blob" />

--- a/CondTools/L1Trigger/interface/WriterProxy.h
+++ b/CondTools/L1Trigger/interface/WriterProxy.h
@@ -71,14 +71,16 @@ class WriterProxyT : public WriterProxy
 		throw cond::Exception( "DataWriter: PoolDBOutputService not available."
 				       ) ;
 	      }
+            poolDb->forceInit();  
 	    cond::persistency::Session session = poolDb->session();
 	    cond::persistency::TransactionScope tr(session.transaction());
 	    // if throw transaction will unroll
-	    tr.start(false);
+///	    tr.start(false);
 
 	    boost::shared_ptr<Type> pointer(new Type (*(handle.product ())));
 	    std::string payloadToken =  session.storePayload( *pointer );
-	    tr.commit();
+///	    tr.commit();
+            tr.close();
 	    return payloadToken ;
         }
 };

--- a/CondTools/L1Trigger/plugins/SealModule.cc
+++ b/CondTools/L1Trigger/plugins/SealModule.cc
@@ -212,13 +212,3 @@ REGISTER_L1_WRITER(L1GtPsbSetupRcd, L1GtPsbSetup);
 #include "CondFormats/DataRecord/interface/L1CaloGeometryRecord.h"
 
 REGISTER_L1_WRITER(L1CaloGeometryRecord, L1CaloGeometry);
-
-// Upgrade Records:
-
-#include "CondFormats/L1TObjects/interface/CaloParams.h"
-#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
-#include "CondFormats/L1TObjects/interface/CaloConfig.h"
-#include "CondFormats/DataRecord/interface/L1TCaloConfigRcd.h"
-using namespace l1t;
-REGISTER_L1_WRITER(L1TCaloParamsRcd, CaloParams);
-REGISTER_L1_WRITER(L1TCaloConfigRcd, CaloConfig);

--- a/CondTools/L1Trigger/scripts/o2o-setIOV-l1Key.sh
+++ b/CondTools/L1Trigger/scripts/o2o-setIOV-l1Key.sh
@@ -2,22 +2,27 @@
 
 # L1Trigger O2O - set IOVs
 
+
 nflag=0
-oflag=0
-pflag=0
-while getopts 'noph' OPTION
+oflag=""
+fflag=""
+xflag=""
+while getopts 'nofxh' OPTION
   do
   case $OPTION in
       n) nflag=1
           ;;
-      o) oflag=1
+      o) oflag="-o"
           ;;
-      p) pflag=1
+      f) fflag="-f"
+	  ;;
+      x) xflag="-x"
 	  ;;
       h) echo "Usage: [-n] runnum L1_KEY"
           echo "  -n: no RS"
           echo "  -o: overwrite RS keys"
-          echo "  -p: centrally installed release, not on local machine"
+	  echo "  -f: force IOV update"
+	  echo "  -x: write to DB instead of local file"
           exit
           ;;
   esac
@@ -28,52 +33,50 @@ shift $(($OPTIND - 1))
 run=$1
 l1Key=$2
 
-release=CMSSW_4_2_3_ONLINE
-version=011
+release=CMSSW_7_4_2
+workdir=/nfshome0/l1emulator/run2/o2o/v7/
+version=015
 
-echo "`date` : o2o-setIOV-l1Key-slc5.sh $run $l1Key" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+logfile=${workdir}/o2o-setIOV-${version}.log
+summaryfile=${workdir}/o2o-summary
+lockfile=o2o-setIOV.lock
+
+
+echo "`date` : o2o-setIOV-l1Key.sh $run $l1Key" | tee -a ${logfile}
+echo "`uptime`" | tee -a ${logfile}
 START=$(date +%s)
 
 if [ $# -lt 2 ]
     then
-    echo "Wrong number of arguments.  Usage: $0 [-n] runnum L1_KEY" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+    echo "Wrong number of arguments.  Usage: $0 [-n] runnum L1_KEY" | tee -a ${logfile}
     exit 127
 fi
 
-# set up environment variables
-cd /cmsnfshome0/nfshome0/popcondev/L1Job/${release}/o2o
-
-if [ ${pflag} -eq 0 ]
-    then
-    export SCRAM_ARCH=""
-    export VO_CMS_SW_DIR=""
-    source /opt/cmssw/cmsset_default.sh
-else
-    source /nfshome0/cmssw2/scripts/setup.sh
-    centralRel="-p"
-fi
-eval `scramv1 run -sh`
+# setup CMSSW
+source /data/cmssw/cmsset_default.sh
+cd ${workdir}/${release}
+cmsenv
+cd ../o2o/
+SCRIPTS=${workdir}/${release}/src/CondTools/L1TriggerExt/scripts
 
 # Check for semaphore file
-if [ -f o2o-setIOV.lock ]
+if [ -f ${lockfile} ]
     then
-    echo "$0 already running.  Aborting process."  | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+    echo "$0 already running.  Aborting process."  | tee -a ${logfile}
     echo "$0 already running.  Aborting process."  1>&2
-    tail -3 /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log >> /nfshome0/popcondev/L1Job/o2o.summary
+    tail -4 ${logfile} >> ${summaryfile}
     exit 50
 else
-    touch o2o-setIOV.lock
+    touch $lockfile
 fi
 
 # Delete semaphore and exit if any signal is trapped
 # KILL signal (9) is not trapped even though it is listed below.
-trap "rm -f o2o-setIOV.lock; mv tmp.log tmp.log.save; exit" 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
+trap "rm -f ${lockfile}; mv tmp.log tmp.log.terminated; exit" 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
 
 # run script; args are run key
 rm -f tmp.log
-echo "`date` : setting TSC IOVs" >& tmp.log
-tscKey=`$CMSSW_BASE/src/CondTools/L1Trigger/scripts/getKeys.sh -t ${l1Key}`
-echo "`date` : parsed tscKey = ${tscKey}" >> tmp.log 2>&1
+echo "`date`" >& tmp.log
 
 # Check if o2o-tscKey.sh is running.  If so, wait 15 seconds to prevent simultaneous writing ot ORCON.
 if [ -f o2o-tscKey.lock ]
@@ -83,49 +86,47 @@ if [ -f o2o-tscKey.lock ]
     echo "Resuming process." >> tmp.log 2>&1
 fi
 
-$CMSSW_BASE/src/CondTools/L1Trigger/scripts/runL1-O2O-iov.sh -x ${centralRel} ${run} ${tscKey} >> tmp.log 2>&1
-o2ocode1=$?
 
 o2ocode2=0
-
-if [ ${oflag} -eq 1 ]
-    then
-    overwrite="-o"
-fi
 
 if [ ${nflag} -eq 0 ]
     then
     echo "`date` : setting RS keys and IOVs" >> tmp.log 2>&1
-    $CMSSW_BASE/src/CondTools/L1Trigger/scripts/runL1-O2O-rs-keysFromL1Key.sh -x ${overwrite} ${centralRel} ${run} ${l1Key} >> tmp.log 2>&1
+    ${SCRIPTS}/runL1-O2O-rs-keysFromL1Key.sh ${xflag} ${oflag} ${fflag} ${run} ${l1Key} >> tmp.log 2>&1
     o2ocode2=$?
 fi
 
-tail -1 /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log >> /nfshome0/popcondev/L1Job/o2o.summary
+echo "`date` : setting TSC IOVs" >> tmp.log 2>&1
+tscKey=`$CMSSW_BASE/src/CondTools/L1Trigger/scripts/getKeys.sh -t ${l1Key}`
+echo "`date` : parsed tscKey = ${tscKey}" >> tmp.log 2>&1
+$SCRIPTS/runL1-O2O-iov.sh ${xflag} ${oflag} ${fflag} ${run} ${tscKey} >> tmp.log 2>&1
+o2ocode1=$?
+
+tail -2 ${logfile} >> ${summaryfile}
 
 # Filter CORAL debug output into different file, which gets deleted if no errors
-grep -E "CORAL.*Info|CORAL.*Debug" tmp.log >& /nfshome0/popcondev/L1Job/coraldebug-${run}.log
-grep -Ev "CORAL.*Info|CORAL.*Debug" tmp.log | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+grep -E "CORAL.*Info|CORAL.*Debug" tmp.log >& coraldebug-${run}.log
+grep -Ev "CORAL.*Info|CORAL.*Debug" tmp.log | tee -a ${logfile}
 #cat tmp.log | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
 
 # log TSC key and RS keys
-echo "runNumber=${run} tscKey=${tscKey}" >> /nfshome0/popcondev/L1Job/keylogs/tsckeys.txt
+echo "runNumber=${run} tscKey=${tscKey}" >> ./keylogs/tsckeys.txt
 
 if [ ${nflag} -eq 0 ]
-    then
-    grep KEYLOG tmp.log | sed 's/KEYLOG //' >> /nfshome0/popcondev/L1Job/keylogs/rskeys.txt
+then
+    grep KEYLOG tmp.log | sed 's/KEYLOG //' >> ./keylogs/rskeys.txt
 fi
 
 rm -f tmp.log
 
-echo "cmsRun status (TSC) ${o2ocode1}" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
-echo "cmsRun status (RS) ${o2ocode2}" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+echo "cmsRun status (TSC) ${o2ocode1}" | tee -a ${logfile} 
+echo "cmsRun status (RS) ${o2ocode2}" | tee -a ${logfile}
 o2ocode=`echo ${o2ocode1} + ${o2ocode2} | bc`
-echo "exit code ${o2ocode}" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
 
 if [ ${o2ocode} -eq 0 ]
-    then
+then
     echo "L1-O2O-INFO: o2o-setIOV-l1Key-slc5.sh successful"
-    rm -f /nfshome0/popcondev/L1Job/coraldebug-${run}.log
+    rm -f coraldebug-${run}.log
 else
     if [ ${o2ocode1} -eq 90 -o ${o2ocode2} -eq 90 ]
 	then
@@ -137,21 +138,21 @@ else
     fi
 fi
 
-echo "`date` : o2o-setIOV-l1Key-slc5.sh finished : ${run} ${l1Key}" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+echo "`date` : o2o-setIOV-l1Key-slc5.sh finished : ${run} ${l1Key}" | tee -a ${logfile}
 
 END=$(date +%s)
 DIFF=$(( $END - $START ))
 if [ ${DIFF} -gt 60 ]
     then
-    echo "O2O SLOW: `date`, ${DIFF} seconds for ${run} ${l1Key}" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+    echo "O2O SLOW: `date`, ${DIFF} seconds for ${run} ${l1Key}" | tee -a ${logfile}
 else
-    echo "Time elapsed: ${DIFF} seconds" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+    echo "Time elapsed: ${DIFF} seconds" | tee -a ${logfile}
 fi
-echo "" | tee -a /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log
+echo "" | tee -a ${logfile}
 
-tail -6 /nfshome0/popcondev/L1Job/o2o-setIOV-${version}.log >> /nfshome0/popcondev/L1Job/o2o.summary
+tail -6 ${logfile} >> ${summaryfile}
 
 # Delete semaphore file
-rm -f o2o-setIOV.lock
+rm -f ${lockfile}
 
 exit ${o2ocode}

--- a/CondTools/L1Trigger/scripts/runL1-O2O-iov.sh
+++ b/CondTools/L1Trigger/scripts/runL1-O2O-iov.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 
 xflag=0
-pflag=0
-while getopts 'xph' OPTION
+CMS_OPTIONS=""
+
+while getopts 'xfh' OPTION
   do
   case $OPTION in
       x) xflag=1
           ;;
-      p) pflag=1
-	  ;;
-      h) echo "Usage: [-x] runnum tsckey"
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
+          ;;
+      h) echo "Usage: [-xf] runnum tsckey"
           echo "  -x: write to ORCON instead of sqlite file"
-          echo "  -p: centrally installed release, not on local machine"
+          echo "  -f: force IOV update"
           exit
           ;;
   esac
@@ -21,102 +22,64 @@ shift $(($OPTIND - 1))
 runnum=$1
 tsckey=$2
 
-if [ ${pflag} -eq 0 ]
-    then
-    export SCRAM_ARCH=""
-    export VO_CMS_SW_DIR=""
-    source /opt/cmssw/cmsset_default.sh
-else
-    source /nfshome0/cmssw2/scripts/setup.sh
-fi
-eval `scramv1 run -sh`
-export TNS_ADMIN=/nfshome0/popcondev/conddb
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS
 
 if [ ${xflag} -eq 0 ]
-    then
+then
     echo "Writing to sqlite_file:l1config.db instead of ORCON."
-    if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=sqlite_file:l1config.db inputDBAuth=. printL1TriggerKeyList=1 | grep ${tsckey} ; then echo "TSC payloads present"
-    else
-	echo "TSC payloads absent; writing now"
-	cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWritePayloadOnline_cfg.py tscKey=${tsckey} outputDBConnect=sqlite_file:l1config.db outputDBAuth=. logTransactions=0 print
-	o2ocode=$?
-	if [ ${o2ocode} -ne 0 ]
-	    then
-	    echo "L1-O2O-ERROR: could not write TSC payloads"
-	    echo "L1-O2O-ERROR: could not write TSC payloads" 1>&2
-	    exit ${o2ocode}
-	fi
-    fi
+    INDB_OPTIONS="inputDBConnect=sqlite_file:l1config.db inputDBAuth=." 
+    OUTDB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+#    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T copyDBAuth=."
+    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS copyDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+else
+    echo "Writing to cms_orcoff_prep"
+    INDB_OPTIONS="inputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS inputDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+    OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+    #echo "Cowardly refusing to write to the online database"
+    #exit
+fi
 
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteIOVOnline_cfg.py tscKey=${tsckey} runNumber=${runnum} outputDBConnect=sqlite_file:l1config.db outputDBAuth=. logTransactions=0 print
+
+if cmsRun ${CMSSW_BASE}/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyList=1 | grep ${tsckey} ; then echo "TSC payloads present"
+else
+    echo "TSC payloads absent; writing now"
+    cmsRun ${CMSSW_BASE}/src/CondTools/L1Trigger/test/L1ConfigWritePayloadOnline_cfg.py tscKey=${tsckey} ${OUTDB_OPTIONS} ${COPY_OPTIONS} logTransactions=0 print
     o2ocode=$?
-    if [ ${o2ocode} -eq 0 ]
-	then
-	echo
-	echo "`date` : checking O2O"
-	if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=sqlite_file:l1config.db inputDBAuth=. printL1TriggerKey=1 runNumber=${runnum} | grep ${tsckey} ; then echo "L1-O2O-INFO: IOV OK"
-	else
-	    echo "L1-O2O-ERROR: IOV NOT OK"
-	    echo "L1-O2O-ERROR: IOV NOT OK" 1>&2
-	    exit 199
-	fi
-    else
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-        else
-            if [ ${o2ocode} -eq 65 ]
-                then
-                echo "L1-O2O-ERROR: problem writing object to ORCON."
-                echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-            fi
-        fi
+    if [ ${o2ocode} -ne 0 ]
+    then
+	echo "L1-O2O-ERROR: could not write TSC payloads"
+	echo "L1-O2O-ERROR: could not write TSC payloads" 1>&2
 	exit ${o2ocode}
     fi
-else
-    echo "`date` : checking for TSC payloads"
-#    if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T inputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T printL1TriggerKeyList=1 | grep ${tsckey} ; then echo "`date` : TSC payloads present"
-#    else
-        echo "`date` : TSC payloads absent; writing now"
-	cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWritePayloadOnline_cfg.py tscKey=${tsckey} outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T print
-	o2ocode1=$?
-	if [ ${o2ocode1} -ne 0 ]
-	    then
-	    echo "L1-O2O-ERROR: could not write TSC payloads"
-	    echo "L1-O2O-ERROR: could not write TSC payloads" 1>&2
-#	    exit ${o2ocode1}
-	fi
-#    fi
+fi
 
-    echo "`date` : setting TSC IOVs"
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteIOVOnline_cfg.py tscKey=${tsckey} runNumber=${runnum} outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T print
-    o2ocode2=$?
-    if [ ${o2ocode2} -eq 0 ]
-	then
-	echo
-	echo "`date` : checking O2O"
-	if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T inputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T printL1TriggerKey=1 runNumber=${runnum} | grep ${tsckey} ; then echo "L1-O2O-INFO: IOV OK"
-	else
-	    echo "L1-O2O-ERROR: IOV NOT OK"
-	    echo "L1-O2O-ERROR: IOV NOT OK" 1>&2
-	    exit 199
-	fi
+cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteIOVOnline_cfg.py ${CMS_OPTIONS} tscKey=${tsckey} runNumber=${runnum} ${OUTDB_OPTIONS} logTransactions=0 print
+o2ocode=$?
+
+if [ ${o2ocode} -eq 0 ]
+then
+    echo
+    echo "`date` : checking O2O"
+    if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKey=1 runNumber=${runnum} | grep ${tsckey} ; then echo "L1-O2O-INFO: IOV OK"
     else
-	if [ ${o2ocode2} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-        else
-            if [ ${o2ocode2} -eq 65 ]
-                then
-                echo "L1-O2O-ERROR: problem writing object to ORCON."
-                echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-            fi
-        fi
-#	exit ${o2ocode}
+	echo "L1-O2O-ERROR: IOV NOT OK"
+	echo "L1-O2O-ERROR: IOV NOT OK" 1>&2
+	exit 199
     fi
-
-    o2ocode=`echo ${o2ocode1} + ${o2ocode2} | bc`
+else
+    if [ ${o2ocode} -eq 66 ]
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+        if [ ${o2ocode} -eq 65 ]
+        then
+            echo "L1-O2O-ERROR: problem writing object to ORCON."
+            echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+        fi
+    fi
     exit ${o2ocode}
 fi
-exit
+
+
+

--- a/CondTools/L1Trigger/scripts/runL1-O2O-key.sh
+++ b/CondTools/L1Trigger/scripts/runL1-O2O-key.sh
@@ -1,25 +1,22 @@
 #!/bin/sh
 
 xflag=0
-oflag=0
 cflag=0
-pflag=0
-while getopts 'xocph' OPTION
+CMS_OPTIONS=""
+
+while getopts 'xoch' OPTION
   do
   case $OPTION in
       x) xflag=1
           ;;
-      o) oflag=1
+      o) CMS_OPTIONS=$CMS_OPTIONS" overwriteKeys=1"
           ;;
       c) cflag=1
           ;;
-      p) pflag=1
-	  ;;
       h) echo "Usage: [-x] [-o] tsckey"
 	  echo "  -x: write to ORCON instead of sqlite file"
 	  echo "  -o: overwrite keys"
 	  echo "  -c: copy non-O2O payloads from ORCON"
-          echo "  -p: centrally installed release, not on local machine"
 	  exit
 	  ;;
   esac
@@ -29,83 +26,49 @@ shift $(($OPTIND - 1))
 tsckey=$1
 shift 1
 
-if [ ${pflag} -eq 0 ]
-    then
-    export SCRAM_ARCH=""
-    export VO_CMS_SW_DIR=""
-    source /opt/cmssw/cmsset_default.sh
-else
-    source /nfshome0/cmssw2/scripts/setup.sh
-fi
-eval `scramv1 run -sh`
-export TNS_ADMIN=/nfshome0/popcondev/conddb
-
-if [ ${oflag} -eq 1 ]
-    then
-    overwrite="overwriteKeys=1"
-fi
-
+COPY_OPTIONS=""
 if [ ${cflag} -eq 1 ]
-    then
-    copyorcon="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T copyDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T"
+then
+#   COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T copyDBAuth=."
+    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS copyDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
 fi
 
 if [ ${xflag} -eq 0 ]
-    then
+then
     echo "Writing to sqlite_file:l1config.db instead of ORCON."
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWritePayloadOnline_cfg.py tscKey=${tsckey} outputDBConnect=sqlite_file:l1config.db ${overwrite} ${copyorcon} outputDBAuth=. logTransactions=0 print
-    o2ocode=$?
-    if [ ${o2ocode} -eq 0 ]
-	then
-	echo
-	echo "`date` : checking O2O"
-	if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=sqlite_file:l1config.db inputDBAuth=. printL1TriggerKeyList=1 | grep ${tsckey} ; then echo "L1TRIGGERKEY WRITTEN SUCCESSFULLY"
-	else
-	    echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED"
-	    echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED" 1>&2
-	    exit 199
-	fi
+    INDB_OPTIONS="inputDBConnect=sqlite_file:l1config.db inputDBAuth=."
+    OUTDB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+else
+    echo "Writing to cms_orcoff_prep"
+    INDB_OPTIONS="inputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS inputDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+    OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+    #echo "Cowardly refusing to write to the online database"
+    #exit
+fi
+
+cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWritePayloadOnline_cfg.py tscKey=${tsckey} ${CMS_OPTIONS} ${OUTDB_OPTIONS} ${COPY_OPTIONS} logTransactions=0 print
+o2ocode=$?
+if [ ${o2ocode} -eq 0 ]
+then
+    echo
+    echo "`date` : checking O2O"
+    if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyList=1 | grep ${tsckey} ; then echo "L1TRIGGERKEY WRITTEN SUCCESSFULLY"
     else
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-        else
-            if [ ${o2ocode} -eq 65 ]
-                then
-                echo "L1-O2O-ERROR: problem writing object to ORCON."
-                echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-            fi
-        fi
-	exit ${o2ocode}
+	echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED"
+	echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED" 1>&2
+	exit 199
     fi
 else
-    echo "Writing to cms_orcon_prod."
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWritePayloadOnline_cfg.py tscKey=${tsckey} outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T ${overwrite} ${copyorcon} print
-    o2ocode=$?
-    if [ ${o2ocode} -eq 0 ]
-	then
-	echo
-	echo "`date` : checking O2O"
-	if cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T inputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T printL1TriggerKeyList=1 | grep ${tsckey} ; then echo "L1TRIGGERKEY WRITTEN SUCCESSFULLY"
-	else
-	    echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED"
-	    echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED" 1>&2
-	    exit 199
-	fi
+    if [ ${o2ocode} -eq 66 ]
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
     else
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-        else
-            if [ ${o2ocode} -eq 65 ]
-                then
-                echo "L1-O2O-ERROR: problem writing object to ORCON."
-                echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-            fi
+        if [ ${o2ocode} -eq 65 ]
+        then
+            echo "L1-O2O-ERROR: problem writing object to ORCON."
+            echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
         fi
-	exit ${o2ocode}
     fi
+    exit ${o2ocode}
 fi
-exit

--- a/CondTools/L1Trigger/scripts/runL1-O2O-rs-keysFromL1Key.sh
+++ b/CondTools/L1Trigger/scripts/runL1-O2O-rs-keysFromL1Key.sh
@@ -1,24 +1,24 @@
-#!/bin/sh
 
 xflag=0
-oflag=0
-pflag=0
 gflag=0
-while getopts 'xopgh' OPTION
+
+CMS_OPTIONS=""
+
+while getopts 'oxfgh' OPTION
   do
   case $OPTION in
+      o) CMS_OPTIONS=$CMS_OPTIONS" overwriteKeys=1"
+          ;;
       x) xflag=1
           ;;
-      o) oflag=1
-          ;;
-      p) pflag=1
-          ;;
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
+	  ;;
       g) gflag=1
 	  ;;
-      h) echo "Usage: [-x] tsckey runnum"
-          echo "  -x: write to ORCON instead of sqlite file"
+      h) echo "Usage: [-x] runnum l1key"
 	  echo "  -o: overwrite keys"
-          echo "  -p: centrally installed release, not on local machine"
+          echo "  -x: write to ORCON instead of sqlite file"
+	  echo "  -f: force IOV update"
 	  echo "  -g: GT RS records only"
           exit
 	  ;;
@@ -29,65 +29,47 @@ shift $(($OPTIND - 1))
 runnum=$1
 l1Key=$2
 
-if [ ${pflag} -eq 0 ]
-    then
-    export SCRAM_ARCH=""
-    export VO_CMS_SW_DIR=""
-    source /opt/cmssw/cmsset_default.sh
-else
-    source /nfshome0/cmssw2/scripts/setup.sh
-fi
-eval `scramv1 run -sh`
-export TNS_ADMIN=/nfshome0/popcondev/conddb
 
-if [ ${oflag} -eq 1 ]
-    then
-    overwrite="overwriteKeys=1"
-fi
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS
 
-if [ ${gflag} -eq 1 ]
-    then
-    rsflag="-g"
+if [ ${gflag} -eq 1 ] 
+then
+     OBJKEYS=`$CMSSW_BASE/src/CondTools/L1Trigger/scripts/getKeys.sh -g ${l1Key}`
 else
-    rsflag="-r"
+     OBJKEYS=`$CMSSW_BASE/src/CondTools/L1Trigger/scripts/getKeys.sh -r ${l1Key}`
 fi
+echo "INFO:  OBJECT KEYS:  " $OBJKEYS
 
 if [ ${xflag} -eq 0 ]
-    then
+then
     echo "Writing to sqlite_file:l1config.db instead of ORCON."
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py runNumber=${runnum} outputDBConnect=sqlite_file:l1config.db outputDBAuth=. ${overwrite} logTransactions=0 `$CMSSW_BASE/src/CondTools/L1Trigger/scripts/getKeys.sh ${rsflag} ${l1Key}` keysFromDB=0 print
-    o2ocode=$?
-    if [ ${o2ocode} -ne 0 ]
+    DB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+else
+    echo "Cowardly refusing to write to the online database"
+    DB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=." 
+    # WHEN READY FOR PRIME TIME:
+    # DB_OPTIONS= "outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=."
+fi
+
+
+cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py runNumber=${runnum} ${DB_OPTIONS} ${CMS_OPTIONS} logTransactions=0 $OBJKEYS keysFromDB=0 print
+o2ocode=$?
+
+if [ ${o2ocode} -ne 0 ] 
+then
+    if [ ${o2ocode} -eq 66 ] 
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+	if [ ${o2ocode} -eq 65 ] 
 	then
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-	else
-	    if [ ${o2ocode} -eq 65 ]
-		then
-		echo "L1-O2O-ERROR: problem writing object to ORCON."
-		echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-	    fi
+	    echo "L1-O2O-ERROR: problem writing object to ORCON."
+	    echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
 	fi
     fi
 else
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py runNumber=${runnum} outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T ${overwrite} `$CMSSW_BASE/src/CondTools/L1Trigger/scripts/getKeys.sh ${rsflag} ${l1Key}` keysFromDB=0 print
-    o2ocode=$?
-    if [ ${o2ocode} -ne 0 ]
-	then
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-	else
-	    if [ ${o2ocode} -eq 65 ]
-		then
-		echo "L1-O2O-ERROR: problem writing object to ORCON."
-		echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-	    fi
-	fi
-    fi
+    echo "runL1-o2o-rs-keysFromL1Key.sh ran successfully."
 fi
-
 exit ${o2ocode}
+

--- a/CondTools/L1Trigger/scripts/runL1-O2O-rs.sh
+++ b/CondTools/L1Trigger/scripts/runL1-O2O-rs.sh
@@ -1,21 +1,22 @@
-#!/bin/sh
 
 xflag=0
-oflag=0
-pflag=0
-while getopts 'xoph' OPTION
+gflag=0
+
+CMS_OPTIONS=""
+
+while getopts 'oxfgh' OPTION
   do
   case $OPTION in
+      o) CMS_OPTIONS=$CMS_OPTIONS" overwriteKeys=1"
+          ;;
       x) xflag=1
           ;;
-      o) oflag=1
-          ;;
-      p) pflag=1
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
 	  ;;
-      h) echo "Usage: [-x] runnum"
-          echo "  -x: write to ORCON instead of sqlite file"
+      h) echo "Usage: [-x] runnum l1key"
 	  echo "  -o: overwrite keys"
-          echo "  -p: centrally installed release, not on local machine"
+          echo "  -x: write to ORCON instead of sqlite file"
+	  echo "  -f: force IOV update"
           exit
 	  ;;
   esac
@@ -23,71 +24,41 @@ done
 shift $(($OPTIND - 1))
 
 runnum=$1
+l1Key=$2
 
-if [ ${pflag} -eq 0 ]
-    then
-    export SCRAM_ARCH=""
-    export VO_CMS_SW_DIR=""
-    source /opt/cmssw/cmsset_default.sh
-else
-    source /nfshome0/cmssw2/scripts/setup.sh
-fi
-eval `scramv1 run -sh`
-export TNS_ADMIN=/nfshome0/popcondev/conddb
 
-if [ ${oflag} -eq 1 ]
-    then
-    overwrite="overwriteKeys=1"
-fi
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS
 
 if [ ${xflag} -eq 0 ]
-    then
+then
     echo "Writing to sqlite_file:l1config.db instead of ORCON."
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSPayloadOnline_cfg.py outputDBConnect=sqlite_file:l1config.db outputDBAuth=. ${overwrite} logTransactions=0 print
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSIOVOnline_cfg.py runNumber=${runnum} outputDBConnect=sqlite_file:l1config.db outputDBAuth=. logTransactions=0 print
-    o2ocode=$?
-    if [ ${o2ocode} -ne 0 ]
-	then
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-	else
-	    if [ ${o2ocode} -eq 65 ]
-		then
-		echo "L1-O2O-ERROR: problem writing object to ORCON."
-		echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-	    fi
-	fi
-    fi
-
-#    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py runNumber=${runnum} outputDBConnect=sqlite_file:l1config.db outputDBAuth=. print
-#    echo "`date` : checking O2O"
-#    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=sqlite_file:l1config.db inputDBAuth=. printRSKeys=1 runNumber=${runnum}
-
+    DB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
 else
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSPayloadOnline_cfg.py outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T ${overwrite} print
-    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSIOVOnline_cfg.py runNumber=${runnum} outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T print
-    o2ocode=$?
-    if [ ${o2ocode} -ne 0 ]
-	then
-	if [ ${o2ocode} -eq 66 ]
-	    then
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
-	    echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
-	else
-	    if [ ${o2ocode} -eq 65 ]
-		then
-		echo "L1-O2O-ERROR: problem writing object to ORCON."
-		echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
-	    fi
-	fi
-    fi
-
-#    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py runNumber=${runnum} outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T print
-#    echo "`date` : checking O2O"
-#    cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/l1o2otestanalyzer_cfg.py inputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T inputDBAuth=/nfshome0/popcondev/conddb_taskWriters/L1T printRSKeys=1 runNumber=${runnum}
-
+    echo "Cowardly refusing to write to the online database"
+    DB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=." 
+    # WHEN READY FOR PRIME TIME:
+    # DB_OPTIONS= "outputDBConnect=oracle://cms_orcon_prod/CMS_COND_31X_L1T outputDBAuth=."
 fi
 
+
+cmsRun $CMSSW_BASE/src/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py runNumber=${runnum} ${DB_OPTIONS} ${CMS_OPTIONS} logTransactions=0 print
+o2ocode=$?
+
+if [ ${o2ocode} -ne 0 ] 
+then
+    if [ ${o2ocode} -eq 66 ] 
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+	if [ ${o2ocode} -eq 65 ] 
+	then
+	    echo "L1-O2O-ERROR: problem writing object to ORCON."
+	    echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+	fi
+    fi
+else
+    echo "runL1-o2o-rs-keysFromL1Key.sh ran successfully."
+fi
 exit ${o2ocode}
+

--- a/CondTools/L1Trigger/src/DataManager.cc
+++ b/CondTools/L1Trigger/src/DataManager.cc
@@ -32,7 +32,7 @@ namespace l1t
     else connection.setMessageVerbosity( coral::Error ) ;
     connection.configure() ;
 
-    session = connection.createSession( connectString, isOMDS );
+    session = connection.createSession( connectString, false );
 }
 
 DataManager::~DataManager ()

--- a/CondTools/L1Trigger/src/DataWriter.cc
+++ b/CondTools/L1Trigger/src/DataWriter.cc
@@ -39,6 +39,8 @@ DataWriter::writePayload( const edm::EventSetup& setup,
   // transaction here will become read-only.
 //   cond::DbSession session = poolDb->session();
 //   cond::DbScopedTransaction tr(session);
+
+  cond::persistency::TransactionScope tr(poolDb->session().transaction());
 //   // if throw transaction will unroll
 //   tr.start(false);
 
@@ -49,6 +51,7 @@ DataWriter::writePayload( const edm::EventSetup& setup,
   edm::LogVerbatim( "L1-O2O" ) << recordType << " PAYLOAD TOKEN "
 			       << payloadToken ;
 
+  tr.close();
 //   tr.commit ();
 
   return payloadToken ;
@@ -68,7 +71,7 @@ DataWriter::writeKeyList( L1TriggerKeyList* keyList,
 
   cond::persistency::Session session = poolDb->session();
   cond::persistency::TransactionScope tr(session.transaction());
-  tr.start( false );
+///  tr.start( false );
 
   // Write L1TriggerKeyList payload and save payload token before committing
   boost::shared_ptr<L1TriggerKeyList> pointer(keyList);
@@ -76,7 +79,8 @@ DataWriter::writeKeyList( L1TriggerKeyList* keyList,
 			
   // Commit before calling updateIOV(), otherwise PoolDBOutputService gets
   // confused.
-  tr.commit ();
+  //tr.commit ();
+  tr.close ();
   
   // Set L1TriggerKeyList IOV
   updateIOV( "L1TriggerKeyListRcd",

--- a/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py
+++ b/CondTools/L1Trigger/test/L1ConfigWriteRSOnline_cfg.py
@@ -36,6 +36,11 @@ options.register('overwriteKeys',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Overwrite existing keys")
+options.register('forceUpdate',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Check all record IOVs even if L1TriggerKey unchanged")
 options.register('logTransactions',
                  1, #default value
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -147,6 +152,9 @@ if options.overwriteKeys == 0:
     process.L1CondDBPayloadWriter.overwriteKeys = False
 else:
     process.L1CondDBPayloadWriter.overwriteKeys = True
+
+if options.forceUpdate == 1:
+    process.L1CondDBIOVWriter.forceUpdate = True
 
 from CondTools.L1Trigger.L1CondDBIOVWriter_cff import initIOVWriter
 initIOVWriter( process,

--- a/CondTools/L1TriggerExt/BuildFile.xml
+++ b/CondTools/L1TriggerExt/BuildFile.xml
@@ -1,0 +1,11 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="CondCore/DBOutputService"/>
+<use   name="CondCore/PluginSystem"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="CondFormats/L1TObjects"/>
+<use   name="CondTools/L1Trigger"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/CondTools/L1TriggerExt/interface/DataWriterExt.h
+++ b/CondTools/L1TriggerExt/interface/DataWriterExt.h
@@ -1,0 +1,101 @@
+#ifndef CondTools_L1Trigger_DataWriter_h
+#define CondTools_L1Trigger_DataWriter_h
+
+// Framework
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/DataKey.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondCore/CondDB/interface/Session.h"
+
+#include "DataFormats/Provenance/interface/RunID.h"
+
+// L1T includes
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+
+#include "CondTools/L1Trigger/interface/WriterProxy.h"
+
+#include <string>
+#include <map>
+
+namespace l1t
+{
+
+/* This class is used to write L1 Trigger configuration data to Pool DB.
+ * It also has a function for reading L1TriggerKey directly from Pool.
+ *
+ * In order to use this class to write payloads, user has to make sure to register datatypes that she or he is
+ * interested to write to the framework. This should be done with macro REGISTER_L1_WRITER(record, type) found in
+ * WriterProxy.h file. Also, one should take care to register these data types to CondDB framework with macro
+ * REGISTER_PLUGIN(record, type) from registration_macros.h found in PluginSystem.
+ */
+
+class DataWriterExt
+{
+ public:
+  DataWriterExt();
+  ~DataWriterExt();
+
+  // Payload and IOV writing functions.  
+
+  // Get payload from EventSetup and write to DB with no IOV
+  // recordType = "record@type", return value is payload token
+  std::string writePayload( const edm::EventSetup& setup,
+			    const std::string& recordType ) ;
+
+  // Use PoolDBOutputService to append IOV with sinceRun to IOV sequence
+  // for given ESRecord.  PoolDBOutputService knows the corresponding IOV tag.
+  // Return value is true if IOV was updated; false if IOV was already
+  // up to date.
+  bool updateIOV( const std::string& esRecordName,
+		  const std::string& payloadToken,
+		  edm::RunNumber_t sinceRun,
+		  bool logTransactions = false ) ;
+
+  // Write L1TriggerKeyListExt payload and set IOV.  Takes ownership of pointer.
+  void writeKeyList( L1TriggerKeyListExt* keyList,
+		     edm::RunNumber_t sinceRun = 0,
+		     bool logTransactions = false ) ;
+
+  // Read object directly from Pool, not from EventSetup.
+  template< class T >
+  void readObject( const std::string& payloadToken,
+		   T& outputObject ) ;
+
+  std::string payloadToken( const std::string& recordName,
+			    edm::RunNumber_t runNumber ) ;
+
+  std::string lastPayloadToken( const std::string& recordName ) ;
+
+  bool fillLastTriggerKeyList( L1TriggerKeyListExt& output ) ;
+
+ protected:
+};
+
+template< class T >
+void DataWriterExt::readObject( const std::string& payloadToken,
+			     T& outputObject )
+{
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if( !poolDb.isAvailable() )
+    {
+      throw cond::Exception( "DataWriter: PoolDBOutputService not available."
+			     ) ;
+    }
+
+  poolDb->forceInit();
+  cond::persistency::Session session = poolDb->session();
+///  session.transaction().start(true);
+ 
+  // Get object from CondDB
+  boost::shared_ptr<T> ref = session.fetchPayload<T>(payloadToken) ;
+  outputObject = *ref ;
+///  session.transaction().commit ();
+}
+
+} // ns
+
+#endif

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -1,0 +1,239 @@
+#ifndef CondTools_L1TriggerExt_L1ConfigOnlineProdBaseExt_h
+#define CondTools_L1TriggerExt_L1ConfigOnlineProdBaseExt_h
+
+// system include files
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
+// user include files
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+
+#include "CondTools/L1Trigger/interface/OMDSReader.h"
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+#include "CondTools/L1Trigger/interface/Exception.h"
+
+#include "FWCore/Utilities/interface/typelookup.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "CondCore/CondDB/interface/Session.h"
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+
+// forward declarations
+
+template< class TRcd, class TData >
+class L1ConfigOnlineProdBaseExt : public edm::ESProducer {
+   public:
+      L1ConfigOnlineProdBaseExt(const edm::ParameterSet&);
+      ~L1ConfigOnlineProdBaseExt();
+
+      boost::shared_ptr< TData > produce(const TRcd& iRecord);
+
+      virtual boost::shared_ptr< TData > newObject(
+	const std::string& objectKey ) = 0 ;
+
+   private:
+      // ----------member data ---------------------------
+
+ protected:
+      l1t::OMDSReader m_omdsReader ;
+      bool m_forceGeneration ;
+
+      // Called from produce methods.
+      // bool is true if the object data should be made.
+      // If bool is false, produce method should throw
+      // DataAlreadyPresentException.
+      bool getObjectKey( const TRcd& record,
+                         boost::shared_ptr< TData > data,
+                         std::string& objectKey ) ;
+
+      // For reading object directly from a CondDB w/o PoolDBOutputService
+      cond::persistency::Session m_dbSession ;
+      bool m_copyFromCondDB ;
+};
+
+
+template< class TRcd, class TData >
+L1ConfigOnlineProdBaseExt<TRcd, TData>::L1ConfigOnlineProdBaseExt(const edm::ParameterSet& iConfig)
+   : m_omdsReader(),
+     m_forceGeneration( iConfig.getParameter< bool >( "forceGeneration" ) ),
+     m_dbSession(),
+     m_copyFromCondDB( false )
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+  setWhatProduced(this);
+
+   //now do what ever other initialization is needed
+
+  if( iConfig.exists( "copyFromCondDB" ) )
+    {
+      m_copyFromCondDB = iConfig.getParameter< bool >( "copyFromCondDB" ) ;
+
+      if( m_copyFromCondDB )
+	{
+	  cond::persistency::ConnectionPool connectionPool;
+	  // Connect DB Session
+	  connectionPool.setAuthenticationPath(
+	     iConfig.getParameter< std::string >( "onlineAuthentication" ) ) ;
+	  connectionPool.configure() ;
+	  m_dbSession = connectionPool.createSession( iConfig.getParameter< std::string >( "onlineDB" ) ) ;
+	}
+    }
+  else
+    {
+      m_omdsReader.connect(
+	iConfig.getParameter< std::string >( "onlineDB" ),
+	iConfig.getParameter< std::string >( "onlineAuthentication" ) ) ;
+    }
+}
+
+template< class TRcd, class TData >
+L1ConfigOnlineProdBaseExt<TRcd, TData>::~L1ConfigOnlineProdBaseExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+template< class TRcd, class TData >
+boost::shared_ptr< TData >
+L1ConfigOnlineProdBaseExt<TRcd, TData>::produce( const TRcd& iRecord )
+{
+   using namespace edm::es;
+   boost::shared_ptr< TData > pData ;
+
+   // Get object key and check if already in ORCON
+   std::string key ;
+   if( getObjectKey( iRecord, pData, key ) || m_forceGeneration )
+   {
+     if( m_copyFromCondDB )
+       {
+	 // Get L1TriggerKeyListExt from EventSetup
+	 const L1TriggerKeyListExtRcd& keyListRcd =
+///	 // Get L1TriggerKeyList from EventSetup
+///	 const L1TriggerKeyListRcd& keyListRcd =
+	   iRecord.template getRecord< L1TriggerKeyListExtRcd >() ;
+	 edm::ESHandle< L1TriggerKeyListExt > keyList ;
+///	   iRecord.template getRecord< L1TriggerKeyListRcd >() ;
+///	 edm::ESHandle< L1TriggerKeyList > keyList ;
+
+	 keyListRcd.get( keyList ) ;
+
+	 // Find payload token
+	 std::string recordName = edm::typelookup::className<TRcd>();
+	 std::string dataType = edm::typelookup::className<TData>();
+	 std::string payloadToken =
+	   keyList->token( recordName, dataType, key ) ;
+
+	 edm::LogVerbatim( "L1-O2O" )
+	   << "Copying payload for " << recordName
+	   << "@" << dataType << " obj key " << key
+	   << " from CondDB." ;
+	 edm::LogVerbatim( "L1-O2O" )
+	   << "TOKEN " << payloadToken ;
+
+	 // Get object from POOL
+	 // Copied from l1t::DataWriter::readObject()
+	 if( !payloadToken.empty() )
+	   {
+	     m_dbSession.transaction().start() ; 
+	     pData = m_dbSession.fetchPayload<TData>( payloadToken ) ;
+	     m_dbSession.transaction().commit ();
+	   }
+       }
+     else
+       {
+	 pData = newObject( key ) ;
+       }
+
+     //     if( pData.get() == 0 )
+     if( pData == boost::shared_ptr< TData >() )
+       {
+	 std::string dataType = edm::typelookup::className<TData>();
+
+	 throw l1t::DataInvalidException( "Unable to generate " +
+					  dataType + " for key " + key +
+					  "." ) ;
+       }
+   }
+   else
+   {
+     std::string dataType = edm::typelookup::className<TData>();
+
+     throw l1t::DataAlreadyPresentException( dataType +
+        " for key " + key + " already in CondDB." ) ;
+   }
+
+   return pData ;
+}
+
+
+template< class TRcd, class TData >
+bool 
+L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(
+  const TRcd& record,
+  boost::shared_ptr< TData > data,
+  std::string& objectKey )
+{
+   // Get L1TriggerKeyExt
+   const L1TriggerKeyExtRcd& keyRcd =
+      record.template getRecord< L1TriggerKeyExtRcd >() ;
+
+   // Explanation of funny syntax: since record is dependent, we are not
+   // expecting getRecord to be a template so the compiler parses it
+   // as a non-template. http://gcc.gnu.org/ml/gcc-bugs/2005-11/msg03685.html
+
+   // If L1TriggerKeyExt is invalid, then all configuration objects are
+   // already in ORCON.
+   edm::ESHandle< L1TriggerKeyExt > key ;
+   try
+   {
+      keyRcd.get( key ) ;
+   }
+   catch( l1t::DataAlreadyPresentException& ex )
+   {
+      objectKey = std::string() ;
+      return false ;      
+   }
+
+   // Get object key from L1TriggerKeyExt
+   std::string recordName = edm::typelookup::className<TRcd>();
+   std::string dataType = edm::typelookup::className<TData>();
+
+   objectKey = key->get( recordName, dataType ) ;
+
+/*    edm::LogVerbatim( "L1-O2O" ) */
+/*      << "L1ConfigOnlineProdBase record " << recordName */
+/*      << " type " << dataType << " obj key " << objectKey ; */
+
+   // Get L1TriggerKeyListExt
+   L1TriggerKeyListExt keyList ;
+///   // Get L1TriggerKeyList
+///   L1TriggerKeyList keyList ;
+   l1t::DataWriterExt dataWriter ;
+///   l1t::DataWriter dataWriter ;
+   if( !dataWriter.fillLastTriggerKeyList( keyList ) )
+     {
+       edm::LogError( "L1-O2O" )
+         << "Problem getting last L1TriggerKeyListExt" ;
+///         << "Problem getting last L1TriggerKeyList" ;
+     }
+
+   // If L1TriggerKeyList does not contain object key, token is empty
+
+   return
+      keyList.token( recordName, dataType, objectKey ) == std::string() ;
+}
+
+#endif

--- a/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
@@ -1,0 +1,36 @@
+#ifndef CondTools_L1TriggerExt_L1ObjectKeysOnlineProdBaseExt_h
+#define CondTools_L1TriggerExt_L1ObjectKeysOnlineProdBaseExt_h
+
+// system include files
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+
+#include "CondTools/L1Trigger/interface/OMDSReader.h"
+
+// forward declarations
+
+class L1ObjectKeysOnlineProdBaseExt : public edm::ESProducer {
+   public:
+      L1ObjectKeysOnlineProdBaseExt(const edm::ParameterSet&);
+      ~L1ObjectKeysOnlineProdBaseExt();
+
+      typedef boost::shared_ptr<L1TriggerKeyExt> ReturnType;
+
+      ReturnType produce(const L1TriggerKeyExtRcd&);
+
+      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) = 0 ;
+   private:
+      // ----------member data ---------------------------
+ protected:
+      l1t::OMDSReader m_omdsReader ;
+};
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/BuildFile.xml
+++ b/CondTools/L1TriggerExt/plugins/BuildFile.xml
@@ -1,0 +1,4 @@
+<use   name="CondTools/L1TriggerExt"/>
+<library   file="*.cc" name="CondToolsL1TriggerExtPlugins">
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.cc
@@ -1,0 +1,210 @@
+#include <sstream>
+
+#include "CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h"
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+#include "CondCore/CondDB/interface/Serialization.h"
+
+L1CondDBIOVWriterExt::L1CondDBIOVWriterExt(const edm::ParameterSet& iConfig)
+   : m_tscKey( iConfig.getParameter<std::string> ("tscKey") ),
+     m_ignoreTriggerKey( iConfig.getParameter<bool> ("ignoreTriggerKey") ),
+     m_logKeys( iConfig.getParameter<bool>( "logKeys" ) ),
+     m_logTransactions( iConfig.getParameter<bool>( "logTransactions" ) ),
+     m_forceUpdate( iConfig.getParameter<bool>( "forceUpdate" ) )
+{
+   //now do what ever initialization is needed
+   typedef std::vector<edm::ParameterSet> ToSave;
+   ToSave toSave = iConfig.getParameter<ToSave> ("toPut");
+   for (ToSave::const_iterator it = toSave.begin (); it != toSave.end (); it++)
+   {
+      std::string record = it->getParameter<std::string> ("record");
+      std::string type = it->getParameter<std::string> ("type");
+      m_recordTypes.push_back( record  + "@" + type ) ;
+   }
+}
+
+
+L1CondDBIOVWriterExt::~L1CondDBIOVWriterExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+// ------------ method called to for each event  ------------
+void
+L1CondDBIOVWriterExt::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   // Get L1TriggerKeyListExt
+   L1TriggerKeyListExt keyList ;
+   l1t::DataWriterExt dataWriter ;
+   if( !dataWriter.fillLastTriggerKeyList( keyList ) )
+     {
+       edm::LogError( "L1-O2O" )
+         << "Problem getting last L1TriggerKeyListExt" ;
+     }
+
+   unsigned long long run = iEvent.id().run() ;
+
+   L1TriggerKeyExt::RecordToKey recordTypeToKeyMap ;
+
+   bool triggerKeyIOVUpdated = true ;
+
+   // Start log string, convert run number into string
+   std::stringstream ss ;
+   ss << run ;
+   std::string log = "KEYLOG runNumber=" + ss.str() ;
+   bool logRecords = true ;
+
+   if( !m_ignoreTriggerKey )
+     {
+       if( !m_tscKey.empty() )
+	 {
+           edm::LogVerbatim( "L1-O2O" )
+             << "Object key for L1TriggerKeyExt@L1TriggerKeyExtRcd: "
+             << m_tscKey ;
+
+	   // Use TSC key and L1TriggerKeyListExt to find next run's
+	   // L1TriggerKey token
+	   std::string keyToken = keyList.token( m_tscKey ) ;
+
+	   // Update IOV sequence for this token with since-time = new run 
+	   triggerKeyIOVUpdated =
+	     m_writer.updateIOV( "L1TriggerKeyExtRcd", keyToken, run, m_logTransactions ) ;
+
+	   // Read current L1TriggerKeyExt directly from ORCON using token
+	   L1TriggerKeyExt key ;
+	   m_writer.readObject( keyToken, key ) ;
+
+	   recordTypeToKeyMap = key.recordToKeyMap() ;
+
+           // Replace spaces in key with ?s.  Do reverse substitution when
+           // making L1TriggerKeyExt.
+	   std::string tmpKey = m_tscKey ;
+           replace( tmpKey.begin(), tmpKey.end(), ' ', '?' ) ;
+           log += " tscKey=" + tmpKey ;
+	   logRecords = false ;
+	 }
+       else
+	 {
+	   // For use with Run Settings, no corresponding L1TrigerKey in
+	   // ORCON.
+
+	   // Get L1TriggerKeyExt from EventSetup
+	   ESHandle< L1TriggerKeyExt > esKey ;
+	   iSetup.get< L1TriggerKeyExtRcd >().get( esKey ) ;
+
+	   recordTypeToKeyMap = esKey->recordToKeyMap() ;
+	 }
+     }
+   else
+     {
+       std::vector<std::string >::const_iterator
+	 recordTypeItr = m_recordTypes.begin() ;
+       std::vector<std::string >::const_iterator
+	 recordTypeEnd = m_recordTypes.end() ;
+
+       for( ; recordTypeItr != recordTypeEnd ; ++recordTypeItr )
+	 {
+	   recordTypeToKeyMap.insert(
+	     std::make_pair( *recordTypeItr, m_tscKey ) ) ;
+	 }
+     }
+
+   // If L1TriggerKeyExt IOV was already up to date, then so are all its
+   // sub-records.
+   bool throwException = false ;
+
+   if( triggerKeyIOVUpdated || m_forceUpdate )
+     {
+       // Loop over record@type in L1TriggerKeyExt
+       L1TriggerKeyExt::RecordToKey::const_iterator itr =
+	 recordTypeToKeyMap.begin() ;
+       L1TriggerKeyExt::RecordToKey::const_iterator end =
+	 recordTypeToKeyMap.end() ;
+
+       for( ; itr != end ; ++itr )
+	 {
+	   std::string recordType = itr->first ;
+	   std::string objectKey = itr->second ;
+
+	   std::string recordName( recordType,
+				   0, recordType.find_first_of("@") ) ;
+
+	   if( logRecords )
+	     {
+	       // Replace spaces in key with ?s.  Do reverse substitution when
+	       // making L1TriggerKeyExt.
+	       std::string tmpKey = objectKey ;
+	       replace( tmpKey.begin(), tmpKey.end(), ' ', '?' ) ;
+	       log += " " + recordName + "Key=" + tmpKey ;
+	     }
+
+	   // Do nothing if object key is null.
+	   if( objectKey == L1TriggerKeyExt::kNullKey )
+	     {
+	       edm::LogVerbatim( "L1-O2O" )
+		 << "L1CondDBIOVWriterExt: null object key for "
+		 << recordType << "; skipping this record." ;
+	     }
+	   else
+	     {
+	       // Find payload token
+               edm::LogVerbatim( "L1-O2O" )
+                 << "Object key for "
+                 << recordType << ": " << objectKey ;
+
+	       std::string payloadToken = keyList.token( recordType,
+							 objectKey ) ;
+	       if( payloadToken.empty() )
+		 {
+		   edm::LogVerbatim( "L1-O2O" )
+		     << "L1CondDBIOVWriterExt: empty payload token for " +
+		     recordType + ", key " + objectKey ;
+
+		   throwException = true ;
+		 }
+	       else
+		 {
+		   m_writer.updateIOV( recordName,
+				       payloadToken,
+				       run,
+				       m_logTransactions ) ;
+		 }
+	     }
+	 }
+     }
+
+   if( m_logKeys )
+     {
+       edm::LogVerbatim( "L1-O2O" ) << log ;
+     }
+
+   if( throwException )
+     {
+       throw cond::Exception( "L1CondDBIOVWriterExt: empty payload tokens" ) ;
+     }
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1CondDBIOVWriterExt::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1CondDBIOVWriterExt::endJob() {
+}
+
+//define this as a plug-in
+//DEFINE_FWK_MODULE(L1CondDBIOVWriterExt);

--- a/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
@@ -1,0 +1,52 @@
+#ifndef CondTools_L1TriggerExt_L1CondDBIOVWriterExt_h
+#define CondTools_L1TriggerExt_L1CondDBIOVWriterExt_h
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+
+class L1CondDBIOVWriterExt : public edm::EDAnalyzer {
+   public:
+      explicit L1CondDBIOVWriterExt(const edm::ParameterSet&);
+      ~L1CondDBIOVWriterExt();
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      // ----------member data ---------------------------
+      l1t::DataWriterExt m_writer ;
+///      l1t::DataWriter m_writer ;
+
+      std::string m_tscKey ;
+
+      // List of record@type, used only for objects not tied to TSC key.
+      // Otherwise, list of records comes from L1TriggerKeyExt.
+      std::vector< std::string > m_recordTypes ;
+
+      // When true, set IOVs for objects not tied to the TSC key.  The records
+      // and objects to be updated are given in the toPut parameter, and
+      // m_tscKey is taken to be a common key for all the toPut objects, not
+      // the TSC key.  The IOV for L1TriggerKeyExt is not updated when
+      // m_ignoreTriggerKey = true.
+      bool m_ignoreTriggerKey ;
+
+      bool m_logKeys ;
+
+      bool m_logTransactions ;
+
+      bool m_forceUpdate ;
+};
+
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -1,0 +1,215 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+L1CondDBPayloadWriterExt::L1CondDBPayloadWriterExt(const edm::ParameterSet& iConfig)
+   : m_writeL1TriggerKeyExt( iConfig.getParameter< bool >( "writeL1TriggerKeyExt" )),
+     m_writeConfigData( iConfig.getParameter< bool >( "writeConfigData" ) ),
+     m_overwriteKeys( iConfig.getParameter< bool >( "overwriteKeys" ) ),
+     m_logTransactions( iConfig.getParameter<bool>( "logTransactions" ) ),
+     m_newL1TriggerKeyListExt( iConfig.getParameter< bool >( "newL1TriggerKeyListExt" ) )
+{
+   //now do what ever initialization is needed
+
+}
+
+
+L1CondDBPayloadWriterExt::~L1CondDBPayloadWriterExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+// ------------ method called to for each event  ------------
+void
+L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent,
+			       const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   // Get L1TriggerKeyListExt and make a copy
+   L1TriggerKeyListExt oldKeyList ;
+
+   if( !m_newL1TriggerKeyListExt )
+     {
+       if( !m_writer.fillLastTriggerKeyList( oldKeyList ) )
+	 {
+	   edm::LogError( "L1-O2O" )
+	     << "Problem getting last L1TriggerKeyListExt" ;
+	 }
+     }
+
+   L1TriggerKeyListExt* keyList = 0 ;
+
+   // Write L1TriggerKeyExt to ORCON with no IOV
+   std::string token ;
+   ESHandle< L1TriggerKeyExt > key ;
+
+   // Before calling writePayload(), check if TSC key is already in
+   // L1TriggerKeyListExt.  writePayload() will not catch this situation in
+   // the case of dummy configurations.
+   bool triggerKeyOK = true ;
+   try
+     {
+       // Get L1TriggerKeyExt
+       iSetup.get< L1TriggerKeyExtRcd >().get( key ) ;
+
+       if( !m_overwriteKeys )
+	 {
+	   triggerKeyOK = oldKeyList.token( key->tscKey() ) == "" ;
+	 }
+     }
+   catch( l1t::DataAlreadyPresentException& ex )
+     {
+       triggerKeyOK = false ;
+       edm::LogVerbatim( "L1-O2O" ) << ex.what() ;
+     }
+
+   if( triggerKeyOK && m_writeL1TriggerKeyExt )
+     {
+       edm::LogVerbatim( "L1-O2O" )
+         << "Object key for L1TriggerKeyExtRcd@L1TriggerKeyExt: "
+         << key->tscKey() ;
+       token = m_writer.writePayload( iSetup,
+				      "L1TriggerKeyExtRcd@L1TriggerKeyExt" ) ;
+     }
+
+   // If L1TriggerKeyExt is invalid, then all configuration data is already in DB
+   bool throwException = false ;
+
+   if( !token.empty() || !m_writeL1TriggerKeyExt )
+   {
+      // Record token in L1TriggerKeyListExt
+      if( m_writeL1TriggerKeyExt )
+	{
+	  keyList = new L1TriggerKeyListExt( oldKeyList ) ;
+	  if( !( keyList->addKey( key->tscKey(),
+				  token,
+				  m_overwriteKeys ) ) )
+	    {
+	      throw cond::Exception( "L1CondDBPayloadWriter: TSC key "
+				     + key->tscKey()
+				     + " already in L1TriggerKeyListExt" ) ;
+	    }
+	}
+
+      if( m_writeConfigData )
+	{
+	  // Loop over record@type in L1TriggerKeyExt
+	  L1TriggerKeyExt::RecordToKey::const_iterator it =
+	    key->recordToKeyMap().begin() ;
+	  L1TriggerKeyExt::RecordToKey::const_iterator end =
+	    key->recordToKeyMap().end() ;
+
+	  for( ; it != end ; ++it )
+	    {
+	      // Do nothing if object key is null.
+	      if( it->second == L1TriggerKeyExt::kNullKey )
+		{
+		  edm::LogVerbatim( "L1-O2O" )
+		    << "L1CondDBPayloadWriter: null object key for "
+		    << it->first << "; skipping this record." ;
+		}
+	      else
+		{
+		  // Check key is new before writing
+		  if( oldKeyList.token( it->first, it->second ) == "" ||
+		      m_overwriteKeys )
+		    {
+		      // Write data to ORCON with no IOV
+		      if( oldKeyList.token( it->first, it->second ) != "" )
+			{
+			  edm::LogVerbatim( "L1-O2O" )
+			    << "*** Overwriting payload: object key for "
+			    << it->first << ": " << it->second ;
+			}
+		      else
+			{
+			  edm::LogVerbatim( "L1-O2O" )
+			    << "object key for "
+			    << it->first << ": " << it->second ;
+			}
+
+		      try
+			{
+			  token = m_writer.writePayload( iSetup, it->first ) ;
+			}
+		      catch( l1t::DataInvalidException& ex )
+			{
+			  edm::LogVerbatim( "L1-O2O" )
+			    << ex.what()
+			    << " Skipping to next record." ;
+
+			  throwException = true ;
+
+			  continue ;
+			}
+
+		      if( !token.empty() )
+			{
+			  // Record token in L1TriggerKeyListExt
+			  if( !keyList )
+			    {
+			      keyList = new L1TriggerKeyListExt( oldKeyList ) ;
+			    }
+
+			  if( !( keyList->addKey( it->first,
+						  it->second,
+						  token,
+						  m_overwriteKeys ) ) )
+			    {
+			      // This should never happen because of the check
+			      // above, but just in case....
+			      throw cond::Exception(
+				"L1CondDBPayloadWriter: subsystem key "
+				+ it->second + " for " + it->first
+				+ " already in L1TriggerKeyListExt" ) ;
+			    }
+			}
+		    }
+		  else
+		    {
+		      edm::LogVerbatim( "L1-O2O" )
+			<< "L1CondDBPayloadWriter: object key "
+			<< it->second << " for " << it->first
+			<< " already in L1TriggerKeyListExt" ;
+		    }
+		}
+	    }
+	}
+   }
+
+   if( keyList )
+   {
+      // Write L1TriggerKeyListExt to ORCON
+      m_writer.writeKeyList( keyList, 0, m_logTransactions ) ;
+   }
+
+   if( throwException )
+     {
+       throw l1t::DataInvalidException( "Payload problem found." ) ;
+     }
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1CondDBPayloadWriterExt::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1CondDBPayloadWriterExt::endJob() {
+}
+
+//define this as a plug-in
+//DEFINE_FWK_MODULE(L1CondDBPayloadWriterExt);

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h
@@ -1,0 +1,45 @@
+#ifndef CondTools_L1TriggerExt_L1CondDBPayloadWriterExt_h
+#define CondTools_L1TriggerExt_L1CondDBPayloadWriterExt_h
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+
+class L1CondDBPayloadWriterExt : public edm::EDAnalyzer {
+   public:
+      explicit L1CondDBPayloadWriterExt(const edm::ParameterSet&);
+      ~L1CondDBPayloadWriterExt();
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      // ----------member data ---------------------------
+      l1t::DataWriterExt m_writer ;
+      // std::string m_tag ; // tag is known by PoolDBOutputService
+
+      // set to false to write config data without valid TSC key
+      bool m_writeL1TriggerKeyExt ;
+
+      // set to false to write config data only
+      bool m_writeConfigData ;
+
+      // substitute new payload tokens for existing keys in L1TriggerKeyListExt
+      bool m_overwriteKeys ;
+
+      bool m_logTransactions ;
+
+      // if true, do not retrieve L1TriggerKeyListExt from EventSetup
+      bool m_newL1TriggerKeyListExt ;
+};
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
@@ -1,0 +1,232 @@
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKey.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+#include "CondTools/L1Trigger/interface/Exception.h"
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+
+//
+// class decleration
+//
+
+class L1O2OTestAnalyzerExt : public edm::EDAnalyzer {
+   public:
+      explicit L1O2OTestAnalyzerExt(const edm::ParameterSet&);
+      ~L1O2OTestAnalyzerExt();
+
+
+   private:
+      virtual void beginJob() override ;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override ;
+
+      // ----------member data ---------------------------
+  bool m_printL1TriggerKeyExt ;
+  bool m_printL1TriggerKeyListExt ;
+  bool m_printESRecords ;
+  bool m_printPayloadTokens ;
+  std::vector< std::string > m_recordsToPrint ;
+};
+
+L1O2OTestAnalyzerExt::L1O2OTestAnalyzerExt(const edm::ParameterSet& iConfig)
+  : m_printL1TriggerKeyExt( iConfig.getParameter<bool> ("printL1TriggerKeyExt") ),
+    m_printL1TriggerKeyListExt( iConfig.getParameter<bool> ("printL1TriggerKeyListExt") ),
+    m_printESRecords( iConfig.getParameter<bool> ("printESRecords") ),
+    m_printPayloadTokens( iConfig.getParameter<bool> ("printPayloadTokens") ),
+    m_recordsToPrint( iConfig.getParameter< std::vector< std::string > >(
+       "recordsToPrint" ) )
+{
+   //now do what ever initialization is needed
+}
+
+
+L1O2OTestAnalyzerExt::~L1O2OTestAnalyzerExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+// ------------ method called to for each event  ------------
+void
+L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   if( m_printL1TriggerKeyListExt )
+     {
+//        ESHandle< L1TriggerKeyListExt > pList ;
+//        iSetup.get< L1TriggerKeyListExtRcd >().get( pList ) ;
+       L1TriggerKeyListExt pList ;
+       l1t::DataWriterExt dataWriter ;
+       if( !dataWriter.fillLastTriggerKeyList( pList ) )
+	 {
+	   edm::LogError( "L1-O2O" )
+	     << "Problem getting last L1TriggerKeyListExt" ;
+	 }
+
+       std::cout << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:"
+		 << std::endl ;
+
+       L1TriggerKeyListExt::KeyToToken::const_iterator iTSCKey =
+	 pList.tscKeyToTokenMap().begin() ;
+       L1TriggerKeyListExt::KeyToToken::const_iterator eTSCKey =
+	 pList.tscKeyToTokenMap().end() ;
+       for( ; iTSCKey != eTSCKey ; ++iTSCKey )
+	 {
+	   std::cout << iTSCKey->first ;
+	   if( m_printPayloadTokens )
+	     {
+	       std::cout << " " << iTSCKey->second ;
+	     }
+	   std::cout << std::endl ;
+	 }
+       std::cout << std::endl ;
+
+       L1TriggerKeyListExt::RecordToKeyToToken::const_iterator iRec =
+	 pList.recordTypeToKeyToTokenMap().begin() ;
+       L1TriggerKeyListExt::RecordToKeyToToken::const_iterator eRec =
+	 pList.recordTypeToKeyToTokenMap().end() ;
+       for( ; iRec != eRec ; ++iRec )
+	 {
+	   const L1TriggerKeyListExt::KeyToToken& keyTokenMap = iRec->second ;
+	   std::cout << "For record@type " << iRec->first << ", found "
+		     << keyTokenMap.size() << " keys:" << std::endl ;
+
+	   L1TriggerKeyListExt::KeyToToken::const_iterator iKey = keyTokenMap.begin();
+	   L1TriggerKeyListExt::KeyToToken::const_iterator eKey = keyTokenMap.end() ;
+	   for( ; iKey != eKey ; ++iKey )
+	     {
+	       std::cout << iKey->first ;
+	       if( m_printPayloadTokens )
+		 {
+		   std::cout << " " << iKey->second ;
+		 }
+	       std::cout << std::endl ;
+	     }
+	   std::cout << std::endl ;
+	 }
+     }
+
+   if( m_printL1TriggerKeyExt )
+     {
+       try
+	 {
+	   ESHandle< L1TriggerKeyExt > pKey ;
+ 	   iSetup.get< L1TriggerKeyExtRcd >().get( pKey ) ;
+
+	   std::cout << std::endl ;
+	   std::cout << "Current TSC key = " << pKey->tscKey()
+		     << std::endl << std::endl ;
+
+	   std::cout << "Current subsystem keys:" << std::endl ;
+	   std::cout << "TSP0 " << pKey->subsystemKey( L1TriggerKeyExt::kuGT )
+		     << std::endl << std::endl ;
+
+	   std::cout << "Object keys:" << std::endl ;
+	   const L1TriggerKeyExt::RecordToKey& recKeyMap = pKey->recordToKeyMap() ;
+	   L1TriggerKeyExt::RecordToKey::const_iterator iRec = recKeyMap.begin() ;
+	   L1TriggerKeyExt::RecordToKey::const_iterator eRec = recKeyMap.end() ;
+	   for( ; iRec != eRec ; ++iRec )
+	     {
+	       std::cout << iRec->first << " " << iRec->second << std::endl ;
+	     }
+	 }
+       catch( cms::Exception& ex )
+	 {
+	   std::cout << "No L1TriggerKeyExt found." << std::endl ;
+	 }
+     }
+
+   if( m_printESRecords )
+     {
+//        ESHandle< L1TriggerKeyListExt > pList ;
+//        iSetup.get< L1TriggerKeyListExtRcd >().get( pList ) ;
+
+       L1TriggerKeyListExt pList ;
+       l1t::DataWriterExt dataWriter ;
+       if( !dataWriter.fillLastTriggerKeyList( pList ) )
+	 {
+	   edm::LogError( "L1-O2O" )
+	     << "Problem getting last L1TriggerKeyListExt" ;
+	 }
+
+       // Start log string, convert run number into string
+       unsigned long long run = iEvent.id().run() ;
+       std::stringstream ss ;
+       ss << run ;
+       std::string log = "runNumber=" + ss.str() ;
+
+       l1t::DataWriterExt writer ;
+
+       std::cout << std::endl << "Run Settings keys:" << std::endl ;
+
+       std::vector< std::string >::const_iterator iRec =
+	 m_recordsToPrint.begin() ;
+       std::vector< std::string >::const_iterator iEnd =
+	 m_recordsToPrint.end() ;
+       for( ; iRec != iEnd ; ++iRec )
+	 {
+	   std::string payloadToken = writer.payloadToken( *iRec,
+							   iEvent.id().run() );
+	   std::string key ;
+
+	   if( *iRec == "L1TriggerKeyExtRcd" )
+	     {
+	       key = pList.tscKey( payloadToken ) ;
+	     }
+	   else
+	     {
+	       key = pList.objectKey( *iRec, payloadToken ) ;
+	     }
+
+	   std::cout << *iRec << " " << key ;
+	   if( m_printPayloadTokens )
+	     {
+	       std::cout << " " << payloadToken ;
+	     }
+	   std::cout << std::endl ;
+
+	   // Replace spaces in key with ?s.  Do reverse substitution when
+	   // making L1TriggerKeyExt.
+	   replace( key.begin(), key.end(), ' ', '?' ) ;
+	   log += " " + *iRec + "Key=" + key ;
+	 }
+
+       std::cout << std::endl << log << std::endl ;
+     }
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1O2OTestAnalyzerExt::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1O2OTestAnalyzerExt::endJob() {
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1O2OTestAnalyzerExt);

--- a/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
@@ -1,0 +1,105 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.h"
+
+#include "CondTools/L1Trigger/interface/Exception.h"
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
+L1SubsystemKeysOnlineProdExt::L1SubsystemKeysOnlineProdExt(const edm::ParameterSet& iConfig)
+   : m_tscKey( iConfig.getParameter< std::string >( "tscKey" ) ),
+     m_omdsReader(
+	iConfig.getParameter< std::string >( "onlineDB" ),
+	iConfig.getParameter< std::string >( "onlineAuthentication" ) ),
+     m_forceGeneration( iConfig.getParameter< bool >( "forceGeneration" ) )
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+  setWhatProduced(this, "SubsystemKeysOnly");
+
+   //now do what ever other initialization is needed
+}
+
+
+L1SubsystemKeysOnlineProdExt::~L1SubsystemKeysOnlineProdExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1SubsystemKeysOnlineProdExt::ReturnType
+L1SubsystemKeysOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
+{
+   using namespace edm::es;
+   boost::shared_ptr<L1TriggerKeyExt> pL1TriggerKey ;
+
+   // Get L1TriggerKeyListExt
+   L1TriggerKeyListExt keyList ;
+   l1t::DataWriterExt dataWriter ;
+   if( !dataWriter.fillLastTriggerKeyList( keyList ) )
+     {
+       edm::LogError( "L1-O2O" )
+	 << "Problem getting last L1TriggerKeyListExt" ;
+     }
+
+   // If L1TriggerKeyListExt does not contain TSC key, token is empty
+   if( keyList.token( m_tscKey ) == std::string() ||
+       m_forceGeneration )
+     {
+       // Instantiate new L1TriggerKey
+       pL1TriggerKey = boost::shared_ptr< L1TriggerKeyExt >(
+	 new L1TriggerKeyExt() ) ;
+       pL1TriggerKey->setTSCKey( m_tscKey ) ;
+
+       edm::LogVerbatim( "L1-O2O" ) << "TSC KEY " << m_tscKey ;
+
+       // Get subsystem keys from OMDS
+
+       // SELECT uGT_KEY FROM TRIGGERSUP_CONF WHERE TRIGGERSUP_CONF.TS_KEY = m_tscKey
+       std::vector< std::string > queryStrings ;
+       queryStrings.push_back( "UGT_KEY" ) ;
+
+       l1t::OMDSReader::QueryResults subkeyResults =
+	 m_omdsReader.basicQuery( queryStrings,
+				  "CMS_TRG_L1_CONF",
+				  "L1_TRG_CONF_KEYS",
+				  "L1_TRG_CONF_KEYS.ID",
+				  m_omdsReader.singleAttribute( m_tscKey ) ) ;
+
+       if( subkeyResults.queryFailed() ||
+	   subkeyResults.numberRows() != 1 ) // check query successful
+	 {
+	   edm::LogError( "L1-O2O" ) << "Problem with subsystem keys." ;
+	   return pL1TriggerKey ;
+	 }
+
+       std::string uGTKey;
+
+       subkeyResults.fillVariable( "UGT_KEY", uGTKey ) ;
+       pL1TriggerKey->setSubsystemKey( L1TriggerKeyExt::kuGT, uGTKey ) ;
+       edm::LogVerbatim( "L1-O2O" ) << "UGT_KEY " << uGTKey ;
+
+   }
+   else
+   {
+     throw l1t::DataAlreadyPresentException(
+        "L1TriggerKeyExt for TSC key " + m_tscKey + " already in CondDB." ) ;
+   }
+
+   return pL1TriggerKey ;
+}
+
+//define this as a plug-in
+//DEFINE_FWK_EVENTSETUP_MODULE(L1SubsystemKeysOnlineProdExt);

--- a/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.h
@@ -1,0 +1,31 @@
+#ifndef CondTools_L1TriggerExt_L1SubsystemKeysOnlineProdExt_h
+#define CondTools_L1TriggerExt_L1SubsystemKeysOnlineProdExt_h
+
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+
+#include "CondTools/L1Trigger/interface/OMDSReader.h"
+
+class L1SubsystemKeysOnlineProdExt : public edm::ESProducer {
+   public:
+      L1SubsystemKeysOnlineProdExt(const edm::ParameterSet&);
+      ~L1SubsystemKeysOnlineProdExt();
+
+      typedef boost::shared_ptr<L1TriggerKeyExt> ReturnType;
+
+      ReturnType produce(const L1TriggerKeyExtRcd&);
+   private:
+      // ----------member data ---------------------------
+      std::string m_tscKey ;
+      l1t::OMDSReader m_omdsReader ;
+      bool m_forceGeneration ;
+};
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.cc
@@ -1,0 +1,66 @@
+#include "CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.h"
+
+L1TriggerKeyDummyProdExt::L1TriggerKeyDummyProdExt(const edm::ParameterSet& iConfig)
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+
+  // Label should be empty, "SubsystemKeysOnly" or any subsystem label expected
+  // by L1TriggerKeyOnlineProd.
+  std::string label = iConfig.getParameter< std::string >( "label" ) ;
+  setWhatProduced(this, label);
+
+   //now do what ever other initialization is needed
+   m_key.setTSCKey( iConfig.getParameter< std::string >( "tscKey" ) ) ;
+   m_key.setSubsystemKey( L1TriggerKeyExt::kuGT,
+			  iConfig.getParameter< std::string >( "uGTKey" ) ) ;
+
+   if( label != "SubsystemKeysOnly" )
+     {
+       typedef std::vector< edm::ParameterSet > ObjectKeys;
+       ObjectKeys keys = iConfig.getParameter< ObjectKeys >( "objectKeys" ) ;
+
+       for( ObjectKeys::const_iterator it = keys.begin ();
+	    it != keys.end() ;
+	    ++it )
+	 {
+	   // Replace ?s with spaces.
+	   std::string key = it->getParameter< std::string >( "key" ) ;
+	   replace( key.begin(), key.end(), '?', ' ' ) ;
+
+	   m_key.add( it->getParameter< std::string >( "record" ),
+		      it->getParameter< std::string >( "type" ),
+		      key ) ;
+	 }
+     }
+}
+
+
+L1TriggerKeyDummyProdExt::~L1TriggerKeyDummyProdExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1TriggerKeyDummyProdExt::ReturnType
+L1TriggerKeyDummyProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
+{
+   using namespace edm::es;
+   boost::shared_ptr<L1TriggerKeyExt> pL1TriggerKey ;
+
+   pL1TriggerKey = boost::shared_ptr< L1TriggerKeyExt >(
+      new L1TriggerKeyExt( m_key ) ) ;
+
+   return pL1TriggerKey ;
+}
+
+//define this as a plug-in
+//DEFINE_FWK_EVENTSETUP_MODULE(L1TriggerKeyDummyProdExt);

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.h
@@ -1,0 +1,29 @@
+#ifndef CondTools_L1TriggerExt_L1TriggerKeyDummyProdExt_h
+#define CondTools_L1TriggerExt_L1TriggerKeyDummyProdExt_h
+
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+
+class L1TriggerKeyDummyProdExt : public edm::ESProducer {
+   public:
+      L1TriggerKeyDummyProdExt(const edm::ParameterSet&);
+      ~L1TriggerKeyDummyProdExt();
+
+      typedef boost::shared_ptr<L1TriggerKeyExt> ReturnType;
+
+      ReturnType produce(const L1TriggerKeyExtRcd&);
+   private:
+      // ----------member data ---------------------------
+      L1TriggerKeyExt m_key ;
+};
+
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.cc
@@ -1,0 +1,40 @@
+#include "CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.h"
+
+L1TriggerKeyListDummyProdExt::L1TriggerKeyListDummyProdExt(const edm::ParameterSet& iConfig)
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+   setWhatProduced(this);
+
+   //now do what ever other initialization is needed
+}
+
+
+L1TriggerKeyListDummyProdExt::~L1TriggerKeyListDummyProdExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1TriggerKeyListDummyProdExt::ReturnType
+L1TriggerKeyListDummyProdExt::produce(const L1TriggerKeyListExtRcd& iRecord)
+{
+   using namespace edm::es;
+   boost::shared_ptr<L1TriggerKeyListExt> pL1TriggerKeyList ;
+
+   pL1TriggerKeyList = boost::shared_ptr< L1TriggerKeyListExt >(
+      new L1TriggerKeyListExt() ) ;
+
+   return pL1TriggerKeyList ;
+}
+
+//define this as a plug-in
+//DEFINE_FWK_EVENTSETUP_MODULE(L1TriggerKeyListDummyProdExt);

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.h
@@ -1,0 +1,27 @@
+#ifndef CondTools_L1Trigger_L1TriggerKeyListDummyProdExt_h
+#define CondTools_L1Trigger_L1TriggerKeyListDummyProdExt_h
+
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+
+class L1TriggerKeyListDummyProdExt : public edm::ESProducer {
+   public:
+      L1TriggerKeyListDummyProdExt(const edm::ParameterSet&);
+      ~L1TriggerKeyListDummyProdExt();
+
+      typedef boost::shared_ptr<L1TriggerKeyListExt> ReturnType;
+
+      ReturnType produce(const L1TriggerKeyListExtRcd&);
+   private:
+      // ----------member data ---------------------------
+};
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -1,0 +1,77 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h"
+
+#include "CondTools/L1Trigger/interface/Exception.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
+L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iConfig)
+  : m_subsystemLabels( iConfig.getParameter< std::vector< std::string > >(
+      "subsystemLabels" ) )
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+   setWhatProduced(this);
+
+   //now do what ever other initialization is needed
+}
+
+
+L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1TriggerKeyOnlineProdExt::ReturnType
+L1TriggerKeyOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
+{
+   using namespace edm::es;
+
+   // Start with "SubsystemKeysOnly"
+   edm::ESHandle< L1TriggerKeyExt > subsystemKeys ;
+   try
+     {
+       iRecord.get( "SubsystemKeysOnly", subsystemKeys ) ;
+     }
+   catch( l1t::DataAlreadyPresentException& ex )
+     {
+       throw ex ;
+     }
+
+   boost::shared_ptr<L1TriggerKeyExt> pL1TriggerKey ;
+   pL1TriggerKey = boost::shared_ptr< L1TriggerKeyExt >(
+     new L1TriggerKeyExt( *subsystemKeys ) ) ;
+
+  // Collate object keys
+  std::vector< std::string >::const_iterator itr = m_subsystemLabels.begin() ;
+  std::vector< std::string >::const_iterator end = m_subsystemLabels.end() ;
+  for( ; itr != end ; ++itr )
+    {
+      edm::ESHandle< L1TriggerKeyExt > objectKeys ;
+      try
+	{
+	  iRecord.get( *itr, objectKeys ) ;
+	}
+      catch( l1t::DataAlreadyPresentException& ex )
+	{
+	  throw ex ;
+	}
+
+      pL1TriggerKey->add( objectKeys->recordToKeyMap() ) ;
+    }
+
+   return pL1TriggerKey ;
+}
+
+//define this as a plug-in
+//DEFINE_FWK_EVENTSETUP_MODULE(L1TriggerKeyOnlineProdExt);

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
@@ -1,0 +1,29 @@
+#ifndef CondTools_L1TriggerExt_L1TriggerKeyOnlineProdExt_h
+#define CondTools_L1TriggerExt_L1TriggerKeyOnlineProdExt_h
+
+#include <memory>
+#include <vector>
+#include <string>
+#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+
+class L1TriggerKeyOnlineProdExt : public edm::ESProducer {
+   public:
+      L1TriggerKeyOnlineProdExt(const edm::ParameterSet&);
+      ~L1TriggerKeyOnlineProdExt();
+
+      typedef boost::shared_ptr<L1TriggerKeyExt> ReturnType;
+
+      ReturnType produce(const L1TriggerKeyExtRcd&);
+   private:
+      // ----------member data ---------------------------
+      std::vector< std::string > m_subsystemLabels ;
+};
+
+#endif

--- a/CondTools/L1TriggerExt/plugins/SealModule.cc
+++ b/CondTools/L1TriggerExt/plugins/SealModule.cc
@@ -1,0 +1,41 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h"
+#include "CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h"
+#include "CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.h"
+#include "CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.h"
+#include "CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.h"
+#include "CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h"
+
+
+using namespace l1t;
+
+DEFINE_FWK_MODULE(L1CondDBPayloadWriterExt);
+DEFINE_FWK_MODULE(L1CondDBIOVWriterExt);
+DEFINE_FWK_EVENTSETUP_MODULE(L1TriggerKeyDummyProdExt);
+DEFINE_FWK_EVENTSETUP_MODULE(L1TriggerKeyListDummyProdExt);
+DEFINE_FWK_EVENTSETUP_MODULE(L1SubsystemKeysOnlineProdExt);
+DEFINE_FWK_EVENTSETUP_MODULE(L1TriggerKeyOnlineProdExt);
+
+#include "CondCore/PluginSystem/interface/registration_macros.h"
+#include "CondTools/L1Trigger/interface/WriterProxy.h"
+
+
+
+// Central L1 records
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+
+REGISTER_L1_WRITER(L1TriggerKeyExtRcd, L1TriggerKeyExt);
+
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+
+REGISTER_L1_WRITER(L1TriggerKeyListExtRcd, L1TriggerKeyListExt);
+
+// Ext Records:
+
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+
+using namespace l1t;
+REGISTER_L1_WRITER(L1TUtmTriggerMenuRcd, L1TUtmTriggerMenu);

--- a/CondTools/L1TriggerExt/python/L1CondDBIOVWriterExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBIOVWriterExt_cff.py
@@ -1,0 +1,33 @@
+def initIOVWriterExt( process,
+                   outputDBConnect = 'sqlite_file:l1config.db',
+                   outputDBAuth = '.',
+                   tagBaseVec = [],
+                   tscKey = 'dummy' ):
+    import FWCore.ParameterSet.Config as cms
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    if len( tagBaseVec ) == 0:
+        from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+        initL1UniformTagsExt()
+        tagBaseVec = initL1UniformTagsExt.tagBaseVec                                
+
+    process.load('CondTools.L1TriggerExt.L1CondDBIOVWriterExt_cfi')
+    process.L1CondDBIOVWriterExt.tscKey = cms.string( tscKey )
+
+    from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
+    initIOVWriterExt.outputDB = cms.Service("PoolDBOutputService",
+                                         CondDBSetup,
+                                         connect = cms.string(outputDBConnect),
+                                         toPut = cms.VPSet(cms.PSet(
+        record = cms.string("L1TriggerKeyExtRcd"),
+        tag = cms.string("L1TriggerKeyExt_" + tagBaseVec[ L1CondEnumExt.L1TriggerKeyExt ])),
+                                                           cms.PSet(
+        record = cms.string("L1TriggerKeyListExtRcd"),
+        tag = cms.string("L1TriggerKeyListExt_" + tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ]))
+                                                           ))
+    initIOVWriterExt.outputDB.DBParameters.authenticationPath = outputDBAuth
+
+    from CondTools.L1TriggerExt.L1SubsystemParamsExt_cfi import initL1SubsystemsExt
+    initL1SubsystemsExt( tagBaseVec = tagBaseVec )
+    initIOVWriterExt.outputDB.toPut.extend(initL1SubsystemsExt.params.recordInfo)
+    process.add_(initIOVWriterExt.outputDB)

--- a/CondTools/L1TriggerExt/python/L1CondDBIOVWriterExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBIOVWriterExt_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+L1CondDBIOVWriterExt = cms.EDAnalyzer("L1CondDBIOVWriterExt",
+                                   toPut = cms.VPSet(),
+                                   tscKey = cms.string('dummy'),
+                                   ignoreTriggerKey = cms.bool(False),
+                                   logKeys = cms.bool(False),
+                                   logTransactions = cms.bool(False),
+                                   forceUpdate = cms.bool(False)
+                                   )
+

--- a/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cff.py
@@ -1,0 +1,24 @@
+def initPayloadWriterExt( process,
+                       outputDBConnect = 'sqlite_file:l1config.db',
+                       outputDBAuth = '.',
+                       tagBaseVec = [] ):
+    import FWCore.ParameterSet.Config as cms
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    if len( tagBaseVec ) == 0:
+        from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+        initL1UniformTagsExt()
+        tagBaseVec = initL1UniformTagsExt.tagBaseVec
+                                    
+    process.load('CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cfi')
+    
+    from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
+    initPayloadWriterExt.outputDB = cms.Service("PoolDBOutputService",
+                                             CondDBSetup,
+                                             connect = cms.string(outputDBConnect),
+                                             toPut = cms.VPSet(cms.PSet(
+        record = cms.string("L1TriggerKeyListExtRcd"),
+        tag = cms.string("L1TriggerKeyListExt_" + tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ]))
+                                                               ))
+    initPayloadWriterExt.outputDB.DBParameters.authenticationPath = outputDBAuth
+    process.add_(initPayloadWriterExt.outputDB)

--- a/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+L1CondDBPayloadWriterExt = cms.EDAnalyzer("L1CondDBPayloadWriterExt",
+                                       writeL1TriggerKeyExt = cms.bool(True),
+                                       writeConfigData = cms.bool(True),
+                                       overwriteKeys = cms.bool(False),
+                                       logTransactions = cms.bool(False),
+                                       newL1TriggerKeyListExt = cms.bool(False)
+                                       )
+
+

--- a/CondTools/L1TriggerExt/python/L1CondDBSourceExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBSourceExt_cff.py
@@ -1,0 +1,58 @@
+# Default behavior: deliver current L1-O2O tags from Frontier.
+
+# IF tagBaseVec is empty then
+#    IF tagBaseVec is given, use uniform tags with the given tagBase
+#    ELSE use current L1-O2O tags
+
+# If tagBase AND tagBaseVec are both given, then tagBaseVec trumps tagBase.
+
+def initCondDBSourceExt( process,
+                      inputDBConnect = 'frontier://FrontierProd/CMS_CONDITIONS',
+                      inputDBAuth = '.',
+                      tagBase = "",
+                      tagBaseVec = [],
+                      includeAllTags = False,
+                      includeRSTags = False,
+                      applyESPrefer = True ):
+    import FWCore.ParameterSet.Config as cms
+    from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    if len( tagBaseVec ) == 0:
+        if len( tagBase ) != 0:
+            from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+            initL1UniformTagsExt( tagBase )
+            tagBaseVec = initL1UniformTagsExt.tagBaseVec
+        else:
+            from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+            initL1O2OTagsExt()
+            tagBaseVec = initL1O2OTagsExt.tagBaseVec
+                                
+    process.l1conddb = cms.ESSource("PoolDBESSource",
+                            CondDBSetup,
+                            connect = cms.string(inputDBConnect),
+                            toGet = cms.VPSet(cms.PSet(
+        record = cms.string('L1TriggerKeyListExtRcd'),
+        tag = cms.string('L1TriggerKeyListExt_' + tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ])
+        ),
+                                              cms.PSet(
+        record = cms.string('L1TriggerKeyExtRcd'),
+        tag = cms.string('L1TriggerKeyExt_' + tagBaseVec[ L1CondEnumExt.L1TriggerKeyExt ])
+        ))
+                                    )
+    process.l1conddb.DBParameters.authenticationPath = inputDBAuth
+
+    # The more records, the longer it takes PoolDBESSource to initialize, so be
+    # selective if possible.
+
+    if includeAllTags == True:
+        from CondTools.L1TriggerExt.L1SubsystemParamsExt_cfi import initL1SubsystemsExt
+        initL1SubsystemsExt( tagBaseVec = tagBaseVec )
+        process.l1conddb.toGet.extend(initL1SubsystemsExt.params.recordInfo)
+    elif includeRSTags == True:
+        from CondTools.L1TriggerExt.L1RSSubsystemParamsExt_cfi import initL1RSSubsystemsExt
+        initL1RSSubsystemsExt( tagBaseVec = tagBaseVec )
+        process.l1conddb.toGet.extend(initL1RSSubsystemsExt.params.recordInfo)
+
+    if applyESPrefer == True:
+        process.es_prefer_l1conddb = cms.ESPrefer("PoolDBESSource","l1conddb")

--- a/CondTools/L1TriggerExt/python/L1CondEnumExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondEnumExt_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+class L1CondEnumExt:
+    L1TriggerKeyListExt=0
+    L1TriggerKeyExt=1
+    L1TUtmTriggerMenu=2
+    NumL1Cond=3
+    

--- a/CondTools/L1TriggerExt/python/L1ConfigRSKeysExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1ConfigRSKeysExt_cff.py
@@ -1,0 +1,11 @@
+# Generate dummy L1TriggerKeyExt with "SubsystemKeysOnly" label
+from CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff import *
+L1TriggerKeyDummyExt.objectKeys = cms.VPSet()
+L1TriggerKeyDummyExt.label = "SubsystemKeysOnly"
+
+# Generate object keys for each subsystem
+##from L1TriggerConfig.DTTrackFinder.L1DTTFRSKeysOnline_cfi import *
+
+# Collate subsystem object keys
+from CondTools.L1TriggerExt.L1TriggerKeyOnlineExt_cfi import *
+L1TriggerKeyOnlineExt.subsystemLabels = cms.vstring( ) #'DTTF' )

--- a/CondTools/L1TriggerExt/python/L1ConfigRSPayloadsExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1ConfigRSPayloadsExt_cff.py
@@ -1,0 +1,1 @@
+#from L1TriggerConfig.DTTrackFinder.L1MuDTTFMasksOnline_cfi import *

--- a/CondTools/L1TriggerExt/python/L1ConfigTSCKeysExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1ConfigTSCKeysExt_cff.py
@@ -1,0 +1,2 @@
+from L1TriggerConfig.L1TUtmTriggerMenuProducers.L1TUtmTriggerMenuObjectKeysOnline_cfi import *
+

--- a/CondTools/L1TriggerExt/python/L1ConfigTSCPayloadsExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1ConfigTSCPayloadsExt_cff.py
@@ -1,0 +1,1 @@
+from L1TriggerConfig.L1TUtmTriggerMenuProducers.L1TUtmTriggerMenuOnline_cfi import *

--- a/CondTools/L1TriggerExt/python/L1O2OTagsExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1O2OTagsExt_cfi.py
@@ -1,0 +1,14 @@
+def initL1O2OTagsExt():
+
+    import FWCore.ParameterSet.Config as cms
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    initL1O2OTagsExt.tagBaseVec = [None] * L1CondEnumExt.NumL1Cond
+
+    initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ] = "Stage2v0_hlt"
+    initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyExt ] = "Stage2v0_hlt"
+
+    initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TUtmTriggerMenu ] = "Stage2v0_hlt"
+    
+#    for i in range( 0, L1CondEnumExt.NumL1Cond ):
+#        print i, initL1O2OTagsExt.tagBaseVec[ i ]

--- a/CondTools/L1TriggerExt/python/L1O2OTestAnalyzerExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1O2OTestAnalyzerExt_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+L1O2OTestAnalyzerExt = cms.EDAnalyzer("L1O2OTestAnalyzerExt",
+                                   printL1TriggerKeyExt = cms.bool(True),
+                                   printL1TriggerKeyListExt = cms.bool(True),
+                                   printPayloadTokens = cms.bool(True),
+                                   printESRecords = cms.bool(True),
+                                   recordsToPrint = cms.vstring()
+#    'L1TUtmTriggerMenuRcd' ) # Run Settings records
+                                  )

--- a/CondTools/L1TriggerExt/python/L1RSSubsystemParamsExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1RSSubsystemParamsExt_cfi.py
@@ -1,0 +1,8 @@
+def initL1RSSubsystemsExt( tagBaseVec = [],
+#                        L1MuDTTFMasksRcdKey = 'dummy',
+):
+
+    import FWCore.ParameterSet.Config as cms
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    initL1RSSubsystemsExt.params = cms.PSet( recordInfo = cms.VPSet() )

--- a/CondTools/L1TriggerExt/python/L1SubsystemKeysOnlineExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1SubsystemKeysOnlineExt_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+L1SubsystemKeysOnlineExt = cms.ESProducer("L1SubsystemKeysOnlineProdExt",
+    onlineAuthentication = cms.string('.'),
+    tscKey = cms.string('dummy'),
+    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
+    forceGeneration = cms.bool(False)
+)
+
+

--- a/CondTools/L1TriggerExt/python/L1SubsystemParamsExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1SubsystemParamsExt_cfi.py
@@ -1,0 +1,24 @@
+def initL1SubsystemsExt( tagBaseVec = [],
+                      objectKey = 'dummy' ):
+
+    import FWCore.ParameterSet.Config as cms
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    if len( tagBaseVec ) == 0:
+        from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+        initL1UniformTagsExt()
+        tagBaseVec = initL1UniformTagsExt.tagBaseVec
+
+    initL1SubsystemsExt.params = cms.PSet(
+        recordInfo = cms.VPSet(
+        cms.PSet(
+            record = cms.string('L1TUtmTriggerMenuRcd'),
+            tag = cms.string('L1TUtmTriggerMenu_' + tagBaseVec[ L1CondEnumExt.L1TUtmTriggerMenu ]),
+            type = cms.string('L1TUtmTriggerMenu'),
+            key = cms.string(objectKey)
+        ))
+        )
+
+    from CondTools.L1TriggerExt.L1RSSubsystemParamsExt_cfi import initL1RSSubsystemsExt
+    initL1RSSubsystemsExt( tagBaseVec )
+    initL1SubsystemsExt.params.recordInfo.extend(initL1RSSubsystemsExt.params.recordInfo)

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyDummyExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyDummyExt_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cfi import *
+from CondTools.L1TriggerExt.L1TriggerKeyRcdSourceExt_cfi import *
+

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyDummyExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyDummyExt_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TriggerKeyDummyExt = cms.ESProducer("L1TriggerKeyDummyProdExt",
+    objectKeys = cms.VPSet(),
+    tscKey = cms.string('dummy'),
+    uGTKey = cms.string('dummy'),
+    label = cms.string('')
+)
+
+from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+initL1UniformTagsExt( tagBase = 'IDEAL' )
+from CondTools.L1TriggerExt.L1SubsystemParamsExt_cfi import initL1SubsystemsExt
+initL1SubsystemsExt( tagBaseVec = initL1UniformTagsExt.tagBaseVec, objectKey = 'dummy' )
+L1TriggerKeyDummyExt.objectKeys.extend(initL1SubsystemsExt.params.recordInfo)

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyListDummyExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyListDummyExt_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondTools.L1TriggerExt.L1TriggerKeyListDummyExt_cfi import *
+from CondTools.L1TriggerExt.L1TriggerKeyListExtRcdSource_cfi import *
+

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyListDummyExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyListDummyExt_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TriggerKeyListDummyExt = cms.ESProducer("L1TriggerKeyListDummyProdExt")
+
+

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyListExtRcdSource_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyListExtRcdSource_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TriggerKeyListExtRcdSource = cms.ESSource("EmptyESSource",
+    recordName = cms.string('L1TriggerKeyListExtRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyOnlineExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyOnlineExt_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TriggerKeyOnlineExt = cms.ESProducer("L1TriggerKeyOnlineProdExt",
+    subsystemLabels = cms.vstring( 'uGT' )
+)
+
+

--- a/CondTools/L1TriggerExt/python/L1TriggerKeyRcdSourceExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1TriggerKeyRcdSourceExt_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TriggerKeyRcdSourceExt = cms.ESSource("EmptyESSource",
+    recordName = cms.string('L1TriggerKeyExtRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+

--- a/CondTools/L1TriggerExt/python/L1UniformTagsExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1UniformTagsExt_cfi.py
@@ -1,0 +1,9 @@
+def initL1UniformTagsExt( tagBase = "IDEAL" ):
+
+    import FWCore.ParameterSet.Config as cms
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+
+    initL1UniformTagsExt.tagBaseVec = []
+    for i in range( 0, L1CondEnumExt.NumL1Cond ):
+        initL1UniformTagsExt.tagBaseVec.append( tagBase )
+#        print i, initL1UniformTagsExt.tagBaseVec[ i ]

--- a/CondTools/L1TriggerExt/scripts/getKeys.sh
+++ b/CondTools/L1TriggerExt/scripts/getKeys.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+tflag=0
+rflag=0
+gflag=0
+while getopts 'trgh' OPTION
+  do
+  case $OPTION in
+      t) tflag=1
+          ;;
+      r) rflag=1
+          ;;
+      g) gflag=1
+	  ;;
+      h) echo "Usage: [-tr] L1_KEY"
+          echo "  -t: print TSC key"
+          echo "  -r: print RS keys"
+	  echo "  -g: GT RS keys only"
+          exit
+          ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+getColumnFromL1Key()
+{
+  COLUMN=$1
+
+  DB="cms_omds_lb"
+  USER="cms_trg_r"
+  PASSWORD_FILE=/nfshome0/centraltspro/secure/$USER.txt
+  PASSWORD=`cat $PASSWORD_FILE`
+
+  RESULT=`sqlplus -s <<!
+    $USER/$PASSWORD@$DB
+    SET FEEDBACK OFF;
+    SET HEADING OFF;
+    SET LINESIZE 500;
+    select $COLUMN
+    from CMS_TRG_L1_CONF.L1_CONF_DETAILS_VIEW
+    where L1_KEY='$L1_KEY';
+    !
+!`
+  
+  echo $RESULT
+}
+
+if [[ $# != 1 ]]; then
+  echo "Usage:"
+  echo "$0 <L1 key>"
+  exit 1
+fi
+
+L1_KEY=$1
+
+if [ ${tflag} -eq 1 ]
+    then
+    TSC_KEY=`getColumnFromL1Key TSC_KEY`
+    echo ${TSC_KEY}
+fi
+
+exit 0
+
+EOF

--- a/CondTools/L1TriggerExt/scripts/getValidTscKeys.sh
+++ b/CondTools/L1TriggerExt/scripts/getValidTscKeys.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# List the Valid TSC Keys in OMDS
+
+lastID=$1
+
+DB="cms_omds_lb"
+USER="cms_trg_r"
+PASSWORD_FILE=/nfshome0/centraltspro/secure/$USER.txt
+PASSWORD=`cat $PASSWORD_FILE`
+
+sqlplus -S ${USER}/${PASSWORD}@${DB} <<EOF
+set linesize 500
+set wrap on
+set heading off
+set pagesize 0
+set feedback off
+select TSC_KEY from cms_l1_hlt.L1_HLT_CONF_LATEST_VALID_VIEW;
+EOF
+
+exit

--- a/CondTools/L1TriggerExt/scripts/runL1-O2O-iov.sh
+++ b/CondTools/L1TriggerExt/scripts/runL1-O2O-iov.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+xflag=0
+CMS_OPTIONS=""
+
+while getopts 'xfh' OPTION
+  do
+  case $OPTION in
+      x) xflag=1
+          ;;
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
+          ;;
+      h) echo "Usage: [-xf] runnum tsckey"
+          echo "  -x: write to ORCON instead of sqlite file"
+          echo "  -f: force IOV update"
+          exit
+          ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+runnum=$1
+tsckey=$2
+
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS
+
+if [ ${xflag} -eq 0 ]
+then
+    echo "Writing to sqlite_file:l1config.db instead of ORCON."
+    INDB_OPTIONS="inputDBConnect=sqlite_file:l1config.db inputDBAuth=." 
+    OUTDB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=sqlite_file:l1config.db"
+#    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS copyDBAuth=/data/O2O/L1T/pro/o2o/"
+#    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS copyDBAuth=/data/O2O/L1T/pro/o2o/"
+else
+    echo "Writing to cms_orcoff_prep"
+#    INDB_OPTIONS="inputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS inputDBAuth=/data/O2O/L1T/pro/o2o/"
+#    OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=/data/O2O/L1T/pro/o2o/"
+    INDB_OPTIONS="inputDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS inputDBAuth=/data/O2O/L1T/pro/o2o/"
+    OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS outputDBAuth=/data/O2O/L1T/pro/o2o/"
+    #echo "Cowardly refusing to write to the online database"
+    #exit
+fi
+
+
+if cmsRun ${CMSSW_BASE}/src/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyListExt=1 | grep ${tsckey} ; then echo "TSC payloads present"
+else
+    echo "TSC payloads absent; writing now"
+    cmsRun ${CMSSW_BASE}/src/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py tscKey=${tsckey} ${OUTDB_OPTIONS} ${COPY_OPTIONS} logTransactions=0 print
+    o2ocode=$?
+    if [ ${o2ocode} -ne 0 ]
+    then
+	echo "L1-O2O-ERROR: could not write TSC payloads"
+	echo "L1-O2O-ERROR: could not write TSC payloads" 1>&2
+	exit ${o2ocode}
+    fi
+fi
+
+cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/L1ConfigWriteIOVOnlineExt_cfg.py ${CMS_OPTIONS} tscKey=${tsckey} runNumber=${runnum} ${OUTDB_OPTIONS} logTransactions=0 print
+o2ocode=$?
+
+if [ ${o2ocode} -eq 0 ]
+then
+    echo
+    echo "`date` : checking O2O"
+    if cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyExt=1 runNumber=${runnum} | grep ${tsckey} ; then echo "L1-O2O-INFO: IOV OK"
+    else
+	echo "L1-O2O-ERROR: IOV NOT OK"
+	echo "L1-O2O-ERROR: IOV NOT OK" 1>&2
+	exit 199
+    fi
+else
+    if [ ${o2ocode} -eq 66 ]
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+        if [ ${o2ocode} -eq 65 ]
+        then
+            echo "L1-O2O-ERROR: problem writing object to ORCON."
+            echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+        fi
+    fi
+    exit ${o2ocode}
+fi
+
+
+

--- a/CondTools/L1TriggerExt/scripts/runL1-O2O-key.sh
+++ b/CondTools/L1TriggerExt/scripts/runL1-O2O-key.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+xflag=0
+cflag=0
+CMS_OPTIONS=""
+
+while getopts 'xoch' OPTION
+  do
+  case $OPTION in
+      x) xflag=1
+          ;;
+      o) CMS_OPTIONS=$CMS_OPTIONS" overwriteKeys=1"
+          ;;
+      c) cflag=1
+          ;;
+      h) echo "Usage: [-x] [-o] tsckey"
+	  echo "  -x: write to ORCON instead of sqlite file"
+	  echo "  -o: overwrite keys"
+	  echo "  -c: copy non-O2O payloads from ORCON"
+	  exit
+	  ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+tsckey=$1
+shift 1
+
+COPY_OPTIONS=""
+if [ ${cflag} -eq 1 ]
+then
+    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS copyDBAuth=/nfshome0/l1emulator/run2/o2o/prod"
+#    COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS copyDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+fi
+
+if [ ${xflag} -eq 0 ]
+then
+    echo "Writing to sqlite_file:l1config.db instead of ORCON."
+    INDB_OPTIONS="inputDBConnect=sqlite_file:l1config.db inputDBAuth=."
+    OUTDB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+else
+    echo "Writing to cms_orcoff_prep"
+#    INDB_OPTIONS="inputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS inputDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+#    OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=/nfshome0/l1emulator/run2/o2o/v1"
+    #echo "Cowardly refusing to write to the online database"
+    INDB_OPTIONS="inputDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS inputDBAuth=/nfshome0/l1emulator/run2/o2o/prod"
+    OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS outputDBAuth=/nfshome0/l1emulator/run2/o2o/prod"  
+    #exit
+fi
+
+cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py tscKey=${tsckey} ${CMS_OPTIONS} ${OUTDB_OPTIONS} ${COPY_OPTIONS} logTransactions=0 print
+o2ocode=$?
+if [ ${o2ocode} -eq 0 ]
+then
+    echo
+    echo "`date` : checking O2O"
+    if cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyListExt=1 | grep ${tsckey} ; then echo "L1TRIGGERKEY WRITTEN SUCCESSFULLY"
+    else
+	echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED"
+	echo "L1-O2O-ERROR: L1TRIGGERKEY WRITING FAILED" 1>&2
+	exit 199
+    fi
+else
+    if [ ${o2ocode} -eq 66 ]
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+        if [ ${o2ocode} -eq 65 ]
+        then
+            echo "L1-O2O-ERROR: problem writing object to ORCON."
+            echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+        fi
+    fi
+    exit ${o2ocode}
+fi

--- a/CondTools/L1TriggerExt/scripts/runL1-O2O-rs-keysFromL1Key.sh
+++ b/CondTools/L1TriggerExt/scripts/runL1-O2O-rs-keysFromL1Key.sh
@@ -1,0 +1,75 @@
+
+xflag=0
+gflag=0
+
+CMS_OPTIONS=""
+
+while getopts 'oxfgh' OPTION
+  do
+  case $OPTION in
+      o) CMS_OPTIONS=$CMS_OPTIONS" overwriteKeys=1"
+          ;;
+      x) xflag=1
+          ;;
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
+	  ;;
+      g) gflag=1
+	  ;;
+      h) echo "Usage: [-x] runnum l1key"
+	  echo "  -o: overwrite keys"
+          echo "  -x: write to ORCON instead of sqlite file"
+	  echo "  -f: force IOV update"
+	  echo "  -g: GT RS records only"
+          exit
+	  ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+runnum=$1
+l1Key=$2
+
+
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS
+
+if [ ${gflag} -eq 1 ] 
+then
+     OBJKEYS=`$CMSSW_BASE/src/CondTools/L1TriggerExt/scripts/getKeys.sh -g ${l1Key}`
+else
+     OBJKEYS=`$CMSSW_BASE/src/CondTools/L1TriggerExt/scripts/getKeys.sh -r ${l1Key}`
+fi
+echo "INFO:  OBJECT KEYS:  " $OBJKEYS
+
+if [ ${xflag} -eq 0 ]
+then
+    echo "Writing to sqlite_file:l1config.db instead of ORCON."
+    DB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+else
+    echo "Cowardly refusing to write to the online database"
+#    DB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=." 
+    # WHEN READY FOR PRIME TIME:
+     DB_OPTIONS="outputDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS outputDBAuth=."
+fi
+
+
+cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/L1ConfigWriteRSOnlineExt_cfg.py runNumber=${runnum} ${DB_OPTIONS} ${CMS_OPTIONS} logTransactions=0 $OBJKEYS keysFromDB=0 print
+o2ocode=$?
+
+if [ ${o2ocode} -ne 0 ] 
+then
+    if [ ${o2ocode} -eq 66 ] 
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+	if [ ${o2ocode} -eq 65 ] 
+	then
+	    echo "L1-O2O-ERROR: problem writing object to ORCON."
+	    echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+	fi
+    fi
+else
+    echo "runL1-o2o-rs-keysFromL1Key.sh ran successfully."
+fi
+exit ${o2ocode}
+

--- a/CondTools/L1TriggerExt/scripts/runL1-O2O-rs.sh
+++ b/CondTools/L1TriggerExt/scripts/runL1-O2O-rs.sh
@@ -1,0 +1,64 @@
+
+xflag=0
+gflag=0
+
+CMS_OPTIONS=""
+
+while getopts 'oxfgh' OPTION
+  do
+  case $OPTION in
+      o) CMS_OPTIONS=$CMS_OPTIONS" overwriteKeys=1"
+          ;;
+      x) xflag=1
+          ;;
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
+	  ;;
+      h) echo "Usage: [-x] runnum l1key"
+	  echo "  -o: overwrite keys"
+          echo "  -x: write to ORCON instead of sqlite file"
+	  echo "  -f: force IOV update"
+          exit
+	  ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+runnum=$1
+l1Key=$2
+
+
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS
+
+if [ ${xflag} -eq 0 ]
+then
+    echo "Writing to sqlite_file:l1config.db instead of ORCON."
+    DB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=." 
+else
+    echo "Cowardly refusing to write to the online database"
+#    DB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=." 
+    # WHEN READY FOR PRIME TIME:
+    DB_OPTIONS="outputDBConnect=oracle://cms_orcon_prod/CMS_CONDITIONS outputDBAuth=."
+fi
+
+
+cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/L1ConfigWriteRSOnlineExt_cfg.py runNumber=${runnum} ${DB_OPTIONS} ${CMS_OPTIONS} logTransactions=0 print
+o2ocode=$?
+
+if [ ${o2ocode} -ne 0 ] 
+then
+    if [ ${o2ocode} -eq 66 ] 
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)."
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check that /nfshome0/centraltspro/secure/authentication.xml is up to date (OMDS)." 1>&2
+    else
+	if [ ${o2ocode} -eq 65 ] 
+	then
+	    echo "L1-O2O-ERROR: problem writing object to ORCON."
+	    echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+	fi
+    fi
+else
+    echo "runL1-o2o-rs-keysFromL1Key.sh ran successfully."
+fi
+exit ${o2ocode}
+

--- a/CondTools/L1TriggerExt/src/DataWriterExt.cc
+++ b/CondTools/L1TriggerExt/src/DataWriterExt.cc
@@ -1,0 +1,214 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+#include "CondTools/L1Trigger/interface/Exception.h"
+#include "CondCore/CondDB/interface/Exception.h"
+
+#include "CondCore/CondDB/interface/Serialization.h"
+
+#include <utility>
+
+namespace l1t
+{
+  DataWriterExt::DataWriterExt(){}
+  DataWriterExt::~DataWriterExt(){}
+
+
+
+std::string
+DataWriterExt::writePayload( const edm::EventSetup& setup,
+			  const std::string& recordType )
+{
+  WriterFactory* factory = WriterFactory::get();
+  std::auto_ptr<WriterProxy> writer(factory->create( recordType + "@Writer" )) ;
+  if( writer.get() == 0 )
+    {
+      throw cond::Exception( "DataWriter: could not create WriterProxy with name "
+			     + recordType + "@Writer" ) ;
+    }
+
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if (!poolDb.isAvailable())
+    {
+      throw cond::Exception( "DataWriter: PoolDBOutputService not available."
+			     ) ;
+    }
+
+  // 2010-02-16: Move session and transaction to WriterProxy::save().  Otherwise, if another transaction is
+  // started while WriterProxy::save() is called (e.g. in a ESProducer like L1ConfigOnlineProdBase), the
+  // transaction here will become read-only.
+//   cond::DbSession session = poolDb->session();
+//   cond::DbScopedTransaction tr(session);
+
+///  cond::persistency::TransactionScope tr(poolDb->session().transaction());
+//   // if throw transaction will unroll
+//   tr.start(false);
+
+  // update key to have new payload registered for record-type pair.
+  //  std::string payloadToken = writer->save( setup, session ) ;
+  std::string payloadToken = writer->save( setup ) ;
+
+  edm::LogVerbatim( "L1-O2O" ) << recordType << " PAYLOAD TOKEN "
+			       << payloadToken ;
+
+////  tr.close();
+//   tr.commit ();
+
+  return payloadToken ;
+}
+
+void
+DataWriterExt::writeKeyList( L1TriggerKeyListExt* keyList,
+			  edm::RunNumber_t sinceRun,
+			  bool logTransactions )
+{
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if( !poolDb.isAvailable() )
+    {
+      throw cond::Exception( "DataWriter: PoolDBOutputService not available."
+			     ) ;
+    }
+
+  poolDb->forceInit();
+  cond::persistency::Session session = poolDb->session();
+  cond::persistency::TransactionScope tr(session.transaction());
+///tr.start( false );
+
+  // Write L1TriggerKeyListExt payload and save payload token before committing
+  boost::shared_ptr<L1TriggerKeyListExt> pointer(keyList);
+  std::string payloadToken = session.storePayload(*pointer );
+			
+  // Commit before calling updateIOV(), otherwise PoolDBOutputService gets
+  // confused.
+///tr.commit ();
+  tr.close ();
+  
+  // Set L1TriggerKeyListExt IOV
+  updateIOV( "L1TriggerKeyListExtRcd",
+	     payloadToken,
+	     sinceRun,
+	     logTransactions ) ;
+}
+
+bool
+DataWriterExt::updateIOV( const std::string& esRecordName,
+		       const std::string& payloadToken,
+		       edm::RunNumber_t sinceRun,
+		       bool logTransactions )
+{
+  edm::LogVerbatim( "L1-O2O" ) << esRecordName
+			       << " PAYLOAD TOKEN " << payloadToken ;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if (!poolDb.isAvailable())
+    {
+      throw cond::Exception( "DataWriter: PoolDBOutputService not available."
+			     ) ;
+    }
+
+  bool iovUpdated = true ;
+
+  if( poolDb->isNewTagRequest( esRecordName ) )
+    {
+      sinceRun = poolDb->beginOfTime() ;
+      poolDb->createNewIOV( payloadToken,
+			    sinceRun,
+			    poolDb->endOfTime(),
+			    esRecordName,
+			    logTransactions ) ;
+    }
+  else
+    {	
+      cond::TagInfo tagInfo ;
+      poolDb->tagInfo( esRecordName, tagInfo ) ;
+
+      if( sinceRun == 0 ) // find last since and add 1
+	{
+	  sinceRun = tagInfo.lastInterval.first ;
+	  ++sinceRun ;
+	}
+
+      if( tagInfo.lastPayloadToken != payloadToken )
+	{
+	  poolDb->appendSinceTime( payloadToken,
+				   sinceRun,
+				   esRecordName,
+				   logTransactions ) ;
+	}
+      else
+	{
+	  iovUpdated = false ;
+	  edm::LogVerbatim( "L1-O2O" ) << "IOV already up to date." ;
+	}
+    }
+
+  if( iovUpdated )
+    {
+      edm::LogVerbatim( "L1-O2O" ) << esRecordName << " "
+				   << poolDb->tag( esRecordName )
+				   << " SINCE " << sinceRun ;
+    }
+
+  return iovUpdated ;
+}
+
+std::string
+DataWriterExt::payloadToken( const std::string& recordName,
+			  edm::RunNumber_t runNumber )
+{
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if( !poolDb.isAvailable() )
+    {
+      throw cond::Exception( "DataWriter: PoolDBOutputService not available."
+			     ) ;
+    }
+
+  // Get tag corresponding to EventSetup record name.
+  std::string iovTag = poolDb->tag( recordName ) ;
+
+  // Get IOV token for tag.
+  cond::persistency::Session session = poolDb->session();
+  cond::persistency::IOVProxy iov = session.readIov( iovTag );
+  session.transaction().start();
+
+  std::string payloadToken("");
+  auto iP = iov.find( runNumber );
+  if( iP != iov.end() ){
+    payloadToken = (*iP).payloadId; 
+  }
+  session.transaction().commit() ;
+  return payloadToken ;
+}
+
+std::string
+DataWriterExt::lastPayloadToken( const std::string& recordName )
+{
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if( !poolDb.isAvailable() )
+    {
+      throw cond::Exception( "DataWriter: PoolDBOutputService not available."
+			     ) ;
+    }
+
+  cond::TagInfo tagInfo ;
+  poolDb->tagInfo( recordName, tagInfo ) ;
+  return tagInfo.lastPayloadToken ;
+}
+
+bool
+DataWriterExt::fillLastTriggerKeyList( L1TriggerKeyListExt& output )
+{
+  std::string keyListToken =
+    lastPayloadToken( "L1TriggerKeyListExtRcd" ) ;
+  if( keyListToken.empty() )
+    {
+      return false ;
+    }
+  else
+    {
+      readObject( keyListToken, output ) ;
+      return true ;
+    }
+}
+
+} // ns

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -1,0 +1,63 @@
+#include "CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h"
+
+#include "CondTools/L1Trigger/interface/Exception.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
+L1ObjectKeysOnlineProdBaseExt::L1ObjectKeysOnlineProdBaseExt(const edm::ParameterSet& iConfig)
+   : m_omdsReader(
+	iConfig.getParameter< std::string >( "onlineDB" ),
+	iConfig.getParameter< std::string >( "onlineAuthentication" ) )
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+
+  // The subsystemLabel is used by L1TriggerKeyOnlineProdExt to identify the
+  // L1TriggerKeysExt to concatenate.
+  setWhatProduced(this,
+		  iConfig.getParameter< std::string >( "subsystemLabel" )
+		  );
+
+   //now do what ever other initialization is needed
+}
+
+
+L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+// ------------ method called to produce the data  ------------
+L1ObjectKeysOnlineProdBaseExt::ReturnType
+L1ObjectKeysOnlineProdBaseExt::produce(const L1TriggerKeyExtRcd& iRecord)
+{
+   using namespace edm::es;
+
+  // Get L1TriggerKeyExt with label "SubsystemKeysOnly".  Re-throw exception if
+  // not present.
+  edm::ESHandle< L1TriggerKeyExt > subsystemKeys ;
+  try
+    {
+      iRecord.get( "SubsystemKeysOnly", subsystemKeys ) ;
+    }
+  catch( l1t::DataAlreadyPresentException& ex )
+    {
+      throw ex ;
+    }
+
+  // Copy L1TriggerKeyExt to new object.
+  boost::shared_ptr<L1TriggerKeyExt> pL1TriggerKey ;
+  pL1TriggerKey = boost::shared_ptr< L1TriggerKeyExt >(
+    new L1TriggerKeyExt( *subsystemKeys ) ) ;
+
+  // Get object keys.
+  fillObjectKeys( pL1TriggerKey ) ;
+
+  return pL1TriggerKey ;
+}
+
+//define this as a plug-in
+//DEFINE_FWK_EVENTSETUP_MODULE(L1ObjectKeysOnlineProdBaseExt);

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteIOVDummyExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteIOVDummyExt_cfg.py
@@ -1,0 +1,86 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWriteIOVDummyExt")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('tscKey',
+                 'dummy', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "TSC key")
+options.register('runNumber',
+                 1000, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number")
+options.register('tagBase',
+                 'IDEAL', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "IOV tags = object_{tagBase}")
+options.register('useO2OTags',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "0 = use uniform tags, 1 = ignore tagBase and use O2O tags")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for output DB")
+options.parseArguments()
+
+# Get L1TriggerKeyListExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+
+# Define CondDB tags
+if options.useO2OTags == 0:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+    initL1UniformTagsExt( tagBase = options.tagBase )
+    tagBaseVec = initL1UniformTagsExt.tagBaseVec
+else:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+    initL1O2OTagsExt()
+    tagBaseVec = initL1O2OTagsExt.tagBaseVec
+    
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBIOVWriterExt_cff import initIOVWriterExt
+initIOVWriterExt( process,
+               outputDBConnect = options.outputDBConnect,
+               outputDBAuth = options.outputDBAuth,
+               tagBaseVec = tagBaseVec,
+               tscKey = options.tscKey )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+process.outputDB = cms.ESSource("PoolDBESSource",
+    process.CondDBCommon,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('L1TriggerKeyListExtRcd'),
+        tag = cms.string('L1TriggerKeyListExt_' + tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ])
+    ))
+)
+
+process.p = cms.Path(process.L1CondDBIOVWriterExt)
+process.outputDB.connect = cms.string(options.outputDBConnect)
+process.outputDB.DBParameters.authenticationPath = options.outputDBAuth

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteIOVOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteIOVOnlineExt_cfg.py
@@ -1,0 +1,91 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWriteIOVOnlineExt")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+# Get L1TriggerKeyListExtExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('tscKey',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "TSC key")
+options.register('runNumber',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for output DB")
+options.register('forceUpdate',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Check all record IOVs even if L1TriggerKey unchanged")
+options.register('logTransactions',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Record transactions in log DB")
+options.parseArguments()
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBIOVWriterExt_cff import initIOVWriterExt
+initIOVWriterExt( process,
+               outputDBConnect = options.outputDBConnect,
+               outputDBAuth = options.outputDBAuth,
+               tagBaseVec = initL1O2OTagsExt.tagBaseVec,
+               tscKey = options.tscKey )
+
+if options.forceUpdate == 1:
+    process.L1CondDBIOVWriterExt.forceUpdate = True
+
+if options.logTransactions == 1:
+#    initIOVWriterExt.outputDB.logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG')
+    initIOVWriterExt.outputDB.logconnect = cms.untracked.string('sqlite_file:l1o2o-log.db')
+    process.L1CondDBIOVWriterExt.logTransactions = True
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+process.outputDB = cms.ESSource("PoolDBESSource",
+                                process.CondDBCommon,
+                                toGet = cms.VPSet(cms.PSet(
+    record = cms.string('L1TriggerKeyListExtRcd'),
+    tag = cms.string('L1TriggerKeyListExt_' + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ])
+    )),
+                                RefreshEachRun=cms.untracked.bool(True)
+                                )
+process.outputDB.connect = cms.string(options.outputDBConnect)
+process.outputDB.DBParameters.authenticationPath = options.outputDBAuth
+
+# CORAL debugging
+process.outputDB.DBParameters.messageLevel = cms.untracked.int32(3)
+
+process.p = cms.Path(process.L1CondDBIOVWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWritePayloadCondDBExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWritePayloadCondDBExt_cfg.py
@@ -1,0 +1,73 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWritePayloadDummy")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('runNumber',
+                 4294967295, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number; default gives latest IOV")
+options.register('inputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for input DB")
+options.register('inputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for input DB")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for output DB")
+options.parseArguments()
+
+# Generate dummy L1TriggerKeyExt and L1TriggerKeyListExt
+process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+# Input DB
+from CondTools.L1TriggerExt.L1CondDBSourceExt_cff import initCondDBSourceExt
+initCondDBSourceExt( process,
+                  inputDBConnect = options.inputDBConnect,
+                  inputDBAuth = options.inputDBAuth,
+                  tagBaseVec = initL1O2OTagsExt.tagBaseVec,
+                  includeAllTags = True,
+                  applyESPrefer = False )
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = initL1O2OTagsExt.tagBaseVec )
+process.L1CondDBPayloadWriterExt.newL1TriggerKeyListExt = True
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWritePayloadDummyExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWritePayloadDummyExt_cfg.py
@@ -1,0 +1,76 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWritePayloadDummy")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('tagBase',
+                 'IDEAL', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "IOV tags = object_{tagBase}")
+options.register('useO2OTags',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "0 = use uniform tags, 1 = ignore tagBase and use O2O tags")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for output DB")
+options.register('startup',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Use L1StartupConfig_cff instead of L1DummyConfig_cff")
+options.parseArguments()
+
+# Generate dummy L1TriggerKey
+process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+
+# Generate dummy configuration data
+if options.startup == 0:
+    process.load("L1Trigger.Configuration.L1DummyConfig_cff")
+    process.load("L1TriggerConfig.L1GtConfigProducers.Luminosity.lumi1031.L1Menu_MC2009_v4_L1T_Scales_20090624_Imp0_Unprescaled_cff")
+else:
+    process.load("L1Trigger.Configuration.L1StartupConfig_cff")
+    process.load("L1TriggerConfig.L1GtConfigProducers.Luminosity.startup.L1Menu_Commissioning2009_v5_L1T_Scales_20080926_startup_Imp0_Unprescaled_cff")
+
+# Define CondDB tags
+if options.useO2OTags == 0:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+    initL1UniformTagsExt( tagBase = options.tagBase )
+    tagBaseVec = initL1UniformTagsExt.tagBaseVec
+else:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+    initL1O2OTagsExt()
+    tagBaseVec = initL1O2OTagsExt.tagBaseVec
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = tagBaseVec )
+
+# Generate dummy L1TriggerKeyListExt
+process.L1CondDBPayloadWriterExt.newL1TriggerKeyListExt = True
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource")
+
+process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py
@@ -1,0 +1,116 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWritePayloadOnline")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('tscKey',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "TSC key")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for output DB")
+options.register('overwriteKeys',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Overwrite existing keys")
+options.register('logTransactions',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Record transactions in log DB")
+options.register('copyNonO2OPayloads',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Copy DTTF TSC payloads from ORCON")
+options.register('copyDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for copy DB")
+options.register('copyDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for copy DB")
+options.parseArguments()
+
+# Generate L1TriggerKeyExt from OMDS
+process.load("CondTools.L1TriggerExt.L1SubsystemKeysOnlineExt_cfi")
+process.L1SubsystemKeysOnlineExt.tscKey = cms.string( options.tscKey )
+process.load("CondTools.L1TriggerExt.L1ConfigTSCKeysExt_cff")
+process.load("CondTools.L1TriggerExt.L1TriggerKeyOnlineExt_cfi")
+process.L1TriggerKeyOnlineExt.subsystemLabels = cms.vstring(
+                                                          'uGT'
+                                                        )
+
+# Generate configuration data from OMDS
+process.load("CondTools.L1TriggerExt.L1ConfigTSCPayloadsExt_cff")
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = initL1O2OTagsExt.tagBaseVec )
+
+if options.logTransactions == 1:
+#    initPayloadWriterExt.outputDB.logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG')
+    initPayloadWriterExt.outputDB.logconnect = cms.untracked.string('sqlite_file:l1o2o-log.db')
+    process.L1CondDBPayloadWriterExt.logTransactions = True
+
+if options.overwriteKeys == 0:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = False
+else:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = True
+                
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Suppress warnings, not actually used, except for copyNonO2OPayloads
+process.outputDB = cms.ESSource("PoolDBESSource",
+                                process.CondDBCommon,
+                                toGet = cms.VPSet(cms.PSet(
+    record = cms.string('L1TriggerKeyListExtRcd'),
+    tag = cms.string( "L1TriggerKeyListExt_" + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ] )
+    )),
+                                RefreshEachRun=cms.untracked.bool(True)
+                                )
+
+if options.copyNonO2OPayloads == 0:
+    process.outputDB.connect = options.outputDBConnect
+    process.outputDB.DBParameters.authenticationPath = options.outputDBAuth
+    process.source = cms.Source("EmptySource")
+else:
+    process.outputDB.connect = options.copyDBConnect
+    process.outputDB.DBParameters.authenticationPath = options.copyDBAuth
+    process.source = cms.Source("EmptyIOVSource",
+                                timetype = cms.string('runnumber'),
+                                firstValue = cms.uint64(4294967295),
+                                lastValue = cms.uint64(4294967295),
+                                interval = cms.uint64(1) )
+                            
+process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteRSIOVOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteRSIOVOnlineExt_cfg.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWriteRSIOVOnline")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('runNumber',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for outputDB")
+options.register('keysFromDB',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "1 = read keys from OMDS, 0 = read keys from command line")
+options.register('logTransactions',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Record transactions in log DB")
+
+options.parseArguments()
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+if options.keysFromDB == 1:
+    process.load("CondTools.L1TriggerExt.L1ConfigRSKeysExt_cff")
+else:
+    process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+    from CondTools.L1TriggerExt.L1RSSubsystemParamsExt_cfi import initL1RSSubsystemsExt
+    initL1RSSubsystemsExt( tagBaseVec = initL1O2OTagsExt.tagBaseVec )
+    process.L1TriggerKeyDummyExt.objectKeys = initL1RSSubsystemsExt.params.recordInfo
+
+# Get L1TriggerKeyListExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.outputDB = cms.ESSource("PoolDBESSource",
+                                process.CondDBCommon,
+                                toGet = cms.VPSet(cms.PSet(
+    record = cms.string('L1TriggerKeyListExtRcd'),
+    tag = cms.string('L1TriggerKeyListExt_' + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ] )
+    ))
+                                )
+process.outputDB.connect = options.outputDBConnect
+process.outputDB.DBParameters.authenticationPath = options.outputDBAuth
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBIOVWriterExt_cff import initIOVWriterExt
+initIOVWriterExt( process,
+               outputDBConnect = options.outputDBConnect,
+               outputDBAuth = options.outputDBAuth,
+               tagBaseVec = initL1O2OTagsExt.tagBaseVec,
+               tscKey = '' )
+process.L1CondDBIOVWriterExt.logKeys = True
+
+if options.logTransactions == 1:
+    initIOVWriterExt.outputDB.logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG')
+    process.L1CondDBIOVWriterExt.logTransactions = True
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+process.p = cms.Path(process.L1CondDBIOVWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteRSOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteRSOnlineExt_cfg.py
@@ -1,0 +1,128 @@
+# This script doesn't work yet.  PoolDBESSource does not see the IOV updates made earlier in the
+# same event.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWriteRSOnline")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('runNumber',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for outputDB")
+options.register('keysFromDB',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "1 = read keys from OMDS, 0 = read keys from command line")
+options.register('overwriteKeys',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Overwrite existing keys")
+options.register('forceUpdate',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Check all record IOVs even if L1TriggerKey unchanged")
+options.register('logTransactions',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Record transactions in log DB")
+
+options.parseArguments()
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+if options.keysFromDB == 1:
+    process.load("CondTools.L1TriggerExt.L1ConfigRSKeysExt_cff")
+else:
+    process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+    from CondTools.L1TriggerExt.L1RSSubsystemParamsExt_cfi import initL1RSSubsystemsExt
+    initL1RSSubsystemsExt( tagBaseVec = initL1O2OTagsExt.tagBaseVec)
+    process.L1TriggerKeyDummyExt.objectKeys = initL1RSSubsystemsExt.params.recordInfo                        
+
+# Get L1TriggerKeyListExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.outputDB = cms.ESSource("PoolDBESSource",
+                                process.CondDBCommon,
+                                toGet = cms.VPSet(cms.PSet(
+    record = cms.string('L1TriggerKeyListExtRcd'),
+    tag = cms.string('L1TriggerKeyListExt_' + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ] )
+    )),
+                                RefreshEachRun=cms.untracked.bool(True)
+                                )
+process.outputDB.connect = options.outputDBConnect
+process.outputDB.DBParameters.authenticationPath = options.outputDBAuth
+
+# Generate configuration data
+process.load("CondTools.L1TriggerExt.L1ConfigRSPayloadsExt_cff")
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = initL1O2OTagsExt.tagBaseVec )
+process.L1CondDBPayloadWriterExt.writeL1TriggerKey = cms.bool(False)
+
+if options.logTransactions == 1:
+#    initPayloadWriterExt.outputDB.logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG')
+    initPayloadWriterExt.outputDB.logconnect = cms.untracked.string('sqlite_file:l1o2o-log.db')
+    process.L1CondDBPayloadWriterExt.logTransactions = True
+
+if options.overwriteKeys == 0:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = False
+else:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = True
+
+from CondTools.L1TriggerExt.L1CondDBIOVWriterExt_cff import initIOVWriterExt
+initIOVWriterExt( process,
+               outputDBConnect = options.outputDBConnect,
+               outputDBAuth = options.outputDBAuth,
+               tagBaseVec = initL1O2OTagsExt.tagBaseVec,
+               tscKey = '' )
+process.L1CondDBIOVWriterExt.logKeys = True
+
+if options.forceUpdate == 1:
+    process.L1CondDBIOVWriterExt.forceUpdate = True
+
+if options.logTransactions == 1:
+#    initIOVWriterExt.outputDB.logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG')
+    initIOVWriterExt.outputDB.logconnect = cms.untracked.string('sqlite_file:l1o2o-log.db')
+    process.L1CondDBIOVWriterExt.logTransactions = True
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+# CORAL debugging
+#process.outputDB.DBParameters.messageLevel = cms.untracked.int32(3)
+
+process.p = cms.Path(process.L1CondDBPayloadWriterExt*process.L1CondDBIOVWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteRSPayloadOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteRSPayloadOnlineExt_cfg.py
@@ -1,0 +1,97 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWriteRSPayloadOnline")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for outputDB")
+options.register('keysFromDB',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "1 = read keys from OMDS, 0 = read keys from command line")
+options.register('overwriteKeys',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Overwrite existing keys")
+options.register('logTransactions',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Record transactions in log DB")
+
+# arguments for setting object keys by hand
+options.register('runNumber',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Dummy argument")
+
+options.parseArguments()
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+if options.keysFromDB == 1:
+    process.load("CondTools.L1TriggerExt.L1ConfigRSKeysExt_cff")
+else:
+    process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+    from CondTools.L1TriggerExt.L1RSSubsystemParamsExt_cfi import initL1RSSubsystemsExt
+    initL1RSSubsystemsExt( tagBaseVec = initL1O2OTagsExt.tagBaseVec )
+    process.L1TriggerKeyDummyExt.objectKeys = initL1RSSubsystemsExt.params.recordInfo
+
+# Get L1TriggerKeyListExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.outputDB = cms.ESSource("PoolDBESSource",
+    process.CondDBCommon,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('L1TriggerKeyListExtRcd'),
+        tag = cms.string('L1TriggerKeyListExt_' + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ] )
+    ))
+)
+#process.es_prefer_outputDB = cms.ESPrefer("PoolDBESSource","outputDB")
+process.outputDB.connect = options.outputDBConnect
+process.outputDB.DBParameters.authenticationPath = options.outputDBAuth
+
+# Generate configuration data
+process.load("CondTools.L1TriggerExt.L1ConfigRSPayloadsExt_cff")
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = initL1O2OTagsExt.tagBaseVec,
+process.L1CondDBPayloadWriterExt.writeL1TriggerKey = cms.bool(False)
+
+if options.logTransactions == 1:
+    initPayloadWriterExt.outputDB.logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG')
+    process.L1CondDBPayloadWriterExt.logTransactions = True
+
+if options.overwriteKeys == 0:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = False
+else:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = True
+                
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource")
+
+process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteSingleIOVExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteSingleIOVExt_cfg.py
@@ -1,0 +1,114 @@
+# Example using L1RCTParameters
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWriteIOVDummy")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('objectKey',
+                 'dummy', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Object key")
+options.register('objectType',
+                 'L1RCTParameters', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "object C++ type")
+options.register('recordName',
+                 'L1RCTParametersRcd', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Name of EventSetup record")
+options.register('tagName',
+                 'L1RCTParameters', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "IOV tags = {tagName}_{tagBase}")
+options.register('useO2OTags',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "0 = use uniform tags, 1 = ignore tagBase and use O2O tags")
+options.register('condIndex',
+                 -999, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Index in L1CondEnum of record")
+options.register('runNumber',
+                 1000, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number")
+options.register('tagBase',
+                 'IDEAL', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "IOV tags = {tagName}_{tagBase}")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for outputDB")
+options.parseArguments()
+
+# Define CondDB tags
+if options.useO2OTags == 0:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+    initL1UniformTagsExt( tagBase = options.tagBase )
+    tagBaseVec = initL1UniformTagsExt.tagBaseVec
+    options.condIndex = 0 # Doesn't matter what index is used with uniform tags
+else:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+    initL1O2OTagsExt()
+    tagBaseVec = initL1O2OTagsExt.tagBaseVec
+
+# Get L1TriggerKeyListExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.outputDB = cms.ESSource("PoolDBESSource",
+    process.CondDBCommon,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('L1TriggerKeyListExtRcd'),
+        tag = cms.string('L1TriggerKeyListExt_' + tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ])
+    ))
+)
+process.outputDB.connect = cms.string(options.outputDBConnect)
+process.outputDB.DBParameters.authenticationPath = options.outputDBAuth
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBIOVWriterExt_cff import initIOVWriterExt
+initIOVWriterExt( process,
+               outputDBConnect = options.outputDBConnect,
+               outputDBAuth = options.outputDBAuth,
+               tagBaseVec = tagBaseVec,
+               tscKey = options.objectKey )
+process.L1CondDBIOVWriterExt.ignoreTriggerKey = cms.bool(True)
+process.L1CondDBIOVWriterExt.toPut = cms.VPSet(cms.PSet(
+    record = cms.string(options.recordName),
+    type = cms.string(options.objectType),
+    tag = cms.string(options.tagName + '_' + tagBaseVec[ options.condIndex ])
+))
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+process.p = cms.Path(process.L1CondDBIOVWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWriteSinglePayloadExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWriteSinglePayloadExt_cfg.py
@@ -1,0 +1,132 @@
+# Example using L1RCTParameters
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWritePayloadDummy")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('objectKey',
+                 'dummy', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "object key")
+options.register('objectType',
+                 'L1RCTParameters', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "object C++ type")
+options.register('recordName',
+                 'L1RCTParametersRcd', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Name of EventSetup record")
+options.register('tagBase',
+                 'IDEAL', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "IOV tags = object_{tagBase}")
+options.register('useO2OTags',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "0 = use uniform tags, 1 = ignore tagBase and use O2O tags")
+options.register('genFromOMDS',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "0 = use dummy payloads, 1 = generate payloads from OMDS")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for outputDB")
+options.register('overwriteKey',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Overwrite existing key")
+options.register('startup',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Use L1StartupConfig_cff instead of L1DummyConfig_cff")
+
+options.parseArguments()
+
+# Define CondDB tags
+if options.useO2OTags == 0:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+    initL1UniformTagsExt( tagBase = options.tagBase )
+    tagBaseVec = initL1UniformTagsExt.tagBaseVec
+else:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+    initL1O2OTagsExt()
+    tagBaseVec = initL1O2OTagsExt.tagBaseVec
+
+# Generate L1TriggerKey
+process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+process.L1TriggerKeyDummyExt.objectKeys = cms.VPSet(cms.PSet(
+    record = cms.string(options.recordName),
+    type = cms.string(options.objectType),
+    key = cms.string(options.objectKey)
+))
+
+# Get L1TriggerKeyListExt from DB
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.outputDB = cms.ESSource("PoolDBESSource",
+    process.CondDBCommon,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('L1TriggerKeyListExtRcd'),
+        tag = cms.string('L1TriggerKeyListExt_' + tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ])
+    ))
+)
+process.es_prefer_outputDB = cms.ESPrefer("PoolDBESSource","outputDB")
+process.outputDB.connect = cms.string(options.outputDBConnect)
+process.outputDB.DBParameters.authenticationPath = cms.untracked.string(options.outputDBAuth)
+
+if options.genFromOMDS == 0:
+    # Generate dummy configuration data
+    if options.startup == 0:
+        process.load("L1Trigger.Configuration.L1DummyConfig_cff")
+        process.load("L1TriggerConfig.L1GtConfigProducers.Luminosity.lumi1031.L1Menu_MC2009_v2_L1T_Scales_20090624_Imp0_Unprescaled_cff")
+    else:
+        process.load("L1Trigger.Configuration.L1StartupConfig_cff")
+        process.load("L1TriggerConfig.L1GtConfigProducers.Luminosity.startup.L1Menu_Commissioning2009_v3_L1T_Scales_20080926_startup_Imp0_Unprescaled_cff")
+
+else:
+    # Generate configuration data from OMDS
+    process.load("CondTools.L1TriggerExt.L1ConfigTSCPayloadsExt_cff")
+    process.load("CondTools.L1TriggerExt.L1ConfigRSPayloadsExt_cff")
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = tagBaseVec )
+process.L1CondDBPayloadWriterExt.writeL1TriggerKeyExt = False
+
+if options.overwriteKey == 0:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = False
+else:
+    process.L1CondDBPayloadWriterExt.overwriteKeys = True
+#    if options.genFromOMDS != 0:
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource")
+
+process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/init_cfg.py
+++ b/CondTools/L1TriggerExt/test/init_cfg.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigWritePayloadDummy")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('tagBase',
+                 'IDEAL', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "IOV tags = object_{tagBase}")
+options.register('useO2OTags',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "0 = use uniform tags, 1 = ignore tagBase and use O2O tags")
+options.register('outputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('outputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for output DB")
+options.parseArguments()
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource")
+
+# Generate dummy L1TriggerKey
+process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+process.L1TriggerKeyDummyExt.objectKeys = cms.VPSet()
+process.L1TriggerKeyDummyExt.tscKey = cms.string(' ')
+
+# Define CondDB tags
+if options.useO2OTags == 0:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1UniformTagsExt_cfi import initL1UniformTagsExt
+    initL1UniformTagsExt( tagBase = options.tagBase )
+    tagBaseVec = initL1UniformTagsExt.tagBaseVec
+else:
+    from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+    from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+    initL1O2OTagsExt()
+    tagBaseVec = initL1O2OTagsExt.tagBaseVec
+
+# writer modules
+from CondTools.L1TriggerExt.L1CondDBPayloadWriterExt_cff import initPayloadWriterExt
+initPayloadWriterExt( process,
+                   outputDBConnect = options.outputDBConnect,
+                   outputDBAuth = options.outputDBAuth,
+                   tagBaseVec = tagBaseVec )
+
+# Generate dummy L1TriggerKeyListExt to initialize DB on the first time ONLY.
+process.L1CondDBPayloadWriterExt.newL1TriggerKeyListExt = True
+
+process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py
+++ b/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py
@@ -1,0 +1,120 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("L1ConfigValidation")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('runNumber',
+                 4294967295, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number; default gives latest IOV")
+options.register('inputDBConnect',
+                 'sqlite_file:l1config.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for input DB")
+options.register('inputDBAuth',
+                 '.', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for input DB")
+options.register('printL1TriggerKeyListExt',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Print all object keys in CondDB")
+options.register('printL1TriggerKeyExt',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Print TSC key, subsystem keys, and object keys")
+options.register('printRSKeys',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Print Run Settings keys")
+options.register('printPayloadTokens',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Print payload tokens (long)")
+options.parseArguments()
+
+# Define CondDB tags
+from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
+from CondTools.L1TriggerExt.L1O2OTagsExt_cfi import initL1O2OTagsExt
+initL1O2OTagsExt()
+
+# Input DB
+from CondTools.L1TriggerExt.L1CondDBSourceExt_cff import initCondDBSourceExt
+initCondDBSourceExt( process,
+                  inputDBConnect = options.inputDBConnect,
+                  inputDBAuth = options.inputDBAuth,
+                  tagBaseVec = initL1O2OTagsExt.tagBaseVec,
+                  includeRSTags = options.printRSKeys )
+
+from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
+outputDB = cms.Service("PoolDBOutputService",
+                       CondDBSetup,
+                       # BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                       connect = cms.string(options.inputDBConnect),
+                       toPut = cms.VPSet(cms.PSet(
+    record = cms.string("L1TriggerKeyExtRcd"),
+    tag = cms.string("L1TriggerKeyExt_" + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyExt ])),
+                                         cms.PSet(
+    record = cms.string("L1TriggerKeyListExtRcd"),
+    tag = cms.string("L1TriggerKeyListExt_" + initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TriggerKeyListExt ]))
+                                         ))
+outputDB.DBParameters.authenticationPath = options.inputDBAuth
+
+# PoolDBOutputService for printing out ESRecords
+if options.printRSKeys == 1:
+    from CondTools.L1TriggerExt.L1RSSubsystemParamsExt_cfi import initL1RSSubsystemsExt
+    initL1RSSubsystemsExt( tagBaseVec = initL1O2OTagsExt.tagBaseVec )
+    outputDB.toPut.extend(initL1RSSubsystemsExt.params.recordInfo)
+
+process.add_(outputDB)
+    
+# Source of events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(options.runNumber),
+    lastValue = cms.uint64(options.runNumber),
+    interval = cms.uint64(1)
+)
+
+# Validation modules
+process.load('CondTools.L1TriggerExt.L1O2OTestAnalyzerExt_cfi')
+process.L1O2OTestAnalyzerExt.printPayloadTokens = False
+
+if options.printL1TriggerKeyExt == 1:
+    process.L1O2OTestAnalyzerExt.printL1TriggerKeyExt = True
+else:
+    process.L1O2OTestAnalyzerExt.printL1TriggerKeyExt = False
+
+if options.printL1TriggerKeyListExt == 1:
+    process.L1O2OTestAnalyzerExt.printL1TriggerKeyListExt = True
+else:
+    process.L1O2OTestAnalyzerExt.printL1TriggerKeyListExt = False
+
+if options.printRSKeys == 1:
+    process.L1O2OTestAnalyzerExt.printESRecords = True
+else:
+    process.L1O2OTestAnalyzerExt.printESRecords = False
+
+if options.printPayloadTokens == 1:
+    process.L1O2OTestAnalyzerExt.printPayloadTokens = True
+else:
+    process.L1O2OTestAnalyzerExt.printPayloadTokens = False
+
+#print process.dumpPython()
+
+process.p = cms.Path(process.L1O2OTestAnalyzerExt)

--- a/L1TriggerConfig/L1TUtmTriggerMenuProducers/BuildFile.xml
+++ b/L1TriggerConfig/L1TUtmTriggerMenuProducers/BuildFile.xml
@@ -1,0 +1,9 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="CondFormats/L1TObjects"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="CondTools/L1TriggerExt"/>
+<use   name="xerces-c"/>
+<use   name="utm"/>
+<flags   EDM_PLUGIN="1"/>

--- a/L1TriggerConfig/L1TUtmTriggerMenuProducers/python/L1TUtmTriggerMenuObjectKeysOnline_cfi.py
+++ b/L1TriggerConfig/L1TUtmTriggerMenuProducers/python/L1TUtmTriggerMenuObjectKeysOnline_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TUtmTriggerMenuObjectKeysOnline = cms.ESProducer("L1TUtmTriggerMenuObjectKeysOnlineProd",
+    onlineAuthentication = cms.string('.'),
+    subsystemLabel = cms.string('uGT'),
+    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R')
+)
+

--- a/L1TriggerConfig/L1TUtmTriggerMenuProducers/python/L1TUtmTriggerMenuOnline_cfi.py
+++ b/L1TriggerConfig/L1TUtmTriggerMenuProducers/python/L1TUtmTriggerMenuOnline_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1TriggerConfig.L1TUtmTriggerMenuProducers.L1TUtmTriggerMenuObjectKeysOnline_cfi import *
+
+L1TUtmTriggerMenuOnlineProd = cms.ESProducer("L1TUtmTriggerMenuOnlineProd",
+    onlineAuthentication = cms.string('.'),
+    forceGeneration = cms.bool(False),
+    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R')
+)
+
+#es_prefer = cms.ESPrefer("L1TCaloParamsStage1OnlineProd","")

--- a/L1TriggerConfig/L1TUtmTriggerMenuProducers/src/L1TUtmTriggerMenuObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TUtmTriggerMenuProducers/src/L1TUtmTriggerMenuObjectKeysOnlineProd.cc
@@ -1,0 +1,57 @@
+#include <iostream>
+#include "CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+class L1TUtmTriggerMenuObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
+private:
+
+public:
+    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+
+    L1TUtmTriggerMenuObjectKeysOnlineProd(const edm::ParameterSet&);
+    ~L1TUtmTriggerMenuObjectKeysOnlineProd(void){}
+};
+
+L1TUtmTriggerMenuObjectKeysOnlineProd::L1TUtmTriggerMenuObjectKeysOnlineProd(const edm::ParameterSet& iConfig)
+  : L1ObjectKeysOnlineProdBaseExt( iConfig ){
+}
+
+
+void L1TUtmTriggerMenuObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+
+    std::string uGTKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kuGT ) ;
+
+    std::string stage2Schema = "CMS_TRG_L1_CONF" ;
+
+    if( !uGTKey.empty() ) {
+       std::string l1_menu_key;
+       std::vector< std::string > queryStrings ;
+       queryStrings.push_back( "L1_MENU" ) ;
+
+        std::string l1_menu_name, ugt_key;
+
+        // select MP7_PP_CONF_KEY from CMS_S1CALOL2.S1CALOL2_CONF where S1CALOL2_CONF_KEY = objectKey ;
+        l1t::OMDSReader::QueryResults queryResult =
+            m_omdsReader.basicQuery( queryStrings,
+                                     stage2Schema,
+                                     "UGT_KEYS",
+                                     "UGT_KEYS.ID",
+                                     m_omdsReader.singleAttribute(uGTKey)
+                                   ) ;
+
+        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
+            edm::LogError( "L1-O2O" ) << "Cannot get UGT_KEYS.L1_MENU}" ;
+            return ;
+        }
+
+        if( !queryResult.fillVariable( "L1_MENU", l1_menu_key) ) l1_menu_key = "";
+        
+        pL1TriggerKey->add( "L1TUtmTriggerMenuRcd",
+                            "L1TUtmTriggerMenu",
+			    l1_menu_key) ;
+    }
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(L1TUtmTriggerMenuObjectKeysOnlineProd);

--- a/L1TriggerConfig/L1TUtmTriggerMenuProducers/src/L1TUtmTriggerMenuOnlineProd.cc
+++ b/L1TriggerConfig/L1TUtmTriggerMenuProducers/src/L1TUtmTriggerMenuOnlineProd.cc
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <fstream>
+#include "tmEventSetup/tmEventSetup.hh"
+
+#include "tmEventSetup/esTriggerMenu.hh"
+#include "tmEventSetup/esAlgorithm.hh"
+#include "tmEventSetup/esCondition.hh"
+#include "tmEventSetup/esObject.hh"
+#include "tmEventSetup/esCut.hh"
+#include "tmEventSetup/esScale.hh"
+#include "tmGrammar/Algorithm.hh"
+
+#include "CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+
+class L1TUtmTriggerMenuOnlineProd : public L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuRcd,L1TUtmTriggerMenu> {
+private:
+public:
+    virtual boost::shared_ptr<L1TUtmTriggerMenu> newObject(const std::string& objectKey) override ;
+
+    L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet&);
+    ~L1TUtmTriggerMenuOnlineProd(void){}
+};
+
+L1TUtmTriggerMenuOnlineProd::L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuRcd,L1TUtmTriggerMenu>(iConfig) {}
+
+boost::shared_ptr<L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const std::string& objectKey) {
+    using namespace edm::es;
+
+    std::string stage2Schema = "CMS_TRG_L1_CONF" ;
+    edm::LogInfo( "L1-O2O: L1TUtmTriggerMenuOnlineProd" ) << "Producing L1TUtmTriggerMenu with key =" << objectKey ;
+
+    if (objectKey.empty()) {
+        edm::LogInfo( "L1-O2O: L1TUtmTriggerMenuOnlineProd" ) << "Key is empty, returning empty CaloParams";
+        return boost::shared_ptr< L1TUtmTriggerMenu > ( new L1TUtmTriggerMenu() );
+    }
+
+    std::vector< std::string > queryColumns;
+    queryColumns.push_back( "CONF" ) ;
+
+    l1t::OMDSReader::QueryResults queryResult =
+            m_omdsReader.basicQuery( queryColumns,
+                                     stage2Schema,
+                                     "UGT_L1_MENU",
+                                     "UGT_L1_MENU.ID",
+                                     m_omdsReader.singleAttribute(objectKey)
+                                   ) ;
+
+    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
+        edm::LogError( "L1-O2O: L1TUtmTriggerMenuOnlineProd" ) << "Cannot get UGT_L1_MENU.CONF for ID="<<objectKey ;
+        return boost::shared_ptr< L1TUtmTriggerMenu >() ;
+    }
+
+    std::string l1Menu;
+    queryResult.fillVariable( "CONF", l1Menu );
+///
+    std::istringstream iss(l1Menu);
+
+    const L1TUtmTriggerMenu * cmenu = reinterpret_cast<const L1TUtmTriggerMenu *>(tmeventsetup::getTriggerMenu(iss));  
+    L1TUtmTriggerMenu * menu = const_cast<L1TUtmTriggerMenu *>(cmenu);
+
+    using namespace edm::es;
+    boost::shared_ptr<L1TUtmTriggerMenu> pMenu ;
+    pMenu = boost::shared_ptr< L1TUtmTriggerMenu >(menu);
+    return pMenu;
+
+///    return boost::shared_ptr< L1TUtmTriggerMenu > ( new L1TUtmTriggerMenu() );
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(L1TUtmTriggerMenuOnlineProd);


### PR DESCRIPTION
This is a long-awaited PR synchronizing an outdated L1T O2O in the release with the extended version
that addresses Stage2 upgrade changes. Most of this code (namely the new CondTools/L1TriggerExt) was already successfully running in 2015, but few recent changes were introduced to keep up with the CondDB development. The current version handles only the highest priority uGT payload, but will soon be extended with other trigger subsystems (short PRs will follow).

This PR also requires the latest-greatest version of the external UTM library so it won't compile unless you follow the instructions at https://gitlab.cern.ch/cms-l1t-utm/utm/blob/master/README.md .
