### PR TITLE
Introducing realistic phase-I simuation key

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,11 +34,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v7',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v8',
+    # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
+    'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2
-    'phase2_design'     :   'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
+    'phase2_design'        : 'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
 }
 
 aliases = {

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -7,20 +7,18 @@ upgradeKeys=['2017',
 	     '2023sim',
 	     '2023LReco',
 	     '2023Reco' 
-	     	       
-	     
 	     ]
 
 
 upgradeGeoms={ '2017' : 'Extended2017',
-	     '2023' : 'Extended2023',   
-	     '2023dev' : 'Extended2023dev', 
-	     '2023sim' : 'Extended2023sim',
-	     '2023LReco': 'Extended2023LReco',
-	     '2023Reco' : 'Extended2023Reco'
+               '2023' : 'Extended2023',   
+               '2023dev' : 'Extended2023dev', 
+               '2023sim' : 'Extended2023sim',
+               '2023LReco': 'Extended2023LReco',
+               '2023Reco' : 'Extended2023Reco'
                }
 	       
-upgradeGTs={ '2017' : 'auto:phase1_2017_design',
+upgradeGTs={ '2017' : 'auto:phase1_2017_realistic',
 	     '2023' :  'auto:run2_mc',
 	     '2023dev' :  'auto:run2_mc',
 	     '2023sim' : 'auto:run2_mc',

--- a/SimCalorimetry/HGCalSimProducers/test/testHGCalDigi_cfg.py
+++ b/SimCalorimetry/HGCalSimProducers/test/testHGCalDigi_cfg.py
@@ -63,7 +63,7 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
 # Other statements
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
 
 process.generator = cms.EDProducer("FlatRandomPtGunProducer",
     PGunParameters = cms.PSet(


### PR DESCRIPTION
# Summary of changes in Global Tags
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v8) as [80X_upgrade2017_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v8/80X_upgrade2017_design_v7): 
  - Introducing several updates to make the GT even with the `run2mc` conditions
- **PhaseI realistic scenario** : [80X_upgrade2017_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_realistic_v0) as [80X_mcRun2_asymptotic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_realistic_v0/80X_mcRun2_asymptotic_v9): 
  - 2017 Tracker and Hcal geometry
  - Pixel Calibration for Phase-I
