### PR TITLE
Use unique_ptr, not auto_ptr

### DIFF
--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -133,7 +133,7 @@ namespace edm {
     //   edm::Handle<edm::View<Y> > inputView2;
     //   event.getByToken(inputToken2V_, inputView2);
     //   // If you are certain the Views are not empty!
-    //   std::auto_ptr<AssocOneToOneView> assoc8(new AssocOneToOneView(
+    //   std::unique_ptr<AssocOneToOneView> assoc8(new AssocOneToOneView(
     //     edm::makeRefToBaseProdFrom(inputView1->refAt(0), event),
     //     edm::makeRefToBaseProdFrom(inputView2->refAt(0), event)
     //   ));

--- a/DataFormats/Common/interface/BaseHolder.h
+++ b/DataFormats/Common/interface/BaseHolder.h
@@ -55,9 +55,9 @@ namespace edm {
       // msg, and return false.
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
                                           std::string& msg) const = 0;
-      virtual std::auto_ptr<RefHolderBase> holder() const = 0;
+      virtual std::unique_ptr<RefHolderBase> holder() const = 0;
 
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const = 0;
+      virtual std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const = 0;
 
       virtual EDProductGetter const* productGetter() const = 0;
 

--- a/DataFormats/Common/interface/BaseVectorHolder.h
+++ b/DataFormats/Common/interface/BaseVectorHolder.h
@@ -51,7 +51,7 @@ namespace edm {
 
       struct const_iterator : public std::iterator <std::random_access_iterator_tag, RefToBase<T> >{
         typedef base_ref_type value_type;
-        typedef std::auto_ptr<value_type> pointer;
+        typedef std::unique_ptr<value_type> pointer;
         typedef std::ptrdiff_t difference_type;
 
         const_iterator() : i(0) { }
@@ -153,7 +153,7 @@ namespace edm {
       virtual const_iterator begin() const = 0;
       virtual const_iterator end() const = 0;
       virtual void push_back(BaseHolder<T> const*) = 0;
-      virtual std::auto_ptr<RefVectorHolderBase> vectorHolder() const = 0;
+      virtual std::unique_ptr<RefVectorHolderBase> vectorHolder() const = 0;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.

--- a/DataFormats/Common/interface/CloningPtr.h
+++ b/DataFormats/Common/interface/CloningPtr.h
@@ -32,7 +32,7 @@ namespace edm {
 public:
     CloningPtr(): ptr_(nullptr) {}
     CloningPtr(const T& iPtr) : ptr_(P::clone(iPtr)) {}
-    CloningPtr(std::auto_ptr<T> iPtr) : ptr_(iPtr.release()) {}
+    CloningPtr(std::unique_ptr<T> iPtr) : ptr_(iPtr.release()) {}
     CloningPtr(const CloningPtr<T,P>& iPtr) : ptr_(P::clone(*(iPtr.ptr_))) {}
     
     CloningPtr<T,P>& operator=(const CloningPtr<T,P>& iRHS) {

--- a/DataFormats/Common/interface/Holder.h
+++ b/DataFormats/Common/interface/Holder.h
@@ -33,10 +33,10 @@ namespace edm {
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
 					  std::string& msg) const override;
 
-      virtual std::auto_ptr<RefHolderBase> holder() const override {
-	return std::auto_ptr<RefHolderBase>( new RefHolder<REF>( ref_ ) );
+      virtual std::unique_ptr<RefHolderBase> holder() const override {
+	return std::unique_ptr<RefHolderBase>( new RefHolder<REF>( ref_ ) );
       }
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
+      virtual std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
       virtual EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
@@ -172,7 +172,7 @@ namespace edm {
   namespace reftobase {
 
     template <typename T, typename REF>
-    std::auto_ptr<BaseVectorHolder<T> > Holder<T,REF>::makeVectorHolder() const {
+    std::unique_ptr<BaseVectorHolder<T> > Holder<T,REF>::makeVectorHolder() const {
       typedef typename HolderToVectorTrait<T, REF>::type helper;
       return helper::makeVectorHolder();
     }

--- a/DataFormats/Common/interface/HolderToVectorTrait.h
+++ b/DataFormats/Common/interface/HolderToVectorTrait.h
@@ -11,13 +11,13 @@ namespace edm {
 
     template <typename T, typename REF>
     struct InvalidHolderToVector {
-      static std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() {
+      static std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() {
 	Exception::throwThis(errors::InvalidReference,
 	  "InvalidHolderToVector: trying to use RefToBase built with "
 	  "an internal type. RefToBase should be built passing an "
 	  "object of type edm::Ref<C>. This exception should never "
 	  "be thrown if a RefToBase was built from a RefProd<C>.");
-        return std::auto_ptr<BaseVectorHolder<T> >();
+        return std::unique_ptr<BaseVectorHolder<T> >();
       }
     };
 
@@ -29,12 +29,12 @@ namespace edm {
 
     template <typename REF>
     struct InvalidRefHolderToRefVector {
-      static std::auto_ptr<RefVectorHolderBase> makeVectorHolder() {
+      static std::unique_ptr<RefVectorHolderBase> makeVectorHolder() {
 	Exception::throwThis(errors::InvalidReference,
 	  "InvalidRefHolderToRefVector: trying to use RefToBaseVector built with "
 	  "an internal type. RefToBase should be built passing an "
 	  "object of type edm::RefVector<C>");
-        return std::auto_ptr<RefVectorHolderBase>();
+        return std::unique_ptr<RefVectorHolderBase>();
       }
     };
     

--- a/DataFormats/Common/interface/HolderToVectorTrait_Ptr_specialization.h
+++ b/DataFormats/Common/interface/HolderToVectorTrait_Ptr_specialization.h
@@ -33,8 +33,8 @@ namespace edm {
 
     template <typename T, typename U>
     struct PtrHolderToVector {
-      static  std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() {
-        return std::auto_ptr<BaseVectorHolder<T> >(new VectorHolder<T, edm::PtrVector<U> >);
+      static  std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() {
+        return std::unique_ptr<BaseVectorHolder<T> >(new VectorHolder<T, edm::PtrVector<U> >);
       }
     };
 
@@ -45,8 +45,8 @@ namespace edm {
 
     template <typename T>
     struct PtrRefHolderToRefVector {
-      static std::auto_ptr<RefVectorHolderBase> makeVectorHolder() {
-        return std::auto_ptr<RefVectorHolderBase>(new RefVectorHolder<edm::PtrVector<T> >);
+      static std::unique_ptr<RefVectorHolderBase> makeVectorHolder() {
+        return std::unique_ptr<RefVectorHolderBase>(new RefVectorHolder<edm::PtrVector<T> >);
       }
     };
 

--- a/DataFormats/Common/interface/HolderToVectorTrait_RefProd_specialization.h
+++ b/DataFormats/Common/interface/HolderToVectorTrait_RefProd_specialization.h
@@ -28,9 +28,9 @@ namespace edm {
 
     template<typename T>
     struct RefProdHolderToVector {
-      static  std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() {
+      static  std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() {
         Exception::throwThis(errors::InvalidReference, "attempting to make a BaseVectorHolder<T> from a RefProd<C>.\n");
-        return std::auto_ptr<BaseVectorHolder<T> >();
+        return std::unique_ptr<BaseVectorHolder<T> >();
       }
     };
 
@@ -40,9 +40,9 @@ namespace edm {
     };
 
     struct RefProdRefHolderToRefVector {
-      static std::auto_ptr<RefVectorHolderBase> makeVectorHolder() {
+      static std::unique_ptr<RefVectorHolderBase> makeVectorHolder() {
         Exception::throwThis(errors::InvalidReference, "attempting to make a BaseVectorHolder<T> from a RefProd<C>.\n");
-        return std::auto_ptr<RefVectorHolderBase>();
+        return std::unique_ptr<RefVectorHolderBase>();
       }
     };
 

--- a/DataFormats/Common/interface/HolderToVectorTrait_Ref_specialization.h
+++ b/DataFormats/Common/interface/HolderToVectorTrait_Ref_specialization.h
@@ -32,11 +32,11 @@ namespace edm {
 
     template <typename T, typename REF>
     struct RefHolderToVector {
-      static  std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() {
+      static  std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() {
         typedef RefVector<typename REF::product_type,
         typename REF::value_type,
         typename REF::finder_type> REFV;
-        return std::auto_ptr<BaseVectorHolder<T> >(new VectorHolder<T, REFV>);
+        return std::unique_ptr<BaseVectorHolder<T> >(new VectorHolder<T, REFV>);
       }
     };
 
@@ -47,11 +47,11 @@ namespace edm {
 
     template <typename REF>
     struct RefRefHolderToRefVector {
-      static std::auto_ptr<RefVectorHolderBase> makeVectorHolder() {
+      static std::unique_ptr<RefVectorHolderBase> makeVectorHolder() {
         typedef RefVector<typename REF::product_type,
         typename REF::value_type,
         typename REF::finder_type> REFV;
-        return std::auto_ptr<RefVectorHolderBase>(new RefVectorHolder<REFV>);
+        return std::unique_ptr<RefVectorHolderBase>(new RefVectorHolder<REFV>);
       }
     };
 

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -43,8 +43,8 @@ namespace edm {
 
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
 					  std::string& msg) const override;
-      virtual std::auto_ptr<RefHolderBase> holder() const override;
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
+      virtual std::unique_ptr<RefHolderBase> holder() const override;
+      virtual std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
       virtual EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
@@ -152,8 +152,8 @@ namespace edm {
     }
 
     template <typename T>
-    std::auto_ptr<RefHolderBase> IndirectHolder<T>::holder() const { 
-      return std::auto_ptr<RefHolderBase>( helper_->clone() ); 
+    std::unique_ptr<RefHolderBase> IndirectHolder<T>::holder() const { 
+      return std::unique_ptr<RefHolderBase>( helper_->clone() ); 
     }
 
     // Free swap function
@@ -173,10 +173,10 @@ namespace edm {
 namespace edm {
   namespace reftobase {
     template <typename T>
-    std::auto_ptr<BaseVectorHolder<T> > IndirectHolder<T>::makeVectorHolder() const {
-      std::auto_ptr<RefVectorHolderBase> p = helper_->makeVectorHolder();
+    std::unique_ptr<BaseVectorHolder<T> > IndirectHolder<T>::makeVectorHolder() const {
+      std::unique_ptr<RefVectorHolderBase> p = helper_->makeVectorHolder();
       std::shared_ptr<RefVectorHolderBase> sp( p.release() );
-      return std::auto_ptr<BaseVectorHolder<T> >( new IndirectVectorHolder<T>( sp ) );
+      return std::unique_ptr<BaseVectorHolder<T> >( new IndirectVectorHolder<T>( sp ) );
     }
   }
 }

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -33,8 +33,8 @@ namespace edm {
       virtual size_type size() const override;
       virtual void clear() override;
       virtual base_ref_type const at(size_type idx) const override;
-      virtual std::auto_ptr<reftobase::RefVectorHolderBase> vectorHolder() const override {
-	return std::auto_ptr<reftobase::RefVectorHolderBase>( helper_->clone() );
+      virtual std::unique_ptr<reftobase::RefVectorHolderBase> vectorHolder() const override {
+	return std::unique_ptr<reftobase::RefVectorHolderBase>( helper_->clone() );
       }
       virtual void push_back( const BaseHolder<T> * r ) override {
 	typedef IndirectHolder<T> holder_type;

--- a/DataFormats/Common/interface/OwnArray.h
+++ b/DataFormats/Common/interface/OwnArray.h
@@ -124,7 +124,7 @@ namespace edm {
     size_type capacity() const { return MAX_SIZE;}
     template <typename D> void push_back(D*& d);
     template <typename D> void push_back(D* const& d);
-    template <typename D> void push_back(std::auto_ptr<D> d);
+    template <typename D> void push_back(std::unique_ptr<D> d);
     void push_back(T const& valueToCopy);
     bool is_back_safe() const;
     void pop_back();
@@ -284,7 +284,7 @@ namespace edm {
   
   template<typename T, unsigned int M, typename P>
   template<typename D>
-  inline void OwnArray<T, M, P>::push_back(std::auto_ptr<D> d) {
+  inline void OwnArray<T, M, P>::push_back(std::unique_ptr<D> d) {
     data_[size_++]=d.release();
   }
   

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -134,16 +134,19 @@ namespace edm {
     template <typename D> void push_back(D*& d);
     template <typename D> void push_back(D* const& d);
     template <typename D> void push_back(std::auto_ptr<D> d);
+    template <typename D> void push_back(std::unique_ptr<D> d);
     void push_back(T const& valueToCopy);
 
     template <typename D> void set(size_t i, D*& d);
     template <typename D> void set(size_t i, D* const & d);
     template <typename D> void set(size_t i, std::auto_ptr<D> d);
+    template <typename D> void set(size_t i, std::unique_ptr<D> d);
     void set(size_t i, T const& valueToCopy);
 
     template <typename D> void insert(const_iterator i, D*& d);
     template <typename D> void insert(const_iterator i, D* const & d);
     template <typename D> void insert(const_iterator i, std::auto_ptr<D> d);
+    template <typename D> void insert(const_iterator i, std::unique_ptr<D> d);
     void insert(const_iterator i, T const& valueToCopy);
 
     bool is_back_safe() const;
@@ -306,13 +309,17 @@ namespace edm {
     data_.push_back(d);
   }
 
-
   template<typename T, typename P>
   template<typename D>
   inline void OwnVector<T, P>::push_back(std::auto_ptr<D> d) {
     data_.push_back(d.release());
   }
 
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::push_back(std::unique_ptr<D> d) {
+    data_.push_back(d.release());
+  }
 
   template<typename T, typename P>
   inline void OwnVector<T, P>::push_back(T const& d) {
@@ -338,7 +345,6 @@ namespace edm {
     data_[i] = d;
   }
 
-
   template<typename T, typename P>
   template<typename D>
   inline void OwnVector<T, P>::set(size_t i, std::auto_ptr<D> d) {
@@ -347,6 +353,13 @@ namespace edm {
     data_[i] = d.release();
   }
 
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::set(size_t i, std::unique_ptr<D> d) {
+    if (d.get() == data_[i]) return; 
+    delete data_[i];
+    data_[i] = d.release();
+  }
 
   template<typename T, typename P>
   inline void OwnVector<T, P>::set(size_t i, T const& d) {
@@ -369,13 +382,17 @@ namespace edm {
     data_.insert(it.base_iter(), d);
   }
 
-
   template<typename T, typename P>
   template<typename D>
   inline void OwnVector<T, P>::insert(const_iterator it, std::auto_ptr<D> d) {
     data_.insert(it.base_iter(), d.release());
   }
 
+  template<typename T, typename P>
+  template<typename D>
+  inline void OwnVector<T, P>::insert(const_iterator it, std::unique_ptr<D> d) {
+    data_.insert(it.base_iter(), d.release());
+  }
 
   template<typename T, typename P>
   inline void OwnVector<T, P>::insert(const_iterator it, T const& d) {

--- a/DataFormats/Common/interface/RefHolder.h
+++ b/DataFormats/Common/interface/RefHolder.h
@@ -11,7 +11,7 @@
 namespace edm {
   namespace reftobase {
     template <class REF>
-    std::auto_ptr<RefVectorHolderBase> RefHolder<REF>::makeVectorHolder() const {
+    std::unique_ptr<RefVectorHolderBase> RefHolder<REF>::makeVectorHolder() const {
       typedef typename RefHolderToRefVectorTrait<REF>::type helper;
       return helper::makeVectorHolder();
     }

--- a/DataFormats/Common/interface/RefHolderBase.h
+++ b/DataFormats/Common/interface/RefHolderBase.h
@@ -37,7 +37,7 @@ namespace edm {
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& ref,
 					  std::string& msg) const = 0;
 
-      virtual std::auto_ptr<RefVectorHolderBase> makeVectorHolder() const = 0;
+      virtual std::unique_ptr<RefVectorHolderBase> makeVectorHolder() const = 0;
       virtual EDProductGetter const* productGetter() const = 0;
 
       /// Checks if product collection is in memory or available

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -33,7 +33,7 @@ namespace edm {
 					  std::string& msg) const override;
       REF const& getRef() const;
       void setRef(REF const& r);
-      virtual std::auto_ptr<RefVectorHolderBase> makeVectorHolder() const override;
+      virtual std::unique_ptr<RefVectorHolderBase> makeVectorHolder() const override;
       virtual EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -102,7 +102,7 @@ namespace edm {
 
     void swap(RefToBase& other);
 
-    std::auto_ptr<reftobase::RefHolderBase> holder() const;
+    std::unique_ptr<reftobase::RefHolderBase> holder() const;
 
     EDProductGetter const* productGetter() const;
 
@@ -374,8 +374,8 @@ namespace edm {
   }
 
   template <class T>
-  std::auto_ptr<reftobase::RefHolderBase> RefToBase<T>::holder() const {
-    return holder_? holder_->holder() : std::auto_ptr<reftobase::RefHolderBase>();
+  std::unique_ptr<reftobase::RefHolderBase> RefToBase<T>::holder() const {
+    return holder_? holder_->holder() : std::unique_ptr<reftobase::RefHolderBase>();
   }
 
   // Free swap function

--- a/DataFormats/Common/interface/RefToBaseVector.h
+++ b/DataFormats/Common/interface/RefToBaseVector.h
@@ -62,7 +62,7 @@ namespace edm {
     void push_back( const RefToBase<T> & );
 
     void fillView(std::vector<void const*>& pointers, FillViewHelperVector& helpers) const;
-    std::auto_ptr<reftobase::RefVectorHolderBase> vectorHolder() const;
+    std::unique_ptr<reftobase::RefVectorHolderBase> vectorHolder() const;
  
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
@@ -263,15 +263,15 @@ namespace edm {
   template <typename T>
   void RefToBaseVector<T>::push_back( const RefToBase<T> & r ) {
     if ( holder_ == nullptr ) {
-      std::auto_ptr<reftobase::BaseVectorHolder<T> > p = r.holder_->makeVectorHolder();
+      std::unique_ptr<reftobase::BaseVectorHolder<T> > p = r.holder_->makeVectorHolder();
       holder_ = p.release();
     }
     holder_->push_back( r.holder_ );
   }
 
   template <typename T>
-  std::auto_ptr<reftobase::RefVectorHolderBase> RefToBaseVector<T>::vectorHolder() const {
-    return holder_ ? holder_->vectorHolder() : std::auto_ptr<reftobase::RefVectorHolderBase>();
+  std::unique_ptr<reftobase::RefVectorHolderBase> RefToBaseVector<T>::vectorHolder() const {
+    return holder_ ? holder_->vectorHolder() : std::unique_ptr<reftobase::RefVectorHolderBase>();
   }
 }
 

--- a/DataFormats/Common/interface/RefTraits.h
+++ b/DataFormats/Common/interface/RefTraits.h
@@ -31,7 +31,7 @@ namespace edm {
                                             typename self::second_argument_type iIndex) {
         typename REFV::const_iterator it = iContainer.begin();
         std::advance(it, iIndex);
-        return it.operator->()->get();;
+        return it.operator->()->get();
       }
     };
     

--- a/DataFormats/Common/interface/VectorHolder.h
+++ b/DataFormats/Common/interface/VectorHolder.h
@@ -71,8 +71,8 @@ namespace edm {
                                "In VectorHolder<T, REFV> trying to push_back wrong reference type");
         refVector_.push_back( h->getRef() );
       }
-      virtual std::auto_ptr<RefVectorHolderBase> vectorHolder() const {
-        return std::auto_ptr<RefVectorHolderBase>( new RefVectorHolder<REFV>( refVector_ ) );
+      virtual std::unique_ptr<RefVectorHolderBase> vectorHolder() const {
+        return std::unique_ptr<RefVectorHolderBase>( new RefVectorHolder<REFV>( refVector_ ) );
       }
       
       /// Checks if product collection is in memory or available

--- a/DataFormats/Common/test/DetSetNewTS_t.cpp
+++ b/DataFormats/Common/test/DetSetNewTS_t.cpp
@@ -157,7 +157,7 @@ void TestDetSet::infrastructure() {
     {
       sync(lock,nt);
       a++;
-      b.fetch_add(1,std::memory_order_acq_rel);;
+      b.fetch_add(1,std::memory_order_acq_rel);
     });
     
     if (i==5) std::cout << "threads "<< lock << " " << a << ' ' << b << std::endl;
@@ -209,7 +209,7 @@ void TestDetSet::fillSeq() {
           // read(detsets);  // cannot read in parallel while filling in this case
           done=true;
         } catch (edm::Exception const&) {
-          trial++;;
+          trial++;
           //read(detsets);
         }
       }

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -208,7 +208,7 @@ void refTest() {
   c.insert(d1);
   c.post_insert();
 
-  std::unique_ptr<coll_type> pC(new coll_type(c));
+  auto pC = std::make_unique<coll_type>(c);
   edm::Wrapper<coll_type> wrapper(std::move(pC));
   DSVGetter<coll_type> theGetter;
   theGetter.prod_ = &wrapper;

--- a/DataFormats/Common/test/OwnArray_t.cpp
+++ b/DataFormats/Common/test/OwnArray_t.cpp
@@ -161,7 +161,7 @@ void take_an_lvalue()
 void take_an_auto_ptr()
 {
   edm::OwnArray<Base,3> v1;
-  std::auto_ptr<Base> p(new Derived(100));
+  std::unique_ptr<Base> p = std::make_unique<Derived>(100);
   v1.push_back(p);
   assert(p.get() == 0);
 }

--- a/DataFormats/Common/test/OwnVector_t.cpp
+++ b/DataFormats/Common/test/OwnVector_t.cpp
@@ -155,15 +155,15 @@ void take_an_lvalue()
   Base* p = new Derived(100);
   v1.push_back(p);
 
-  assert(p == 0);
+  assert(p == nullptr);
 }
 
 void take_an_auto_ptr()
 {
   edm::OwnVector<Base> v1;
-  std::auto_ptr<Base> p(new Derived(100));
-  v1.push_back(p);
-  assert(p.get() == 0);
+  std::unique_ptr<Base> p = std::make_unique<Derived>(100);
+  v1.push_back(std::move(p));
+  assert(p.get() == nullptr);
 }
 
 void set_at_index()
@@ -172,13 +172,13 @@ void set_at_index()
   Base* p = new Derived(100);
   Base* backup = p;
   v1.push_back(p);
-  assert(p == 0);
+  assert(p == nullptr);
   assert(&v1[0] == backup);
   Base* p2 = new Derived(101);
   Base* backup2 = p2;
   assert(backup2 != backup);
   v1.set(0, p2);
-  assert(p2 == 0);
+  assert(p2 == nullptr);
   assert(&v1[0] == backup2);
 }
 
@@ -192,9 +192,9 @@ void insert_with_iter()
   v1.push_back(p[0]);
   v1.push_back(p[2]);
   v1.insert(v1.begin()+1, p[1]);
-  assert(p[0] == 0);
-  assert(p[1] == 0);
-  assert(p[2] == 0);
+  assert(p[0] == nullptr);
+  assert(p[1] == nullptr);
+  assert(p[2] == nullptr);
   assert(&v1[0] == backup[0]);
   assert(&v1[1] == backup[1]);
   assert(&v1[2] == backup[2]);

--- a/DataFormats/Common/test/Ref_t.cpp
+++ b/DataFormats/Common/test/Ref_t.cpp
@@ -79,7 +79,7 @@ void TestRef::nondefault_ctor() {
   edm::ProductID id(1, 201U);
   CPPUNIT_ASSERT(id.isValid());
 
-  std::unique_ptr<product1_t> prod(new product1_t);
+  auto prod = std::make_unique<product1_t>();
   prod->push_back(1);
   prod->push_back(2);
   getter.addProduct(id, std::move(prod));
@@ -110,7 +110,7 @@ void TestRef::nondefault_ctor() {
 //   edm::ProductID id(1, 201U);
 //   CPPUNIT_ASSERT(id.isValid());
 
-//   std::auto_ptr<product2_t> prod(new product2_t);
+//   auto prod = std::make_unique<product2_t>();
 //   prod->insert(std::make_pair(std::string("a"), 1));
 //   prod->insert(std::make_pair(std::string("b"), 2));
 //   prod->insert(std::make_pair(std::string("c"), 3));
@@ -135,7 +135,7 @@ void TestRef::using_wrong_productid() {
   edm::ProductID id(1, 1U);
   CPPUNIT_ASSERT(id.isValid());
 
-  std::unique_ptr<product1_t> prod(new product1_t);
+  auto prod = std::make_unique<product1_t>();
   prod->push_back(1);
   prod->push_back(2);
   getter.addProduct(id, std::move(prod));
@@ -160,7 +160,7 @@ void TestRef::threading()
   edm::ProductID id(1, 1U);
   CPPUNIT_ASSERT(id.isValid());
   
-  std::unique_ptr<product1_t> prod(new product1_t);
+  auto prod = std::make_unique<product1_t>();
   prod->push_back(1);
   prod->push_back(2);
   getter.addProduct(id, std::move(prod));

--- a/DataFormats/Common/test/Wrapper_t.cpp
+++ b/DataFormats/Common/test/Wrapper_t.cpp
@@ -31,15 +31,14 @@ class SwappyNoCopy
 
 void work()
 {
-  std::unique_ptr<CopyNoSwappy> thing(new CopyNoSwappy);
+  auto thing = std::make_unique<CopyNoSwappy>();
   edm::Wrapper<CopyNoSwappy> wrap(std::move(thing));
 
-  std::unique_ptr<SwappyNoCopy> thing2(new SwappyNoCopy);
+  auto thing2 = std::make_unique<SwappyNoCopy>();
   edm::Wrapper<SwappyNoCopy> wrap2(std::move(thing2));
 
 
-  std::unique_ptr<std::vector<double> >
-    thing3(new std::vector<double>(10,2.2));
+  auto thing3 = std::make_unique<std::vector<double>>(10,2.2);
   assert(thing3->size() == 10);
 
   edm::Wrapper<std::vector<double> > wrap3(std::move(thing3));

--- a/DataFormats/Common/test/atomicptrcache_t.cppunit.cc
+++ b/DataFormats/Common/test/atomicptrcache_t.cppunit.cc
@@ -28,9 +28,8 @@ testAtomicPtrCache::check()
     CPPUNIT_ASSERT(false == cache.isSet());
     CPPUNIT_ASSERT(nullptr == cache.operator->());
     CPPUNIT_ASSERT(nullptr == cache.load());
-    std::unique_ptr<Vec> p{ new Vec{values} };
 
-    cache.set(std::move(p));
+    cache.set(std::make_unique<Vec>(values));
     CPPUNIT_ASSERT(true == cache.isSet());
     CPPUNIT_ASSERT(cache->size() == values.size());
     CPPUNIT_ASSERT((*cache).size() == values.size());

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -318,7 +318,7 @@ namespace {
 
 void testPtr::getTest() {
    typedef std::vector<IntValue> IntCollection;
-   std::unique_ptr<IntCollection> ptr(new IntCollection);
+   auto ptr = std::make_unique<IntCollection>();
 
    ptr->push_back(0);
    ptr->push_back(1);
@@ -349,7 +349,7 @@ void testPtr::getTest() {
 
    {
      typedef std::vector<IntValue2> SDCollection;
-     std::unique_ptr<SDCollection> ptr(new SDCollection);
+     auto ptr = std::make_unique<SDCollection>();
      
      ptr->push_back(IntValue2(0));
      ptr->back().value_ = 0;

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -152,7 +152,7 @@ void
 testPtrVector::get() {
   using namespace test_with_dictionaries;
   typedef std::vector<IntValue> IntCollection;
-  std::unique_ptr<IntCollection> ptr(new IntCollection);
+  auto ptr = std::make_unique<IntCollection>();
 
   ptr->push_back(0);
   ptr->push_back(1);
@@ -189,7 +189,7 @@ testPtrVector::get() {
 
   /*
   typedef std::vector<Inherit1> I1Collection;
-  std::auto_ptr<I1Collection> ptr(new I1Collection);
+  auto ptr = std::make_unique<I1Collection>();
 
   ptr->push_back(0);
   ptr->push_back(1);

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -214,7 +214,7 @@ namespace {
 
 void testRef::getTest() {
    typedef std::vector<IntValue> IntCollection;
-   std::unique_ptr<IntCollection> ptr(new IntCollection);
+   auto ptr = std::make_unique<IntCollection>();
 
    ptr->push_back(0);
    ptr->push_back(1);

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -196,7 +196,7 @@ namespace {
 
 void testRefToBaseProd::getTest() {
    typedef std::vector<IntValue> IntCollection;
-   std::unique_ptr<IntCollection> ptr(new IntCollection);
+   auto ptr = std::make_unique<IntCollection>();
 
    ptr->push_back(0);
    ptr->push_back(1);
@@ -236,7 +236,7 @@ void testRefToBaseProd::getTest() {
 
    {
       typedef std::vector<IntValue2> SDCollection;
-      std::unique_ptr<SDCollection> ptr(new SDCollection);
+      auto ptr = std::make_unique<SDCollection>();
 
       ptr->push_back(IntValue2(0));
       ptr->back().value_ = 0;

--- a/DataFormats/Common/test/testBoostRange.cpp
+++ b/DataFormats/Common/test/testBoostRange.cpp
@@ -37,7 +37,7 @@ void testFill<edm::PtrVector<Dummy> >(edm::PtrVector<Dummy> &r) {
 }
 //template<>
 //void testFill<edm::OwnVector<Dummy> >(edm::OwnVector<Dummy> &r) {
-//    for(int i = 0; i < 12; ++i) { r.push_back(std::auto_ptr<Dummy>(new Dummy(i))); }
+//    for(int i = 0; i < 12; ++i) { r.push_back(std::make_unique<Dummy>(i)); }
 //}
 
 bool operator==(edm::Ref<Coll>  const& ref, int i) { return (int(ref.key()) == i) && (ref->id == i); }

--- a/DataFormats/Common/test/testMultiAssociation.cc
+++ b/DataFormats/Common/test/testMultiAssociation.cc
@@ -200,9 +200,9 @@ testMultiAssociation::testMultiAssociation() {
 
   for(size_t j = 0; j < 10; ++j) der1s.push_back(DummyDer1());
   for(size_t j = 0; j < 10; ++j) {
-        if(j % 3 == 0) bases.push_back(std::auto_ptr<DummyBase>(new DummyBase()));
-        if(j % 3 == 1) bases.push_back(std::auto_ptr<DummyDer1>(new DummyDer1()));
-        if(j % 3 == 2) bases.push_back(std::auto_ptr<DummyDer2>(new DummyDer2()));
+        if(j % 3 == 0) bases.push_back(std::make_unique<DummyBase>());
+        if(j % 3 == 1) bases.push_back(std::make_unique<DummyDer1>());
+        if(j % 3 == 2) bases.push_back(std::make_unique<DummyDer2>());
         CPPUNIT_ASSERT(bases[j].id() == int(j % 3));
   }
   edm::TestHandle<CObj> handleObj(&der1s, ProductID(10));

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -37,7 +37,7 @@ namespace edm {
         return TypeID(typeid(void));
       }
       void* p = cl->New();
-      int offset = cl->GetBaseClassOffset(wbClass) + vtcOffset;;
+      int offset = cl->GetBaseClassOffset(wbClass) + vtcOffset;
       std::unique_ptr<ViewTypeChecker> checker = getAnyPtr<ViewTypeChecker>(p, offset);
       if(mayBeRefVector) {
         std::type_info const& ti = checker->memberTypeInfo(); 

--- a/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
@@ -39,18 +39,18 @@ public:
     nullPHID = ProcessHistoryID();
 
     ProcessConfiguration pc;
-    std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
+    auto processHistory1 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
     fakePHID1 = ph1.id();
 
-    std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
+    auto processHistory2 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
+    auto processHistory3 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph3 = *processHistory3;
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -35,18 +35,18 @@ public:
     nullPHID = ProcessHistoryID();
 
     ProcessConfiguration pc;
-    std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
+    auto processHistory1 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
     fakePHID1 = ph1.id();
 
-    std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
+    auto processHistory2 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
+    auto processHistory3 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph3 = *processHistory3;
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -49,18 +49,18 @@ public:
     nullPHID = ProcessHistoryID();
 
     ProcessConfiguration pc;
-    std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
+    auto processHistory1 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
     fakePHID1 = ph1.id();
 
-    std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
+    auto processHistory2 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
+    auto processHistory3 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph3 = *processHistory3;
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);

--- a/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
@@ -49,18 +49,18 @@ public:
     nullPHID = ProcessHistoryID();
 
     ProcessConfiguration pc;
-    std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
+    auto processHistory1 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
     fakePHID1 = ph1.id();
 
-    std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
+    auto processHistory2 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
+    auto processHistory3 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph3 = *processHistory3;
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);

--- a/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
@@ -49,18 +49,18 @@ public:
     nullPHID = ProcessHistoryID();
 
     ProcessConfiguration pc;
-    std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
+    auto processHistory1 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
     fakePHID1 = ph1.id();
 
-    std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
+    auto processHistory2 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
+    auto processHistory3 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph3 = *processHistory3;
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -55,18 +55,18 @@ public:
     nullPHID = ProcessHistoryID();
 
     ProcessConfiguration pc;
-    std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
+    auto processHistory1 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
     fakePHID1 = ph1.id();
 
-    std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
+    auto processHistory2 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
+    auto processHistory3 = std::make_unique<ProcessHistory>();
     ProcessHistory& ph3 = *processHistory3;
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -210,7 +210,7 @@ class ESProducer : public ESProxyFactoryProducer
          void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {
 	    typedef eventsetup::CallbackProxy<T, TRecord, TProduct> ProxyType;
 	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T> > FactoryType;
-            registerFactory(std::auto_ptr<FactoryType>(new FactoryType(iCallback)), iLabel.default_);
+            registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.default_);
          }
       
       template<typename T, typename TProduct, typename TRecord, int IIndex>
@@ -224,7 +224,7 @@ class ESProducer : public ESProxyFactoryProducer
             }
 	    typedef eventsetup::CallbackProxy<T, TRecord, es::L<TProduct, IIndex> > ProxyType;
 	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T> > FactoryType;
-            registerFactory(std::auto_ptr<FactoryType>(new FactoryType(iCallback)), iLabel.labels_[IIndex]);
+            registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.labels_[IIndex]);
          }
       
       // ---------- member data --------------------------------

--- a/FWCore/Framework/interface/ESProducerLooper.h
+++ b/FWCore/Framework/interface/ESProducerLooper.h
@@ -51,7 +51,7 @@ namespace edm {
         
       //use this to 'snoop' on what records are being used by the Producer
       virtual void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
-                                          std::auto_ptr<eventsetup::ProxyFactoryBase>& iFactory,
+                                          std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
                                           const std::string& iLabel= std::string() );
 private:
       ESProducerLooper(const ESProducerLooper&); // stop default

--- a/FWCore/Framework/interface/ESProducts.h
+++ b/FWCore/Framework/interface/ESProducts.h
@@ -66,6 +66,25 @@ namespace edm {
             typedef Null head_type;
          };
          
+         template<typename T> struct OneHolder<std::unique_ptr<T>> {
+            typedef std::unique_ptr<T> Type;
+            OneHolder() {}
+            OneHolder(OneHolder<Type> const& iOther): value_(const_cast<OneHolder<Type>&>(iOther).value_) {}
+            OneHolder(Type iPtr): value_(iPtr) {}
+            
+            
+            OneHolder<Type> const& operator=(OneHolder<Type> iRHS) { value_ = iRHS.value_; return *this; }
+            template<typename S>
+            void setFromRecursive(S& iGiveValues) {
+               iGiveValues.setFrom(value_);
+            }
+            
+            void assignTo(Type& oValue) { oValue = value_;}
+            mutable Type value_; //mutable needed for std::unique_ptr
+            typedef Type tail_type;
+            typedef Null head_type;
+         };
+         
          template<typename T> OneHolder<T> operator<<(const Produce&, T iValue) {
             return OneHolder<T>(iValue);
          }

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -25,7 +25,7 @@ Example: register one Factory that creates a proxy that takes no arguments
 
    FooProd::FooProd(const edm::ParameterSet&) {
       typedef edm::eventsetup::ProxyFactoryTemplate<FooProxy> > TYPE;
-      registerFactory(std::auto_ptr<TYPE>(new TYPE());
+      registerFactory(std::make_unique<TYPE>();
    };
    
 \endcode
@@ -39,7 +39,7 @@ class BarProd : public edm::ESProxyFactoryProducer { ... };
 
 BarProd::BarProd(const edm::ParameterSet& iPS) {
    typedef edm::eventsetup::ProxyArgumentFactoryTemplate<FooProxy, edm::ParmeterSet> TYPE;
-   registerFactory(std::auto_ptr<TYPE>(new TYPE(iPS));
+   registerFactory(std::make_unique<TYPE>(iPS);
 };
 
 \endcode
@@ -104,17 +104,17 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
          be called in inheriting class' constructor.
       */
       template< class TFactory>
-         void registerFactory(std::auto_ptr<TFactory> iFactory,
+         void registerFactory(std::unique_ptr<TFactory> iFactory,
                               const std::string& iLabel = std::string()) {
-            std::auto_ptr<eventsetup::ProxyFactoryBase> temp(iFactory.release());
+            std::unique_ptr<eventsetup::ProxyFactoryBase> temp(iFactory.release());
             registerFactoryWithKey(
                                    eventsetup::EventSetupRecordKey::makeKey<typename TFactory::record_type>(),
-                                   temp,
+                                   std::move(temp),
                                    iLabel);
          }
       
       virtual void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
-                                          std::auto_ptr<eventsetup::ProxyFactoryBase>& iFactory,
+                                          std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
                                           const std::string& iLabel= std::string() );
 
    private:

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -226,8 +226,8 @@ namespace edm {
               ServiceToken const& token,
               serviceregistry::ServiceLegacy);
 
-    void terminateMachine(std::auto_ptr<statemachine::Machine>&);
-    std::auto_ptr<statemachine::Machine> createStateMachine();
+    void terminateMachine(std::unique_ptr<statemachine::Machine>);
+    std::unique_ptr<statemachine::Machine> createStateMachine();
 
     void setupSignal();
 

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -108,12 +108,12 @@ class EventSetupProvider {
    protected:
 
       template <typename T>
-         void insert(std::auto_ptr<T> iRecordProvider) {
-            std::auto_ptr<EventSetupRecordProvider> temp(iRecordProvider.release());
+         void insert(std::unique_ptr<T> iRecordProvider) {
+            std::unique_ptr<EventSetupRecordProvider> temp(iRecordProvider.release());
             insert(eventsetup::heterocontainer::makeKey<
                     typename T::RecordType,
                        eventsetup::EventSetupRecordKey>(),
-                    temp);
+                    std::move(temp));
          }
 
    private:
@@ -121,7 +121,7 @@ class EventSetupProvider {
 
       EventSetupProvider const& operator=(EventSetupProvider const&); // stop default
 
-      void insert(EventSetupRecordKey const&, std::auto_ptr<EventSetupRecordProvider>);
+      void insert(EventSetupRecordKey const&, std::unique_ptr<EventSetupRecordProvider>);
 
       // ---------- member data --------------------------------
       EventSetup eventSetup_;

--- a/FWCore/Framework/interface/EventSetupProviderMaker.h
+++ b/FWCore/Framework/interface/EventSetupProviderMaker.h
@@ -11,7 +11,7 @@ namespace edm {
     class EventSetupProvider;
     class EventSetupsController;
 
-    std::auto_ptr<EventSetupProvider>
+    std::unique_ptr<EventSetupProvider>
     makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex);
 
     void

--- a/FWCore/Framework/interface/EventSetupRecordProviderFactory.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderFactory.h
@@ -33,7 +33,7 @@ class EventSetupRecordProviderFactory
       virtual ~EventSetupRecordProviderFactory();
 
       // ---------- const member functions ---------------------
-      virtual std::auto_ptr<EventSetupRecordProvider> makeRecordProvider() const = 0;
+      virtual std::unique_ptr<EventSetupRecordProvider> makeRecordProvider() const = 0;
 
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/EventSetupRecordProviderFactoryManager.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderFactoryManager.h
@@ -38,7 +38,7 @@ class EventSetupRecordProviderFactoryManager
       virtual ~EventSetupRecordProviderFactoryManager();
 
       // ---------- const member functions ---------------------
-      std::auto_ptr<EventSetupRecordProvider> makeRecordProvider(const EventSetupRecordKey&) const;
+      std::unique_ptr<EventSetupRecordProvider> makeRecordProvider(const EventSetupRecordKey&) const;
 
       // ---------- static member functions --------------------
       static EventSetupRecordProviderFactoryManager& instance();

--- a/FWCore/Framework/interface/EventSetupRecordProviderFactoryTemplate.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderFactoryTemplate.h
@@ -44,8 +44,8 @@ class EventSetupRecordProviderFactoryTemplate : public EventSetupRecordProviderF
       //virtual ~EventSetupRecordProviderFactoryTemplate();
 
       // ---------- const member functions ---------------------
-      virtual std::auto_ptr<EventSetupRecordProvider> makeRecordProvider() const {
-         return std::auto_ptr<EventSetupRecordProvider>(
+      virtual std::unique_ptr<EventSetupRecordProvider> makeRecordProvider() const {
+         return std::unique_ptr<EventSetupRecordProvider>(
                      new EventSetupRecordProviderTemplate<T>());
       }
 

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -41,19 +41,17 @@ event.getByLabel("market", "apple", fruits);
 Putting Data
 
 \code
-std::unique_ptr<AppleCollection> pApples(new AppleCollection);
   
 //fill the collection
 ...
-event.put(std::move(pApples));
+event.put(std::make_unique<AppleCollection>());
 \endcode
 
 \code
-std::unique_ptr<FruitCollection> pFruits(new FruitCollection);
 
 //fill the collection
 ...
-event.put("apple", std::move(pFruits));
+event.put(std::make_unique<FruitCollection>());
 \endcode
 
 
@@ -63,7 +61,7 @@ NOTE: The edm::RefProd returned will not work until after the
 edm::PrincipalGetAdapter has been committed (which happens after the
 EDProducer::produce method has ended)
 \code
-std::unique_ptr<AppleCollection> pApples(new AppleCollection);
+auto pApples = std::make_unique<AppleCollection>();
 
 edm::RefProd<AppleCollection> refApples = event.getRefBeforePut<AppleCollection>();
 

--- a/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
@@ -41,8 +41,8 @@ class ProxyArgumentFactoryTemplate : public ProxyFactoryBase
       //virtual ~ProxyArgumentFactoryTemplate()
 
       // ---------- const member functions ---------------------
-      virtual std::auto_ptr<DataProxy> makeProxy() const {
-         return std::auto_ptr<DataProxy>(new T(arg_));
+      virtual std::unique_ptr<DataProxy> makeProxy() const {
+         return std::make_unique<T>(arg_);
       }
             
       virtual DataKey makeKey(const std::string& iName) const {

--- a/FWCore/Framework/interface/ProxyFactoryBase.h
+++ b/FWCore/Framework/interface/ProxyFactoryBase.h
@@ -37,7 +37,7 @@ class ProxyFactoryBase
       virtual ~ProxyFactoryBase() {}
 
       // ---------- const member functions ---------------------
-      virtual std::auto_ptr<DataProxy> makeProxy() const = 0;
+      virtual std::unique_ptr<DataProxy> makeProxy() const = 0;
       
       virtual DataKey makeKey(const std::string& iName) const = 0;
       // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/ProxyFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyFactoryTemplate.h
@@ -41,8 +41,8 @@ class ProxyFactoryTemplate : public ProxyFactoryBase
       //virtual ~ProxyFactoryTemplate();
 
       // ---------- const member functions ---------------------
-      virtual std::auto_ptr<DataProxy> makeProxy() const {
-         return std::auto_ptr<DataProxy>(new T);
+      virtual std::unique_ptr<DataProxy> makeProxy() const {
+         return std::make_unique<T>();
       }
       
       

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -45,7 +45,7 @@ namespace edm {
     std::shared_ptr<CommonParams>
     initMisc(ParameterSet& parameterSet);
 
-    std::auto_ptr<Schedule>
+    std::unique_ptr<Schedule>
     initSchedule(ParameterSet& parameterSet,
                  bool hasSubprocesses,
                  PreallocationConfiguration const& iAllocConfig,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -193,7 +193,7 @@ namespace edm {
     template<typename ModType>
     static std::unique_ptr<Base> makeModule(ParameterSet const& pset) {
       typedef typename stream::BaseToAdaptor<Base,ModType>::Type Adaptor;
-      std::unique_ptr<Adaptor> module = std::unique_ptr<Adaptor>(new Adaptor(pset));
+      auto module = std::make_unique<Adaptor>(pset);
       return std::unique_ptr<Base>(module.release());
     }
   };

--- a/FWCore/Framework/interface/stream/EDFilterAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptor.h
@@ -47,7 +47,7 @@ namespace edm {
     template<typename ModType>
     static std::unique_ptr<Base> makeModule(ParameterSet const& pset) {
       typedef typename stream::BaseToAdaptor<Base,ModType>::Type Adaptor;
-      std::unique_ptr<Adaptor> module = std::unique_ptr<Adaptor>(new Adaptor(pset));
+      auto module = std::make_unique<Adaptor>(pset);
       return std::unique_ptr<Base>(module.release());
     }
   };

--- a/FWCore/Framework/interface/stream/EDProducerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptor.h
@@ -45,7 +45,7 @@ namespace edm {
     template<typename ModType>
     static std::unique_ptr<Base> makeModule(ParameterSet const& pset) {
       typedef typename stream::BaseToAdaptor<Base,ModType>::Type Adaptor;
-      std::unique_ptr<Adaptor> module = std::unique_ptr<Adaptor>(new Adaptor(pset));
+      auto module = std::make_unique<Adaptor>(pset);
       return std::unique_ptr<Base>(module.release());
     }
   };

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -80,8 +80,8 @@ namespace edm {
     edm::Event const& constEvent = event;
     selector_->preChoose(inputCollection, constEvent, eventSetup);
 
-    std::auto_ptr<Collection> thinnedCollection(new Collection);
-    std::auto_ptr<ThinnedAssociation> thinnedAssociation(new ThinnedAssociation);
+    auto thinnedCollection = std::make_unique<Collection>();
+    auto thinnedAssociation = std::make_unique<ThinnedAssociation>();
 
     unsigned int iIndex = 0;
     for(auto iter = inputCollection->begin(), iterEnd = inputCollection->end();
@@ -91,11 +91,11 @@ namespace edm {
         thinnedAssociation->push_back(iIndex);
       }
     }
-    OrphanHandle<Collection> orphanHandle = event.put(thinnedCollection);
+    OrphanHandle<Collection> orphanHandle = event.put(std::move(thinnedCollection));
 
     thinnedAssociation->setParentCollectionID(inputCollection.id());
     thinnedAssociation->setThinnedCollectionID(orphanHandle.id());
-    event.put(thinnedAssociation);
+    event.put(std::move(thinnedAssociation));
   }
 
   template <typename Collection, typename Selector>

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -396,7 +396,7 @@ EDConsumerBase::modulesDependentUpon(std::string const& iProcessName,
         "' may consume product of type '" << info.m_type.className() << 
         "' with input tag '" << &(m_tokenLabels[start]) <<
         ':' << &(m_tokenLabels[start+labels.m_deltaToProductInstance]) <<
-        ':' << processName << "'";;
+        ':' << processName << "'";
       }
       if((not processName) or processName[0]==0 or iProcessName == processName) {
         uniqueModules.insert(&(m_tokenLabels[start]));

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -155,7 +155,7 @@ namespace edm {
    
   void 
   EDLooperBase::copyInfo(const ScheduleInfo& iInfo){
-    scheduleInfo_ = std::auto_ptr<ScheduleInfo>(new ScheduleInfo(iInfo));
+    scheduleInfo_ = std::make_unique<ScheduleInfo>(iInfo);
   }
   void 
   EDLooperBase::setModuleChanger(ModuleChanger* iChanger) {

--- a/FWCore/Framework/src/ESProducerLooper.cc
+++ b/FWCore/Framework/src/ESProducerLooper.cc
@@ -76,11 +76,11 @@ ESProducerLooper::setIntervalFor(const EventSetupRecordKey&,
 //use this to 'snoop' on what records are being used by the Producer
 void 
 ESProducerLooper::registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
-                                         std::auto_ptr<eventsetup::ProxyFactoryBase>& iFactory,
+                                         std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
                                          const std::string& iLabel )
 {
   findingRecordWithKey(iRecord);
-  ESProxyFactoryProducer::registerFactoryWithKey(iRecord, iFactory,iLabel);
+  ESProxyFactoryProducer::registerFactoryWithKey(iRecord, std::move(iFactory), iLabel);
 }
 
 //

--- a/FWCore/Framework/src/ESProxyFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProxyFactoryProducer.cc
@@ -82,7 +82,7 @@ ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord,
 
 void
 ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecord ,
-                                             std::auto_ptr<ProxyFactoryBase>& iFactory,
+                                             std::unique_ptr<ProxyFactoryBase> iFactory,
                                              const std::string& iLabel )
 {
    if(nullptr == iFactory.get()) {

--- a/FWCore/Framework/src/EventForOutput.cc
+++ b/FWCore/Framework/src/EventForOutput.cc
@@ -39,7 +39,7 @@ namespace edm {
 
   ProductProvenanceRetriever const*
   EventForOutput::productProvenanceRetrieverPtr() const {
-   return eventPrincipal().productProvenanceRetrieverPtr();;
+   return eventPrincipal().productProvenanceRetrieverPtr();
   }
 
   BranchListIndexes const&

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -105,7 +105,7 @@ EventSetupProvider::~EventSetupProvider()
 // member functions
 //
 void 
-EventSetupProvider::insert(const EventSetupRecordKey& iKey, std::auto_ptr<EventSetupRecordProvider> iProvider)
+EventSetupProvider::insert(const EventSetupRecordKey& iKey, std::unique_ptr<EventSetupRecordProvider> iProvider)
 {
    std::shared_ptr<EventSetupRecordProvider> temp(iProvider.release());
    providers_[iKey] = temp;

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -22,13 +22,13 @@
 namespace edm {
   namespace eventsetup {
   // ---------------------------------------------------------------
-    std::auto_ptr<EventSetupProvider>
+    std::unique_ptr<EventSetupProvider>
     makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex) {
       std::vector<std::string> prefers =
         params.getParameter<std::vector<std::string> >("@all_esprefers");
 
       if(prefers.empty()) {
-        return std::auto_ptr<EventSetupProvider>(new EventSetupProvider(subProcessIndex));
+        return std::make_unique<EventSetupProvider>(subProcessIndex);
       }
 
       EventSetupProvider::PreferredProviderInfo preferInfo;
@@ -96,7 +96,7 @@ namespace edm {
                                         preferPSet.getParameter<std::string>("@module_label"),
                                         false)] = recordToData;
       }
-      return std::auto_ptr<EventSetupProvider>(new EventSetupProvider(subProcessIndex, &preferInfo));
+      return std::make_unique<EventSetupProvider>(subProcessIndex, &preferInfo);
     }
 
     // ---------------------------------------------------------------
@@ -148,7 +148,7 @@ namespace edm {
         moduleLabel = modtype;
       }
 
-      std::auto_ptr<ParameterSetDescriptionFillerBase> filler(
+      std::unique_ptr<ParameterSetDescriptionFillerBase> filler(
         ParameterSetDescriptionFillerPluginFactory::get()->create(modtype));
       ConfigurationDescriptions descriptions(filler->baseType());
       filler->fill(descriptions);

--- a/FWCore/Framework/src/EventSetupRecordProviderFactoryManager.cc
+++ b/FWCore/Framework/src/EventSetupRecordProviderFactoryManager.cc
@@ -68,7 +68,7 @@ EventSetupRecordProviderFactoryManager::addFactory(const EventSetupRecordProvide
 //
 // const member functions
 //
-std::auto_ptr<EventSetupRecordProvider> 
+std::unique_ptr<EventSetupRecordProvider> 
 EventSetupRecordProviderFactoryManager::makeRecordProvider(const EventSetupRecordKey& iKey) const
 {
    std::map<EventSetupRecordKey, const EventSetupRecordProviderFactory*>::const_iterator itFound= factories_.find(iKey);
@@ -77,7 +77,7 @@ EventSetupRecordProviderFactoryManager::makeRecordProvider(const EventSetupRecor
    
    const EventSetupRecordProviderFactory* factory = itFound->second;
    assert(0 != factory);
-   return std::auto_ptr<EventSetupRecordProvider>(factory->makeRecordProvider());
+   return std::unique_ptr<EventSetupRecordProvider>(factory->makeRecordProvider());
 }
 
 //

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -285,7 +285,7 @@ namespace edm {
   // containing Products.
   std::unique_ptr<FileBlock>
   InputSource::readFile_() {
-    return std::unique_ptr<FileBlock>(new FileBlock);
+    return std::make_unique<FileBlock>();
   }
 
   void

--- a/FWCore/Framework/src/InputSourceFactory.cc
+++ b/FWCore/Framework/src/InputSourceFactory.cc
@@ -29,17 +29,16 @@ namespace edm {
     return &singleInstance_;
   }
 
-  std::auto_ptr<InputSource>
+  std::unique_ptr<InputSource>
   InputSourceFactory::makeInputSource(ParameterSet const& conf,
 					InputSourceDescription const& desc) const
     
   {
     std::string modtype = conf.getParameter<std::string>("@module_type");
     FDEBUG(1) << "InputSourceFactory: module_type = " << modtype << std::endl;
-    std::auto_ptr<InputSource> wm;
-    wm = std::auto_ptr<InputSource>(InputSourcePluginFactory::get()->create(modtype,conf,desc));
+    std::unique_ptr<InputSource> wm = std::unique_ptr<InputSource>(InputSourcePluginFactory::get()->create(modtype,conf,desc));
     
-    if(wm.get()==0) {
+    if(wm.get() == nullptr) {
 	throw edm::Exception(errors::Configuration,"NoSourceModule")
 	  << "InputSource Factory:\n"
 	  << "Cannot find source type from ParameterSet: "

--- a/FWCore/Framework/src/InputSourceFactory.h
+++ b/FWCore/Framework/src/InputSourceFactory.h
@@ -19,7 +19,7 @@ namespace edm {
 
     static InputSourceFactory const* get();
 
-    std::auto_ptr<InputSource>
+    std::unique_ptr<InputSource>
       makeInputSource(ParameterSet const&,
 		       InputSourceDescription const&) const;
     

--- a/FWCore/Framework/src/MakeModuleHelper.h
+++ b/FWCore/Framework/src/MakeModuleHelper.h
@@ -36,7 +36,7 @@ namespace edm {
 
     template<typename T>
     static std::unique_ptr<Base> makeModule(ParameterSet const& pset) {
-      std::unique_ptr<T> module{new T(pset)};
+      auto module = std::make_unique<T>(pset);
       return std::unique_ptr<Base>(module.release());
     }
   };

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -104,13 +104,13 @@ namespace edm {
       return std::move(std::unique_ptr<edm::OutputModuleCommunicator>{});
     }
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::OutputModule * iMod){
-      return std::move(std::unique_ptr<edm::OutputModuleCommunicator>{ new OutputModuleCommunicatorT<edm::OutputModule>(iMod) });
+      return std::make_unique<OutputModuleCommunicatorT<edm::OutputModule>>(iMod);
     }
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::global::OutputModuleBase * iMod){
-      return std::move(std::unique_ptr<edm::OutputModuleCommunicator>{ new OutputModuleCommunicatorT<edm::global::OutputModuleBase>(iMod) });
+      return std::make_unique<OutputModuleCommunicatorT<edm::global::OutputModuleBase>>(iMod);
     }
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase * iMod){
-      return std::move(std::unique_ptr<edm::OutputModuleCommunicator>{ new OutputModuleCommunicatorT<edm::one::OutputModuleBase>(iMod) });
+      return std::make_unique<OutputModuleCommunicatorT<edm::one::OutputModuleBase>>(iMod);
     }
   }
 }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -285,14 +285,12 @@ namespace edm {
 
   void
   Principal::addInputProduct(std::shared_ptr<BranchDescription const> bd) {
-    std::unique_ptr<ProductResolverBase> phb(new InputProductResolver(std::move(bd)));
-    addProductOrThrow(std::move(phb));
+    addProductOrThrow(std::make_unique<InputProductResolver>(std::move(bd)));
   }
 
   void
   Principal::addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd) {
-    std::unique_ptr<ProductResolverBase> phb(new UnscheduledProductResolver(std::move(bd)));
-    addProductOrThrow(std::move(phb));
+    addProductOrThrow(std::make_unique<UnscheduledProductResolver>(std::move(bd)));
   }
 
   void
@@ -300,14 +298,12 @@ namespace edm {
     ProductResolverIndex index = preg_->indexFrom(bd->originalBranchID());
     assert(index != ProductResolverIndexInvalid);
 
-    std::unique_ptr<ProductResolverBase> phb(new AliasProductResolver(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
-    addProductOrThrow(std::move(phb));
+    addProductOrThrow(std::make_unique<AliasProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
   }
 
   void
   Principal::addParentProcessProduct(std::shared_ptr<BranchDescription const> bd) {
-    std::unique_ptr<ProductResolverBase> phb(new ParentProcessProductResolver(std::move(bd)));
-    addProductOrThrow(std::move(phb));
+    addProductOrThrow(std::make_unique<ParentProcessProductResolver>(std::move(bd)));
   }
 
   // "Zero" the principal so it can be reused for another Event.

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -97,7 +97,7 @@ namespace edm {
 
     //add the ProductRegistry as a service ONLY for the construction phase
     typedef serviceregistry::ServiceWrapper<ConstProductRegistry> w_CPR;
-    auto reg = std::make_shared<w_CPR>(std::auto_ptr<ConstProductRegistry>(new ConstProductRegistry(*preg_)));
+    auto reg = std::make_shared<w_CPR>(std::make_unique<ConstProductRegistry>(*preg_));
     ServiceToken tempToken(ServiceRegistry::createContaining(reg,
                                                              token,
                                                              serviceregistry::kOverlapIsError));
@@ -108,7 +108,7 @@ namespace edm {
     typedef service::TriggerNamesService TNS;
     typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-    auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(parameterSet)));
+    auto tnsptr = std::make_shared<w_TNS>(std::make_unique<TNS>(parameterSet));
 
     return ServiceRegistry::createContaining(tnsptr,
                                              tempToken,
@@ -130,13 +130,13 @@ namespace edm {
     return common;
   }
 
-  std::auto_ptr<Schedule>
+  std::unique_ptr<Schedule>
   ScheduleItems::initSchedule(ParameterSet& parameterSet,
                               bool hasSubprocesses,
                               PreallocationConfiguration const& config,
                               ProcessContext const* processContext) {
-    std::auto_ptr<Schedule> schedule(
-        new Schedule(parameterSet,
+    return std::make_unique<Schedule>(
+                     parameterSet,
                      ServiceRegistry::instance().get<service::TriggerNamesService>(),
                      *preg_,
                      *branchIDListHelper_,
@@ -146,8 +146,7 @@ namespace edm {
                      processConfiguration(),
                      hasSubprocesses,
                      config,
-                     processContext));
-    return schedule;
+                     processContext);
   }
 
   void

--- a/FWCore/Framework/src/TriggerResultInserter.cc
+++ b/FWCore/Framework/src/TriggerResultInserter.cc
@@ -22,9 +22,6 @@ namespace edm
 
   void TriggerResultInserter::produce(StreamID id, edm::Event& e, edm::EventSetup const&) const
   {
-    std::unique_ptr<TriggerResults>
-      results(new TriggerResults(*resultsPerStream_[id.value()], pset_id_));
-
-    e.put(std::move(results));
+    e.put(std::make_unique<TriggerResults>(*resultsPerStream_[id.value()], pset_id_));
   }
 }

--- a/FWCore/Framework/src/WorkerMaker.h
+++ b/FWCore/Framework/src/WorkerMaker.h
@@ -93,7 +93,7 @@ protected:
     typedef edm::WorkerT<ModuleType> WorkerType;
 
     maker::ModuleHolderT<ModuleType> const* h = dynamic_cast<maker::ModuleHolderT<ModuleType> const*>(mod);
-    return std::unique_ptr<Worker>(new WorkerType(h->module(), md, actions));
+    return std::make_unique<WorkerType>(h->module(), md, actions);
   }
   
 

--- a/FWCore/Framework/test/DummyEventSetupRecordRetriever.h
+++ b/FWCore/Framework/test/DummyEventSetupRecordRetriever.h
@@ -41,8 +41,7 @@ namespace edm {
       }
       
       std::unique_ptr<DummyEventSetupData> produce(const DummyEventSetupRecord&) {
-         std::unique_ptr<DummyEventSetupData> data(new DummyEventSetupData(1));
-         return data;
+         return std::make_unique<DummyEventSetupData>(1);
       }
    protected:
 

--- a/FWCore/Framework/test/EventSelExc_t.cpp
+++ b/FWCore/Framework/test/EventSelExc_t.cpp
@@ -266,7 +266,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
+  auto tnsptr = std::make_shared<w_TNS>(std::make_unique<TNS>(proc_pset));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/EventSelOverlap_t.cpp
+++ b/FWCore/Framework/test/EventSelOverlap_t.cpp
@@ -224,7 +224,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
+  auto tnsptr = std::make_shared<w_TNS>(std::make_unique<TNS>(proc_pset));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/EventSelWildcard_t.cpp
+++ b/FWCore/Framework/test/EventSelWildcard_t.cpp
@@ -337,7 +337,7 @@ try {
   ans.push_back(ans3);
   
   
-  std::vector<bool> ans4;  	// Answers for criteria 4:{{"DEBUG*1","HLT?2"}};;
+  std::vector<bool> ans4;  	// Answers for criteria 4:{{"DEBUG*1","HLT?2"}};
   ans4.push_back (false);	// f f f f f f f f f f f f
   ans4.push_back (true);	// t t t t t t t t t t t t
   ans4.push_back (false);	// t f f f f f f f f f f f
@@ -448,7 +448,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
+  auto tnsptr = std::make_shared<w_TNS>(std::make_unique<TNS>(proc_pset));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/EventSelector_t.cpp
+++ b/FWCore/Framework/test/EventSelector_t.cpp
@@ -264,7 +264,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
+  auto tnsptr = std::make_shared<w_TNS>(std::make_unique<TNS>(proc_pset));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -334,7 +334,7 @@ void testEvent::setUp() {
 
   ProcessConfiguration processLate("LATE", processParamsLate.id(), getReleaseVersion(), getPassID());
 
-  std::auto_ptr<ProcessHistory> processHistory(new ProcessHistory);
+  auto processHistory = std::make_unique<ProcessHistory>();
   ProcessHistory& ph = *processHistory;
   processHistory->push_back(processEarly);
   processHistory->push_back(processLate);
@@ -416,16 +416,14 @@ void testEvent::getByTokenFromEmpty() {
 }
 
 void testEvent::putAnIntProduct() {
-  std::auto_ptr<edmtest::IntProduct> three(new edmtest::IntProduct(3));
-  currentEvent_->put(three, "int1");
+  currentEvent_->put(std::make_unique<edmtest::IntProduct>(3), "int1");
   CPPUNIT_ASSERT(currentEvent_->size() == 1);
   ProducerBase::commitEvent(*currentEvent_);
   CPPUNIT_ASSERT(currentEvent_->size() == 1);
 }
 
 void testEvent::putAndGetAnIntProduct() {
-  std::auto_ptr<edmtest::IntProduct> four(new edmtest::IntProduct(4));
-  currentEvent_->put(four, "int1");
+  currentEvent_->put(std::make_unique<edmtest::IntProduct>(4), "int1");
   ProducerBase::commitEvent(*currentEvent_);
 
   InputTag should_match("modMulti", "int1", "CURRENT");
@@ -497,10 +495,10 @@ void testEvent::transaction() {
   CPPUNIT_ASSERT(principal_->size() == 0);
   {
     typedef edmtest::IntProduct product_t;
-    typedef std::auto_ptr<product_t> ap_t;
+    typedef std::unique_ptr<product_t> ap_t;
 
     ap_t three(new product_t(3));
-    currentEvent_->put(three, "int1");
+    currentEvent_->put(std::move(three), "int1");
     CPPUNIT_ASSERT(principal_->size() == 0);
     CPPUNIT_ASSERT(currentEvent_->size() == 1);
     // DO NOT COMMIT!
@@ -525,13 +523,13 @@ void testEvent::getByLabel() {
   addProduct(std::move(three), "int3_tag");
   addProduct(std::move(four),  "nolabel_tag");
 
-  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
+  auto ap_vthing = std::make_unique<std::vector<edmtest::Thing>>();
   addProduct(std::move(ap_vthing), "thing", "");
 
   ap_t oneHundred(new product_t(100));
   addProduct(std::move(oneHundred), "int1_tag_late", "int1");
 
-  std::unique_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
+  auto twoHundred = std::make_unique<edmtest::IntProduct>(200);
   currentEvent_->put(std::move(twoHundred), "int1");
   ProducerBase::commitEvent(*currentEvent_);
 
@@ -610,13 +608,13 @@ void testEvent::getByToken() {
   addProduct(std::move(three), "int3_tag");
   addProduct(std::move(four),  "nolabel_tag");
   
-  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
+  auto ap_vthing = std::make_unique<std::vector<edmtest::Thing>>();
   addProduct(std::move(ap_vthing), "thing", "");
   
   ap_t oneHundred(new product_t(100));
   addProduct(std::move(oneHundred), "int1_tag_late", "int1");
   
-  std::unique_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
+  auto twoHundred = std::make_unique<edmtest::IntProduct>(200);
   currentEvent_->put(std::move(twoHundred), "int1");
   ProducerBase::commitEvent(*currentEvent_);
   
@@ -691,17 +689,17 @@ void testEvent::getManyByType() {
   addProduct(std::move(three), "int3_tag");
   addProduct(std::move(four),  "nolabel_tag");
 
-  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
+  auto ap_vthing = std::make_unique<std::vector<edmtest::Thing>>();
   addProduct(std::move(ap_vthing), "thing", "");
 
-  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing2(new std::vector<edmtest::Thing>);
+  auto ap_vthing2 = std::make_unique<std::vector<edmtest::Thing>>();
   addProduct(std::move(ap_vthing2), "thing2", "inst2");
 
   ap_t oneHundred(new product_t(100));
   addProduct(std::move(oneHundred), "int1_tag_late", "int1");
 
-  std::auto_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
-  currentEvent_->put(twoHundred, "int1");
+  auto twoHundred = std::make_unique<edmtest::IntProduct>(200);
+  currentEvent_->put(std::move(twoHundred), "int1");
   ProducerBase::commitEvent(*currentEvent_);
 
   CPPUNIT_ASSERT(currentEvent_->size() == 8);

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -40,9 +40,8 @@ namespace callbacktest {
 
    struct AutoPtrProd {
       AutoPtrProd() : value_(0) {}
-      std::auto_ptr<Data> method(const Record&) {
-         std::auto_ptr<Data> temp(new Data(++value_));
-         return temp;
+      std::unique_ptr<Data> method(const Record&) {
+         return std::make_unique<Data>(++value_);
       }
       
       int value_;
@@ -128,14 +127,14 @@ void testCallback::constPtrTest()
    
 }
 
-typedef Callback<AutoPtrProd, std::auto_ptr<Data>, Record> AutoPtrCallback;
+typedef Callback<AutoPtrProd, std::unique_ptr<Data>, Record> AutoPtrCallback;
 
 void testCallback::autoPtrTest()
 {
    AutoPtrProd prod;
    
    AutoPtrCallback callback(&prod, &AutoPtrProd::method);
-   std::auto_ptr<Data> handle;
+   std::unique_ptr<Data> handle;
    
    
    callback.holdOntoPointer(&handle);

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -185,7 +185,7 @@ private:
 using namespace edm::eventsetup;
 void testdependentrecord::dependentConstructorTest()
 {
-   std::auto_ptr<EventSetupRecordProvider> depProvider =
+   std::unique_ptr<EventSetupRecordProvider> depProvider =
    EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(DepRecord::keyForClass());
    
    CPPUNIT_ASSERT(1 == depProvider->dependentRecords().size());
@@ -606,7 +606,7 @@ void testdependentrecord::timeAndRunTest()
 
 void testdependentrecord::dependentSetproviderTest()
 {
-   std::auto_ptr<EventSetupRecordProvider> depProvider =
+   std::unique_ptr<EventSetupRecordProvider> depProvider =
    EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(DepRecord::keyForClass());
    
    std::shared_ptr<EventSetupRecordProvider> dummyProvider(

--- a/FWCore/Framework/test/edproducer_productregistry_callback.cc
+++ b/FWCore/Framework/test/edproducer_productregistry_callback.cc
@@ -120,11 +120,11 @@ void  testEDProducerProductRegistryCallback::testCircularRef() {
    SignallingProductRegistry preg;
 
    //Need access to the ConstProductRegistry service
-   std::auto_ptr<ConstProductRegistry> cReg(new ConstProductRegistry(preg));
-   ServiceToken token = ServiceRegistry::createContaining(cReg);
+   auto cReg = std::make_unique<ConstProductRegistry>(preg);
+   ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
    ServiceRegistry::Operate startServices(token);
    
-   std::auto_ptr<Maker> f(new WorkerMaker<TestMod>);
+   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
    
    ParameterSet p1;
    p1.addParameter("@module_type",std::string("TestMod") );
@@ -148,7 +148,7 @@ void  testEDProducerProductRegistryCallback::testCircularRef() {
    edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
    edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
    
-   std::auto_ptr<Maker> lM(new WorkerMaker<ListenMod>);
+   std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
    ParameterSet l1;
    l1.addParameter("@module_type",std::string("ListenMod") );
    l1.addParameter("@module_label",std::string("l1") );
@@ -196,11 +196,11 @@ void  testEDProducerProductRegistryCallback::testCircularRef2() {
    SignallingProductRegistry preg;
    
    //Need access to the ConstProductRegistry service
-   std::auto_ptr<ConstProductRegistry> cReg(new ConstProductRegistry(preg));
-   ServiceToken token = ServiceRegistry::createContaining(cReg);
+   auto cReg = std::make_unique<ConstProductRegistry>(preg);
+   ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
    ServiceRegistry::Operate startServices(token);
    
-   std::auto_ptr<Maker> f(new WorkerMaker<TestMod>);
+   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
    
    ParameterSet p1;
    p1.addParameter("@module_type",std::string("TestMod") );
@@ -224,7 +224,7 @@ void  testEDProducerProductRegistryCallback::testCircularRef2() {
    edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
    edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
    
-   std::auto_ptr<Maker> lM(new WorkerMaker<ListenMod>);
+   std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
    ParameterSet l1;
    l1.addParameter("@module_type",std::string("ListenMod") );
    l1.addParameter("@module_label",std::string("l1") );
@@ -271,11 +271,11 @@ void  testEDProducerProductRegistryCallback::testTwoListeners(){
    SignallingProductRegistry preg;
    
    //Need access to the ConstProductRegistry service
-   std::auto_ptr<ConstProductRegistry> cReg(new ConstProductRegistry(preg));
-   ServiceToken token = ServiceRegistry::createContaining(cReg);
+   auto cReg = std::make_unique<ConstProductRegistry>(preg);
+   ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
    ServiceRegistry::Operate startServices(token);
    
-   std::auto_ptr<Maker> f(new WorkerMaker<TestMod>);
+   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
    
    ParameterSet p1;
    p1.addParameter("@module_type",std::string("TestMod") );
@@ -299,14 +299,14 @@ void  testEDProducerProductRegistryCallback::testTwoListeners(){
    edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
    edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
    
-   std::auto_ptr<Maker> lM(new WorkerMaker<ListenMod>);
+   std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
    ParameterSet l1;
    l1.addParameter("@module_type",std::string("ListenMod") );
    l1.addParameter("@module_label",std::string("l1") );
    l1.addParameter("@module_edm_type",std::string("EDProducer") );
    l1.registerIt();
    
-   std::auto_ptr<Maker> lFM(new WorkerMaker<ListenFloatMod>);
+   std::unique_ptr<Maker> lFM = std::make_unique<WorkerMaker<ListenFloatMod>>();
    ParameterSet l2;
    l2.addParameter("@module_type",std::string("ListenMod") );
    l2.addParameter("@module_label",std::string("l2") );

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -102,8 +102,7 @@ public:
    }
    std::unique_ptr<DummyData> produce(const DummyRecord&) {
       ++data_.value_;
-      std::unique_ptr<DummyData> ptr(new DummyData(data_));
-      return std::move(ptr);
+      return std::make_unique<DummyData>(data_);
    }
 private:
    DummyData data_;

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -58,7 +58,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEventGetRefBeforePut);
 
 void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
 
-  std::auto_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
+  auto preg = std::make_unique<edm::ProductRegistry>();
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
@@ -128,7 +128,7 @@ void testEventGetRefBeforePut::getRefTest() {
 
   product.init();
 
-  std::auto_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
+  auto preg = std::make_unique<edm::ProductRegistry>();
   preg->addProduct(product);
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
@@ -156,7 +156,7 @@ void testEventGetRefBeforePut::getRefTest() {
     edm::ModuleDescription modDesc("Blah", label, pcPtr.get());
 
     edm::Event event(ep, modDesc, nullptr);
-    std::unique_ptr<edmtest::IntProduct> pr(new edmtest::IntProduct);
+    auto pr = std::make_unique<edmtest::IntProduct>();
     pr->value = 10;
 
     refToProd = event.getRefBeforePut<edmtest::IntProduct>(productInstanceName);

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -160,7 +160,7 @@ void test_ep::setUp() {
     typedef edmtest::DummyProduct PRODUCT_TYPE;
     typedef edm::Wrapper<PRODUCT_TYPE> WDP;
 
-    std::unique_ptr<edm::WrapperBase> product(new WDP(std::auto_ptr<PRODUCT_TYPE>(new PRODUCT_TYPE)));
+    std::unique_ptr<edm::WrapperBase> product = std::make_unique<WDP>(std::make_unique<PRODUCT_TYPE>());
 
     std::string tag("rick");
     assert(branchDescriptions_[tag]);

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -154,8 +154,8 @@ void testEventsetup::getExcTest()
 class DummyEventSetupProvider : public edm::eventsetup::EventSetupProvider {
 public:
    template<class T>
-   void insert(std::auto_ptr<T> iRecord) {
-      edm::eventsetup::EventSetupProvider::insert(iRecord);
+   void insert(std::unique_ptr<T> iRecord) {
+      edm::eventsetup::EventSetupProvider::insert(std::move(iRecord));
    }
 };
 
@@ -163,9 +163,9 @@ void testEventsetup::recordProviderTest()
 {
    DummyEventSetupProvider provider;
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
-   std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
+   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
    
-   provider.insert(dummyRecordProvider);
+   provider.insert(std::move(dummyRecordProvider));
    
    //NOTE: use 'invalid' timestamp since the default 'interval of validity'
    //       for a Record is presently an 'invalid' timestamp on both ends.
@@ -206,12 +206,12 @@ void testEventsetup::recordValidityTest()
 {
    DummyEventSetupProvider provider;
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
-   std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
+   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
 
    std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
    dummyRecordProvider->addFinder(finder);
    
-   provider.insert(dummyRecordProvider);
+   provider.insert(std::move(dummyRecordProvider));
    
    {
       Timestamp time_1(1);
@@ -243,12 +243,12 @@ void testEventsetup::recordValidityExcTest()
 {
    DummyEventSetupProvider provider;
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
-   std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
+   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
 
    std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
    dummyRecordProvider->addFinder(finder);
    
-   provider.insert(dummyRecordProvider);
+   provider.insert(std::move(dummyRecordProvider));
    
    {
       EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(1)));
@@ -724,12 +724,12 @@ void testEventsetup::iovExtentionTest()
 {
   DummyEventSetupProvider provider;
   typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
-  std::auto_ptr<DummyRecordProvider > dummyRecordProvider(new DummyRecordProvider());
+  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
   
   std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
   dummyRecordProvider->addFinder(finder);
   
-  provider.insert(dummyRecordProvider);
+  provider.insert(std::move(dummyRecordProvider));
   
   const Timestamp time_2(2);
   finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{3}}));

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -85,7 +85,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEventsetupRecord);
 
 void testEventsetupRecord::factoryTest()
 {
-   std::auto_ptr<EventSetupRecordProvider> dummyProvider =
+   std::unique_ptr<EventSetupRecordProvider> dummyProvider =
    EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(
                               EventSetupRecordKey::makeKey<DummyRecord>());
    
@@ -451,7 +451,7 @@ void testEventsetupRecord::doGetExepTest()
 
 void testEventsetupRecord::proxyResetTest()
 {
-  std::auto_ptr<EventSetupRecordProvider> dummyProvider =
+  std::unique_ptr<EventSetupRecordProvider> dummyProvider =
   EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(
                                                                         EventSetupRecordKey::makeKey<DummyRecord>());
   
@@ -502,7 +502,7 @@ void testEventsetupRecord::proxyResetTest()
 
 void testEventsetupRecord::transientTest()
 {
-   std::auto_ptr<EventSetupRecordProvider> dummyProvider =
+   std::unique_ptr<EventSetupRecordProvider> dummyProvider =
    EventSetupRecordProviderFactoryManager::instance().makeRecordProvider(
                                                                          EventSetupRecordKey::makeKey<DummyRecord>());
    

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -130,8 +130,8 @@ void testGenericHandle::getbyLabelTest() {
   typedef edmtest::DummyProduct DP;
   typedef edm::Wrapper<DP> WDP;
 
-  std::unique_ptr<DP> pr(new DP);
-  std::unique_ptr<edm::WrapperBase> pprod(new WDP(std::move(pr)));
+  auto pr = std::make_unique<DP>();
+  std::unique_ptr<edm::WrapperBase> pprod = std::make_unique<WDP>(std::move(pr));
   std::string label("fred");
   std::string productInstanceName("Rick");
 
@@ -159,7 +159,7 @@ void testGenericHandle::getbyLabelTest() {
 
   product.init();
 
-  std::unique_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
+  auto preg = std::make_unique<edm::ProductRegistry>();
   preg->addProduct(product);
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -249,7 +249,7 @@ m_ep()
   proc_pset.addParameter<std::vector<std::string>>("@end_paths", endPaths);
 
   // Now create and setup the service
-  tnsptr_.reset(new w_TNS(std::auto_ptr<TNS>(new TNS(proc_pset))));
+  tnsptr_.reset(new w_TNS(std::make_unique<TNS>(proc_pset)));
   
   serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
   

--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -53,7 +53,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testmaker2);
 void testmaker2::maker2Test()
 //int main()
 {
-  std::auto_ptr<Maker> f(new WorkerMaker<TestMod>);
+  std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
 
   ParameterSet p1;
   p1.addParameter("@module_type",std::string("TestMod") );

--- a/FWCore/Framework/test/maker_t.cppunit.cc
+++ b/FWCore/Framework/test/maker_t.cppunit.cc
@@ -41,8 +41,8 @@ void testmaker::makerTest()
     //std::cout << (*ib)->name() << std::endl;
     // }
 
-    std::shared_ptr<ParameterSet> p1 = makePSet(*edm::pset::parse(param1.c_str()));;
-    std::shared_ptr<ParameterSet> p2 = makePSet(*edm::pset::parse(param2.c_str()));;
+    std::shared_ptr<ParameterSet> p1 = makePSet(*edm::pset::parse(param1.c_str()));
+    std::shared_ptr<ParameterSet> p2 = makePSet(*edm::pset::parse(param2.c_str()));
 
     std::cerr << p1->getParameter<std::string>("@module_type");
 
@@ -50,8 +50,8 @@ void testmaker::makerTest()
 
     edm::ProductRegistry preg;
 
-    std::auto_ptr<Worker> w1 = f->makeWorker(*p1, preg, table, "PROD", 0, 0);
-    std::auto_ptr<Worker> w2 = f->makeWorker(*p2, preg, table, "PROD", 0, 0);
+    std::unique_ptr<Worker> w1 = f->makeWorker(*p1, preg, table, "PROD", 0, 0);
+    std::unique_ptr<Worker> w2 = f->makeWorker(*p2, preg, table, "PROD", 0, 0);
   }
   catch(cms::Exception& e) {
       std::cerr << "cms::Exception: " << e.explainSelf() << std::endl;

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -327,7 +327,7 @@ m_ep()
   proc_pset.addParameter<std::vector<std::string>>("@end_paths", endPaths);
 
   // Now create and setup the service
-  tnsptr_.reset(new w_TNS(std::auto_ptr<TNS>(new TNS(proc_pset))));
+  tnsptr_.reset(new w_TNS(std::make_unique<TNS>(proc_pset)));
   
   serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
   

--- a/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
@@ -34,18 +34,14 @@ private:
 class Test1Producer : public ESProxyFactoryProducer {
 public:
    Test1Producer() {
-      std::auto_ptr<ProxyFactoryTemplate<DummyProxy> > pFactory(new 
-                                                                 ProxyFactoryTemplate<DummyProxy>());
-      registerFactory(pFactory);
+      registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>());
    }
 };
 
 class TestLabelProducer : public ESProxyFactoryProducer {
 public:
    TestLabelProducer() {
-      std::auto_ptr<ProxyFactoryTemplate<DummyProxy> > pFactory(new 
-                                                                ProxyFactoryTemplate<DummyProxy>());
-      registerFactory(pFactory,"fred");
+      registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>(), "fred");
    }
 };
 

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -123,7 +123,7 @@ private:
     static unsigned int m_count;
     
     static std::unique_ptr<int> initializeGlobalCache(edm::ParameterSet const&) {
-      return std::unique_ptr<int>{new int{1}};
+      return std::make_unique<int>(1);
     }
     GlobalProd(edm::ParameterSet const&, const int* iGlobal) { CPPUNIT_ASSERT(*iGlobal == 1); }
     

--- a/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
+++ b/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
@@ -38,8 +38,7 @@ namespace edmtest {
     }
 
     virtual void produce(edm::Event& e, edm::EventSetup const& ){
-      std::unique_ptr<DeleteEarly> p(new DeleteEarly);
-      e.put(std::move(p));
+      e.put(std::make_unique<DeleteEarly>());
     }
 
   };

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -49,7 +49,7 @@ struct UnsafeCache {
     
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
       ++m_count;
-      std::unique_ptr<UnsafeCache> pCache(new UnsafeCache);
+      auto pCache = std::make_unique<UnsafeCache>();
       pCache->value = iID.value();
       return pCache;
     }
@@ -208,7 +208,7 @@ struct UnsafeCache {
 
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
       ++m_count;
-      return std::unique_ptr<UnsafeCache>(new UnsafeCache);
+      return std::make_unique<UnsafeCache>();
     }
 
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
@@ -258,7 +258,7 @@ struct UnsafeCache {
 
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
       ++m_count;
-      return std::unique_ptr<UnsafeCache>(new UnsafeCache);
+      return std::make_unique<UnsafeCache>();
     }
 
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -66,7 +66,7 @@ struct Dummy {
    
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
       ++m_count;
-      std::unique_ptr<UnsafeCache> sCache(new UnsafeCache);
+      auto sCache = std::make_unique<UnsafeCache>();
       ++(sCache->strm);
       sCache->value = iID.value();
       return sCache;
@@ -189,7 +189,7 @@ struct Dummy {
     }
  
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
-      return std::unique_ptr<UnsafeCache>{new UnsafeCache};
+      return std::make_unique<UnsafeCache>();
     }
 
     void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
@@ -258,7 +258,7 @@ struct Dummy {
     }
 
    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
-      return std::unique_ptr<UnsafeCache>{new UnsafeCache};
+      return std::make_unique<UnsafeCache>();
     }
 
    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
@@ -324,7 +324,7 @@ struct Dummy {
 
     std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
       ++m_count;
-      return std::unique_ptr<Cache>(new Cache);
+      return std::make_unique<Cache>();
     }
     
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
@@ -386,7 +386,7 @@ struct Dummy {
 
     std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
       ++m_count;
-      return std::unique_ptr<Cache>(new Cache);
+      return std::make_unique<Cache>();
     }
   
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -65,7 +65,7 @@ struct Dummy {
 
    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
       ++m_count;
-      std::unique_ptr<UnsafeCache> sCache(new UnsafeCache);
+      auto sCache = std::make_unique<UnsafeCache>();
       ++(sCache->strm);
       sCache->value = iID.value();
       return sCache;
@@ -170,7 +170,7 @@ struct Dummy {
     }
 
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
-      return std::unique_ptr<UnsafeCache>{new UnsafeCache};
+      return std::make_unique<UnsafeCache>();
     }
     
     void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
@@ -238,7 +238,7 @@ struct Dummy {
     }
 
    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
-      return std::unique_ptr<UnsafeCache>{new UnsafeCache};
+      return std::make_unique<UnsafeCache>();
     }
 
     void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
@@ -303,7 +303,7 @@ struct Dummy {
     mutable std::atomic<unsigned int> m_count{0};
    
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
-       return std::unique_ptr<UnsafeCache>(new UnsafeCache);
+      return std::make_unique<UnsafeCache>();
     }
 
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const& iRun, edm::EventSetup const&) const override {
@@ -364,7 +364,7 @@ struct Dummy {
     mutable std::atomic<unsigned int> m_count{0};
   
     std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
-      return std::unique_ptr<UnsafeCache>(new UnsafeCache);
+      return std::make_unique<UnsafeCache>();
     }
 
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -164,17 +164,17 @@ namespace edmtest {
     processHistoryIndex_(0),
     testAlias_(ps.getUntrackedParameter<bool>("testAlias", false)) {
 
-    std::unique_ptr<edmtest::Thing> ap_thing(new edmtest::Thing);
+    auto ap_thing = std::make_unique<edmtest::Thing>();
     edm::Wrapper<edmtest::Thing> w_thing(std::move(ap_thing));
     assert(!w_thing.isMergeable());
     assert(!w_thing.hasIsProductEqual());
 
-    std::unique_ptr<edmtest::ThingWithMerge> ap_thingwithmerge(new edmtest::ThingWithMerge);
+    auto ap_thingwithmerge = std::make_unique<edmtest::ThingWithMerge>();
     edm::Wrapper<edmtest::ThingWithMerge> w_thingWithMerge(std::move(ap_thingwithmerge));
     assert(w_thingWithMerge.isMergeable());
     assert(!w_thingWithMerge.hasIsProductEqual());
 
-    std::unique_ptr<edmtest::ThingWithIsEqual> ap_thingwithisequal(new edmtest::ThingWithIsEqual);
+    auto ap_thingwithisequal = std::make_unique<edmtest::ThingWithIsEqual>();
     edm::Wrapper<edmtest::ThingWithIsEqual> w_thingWithIsEqual(std::move(ap_thingwithisequal));
     assert(!w_thingWithIsEqual.isMergeable());
     assert(w_thingWithIsEqual.hasIsProductEqual());

--- a/FWCore/Framework/test/stubs/TestPRegisterModule1.cc
+++ b/FWCore/Framework/test/stubs/TestPRegisterModule1.cc
@@ -25,6 +25,5 @@ void TestPRegisterModule1::produce(Event& e, EventSetup const&)
 {
   
   std::string myname = pset_.getParameter<std::string>("@module_label");
-  std::unique_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
-  e.put(std::move(product));
+  e.put(std::make_unique<edmtest::StringProduct>(myname));
 }

--- a/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
+++ b/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
@@ -56,6 +56,5 @@ TestPRegisterModule2::TestPRegisterModule2(edm::ParameterSet const&){
      e.getByLabel("m2",stringp);
      CPPUNIT_ASSERT(stringp->name_=="m1");
 
-     std::unique_ptr<edmtest::DoubleProduct> product(new edmtest::DoubleProduct);
-     e.put(std::move(product));
+     e.put(std::make_unique<edmtest::DoubleProduct>());
   }

--- a/FWCore/Framework/test/stubs/TestSchedulerModule1.cc
+++ b/FWCore/Framework/test/stubs/TestSchedulerModule1.cc
@@ -36,8 +36,7 @@ private:
 void TestSchedulerModule1::produce(Event& e, EventSetup const&)
 {
   std::string myname = pset_.getParameter<std::string>("module_name");
-  std::unique_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
-  e.put(std::move(product));
+  e.put(std::make_unique<edmtest::StringProduct>(myname));
 }
 
 DEFINE_FWK_MODULE(TestSchedulerModule1);

--- a/FWCore/Framework/test/stubs/TestSchedulerModule2.cc
+++ b/FWCore/Framework/test/stubs/TestSchedulerModule2.cc
@@ -37,8 +37,7 @@ namespace edm{
   {
 
     std::string myname = pset_.getParameter<std::string>("module_name");
-    std::unique_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
-    e.put(std::move(product));
+    e.put(std::make_unique<edmtest::StringProduct>(myname));
     
   }
 }//namespace  

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -48,7 +48,7 @@ struct Cache {
    
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const& p) {
       ++m_count;
-      return std::unique_ptr<Cache>{ new Cache };
+      return std::make_unique<Cache>();
     }
 
     GlobalIntAnalyzer(edm::ParameterSet const& p, Cache const * iGlobal)  {

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -49,7 +49,7 @@ struct Cache {
     
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
       ++m_count;
-      return std::unique_ptr<Cache>{ new Cache };
+      return std::make_unique<Cache>();
     }
 
     GlobalIntFilter(edm::ParameterSet const& p, const Cache* iGlobal) {

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -57,7 +57,7 @@ struct UnsafeCache {
 
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
       ++m_count;
-      return std::unique_ptr<Cache>{new Cache};
+      return std::make_unique<Cache>();
     }
 
     GlobalIntProducer(edm::ParameterSet const& p, const Cache* iGlobal)  {

--- a/FWCore/Framework/test/stubs/ToyDoubleProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyDoubleProducers.cc
@@ -48,10 +48,8 @@ namespace edmtest {
   ToyDoubleProducer::produce(edm::Event& e, edm::EventSetup const&) {
 
     // Make output
-    std::unique_ptr<DoubleProduct> p(new DoubleProduct(value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<DoubleProduct>(value_));
   }
-
 }
 
 using edmtest::ToyDoubleProducer;

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -91,8 +91,7 @@ namespace edmtest {
   void
   IntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<IntProduct> p(new IntProduct(value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<IntProduct>(value_));
   }
 
   //--------------------------------------------------------------------
@@ -117,8 +116,7 @@ namespace edmtest {
   void
   IntLegacyProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<IntProduct> p(new IntProduct(value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<IntProduct>(value_));
   }
   
   //--------------------------------------------------------------------
@@ -147,8 +145,7 @@ namespace edmtest {
 
   void
   ConsumingIntProducer::produce(edm::Event& e, edm::EventSetup const&) {
-    std::unique_ptr<IntProduct> p(new IntProduct(value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<IntProduct>(value_));
   }
 
   //--------------------------------------------------------------------
@@ -172,8 +169,7 @@ namespace edmtest {
   void
   EventNumberIntProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    std::unique_ptr<UInt64Product> p(new UInt64Product(e.id().event()));
-    e.put(std::move(p));
+    e.put(std::make_unique<UInt64Product>(e.id().event()));
   }
 
 
@@ -199,8 +195,7 @@ namespace edmtest {
   void
   TransientIntProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    std::unique_ptr<TransientIntProduct> p(new TransientIntProduct(value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<TransientIntProduct>(value_));
   }
 
   //--------------------------------------------------------------------
@@ -228,8 +223,7 @@ namespace edmtest {
     edm::Handle<TransientIntProduct> result;
     bool ok = e.getByLabel("TransientThing", result);
     assert(ok);
-    std::unique_ptr<IntProduct> p(new IntProduct(result.product()->value));
-    e.put(std::move(p));
+    e.put(std::make_unique<IntProduct>(result.product()->value));
   }
 
   //--------------------------------------------------------------------
@@ -254,8 +248,7 @@ namespace edmtest {
   void
   Int16_tProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    std::unique_ptr<Int16_tProduct> p(new Int16_tProduct(value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<Int16_tProduct>(value_));
   }
 
   //
@@ -285,8 +278,7 @@ namespace edmtest {
       e.getByLabel(label, anInt);
       value += anInt->value;
     }
-    std::unique_ptr<IntProduct> p(new IntProduct(value));
-    e.put(std::move(p));
+    e.put(std::make_unique<IntProduct>(value));
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -69,10 +69,8 @@ namespace edmtest {
         assert(guts[i-1].id() > guts[i].id());
     }
 
-    std::unique_ptr<SCSimpleProduct> p(new SCSimpleProduct(guts));
-
     // Put the product into the Event, thus sorting it.
-    e.put(std::move(p));
+    e.put(std::make_unique<SCSimpleProduct>(guts));
   }
 
   //--------------------------------------------------------------------
@@ -105,27 +103,27 @@ namespace edmtest {
   OVSimpleProducer::produce(edm::Event& e,
                             edm::EventSetup const& /* unused */) {
     // Fill up a collection
-    std::unique_ptr<OVSimpleProduct> p(new OVSimpleProduct());
+    auto p = std::make_unique<OVSimpleProduct>();
 
     for(int i = 0; i < size_; ++i) {
-        std::auto_ptr<Simple> simple(new Simple());
+        auto simple = std::make_unique<Simple>();
         simple->key = size_ - i;
         simple->value = 1.5 * i;
-        p->push_back(simple);
+        p->push_back(std::move(simple));
     }
 
     // Put the product into the Event
     e.put(std::move(p));
 
     // Fill up a collection of SimpleDerived objects
-    std::unique_ptr<OVSimpleDerivedProduct> pd(new OVSimpleDerivedProduct());
+    auto pd = std::make_unique<OVSimpleDerivedProduct>();
 
     for(int i = 0; i < size_; ++i) {
-        std::auto_ptr<SimpleDerived> simpleDerived(new SimpleDerived());
+        auto simpleDerived = std::make_unique<SimpleDerived>();
         simpleDerived->key = size_ - i;
         simpleDerived->value = 1.5 * i + 100.0;
         simpleDerived->dummy = 0.0;
-        pd->push_back(simpleDerived);
+        pd->push_back(std::move(simpleDerived));
     }
 
     // Put the product into the Event
@@ -160,7 +158,7 @@ namespace edmtest {
   VSimpleProducer::produce(edm::Event& e,
                            edm::EventSetup const& /* unused */) {
     // Fill up a collection
-    std::unique_ptr<VSimpleProduct> p(new VSimpleProduct());
+    auto p = std::make_unique<VSimpleProduct>();
 
     for(int i = 0; i < size_; ++i) {
         Simple simple;
@@ -199,7 +197,7 @@ namespace edmtest {
     edm::Handle<std::vector<edmtest::Simple> > vs;
     e.getByLabel(src_, vs);
     // Fill up a collection
-    std::unique_ptr<AVSimpleProduct> p(new AVSimpleProduct(edm::RefProd<std::vector<edmtest::Simple> >(vs)));
+    auto p = std::make_unique<AVSimpleProduct>(edm::RefProd<std::vector<edmtest::Simple>>(vs));
 
     for(unsigned int i = 0; i < vs->size(); ++i) {
         edmtest::Simple simple;
@@ -268,7 +266,7 @@ namespace edmtest {
       assert(guts[i-1].data > guts[i].data);
     }
 
-    std::unique_ptr<product_type> p(new product_type());
+    auto p = std::make_unique<product_type>();
     int n = 0;
     for(int id = 1; id<size_; ++id) {
       ++n;
@@ -341,7 +339,7 @@ namespace edmtest {
     typedef typename product_type::FastFiller detset;
     typedef typename detset::id_type       id_type;
 
-    std::unique_ptr<product_type> p(new product_type());
+    auto p = std::make_unique<product_type>();
     product_type& v = *p;
 
     unsigned int n = 0;
@@ -385,8 +383,7 @@ namespace edmtest {
     edm::Handle<IntProduct> parent;
     e.getByLabel(label_, parent);
 
-    std::unique_ptr<Prodigal> p(new Prodigal(parent->value));
-    e.put(std::move(p));
+    e.put(std::make_unique<Prodigal>(parent->value));
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToyRefProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyRefProducers.cc
@@ -68,7 +68,7 @@ namespace edmtest {
     e.getByToken(target_, input);
     assert(input.isValid());
 
-    std::unique_ptr<product_type> prod(new product_type());
+    auto prod = std::make_unique<product_type>();
 
     typedef product_type::value_type ref;
     for(size_t i = 0, sz = input->size(); i != sz; ++i) {
@@ -111,8 +111,7 @@ namespace edmtest {
       refVector.push_back(input->refAt(i));
     }
 
-    std::unique_ptr<product_type> prod(new product_type(refVector));
-    e.put(std::move(prod));
+    e.put(std::make_unique<product_type>(refVector));
   }
 
   //--------------------------------------------------------------------
@@ -142,7 +141,7 @@ namespace edmtest {
     e.getByToken(target_, input);
     assert(input.isValid());
 
-    std::unique_ptr<product_type> prod(new product_type());
+    auto prod = std::make_unique<product_type>();
 
     typedef product_type::value_type ref;
     for(size_t i = 0, sz = input->size(); i != sz; ++i)
@@ -178,7 +177,7 @@ namespace edmtest {
     e.getByToken(target_, input);
     assert(input.isValid());
 
-    std::unique_ptr<product_type> prod(new product_type());
+    auto prod = std::make_unique<product_type>();
 
     typedef product_type::value_type ref;
     for(size_t i = 0, sz = input->size(); i != sz; ++i)

--- a/FWCore/Framework/test/stubs/ToySTLProducers.cc
+++ b/FWCore/Framework/test/stubs/ToySTLProducers.cc
@@ -56,7 +56,7 @@ namespace edmtest {
   void
   IntVectorProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<std::vector<int> > p(new std::vector<int>(count_, value_));
+    auto p = std::make_unique<std::vector<int>>(count_, value_);
     if(delta_ != 0) {
       for(unsigned int i = 0; i < p->size(); ++i) {
         p->at(i) = value_ + i * delta_;
@@ -83,11 +83,9 @@ namespace edmtest {
   void
   IntVectorSetProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<std::vector<int> > p(new std::vector<int>(1,11));
-    e.put(std::move(p));
+    e.put(std::make_unique<std::vector<int>>(1, 11));
 
-    std::unique_ptr<std::set<int> > apset(new std::set<int>);
-    e.put(std::move(apset));
+    e.put(std::make_unique<std::set<int>>());
   }
 
   //--------------------------------------------------------------------
@@ -111,8 +109,7 @@ namespace edmtest {
   void
   IntListProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<std::list<int> > p(new std::list<int>(count_, value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<std::list<int>>(count_, value_));
   }
 
   //--------------------------------------------------------------------
@@ -136,8 +133,7 @@ namespace edmtest {
   void
   IntDequeProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<std::deque<int> > p(new std::deque<int>(count_, value_));
-    e.put(std::move(p));
+    e.put(std::make_unique<std::deque<int>>(count_, value_));
   }
 
   //--------------------------------------------------------------------
@@ -161,7 +157,7 @@ namespace edmtest {
   void
   IntSetProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<std::set<int> > p(new std::set<int>());
+    auto p = std::make_unique<std::set<int>>();
     for(int i = start_; i < stop_; ++i) p->insert(i);
     e.put(std::move(p));
   }

--- a/FWCore/Integration/test/AssociationMapProducer.cc
+++ b/FWCore/Integration/test/AssociationMapProducer.cc
@@ -82,47 +82,47 @@ namespace edmtest {
     // the same content as was put in. Note that the particular values
     // used are arbitrary and have no meaning.
 
-    std::auto_ptr<AssocOneToOne> assoc1(new AssocOneToOne(&event.productGetter()));
+    auto assoc1 = std::make_unique<AssocOneToOne>(&event.productGetter());
     assoc1->insert(edm::Ref<std::vector<int> >(inputCollection1, 0),
                    edm::Ref<std::vector<int> >(inputCollection2, 1));
     assoc1->insert(edm::Ref<std::vector<int> >(inputCollection1, 2),
                    edm::Ref<std::vector<int> >(inputCollection2, 3));
-    event.put(assoc1);
+    event.put(std::move(assoc1));
 
-    std::auto_ptr<AssocOneToOne> assoc2(new AssocOneToOne(inputCollection1, inputCollection2));
+    auto assoc2 = std::make_unique<AssocOneToOne>(inputCollection1, inputCollection2);
     assoc2->insert(edm::Ref<std::vector<int> >(inputCollection1, 0),
                    edm::Ref<std::vector<int> >(inputCollection2, 1));
     assoc2->insert(edm::Ref<std::vector<int> >(inputCollection1, 2),
                    edm::Ref<std::vector<int> >(inputCollection2, 4));
-    event.put(assoc2, "twoArg");
+    event.put(std::move(assoc2), "twoArg");
 
-    std::auto_ptr<AssocOneToValue> assoc3(new AssocOneToValue(&event.productGetter()));
+    auto assoc3 = std::make_unique<AssocOneToValue>(&event.productGetter());
     assoc3->insert(edm::Ref<std::vector<int> >(inputCollection1, 0), 11.0);
     assoc3->insert(edm::Ref<std::vector<int> >(inputCollection1, 2), 12.0);
-    event.put(assoc3);
+    event.put(std::move(assoc3));
 
-    std::auto_ptr<AssocOneToValue> assoc4(new AssocOneToValue(inputCollection1));
+    auto assoc4 = std::make_unique<AssocOneToValue>(inputCollection1);
     assoc4->insert(edm::Ref<std::vector<int> >(inputCollection1, 0), 21.0);
     assoc4->insert(edm::Ref<std::vector<int> >(inputCollection1, 2), 22.0);
-    event.put(assoc4, "handleArg");
+    event.put(std::move(assoc4), "handleArg");
 
-    std::auto_ptr<AssocOneToMany> assoc5(new AssocOneToMany(&event.productGetter()));
+    auto assoc5 = std::make_unique<AssocOneToMany>(&event.productGetter());
     assoc5->insert(edm::Ref<std::vector<int> >(inputCollection1, 0),
                    edm::Ref<std::vector<int> >(inputCollection2, 1));
     assoc5->insert(edm::Ref<std::vector<int> >(inputCollection1, 2),
                    edm::Ref<std::vector<int> >(inputCollection2, 4));
     assoc5->insert(edm::Ref<std::vector<int> >(inputCollection1, 2),
                    edm::Ref<std::vector<int> >(inputCollection2, 6));
-    event.put(assoc5);
+    event.put(std::move(assoc5));
 
-    std::auto_ptr<AssocOneToManyWithQuality> assoc6(new AssocOneToManyWithQuality(&event.productGetter()));
+    auto assoc6 = std::make_unique<AssocOneToManyWithQuality>(&event.productGetter());
     assoc6->insert(edm::Ref<std::vector<int> >(inputCollection1, 0),
                    AssocOneToManyWithQuality::data_type(edm::Ref<std::vector<int> >(inputCollection2, 1), 31.0));
     assoc6->insert(edm::Ref<std::vector<int> >(inputCollection1, 2),
                    AssocOneToManyWithQuality::data_type(edm::Ref<std::vector<int> >(inputCollection2, 4), 32.0));
     assoc6->insert(edm::Ref<std::vector<int> >(inputCollection1, 2),
                    AssocOneToManyWithQuality::data_type(edm::Ref<std::vector<int> >(inputCollection2, 7), 33.0));
-    event.put(assoc6);
+    event.put(std::move(assoc6));
 
     edm::Handle<edm::View<int> > inputView1;
     event.getByToken(inputToken1V_, inputView1);
@@ -130,19 +130,17 @@ namespace edmtest {
     edm::Handle<edm::View<int> > inputView2;
     event.getByToken(inputToken2V_, inputView2);
 
-    std::auto_ptr<AssocOneToOneView> assoc7(new AssocOneToOneView(&event.productGetter()));
+    auto assoc7 = std::make_unique<AssocOneToOneView>(&event.productGetter());
     assoc7->insert(inputView1->refAt(0), inputView2->refAt(3));
     assoc7->insert(inputView1->refAt(2), inputView2->refAt(4));
-    event.put(assoc7);
+    event.put(std::move(assoc7));
 
-    std::auto_ptr<AssocOneToOneView> assoc8(new AssocOneToOneView(
-      edm::makeRefToBaseProdFrom(inputView1->refAt(0), event),
-      edm::makeRefToBaseProdFrom(inputView2->refAt(0), event)
-    ));
+    auto assoc8 = std::make_unique<AssocOneToOneView>(edm::makeRefToBaseProdFrom(inputView1->refAt(0), event),
+                                                      edm::makeRefToBaseProdFrom(inputView2->refAt(0), event));
 
     assoc8->insert(inputView1->refAt(0), inputView2->refAt(5));
     assoc8->insert(inputView1->refAt(2), inputView2->refAt(6));
-    event.put(assoc8, "twoArg");
+    event.put(std::move(assoc8), "twoArg");
   }
 }
 using edmtest::AssociationMapProducer;

--- a/FWCore/Integration/test/DoodadESProducer.cc
+++ b/FWCore/Integration/test/DoodadESProducer.cc
@@ -83,7 +83,7 @@ DoodadESProducer::produce(GadgetRcd const& /*iRecord*/) {
 
    using namespace edmtest;
 
-   std::unique_ptr<Doodad> pDoodad(new Doodad) ;
+   auto pDoodad = std::make_unique<Doodad>();
 
    pDoodad->a = 1;
 

--- a/FWCore/Integration/test/DoodadESSource.cc
+++ b/FWCore/Integration/test/DoodadESSource.cc
@@ -84,7 +84,7 @@ DoodadESSource::DoodadESSource(edm::ParameterSet const& pset)
 
 std::unique_ptr<Doodad> 
 DoodadESSource::produce(const GadgetRcd&) {
-   std::unique_ptr<Doodad> data(new Doodad());
+   auto data = std::make_unique<Doodad>();
    data->a = nCalls_;
    ++nCalls_;
    return data;

--- a/FWCore/Integration/test/HistProducer.cc
+++ b/FWCore/Integration/test/HistProducer.cc
@@ -16,10 +16,9 @@ namespace edmtest {
   // Functions that gets called by framework every event
   void HistProducer::produce(edm::Event& e, edm::EventSetup const&) {
 
-    std::unique_ptr<TH1F> result(new TH1F);  //Empty
-    e.put(std::move(result));
-    //std::auto_ptr<ThingWithHist> result2(new ThingWithHist);  //Empty
-    //e.put(result2);
+    //Empty Histograms
+    e.put(std::make_unique<TH1F>());
+    //e.put(std::make_unique<ThingWithHist>());
   }
 
 }

--- a/FWCore/Integration/test/IntSource.cc
+++ b/FWCore/Integration/test/IntSource.cc
@@ -35,8 +35,7 @@ namespace edm {
 
   void
   IntSource::produce(edm::Event& e) {
-    std::unique_ptr<edmtest::IntProduct> p(new edmtest::IntProduct(4));
-    e.put(std::move(p));
+    e.put(std::make_unique<edmtest::IntProduct>(4));
   }
 
   void

--- a/FWCore/Integration/test/ManyProductProducer.cc
+++ b/FWCore/Integration/test/ManyProductProducer.cc
@@ -48,8 +48,7 @@ namespace edmtest {
   void ManyProductProducer::produce(edm::Event& e, edm::EventSetup const&) {
     for(unsigned int i = 0; i < nProducts_; ++i) {
     
-      std::unique_ptr<IntProduct> p(new IntProduct(1));
-      e.put(std::move(p), instanceNames_[i]);
+      e.put(std::make_unique<IntProduct>(1), instanceNames_[i]);
     }
   }
 

--- a/FWCore/Integration/test/OtherThingProducer.cc
+++ b/FWCore/Integration/test/OtherThingProducer.cc
@@ -47,7 +47,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<OtherThingCollection> result(new OtherThingCollection);  //Empty
+    auto result = std::make_unique<OtherThingCollection>();  //Empty
 
     // Step C: Get data for algorithm
     edm::Handle<ThingCollection> parentHandle;

--- a/FWCore/Integration/test/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/test/ProducerWithPSetDesc.cc
@@ -429,7 +429,7 @@ namespace edmtest {
     // This serves no purpose, I just put it here so the module does something
     // Probably could just make this method do nothing and it would not
     // affect the test.
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
     e.put(std::move(result));
   }
 
@@ -770,22 +770,22 @@ namespace edmtest {
     pn = wildcardPset.addWildcardUntracked<double>(std::string("*"));
     pn->setComment("A comment for a wildcard parameter");
 
-    std::auto_ptr<edm::ParameterDescriptionNode> wnode(new edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireExactlyOne, true));
-    wildcardPset.addOptionalNode(wnode, false);
+    std::unique_ptr<edm::ParameterDescriptionNode> wnode = std::make_unique<edm::ParameterWildcard<edm::ParameterSetDescription>>("*", edm::RequireExactlyOne, true);
+    wildcardPset.addOptionalNode(std::move(wnode), false);
 
     edm::ParameterSetDescription wSet1;
     wSet1.add<unsigned int>("Drinks", 5);
 
-    std::auto_ptr<edm::ParameterDescriptionNode> wnode2(new edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireAtLeastOne, true, wSet1));
-    wildcardPset.addOptionalNode(wnode2, false);
+    std::unique_ptr<edm::ParameterDescriptionNode> wnode2 = std::make_unique<edm::ParameterWildcard<edm::ParameterSetDescription>>("*", edm::RequireAtLeastOne, true, wSet1);
+    wildcardPset.addOptionalNode(std::move(wnode2), false);
 
-    std::auto_ptr<edm::ParameterDescriptionNode> wnode3(new edm::ParameterWildcard<std::vector<edm::ParameterSet> >("*", edm::RequireExactlyOne, true));
-    wildcardPset.addOptionalNode(wnode3, false);
+    std::unique_ptr<edm::ParameterDescriptionNode> wnode3 = std::make_unique<edm::ParameterWildcard<std::vector<edm::ParameterSet>>>("*", edm::RequireExactlyOne, true);
+    wildcardPset.addOptionalNode(std::move(wnode3), false);
 
     wSet1.add<unsigned int>("Drinks2", 11);
 
-    std::auto_ptr<edm::ParameterDescriptionNode> wnode4(new edm::ParameterWildcard<std::vector<edm::ParameterSet> >("*", edm::RequireAtLeastOne, true, wSet1));
-    wildcardPset.addOptionalNode(wnode4, false);
+    std::unique_ptr<edm::ParameterDescriptionNode> wnode4 = std::make_unique<edm::ParameterWildcard<std::vector<edm::ParameterSet>>>("*", edm::RequireAtLeastOne, true, wSet1);
+    wildcardPset.addOptionalNode(std::move(wnode4), false);
 
     iDesc.add("wildcardPset", wildcardPset);
 

--- a/FWCore/Integration/test/ThingExtSource.cc
+++ b/FWCore/Integration/test/ThingExtSource.cc
@@ -30,7 +30,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -44,7 +44,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -57,7 +57,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -71,7 +71,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -84,7 +84,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -26,7 +26,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -40,7 +40,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -53,7 +53,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -67,7 +67,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -80,7 +80,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);

--- a/FWCore/Integration/test/ThingSource.cc
+++ b/FWCore/Integration/test/ThingSource.cc
@@ -23,7 +23,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -37,7 +37,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -50,7 +50,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -64,7 +64,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
@@ -77,7 +77,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    auto result = std::make_unique<ThingCollection>();  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);

--- a/FWCore/Integration/test/ThingWithMergeProducer.cc
+++ b/FWCore/Integration/test/ThingWithMergeProducer.cc
@@ -66,15 +66,15 @@ namespace edmtest {
       e.getByLabel(tag, h);
     }
 
-    std::unique_ptr<Thing> result(new Thing);
+    auto result = std::make_unique<Thing>();
     result->a = 11;
     if (!noPut_) e.put(std::move(result), std::string("event"));
 
-    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    auto result2 = std::make_unique<ThingWithMerge>();
     result2->a = 12;
     if (!noPut_) e.put(std::move(result2), std::string("event"));
 
-    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    auto result3 = std::make_unique<ThingWithIsEqual>();
     result3->a = 13;
     if (changeIsEqualValue_) result3->a = 14;
     if (!noPut_) e.put(std::move(result3), std::string("event"));
@@ -82,15 +82,15 @@ namespace edmtest {
 
   void ThingWithMergeProducer::beginLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) {
 
-    std::unique_ptr<Thing> result(new Thing);
+    auto result = std::make_unique<Thing>();
     result->a = 101;
     if (!noPut_) lb.put(std::move(result), "beginLumi");
 
-    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    auto result2 = std::make_unique<ThingWithMerge>();
     result2->a = 102;
     if (!noPut_) lb.put(std::move(result2), "beginLumi");
 
-    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    auto result3 = std::make_unique<ThingWithIsEqual>();
     result3->a = 103;
     if (changeIsEqualValue_) result3->a = 104;
     if (!noPut_) lb.put(std::move(result3), "beginLumi");
@@ -98,15 +98,15 @@ namespace edmtest {
 
   void ThingWithMergeProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) {
 
-    std::unique_ptr<Thing> result(new Thing);
+    auto result = std::make_unique<Thing>();
     result->a = 1001;
     if (!noPut_) lb.put(std::move(result), "endLumi");
 
-    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    auto result2 = std::make_unique<ThingWithMerge>();
     result2->a = 1002;
     if (!noPut_) lb.put(std::move(result2), "endLumi");
 
-    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    auto result3 = std::make_unique<ThingWithIsEqual>();
     result3->a = 1003;
     if (changeIsEqualValue_) result3->a = 1004;
     if (!noPut_) lb.put(std::move(result3), "endLumi");
@@ -115,15 +115,15 @@ namespace edmtest {
   // Functions that gets called by framework every run
   void ThingWithMergeProducer::beginRunProduce(edm::Run& r, edm::EventSetup const&) {
 
-    std::unique_ptr<Thing> result(new Thing);
+    auto result = std::make_unique<Thing>();
     result->a = 10001;
     if (!noPut_) r.put(std::move(result), "beginRun");
 
-    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    auto result2 = std::make_unique<ThingWithMerge>();
     result2->a = 10002;
     if (!noPut_) r.put(std::move(result2), "beginRun");
 
-    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    auto result3 = std::make_unique<ThingWithIsEqual>();
     result3->a = 10003;
     if (changeIsEqualValue_) result3->a = 10004;
     if (!noPut_) r.put(std::move(result3), "beginRun");
@@ -131,15 +131,15 @@ namespace edmtest {
 
   void ThingWithMergeProducer::endRunProduce(edm::Run& r, edm::EventSetup const&) {
 
-    std::unique_ptr<Thing> result(new Thing);
+    auto result = std::make_unique<Thing>();
     result->a = 100001;
     if (!noPut_) r.put(std::move(result), "endRun");
 
-    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    auto result2 = std::make_unique<ThingWithMerge>();
     result2->a = 100002;
     if (!noPut_) r.put(std::move(result2), "endRun");
 
-    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    auto result3 = std::make_unique<ThingWithIsEqual>();
     result3->a = 100003;
     if (changeIsEqualValue_) result3->a = 100004;
     if (!noPut_) r.put(std::move(result3), "endRun");

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -101,7 +101,7 @@ namespace edm {
   std::unique_ptr<FileBlock>
   ThrowingSource::readFile_() {
     if (whenToThrow_ == kReadFile) throw cms::Exception("TestThrow") << "ThrowingSource::readFile_";
-    return std::unique_ptr<FileBlock>(new FileBlock);
+    return std::make_unique<FileBlock>();
   }
 
   void

--- a/FWCore/Integration/test/TrackOfThingsProducer.cc
+++ b/FWCore/Integration/test/TrackOfThingsProducer.cc
@@ -54,7 +54,7 @@ namespace edmtest {
     edm::Handle<ThingCollection> inputCollection;
     event.getByToken(inputToken_, inputCollection);
 
-    std::auto_ptr<TrackOfThingsCollection> result(new TrackOfThingsCollection);
+    auto result = std::make_unique<TrackOfThingsCollection>();
 
     // Arbitrarily fabricate some fake data with TrackOfThings pointing to
     // Thing objects in products written to the event by a different module.
@@ -90,7 +90,7 @@ namespace edmtest {
       result->push_back(trackOfThings);
     }
 
-    event.put(result);
+    event.put(std::move(result));
   }
 }
 using edmtest::TrackOfThingsProducer;

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -103,7 +103,7 @@ WhatsItESProducer::produce(const GadgetRcd& iRecord)
    edm::ESHandle<Doodad> doodad;
    iRecord.get(dataLabel_,doodad);
    
-   std::unique_ptr<WhatsIt> pWhatsIt(new WhatsIt) ;
+   auto pWhatsIt = std::make_unique<WhatsIt>() ;
 
    pWhatsIt->a = doodad->a;
 

--- a/FWCore/Integration/test/standalone_t.cppunit.cc
+++ b/FWCore/Integration/test/standalone_t.cppunit.cc
@@ -31,7 +31,7 @@ class testStandalone: public CppUnit::TestFixture
 
   void setUp()
   {
-    m_handler = std::unique_ptr<edm::AssertHandler>(new edm::AssertHandler());
+    m_handler = std::make_unique<edm::AssertHandler>();
   }
 
   void tearDown(){

--- a/FWCore/MessageService/test/makeJobReport.cpp
+++ b/FWCore/MessageService/test/makeJobReport.cpp
@@ -14,8 +14,7 @@ void work()
   std::cout << "Testing JobReport" << std::endl;
   std::ostringstream ost;
   {
-  std::auto_ptr<edm::JobReport> theReport(new edm::JobReport(&ost) ); 
-  
+  auto theReport = std::make_unique<edm::JobReport>(&ost); 
   
 
   std::vector<std::string> inputBranches;

--- a/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
+++ b/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
@@ -44,7 +44,7 @@ namespace edm {
     history_.push_back(aux);
 
     //Serialize into std::vector 
-    std::unique_ptr<std::vector<EventAuxiliary > > result(new std::vector<EventAuxiliary>);
+    auto result = std::make_unique<std::vector<EventAuxiliary>>();
     for(size_t j = 0; j < history_.size(); ++j) { 
       result->push_back(history_[j]);
     }

--- a/FWCore/Modules/src/LogErrorHarvester.cc
+++ b/FWCore/Modules/src/LogErrorHarvester.cc
@@ -55,11 +55,9 @@ namespace edm {
   LogErrorHarvester::produce(Event& iEvent, EventSetup const&) {
     const auto index = iEvent.streamID().value();
     if(!FreshErrorsExist(index)) {
-      std::unique_ptr<std::vector<ErrorSummaryEntry> > errors(new std::vector<ErrorSummaryEntry>());
-      iEvent.put(std::move(errors));
+      iEvent.put(std::make_unique<std::vector<ErrorSummaryEntry>>());
     } else {
-      std::unique_ptr<std::vector<ErrorSummaryEntry> > errors(new std::vector<ErrorSummaryEntry>(LoggedErrorsSummary(index)));
-      iEvent.put(std::move(errors));
+      iEvent.put(std::make_unique<std::vector<ErrorSummaryEntry>>(LoggedErrorsSummary(index)));
     }
   }
 

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -95,7 +95,7 @@ namespace {
 
     ++iPlugin;
 
-    std::auto_ptr<edm::ParameterSetDescriptionFillerBase> filler;
+    std::unique_ptr<edm::ParameterSetDescriptionFillerBase> filler;
 
     try {
       filler.reset(factory->create(pluginInfo.name_));

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -79,7 +79,7 @@ namespace {
 
   void writeCfisForPlugin(std::string const& pluginName,
                           edm::ParameterSetDescriptionFillerPluginFactory* factory) {
-    std::auto_ptr<edm::ParameterSetDescriptionFillerBase> filler(factory->create(pluginName));
+    std::unique_ptr<edm::ParameterSetDescriptionFillerBase> filler(factory->create(pluginName));
 
     std::string baseType = filler->baseType();
 

--- a/FWCore/ParameterSet/interface/ANDGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ANDGroupDescription.h
@@ -20,14 +20,14 @@ namespace edm {
     ANDGroupDescription(ParameterDescriptionNode const& node_left,
                         ParameterDescriptionNode const& node_right);
 
-    ANDGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+    ANDGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                         ParameterDescriptionNode const& node_right);
 
     ANDGroupDescription(ParameterDescriptionNode const& node_left,
-                        std::auto_ptr<ParameterDescriptionNode> node_right);
+                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    ANDGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                        std::auto_ptr<ParameterDescriptionNode> node_right);
+    ANDGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
     virtual ParameterDescriptionNode* clone() const {
       return new ANDGroupDescription(*this);

--- a/FWCore/ParameterSet/interface/IfExistsDescription.h
+++ b/FWCore/ParameterSet/interface/IfExistsDescription.h
@@ -20,14 +20,14 @@ namespace edm {
     IfExistsDescription(ParameterDescriptionNode const& node_left,
                         ParameterDescriptionNode const& node_right);
 
-    IfExistsDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+    IfExistsDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                         ParameterDescriptionNode const& node_right);
 
     IfExistsDescription(ParameterDescriptionNode const& node_left,
-                        std::auto_ptr<ParameterDescriptionNode> node_right);
+                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    IfExistsDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                        std::auto_ptr<ParameterDescriptionNode> node_right);
+    IfExistsDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
     virtual ParameterDescriptionNode* clone() const {
       return new IfExistsDescription(*this);

--- a/FWCore/ParameterSet/interface/ORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ORGroupDescription.h
@@ -20,14 +20,14 @@ namespace edm {
     ORGroupDescription(ParameterDescriptionNode const& node_left,
                        ParameterDescriptionNode const& node_right);
 
-    ORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+    ORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                        ParameterDescriptionNode const& node_right);
 
     ORGroupDescription(ParameterDescriptionNode const& node_left,
-                       std::auto_ptr<ParameterDescriptionNode> node_right);
+                       std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    ORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                       std::auto_ptr<ParameterDescriptionNode> node_right);
+    ORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                       std::unique_ptr<ParameterDescriptionNode> node_right);
 
     virtual ParameterDescriptionNode* clone() const {
       return new ORGroupDescription(*this);

--- a/FWCore/ParameterSet/interface/ParameterDescriptionCases.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionCases.h
@@ -39,64 +39,64 @@ namespace edm {
   public:
     typedef std::map<T, edm::value_ptr<ParameterDescriptionNode> > CaseMap;
 
-    void insert(T caseValue, std::auto_ptr<ParameterDescriptionNode> node) {
+    void insert(T caseValue, std::unique_ptr<ParameterDescriptionNode> node) {
       std::pair<T, edm::value_ptr<ParameterDescriptionNode> > casePair(caseValue,edm::value_ptr<ParameterDescriptionNode>());
       std::pair<typename CaseMap::iterator,bool> status;
       status = caseMap_->insert(casePair);
-      (*caseMap_)[caseValue] = node;
+      (*caseMap_)[caseValue] = std::move(node);
       if (status.second == false) duplicateCaseValues_ = true;
     }
 
-    std::auto_ptr<CaseMap> caseMap() { return caseMap_; }
+    std::unique_ptr<CaseMap> caseMap() { return std::move(caseMap_); }
     bool duplicateCaseValues() const { return duplicateCaseValues_; }
 
   private:
 
     friend
-    std::auto_ptr<ParameterDescriptionCases<bool> >
+    std::unique_ptr<ParameterDescriptionCases<bool> >
     operator>>(bool caseValue,
-               std::auto_ptr<ParameterDescriptionNode> node);
+               std::unique_ptr<ParameterDescriptionNode> node);
 
     friend
-    std::auto_ptr<ParameterDescriptionCases<int> >
+    std::unique_ptr<ParameterDescriptionCases<int> >
     operator>>(int caseValue,
-               std::auto_ptr<ParameterDescriptionNode> node);
+               std::unique_ptr<ParameterDescriptionNode> node);
 
     friend
-    std::auto_ptr<ParameterDescriptionCases<std::string> >
+    std::unique_ptr<ParameterDescriptionCases<std::string> >
     operator>>(std::string const& caseValue,
-               std::auto_ptr<ParameterDescriptionNode> node);
+               std::unique_ptr<ParameterDescriptionNode> node);
 
     friend
-    std::auto_ptr<ParameterDescriptionCases<std::string> >
+    std::unique_ptr<ParameterDescriptionCases<std::string> >
     operator>>(char const* caseValue,
-               std::auto_ptr<ParameterDescriptionNode> node);
+               std::unique_ptr<ParameterDescriptionNode> node);
 
     // The constructor is intentionally private so that only the operator>> functions
     // can create these. 
-    ParameterDescriptionCases(T const& caseValue, std::auto_ptr<ParameterDescriptionNode> node) :
+    ParameterDescriptionCases(T const& caseValue, std::unique_ptr<ParameterDescriptionNode> node) :
       caseMap_(new CaseMap),
       duplicateCaseValues_(false)
     {
       std::pair<T, edm::value_ptr<ParameterDescriptionNode> > casePair(caseValue,edm::value_ptr<ParameterDescriptionNode>());
       caseMap_->insert(casePair);
-      (*caseMap_)[caseValue] = node;
+      (*caseMap_)[caseValue] = std::move(node);
     }
 
-    std::auto_ptr<CaseMap> caseMap_;
+    std::unique_ptr<CaseMap> caseMap_;
     bool duplicateCaseValues_;
   };
 
-  std::auto_ptr<ParameterDescriptionCases<bool> >
-  operator||(std::auto_ptr<ParameterDescriptionCases<bool> >,
-             std::auto_ptr<ParameterDescriptionCases<bool> >);
+  std::unique_ptr<ParameterDescriptionCases<bool> >
+  operator||(std::unique_ptr<ParameterDescriptionCases<bool> >,
+             std::unique_ptr<ParameterDescriptionCases<bool> >);
 
-  std::auto_ptr<ParameterDescriptionCases<int> >
-  operator||(std::auto_ptr<ParameterDescriptionCases<int> >,
-             std::auto_ptr<ParameterDescriptionCases<int> >);
+  std::unique_ptr<ParameterDescriptionCases<int> >
+  operator||(std::unique_ptr<ParameterDescriptionCases<int> >,
+             std::unique_ptr<ParameterDescriptionCases<int> >);
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
-  operator||(std::auto_ptr<ParameterDescriptionCases<std::string> >,
-	     std::auto_ptr<ParameterDescriptionCases<std::string> >);
+  std::unique_ptr<ParameterDescriptionCases<std::string> >
+  operator||(std::unique_ptr<ParameterDescriptionCases<std::string> >,
+	     std::unique_ptr<ParameterDescriptionCases<std::string> >);
 }
 #endif

--- a/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
@@ -259,90 +259,90 @@ namespace edm {
 
   // operator>> ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionCases<bool> >
+  std::unique_ptr<ParameterDescriptionCases<bool> >
   operator>>(bool caseValue,
              ParameterDescriptionNode const& node);
 
-  std::auto_ptr<ParameterDescriptionCases<int> >
+  std::unique_ptr<ParameterDescriptionCases<int> >
   operator>>(int caseValue,
              ParameterDescriptionNode const& node);
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string> >
   operator>>(std::string const& caseValue,
              ParameterDescriptionNode const& node);
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string> >
   operator>>(char const* caseValue,
              ParameterDescriptionNode const& node);
 
-  std::auto_ptr<ParameterDescriptionCases<bool> >
+  std::unique_ptr<ParameterDescriptionCases<bool> >
   operator>>(bool caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node);
+             std::unique_ptr<ParameterDescriptionNode> node);
 
-  std::auto_ptr<ParameterDescriptionCases<int> >
+  std::unique_ptr<ParameterDescriptionCases<int> >
   operator>>(int caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node);
+             std::unique_ptr<ParameterDescriptionNode> node);
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string> >
   operator>>(std::string const& caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node);
+             std::unique_ptr<ParameterDescriptionNode> node);
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string> >
   operator>>(char const* caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node);
+             std::unique_ptr<ParameterDescriptionNode> node);
 
   // operator&& ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator&&(ParameterDescriptionNode const& node_left,
              ParameterDescriptionNode const& node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator&&(std::auto_ptr<ParameterDescriptionNode> node_left,
+  std::unique_ptr<ParameterDescriptionNode>
+  operator&&(std::unique_ptr<ParameterDescriptionNode> node_left,
              ParameterDescriptionNode const& node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator&&(ParameterDescriptionNode const& node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right);
+             std::unique_ptr<ParameterDescriptionNode> node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator&&(std::auto_ptr<ParameterDescriptionNode> node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right);
+  std::unique_ptr<ParameterDescriptionNode>
+  operator&&(std::unique_ptr<ParameterDescriptionNode> node_left,
+             std::unique_ptr<ParameterDescriptionNode> node_right);
 
   // operator|| ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator||(ParameterDescriptionNode const& node_left,
              ParameterDescriptionNode const& node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator||(std::auto_ptr<ParameterDescriptionNode> node_left,
+  std::unique_ptr<ParameterDescriptionNode>
+  operator||(std::unique_ptr<ParameterDescriptionNode> node_left,
              ParameterDescriptionNode const& node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator||(ParameterDescriptionNode const& node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right);
+             std::unique_ptr<ParameterDescriptionNode> node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator||(std::auto_ptr<ParameterDescriptionNode> node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right);
+  std::unique_ptr<ParameterDescriptionNode>
+  operator||(std::unique_ptr<ParameterDescriptionNode> node_left,
+             std::unique_ptr<ParameterDescriptionNode> node_right);
 
   // operator^  ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator^(ParameterDescriptionNode const& node_left,
             ParameterDescriptionNode const& node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator^(std::auto_ptr<ParameterDescriptionNode> node_left,
+  std::unique_ptr<ParameterDescriptionNode>
+  operator^(std::unique_ptr<ParameterDescriptionNode> node_left,
             ParameterDescriptionNode const& node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator^(ParameterDescriptionNode const& node_left,
-            std::auto_ptr<ParameterDescriptionNode> node_right);
+            std::unique_ptr<ParameterDescriptionNode> node_right);
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator^(std::auto_ptr<ParameterDescriptionNode> node_left,
-            std::auto_ptr<ParameterDescriptionNode> node_right);
+  std::unique_ptr<ParameterDescriptionNode>
+  operator^(std::unique_ptr<ParameterDescriptionNode> node_left,
+            std::unique_ptr<ParameterDescriptionNode> node_right);
 }
 #endif

--- a/FWCore/ParameterSet/interface/ParameterSwitch.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitch.h
@@ -29,7 +29,7 @@ namespace edm {
     typedef typename std::map<T, edm::value_ptr<ParameterDescriptionNode> >::const_iterator CaseMapConstIter;
 
     ParameterSwitch(ParameterDescription<T> const& switchParameter,
-                    std::auto_ptr<ParameterDescriptionCases<T> > cases) :
+                    std::unique_ptr<ParameterDescriptionCases<T> > cases) :
       switch_(switchParameter),
       cases_(*cases->caseMap())
     {

--- a/FWCore/ParameterSet/interface/XORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/XORGroupDescription.h
@@ -20,14 +20,14 @@ namespace edm {
     XORGroupDescription(ParameterDescriptionNode const& node_left,
                         ParameterDescriptionNode const& node_right);
 
-    XORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+    XORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                         ParameterDescriptionNode const& node_right);
 
     XORGroupDescription(ParameterDescriptionNode const& node_left,
-                        std::auto_ptr<ParameterDescriptionNode> node_right);
+                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    XORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                        std::auto_ptr<ParameterDescriptionNode> node_right);
+    XORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
     virtual ParameterDescriptionNode* clone() const {
       return new XORGroupDescription(*this);

--- a/FWCore/ParameterSet/src/ANDGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ANDGroupDescription.cc
@@ -18,24 +18,24 @@ namespace edm {
   }
 
   ANDGroupDescription::
-  ANDGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+  ANDGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                       ParameterDescriptionNode const& node_right) :
-    node_left_(node_left),
+    node_left_(std::move(node_left)),
     node_right_(node_right.clone()) {
   }
 
   ANDGroupDescription::
   ANDGroupDescription(ParameterDescriptionNode const& node_left,
-                      std::auto_ptr<ParameterDescriptionNode> node_right) :
+                      std::unique_ptr<ParameterDescriptionNode> node_right) :
     node_left_(node_left.clone()),
-    node_right_(node_right) {
+    node_right_(std::move(node_right)) {
   }
 
   ANDGroupDescription::
-  ANDGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                      std::auto_ptr<ParameterDescriptionNode> node_right) :
-    node_left_(node_left),
-    node_right_(node_right) {
+  ANDGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                      std::unique_ptr<ParameterDescriptionNode> node_right) :
+    node_left_(std::move(node_left)),
+    node_right_(std::move(node_right)) {
   }
 
   void

--- a/FWCore/ParameterSet/src/FillDescriptionFromPSet.cc
+++ b/FWCore/ParameterSet/src/FillDescriptionFromPSet.cc
@@ -135,12 +135,11 @@ namespace edm {
       }
       ParameterSetDescription emptyDescription;
 
-      std::auto_ptr<ParameterDescription<std::vector<ParameterSet> > >
-        pd(new ParameterDescription<std::vector<ParameterSet> >(vpset_entry->first, emptyDescription, vpset_entry->second.isTracked(), nestedVPset));
+      auto pd = std::make_unique<ParameterDescription<std::vector<ParameterSet>>>(vpset_entry->first, emptyDescription, vpset_entry->second.isTracked(), nestedVPset);
 
       pd->setPartOfDefaultOfVPSet(true);
-      std::auto_ptr<ParameterDescriptionNode> node(pd);
-      desc.addNode(node);
+      std::unique_ptr<ParameterDescriptionNode> node(std::move(pd));
+      desc.addNode(std::move(node));
     }
   }
 }

--- a/FWCore/ParameterSet/src/IfExistsDescription.cc
+++ b/FWCore/ParameterSet/src/IfExistsDescription.cc
@@ -18,24 +18,24 @@ namespace edm {
   }
 
   IfExistsDescription::
-  IfExistsDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+  IfExistsDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                       ParameterDescriptionNode const& node_right) :
-    node_left_(node_left),
+    node_left_(std::move(node_left)),
     node_right_(node_right.clone()) {
   }
 
   IfExistsDescription::
   IfExistsDescription(ParameterDescriptionNode const& node_left,
-                      std::auto_ptr<ParameterDescriptionNode> node_right) :
+                      std::unique_ptr<ParameterDescriptionNode> node_right) :
     node_left_(node_left.clone()),
-    node_right_(node_right) {
+    node_right_(std::move(node_right)) {
   }
 
   IfExistsDescription::
-  IfExistsDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                      std::auto_ptr<ParameterDescriptionNode> node_right) :
-    node_left_(node_left),
-    node_right_(node_right) {
+  IfExistsDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                      std::unique_ptr<ParameterDescriptionNode> node_right) :
+    node_left_(std::move(node_left)),
+    node_right_(std::move(node_right)) {
   }
 
   void

--- a/FWCore/ParameterSet/src/ORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ORGroupDescription.cc
@@ -18,24 +18,24 @@ namespace edm {
   }
 
   ORGroupDescription::
-  ORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+  ORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                      ParameterDescriptionNode const& node_right) :
-    node_left_(node_left),
+    node_left_(std::move(node_left)),
     node_right_(node_right.clone()) {
   }
 
   ORGroupDescription::
   ORGroupDescription(ParameterDescriptionNode const& node_left,
-                     std::auto_ptr<ParameterDescriptionNode> node_right) :
+                     std::unique_ptr<ParameterDescriptionNode> node_right) :
     node_left_(node_left.clone()),
-    node_right_(node_right) {
+    node_right_(std::move(node_right)) {
   }
 
   ORGroupDescription::
-  ORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                     std::auto_ptr<ParameterDescriptionNode> node_right) :
-    node_left_(node_left),
-    node_right_(node_right) {
+  ORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                     std::unique_ptr<ParameterDescriptionNode> node_right) :
+    node_left_(std::move(node_left)),
+    node_right_(std::move(node_right)) {
   }
 
   void

--- a/FWCore/ParameterSet/src/ParameterDescriptionCases.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionCases.cc
@@ -4,47 +4,47 @@
 
 namespace edm {
 
-  std::auto_ptr<ParameterDescriptionCases<bool> >
-  operator||(std::auto_ptr<ParameterDescriptionCases<bool> > left,
-             std::auto_ptr<ParameterDescriptionCases<bool> > right) {
+  std::unique_ptr<ParameterDescriptionCases<bool> >
+  operator||(std::unique_ptr<ParameterDescriptionCases<bool> > left,
+             std::unique_ptr<ParameterDescriptionCases<bool> > right) {
 
-    std::auto_ptr<std::map<bool, edm::value_ptr<ParameterDescriptionNode> > > rightCases = right->caseMap();
+    std::unique_ptr<std::map<bool, edm::value_ptr<ParameterDescriptionNode> > > rightCases = right->caseMap();
     for (std::map<bool, edm::value_ptr<ParameterDescriptionNode> >::const_iterator iter = rightCases->begin(),
 	                                                                           iEnd = rightCases->end();
          iter != iEnd; ++iter) {
       bool caseValue = iter->first;
-      std::auto_ptr<ParameterDescriptionNode> node(iter->second->clone());
-      left->insert(caseValue, node);
+      std::unique_ptr<ParameterDescriptionNode> node(iter->second->clone());
+      left->insert(caseValue, std::move(node));
     }
     return left;
   }
 
-  std::auto_ptr<ParameterDescriptionCases<int> >
-  operator||(std::auto_ptr<ParameterDescriptionCases<int> > left,
-             std::auto_ptr<ParameterDescriptionCases<int> > right) {
+  std::unique_ptr<ParameterDescriptionCases<int> >
+  operator||(std::unique_ptr<ParameterDescriptionCases<int> > left,
+             std::unique_ptr<ParameterDescriptionCases<int> > right) {
 
-    std::auto_ptr<std::map<int, edm::value_ptr<ParameterDescriptionNode> > > rightCases = right->caseMap();
+    std::unique_ptr<std::map<int, edm::value_ptr<ParameterDescriptionNode> > > rightCases = right->caseMap();
     for (std::map<int, edm::value_ptr<ParameterDescriptionNode> >::const_iterator iter = rightCases->begin(),
 	                                                                          iEnd = rightCases->end();
          iter != iEnd; ++iter) {
       int caseValue = iter->first;
-      std::auto_ptr<ParameterDescriptionNode> node(iter->second->clone());
-      left->insert(caseValue, node);
+      std::unique_ptr<ParameterDescriptionNode> node(iter->second->clone());
+      left->insert(caseValue, std::move(node));
     }
     return left;
   }
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
-  operator||(std::auto_ptr<ParameterDescriptionCases<std::string> > left,
-             std::auto_ptr<ParameterDescriptionCases<std::string> > right) {
+  std::unique_ptr<ParameterDescriptionCases<std::string> >
+  operator||(std::unique_ptr<ParameterDescriptionCases<std::string> > left,
+             std::unique_ptr<ParameterDescriptionCases<std::string> > right) {
 
-    std::auto_ptr<std::map<std::string, edm::value_ptr<ParameterDescriptionNode> > > rightCases = right->caseMap();
+    std::unique_ptr<std::map<std::string, edm::value_ptr<ParameterDescriptionNode> > > rightCases = right->caseMap();
     for (std::map<std::string, edm::value_ptr<ParameterDescriptionNode> >::const_iterator iter = rightCases->begin(),
 	                                                                        iEnd = rightCases->end();
          iter != iEnd; ++iter) {
       std::string caseValue = iter->first;
-      std::auto_ptr<ParameterDescriptionNode> node(iter->second->clone());
-      left->insert(caseValue, node);
+      std::unique_ptr<ParameterDescriptionNode> node(iter->second->clone());
+      left->insert(caseValue, std::move(node));
     }
     return left;
   }

--- a/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
@@ -130,138 +130,138 @@ namespace edm {
 
   // operator>> ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionCases<bool> >
+  std::unique_ptr<ParameterDescriptionCases<bool>>
   operator>>(bool caseValue,
              ParameterDescriptionNode const& node) {
-    std::auto_ptr<ParameterDescriptionNode> clonedNode(node.clone());
-    return caseValue >> clonedNode;
+    std::unique_ptr<ParameterDescriptionNode> clonedNode(node.clone());
+    return caseValue >> std::move(clonedNode);
   }
 
-  std::auto_ptr<ParameterDescriptionCases<int> >
+  std::unique_ptr<ParameterDescriptionCases<int>>
   operator>>(int caseValue,
              ParameterDescriptionNode const& node) {
-    std::auto_ptr<ParameterDescriptionNode> clonedNode(node.clone());
-    return caseValue >> clonedNode;
+    std::unique_ptr<ParameterDescriptionNode> clonedNode(node.clone());
+    return caseValue >> std::move(clonedNode);
   }
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string>>
   operator>>(std::string const& caseValue,
              ParameterDescriptionNode const& node) {
-    std::auto_ptr<ParameterDescriptionNode> clonedNode(node.clone());
-    return caseValue >> clonedNode;
+    std::unique_ptr<ParameterDescriptionNode> clonedNode(node.clone());
+    return caseValue >> std::move(clonedNode);
   }
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string>>
   operator>>(char const* caseValue,
              ParameterDescriptionNode const& node) {
-    std::auto_ptr<ParameterDescriptionNode> clonedNode(node.clone());
-    return caseValue >> clonedNode;
+    std::unique_ptr<ParameterDescriptionNode> clonedNode(node.clone());
+    return caseValue >> std::move(clonedNode);
   }
 
-  std::auto_ptr<ParameterDescriptionCases<bool> >
+  std::unique_ptr<ParameterDescriptionCases<bool>>
   operator>>(bool caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node) {
-    return std::auto_ptr<ParameterDescriptionCases<bool> >(
-      new ParameterDescriptionCases<bool>(caseValue, node));
+             std::unique_ptr<ParameterDescriptionNode> node) {
+    return std::unique_ptr<ParameterDescriptionCases<bool>>(
+      new ParameterDescriptionCases<bool>(caseValue, std::move(node)));
   }
 
-  std::auto_ptr<ParameterDescriptionCases<int> >
+  std::unique_ptr<ParameterDescriptionCases<int>>
   operator>>(int caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node) {
-    return std::auto_ptr<ParameterDescriptionCases<int> >(
-      new ParameterDescriptionCases<int>(caseValue, node));
+             std::unique_ptr<ParameterDescriptionNode> node) {
+    return std::unique_ptr<ParameterDescriptionCases<int>>(
+      new ParameterDescriptionCases<int>(caseValue, std::move(node)));
   }
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string>>
   operator>>(std::string const& caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node) {
-    return std::auto_ptr<ParameterDescriptionCases<std::string> >(
-      new ParameterDescriptionCases<std::string>(caseValue, node));
+             std::unique_ptr<ParameterDescriptionNode> node) {
+    return std::unique_ptr<ParameterDescriptionCases<std::string>>(
+      new ParameterDescriptionCases<std::string>(caseValue, std::move(node)));
   }
 
-  std::auto_ptr<ParameterDescriptionCases<std::string> >
+  std::unique_ptr<ParameterDescriptionCases<std::string>>
   operator>>(char const* caseValue,
-             std::auto_ptr<ParameterDescriptionNode> node) {
+             std::unique_ptr<ParameterDescriptionNode> node) {
     std::string caseValueString(caseValue);
-    return std::auto_ptr<ParameterDescriptionCases<std::string> >(
-      new ParameterDescriptionCases<std::string>(caseValue, node));
+    return std::unique_ptr<ParameterDescriptionCases<std::string>>(
+      new ParameterDescriptionCases<std::string>(caseValue, std::move(node)));
   }
 
   // operator&& ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator&&(ParameterDescriptionNode const& node_left,
              ParameterDescriptionNode const& node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ANDGroupDescription(node_left, node_right));
+    return std::make_unique<ANDGroupDescription>(node_left, node_right);
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator&&(std::auto_ptr<ParameterDescriptionNode> node_left,
+  std::unique_ptr<ParameterDescriptionNode>
+  operator&&(std::unique_ptr<ParameterDescriptionNode> node_left,
              ParameterDescriptionNode const& node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ANDGroupDescription(node_left, node_right));
+    return std::make_unique<ANDGroupDescription>(std::move(node_left), node_right);
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator&&(ParameterDescriptionNode const& node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ANDGroupDescription(node_left, node_right));
+             std::unique_ptr<ParameterDescriptionNode> node_right) {
+    return std::make_unique<ANDGroupDescription>(node_left, std::move(node_right));
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator&&(std::auto_ptr<ParameterDescriptionNode> node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ANDGroupDescription(node_left, node_right));
+  std::unique_ptr<ParameterDescriptionNode>
+  operator&&(std::unique_ptr<ParameterDescriptionNode> node_left,
+             std::unique_ptr<ParameterDescriptionNode> node_right) {
+    return std::make_unique<ANDGroupDescription>(std::move(node_left), std::move(node_right));
   }
 
   // operator|| ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator||(ParameterDescriptionNode const& node_left,
              ParameterDescriptionNode const& node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ORGroupDescription(node_left, node_right));
+    return std::make_unique<ORGroupDescription>(node_left, node_right);
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator||(std::auto_ptr<ParameterDescriptionNode> node_left,
+  std::unique_ptr<ParameterDescriptionNode>
+  operator||(std::unique_ptr<ParameterDescriptionNode> node_left,
              ParameterDescriptionNode const& node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ORGroupDescription(node_left, node_right));
+    return std::make_unique<ORGroupDescription>(std::move(node_left), node_right);
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator||(ParameterDescriptionNode const& node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ORGroupDescription(node_left, node_right));
+             std::unique_ptr<ParameterDescriptionNode> node_right) {
+    return std::make_unique<ORGroupDescription>(node_left, std::move(node_right));
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator||(std::auto_ptr<ParameterDescriptionNode> node_left,
-             std::auto_ptr<ParameterDescriptionNode> node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new ORGroupDescription(node_left, node_right));
+  std::unique_ptr<ParameterDescriptionNode>
+  operator||(std::unique_ptr<ParameterDescriptionNode> node_left,
+             std::unique_ptr<ParameterDescriptionNode> node_right) {
+    return std::make_unique<ORGroupDescription>(std::move(node_left), std::move(node_right));
   }
 
   // operator^  ---------------------------------------------
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator^(ParameterDescriptionNode const& node_left,
             ParameterDescriptionNode const& node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new XORGroupDescription(node_left, node_right));
+    return std::make_unique<XORGroupDescription>(node_left, node_right);
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator^(std::auto_ptr<ParameterDescriptionNode> node_left,
+  std::unique_ptr<ParameterDescriptionNode>
+  operator^(std::unique_ptr<ParameterDescriptionNode> node_left,
             ParameterDescriptionNode const& node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new XORGroupDescription(node_left, node_right));
+    return std::make_unique<XORGroupDescription>(std::move(node_left), node_right);
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
+  std::unique_ptr<ParameterDescriptionNode>
   operator^(ParameterDescriptionNode const& node_left,
-            std::auto_ptr<ParameterDescriptionNode> node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new XORGroupDescription(node_left, node_right));
+            std::unique_ptr<ParameterDescriptionNode> node_right) {
+    return std::make_unique<XORGroupDescription>(node_left, std::move(node_right));
   }
 
-  std::auto_ptr<ParameterDescriptionNode>
-  operator^(std::auto_ptr<ParameterDescriptionNode> node_left,
-            std::auto_ptr<ParameterDescriptionNode> node_right) {
-    return std::auto_ptr<ParameterDescriptionNode>(new XORGroupDescription(node_left, node_right));
+  std::unique_ptr<ParameterDescriptionNode>
+  operator^(std::unique_ptr<ParameterDescriptionNode> node_left,
+            std::unique_ptr<ParameterDescriptionNode> node_right) {
+    return std::make_unique<XORGroupDescription>(std::move(node_left), std::move(node_right));
   }
 }

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -145,7 +145,7 @@ namespace edm {
     assert(!isRegistered());
     psettable::iterator it = psetTable_.find(name);
     assert(it != psetTable_.end());
-    std::unique_ptr<ParameterSet> pset = std::make_unique<ParameterSet>();
+    auto pset = std::make_unique<ParameterSet>();
     std::swap(*pset, it->second.psetForUpdate());
     psetTable_.erase(it);
     return pset;
@@ -174,7 +174,7 @@ namespace edm {
     assert(!isRegistered());
     vpsettable::iterator it = vpsetTable_.find(name);
     assert(it != vpsetTable_.end());
-    std::unique_ptr<std::vector<ParameterSet> > vpset = std::make_unique<std::vector<ParameterSet> >();
+    auto vpset = std::make_unique<std::vector<ParameterSet>>();
     std::swap(*vpset, it->second.vpsetForUpdate());
     vpsetTable_.erase(it);
     return vpset;

--- a/FWCore/ParameterSet/src/ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescription.cc
@@ -57,32 +57,32 @@ namespace edm {
   ParameterDescriptionNode*
   ParameterSetDescription::
   addNode(ParameterDescriptionNode const& node) {
-    std::auto_ptr<ParameterDescriptionNode> clonedNode(node.clone());
-    return addNode(clonedNode, false, true);
+    std::unique_ptr<ParameterDescriptionNode> clonedNode(node.clone());
+    return addNode(std::move(clonedNode), false, true);
   }
 
   ParameterDescriptionNode*
   ParameterSetDescription::
-  addNode(std::auto_ptr<ParameterDescriptionNode> node) {
-    return addNode(node, false, true);
+  addNode(std::unique_ptr<ParameterDescriptionNode> node) {
+    return addNode(std::move(node), false, true);
   }
 
   ParameterDescriptionNode*
   ParameterSetDescription::
   addOptionalNode(ParameterDescriptionNode const& node, bool writeToCfi) {
-    std::auto_ptr<ParameterDescriptionNode> clonedNode(node.clone());
-    return addNode(clonedNode, true, writeToCfi);
+    std::unique_ptr<ParameterDescriptionNode> clonedNode(node.clone());
+    return addNode(std::move(clonedNode), true, writeToCfi);
   }
 
   ParameterDescriptionNode*
   ParameterSetDescription::
-  addOptionalNode(std::auto_ptr<ParameterDescriptionNode> node, bool writeToCfi) {
-    return addNode(node, true, writeToCfi);
+  addOptionalNode(std::unique_ptr<ParameterDescriptionNode> node, bool writeToCfi) {
+    return addNode(std::move(node), true, writeToCfi);
   }
 
   ParameterDescriptionNode*
   ParameterSetDescription::
-  addNode(std::auto_ptr<ParameterDescriptionNode> node,
+  addNode(std::unique_ptr<ParameterDescriptionNode> node,
       bool optional,
       bool writeToCfi) {
   
@@ -97,7 +97,7 @@ namespace edm {
     entry.setOptional(optional);
     entry.setWriteToCfi(writeToCfi);
     entries_.push_back(entry);
-    return entries_.back().setNode(node);
+    return entries_.back().setNode(std::move(node));
   }
 
   void
@@ -400,7 +400,7 @@ namespace edm {
   ifExists(ParameterDescriptionNode const& node1,
            ParameterDescriptionNode const& node2,
            bool optional, bool writeToCfi) {
-    std::auto_ptr<ParameterDescriptionNode> pdIfExists(new IfExistsDescription(node1, node2));
-    return addNode(pdIfExists, optional, writeToCfi);
+    std::unique_ptr<ParameterDescriptionNode> pdIfExists = std::make_unique<IfExistsDescription>(node1, node2);
+    return addNode(std::move(pdIfExists), optional, writeToCfi);
   }
 }

--- a/FWCore/ParameterSet/src/ParameterSetEntry.cc
+++ b/FWCore/ParameterSet/src/ParameterSetEntry.cc
@@ -91,7 +91,7 @@ namespace edm {
 
   void ParameterSetEntry::fillPSet() const {
     if(nullptr == thePSet_.load()) {
-      std::unique_ptr<ParameterSet> tmp(new ParameterSet(getParameterSet(theID_)));
+      auto tmp = std::make_unique<ParameterSet>(getParameterSet(theID_));
       ParameterSet* expected = nullptr;
       if(thePSet_.compare_exchange_strong(expected, tmp.get())) {
         // thePSet_ was equal to nullptr and now is equal to tmp.get()

--- a/FWCore/ParameterSet/src/VParameterSetEntry.cc
+++ b/FWCore/ParameterSet/src/VParameterSetEntry.cc
@@ -92,7 +92,7 @@ namespace edm {
 
   void VParameterSetEntry::fillVPSet() const {
     if(nullptr == theVPSet_.load()) {
-      std::unique_ptr<std::vector<ParameterSet> > tmp(new std::vector<ParameterSet>);
+      auto tmp = std::make_unique<std::vector<ParameterSet>>();
       tmp->reserve(theIDs_->size());
       for (auto const& theID : *theIDs_) {
         tmp->push_back(getParameterSet(theID));

--- a/FWCore/ParameterSet/src/XORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/XORGroupDescription.cc
@@ -16,24 +16,24 @@ namespace edm {
   }
 
   XORGroupDescription::
-  XORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
+  XORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                       ParameterDescriptionNode const& node_right) :
-    node_left_(node_left),
+    node_left_(std::move(node_left)),
     node_right_(node_right.clone()) {
   }
 
   XORGroupDescription::
   XORGroupDescription(ParameterDescriptionNode const& node_left,
-                      std::auto_ptr<ParameterDescriptionNode> node_right) :
+                      std::unique_ptr<ParameterDescriptionNode> node_right) :
     node_left_(node_left.clone()),
-    node_right_(node_right) {
+    node_right_(std::move(node_right)) {
   }
 
   XORGroupDescription::
-  XORGroupDescription(std::auto_ptr<ParameterDescriptionNode> node_left,
-                      std::auto_ptr<ParameterDescriptionNode> node_right) :
-    node_left_(node_left),
-    node_right_(node_right) {
+  XORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
+                      std::unique_ptr<ParameterDescriptionNode> node_right) :
+    node_left_(std::move(node_left)),
+    node_right_(std::move(node_right)) {
   }
 
   void

--- a/FWCore/ParameterSet/test/parameterSetDescription_t.cc
+++ b/FWCore/ParameterSet/test/parameterSetDescription_t.cc
@@ -438,7 +438,7 @@ namespace testParameterSetDescription {
 
   void testXor() {
     edm::ParameterSetDescription psetDesc1;
-    std::auto_ptr<edm::ParameterDescriptionNode> node1(
+    std::unique_ptr<edm::ParameterDescriptionNode> node1(
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) and
                edm::ParameterDescription<double>("x2", 101.0, true)) xor
@@ -461,7 +461,7 @@ namespace testParameterSetDescription {
     assert(node1->howManyXORSubNodesExist(pset2) == 4);
 
     // 0 of the options existing should fail validation
-    psetDesc1.addNode(node1);
+    psetDesc1.addNode(std::move(node1));
     try {
       psetDesc1.validate(pset1);
       assert(0);
@@ -478,7 +478,7 @@ namespace testParameterSetDescription {
     // One of the labels cannot already exist in the description
     edm::ParameterSetDescription psetDesc2;
     psetDesc2.add<unsigned>("xvalue1", 1U);
-    std::auto_ptr<edm::ParameterDescriptionNode> node2(
+    std::unique_ptr<edm::ParameterDescriptionNode> node2(
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) and
                edm::ParameterDescription<double>("x2", 101.0, true)) xor
@@ -486,21 +486,21 @@ namespace testParameterSetDescription {
               (edm::ParameterDescription<double>("xvalue1", 101.0, true) or
                edm::ParameterDescription<double>("x2", 101.0, true)));
     try {
-      psetDesc2.addNode(node2);
+      psetDesc2.addNode(std::move(node2));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
 
     // One of the labels cannot already exist in the description, other order
     edm::ParameterSetDescription psetDesc3;
-    std::auto_ptr<edm::ParameterDescriptionNode> node3(
+    std::unique_ptr<edm::ParameterDescriptionNode> node3(
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) and
                edm::ParameterDescription<double>("x2", 101.0, true)) xor
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("xvalue1", 101.0, true) or
                edm::ParameterDescription<double>("x2", 101.0, true)));
-    psetDesc3.addNode(node3);
+    psetDesc3.addNode(std::move(node3));
     try {
       psetDesc3.add<unsigned>("xvalue1", 1U);
       assert(0);
@@ -509,14 +509,14 @@ namespace testParameterSetDescription {
 
     // A parameter cannot use the same type as a wildcard
     edm::ParameterSetDescription psetDesc4;
-    std::auto_ptr<edm::ParameterDescriptionNode> node4(
+    std::unique_ptr<edm::ParameterDescriptionNode> node4(
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) and
                edm::ParameterDescription<unsigned>("x2", 101, true)) xor
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) or
                edm::ParameterDescription<double>("x2", 101.0, true)));
-    psetDesc4.addNode(node4);
+    psetDesc4.addNode(std::move(node4));
 
     edm::ParameterWildcard<unsigned> w4("*", edm::RequireAtLeastOne, true);
     try {
@@ -527,14 +527,14 @@ namespace testParameterSetDescription {
 
     // A parameter cannot use the same type as a wildcard
     edm::ParameterSetDescription psetDesc5;
-    std::auto_ptr<edm::ParameterDescriptionNode> node5(
+    std::unique_ptr<edm::ParameterDescriptionNode> node5(
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) and
                edm::ParameterWildcard<unsigned>("*", edm::RequireAtLeastOne, true)) xor
               edm::ParameterDescription<double>("x1", 101.0, true) xor
               (edm::ParameterDescription<double>("x1", 101.0, true) or
                edm::ParameterWildcard<unsigned>("*", edm::RequireAtLeastOne, true)));
-    psetDesc5.addNode(node5);
+    psetDesc5.addNode(std::move(node5));
 
     edm::ParameterDescription<unsigned> n5("z5", edm::RequireAtLeastOne, true);
     try {
@@ -549,7 +549,7 @@ namespace testParameterSetDescription {
   void testOr() {
 
     edm::ParameterSetDescription psetDesc1;
-    std::auto_ptr<edm::ParameterDescriptionNode> node1(
+    std::unique_ptr<edm::ParameterDescriptionNode> node1(
               edm::ParameterDescription<double>("x1", 101.0, true) or
               (edm::ParameterDescription<double>("x2", 101.0, true) and
                edm::ParameterDescription<double>("x3", 101.0, true)) or
@@ -575,7 +575,7 @@ namespace testParameterSetDescription {
     assert(node1->howManyXORSubNodesExist(pset2) == 1);
 
     // 0 of the options existing should fail validation
-    psetDesc1.addNode(node1);
+    psetDesc1.addNode(std::move(node1));
     psetDesc1.validate(pset1);
 
     // More than one of the options existing should succeed
@@ -584,25 +584,25 @@ namespace testParameterSetDescription {
     // One of the labels cannot already exist in the description
     edm::ParameterSetDescription psetDesc2;
     psetDesc2.add<unsigned>("x1", 1U);
-    std::auto_ptr<edm::ParameterDescriptionNode> node2(
+    std::unique_ptr<edm::ParameterDescriptionNode> node2(
               edm::ParameterDescription<double>("x1", 101.0, true) or
               (edm::ParameterDescription<double>("x2", 101.0, true) and
                edm::ParameterDescription<double>("x3", 101.0, true)) or
               edm::ParameterDescription<double>("x4", 101.0, true));
     try {
-      psetDesc2.addNode(node2);
+      psetDesc2.addNode(std::move(node2));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
 
     // One of the labels cannot already exist in the description, other order
     edm::ParameterSetDescription psetDesc3;
-    std::auto_ptr<edm::ParameterDescriptionNode> node3(
+    std::unique_ptr<edm::ParameterDescriptionNode> node3(
               edm::ParameterDescription<double>("x1", 101.0, true) or
               (edm::ParameterDescription<double>("x2", 101.0, true) and
                edm::ParameterDescription<double>("x3", 101.0, true)) or
               edm::ParameterDescription<double>("x4", 101.0, true));
-    psetDesc3.addNode(node3);
+    psetDesc3.addNode(std::move(node3));
 
     try {
       psetDesc3.add<unsigned>("x1", 1U);
@@ -612,13 +612,13 @@ namespace testParameterSetDescription {
 
     // Put the duplicate labels in different nodes of the "or" expression
     edm::ParameterSetDescription psetDesc4;
-    std::auto_ptr<edm::ParameterDescriptionNode> node4(
+    std::unique_ptr<edm::ParameterDescriptionNode> node4(
               edm::ParameterDescription<double>("x1", 101.0, true) or
               (edm::ParameterDescription<double>("x2", 101.0, true) and
                edm::ParameterDescription<double>("x3", 101.0, true)) or
               edm::ParameterDescription<double>("x1", 101.0, true));
     try {
-      psetDesc4.addNode(node4);
+      psetDesc4.addNode(std::move(node4));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -626,13 +626,13 @@ namespace testParameterSetDescription {
     // A type used in a wildcard should not be the same as a type
     // used for another parameter
     edm::ParameterSetDescription psetDesc5;
-    std::auto_ptr<edm::ParameterDescriptionNode> node5(
+    std::unique_ptr<edm::ParameterDescriptionNode> node5(
               edm::ParameterWildcard<double>("*", edm::RequireAtLeastOne, true) or
               (edm::ParameterDescription<double>("x2", 101.0, true) and
                edm::ParameterDescription<unsigned>("x3", 101U, true)) or
               edm::ParameterDescription<unsigned>("x1", 101U, true));
     try {
-      psetDesc5.addNode(node5);
+      psetDesc5.addNode(std::move(node5));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -641,13 +641,13 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc6;
     psetDesc6.add<double>("x0", 1.0);
-    std::auto_ptr<edm::ParameterDescriptionNode> node6(
+    std::unique_ptr<edm::ParameterDescriptionNode> node6(
               edm::ParameterWildcard<double>("*", edm::RequireAtLeastOne, true) or
               (edm::ParameterDescription<unsigned>("x2", 101U, true) and
                edm::ParameterDescription<unsigned>("x3", 101U, true)) or
               edm::ParameterDescription<unsigned>("x1", 101U, true));
     try {
-      psetDesc6.addNode(node6);
+      psetDesc6.addNode(std::move(node6));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -656,13 +656,13 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc7;
     psetDesc7.addWildcard<double>("*");
-    std::auto_ptr<edm::ParameterDescriptionNode> node7(
+    std::unique_ptr<edm::ParameterDescriptionNode> node7(
               edm::ParameterDescription<double>("x0", 1.0, true) or
               (edm::ParameterDescription<unsigned>("x2", 101U, true) and
                edm::ParameterDescription<unsigned>("x3", 101U, true)) or
               edm::ParameterDescription<unsigned>("x1", 101U, true));
     try {
-      psetDesc7.addNode(node7);
+      psetDesc7.addNode(std::move(node7));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -673,7 +673,7 @@ namespace testParameterSetDescription {
   void testAnd() {
 
     edm::ParameterSetDescription psetDesc1;
-    std::auto_ptr<edm::ParameterDescriptionNode> node1(
+    std::unique_ptr<edm::ParameterDescriptionNode> node1(
               edm::ParameterDescription<double>("x1", 101.0, true) and
               (edm::ParameterDescription<double>("x2", 101.0, true) or
                edm::ParameterDescription<double>("x3", 101.0, true)) and
@@ -705,7 +705,7 @@ namespace testParameterSetDescription {
     assert(node1->partiallyExists(pset3) == true);
     assert(node1->howManyXORSubNodesExist(pset3) == 0);
 
-    psetDesc1.addNode(node1);
+    psetDesc1.addNode(std::move(node1));
     psetDesc1.validate(pset1);
     psetDesc1.validate(pset2);
     psetDesc1.validate(pset3);
@@ -713,25 +713,25 @@ namespace testParameterSetDescription {
     // One of the labels cannot already exist in the description
     edm::ParameterSetDescription psetDesc2;
     psetDesc2.add<unsigned>("x1", 1U);
-    std::auto_ptr<edm::ParameterDescriptionNode> node2(
+    std::unique_ptr<edm::ParameterDescriptionNode> node2(
               edm::ParameterDescription<double>("x1", 101.0, true) and
               (edm::ParameterDescription<double>("x2", 101.0, true) or
                edm::ParameterDescription<double>("x3", 101.0, true)) and
               edm::ParameterDescription<double>("x4", 101.0, true));
     try {
-      psetDesc2.addNode(node2);
+      psetDesc2.addNode(std::move(node2));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
 
     // One of the labels cannot already exist in the description, other order
     edm::ParameterSetDescription psetDesc3;
-    std::auto_ptr<edm::ParameterDescriptionNode> node3(
+    std::unique_ptr<edm::ParameterDescriptionNode> node3(
               edm::ParameterDescription<double>("x1", 101.0, true) and
               (edm::ParameterDescription<double>("x2", 101.0, true) or
                edm::ParameterDescription<double>("x3", 101.0, true)) and
               edm::ParameterDescription<double>("x4", 101.0, true));
-    psetDesc3.addNode(node3);
+    psetDesc3.addNode(std::move(node3));
 
     try {
       psetDesc3.add<unsigned>("x1", 1U);
@@ -741,13 +741,13 @@ namespace testParameterSetDescription {
 
     // Put the duplicate labels in different nodes of the "and" expression
     edm::ParameterSetDescription psetDesc4;
-    std::auto_ptr<edm::ParameterDescriptionNode> node4(
+    std::unique_ptr<edm::ParameterDescriptionNode> node4(
               edm::ParameterDescription<double>("x1", 101.0, true) and
               (edm::ParameterDescription<double>("x2", 101.0, true) or
                edm::ParameterDescription<double>("x3", 101.0, true)) and
               edm::ParameterDescription<double>("x1", 101.0, true));
     try {
-      psetDesc4.addNode(node4);
+      psetDesc4.addNode(std::move(node4));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -755,13 +755,13 @@ namespace testParameterSetDescription {
     // A type used in a wildcard should not be the same as a type
     // used for another parameter
     edm::ParameterSetDescription psetDesc5;
-    std::auto_ptr<edm::ParameterDescriptionNode> node5(
+    std::unique_ptr<edm::ParameterDescriptionNode> node5(
               edm::ParameterWildcard<double>("*", edm::RequireAtLeastOne, true) and
               (edm::ParameterDescription<double>("x2", 101.0, true) or
                edm::ParameterDescription<unsigned>("x3", 101U, true)) and
               edm::ParameterDescription<unsigned>("x1", 101U, true));
     try {
-      psetDesc5.addNode(node5);
+      psetDesc5.addNode(std::move(node5));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -770,13 +770,13 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc6;
     psetDesc6.add<double>("x0", 1.0);
-    std::auto_ptr<edm::ParameterDescriptionNode> node6(
+    std::unique_ptr<edm::ParameterDescriptionNode> node6(
               edm::ParameterWildcard<double>("*", edm::RequireAtLeastOne, true) and
               (edm::ParameterDescription<unsigned>("x2", 101U, true) or
                edm::ParameterDescription<unsigned>("x3", 101U, true)) and
               edm::ParameterDescription<unsigned>("x1", 101U, true));
     try {
-      psetDesc6.addNode(node6);
+      psetDesc6.addNode(std::move(node6));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -785,13 +785,13 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc7;
     psetDesc7.addWildcard<double>("*");
-    std::auto_ptr<edm::ParameterDescriptionNode> node7(
+    std::unique_ptr<edm::ParameterDescriptionNode> node7(
               edm::ParameterDescription<double>("x0", 1.0, true) and
               (edm::ParameterDescription<unsigned>("x2", 101U, true) or
                edm::ParameterDescription<unsigned>("x3", 101U, true)) and
               edm::ParameterDescription<unsigned>("x1", 101U, true));
     try {
-      psetDesc7.addNode(node7);
+      psetDesc7.addNode(std::move(node7));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -802,20 +802,20 @@ namespace testParameterSetDescription {
   void testIfExists() {
 
     edm::ParameterSetDescription psetDesc1;
-    std::auto_ptr<edm::ParameterDescriptionNode> node1(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node1(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterDescription<double>("x1", 101.0, true),
         (edm::ParameterDescription<double>("x2", 101.0, true) and
          edm::ParameterDescription<double>("x3", 101.0, true))));
 
-    std::auto_ptr<edm::ParameterDescriptionNode> node1a(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node1a(
+      std::make_unique<edm::IfExistsDescription>(
         (edm::ParameterDescription<double>("x2", 101.0, true) and
          edm::ParameterDescription<double>("x3", 101.0, true)),
         edm::ParameterDescription<double>("x1", 101.0, true)));
 
-    std::auto_ptr<edm::ParameterDescriptionNode> node1b(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node1b(
+      std::make_unique<edm::IfExistsDescription>(
         (edm::ParameterDescription<double>("x1", 101.0, true) xor
          edm::ParameterDescription<int>("x1", 101, true)),
         (edm::ParameterDescription<double>("x2", 101.0, true) and
@@ -859,7 +859,7 @@ namespace testParameterSetDescription {
     assert(node1a->exists(pset4) == false);
     assert(node1b->exists(pset4) == false);
 
-    psetDesc1.addNode(node1);
+    psetDesc1.addNode(std::move(node1));
     psetDesc1.validate(pset1);
     psetDesc1.validate(pset2);
     psetDesc1.validate(pset3);
@@ -868,26 +868,26 @@ namespace testParameterSetDescription {
     // One of the labels cannot already exist in the description
     edm::ParameterSetDescription psetDesc2;
     psetDesc2.add<unsigned>("x1", 1U);
-    std::auto_ptr<edm::ParameterDescriptionNode> node2(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node2(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterDescription<double>("x1", 101.0, true),
         (edm::ParameterDescription<double>("x2", 101.0, true) and
          edm::ParameterDescription<double>("x3", 101.0, true))));
 
     try {
-      psetDesc2.addNode(node2);
+      psetDesc2.addNode(std::move(node2));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
 
     // One of the labels cannot already exist in the description, other order
     edm::ParameterSetDescription psetDesc3;
-    std::auto_ptr<edm::ParameterDescriptionNode> node3(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node3(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterDescription<double>("x1", 101.0, true),
         (edm::ParameterDescription<double>("x2", 101.0, true) and
          edm::ParameterDescription<double>("x3", 101.0, true))));
-    psetDesc3.addNode(node3);
+    psetDesc3.addNode(std::move(node3));
 
     try {
       psetDesc3.add<unsigned>("x1", 1U);
@@ -897,13 +897,13 @@ namespace testParameterSetDescription {
 
     // Put the duplicate labels in different nodes of the "and" expression
     edm::ParameterSetDescription psetDesc4;
-    std::auto_ptr<edm::ParameterDescriptionNode> node4(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node4(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterDescription<double>("x1", 101.0, true),
         (edm::ParameterDescription<double>("x2", 101.0, true) and
          edm::ParameterDescription<double>("x1", 101.0, true))));
     try {
-      psetDesc4.addNode(node4);
+      psetDesc4.addNode(std::move(node4));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -911,13 +911,13 @@ namespace testParameterSetDescription {
     // A type used in a wildcard should not be the same as a type
     // used for another parameter
     edm::ParameterSetDescription psetDesc5;
-    std::auto_ptr<edm::ParameterDescriptionNode> node5(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node5(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterDescription<double>("x1", 101.0, true),
         (edm::ParameterDescription<unsigned>("x2", 101U, true) and
          edm::ParameterWildcard<double>("*", edm::RequireAtLeastOne, true))));
     try {
-      psetDesc5.addNode(node5);
+      psetDesc5.addNode(std::move(node5));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -926,13 +926,13 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc6;
     psetDesc6.add<double>("x0", 1.0);
-    std::auto_ptr<edm::ParameterDescriptionNode> node6(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node6(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterWildcard<double>("*", edm::RequireAtLeastOne, true),
         (edm::ParameterDescription<unsigned>("x2", 101U, true) and
          edm::ParameterDescription<unsigned>("x3", 102U, true))));
     try {
-      psetDesc6.addNode(node6);
+      psetDesc6.addNode(std::move(node6));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -941,13 +941,13 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc7;
     psetDesc7.addWildcard<double>("*");
-    std::auto_ptr<edm::ParameterDescriptionNode> node7(
-      new edm::IfExistsDescription(
+    std::unique_ptr<edm::ParameterDescriptionNode> node7(
+      std::make_unique<edm::IfExistsDescription>(
         edm::ParameterDescription<double>("x1", 11.0, true),
         (edm::ParameterDescription<unsigned>("x2", 101U, true) and
          edm::ParameterDescription<unsigned>("x3", 102U, true))));
     try {
-      psetDesc7.addNode(node7);
+      psetDesc7.addNode(std::move(node7));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -958,8 +958,8 @@ namespace testParameterSetDescription {
   void testAllowedLabels() {
 
     edm::ParameterSetDescription psetDesc1;
-    std::auto_ptr<edm::ParameterDescriptionNode> node1(
-      new edm::AllowedLabelsDescription<int>("allowedLabels", true));
+    std::unique_ptr<edm::ParameterDescriptionNode> node1(
+      std::make_unique<edm::AllowedLabelsDescription<int>>("allowedLabels", true));
 
     edm::ParameterSet pset1;
 
@@ -978,11 +978,11 @@ namespace testParameterSetDescription {
     // One of the labels cannot already exist in the description
     edm::ParameterSetDescription psetDesc2;
     psetDesc2.add<unsigned>("x1", 1U);
-    std::auto_ptr<edm::ParameterDescriptionNode> node2(
-      new edm::AllowedLabelsDescription<int>("x1", true));
+    std::unique_ptr<edm::ParameterDescriptionNode> node2(
+      std::make_unique<edm::AllowedLabelsDescription<int>>("x1", true));
 
     try {
-      psetDesc2.addNode(node2);
+      psetDesc2.addNode(std::move(node2));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }
@@ -991,10 +991,10 @@ namespace testParameterSetDescription {
     // used for another parameter node
     edm::ParameterSetDescription psetDesc3;
     psetDesc3.addWildcard<std::vector<std::string> >("*");
-    std::auto_ptr<edm::ParameterDescriptionNode> node3(
-      new edm::AllowedLabelsDescription<int>("x1", true));
+    std::unique_ptr<edm::ParameterDescriptionNode> node3(
+      std::make_unique<edm::AllowedLabelsDescription<int>>("x1", true));
     try {
-      psetDesc3.addNode(node3);
+      psetDesc3.addNode(std::move(node3));
       assert(0);
     }
     catch(edm::Exception const&) { /* There should be an exception */ }

--- a/FWCore/PluginManager/interface/PresenceFactory.h
+++ b/FWCore/PluginManager/interface/PresenceFactory.h
@@ -18,7 +18,7 @@ namespace edm {
 
     static PresenceFactory* get();
 
-    std::auto_ptr<Presence>
+    std::unique_ptr<Presence>
       makePresence(std::string const & presence_type) const;
 
   private:

--- a/FWCore/PluginManager/src/PresenceFactory.cc
+++ b/FWCore/PluginManager/src/PresenceFactory.cc
@@ -20,10 +20,10 @@ namespace edm {
     return &singleInstance_;
   }
 
-  std::auto_ptr<Presence>
+  std::unique_ptr<Presence>
   PresenceFactory::
   makePresence(std::string const & presence_type) const {
-    std::auto_ptr<Presence> sp(PresencePluginFactory::get()->create(presence_type));
+    std::unique_ptr<Presence> sp(PresencePluginFactory::get()->create(presence_type));
 
     if(sp.get()==0) {
 	throw edm::Exception(errors::Configuration, "NoPresenceModule")

--- a/FWCore/PluginManager/test/pluginfactory_t.cc
+++ b/FWCore/PluginManager/test/pluginfactory_t.cc
@@ -62,7 +62,7 @@ TestPluginFactory::test()
 {
   using namespace edmplugin;
   
-  std::auto_ptr<edmplugintest::DummyBase> p(FactoryType::get()->create("Dummy"));
+  std::unique_ptr<edmplugintest::DummyBase> p(FactoryType::get()->create("Dummy"));
   CPPUNIT_ASSERT(0 != p.get());
 }  
 
@@ -72,6 +72,6 @@ TestPluginFactory::testTry()
   using namespace edmplugin;
   CPPUNIT_ASSERT(0 == FactoryType::get()->tryToCreate("ThisDoesNotExist"));
   
-  std::auto_ptr<edmplugintest::DummyBase> p(FactoryType::get()->tryToCreate("Dummy"));
+  std::unique_ptr<edmplugintest::DummyBase> p(FactoryType::get()->tryToCreate("Dummy"));
   CPPUNIT_ASSERT(0 != p.get());
 }  

--- a/FWCore/PluginManager/test/pluginmanager_t.cc
+++ b/FWCore/PluginManager/test/pluginmanager_t.cc
@@ -99,13 +99,13 @@ TestPluginManager::test()
   edmplugin::PluginManager::get()->justLoaded_.connect([&nTimesLoaded](const edmplugin::SharedLibrary&){++nTimesLoaded;});
   
   toLoadPlugin="DummyOne";
-  std::auto_ptr<DummyBase> ptr(DummyFactory::get()->create("DummyOne"));
+  std::unique_ptr<DummyBase> ptr(DummyFactory::get()->create("DummyOne"));
   CPPUNIT_ASSERT(1==ptr->value());
   CPPUNIT_ASSERT(nTimesAsked == 1);
   CPPUNIT_ASSERT(nTimesGoingToLoad==1);
   CPPUNIT_ASSERT(nTimesLoaded==1);
   CPPUNIT_ASSERT(db.loadableFor("Test Dummy", "DummyThree") == "static");
-  std::auto_ptr<DummyBase> ptr2(DummyFactory::get()->create("DummyThree"));
+  std::unique_ptr<DummyBase> ptr2(DummyFactory::get()->create("DummyThree"));
   CPPUNIT_ASSERT(3==ptr2->value());
   CPPUNIT_ASSERT(nTimesAsked == 1); //no request to load
   CPPUNIT_ASSERT(nTimesGoingToLoad==1);

--- a/FWCore/ROOTTests/test/tprofile_threaded_t.cc
+++ b/FWCore/ROOTTests/test/tprofile_threaded_t.cc
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
   
   for(int i=0; i<kNThreads; ++i) {
     std::ostringstream s;
-    profiles.push_back(std::unique_ptr<TProfile>(new TProfile(s.str().c_str(),s.str().c_str(), 100,10,11,0,10)));
+    profiles.push_back(std::make_unique<TProfile>(s.str().c_str(),s.str().c_str(), 100,10,11,0,10));
     profiles.back()->SetCanExtend(TH1::kAllAxes);
     auto profile = profiles.back().get();
     threads.emplace_back([i,profile,&canStart]() {

--- a/FWCore/ServiceRegistry/interface/ServiceMaker.h
+++ b/FWCore/ServiceRegistry/interface/ServiceMaker.h
@@ -46,25 +46,25 @@ namespace edm {
       template<typename T, typename TConcrete = T>
          struct AllArgsMaker : public MakerBase<T, TConcrete> {
 
-         std::auto_ptr<T> make(ParameterSet const& iPS,
+         std::unique_ptr<T> make(ParameterSet const& iPS,
                                ActivityRegistry& iAR) const {
-            return std::auto_ptr<T>(new TConcrete(iPS, iAR));
+            return std::make_unique<TConcrete>(iPS, iAR);
          }
       };
 
       template<typename T, typename TConcrete = T>
       struct ParameterSetMaker : public MakerBase<T, TConcrete> {
-         std::auto_ptr<T> make(ParameterSet const& iPS,
+         std::unique_ptr<T> make(ParameterSet const& iPS,
                                ActivityRegistry& /* iAR */) const {
-            return std::auto_ptr<T>(new TConcrete(iPS));
+            return std::make_unique<TConcrete>(iPS);
          }
       };
 
       template<typename T, typename TConcrete = T>
       struct NoArgsMaker : public MakerBase<T, TConcrete> {
-         std::auto_ptr<T> make(ParameterSet const& /* iPS */,
+         std::unique_ptr<T> make(ParameterSet const& /* iPS */,
                                ActivityRegistry& /* iAR */) const {
-            return std::auto_ptr<T>(new TConcrete());
+            return std::make_unique<TConcrete>();
          }
       };
 
@@ -82,8 +82,8 @@ public:
                            ActivityRegistry& iAR,
                            ServicesManager& oSM) const {
             TMaker maker;
-            std::auto_ptr<T> pService(maker.make(iPS, iAR));
-            auto ptr = std::make_shared<ServiceWrapper<T> >(pService);
+            std::unique_ptr<T> pService(maker.make(iPS, iAR));
+            auto ptr = std::make_shared<ServiceWrapper<T> >(std::move(pService));
             return oSM.put(ptr);
          }
 

--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -97,20 +97,20 @@ namespace edm {
                                     bool associate = true);
       /// create a service token that holds the service defined by iService
       template<typename T>
-      static ServiceToken createContaining(std::auto_ptr<T> iService){
+      static ServiceToken createContaining(std::unique_ptr<T> iService){
          std::vector<edm::ParameterSet> config;
          auto manager = std::make_shared<serviceregistry::ServicesManager>(config);
-         auto wrapper = std::make_shared<serviceregistry::ServiceWrapper<T> >(iService);
+         auto wrapper = std::make_shared<serviceregistry::ServiceWrapper<T> >(std::move(iService));
          manager->put(wrapper);
          return manager;
       }
       template<typename T>
-      static ServiceToken createContaining(std::auto_ptr<T> iService,
+      static ServiceToken createContaining(std::unique_ptr<T> iService,
                                            ServiceToken iToken,
                                            serviceregistry::ServiceLegacy iLegacy){
          std::vector<edm::ParameterSet> config;
          auto manager = std::make_shared<serviceregistry::ServicesManager>(iToken, iLegacy, config);
-         auto wrapper = std::make_shared<serviceregistry::ServiceWrapper<T> >(iService);
+         auto wrapper = std::make_shared<serviceregistry::ServiceWrapper<T> >(std::move(iService));
          manager->put(wrapper);
          return manager;
       }

--- a/FWCore/ServiceRegistry/interface/ServiceWrapper.h
+++ b/FWCore/ServiceRegistry/interface/ServiceWrapper.h
@@ -37,8 +37,8 @@ namespace edm {
       {
 
 public:
-         ServiceWrapper(std::auto_ptr<T> iService) :
-         service_(iService) {}
+         ServiceWrapper(std::unique_ptr<T> iService) :
+         service_(std::move(iService)) {}
          //virtual ~ServiceWrapper();
          
          // ---------- const member functions ---------------------
@@ -55,7 +55,7 @@ private:
          const ServiceWrapper& operator=(const ServiceWrapper&); // stop default
          
          // ---------- member data --------------------------------
-         edm::propagate_const<std::auto_ptr<T>> service_;
+         edm::propagate_const<std::unique_ptr<T>> service_;
          
       };
    }

--- a/FWCore/ServiceRegistry/src/ServicesManager.cc
+++ b/FWCore/ServiceRegistry/src/ServicesManager.cc
@@ -293,7 +293,7 @@ namespace edm {
            if(itMaker != type2Maker_->end()) {
 
              std::string serviceType = itMaker->second.pset_->getParameter<std::string>("@service_type");
-             std::auto_ptr<ParameterSetDescriptionFillerBase> filler(
+             std::unique_ptr<ParameterSetDescriptionFillerBase> filler(
                ParameterSetDescriptionFillerPluginFactory::get()->create(serviceType));
              ConfigurationDescriptions descriptions(filler->baseType());
              filler->fill(descriptions);

--- a/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
+++ b/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
@@ -77,9 +77,9 @@ testServiceRegistry::externalServiceTest()
    edm::AssertHandler ah;
 
    {
-      std::auto_ptr<DummyService> dummyPtr(new DummyService);
+      auto dummyPtr = std::make_unique<DummyService>();
       dummyPtr->value_ = 2;
-      edm::ServiceToken token(edm::ServiceRegistry::createContaining(dummyPtr));
+      edm::ServiceToken token(edm::ServiceRegistry::createContaining(std::move(dummyPtr)));
       {         
          edm::ServiceRegistry::Operate operate(token);
          edm::Service<DummyService> dummy;
@@ -98,7 +98,7 @@ testServiceRegistry::externalServiceTest()
          pss.push_back(ps);
       
          edm::ServiceToken token(edm::ServiceRegistry::createSet(pss));
-         edm::ServiceToken token2(edm::ServiceRegistry::createContaining(dummyPtr,
+         edm::ServiceToken token2(edm::ServiceRegistry::createContaining(std::move(dummyPtr),
                                                                          token,
                                                                          edm::serviceregistry::kOverlapIsError));
          
@@ -111,8 +111,8 @@ testServiceRegistry::externalServiceTest()
    }
 
    {
-      std::auto_ptr<DummyService> dummyPtr(new DummyService);
-      auto wrapper = std::make_shared<edm::serviceregistry::ServiceWrapper<DummyService> >(dummyPtr);
+      auto dummyPtr = std::make_unique<DummyService>();
+      auto wrapper = std::make_shared<edm::serviceregistry::ServiceWrapper<DummyService> >(std::move(dummyPtr));
       edm::ServiceToken token(edm::ServiceRegistry::createContaining(wrapper));
 
       wrapper->get().value_ = 2;
@@ -135,7 +135,7 @@ testServiceRegistry::externalServiceTest()
          pss.push_back(ps);
          
          edm::ServiceToken token(edm::ServiceRegistry::createSet(pss));
-         edm::ServiceToken token2(edm::ServiceRegistry::createContaining(dummyPtr,
+         edm::ServiceToken token2(edm::ServiceRegistry::createContaining(std::move(dummyPtr),
                                                                          token,
                                                                          edm::serviceregistry::kOverlapIsError));
          

--- a/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
+++ b/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
@@ -47,9 +47,7 @@ int main() try {
 
   edm::ActivityRegistry ar;
   edm::ParameterSet pset;
-  std::auto_ptr<Service0> s0(new Service0(pset, ar));  
-  auto wrapper = std::make_shared<ServiceWrapper<Service0> >(s0);
-  legacy->put(wrapper);
+  legacy->put(std::make_shared<ServiceWrapper<Service0>>(std::make_unique<Service0>(pset, ar)));
   legacy->copySlotsFrom(ar);
   edm::ServiceToken legacyToken = TestServicesManagerOrder::makeToken(legacy);
 
@@ -83,9 +81,7 @@ int main() try {
 
   edm::ActivityRegistry ar4;
   edm::ParameterSet pset4;
-  std::auto_ptr<Service4> s4(new Service4(pset4, ar4));  
-  auto wrapper4 = std::make_shared<ServiceWrapper<Service4> >(s4);
-  sm.put(wrapper4);
+  sm.put(std::make_shared<ServiceWrapper<Service4>>(std::make_unique<Service4>(pset4, ar4)));
   sm.copySlotsFrom(ar4);
 
 

--- a/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
@@ -72,8 +72,7 @@ testServicesManager::putGetTest()
    }
    CPPUNIT_ASSERT(exceptionThrown);
    
-   std::auto_ptr< DummyService > pService(new DummyService);
-   auto ptrWrapper = std::make_shared<ServiceWrapper<DummyService> >(pService);
+   auto ptrWrapper = std::make_shared<ServiceWrapper<DummyService>>(std::make_unique<DummyService>());
 
    CPPUNIT_ASSERT(sm.put(ptrWrapper));
 

--- a/FWCore/Services/bin/cmsGetFnConnect.cc
+++ b/FWCore/Services/bin/cmsGetFnConnect.cc
@@ -29,8 +29,8 @@ main(int argc, char* argv[])
     }
 
     try {
-      std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-      auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
+      std::unique_ptr<edm::SiteLocalConfig> slcptr = std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
+      auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
       edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
       edm::ServiceRegistry::Operate operate(slcToken);
 

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -351,7 +351,7 @@ namespace edm {
     void
     SiteLocalConfigService::parse(std::string const& url) {
       cms::concurrency::xercesInitialize();
-      std::auto_ptr<XercesDOMParser> parser(new XercesDOMParser);
+      auto parser = std::make_unique<XercesDOMParser>();
       try {
         parser->setValidationScheme(XercesDOMParser::Val_Auto);
         parser->setDoNamespaces(false);

--- a/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
@@ -102,7 +102,7 @@ __class__::produce(const recordname& iRecord)
     out1 = []
     out2 = []
     for dtype in __datatypes__:
-        out1.append("   std::auto_ptr<%s> p%s;" % (dtype, dtype))
+        out1.append("   std::unique_ptr<%s> p%s;" % (dtype, dtype))
         out2.append("p%s" % dtype)
     output  = '\n'.join(out1)
     output += "\n   return products(%s);\n" % ','.join(out2)

--- a/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
@@ -124,8 +124,7 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    //Use the ExampleData to create an ExampleData2 which 
    // is put into the Event
-   std::unique_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
-   iEvent.put(std::move(pOut));
+   iEvent.put(std::make_unique<ExampleData2>(*pIn));
 */
 
 /* this is an EventSetup example
@@ -141,7 +140,7 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 @example_myparticle    iEvent.getByLabel( electronTags_, electrons );
 @example_myparticle    
 @example_myparticle    // create a new collection of Particle objects
-@example_myparticle    unique_ptr<MyParticleCollection> newParticles( new MyParticleCollection );
+@example_myparticle    auto newParticles = std::make_ unique<MyParticleCollection>();
 @example_myparticle 
 @example_myparticle    // if the number of electrons or muons is 4 (or 2 and 2), costruct a new particle
 @example_myparticle    if( muons->size() == 4 || electrons->size() == 4 || ( muons->size() == 2 && electrons->size() == 2 ) ) {

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/EventHypothesisProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/EventHypothesisProducer.cc
@@ -83,7 +83,7 @@ __class__Producer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup )
 
 
   // Here is where we write the hypotheses to the event stream
-  std::auto_ptr<std::vector<__class__> > ap_hyps( hyps );
-  iEvent.put( ap_hyps, outputName_);
+  std::unique_ptr<std::vector<__class__> > ap_hyps( hyps );
+  iEvent.put( std::move(ap_hyps), outputName_);
 
 }

--- a/FWCore/Skeletons/scripts/mkTemplates/TSelector/TSelector.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/TSelector/TSelector.cc
@@ -105,7 +105,7 @@ void __class__::begin(TList*& toWorkers)
 // The argument 'fromWorkers' contains the accumulated output of all Workers
 void __class__::terminate(TList& fromWorkers) {
   using namespace std;
-  std::auto_ptr<TCanvas> canvas( new TCanvas() );
+  auto canvas = std::make_unique<TCanvas>();
 //  {
 //    TObject* hist = fromWorkers.FindObject(kA);
 //    if(0!=hist) {

--- a/FWCore/Sources/interface/EventSkipperByID.h
+++ b/FWCore/Sources/interface/EventSkipperByID.h
@@ -23,7 +23,7 @@ namespace edm {
     bool skippingEvents() const {return skippingEvents_;}
     bool somethingToSkip() const {return somethingToSkip_;}
     static
-    std::auto_ptr<EventSkipperByID>create(ParameterSet const& pset);
+    std::unique_ptr<EventSkipperByID>create(ParameterSet const& pset);
     static void fillDescription(ParameterSetDescription & desc);
 
   private:

--- a/FWCore/Sources/src/EventSkipperByID.cc
+++ b/FWCore/Sources/src/EventSkipperByID.cc
@@ -30,9 +30,9 @@ namespace edm {
 
   EventSkipperByID::~EventSkipperByID() {}
 
-  std::auto_ptr<EventSkipperByID>
+  std::unique_ptr<EventSkipperByID>
   EventSkipperByID::create(ParameterSet const& pset) {
-    std::auto_ptr<EventSkipperByID> evSkp(new EventSkipperByID(pset));
+    auto evSkp = std::make_unique<EventSkipperByID>(pset);
     if (!evSkp->somethingToSkip()) {
       evSkp.reset();
     }

--- a/FWCore/Utilities/interface/ExceptionCollector.h
+++ b/FWCore/Utilities/interface/ExceptionCollector.h
@@ -41,8 +41,8 @@ namespace edm {
 
   private:
     std::string initialMessage_;
-    std::auto_ptr<cms::Exception> firstException_;
-    std::auto_ptr<cms::Exception> accumulatedExceptions_;
+    std::unique_ptr<cms::Exception> firstException_;
+    std::unique_ptr<cms::Exception> accumulatedExceptions_;
     int nExceptions_;
   };
 }

--- a/FWCore/Utilities/interface/atomic_value_ptr.h
+++ b/FWCore/Utilities/interface/atomic_value_ptr.h
@@ -103,20 +103,6 @@ namespace edm {
     }
 
     // --------------------------------------------------
-    // Copy-like construct/assign from auto_ptr<>:
-    // --------------------------------------------------
-
-    atomic_value_ptr(std::auto_ptr<T> orig) :
-      myP(orig.release()) {
-    }
-
-    atomic_value_ptr& operator=(std::auto_ptr<T> orig) {
-      atomic_value_ptr<T> local(orig);
-      exchangeWithLocal(local);
-      return *this;
-    }
-
-    // --------------------------------------------------
     // move-like construct/assign from unique_ptr<>:
     // --------------------------------------------------
 
@@ -126,7 +112,7 @@ namespace edm {
     }
 
     atomic_value_ptr& operator=(std::unique_ptr<T> orig) {
-      atomic_value_ptr<T> local(orig);
+      atomic_value_ptr<T> local(std::move(orig));
       exchangeWithLocal(local);
       return *this;
     }

--- a/FWCore/Utilities/interface/value_ptr.h
+++ b/FWCore/Utilities/interface/value_ptr.h
@@ -135,20 +135,6 @@ namespace edm {
     }
 
     // --------------------------------------------------
-    // Copy-like construct/assign from auto_ptr<>:
-    // --------------------------------------------------
-
-    value_ptr(std::auto_ptr<T> orig) :
-      myP(orig.release()) {
-    }
-
-    value_ptr& operator=(std::auto_ptr<T> orig) {
-      value_ptr<T> temp(orig);
-      swap(temp);
-      return *this;
-    }
-
-    // --------------------------------------------------
     // Move-like construct/assign from unique_ptr<>:
     // --------------------------------------------------
 
@@ -156,7 +142,7 @@ namespace edm {
       myP(orig.release()) { orig=nullptr; }
 
     value_ptr& operator=(std::unique_ptr<T> orig) {
-      value_ptr<T> temp(orig);
+      value_ptr<T> temp(std::move(orig));
       swap(temp);
       return *this;
     }

--- a/FWCore/Utilities/src/TestHelper.cc
+++ b/FWCore/Utilities/src/TestHelper.cc
@@ -25,7 +25,7 @@ int run_script(std::string const& shell, std::string const& script) {
   int status = 0;
 
   if((pid = fork()) < 0) {
-      std::cerr << "fork failed, to run " << script << std::endl;;
+      std::cerr << "fork failed, to run " << script << std::endl;
       return -1;
   }
 
@@ -89,13 +89,13 @@ int do_work(int argc, char* argv[], char** env) {
   if(!topdir) topdir = getenv("LOCALRT");
   try {
     if(!edm::untaintString(topdir, goodDirectory)) {
-      std::cerr << "Invalid top directory '" << topdir << "'" << std::endl;;
+      std::cerr << "Invalid top directory '" << topdir << "'" << std::endl;
       return -1;
     }
   }
   catch(std::runtime_error const& e) {
-    std::cerr << "Invalid top directory '" << topdir << "'" << std::endl;;
-    std::cerr << "e.what" << std::endl;;
+    std::cerr << "Invalid top directory '" << topdir << "'" << std::endl;
+    std::cerr << "e.what" << std::endl;
     return -1;
   }
 
@@ -119,19 +119,19 @@ int do_work(int argc, char* argv[], char** env) {
   int rc = 0;
 
   if(!topdir) {
-    std::cerr << "Neither SCRAMRT_LOCALRT nor LOCALRT is defined" << std::endl;;
+    std::cerr << "Neither SCRAMRT_LOCALRT nor LOCALRT is defined" << std::endl;
     return -1;
   }
 
   try {
     if(!edm::untaintString(argv[2], goodDirectory)) {
-      std::cerr << "Invalid test directory '" << argv[2] << "'" << std::endl;;
+      std::cerr << "Invalid test directory '" << argv[2] << "'" << std::endl;
       return -1;
     }
   }
   catch(std::runtime_error const& e) {
-    std::cerr << "Invalid test directory '" << argv[2] << "'" << std::endl;;
-    std::cerr << "e.what" << std::endl;;
+    std::cerr << "Invalid test directory '" << argv[2] << "'" << std::endl;
+    std::cerr << "e.what" << std::endl;
     return -1;
   }
 
@@ -145,19 +145,19 @@ int do_work(int argc, char* argv[], char** env) {
   std::cout << "testbin is: " << testbin << '\n';
 
   if(setenv("LOCAL_TEST_DIR", testdir.c_str(),1) != 0) {
-    std::cerr << "Could not set LOCAL_TEST_DIR to " << testdir << std::endl;;
+    std::cerr << "Could not set LOCAL_TEST_DIR to " << testdir << std::endl;
     return -1;
   }
   if(setenv("LOCAL_TMP_DIR", tmpdir.c_str(),1) != 0) {
-    std::cerr << "Could not set LOCAL_TMP_DIR to " << tmpdir << std::endl;;
+    std::cerr << "Could not set LOCAL_TMP_DIR to " << tmpdir << std::endl;
     return -1;
   }
   if(setenv("LOCAL_TOP_DIR", topdir,1) != 0) {
-    std::cerr << "Could not set LOCAL_TOP_DIR to " << topdir << std::endl;;
+    std::cerr << "Could not set LOCAL_TOP_DIR to " << topdir << std::endl;
     return -1;
   }
   if(setenv("LOCAL_TEST_BIN", testbin.c_str(),1) != 0) {
-    std::cerr << "Could not set LOCAL_TEST_BIN to " << testbin << std::endl;;
+    std::cerr << "Could not set LOCAL_TEST_BIN to " << testbin << std::endl;
     return -1;
   }
 

--- a/FWCore/Utilities/test/Exception_t.cpp
+++ b/FWCore/Utilities/test/Exception_t.cpp
@@ -314,7 +314,7 @@ int main() {
     errorMessage(e7.explainSelf(),expected7_4);
     abort();
   }
-  std::auto_ptr<cms::Exception> ptr(e7.clone());
+  std::unique_ptr<cms::Exception> ptr(e7.clone());
   e7.clearMessage();
   std::string expected7_5("An exception of category 'DEF' occurred while\n"
                           "   [0] new3\n"

--- a/FWCore/Utilities/test/atomic_value_ptr_t.cpp
+++ b/FWCore/Utilities/test/atomic_value_ptr_t.cpp
@@ -42,14 +42,14 @@ int main()
   assert(simple::count == 0);
 
   {
-    std::auto_ptr<simple> c(new simple(11));
-    std::auto_ptr<simple> d(new simple(11));
+    auto c = std::make_unique<simple>(11);
+    auto d = std::make_unique<simple>(11);
     assert(c.get() != nullptr);
     assert(d.get() != nullptr);
     simple* pc = c.get();
     simple* pd = d.get();
 
-    edm::atomic_value_ptr<simple> e(c);
+    edm::atomic_value_ptr<simple> e(std::move(c));
     assert(c.get() == nullptr);
     assert(*d == *e);
     assert(e.operator->() == pc);
@@ -60,7 +60,7 @@ int main()
     }
     else {
     }
-    f = d;
+    f = std::move(d);
     assert(d.get() == nullptr);
     assert(*e == *f);
     assert(f.operator->() == pd);

--- a/FWCore/Utilities/test/reusableobjectholder_t.cppunit.cpp
+++ b/FWCore/Utilities/test/reusableobjectholder_t.cppunit.cpp
@@ -32,7 +32,7 @@ void reusableobjectholder_test::testConstruction()
       auto p = intHolder.tryToGet();
       CPPUNIT_ASSERT(p.get() ==0);
    
-      intHolder.add(std::unique_ptr<int>(new int(1)));
+      intHolder.add(std::make_unique<int>(1));
       p = intHolder.tryToGet();
       CPPUNIT_ASSERT(p.get() != 0);
       CPPUNIT_ASSERT(*p == 1);
@@ -65,7 +65,7 @@ void reusableobjectholder_test::testDeletion()
    //should also test that makeOrGetAndClear actually does a clear on returned objects
    {
       edm::ReusableObjectHolder<int> intHolder;
-      intHolder.add(std::unique_ptr<int>(new int(1)));
+      intHolder.add(std::make_unique<int>(1));
       {
          auto p = intHolder.tryToGet();
          CPPUNIT_ASSERT(p.get() != 0);

--- a/FWCore/Utilities/test/value_ptr_t.cpp
+++ b/FWCore/Utilities/test/value_ptr_t.cpp
@@ -42,14 +42,14 @@ int main()
   assert(simple::count == 0);
 
   {
-    std::auto_ptr<simple> c(new simple(11));
-    std::auto_ptr<simple> d(new simple(11));
+    auto c = std::make_unique<simple>(11);
+    auto d = std::make_unique<simple>(11);
     assert(c.get() != nullptr);
     assert(d.get() != nullptr);
     simple* pc = c.get();
     simple* pd = d.get();
 
-    edm::value_ptr<simple> e(c);
+    edm::value_ptr<simple> e(std::move(c));
     assert(c.get() == nullptr);
     assert(*d == *e);
     assert(e.operator->() == pc);
@@ -60,7 +60,7 @@ int main()
     }
     else {
     }
-    f = d;
+    f = std::move(d);
     assert(d.get() == nullptr);
     assert(*e == *f);
     assert(f.operator->() == pd);

--- a/IOMC/Input/src/MCFileSource.cc
+++ b/IOMC/Input/src/MCFileSource.cc
@@ -52,9 +52,9 @@ bool MCFileSource::setRunAndEventInfo(EventID&, TimeValue_t&, EventAuxiliary::Ex
 void MCFileSource::produce(Event &e) {
   // Store one HepMC event in the Event.
 
-  std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct());  
+  auto bare_product = std::make_unique<HepMCProduct>();  
   bare_product->addHepMCData(evt_);
-  e.put(bare_product);
+  e.put(std::move(bare_product));
 }
 
 }

--- a/IOMC/RandomEngine/src/RandomEngineStateProducer.cc
+++ b/IOMC/RandomEngine/src/RandomEngineStateProducer.cc
@@ -23,9 +23,9 @@ void
 RandomEngineStateProducer::produce(edm::StreamID iID, edm::Event& ev, edm::EventSetup const&) const {
   edm::Service<edm::RandomNumberGenerator> randomService;
   if(randomService.isAvailable()) {
-    std::auto_ptr<edm::RandomEngineStates> states(new edm::RandomEngineStates);
+    auto states = std::make_unique<edm::RandomEngineStates>();
     states->setRandomEngineStates(randomService->getEventCache(ev.streamID()));
-    ev.put(states);
+    ev.put(std::move(states));
   }
 }
 
@@ -33,9 +33,9 @@ void
 RandomEngineStateProducer::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) const {
   edm::Service<edm::RandomNumberGenerator> randomService;
   if(randomService.isAvailable()) {
-    std::auto_ptr<edm::RandomEngineStates> states(new edm::RandomEngineStates);
+    auto states = std::make_unique<edm::RandomEngineStates>();
     states->setRandomEngineStates(randomService->getLumiCache(lb.index()));
-    lb.put(states, "beginLumi");
+    lb.put(std::move(states), "beginLumi");
   }
 }
 

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -372,7 +372,7 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
 std::unique_ptr<TestRandomNumberServiceStreamCache>
 TestRandomNumberServiceGlobal::beginStream(edm::StreamID streamID) const {
 
-  std::unique_ptr<TestRandomNumberServiceStreamCache> streamCache(new TestRandomNumberServiceStreamCache);
+  auto streamCache = std::make_unique<TestRandomNumberServiceStreamCache>();
 
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine& engine = rng->getEngine(streamID);

--- a/IOPool/Common/bin/EdmCopyUtil.cpp
+++ b/IOPool/Common/bin/EdmCopyUtil.cpp
@@ -22,8 +22,8 @@
 
 static int copy_files(const boost::program_options::variables_map &vm) {
 
-  std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-  auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
+  std::unique_ptr<edm::SiteLocalConfig> slcptr = std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
+  auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
   edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
   edm::ServiceRegistry::Operate operate(slcToken);
 

--- a/IOPool/Common/bin/EdmFileUtil.cpp
+++ b/IOPool/Common/bin/EdmFileUtil.cpp
@@ -80,8 +80,8 @@ int main(int argc, char* argv[]) {
 
   int rc = 0;
   try {
-    std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
+    std::unique_ptr<edm::SiteLocalConfig> slcptr = std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
+    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
     edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
     edm::ServiceRegistry::Operate operate(slcToken);
 

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -374,8 +374,8 @@ namespace {
   std::unique_ptr<TFile>
   makeTFileWithLookup(std::string const& filename) {
     // See if it is a logical file name.
-    std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
+    std::unique_ptr<edm::SiteLocalConfig> slcptr = std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
+    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
     edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
     edm::ServiceRegistry::Operate operate(slcToken);
     std::string override;

--- a/IOPool/Input/src/ProvenanceAdaptor.cc
+++ b/IOPool/Input/src/ProvenanceAdaptor.cc
@@ -123,8 +123,8 @@ namespace edm {
       }
       stable_sort_all(orderedProducts, Sorter(processHistories));
 
-      std::unique_ptr<BranchIDLists> pv(new BranchIDLists);
-      std::unique_ptr<BranchIDList> p(new BranchIDList);
+      auto pv = std::make_unique<BranchIDLists>();
+      auto p = std::make_unique<BranchIDList>();
       std::string processName;
       BranchListIndex blix = 0;
       for (OrderedProducts::const_iterator it = orderedProducts.begin(), itEnd = orderedProducts.end(); it != itEnd; ++it) {

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -292,7 +292,7 @@ namespace edm {
       metaDataTree->SetBranchAddress(poolNames::processConfigurationBranchName().c_str(), &procConfigVectorPtr);
     }
 
-    std::unique_ptr<BranchIDLists> branchIDListsAPtr(new BranchIDLists);
+    auto branchIDListsAPtr = std::make_unique<BranchIDLists>();
     BranchIDLists* branchIDListsPtr = branchIDListsAPtr.get();
     if(metaDataTree->FindBranch(poolNames::branchIDListBranchName().c_str()) != nullptr) {
       metaDataTree->SetBranchAddress(poolNames::branchIDListBranchName().c_str(), &branchIDListsPtr);
@@ -452,7 +452,7 @@ namespace edm {
       treePointers_[prod.branchType()]->setPresence(prod, newBranchToOldBranch(prod.branchName()));
     }
 
-    std::unique_ptr<ProductRegistry> newReg(new ProductRegistry);
+    auto newReg = std::make_unique<ProductRegistry>();
 
     // Do the translation from the old registry to the new one
     {
@@ -643,19 +643,19 @@ namespace edm {
 
   std::unique_ptr<FileBlock>
   RootFile::createFileBlock() const {
-    return std::unique_ptr<FileBlock>(new FileBlock(fileFormatVersion(),
-                                                     eventTree_.tree(),
-                                                     eventTree_.metaTree(),
-                                                     lumiTree_.tree(),
-                                                     lumiTree_.metaTree(),
-                                                     runTree_.tree(),
-                                                     runTree_.metaTree(),
-                                                     whyNotFastClonable(),
-                                                     hasNewlyDroppedBranch(),
-                                                     file_,
-                                                     branchListIndexesUnchanged(),
-                                                     modifiedIDs(),
-                                                     branchChildren()));
+    return std::make_unique<FileBlock>(fileFormatVersion(),
+                                       eventTree_.tree(),
+                                       eventTree_.metaTree(),
+                                       lumiTree_.tree(),
+                                       lumiTree_.metaTree(),
+                                       runTree_.tree(),
+                                       runTree_.metaTree(),
+                                       whyNotFastClonable(),
+                                       hasNewlyDroppedBranch(),
+                                       file_,
+                                       branchListIndexesUnchanged(),
+                                       modifiedIDs(),
+                                       branchChildren());
   }
 
   std::string const&
@@ -1720,7 +1720,7 @@ namespace edm {
       }
 
       // Also delete the dropped associations from the ThinnedAssociationsHelper
-      std::unique_ptr<ThinnedAssociationsHelper> temp(new ThinnedAssociationsHelper);
+      auto temp = std::make_unique<ThinnedAssociationsHelper>();
       for(auto const& associationBranches : fileThinnedAssociationsHelper_->data()) {
         auto iter = keepAssociation.find(associationBranches.association());
         if(iter != keepAssociation.end() && iter->second) {
@@ -1781,16 +1781,16 @@ namespace edm {
   RootFile::makeProvenanceReaderMaker(InputType inputType) {
     if(fileFormatVersion_.storedProductProvenanceUsed()) {
       readParentageTree(inputType);
-      return std::unique_ptr<MakeProvenanceReader>(new MakeReducedProvenanceReader(parentageIDLookup_));
+      return std::make_unique<MakeReducedProvenanceReader>(parentageIDLookup_);
     } else if(fileFormatVersion_.splitProductIDs()) {
       readParentageTree(inputType);
-      return std::unique_ptr<MakeProvenanceReader>(new MakeFullProvenanceReader);
+      return std::make_unique<MakeFullProvenanceReader>();
     } else if(fileFormatVersion_.perEventProductIDs()) {
-      std::unique_ptr<EntryDescriptionMap> entryDescriptionMap(new EntryDescriptionMap);
+      auto entryDescriptionMap = std::make_unique<EntryDescriptionMap>();
       readEntryDescriptionTree(*entryDescriptionMap, inputType);
-      return std::unique_ptr<MakeProvenanceReader>(new MakeOldProvenanceReader(std::move(entryDescriptionMap)));
+      return std::make_unique<MakeOldProvenanceReader>(std::move(entryDescriptionMap));
     } else {
-      return std::unique_ptr<MakeProvenanceReader>(new MakeDummyProvenanceReader);
+      return std::make_unique<MakeDummyProvenanceReader>();
     }
   }
 
@@ -1975,21 +1975,21 @@ namespace edm {
 
   std::unique_ptr<ProvenanceReaderBase>
   MakeDummyProvenanceReader::makeReader(RootTree&, DaqProvenanceHelper const*) const {
-     return std::unique_ptr<ProvenanceReaderBase>(new DummyProvenanceReader);
+     return std::make_unique<DummyProvenanceReader>();
   }
 
   std::unique_ptr<ProvenanceReaderBase>
   MakeOldProvenanceReader::makeReader(RootTree& rootTree, DaqProvenanceHelper const* daqProvenanceHelper) const {
-    return std::unique_ptr<ProvenanceReaderBase>(new OldProvenanceReader(&rootTree, *entryDescriptionMap_, daqProvenanceHelper));
+    return std::make_unique<OldProvenanceReader>(&rootTree, *entryDescriptionMap_, daqProvenanceHelper);
   }
 
   std::unique_ptr<ProvenanceReaderBase>
   MakeFullProvenanceReader::makeReader(RootTree& rootTree, DaqProvenanceHelper const* daqProvenanceHelper) const {
-    return std::unique_ptr<ProvenanceReaderBase>(new FullProvenanceReader(&rootTree, daqProvenanceHelper));
+    return std::make_unique<FullProvenanceReader>(&rootTree, daqProvenanceHelper);
   }
 
   std::unique_ptr<ProvenanceReaderBase>
   MakeReducedProvenanceReader::makeReader(RootTree& rootTree, DaqProvenanceHelper const* daqProvenanceHelper) const {
-    return std::unique_ptr<ProvenanceReaderBase>(new ReducedProvenanceReader(&rootTree, parentageIDLookup_, daqProvenanceHelper));
+    return std::make_unique<ReducedProvenanceReader>(&rootTree, parentageIDLookup_, daqProvenanceHelper);
   }
 }

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -234,7 +234,7 @@ namespace edm {
     std::shared_ptr<InputFile> filePtr;
     std::list<std::string> originalInfo;
     try {
-      std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? new InputSource::FileOpenSentry(*input, lfn_, usedFallback_) : nullptr);
+      std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, usedFallback_) : nullptr);
       filePtr = std::make_shared<InputFile>(gSystem->ExpandPathName(fileName().c_str()), "  Initiating request to open file ", inputType);
     }
     catch (cms::Exception const& e) {
@@ -259,7 +259,7 @@ namespace edm {
     if(!filePtr && (hasFallbackUrl)) {
       try {
         usedFallback_ = true;
-        std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? new InputSource::FileOpenSentry(*input, lfn_, usedFallback_) : nullptr);
+        std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, usedFallback_) : nullptr);
         std::string fallbackFullName = gSystem->ExpandPathName(fallbackFileName().c_str());
         filePtr.reset(new InputFile(fallbackFullName.c_str(), "  Fallback request to file ", inputType));
       }

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -86,7 +86,7 @@ namespace edm {
       }
     }
     if(!rootFile()) {
-      return std::unique_ptr<FileBlock>(new FileBlock);
+      return std::make_unique<FileBlock>();
     }
     return rootFile()->createFileBlock();
   }
@@ -95,8 +95,7 @@ namespace edm {
   RootPrimaryFileSequence::closeFile_() {
     // close the currently open file, if any, and delete the RootFile object.
     if(rootFile()) {
-      std::unique_ptr<InputSource::FileCloseSentry>
-      sentry(new InputSource::FileCloseSentry(input_, lfn(), usedFallback()));
+      auto sentry = std::make_unique<InputSource::FileCloseSentry>(input_, lfn(), usedFallback());
       rootFile()->close();
       if(duplicateChecker_) duplicateChecker_->inputFileClosed();
       rootFile().reset();
@@ -171,7 +170,7 @@ namespace edm {
     if(atFirstFile()) {
       return false;
     }
-    setAtPreviousFile();;
+    setAtPreviousFile();
 
     initFile(false);
 

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -141,7 +141,7 @@ namespace edm {
     WTC const* wtp = static_cast<WTC const*>(ep);
     assert(wtp);
     TC const* tp = wtp->product();
-    std::unique_ptr<TC> thing(new TC(*tp));
+    auto thing = std::make_unique<TC>(*tp);
 
     // Put output into event
     e.put(std::move(thing));

--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -107,9 +107,9 @@ void readfile(std::string filename, std::string outfile) {
     std::cout << "\n\n-------------EVENT Messages-------------------" << std::endl;
 
     bool first_event(true);
-    std::auto_ptr<EventMsgView> firstEvtView(0);
+    std::unique_ptr<EventMsgView> firstEvtView(nullptr);
     std::vector<unsigned char> savebuf(0);
-    EventMsgView const* eview(0);
+    EventMsgView const* eview(nullptr);
     seenEventMap.clear();
 
     while(stream_reader.next()) {

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -35,8 +35,8 @@ namespace edm {
     virtual void doOutputHeader(InitMsgBuilder const& init_message) = 0;
     virtual void doOutputEvent(EventMsgBuilder const& msg) = 0;
 
-    std::auto_ptr<InitMsgBuilder> serializeRegistry();
-    std::auto_ptr<EventMsgBuilder> serializeEvent(EventForOutput const& e); 
+    std::unique_ptr<InitMsgBuilder> serializeRegistry();
+    std::unique_ptr<EventMsgBuilder> serializeEvent(EventForOutput const& e); 
     Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const;
     void setHltMask(EventForOutput const& e);
     void setLumiSection();

--- a/IOPool/Streamer/src/DumpTools.cc
+++ b/IOPool/Streamer/src/DumpTools.cc
@@ -98,7 +98,7 @@ void dumpInitVerbose(const InitMsgView* view)
   TClass* desc = getTClass(typeid(SendJobHeader));
   TBufferFile xbuf(TBuffer::kRead, view->descLength(),
                (char*)view->descData(), kFALSE);
-  std::auto_ptr<SendJobHeader> sd((SendJobHeader*)xbuf.ReadObjectAny(desc));
+  std::unique_ptr<SendJobHeader> sd((SendJobHeader*)xbuf.ReadObjectAny(desc));
 
   if (sd.get() == 0) {
     std::cout << "Unable to determine the product registry - "

--- a/IOPool/Streamer/src/StreamerFileReader.cc
+++ b/IOPool/Streamer/src/StreamerFileReader.cc
@@ -29,9 +29,9 @@ namespace edm {
   void
   StreamerFileReader::reset_() {
     if (streamerNames_.size() > 1) {
-      streamReader_ = std::unique_ptr<StreamerInputFile>(new StreamerInputFile(streamerNames_, eventSkipperByID()));
+      streamReader_ = std::make_unique<StreamerInputFile>(streamerNames_, eventSkipperByID());
     } else if (streamerNames_.size() == 1) {
-      streamReader_ = std::unique_ptr<StreamerInputFile>(new StreamerInputFile(streamerNames_.at(0), eventSkipperByID()));
+      streamReader_ = std::make_unique<StreamerInputFile>(streamerNames_.at(0), eventSkipperByID());
     } else {
       throw Exception(errors::FileReadError, "StreamerFileReader::StreamerFileReader")
          << "No fileNames were specified\n";

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -58,7 +58,7 @@ namespace edm {
   // ---------------------------------------
   std::unique_ptr<FileBlock>
   StreamerInputSource::readFile_() {
-    return std::unique_ptr<FileBlock>(new FileBlock);
+    return std::make_unique<FileBlock>();
   }
 
   void

--- a/IOPool/Streamer/test/StreamThingProducer.cc
+++ b/IOPool/Streamer/test/StreamThingProducer.cc
@@ -50,7 +50,7 @@ namespace edmtest_thing
   void StreamThingProducer::produce(edm::Event& e, edm::EventSetup const&)
   {
     for(int i = 0; i < inst_count_; ++i) {
-      std::unique_ptr<WriteThis> result(new WriteThis(size_));
+      auto result = std::make_unique<WriteThis>(size_);
 
         // The purpose of this masking is to allow
         // some limited control of how much smaller these
@@ -65,12 +65,9 @@ namespace edmtest_thing
       e.put(std::move(result),names_[i]);
     }
 
-    //std::auto_ptr<TestDbl> d(new TestDbl);
-    //e.put(d);
-    //std::auto_ptr<StreamTestSimple> d1(new StreamTestSimple);
-    //e.put(d1);
-    //std::auto_ptr<Pig> d1(new Pig);
-    //e.put(d1);
+    //e.put(std::make_unique<TestDbl>());
+    //e.put(std::make_unique<StreamTestSimple>());
+    //e.put(std::make_unique<Pig>());
   }
 }
 

--- a/IOPool/TFileAdaptor/test/tfileTest.cpp
+++ b/IOPool/TFileAdaptor/test/tfileTest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
   if (argc > 1) fname = argv[1];
 
   {
-    std::auto_ptr<TFile> g(TFile::Open(fname.c_str(), "recreate", "", 1));
+    std::unique_ptr<TFile> g(TFile::Open(fname.c_str(), "recreate", "", 1));
     g->Close();
   }
   try {
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
       std::cout << "error was " << err << "\n";
 
     if (!result) {
-      std::auto_ptr<TFile> f(TFile::Open(fname.c_str()));
+      std::unique_ptr<TFile> f(TFile::Open(fname.c_str()));
       std::cout << "file size " << f->GetSize() << std::endl;
       f->ls();
     }

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -158,7 +158,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
             auto source =
 	      (edm::ParameterDescription<std::string>("algo", true) and edm::ParameterDescription<std::string>("algopt", true)) xor
 	      (edm::ParameterDescription<edm::FileInPath>("resolutionFile", true) and edm::ParameterDescription<edm::FileInPath>("scaleFactorFile", true));
-            desc.addNode(source);
+            desc.addNode(std::move(source));
 
             pat::GenJetMatcher::fillDescriptions(desc);
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -57,13 +57,14 @@ void EcalUncalibRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions&
     auto itInfos = infos.begin();
     assert(itInfos != infos.end());
 
-    std::auto_ptr<edm::ParameterDescriptionCases<std::string>> s;
+    std::unique_ptr<edm::ParameterDescriptionCases<std::string>> s;
     {
-      s = itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_)->getAlgoDescription(), true);
+      s = (itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_)->getAlgoDescription(), true));
     }
-    for (++itInfos; itInfos != infos.end(); ++itInfos)
-      s = s or itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_)->getAlgoDescription(), true);
-    desc.ifValue(edm::ParameterDescription<std::string>("algo", "EcalUncalibRecHitWorkerMultiFit", true), s);
+    for (++itInfos; itInfos != infos.end(); ++itInfos) {
+      s = (std::move(s) or itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_)->getAlgoDescription(), true));
+    }
+    desc.ifValue(edm::ParameterDescription<std::string>("algo", "EcalUncalibRecHitWorkerMultiFit", true), std::move(s));
     
     descriptions.addDefault(desc);
   }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -277,7 +277,7 @@ RequestManager::updateCurrentServer()
 void
 RequestManager::queueUpdateCurrentServer(const std::string &id)
 {
-    std::unique_ptr<std::string> hostname(new std::string(id));
+    auto hostname = std::make_unique<std::string>(id);
     if (Source::getHostname(id, *hostname))
     {
         std::string *null_hostname = nullptr;


### PR DESCRIPTION
Replace almost all uses of std::auto_ptr with std::unique_ptr in the framework. Two packages outside the framework are minimally affected.
Other minor C++ improvements were made in a very few files that were modified anyway.
There are three places in the framework where use of std::auto_ptr remains in place for now, because
many packages outside the framework would have been affected. These are:
a) The put() interface, for Event, Run, and LuminosityBlock.
b) The interface to the EventSetup system
c) The use of OwnVector
These still support both auto_ptr and unique_ptr for now, and will be migrated solely to unique_ptr at a later time, if time permits.
Also, this PR adds the use of std::make_unique everywhere in the framework where it does not cause complications.
Unrelated to the above, I also fixed a few statements that had an extra semicolon at the end.
