### PR TITLE
Speedup Gsf component merging, return components by const reference

### DIFF
--- a/CommonTools/Utils/interface/DynArray.h
+++ b/CommonTools/Utils/interface/DynArray.h
@@ -7,6 +7,15 @@ public:
    T * a=nullptr;
    unsigned int s=0;
 public :
+   using size_type = unsigned int;
+   using value_type = T;
+   using reference = T&;
+   using const_reference = T const&;
+
+  DynArray(){}
+
+  explicit DynArray(unsigned char * storage) : a((T*)(storage)), s(0){}
+
   DynArray(unsigned char * storage, unsigned int isize) : a((T*)(storage)), s(isize){
     for (auto i=0U; i<s; ++i) new((begin()+i)) T();
   }
@@ -14,17 +23,38 @@ public :
     for (auto i=0U; i<s; ++i) new((begin()+i)) T(it);
   }
 
+  DynArray(DynArray const&) = delete;
+  DynArray & operator=(DynArray const &) = delete;
+
+  DynArray(DynArray && other) { a=other.a; s=other.s; other.s=0; other.a=nullptr;}
+  DynArray & operator=(DynArray && other) { a=other.a; s=other.s; other.s=0; other.a=nullptr; return *this;}
+
+
   ~DynArray() { for (auto i=0U; i<s; ++i) a[i].~T(); }
 
    T & operator[](unsigned int i) { return a[i];}
    T * begin() { return a;}
    T * end() { return a+s;}
+   T & front() { return a[0];}
+   T & back() { return a[s-1];}
+
    T const & operator[](unsigned int i) const { return a[i];}
    T const * begin() const { return a;}
    T const * end() const { return a+s;}
    unsigned int size() const { return s;}
+   bool empty() const { return 0==s;}
+
+   T const &front() const { return a[0];}
+   T const & back() const { return a[s-1];}
+
+   void pop_back() {back().~T(); --s;}
+   void push_back(T const& t) {new((begin()+s)) T(t);++s;}
+   void	push_back(T && t) {new((begin()+s)) T(t);++s;}
+
+
 };
 
+#define unInitDynArray(T,n,x)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage)
 #define declareDynArray(T,n,x)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage,n)
 #define initDynArray(T,n,x,i)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage,n,i)
 

--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -40,3 +40,8 @@
   <use name="CommonTools/Utils"/>
 </bin>
 
+
+<bin file="testDynArray.cpp">
+</bin>
+
+

--- a/CommonTools/Utils/test/testDynArray.cpp
+++ b/CommonTools/Utils/test/testDynArray.cpp
@@ -3,7 +3,8 @@
 
 
 struct A {
-
+A(){}
+A(int ii) : i(ii){}
 int i=-3;
 double k=0.1;
 
@@ -14,6 +15,7 @@ virtual ~A(){}
 
 #include<cassert>
 #include<iostream>
+#include<queue>
 
 int main(int s, char **) {
 
@@ -29,6 +31,8 @@ int main(int s, char **) {
   // T b[n];
   declareDynArray(T,n,b);
 
+  b[0].i=42;
+  b[n-1].i=-42;
 
   auto pa = [&](auto i) { a[1].k=0.3; return a[i].k; };
   auto pb = [&](auto i) { b[1].k=0.5; return b[i].k; };
@@ -38,8 +42,42 @@ int main(int s, char **) {
   std::cout << a[n-1].k << ' ' << pa(1) << ' ' << loop(2.3) << std::endl;
   std::cout << b[n-1].k << ' ' << pb(1) << std::endl;
 
+  assert(b.back().i==-42);
+  assert(b.front().i==42);
+
   initDynArray(bool,n,q,true);
   if (q[n-1]) std::cout << "ok" << std::endl;	
 
+  auto sn = 2*n;
+  unInitDynArray(T,sn+n,c);
+  assert(c.size()==0);
+  for(int i=0;i<int(sn);++i) c.push_back(i);
+  assert(c.size()==sn);
+  assert(c.front().i==0);
+  assert(c.back().i==int(sn-1));
+
+  c = std::move(a);  
+
+  assert(c.size()==n);
+  assert(a.empty());
+  assert(c[1].k==0.3);
+
+  auto cmp = [](int i, int j){return i<j;};
+
+  unInitDynArray(int,sn,qst); // queue storage
+  std::priority_queue<int,DynArray<int>,decltype(cmp)> qq(cmp,std::move(qst));
+  assert(qq.empty());
+  for(int i=0;i<int(sn);++i) qq.push(i+1);
+  assert(qq.size()==sn);
+  for(int i=0;i<int(sn);++i) {
+   assert(qq.size()==sn-i);
+   assert(qq.top()==int(sn-i));
+   qq.pop();
+  }
+
+  assert(qq.empty());
+  qq.push(3); qq.push(7); qq.push(-3);
+  assert(qq.top()==7);
+  
   return 0;
 };

--- a/CommonTools/Utils/test/testDynArray.cpp
+++ b/CommonTools/Utils/test/testDynArray.cpp
@@ -55,16 +55,21 @@ int main(int s, char **) {
   assert(c.size()==sn);
   assert(c.front().i==0);
   assert(c.back().i==int(sn-1));
+  c[1].k=3.14;
 
-  c = std::move(a);  
+  a = std::move(c);  
 
-  assert(c.size()==n);
-  assert(a.empty());
-  assert(c[1].k==0.3);
+  assert(a.size()==sn);
+  assert(c.empty());
+  assert(a[1].k==3.14);
 
-  auto cmp = [](int i, int j){return i<j;};
+  std::swap(a,b);
+  assert(b.size()==sn);
+  assert(a.size()==n);
+
 
   unInitDynArray(int,sn,qst); // queue storage
+  auto cmp = [](int i, int j){return i<j;};
   std::priority_queue<int,DynArray<int>,decltype(cmp)> qq(cmp,std::move(qst));
   assert(qq.empty());
   for(int i=0;i<int(sn);++i) qq.push(i+1);

--- a/RecoParticleFlow/PFTracking/src/PFGsfHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFGsfHelper.cc
@@ -23,6 +23,8 @@
 #include "TrackingTools/GsfTools/interface/MultiGaussianState1D.h"
 #include "TrackingTools/GsfTools/interface/GaussianSumUtilities1D.h"
 #include "RecoParticleFlow/PFTracking/interface/CollinearFitAtTM.h"
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
+
 using namespace std;
 using namespace reco;
 using namespace edm;
@@ -49,13 +51,13 @@ PFGsfHelper::PFGsfHelper(const TrajectoryMeasurement& tm){
     mode_Px = 0.;
     mode_Py = 0.;
     mode_Pz = 0.;
-    std::vector<TrajectoryStateOnSurface> components(theUpdateState.components());
-    unsigned int numb = components.size();
-
+    GetComponents comps(theUpdateState);
+    auto const &  components = comps();
+    auto numb=components.size();
     std::vector<SingleGaussianState1D> pxStates; pxStates.reserve(numb);
     std::vector<SingleGaussianState1D> pyStates; pyStates.reserve(numb);
     std::vector<SingleGaussianState1D> pzStates; pzStates.reserve(numb);
-    for ( std::vector<TrajectoryStateOnSurface>::const_iterator ic=components.begin();
+    for (auto ic=components.begin();
 	  ic!=components.end(); ++ic ) {
       GlobalVector momentum(ic->globalMomentum());
       AlgebraicSymMatrix66 cov(ic->cartesianError().matrix());

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -707,6 +707,8 @@ GroupedCkfTrajectoryBuilder::groupedIntermediaryClean (TempTrajectoryContainer& 
   LayersInTraj layers[theTrajectories.size()];
   int ntraj=0;
   for ( auto & t :  theTrajectories) {
+    if ( t.isValid() && !t.lastMeasurement().recHitP())
+       std::cout << "missing hit in lastMeasurement????" << std::endl;
     if ( t.isValid() && t.lastMeasurement().recHitR().isValid() )
       layers[ntraj++].fill(t);
   }

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -707,8 +707,6 @@ GroupedCkfTrajectoryBuilder::groupedIntermediaryClean (TempTrajectoryContainer& 
   LayersInTraj layers[theTrajectories.size()];
   int ntraj=0;
   for ( auto & t :  theTrajectories) {
-    if ( t.isValid() && !t.lastMeasurement().recHitP())
-       std::cout << "missing hit in lastMeasurement????" << std::endl;
     if ( t.isValid() && t.lastMeasurement().recHitR().isValid() )
       layers[ntraj++].fill(t);
   }

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -20,6 +20,8 @@
 
 #include "TrackingTools/GsfTracking/interface/TrajGsfTrackAssociation.h"
 
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
+
 #include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -208,10 +210,8 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
 
     //build the GsfTrackExtra
     std::vector<reco::GsfComponent5D> outerStates;
-    outerStates.reserve(outertsos.components().size());
     fillStates(outertsos,outerStates);
     std::vector<reco::GsfComponent5D> innerStates;
-    innerStates.reserve(innertsos.components().size());
     fillStates(innertsos,innerStates);
     
 
@@ -271,11 +271,11 @@ GsfTrackProducerBase::fillStates (TrajectoryStateOnSurface tsos,
 {
   reco::GsfComponent5D::ParameterVector pLocS;
   reco::GsfComponent5D::CovarianceMatrix cLocS;
-  std::vector<TrajectoryStateOnSurface> components(tsos.components());
-  for ( std::vector<TrajectoryStateOnSurface>::const_iterator i=components.begin();
-	i!=components.end(); ++i ) {
-    states.push_back(reco::GsfComponent5D(i->weight(),i->localParameters().vector(),i->localError().matrix()));
-  }
+  GetComponents comps(tsos);
+  auto const &  components = comps();
+  states.reserve(components.size());
+  for (auto const & st : components)
+    states.emplace_back(st.weight(),st.localParameters().vector(),st.localError().matrix());
 }
 
 void

--- a/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
@@ -8,7 +8,7 @@ namespace GaussianStateConversions {
 
   MultiGaussianState<3> multiGaussianStateFromVertex (const VertexState aState)
   {
-    typedef boost::shared_ptr< SingleGaussianState<3> > SingleStatePtr;
+    typedef std::shared_ptr< SingleGaussianState<3> > SingleStatePtr;
     const std::vector<VertexState> components = aState.components();
     MultiGaussianState<3>::SingleStateContainer singleStates;
     singleStates.reserve(components.size());

--- a/TrackingTools/GeomPropagators/src/AnalyticalImpactPointExtrapolator.cc
+++ b/TrackingTools/GeomPropagators/src/AnalyticalImpactPointExtrapolator.cc
@@ -50,7 +50,7 @@ AnalyticalImpactPointExtrapolator::extrapolateFullState (const TrajectoryStateOn
   //
   TrajectoryStateOnSurface singleState = 
     extrapolateSingleState(*tsos.freeTrajectoryState(),vertex);
-  if ( !singleState.isValid() || tsos.components().size()==1 )  return singleState;
+  if ( !singleState.isValid() || tsos.singleState() )  return singleState;
   //
   // propagate multiTsos to plane found above
   //

--- a/TrackingTools/GeomPropagators/src/AnalyticalTrajectoryExtrapolatorToLine.cc
+++ b/TrackingTools/GeomPropagators/src/AnalyticalTrajectoryExtrapolatorToLine.cc
@@ -46,7 +46,7 @@ AnalyticalTrajectoryExtrapolatorToLine::extrapolateFullState (const TrajectorySt
   //
   TrajectoryStateOnSurface singleState = 
     extrapolateSingleState(*tsos.freeTrajectoryState(),line);
-  if ( !singleState.isValid() || tsos.components().size()==1 )  return singleState;
+  if ( !singleState.isValid() || tsos.singleState() )  return singleState;
   //
   // propagate multiTsos to plane found above
   //

--- a/TrackingTools/GsfTools/interface/BasicMultiTrajectoryState.h
+++ b/TrackingTools/GsfTools/interface/BasicMultiTrajectoryState.h
@@ -37,9 +37,11 @@ public:
     return build<BasicMultiTrajectoryState>(*this);
   }
 
-  virtual std::vector<TrajectoryStateOnSurface> components() const {
+  using	Components = BasicTrajectoryState::Components;
+  Components const & components() const {
     return theStates;
   }
+  bool singleState() const override { return false;}
 
 
   virtual bool canUpdateLocalParameters() const { return false; }
@@ -56,7 +58,7 @@ public:
                        const SurfaceSide side) override;
 private:
 
-  std::vector<TSOS> theStates;
+  Components theStates;
 
   void combine() dso_internal;
 

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.h
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.h
@@ -21,7 +21,7 @@ class CloseComponentsMerger : public MultiGaussianStateMerger<N> {
  private:
   typedef SingleGaussianState<N> SingleState;
   typedef MultiGaussianState<N> MultiState;
-  typedef boost::shared_ptr<SingleState> SingleStatePtr;
+  typedef std::shared_ptr<SingleState> SingleStatePtr;
 
  public:
 

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.h
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.h
@@ -5,8 +5,8 @@
 #include "TrackingTools/GsfTools/interface/DistanceBetweenComponents.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointerByClone.h"
 
-#include "boost/shared_ptr.hpp"
 #include <map>
+#include <algorithm>
 
 
 /** Merging of a Gaussian mixture by clustering components
@@ -16,19 +16,19 @@
  */
 
 template <unsigned int N>
-class CloseComponentsMerger : public MultiGaussianStateMerger<N> {
+class CloseComponentsMerger final : public MultiGaussianStateMerger<N> {
 
  private:
-  typedef SingleGaussianState<N> SingleState;
-  typedef MultiGaussianState<N> MultiState;
-  typedef std::shared_ptr<SingleState> SingleStatePtr;
+  using SingleState = SingleGaussianState<N>;
+  using MultiState =  MultiGaussianState<N> ;
+  using SingleStatePtr = std::shared_ptr<SingleState>;
 
  public:
 
   CloseComponentsMerger(int n,
 			   const DistanceBetweenComponents<N>* distance);
 
-  virtual CloseComponentsMerger* clone() const
+  CloseComponentsMerger* clone() const override
   {  
     return new CloseComponentsMerger(*this);
   }
@@ -36,8 +36,10 @@ class CloseComponentsMerger : public MultiGaussianStateMerger<N> {
   /** Method which does the actual merging. Returns a trimmed MultiGaussianState.
    */
 
-  virtual MultiState merge(const MultiState& mgs) const;
+  MultiState merge(const MultiState& mgs) const override;
   
+  MultiState mergeOld(const MultiState& mgs) const;
+
 
 public:
   typedef std::multimap< double, SingleStatePtr > SingleStateMap;

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -36,10 +36,9 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
   while (true) {
     SingleStateVector merged; merged.reserve(noComp);
     
-    float weights[noComp];
-    bool active[noComp];
+    declareDynArray(float,noComp,weights);
+    initDynArray(bool,noComp,active,true);
     for (int i=0; i<noComp; ++i) {
-       active[i]=true;
        weights[i]=ori[i]->weight();
     }
 

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -33,7 +33,7 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
   if (noComp <=theMaxNumberOfComponents) return mgs;
 
 
-  while (true) {
+  while (true) { // termitates when the nunmber of components becomes less than allowed maximum
     SingleStateVector merged; merged.reserve(noComp);
     
     declareDynArray(float,noComp,weights);

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -21,7 +21,7 @@ template <unsigned int N> MultiGaussianState<N>
 CloseComponentsMerger<N>::merge (const MultiState& mgs) const
 {
 
-  auto oldRes = mergeOld(mgs);
+  //auto oldRes = mergeOld(mgs);
 
   typedef std::vector<SingleStatePtr>  SingleStateVector;
 
@@ -44,7 +44,8 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
     }
 
     auto cmp = [&](int i, int j) { return weights[i] > weights[j];};
-    std::priority_queue<int, std::vector<int>, decltype(cmp)> toMerge(cmp);
+    unInitDynArray(int,noComp,qst); // queue storage
+    std::priority_queue<int, DynArray<int>, decltype(cmp)> toMerge(cmp,std::move(qst));
     for (int i=0; i<noComp; ++i) toMerge.push(i);
 
     auto minDistToMax = [&]()->int {

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -52,7 +52,7 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
       active[topI]=false;
       for (int i=0; i<noComp; ++i) {
          if (!active[i]) continue;
-         assert(weights[topI]<=weights[i]);
+         // assert(weights[topI]<=weights[i]);
          auto dist = (*theDistance)(tc,*ori[i]);
          if (dist<mind) {
            mind=dist; im = i;
@@ -75,21 +75,21 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
       --nComp;
       nAct-=2;
       merged.push_back(MultiGaussianStateCombiner<N>().combine(comp));
-      assert(toMerge.size()>=0);
-      assert(int(toMerge.size())>=nAct);   
+      // assert(toMerge.size()>=0);
+      // assert(int(toMerge.size())>=nAct);   
     }
 
-    std::cout << theMaxNumberOfComponents << ' ' << noComp << ' ' << nComp << ' ' << nAct << ' ' << toMerge.size() << std::endl;
+    // std::cout << theMaxNumberOfComponents << ' ' << noComp << ' ' << nComp << ' ' << nAct << ' ' << toMerge.size() << std::endl;
 
     if (nComp <= theMaxNumberOfComponents) { // end game
 
-        
+        /*
         {
           int kk=merged.size();
           for (int i=0; i<noComp; ++i) { if (active[i]) ++kk;}
           assert(kk==nComp);
         }
-        
+        */
  
       MultiGaussianStateAssembler<N> result;
 
@@ -98,14 +98,14 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
 
       auto res = result.combinedState();
       
-      
+      /*
       assert(res.components().size()==oldRes.components().size());
       std::cout << res.weight() << ' ' << oldRes.weight() << std::endl;
       for(auto const & c : res.components()) std::cout << c->weight() << '/';
       std::cout << std::endl;
       for(auto const & c : oldRes.components()) std::cout << c->weight() <<	'/';
       std::cout	<< std::endl;
-      
+      */
 
       return res;
     }
@@ -216,7 +216,7 @@ CloseComponentsMerger<N>::compWithMinDistToLargestWeight(SingleStateMap& unmerge
   for (typename SingleStateMap::iterator it = unmergedComp.begin();
        it != unmergedComp.end(); it++) {
     if (it != unmergedComp.begin()) {
-      assert(unmergedComp.begin()->first >=it->first);
+      // assert(unmergedComp.begin()->first >=it->first);
       double dist = (*theDistance)(*unmergedComp.begin()->second, *it->second);
       if (dist < minDist) {
 	iterMinDist = it;

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -3,6 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
+#include <queue>
 #include <cfloat>
 
 template <unsigned int N>
@@ -32,26 +33,26 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
   while (true) {
     SingleStateVector merged; merged.reserve(noComp);
     
-    int  toMerge[noComp];
     float weights[noComp];
     bool active[noComp];
     for (int i=0; i<noComp; ++i) {
-       toMerge[i]=i;
        active[i]=true;
        weights[i]=ori[i]->weight();
     }
-    auto cmp = [&](int i, int j) { return weights[i]> weights[j];};
 
-    std::make_heap(toMerge,toMerge+noComp,cmp);
+    auto cmp = [&](int i, int j) { return weights[i] > weights[j];};
+    std::priority_queue<int, std::vector<int>, decltype(cmp)> toMerge(cmp);
+    for (int i=0; i<noComp; ++i) toMerge.push(i);
 
     auto minDistToMax = [&]()->int {
       auto mind = std::numeric_limits<double>::max();
       int im = 0; 
-      auto topI = toMerge[0];
+      auto topI = toMerge.top();
       auto const & tc = *ori[topI];
       active[topI]=false;
       for (int i=0; i<noComp; ++i) {
          if (!active[i]) continue;
+         assert(weights[topI]<=weights[i]);
          auto dist = (*theDistance)(tc,*ori[i]);
          if (dist<mind) {
            mind=dist; im = i;
@@ -62,50 +63,49 @@ CloseComponentsMerger<N>::merge (const MultiState& mgs) const
 
     auto nComp = noComp;
     auto nAct=nComp;
-    auto ntoMerge= noComp;
     while ( (nAct>0) & (nComp > theMaxNumberOfComponents)) {
-      if (nAct==1) { merged.push_back(ori[toMerge[0]]); nAct=0; break;}
+      if (nAct==1) { merged.push_back(ori[toMerge.top()]); nAct=0; break;}
 
       auto ii = minDistToMax();      
       SingleStateVector comp;
-      comp.push_back(ori[toMerge[0]]);
+      comp.push_back(ori[toMerge.top()]);
       comp.push_back(ori[ii]);
       active[ii]=false;
-      while( (ntoMerge>0) & (!active[toMerge[0]])) {std::pop_heap(toMerge,toMerge+ntoMerge,cmp); --ntoMerge;}
+      while( (!toMerge.empty()) & (!active[toMerge.top()])) {toMerge.pop();}
       --nComp;
       nAct-=2;
       merged.push_back(MultiGaussianStateCombiner<N>().combine(comp));
-      // assert(ntoMerge>=0);
-      // assert(ntoMerge>=nAct);   
+      assert(toMerge.size()>=0);
+      assert(int(toMerge.size())>=nAct);   
     }
 
-    // std::cout << theMaxNumberOfComponents << ' ' << noComp << ' ' << nComp << ' ' << nAct << ' ' << ntoMerge << std::endl;
+    std::cout << theMaxNumberOfComponents << ' ' << noComp << ' ' << nComp << ' ' << nAct << ' ' << toMerge.size() << std::endl;
 
     if (nComp <= theMaxNumberOfComponents) { // end game
 
-        /*
+        
         {
           int kk=merged.size();
           for (int i=0; i<noComp; ++i) { if (active[i]) ++kk;}
           assert(kk==nComp);
         }
-        */
+        
  
-      MultiGaussianStateAssembler<N> result(mgs);
+      MultiGaussianStateAssembler<N> result;
 
       for (int i=0; i<noComp; ++i) { if (active[i]) result.addState(ori[i]);}
       for (auto && s : merged) result.addState(s);
 
       auto res = result.combinedState();
       
-      /*
+      
       assert(res.components().size()==oldRes.components().size());
       std::cout << res.weight() << ' ' << oldRes.weight() << std::endl;
       for(auto const & c : res.components()) std::cout << c->weight() << '/';
       std::cout << std::endl;
       for(auto const & c : oldRes.components()) std::cout << c->weight() <<	'/';
       std::cout	<< std::endl;
-      */
+      
 
       return res;
     }
@@ -188,7 +188,7 @@ CloseComponentsMerger<N>::mergeOld (const MultiState& mgs) const
     }
   }
 
-  MultiGaussianStateAssembler<N> result(mgs);
+  MultiGaussianStateAssembler<N> result;
 
   for ( typename SingleStateMap::const_iterator it = mapUnmergedComp.begin();
        it != mapUnmergedComp.end(); it++) {
@@ -216,6 +216,7 @@ CloseComponentsMerger<N>::compWithMinDistToLargestWeight(SingleStateMap& unmerge
   for (typename SingleStateMap::iterator it = unmergedComp.begin();
        it != unmergedComp.end(); it++) {
     if (it != unmergedComp.begin()) {
+      assert(unmergedComp.begin()->first >=it->first);
       double dist = (*theDistance)(*unmergedComp.begin()->second, *it->second);
       if (dist < minDist) {
 	iterMinDist = it;

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <queue>
 #include <cfloat>
+#include "CommonTools/Utils/interface/DynArray.h"
+
+
 
 template <unsigned int N>
 CloseComponentsMerger<N>::CloseComponentsMerger (int maxNumberOfComponents,

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -98,7 +98,7 @@ typename CloseComponentsMerger<N>::MinDistResult
 CloseComponentsMerger<N>::compWithMinDistToLargestWeight(SingleStateMap& unmergedComp) const {
 // template <unsigned int N>
 // std::pair<SingleGaussianState<N>, 
-// 	  typename std::multimap<double, boost::shared_ptr< MultiGaussianState<N> > >::iterator>
+// 	  typename std::multimap<double, std::shared_ptr< MultiGaussianState<N> > >::iterator>
 // CloseComponentsMerger<N>::compWithMinDistToLargestWeight(SingleStateMap& unmergedComp) const {
   double large = DBL_MAX;
   double minDist = large;

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -11,8 +11,118 @@ CloseComponentsMerger<N>::CloseComponentsMerger (int maxNumberOfComponents,
   theMaxNumberOfComponents(maxNumberOfComponents),
   theDistance(distance->clone()) {}
 
+
+
 template <unsigned int N> MultiGaussianState<N>
 CloseComponentsMerger<N>::merge (const MultiState& mgs) const
+{
+
+  auto oldRes = mergeOld(mgs);
+
+  typedef std::vector<SingleStatePtr>  SingleStateVector;
+
+
+  auto ori = mgs.components();
+  SingleStateVector finalComponents;
+
+  int noComp = ori.size();
+  if (noComp <=theMaxNumberOfComponents) return mgs;
+
+
+  while (true) {
+    SingleStateVector merged; merged.reserve(noComp);
+    
+    int  toMerge[noComp];
+    float weights[noComp];
+    bool active[noComp];
+    for (int i=0; i<noComp; ++i) {
+       toMerge[i]=i;
+       active[i]=true;
+       weights[i]=ori[i]->weight();
+    }
+    auto cmp = [&](int i, int j) { return weights[i]> weights[j];};
+
+    std::make_heap(toMerge,toMerge+noComp,cmp);
+
+    auto minDistToMax = [&]()->int {
+      auto mind = std::numeric_limits<double>::max();
+      int im = 0; 
+      auto topI = toMerge[0];
+      auto const & tc = *ori[topI];
+      active[topI]=false;
+      for (int i=0; i<noComp; ++i) {
+         if (!active[i]) continue;
+         auto dist = (*theDistance)(tc,*ori[i]);
+         if (dist<mind) {
+           mind=dist; im = i;
+         }         
+      }
+      return im;
+    };
+
+    auto nComp = noComp;
+    auto nAct=nComp;
+    auto ntoMerge= noComp;
+    while ( (nAct>0) & (nComp > theMaxNumberOfComponents)) {
+      if (nAct==1) { merged.push_back(ori[toMerge[0]]); nAct=0; break;}
+
+      auto ii = minDistToMax();      
+      SingleStateVector comp;
+      comp.push_back(ori[toMerge[0]]);
+      comp.push_back(ori[ii]);
+      active[ii]=false;
+      while( (ntoMerge>0) & (!active[toMerge[0]])) {std::pop_heap(toMerge,toMerge+ntoMerge,cmp); --ntoMerge;}
+      --nComp;
+      nAct-=2;
+      merged.push_back(MultiGaussianStateCombiner<N>().combine(comp));
+      // assert(ntoMerge>=0);
+      // assert(ntoMerge>=nAct);   
+    }
+
+    // std::cout << theMaxNumberOfComponents << ' ' << noComp << ' ' << nComp << ' ' << nAct << ' ' << ntoMerge << std::endl;
+
+    if (nComp <= theMaxNumberOfComponents) { // end game
+
+        /*
+        {
+          int kk=merged.size();
+          for (int i=0; i<noComp; ++i) { if (active[i]) ++kk;}
+          assert(kk==nComp);
+        }
+        */
+ 
+      MultiGaussianStateAssembler<N> result(mgs);
+
+      for (int i=0; i<noComp; ++i) { if (active[i]) result.addState(ori[i]);}
+      for (auto && s : merged) result.addState(s);
+
+      auto res = result.combinedState();
+      
+      /*
+      assert(res.components().size()==oldRes.components().size());
+      std::cout << res.weight() << ' ' << oldRes.weight() << std::endl;
+      for(auto const & c : res.components()) std::cout << c->weight() << '/';
+      std::cout << std::endl;
+      for(auto const & c : oldRes.components()) std::cout << c->weight() <<	'/';
+      std::cout	<< std::endl;
+      */
+
+      return res;
+    }
+
+    // assert(nAct==0);
+    std::swap(ori,merged); noComp=ori.size();
+  }
+
+  // 
+
+}
+
+
+
+
+template <unsigned int N> MultiGaussianState<N>
+CloseComponentsMerger<N>::mergeOld (const MultiState& mgs) const
 {
   typedef std::vector<SingleStatePtr>  SingleStateVector;
   SingleStateVector unmergedComponents(mgs.components());

--- a/TrackingTools/GsfTools/interface/GaussianStateLessWeight.h
+++ b/TrackingTools/GsfTools/interface/GaussianStateLessWeight.h
@@ -12,7 +12,7 @@ template <unsigned int N>
 class GaussianStateLessWeight {
   
 private:
-  typedef boost::shared_ptr< SingleGaussianState<N> > SingleStatePtr;
+  typedef std::shared_ptr< SingleGaussianState<N> > SingleStatePtr;
 
 public:
   GaussianStateLessWeight() {}

--- a/TrackingTools/GsfTools/interface/GaussianSumUtilities.icc
+++ b/TrackingTools/GsfTools/interface/GaussianSumUtilities.icc
@@ -107,11 +107,11 @@ GaussianSumUtilities<N>::computeMode () const
   //
   SingleStateContainer newStates;
   newStates.reserve(size());
-  for ( typename SingleStateContainer::const_iterator i=components().begin();
+  for ( auto i=components().begin();
  	i!=components().end(); i++ ) {
     Vector newMean = rotT*((**i).mean()-trans);
     Matrix newCov = ROOT::Math::Similarity(rotT,(**i).covariance());
-    SingleStatePtr sgs(new SingleState(newMean,newCov,(**i).weight()));
+    auto sgs = make_shared<SingleState>(newMean,newCov,(**i).weight());
     newStates.push_back(sgs);
   }
   MultiState newState(newStates);

--- a/TrackingTools/GsfTools/interface/GetComponents.h
+++ b/TrackingTools/GsfTools/interface/GetComponents.h
@@ -1,0 +1,15 @@
+#ifndef GsfToolsGetComponents_H
+#define GsfToolsGetComponents_H
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+ struct GetComponents {
+  explicit GetComponents(TrajectoryStateOnSurface const &tsos) : 
+    comps(&single) {
+    if (tsos.singleState()) single.push_back(tsos);
+    else comps = &tsos.components();
+  }
+  TrajectoryStateOnSurface::Components const & operator()() const { return *comps;}
+
+ TrajectoryStateOnSurface::Components single;
+ TrajectoryStateOnSurface::Components const * comps;
+};
+#endif

--- a/TrackingTools/GsfTools/interface/GsfMatrixTools.h
+++ b/TrackingTools/GsfTools/interface/GsfMatrixTools.h
@@ -14,10 +14,10 @@ namespace GsfMatrixTools {
 //     return vector*matrix*vector;
 //   }
 
-  template <unsigned int N>
-  double trace (const ROOT::Math::SMatrix<double, N, N>& matrix) {
-    double result(0.);
-    for ( unsigned int i=0; i<N; i++ )  result += matrix(i,i);
+  template <typename T, unsigned int N>
+  T trace (ROOT::Math::SMatrix<T, N, N> const & matrix) {
+    T result = 0;
+    for ( unsigned int i=0; i<N; ++i )  result += matrix(i,i);
     return result;
   }
 
@@ -26,23 +26,21 @@ namespace GsfMatrixTools {
    *   a(i,j)*b(j,i) = a(i,j)*b(i,j) sum over i and j
    */
   template<typename T, unsigned int N>
-  double trace(ROOT::Math::SMatrix<T,N,N,ROOT::Math::MatRepSym<T,N> > const & a,
-	       ROOT::Math::SMatrix<T,N,N,ROOT::Math::MatRepSym<T,N> > const & b) {
-    typedef typename ROOT::Math::SMatrix<T,N,N,ROOT::Math::MatRepSym<T,N> >::const_iterator CI;
-    CI i1 = a.begin();
-    CI e1 = a.end();
-    CI i2 = b.begin();
-    //  CI e2 = b.end();
+  T trace(ROOT::Math::SMatrix<T,N,N,ROOT::Math::MatRepSym<T,N> > const & a,
+	  ROOT::Math::SMatrix<T,N,N,ROOT::Math::MatRepSym<T,N> > const & b) {
+    auto i1 = a.begin();
+    auto e1 = a.end();
+    auto i2 = b.begin();
   
     T res =0;
     // sum of the lower triangle;
     for (;i1!=e1; i1++, i2++)
       res += (*i1)*(*i2);
-    res *=2.;
+    res *= T(2.);
     // remove the duplicated diagonal...
-    for (unsigned int i=0;i<N;i++)
+    for (unsigned int i=0;i<N;++i)
       res -= a(i,i)*b(i,i);
-  return res;
+    return res;
   }
   
 }

--- a/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.h
+++ b/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.h
@@ -7,27 +7,18 @@
  */
 
 template <unsigned int N>
-class KullbackLeiblerDistance : public DistanceBetweenComponents<N> {
-
-private:
-  typedef typename SingleGaussianState<N>::Vector Vector;
-  typedef typename SingleGaussianState<N>::Matrix Matrix;
-  
+class KullbackLeiblerDistance final : public DistanceBetweenComponents<N> {
 public:
   
   /** Method which calculates the actual Kullback-Leibler distance.
    */
-
-  virtual double operator() (const SingleGaussianState<N>&, 
-			     const SingleGaussianState<N>&) const;
+ double operator() (const SingleGaussianState<N>&, 
+			     const SingleGaussianState<N>&) const override;
 
   virtual KullbackLeiblerDistance<N>* clone() const
   {  
     return new KullbackLeiblerDistance<N>(*this);
   }
-
-// private:
-//   double trace (const Matrix& matrix) const;
 };  
 
 #include "TrackingTools/GsfTools/interface/KullbackLeiblerDistance.icc"

--- a/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.icc
+++ b/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.icc
@@ -6,29 +6,22 @@ namespace KullbackLeiblerDistanceDetails {
   compute (SingleGaussianState<N>  const & sgs1, 
 	   SingleGaussianState<N>  const & sgs2) {
     
-    //ThS: That check will have to happen somewhere else for TSOS...
-  typedef ROOT::Math::SVector<double, N> Vector;
-  typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > Matrix;
+  using Vector = ROOT::Math::SVector<double, N>;
+  using Matrix = ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N>>;
+
+    // a = b+c; does not vectorize for SMatrix...
      
-    //   if (&tsos1.surface() != &tsos2.surface()) {
-    //     cout << "Trying to calculate distance between components defined "
-    // 	 << "at different surfaces - returning zero!" << endl;
-    //     return 0.;
-    //   }
-    
-    const Vector& mu1 = sgs1.mean();
-    const Matrix& V1 = sgs1.covariance();
+    Vector mudiff = sgs1.mean();
+    Matrix Vdiff = sgs1.covariance();
     const Vector& mu2 = sgs2.mean();
     const Matrix& V2 = sgs2.covariance();
     
-    //   Matrix G1(V1); G1.Invert();
-    //   Matrix G2(V2); G2.Invert();
-    const Matrix& G1 = sgs1.weightMatrix();
+    Matrix Gsum = sgs1.weightMatrix();
     const Matrix& G2 = sgs2.weightMatrix();
-    Vector mudiff = mu1 - mu2;
-    Matrix Vdiff = V1 - V2;
-    Matrix Gdiff = G2 - G1;
-    Matrix Gsum = G1 + G2;
+    mudiff -= mu2;
+    Vdiff -= V2;
+    Matrix Gdiff = G2 - Gsum;
+    Gsum += G2;
     
     //   double dist = (Vdiff * Gdiff).trace() + Gsum.similarity(mudiff);
     double dist = GsfMatrixTools::trace(Vdiff,Gdiff) +
@@ -48,12 +41,3 @@ KullbackLeiblerDistance<N>::operator() (const SingleGaussianState<N> & sgs1,
   return KullbackLeiblerDistanceDetails::compute<N>(sgs1,sgs2);
   
 }
-
-// template <unsigned int N> double 
-// KullbackLeiblerDistance<N>::trace (const Matrix& matrix) const
-// {
-//   double result(0);
-//   for ( unsigned int i=0; i<N; i++ )  result += matrix(i,i);
-//   return result;
-// }
-

--- a/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.icc
+++ b/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.icc
@@ -9,8 +9,22 @@ namespace KullbackLeiblerDistanceDetails {
   using Vector = ROOT::Math::SVector<double, N>;
   using Matrix = ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N>>;
 
-    // a = b+c; does not vectorize for SMatrix...
      
+
+    const Vector& mu1 = sgs1.mean();
+    const Matrix& V1 = sgs1.covariance();
+    const Vector& mu2 = sgs2.mean();
+    const Matrix& V2 = sgs2.covariance();
+
+    const Matrix& G1 = sgs1.weightMatrix();
+    const Matrix& G2 = sgs2.weightMatrix();
+    Vector mudiff = mu1 - mu2;
+    Matrix Vdiff = V1 - V2;
+    Matrix Gdiff = G2 - G1;
+    Matrix Gsum = G1 + G2;
+
+
+/*  for sse above is faster (less instructions, less CPI) for avx2 equivelent maybe below faster
     Vector mudiff = sgs1.mean();
     Matrix Vdiff = sgs1.covariance();
     const Vector& mu2 = sgs2.mean();
@@ -22,7 +36,8 @@ namespace KullbackLeiblerDistanceDetails {
     Vdiff -= V2;
     Matrix Gdiff = G2 - Gsum;
     Gsum += G2;
-    
+*/  
+  
     //   double dist = (Vdiff * Gdiff).trace() + Gsum.similarity(mudiff);
     double dist = GsfMatrixTools::trace(Vdiff,Gdiff) +
       ROOT::Math::Similarity(mudiff,Gsum);

--- a/TrackingTools/GsfTools/interface/MultiGaussianState.h
+++ b/TrackingTools/GsfTools/interface/MultiGaussianState.h
@@ -20,8 +20,8 @@ public:
   typedef typename SingleGaussianState<N>::Vector Vector;
   typedef typename SingleGaussianState<N>::Matrix Matrix;
   typedef SingleGaussianState<N> SingleState;
-  typedef boost::shared_ptr<SingleState> SingleStatePtr;
-//   typedef std::vector< boost::shared_ptr<const SingleState> > SingleStateContainer;
+  typedef std::shared_ptr<SingleState> SingleStatePtr;
+//   typedef std::vector< std::shared_ptr<const SingleState> > SingleStateContainer;
   typedef std::vector< SingleStatePtr > SingleStateContainer;
 
 public:

--- a/TrackingTools/GsfTools/interface/MultiGaussianState.icc
+++ b/TrackingTools/GsfTools/interface/MultiGaussianState.icc
@@ -3,11 +3,11 @@
 
 // template <unsigned int N>
 // MultiGaussianState<N>::MultiGaussianState
-// (const std::vector< boost::shared_ptr<SingleState> >& stateV) :
+// (const std::vector< std::shared_ptr<SingleState> >& stateV) :
 //   theCombinedStateUp2Date(false) {
 //   theComponents.reserve(stateV.size());
-//   for ( typename std::vector< boost::shared_ptr<SingleState> >::const_iterator ic=stateV.begin();
-// 	ic!=stateV.end(); ++ic )  theComponents.push_back( boost::shared_ptr<const SingleState>(*ic) );
+//   for ( typename std::vector< std::shared_ptr<SingleState> >::const_iterator ic=stateV.begin();
+// 	ic!=stateV.end(); ++ic )  theComponents.push_back( std::shared_ptr<const SingleState>(*ic) );
 // }
 
 template <unsigned int N>

--- a/TrackingTools/GsfTools/interface/MultiGaussianStateAssembler.h
+++ b/TrackingTools/GsfTools/interface/MultiGaussianStateAssembler.h
@@ -23,7 +23,7 @@ public:
   //
   // constructors
   //
-  MultiGaussianStateAssembler (const MultiState & state);
+  MultiGaussianStateAssembler() = default;
   
   /** Adds a new MultiGaussianState to the list 
    *  of components
@@ -64,12 +64,11 @@ private:
   void removeSmallWeights ();
 
 private:
-  const MultiState theInitialState;
-  double minFractionalWeight;
+  double minFractionalWeight = 1.e-16;
 
-  bool combinationDone;
+  bool combinationDone=false;
 
-  double theValidWeightSum;
+  double theValidWeightSum=0;
   SingleStateContainer theStates;
   
 };

--- a/TrackingTools/GsfTools/interface/MultiGaussianStateAssembler.icc
+++ b/TrackingTools/GsfTools/interface/MultiGaussianStateAssembler.icc
@@ -3,12 +3,6 @@
 
 
 template <unsigned int N>
-MultiGaussianStateAssembler<N>::MultiGaussianStateAssembler (const MultiState & state) :
-  theInitialState(state), minFractionalWeight(1.e-16),
-  combinationDone(false), theValidWeightSum(0.)
-{}
-
-template <unsigned int N>
 void MultiGaussianStateAssembler<N>::addState (const SingleStatePtr& sgs)
 {
   //

--- a/TrackingTools/GsfTools/interface/MultiGaussianStateCombiner.icc
+++ b/TrackingTools/GsfTools/interface/MultiGaussianStateCombiner.icc
@@ -17,9 +17,6 @@ MultiGaussianStateCombiner<N>::combine(const VSC& theComponents) const
   if (theComponents.empty()) {
     throw cms::Exception("LogicError") 
       << "MultiGaussianStateCombiner:: state container to collapse is empty";
-//     return SingleState(SingleState::Vector(),SingleState::Matrix(),0.);
-//     return SingleState(typename SingleState::Vector(),
-// 		       typename SingleState::Matrix(),0.);
     return SingleStatePtr();
   }
 
@@ -33,7 +30,7 @@ MultiGaussianStateCombiner<N>::combine(const VSC& theComponents) const
   double weightSum = 0.;
   double weight;
   typename SingleState::Matrix measCovar1, measCovar2;
-  for ( typename VSC::const_iterator mixtureIter1 = theComponents.begin();
+  for ( auto mixtureIter1 = theComponents.begin();
   	mixtureIter1 != theComponents.end(); mixtureIter1++ ) {
     weight = (*mixtureIter1)->weight();
     weightSum += weight;
@@ -42,17 +39,9 @@ MultiGaussianStateCombiner<N>::combine(const VSC& theComponents) const
     meanMean += weight * mean1;
     measCovar1 += weight * (**mixtureIter1).covariance();
 
-    for ( typename VSC::const_iterator mixtureIter2 = mixtureIter1+1;
+    for (auto mixtureIter2 = mixtureIter1+1;
   	mixtureIter2 != theComponents.end(); mixtureIter2++ ) {
       typename SingleState::Vector posDiff = mean1 - (**mixtureIter2).mean();
-//       SingleState::Matrix s(1,1); //stupid trick to make CLHEP work decently
-//       measCovar2 +=weight * (*mixtureIter2).weight() *
-//       				s.similarity(posDiff.T().T());
-//       typename SingleState::Matrix mat;
-//       for ( unsigned int i1=0; i1<N; i1++ ) {
-// 	for ( unsigned int i2=0; i2<=i1; i2++ )  mat(i1,i2) = posDiff(i1)*posDiff(i2);
-//       }
-//       measCovar2 += weight * (*mixtureIter2).weight() * mat;
       // 
       // TensorProd yields a general matrix - need to convert to a symm. matrix
       ROOT::Math::SMatrix<double,N,N> covGen = ROOT::Math::TensorProd(posDiff,posDiff);
@@ -69,12 +58,12 @@ MultiGaussianStateCombiner<N>::combine(const VSC& theComponents) const
     meanMean *= 0.;
     weightSum = 0.;
   } else {
-    meanMean /= weightSum;
-    measCovar1 *= (1./weightSum);
-    measCovar2 *= (1./weightSum/weightSum);
+    auto wsInv = 1./weightSum;
+    meanMean *= wsInv;
+    measCovar1 *= wsInv;
+    measCovar2 *= wsInv*wsInv; 
     measCovar = measCovar1 + measCovar2;
-//     measCovar = measCovar1/weightSum + measCovar2/weightSum/weightSum;
   }
 
-  return SingleStatePtr(new SingleState(meanMean, measCovar, weightSum));
+  return std::make_shared<SingleState>(meanMean, measCovar, weightSum);
 }

--- a/TrackingTools/GsfTools/interface/SingleGaussianState.h
+++ b/TrackingTools/GsfTools/interface/SingleGaussianState.h
@@ -12,41 +12,16 @@
 
 template <unsigned int N> class SingleGaussianState {
 public:
-  typedef ROOT::Math::SVector<double, N> Vector;
-  typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > Matrix;
+  using Vector = ROOT::Math::SVector<double, N>;
+  using Matrix = ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N>>;
   
 public:
-  SingleGaussianState() :
-    theHasWeightMatrix(false) {
-//     ++instances_;++maxInstances_;
-  }
+  SingleGaussianState() {}
 
-//   SingleGaussianState(const SingleGaussianState<N>& rhs) :
-//     theWeight(rhs.theWeight), theMean(rhs.theMean), theCovariance(rhs.theCovariance),
-//     theHasWeightMatrix(rhs.theHasWeightMatrix), theWeightMatrix(rhs.theWeightMatrix) {
-//     ++instances_;++maxInstances_;
-//   }
-  
   SingleGaussianState(const Vector& aMean,
 		      const Matrix& aCovariance, 
 		      double aWeight = 1.) : 
-    theCovariance(aCovariance), theMean(aMean), theWeight(aWeight), 
-    theHasWeightMatrix(false) {
-//     ++instances_;++maxInstances_;
-  }
-  
-  ~SingleGaussianState() {
-//     --instances_;
-  }
-  
-  //   /**
-//    * Creates a new single-state with the given information.
-//    * For this base class, no information is passed from the initial 
-//    * instance.
-//    */
-//   SingleGaussianState 
-//   	createState(const AlgebraicVector & aMean, 
-// 		       const AlgebraicSymMatrix & aCovariance, double aWeight = 1) const;
+    theCovariance(aCovariance), theMean(aMean), theWeight(aWeight) {}  
 
   /// weight
   inline double weight() const {return theWeight;}
@@ -61,24 +36,15 @@ public:
   /// change weight
   void rescaleWeight (double scale) {theWeight *= scale;}
 
-// protected:
 private:
   Matrix theCovariance;
   Vector theMean;
   double theWeight;
 
   mutable Matrix theWeightMatrix = ROOT::Math::SMatrixNoInit();
-  mutable bool theHasWeightMatrix;
-
-// public:
-//   static int instances_;
-//   static int maxInstances_;
-//   static int constructsWeightMatrix_;
+  mutable bool theHasWeightMatrix = false;
 };
 
 #include "TrackingTools/GsfTools/interface/SingleGaussianState.icc"
 
-// template <unsigned int N> int SingleGaussianState<N>::instances_ = 0;
-// template <unsigned int N> int SingleGaussianState<N>::maxInstances_ = 0;
-// template <unsigned int N> int SingleGaussianState<N>::constructsWeightMatrix_ = 0;
 #endif

--- a/TrackingTools/GsfTools/interface/SingleGaussianState.icc
+++ b/TrackingTools/GsfTools/interface/SingleGaussianState.icc
@@ -6,6 +6,5 @@ SingleGaussianState<N>::weightMatrix () const {
       invertPosDefMatrix(theCovariance,theWeightMatrix);
     theHasWeightMatrix = true;
   }
-    //     ++constructsWeightMatrix_;
-    return theWeightMatrix;
+  return theWeightMatrix;
 }

--- a/TrackingTools/GsfTools/interface/SingleGaussianState1D.h
+++ b/TrackingTools/GsfTools/interface/SingleGaussianState1D.h
@@ -36,7 +36,7 @@ public:
     return theStandardDeviation;
   }
 //   /// state
-//   boost::shared_ptr<SingleState> state() {return theState;}
+//   std::shared_ptr<SingleState> state() {return theState;}
 
 private:
   double theWeight;

--- a/TrackingTools/GsfTools/plugins/BuildFile.xml
+++ b/TrackingTools/GsfTools/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/GsfTools"/>
 <use   name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.h
+++ b/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.h
@@ -16,7 +16,7 @@ class  CloseComponentsMergerESProducer: public edm::ESProducer{
  public:
   CloseComponentsMergerESProducer(const edm::ParameterSet & p);
   virtual ~CloseComponentsMergerESProducer(); 
-  boost::shared_ptr< MultiGaussianStateMerger<N> > produce(const TrackingComponentsRecord &);
+  std::shared_ptr< MultiGaussianStateMerger<N> > produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc
+++ b/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc
@@ -44,7 +44,7 @@ CloseComponentsMergerESProducer<N>::~CloseComponentsMergerESProducer() {
 }
 
 template <unsigned int N>
-typename boost::shared_ptr< MultiGaussianStateMerger<N> > 
+typename std::shared_ptr< MultiGaussianStateMerger<N> > 
 CloseComponentsMergerESProducer<N>::produce(const TrackingComponentsRecord & iRecord){ 
 
   int maxComp = pset_.getParameter<int>("MaxComponents");
@@ -54,7 +54,7 @@ CloseComponentsMergerESProducer<N>::produce(const TrackingComponentsRecord & iRe
   iRecord.get(distName,distProducer);
   
   return 
-    boost::shared_ptr< MultiGaussianStateMerger<N> >
+    std::shared_ptr< MultiGaussianStateMerger<N> >
     (new CloseComponentsMerger<N>(maxComp,distProducer.product()));
 }
 

--- a/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.h
+++ b/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.h
@@ -16,7 +16,7 @@ class  DistanceBetweenComponentsESProducer : public edm::ESProducer{
  public:
   DistanceBetweenComponentsESProducer(const edm::ParameterSet & p);
   virtual ~DistanceBetweenComponentsESProducer(); 
-  boost::shared_ptr< DistanceBetweenComponents<N> > produce(const TrackingComponentsRecord &);
+  std::shared_ptr< DistanceBetweenComponents<N> > produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.icc
+++ b/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.icc
@@ -23,16 +23,16 @@ template <unsigned int N>
 DistanceBetweenComponentsESProducer<N>::~DistanceBetweenComponentsESProducer() {}
 
 template <unsigned int N>
-typename boost::shared_ptr< DistanceBetweenComponents<N> > 
+typename std::shared_ptr< DistanceBetweenComponents<N> > 
 DistanceBetweenComponentsESProducer<N>::produce(const TrackingComponentsRecord & iRecord){ 
 
   std::string distName = pset_.getParameter<std::string>("DistanceMeasure");
   
-  boost::shared_ptr< DistanceBetweenComponents<N> > distance;
+  std::shared_ptr< DistanceBetweenComponents<N> > distance;
   if ( distName == "KullbackLeibler" )
-    distance = boost::shared_ptr< DistanceBetweenComponents<N> >(new KullbackLeiblerDistance<N>());
+    distance = std::shared_ptr< DistanceBetweenComponents<N> >(new KullbackLeiblerDistance<N>());
 // //   else if ( distName == "Mahalanobis" )
-// //     distance = boost::shared_ptr<DistanceBetweenComponents>(new MahalanobisDistance());
+// //     distance = std::shared_ptr<DistanceBetweenComponents>(new MahalanobisDistance());
   
   return distance;
 }

--- a/TrackingTools/GsfTools/src/MultiGaussianState1D.cc
+++ b/TrackingTools/GsfTools/src/MultiGaussianState1D.cc
@@ -32,7 +32,7 @@ void MultiGaussianState1D::checkCombinedState() const
   theCombinedState = combiner.combine(theComponents);
 
 //   typedef SingleGaussianState<1> SingleState;
-//   typedef boost::shared_ptr< SingleGaussianState<1> > SingleStatePtr;
+//   typedef std::shared_ptr< SingleGaussianState<1> > SingleStatePtr;
 //   typedef std::vector< SingleStatePtr > SingleStateContainer;
 
 //   SingleStateContainer components;

--- a/TrackingTools/GsfTools/src/MultiGaussianStateTransform.cc
+++ b/TrackingTools/GsfTools/src/MultiGaussianStateTransform.cc
@@ -1,4 +1,5 @@
 #include "TrackingTools/GsfTools/interface/MultiGaussianStateTransform.h"
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 #include "TrackingTools/GsfTools/interface/MultiGaussianState1D.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtraFwd.h"
@@ -86,10 +87,11 @@ MultiGaussianStateTransform::multiState1D (const std::vector<MultiGaussianState<
 MultiGaussianState<5> 
 MultiGaussianStateTransform::multiState (const TrajectoryStateOnSurface tsos)
 {
-  std::vector<TrajectoryStateOnSurface> tsosComponents(tsos.components());
+  GetComponents comps(tsos);
+  auto const & tsosComponents = comps();
   MultiGaussianState<5>::SingleStateContainer components;
   components.reserve(tsosComponents.size());
-  for ( std::vector<TrajectoryStateOnSurface>::const_iterator i=tsosComponents.begin();
+  for (auto i=tsosComponents.begin();
 	i!=tsosComponents.end(); ++i ) {
     MultiGaussianState<5>::SingleStatePtr 
       sgs(new MultiGaussianState<5>::SingleState(i->localParameters().vector(),
@@ -106,10 +108,11 @@ MultiGaussianStateTransform::multiState1D (const TrajectoryStateOnSurface tsos,
 {
   if ( index>=N )  
     throw cms::Exception("LogicError") << "MultiGaussianStateTransform: index out of range";
-  std::vector<TrajectoryStateOnSurface> tsosComponents(tsos.components());
+  GetComponents comps(tsos);
+  auto const & tsosComponents = comps();
   MultiGaussianState1D::SingleState1dContainer components;
   components.reserve(tsosComponents.size());
-  for ( std::vector<TrajectoryStateOnSurface>::const_iterator i=tsosComponents.begin();
+  for (auto i=tsosComponents.begin();
 	i!=tsosComponents.end(); ++i ) {
     components.push_back(SingleGaussianState1D(i->localParameters().vector()(index),
 					       i->localError().matrix()(index,index),

--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
@@ -1,5 +1,5 @@
 #include "TrackingTools/GsfTools/interface/MultiTrajectoryStateAssembler.h"
-
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 #include "TrackingTools/GsfTools/interface/BasicMultiTrajectoryState.h"
 #include "TrackingTools/GsfTools/src/TrajectoryStateLessWeight.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -34,7 +34,8 @@ void MultiTrajectoryStateAssembler::addState (const TrajectoryStateOnSurface tso
   //
   // Add components (i.e. state to be added can be single or multi state)
   //
-  MultiTSOS components(tsos.components());
+  GetComponents comps(tsos);
+  MultiTSOS components(comps());
   addStateVector(components);
 }
 

--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateMode.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateMode.cc
@@ -1,4 +1,6 @@
 #include "TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h"
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
@@ -24,8 +26,9 @@ MultiTrajectoryStateMode::momentumFromModeCartesian (const TrajectoryStateOnSurf
   //  
   // 1D mode computation for px, py and pz
   // 
-  std::vector<TrajectoryStateOnSurface> components(tsos.components());
-  unsigned int numb = components.size();
+  GetComponents comps(tsos);
+  auto const & components = comps();
+  auto numb = components.size();
   // vectors of components in x, y and z
   std::vector<SingleGaussianState1D> pxStates; pxStates.reserve(numb);
   std::vector<SingleGaussianState1D> pyStates; pyStates.reserve(numb);
@@ -71,8 +74,10 @@ MultiTrajectoryStateMode::positionFromModeCartesian (const TrajectoryStateOnSurf
   //  
   // 1D mode computation for x, y and z
   // 
-  std::vector<TrajectoryStateOnSurface> components(tsos.components());
-  unsigned int numb = components.size();
+  
+  GetComponents comps(tsos);
+  auto const & components = comps();
+  auto numb = components.size();
   // vectors of components in x, y and z
   std::vector<SingleGaussianState1D> xStates; xStates.reserve(numb);
   std::vector<SingleGaussianState1D> yStates; yStates.reserve(numb);
@@ -263,8 +268,9 @@ MultiTrajectoryStateMode::momentumFromModePPhiEta (const TrajectoryStateOnSurfac
   //  
   // 1D mode computation for p, phi, eta
   // 
-  std::vector<TrajectoryStateOnSurface> components(tsos.components());
-  unsigned int numb = components.size();
+  GetComponents comps(tsos);
+  auto const & components = comps();
+  auto numb = components.size();
   // vectors of components in p, phi and eta
   std::vector<SingleGaussianState1D> pStates; pStates.reserve(numb);
   std::vector<SingleGaussianState1D> phiStates; phiStates.reserve(numb);

--- a/TrackingTools/GsfTools/test/BuildFile.xml
+++ b/TrackingTools/GsfTools/test/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="TrackingTools/GsfTools"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="rootmath"/>

--- a/TrackingTools/GsfTools/test/KullbackLeiblerDistance_t.cpp
+++ b/TrackingTools/GsfTools/test/KullbackLeiblerDistance_t.cpp
@@ -128,6 +128,20 @@ int main(int argc, char * argv[]) {
 
   std:: cout << res << " " << res2 << std::endl;
 
+   res=0;
+   st();
+   edm::HRTimeType s= edm::hrRealTime();
+   for (int i=0; i<100;	++i) 
+   for ( auto const & s : vgs)
+     res+= d(vgs.front(),s);
+   edm::HRTimeType e = edm::hrRealTime();
+   en();
+ 
+   std::cout << e-s << std::endl;
+ 
+  std:: cout << res << std::endl;
+
+
   return 0;
 
 }

--- a/TrackingTools/GsfTools/test/traceSymMult_t.cpp
+++ b/TrackingTools/GsfTools/test/traceSymMult_t.cpp
@@ -67,7 +67,7 @@ int main(int args, char ** argv) {
 
   double one = GsfMatrixTools::trace(cov1,cov2);
 
-  double two =  GsfMatrixTools::trace<5>(cov1*cov2); 
+  double two =  GsfMatrixTools::trace<double,5>(cov1*cov2); 
  
   if (fabs(one-two)>1.e-12) std::cout << "vincenzo was wrong!" << std::endl;
   std::cout << one << " " << two << " "<< one-two << std::endl;  
@@ -78,7 +78,7 @@ int main(int args, char ** argv) {
     en();
   } else {
     st();
-    two =  GsfMatrixTools::trace<5>(cov2*cov1); 
+    two =  GsfMatrixTools::trace<double,5>(cov2*cov1); 
     en();
   }
 

--- a/TrackingTools/GsfTracking/interface/MultiTrajectoryStateMerger.h
+++ b/TrackingTools/GsfTracking/interface/MultiTrajectoryStateMerger.h
@@ -22,7 +22,7 @@ public:
   }
 
  private:
-  const boost::shared_ptr< const MultiGaussianStateMerger<5> > theMultiStateMerger;
+  const std::shared_ptr< const MultiGaussianStateMerger<5> > theMultiStateMerger;
 };  
 
 #endif

--- a/TrackingTools/GsfTracking/interface/TsosGaussianStateConversions.h
+++ b/TrackingTools/GsfTracking/interface/TsosGaussianStateConversions.h
@@ -4,9 +4,9 @@
 #include "TrackingTools/GsfTools/interface/MultiGaussianState.h"
 
 namespace GaussianStateConversions {
-  MultiGaussianState<5> multiGaussianStateFromTSOS (const TrajectoryStateOnSurface tsos);
+  MultiGaussianState<5> multiGaussianStateFromTSOS (const TrajectoryStateOnSurface & tsos);
   TrajectoryStateOnSurface tsosFromMultiGaussianState (const MultiGaussianState<5>& multiState,
-							  const TrajectoryStateOnSurface refTsos);
+							  const TrajectoryStateOnSurface & refTsos);
 }
 
 #endif

--- a/TrackingTools/GsfTracking/plugins/GsfMaterialEffectsESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfMaterialEffectsESProducer.cc
@@ -26,7 +26,7 @@ GsfMaterialEffectsESProducer::GsfMaterialEffectsESProducer(const edm::ParameterS
 
 GsfMaterialEffectsESProducer::~GsfMaterialEffectsESProducer() {}
 
-boost::shared_ptr<GsfMaterialEffectsUpdator> 
+std::shared_ptr<GsfMaterialEffectsUpdator> 
 GsfMaterialEffectsESProducer::produce(const TrackingComponentsRecord & iRecord){ 
   double mass = pset_.getParameter<double>("Mass");
   std::string msName = pset_.getParameter<std::string>("MultipleScatteringUpdator");
@@ -50,8 +50,8 @@ GsfMaterialEffectsESProducer::produce(const TrackingComponentsRecord & iRecord){
     elUpdator = new GsfMaterialEffectsAdapter(EnergyLossUpdator(mass));
   }
 
-  boost::shared_ptr<GsfMaterialEffectsUpdator> updator =
-    boost::shared_ptr<GsfMaterialEffectsUpdator>(new GsfCombinedMaterialEffectsUpdator(*msUpdator,
+  std::shared_ptr<GsfMaterialEffectsUpdator> updator =
+    std::shared_ptr<GsfMaterialEffectsUpdator>(new GsfCombinedMaterialEffectsUpdator(*msUpdator,
 										       *elUpdator));
   delete msUpdator;
   delete elUpdator;

--- a/TrackingTools/GsfTracking/plugins/GsfMaterialEffectsESProducer.h
+++ b/TrackingTools/GsfTracking/plugins/GsfMaterialEffectsESProducer.h
@@ -17,7 +17,7 @@ class  GsfMaterialEffectsESProducer: public edm::ESProducer{
  public:
   GsfMaterialEffectsESProducer(const edm::ParameterSet & p);
   virtual ~GsfMaterialEffectsESProducer(); 
-  boost::shared_ptr<GsfMaterialEffectsUpdator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<GsfMaterialEffectsUpdator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.cc
@@ -29,7 +29,7 @@ GsfTrajectoryFitterESProducer::GsfTrajectoryFitterESProducer(const edm::Paramete
 
 GsfTrajectoryFitterESProducer::~GsfTrajectoryFitterESProducer() {}
 
-boost::shared_ptr<TrajectoryFitter> 
+std::shared_ptr<TrajectoryFitter> 
 GsfTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
   //
   // material effects
@@ -67,7 +67,7 @@ GsfTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord & iRecord){
   //
   // create algorithm
   //
-  return boost::shared_ptr<TrajectoryFitter>(new GsfTrajectoryFitter(propagator,
+  return std::shared_ptr<TrajectoryFitter>(new GsfTrajectoryFitter(propagator,
 								     GsfMultiStateUpdator(), 
 								     estimator,merger,
 								     geo.product()));

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.h
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.h
@@ -14,7 +14,7 @@ class  GsfTrajectoryFitterESProducer: public edm::ESProducer{
  public:
   GsfTrajectoryFitterESProducer(const edm::ParameterSet & p);
   virtual ~GsfTrajectoryFitterESProducer(); 
-  boost::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
+  std::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.cc
@@ -27,7 +27,7 @@ GsfTrajectorySmootherESProducer::GsfTrajectorySmootherESProducer(const edm::Para
 
 GsfTrajectorySmootherESProducer::~GsfTrajectorySmootherESProducer() {}
 
-boost::shared_ptr<TrajectorySmoother> 
+std::shared_ptr<TrajectorySmoother> 
 GsfTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
   //
   // material effects
@@ -66,7 +66,7 @@ GsfTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord & iRecord)
   //
   //   bool matBefUpd = pset_.getParameter<bool>("MaterialBeforeUpdate");
   double scale = pset_.getParameter<double>("ErrorRescaling");
-  return boost::shared_ptr<TrajectorySmoother>(new GsfTrajectorySmoother(propagator,
+  return std::shared_ptr<TrajectorySmoother>(new GsfTrajectorySmoother(propagator,
 									 GsfMultiStateUpdator(), 
 									 estimator,merger,
 // 									 matBefUpd,

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.h
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.h
@@ -14,7 +14,7 @@ class  GsfTrajectorySmootherESProducer: public edm::ESProducer{
  public:
   GsfTrajectorySmootherESProducer(const edm::ParameterSet & p);
   virtual ~GsfTrajectorySmootherESProducer(); 
-  boost::shared_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
+  std::shared_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTracking/src/FullConvolutionWithMaterial.cc
+++ b/TrackingTools/GsfTracking/src/FullConvolutionWithMaterial.cc
@@ -5,19 +5,13 @@ TrajectoryStateOnSurface
 FullConvolutionWithMaterial::operator() (const TrajectoryStateOnSurface& tsos,
 					 const PropagationDirection propDir) const {
   //
-  // decomposition of input state
-  //
-  auto && input = tsos.components();
-  //
   // vector of result states
-  //
   MultiTrajectoryStateAssembler result;
   //
   // now add material effects to each component
   //
-  for (auto const & iTsos : input) {
+  for (auto const & iTsos : tsos.components()) {
     // add material
-    //
     TrajectoryStateOnSurface updatedTSoS = 
       theMEUpdator->updateState(iTsos,propDir);
     if ( updatedTSoS.isValid() )

--- a/TrackingTools/GsfTracking/src/GsfChi2MeasurementEstimator.cc
+++ b/TrackingTools/GsfTracking/src/GsfChi2MeasurementEstimator.cc
@@ -1,6 +1,6 @@
 #include "TrackingTools/GsfTracking/interface/GsfChi2MeasurementEstimator.h"
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 
-// #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/GsfTracking/interface/PosteriorWeightsCalculator.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -9,23 +9,22 @@ std::pair<bool,double>
 GsfChi2MeasurementEstimator::estimate (const TrajectoryStateOnSurface& tsos,
 				       const TrackingRecHit& hit) const {
 
-  std::vector<TrajectoryStateOnSurface> tsvec = tsos.components();
+  GetComponents comps(tsos);
+  auto const & tsvec = comps();
   if (tsvec.empty()) {
     edm::LogError("GsfChi2MeasurementEstimator") 
       << "Trying to calculate chi2 of hit with respect to empty mixture!";
     return std::make_pair(false,0.);
   }
 
-  std::vector<double> weights = PosteriorWeightsCalculator(tsvec).weights(hit);
+  auto const & weights = PosteriorWeightsCalculator(tsvec).weights(hit);
   if ( weights.empty() )  return std::make_pair(false,0);
 
   //   Chi2MeasurementEstimator est(chiSquaredCut());
   double chi2 = 0.;
   int i = 0;
-  for (std::vector<TrajectoryStateOnSurface>::const_iterator it = tsvec.begin();
-       it != tsvec.end(); it++) {
-    chi2 += weights[i++] * theEstimator.estimate(*it,hit).second;
-  }
+  for (auto const & ts : tsvec)
+    chi2 += weights[i++] * theEstimator.estimate(ts,hit).second;
   // Done - normalisation of weights is ensured 
   // by PosteriorWeightsCalculator
   return returnIt(chi2);

--- a/TrackingTools/GsfTracking/src/GsfMaterialEffectsUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMaterialEffectsUpdator.cc
@@ -21,9 +21,9 @@ GsfMaterialEffectsUpdator::updateState (const TrajectoryStateOnSurface& TSoS,
   if ( !surface.mediumProperties().isValid() )  return TSoS;
   SurfaceSide side = propDir==alongMomentum ? afterSurface : beforeSurface;
   // single input state?
-  if ( TSoS.components().size()>1 )
+  if (!TSoS.singleState() )
     throw cms::Exception("LogicError") << "GsfMaterialEffectsUpdator::updateState used with MultiTSOS";
-  double weight = TSoS.weight();
+  auto weight = TSoS.weight();
   //
   // Get components (will force recalculation, if necessary)
   //

--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -1,5 +1,5 @@
 #include "TrackingTools/GsfTracking/interface/GsfMultiStateUpdator.h"
-
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
 #include "TrackingTools/PatternTools/interface/MeasurementExtractor.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
@@ -12,8 +12,8 @@
 
 TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSurface& tsos,
 						      const TrackingRecHit& aRecHit) const {
-  
-  auto && predictedComponents = tsos.components();
+  GetComponents comps(tsos);  
+  auto const & predictedComponents = comps();
   if (predictedComponents.empty()) {
     edm::LogError("GsfMultiStateUpdator") << "Trying to update trajectory state with zero components! " ;
     return TrajectoryStateOnSurface();

--- a/TrackingTools/GsfTracking/src/TsosGaussianStateConversions.cc
+++ b/TrackingTools/GsfTracking/src/TsosGaussianStateConversions.cc
@@ -12,15 +12,15 @@ namespace GaussianStateConversions {
   {
     if ( !tsos.isValid() )  return MultiGaussianState<5>();
 
-    using SingleStatePtr = boost::shared_ptr<SingleGaussianState<5>>;
+    using SingleStatePtr = std::shared_ptr<SingleGaussianState<5>>;
     auto const & components = tsos.components();
     MultiGaussianState<5>::SingleStateContainer singleStates;
     singleStates.reserve(components.size());
     for (auto const & ic : components) {
       if ( ic.isValid() ) {
-	SingleStatePtr sgs(new SingleGaussianState<5>(ic.localParameters().vector(),
+	auto sgs = std::make_shared<SingleGaussianState<5>>(ic.localParameters().vector(),
 							      ic.localError().matrix(),
-							      ic.weight()));
+							      ic.weight());
 	singleStates.push_back(sgs);
       }
     }

--- a/TrackingTools/GsfTracking/src/TsosGaussianStateConversions.cc
+++ b/TrackingTools/GsfTracking/src/TsosGaussianStateConversions.cc
@@ -2,13 +2,12 @@
 
 #include "TrackingTools/GsfTools/interface/SingleGaussianState.h"
 #include "TrackingTools/GsfTools/interface/BasicMultiTrajectoryState.h"
-#include "boost/shared_ptr.hpp"
 
 using namespace SurfaceSideDefinition;
 
 namespace GaussianStateConversions {
 
-  MultiGaussianState<5> multiGaussianStateFromTSOS (const TrajectoryStateOnSurface tsos)
+  MultiGaussianState<5> multiGaussianStateFromTSOS (const TrajectoryStateOnSurface & tsos)
   {
     if ( !tsos.isValid() )  return MultiGaussianState<5>();
 
@@ -28,7 +27,7 @@ namespace GaussianStateConversions {
   }
 
   TrajectoryStateOnSurface tsosFromMultiGaussianState (const MultiGaussianState<5>& multiState,
-							  const TrajectoryStateOnSurface refTsos)
+							  const TrajectoryStateOnSurface & refTsos)
   {
     if ( multiState.components().empty() )  return TrajectoryStateOnSurface();
     const Surface & surface = refTsos.surface();

--- a/TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h
@@ -18,7 +18,10 @@ public:
     return build<BasicSingleTrajectoryState>(*this);
   }
 
-  std::vector<TrajectoryStateOnSurface> components() const override;
+  using	Components = BasicTrajectoryState::Components;
+
+  Components const & components() const override;
+  bool singleState() const override { return true;}
 
 
 };

--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -22,8 +22,6 @@
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "TrackingTools/TrajectoryParametrization/interface/TrajectoryStateExceptions.h"
 
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
-
 /// vvv DEBUG
 // #include <iostream>
 
@@ -297,7 +295,9 @@ public:
  }
 
 public:
-  virtual std::vector<TrajectoryStateOnSurface> components() const =0;
+  using Components = std::vector<TrajectoryStateOnSurface>;
+  virtual Components const & components() const =0;
+  virtual bool singleState() const=0;
 
 private:
 

--- a/TrackingTools/TrajectoryState/interface/ProxyBase11.h
+++ b/TrackingTools/TrajectoryState/interface/ProxyBase11.h
@@ -3,7 +3,10 @@
 
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "FWCore/Utilities/interface/Likely.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
+
+#ifdef TR_DEBUG
+#include<iostream>
+#endif
 
 #include "ChurnAllocator.h"
 
@@ -64,8 +67,7 @@ public:
 
   void check() const {
 #ifdef TR_DEBUG
-    if  unlikely(!theData)
-      throw TrajectoryStateException("Error: uninitialized ProxyBase11 used");
+    if  unlikely(!theData) std::cout << "dead proxyBase11 " << references() << std::endl;
 #endif
   }
 

--- a/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h
+++ b/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h
@@ -129,9 +129,12 @@ public:
     unsharedData().rescaleError(factor);
   }
 
-  std::vector<TrajectoryStateOnSurface> components() const {
+  using	Components = BasicTrajectoryState::Components;
+  Components const & components() const {
     return data().components();
   }
+  bool singleState() const { return data().singleState();}
+
 
   /// Position relative to material, defined relative to momentum vector.
   SurfaceSide surfaceSide() const {

--- a/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
@@ -304,10 +304,9 @@ BasicTrajectoryState::rescaleError(double factor) {
 
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include<iostream>
 BasicSingleTrajectoryState::Components const &
 BasicSingleTrajectoryState::components() const {
-  std::cout << "who is calling me"<< std::endl;
+  edm::LogError("BasicSingleTrajectoryState") << "asking for componenets to a SingleTrajectoryState"<< std::endl;
   assert(false);
 }
 

--- a/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
@@ -304,11 +304,10 @@ BasicTrajectoryState::rescaleError(double factor) {
 
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-std::vector<TrajectoryStateOnSurface> 
+#include<iostream>
+BasicSingleTrajectoryState::Components const &
 BasicSingleTrajectoryState::components() const {
-  std::vector<TrajectoryStateOnSurface> result; result.reserve(1);
-  result.emplace_back(clone());
-  //  result.emplace_back(const_cast<BasicTrajectoryState*>(this));
-  return result;
+  std::cout << "who is calling me"<< std::endl;
+  assert(false);
 }
 


### PR DESCRIPTION
Major speedup of the Gsf component merging algo.
Apparently the algo (even in the original form) is not doing what was supposed to do.
This PR is purely technical. A fix of the algo logic will be submitted once fully validated.
For this reason the old algo and debug code is still left in place (commented out)

Took the opportunity to fix a long standing issue with the return of components by a TSOS
as discussed also in #13818

touches TSOS, expect recompilation of half of the universe 

negligible regressions expected due to numerics
