### PR TITLE
Fix crash in HcalDumpConditions.cc 

### DIFF
--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -66,7 +66,8 @@ namespace edmtest
   void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo)
   {
     edm::ESHandle<S> p;
-    context.get<SRcd>().get(p);
+    if( name == "ChannelQuality") context.get<SRcd>().get("withTopo", p);
+    else context.get<SRcd>().get(p);
     S* myobject = new S(*p.product());
     if( topo ) myobject->setTopo(topo);
     


### PR DESCRIPTION
This is to fix a direct text to text dump crash in the HcalDumpConditions.cc file.
