### PR TITLE
Cleanup of EG HLT filters

### DIFF
--- a/HLTrigger/Egamma/interface/HLTDisplacedEgammaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTDisplacedEgammaFilter.h
@@ -32,9 +32,7 @@ class HLTDisplacedEgammaFilter : public HLTFilter {
       edm::InputTag inputTag_; // input tag identifying product contains egammas
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
       int    ncandcut_;        // number of egammas required
-      bool   relaxed_;
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
       edm::InputTag rechitsEB ;
       edm::InputTag rechitsEE ;
       edm::EDGetTokenT<EcalRecHitCollection> rechitsEBToken_;

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtDeltaPhiFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtDeltaPhiFilter.h
@@ -33,9 +33,7 @@ class HLTEgammaDoubleEtDeltaPhiFilter : public HLTFilter {
       double etcut_;           // Et threshold in GeV
       double minDeltaPhi_;    // minimum deltaPhi
  //   int    ncandcut_;        // number of egammas required
-      bool   relaxed_;
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
 };
 
 #endif //HLTEgammaDoubleEtDeltaPhiFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtFilter.h
@@ -37,9 +37,8 @@ class HLTEgammaDoubleEtFilter : public HLTFilter {
   double etcut1_;           // Et threshold in GeV
   double etcut2_;           // Et threshold in GeV
   int    npaircut_;        // number of egammas required
-  bool   relaxed_;
-  edm::InputTag L1IsoCollTag_;
-  edm::InputTag L1NonIsoCollTag_;
+
+  edm::InputTag l1EGTag_;
 };
 
 #endif //HLTEgammaDoubleEtFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaEtFilter.h
@@ -33,9 +33,8 @@ class HLTEgammaEtFilter : public HLTFilter {
       double etcutEB_;           // Barrel Et threshold in GeV
       double etcutEE_;           // Endcap Et threshold in GeV
       int    ncandcut_;        // number of egammas required
-      bool   relaxed_;
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+
+      edm::InputTag l1EGTag_;
 };
 
 #endif //HLTEgammaEtFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaEtFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaEtFilterPairs.h
@@ -34,9 +34,7 @@ class HLTEgammaEtFilterPairs : public HLTFilter {
       double etcutEB2_;           // Et threshold in GeV
       double etcutEE1_;           // Et threshold in GeV
       double etcutEE2_;           // Et threshold in GeV
-      bool   relaxed_;
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
 };
 
 #endif //HLTEgammaEtFilterPairs_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
@@ -29,12 +29,10 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
-      edm::InputTag candTag_; // input tag identifying product that contains filtered photons
-      edm::InputTag isoTag_; // input tag identifying product that contains isolated map
-      edm::InputTag nonIsoTag_; // input tag identifying product that contains non-isolated map
+      edm::InputTag candTag_; // input tag identifying product that contains filtered candidates
+      edm::InputTag varTag_; // input tag identifying product that contains the variable map
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> isoToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> nonIsoToken_;
+      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> varToken_;
       bool lessThan_;           // the cut is "<" or ">" ?
       bool useEt_;              // use E or Et in relative isolation cuts
 /*  Barrel quadratic threshold function:
@@ -56,12 +54,10 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
       double thrOverEEE2_;       // coefficient for first order term - ECAL endcap region 2
       double thrOverE2EB2_;      // coefficient for second order term - ECAL barrel region 2
       double thrOverE2EE2_;      // coefficient for second order term - ECAL endcap region 2
-      int    ncandcut_;        // number of photons required
-      bool doIsolated_;
+      int    ncandcut_;        // number of candidates required
 
       bool   store_;
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
 };
 
 #endif //HLTEgammaGenericQuadraticEtaFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
@@ -29,12 +29,11 @@ class HLTEgammaGenericQuadraticFilter : public HLTFilter {
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
-      edm::InputTag candTag_; // input tag identifying product that contains filtered photons
-      edm::InputTag isoTag_; // input tag identifying product that contains isolated map
-      edm::InputTag nonIsoTag_; // input tag identifying product that contains non-isolated map
+      edm::InputTag candTag_; // input tag identifying product that contains filtered candidates
+      edm::InputTag varTag_; // input tag identifying product that contains the variable map
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> isoToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> nonIsoToken_;
+      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> varToken_;
+
       bool lessThan_;           // the cut is "<" or ">" ?
       bool useEt_;              // use E or Et in relative isolation cuts
 /*  Barrel quadratic threshold function:
@@ -48,11 +47,9 @@ class HLTEgammaGenericQuadraticFilter : public HLTFilter {
       double thrOverEEE_;       // coefficient for first order term - ECAL endcap
       double thrOverE2EB_;      // coefficient for second order term - ECAL barrel
       double thrOverE2EE_;      // coefficient for second order term - ECAL endcap
-      int    ncandcut_;        // number of photons required
-      bool doIsolated_;
+      int    ncandcut_;        // number of candidates required
 
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
 };
 
 #endif //HLTEgammaGenericQuadraticFilter_h

--- a/HLTrigger/Egamma/interface/HLTElectronEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronEtFilter.h
@@ -34,10 +34,7 @@ class HLTElectronEtFilter : public HLTFilter {
       double EtEB_;     // threshold for regular cut (x < thr) - ECAL barrel
       double EtEE_;     // threshold for regular cut (x < thr) - ECAL endcap
 
-      bool doIsolated_;
-
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
       int ncandcut_;
 };
 

--- a/HLTrigger/Egamma/interface/HLTElectronGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronGenericFilter.h
@@ -30,11 +30,9 @@ class HLTElectronGenericFilter : public HLTFilter {
 
    private:
       edm::InputTag candTag_; // input tag identifying product that contains filtered electrons
-      edm::InputTag isoTag_; // input tag identifying product that contains isolated map
-      edm::InputTag nonIsoTag_; // input tag identifying product that contains non-isolated map
+      edm::InputTag varTag_; // input tag identifying product that contains the variable map
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
-      edm::EDGetTokenT<reco::ElectronIsolationMap> isoToken_;
-      edm::EDGetTokenT<reco::ElectronIsolationMap> nonIsoToken_;
+      edm::EDGetTokenT<reco::ElectronIsolationMap> varToken_;
       bool lessThan_;           // the cut is "<" or ">" ?
       double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel
       double thrRegularEE_;     // threshold for regular cut (x < thr) - ECAL endcap
@@ -43,10 +41,8 @@ class HLTElectronGenericFilter : public HLTFilter {
       double thrTimesPtEB_;      // threshold for x*p_T < thr cut (isolations) - ECAL barrel
       double thrTimesPtEE_;      // threshold for x*p_T < thr cut (isolations) - ECAL endcap
       int    ncandcut_;        // number of electrons required
-      bool doIsolated_;
 
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
 };
 
 #endif //HLTElectronGenericFilter_h

--- a/HLTrigger/Egamma/interface/HLTElectronPFMTFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronPFMTFilter.h
@@ -27,8 +27,6 @@
 #include "TLorentzVector.h"
 #include "TVector3.h"
 
-
-
 //
 // class declaration
 //
@@ -50,10 +48,8 @@ class HLTElectronPFMTFilter : public HLTFilter {
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputEleToken_;
       double lowerMTCut_;
       double upperMTCut_;
-      bool   relaxed_;
       int    minN_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag l1EGTag_;
       
 };
 

--- a/HLTrigger/Egamma/interface/HLTElectronPixelMatchFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronPixelMatchFilter.h
@@ -34,22 +34,14 @@ class HLTElectronPixelMatchFilter : public HLTFilter {
   edm::InputTag candTag_;     // input tag identifying product contains filtered egammas
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
   
-  edm::InputTag L1IsoPixelSeedsTag_; // input tag for the pixel seed - supercluster map
-  //edm::InputTag L1IsoPixelmapendcapTag_; // input tag for the pixel seed - supercluster map
-  edm::EDGetTokenT<reco::ElectronSeedCollection> L1IsoPixelSeedsToken_;
-  
-  edm::InputTag L1NonIsoPixelSeedsTag_; // input tag for the pixel seed - supercluster map
-  //edm::InputTag L1NonIsoPixelmapendcapTag_; // input tag for the pixel seed - supercluster map
-  edm::EDGetTokenT<reco::ElectronSeedCollection> L1NonIsoPixelSeedsToken_;
+  edm::InputTag l1PixelSeedsTag_; // input tag for the pixel seed - supercluster map
+  edm::EDGetTokenT<reco::ElectronSeedCollection> l1PixelSeedsToken_;
   
   double npixelmatchcut_;     // number of pixelmatch hits
   int    ncandcut_;           // number of electrons required
   
-  bool doIsolated_;
-  edm::InputTag L1IsoCollTag_; 
-  edm::InputTag L1NonIsoCollTag_;
+  edm::InputTag l1EGTag_;
   
-
   // cuts on s2
   float s2BarrelThres_ ;
   float s2InterThres_;

--- a/HLTrigger/Egamma/interface/HLTGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTGenericFilter.h
@@ -49,12 +49,10 @@ private:
     float getEnergy(T1Ref) const;
     float getEt(T1Ref) const;
     
-    edm::InputTag candTag_; // input tag identifying product that contains filtered photons
-    edm::InputTag isoTag_; // input tag identifying product that contains isolated map
-    edm::InputTag nonIsoTag_; // input tag identifying product that contains non-isolated map
+    edm::InputTag candTag_; // input tag identifying product that contains filtered candidates
+    edm::InputTag varTag_; // input tag identifying product that contains variable map
     edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
-    edm::EDGetTokenT<T1IsolationMap> isoToken_;
-    edm::EDGetTokenT<T1IsolationMap> nonIsoToken_;
+    edm::EDGetTokenT<T1IsolationMap> varToken_;
     bool lessThan_;           // the cut is "<" or ">" ?
     bool useEt_;              // use E or Et in relative isolation cuts
     double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel
@@ -63,11 +61,9 @@ private:
     double thrOverEEE_;       // threshold for x/E < thr cut (isolations) - ECAL endcap
     double thrOverE2EB_;      // threshold for x/E^2 < thr cut (isolations) - ECAL barrel
     double thrOverE2EE_;      // threshold for x/E^2 < thr cut (isolations) - ECAL endcap
-    int    ncandcut_;        // number of photons required
-    bool doIsolated_;
+    int    ncandcut_;        // number of candidates required
     
-    edm::InputTag L1IsoCollTag_;
-    edm::InputTag L1NonIsoCollTag_;
+    edm::InputTag l1EGTag_;
 };
 
 #endif //HLTGenericFilter_h

--- a/HLTrigger/Egamma/interface/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMMassFilter.h
@@ -72,11 +72,9 @@ class HLTPMMassFilter : public HLTFilter {
       int    nZcandcut_;           // number of Z candidates required
       bool   reqOppCharge_;
 
-      bool   relaxed_;
       bool   isElectron1_;
       bool   isElectron2_;
-      edm::InputTag L1IsoCollTag_;
-      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag l1EGTag_;
 
 };
 

--- a/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
@@ -21,32 +21,30 @@
 //
 HLTDisplacedEgammaFilter::HLTDisplacedEgammaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-  inputTag_    = iConfig.getParameter< edm::InputTag > ("inputTag");
-  ncandcut_    = iConfig.getParameter<int> ("ncandcut");
-  relaxed_     = iConfig.getParameter<bool> ("relaxed") ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
+  inputTag_       = iConfig.getParameter< edm::InputTag > ("inputTag");
+  ncandcut_       = iConfig.getParameter<int> ("ncandcut");
+  l1EGTag_        = iConfig.getParameter< edm::InputTag > ("l1EGCand");
 
-  inputTrk   = iConfig.getParameter< edm::InputTag > ("inputTrack");
-  trkPtCut   = iConfig.getParameter<double> ("trackPtCut");
-  trkdRCut   = iConfig.getParameter<double> ("trackdRCut");
-  maxTrkCut  = iConfig.getParameter<int> ("maxTrackCut");
+  inputTrk        = iConfig.getParameter< edm::InputTag > ("inputTrack");
+  trkPtCut        = iConfig.getParameter<double> ("trackPtCut");
+  trkdRCut        = iConfig.getParameter<double> ("trackdRCut");
+  maxTrkCut       = iConfig.getParameter<int> ("maxTrackCut");
 
-  rechitsEB  = iConfig.getParameter< edm::InputTag > ("RecHitsEB");
-  rechitsEE  = iConfig.getParameter< edm::InputTag > ("RecHitsEE");
+  rechitsEB       = iConfig.getParameter< edm::InputTag > ("RecHitsEB");
+  rechitsEE       = iConfig.getParameter< edm::InputTag > ("RecHitsEE");
 
-  EBOnly       = iConfig.getParameter<bool> ("EBOnly") ;
-  sMin_min     = iConfig.getParameter<double> ("sMin_min");
-  sMin_max     = iConfig.getParameter<double> ("sMin_max");
-  sMaj_min     = iConfig.getParameter<double> ("sMaj_min");
-  sMaj_max     = iConfig.getParameter<double> ("sMaj_max");
-  seedTimeMin  = iConfig.getParameter<double> ("seedTimeMin");
-  seedTimeMax  = iConfig.getParameter<double> ("seedTimeMax");
+  EBOnly          = iConfig.getParameter<bool> ("EBOnly") ;
+  sMin_min        = iConfig.getParameter<double> ("sMin_min");
+  sMin_max        = iConfig.getParameter<double> ("sMin_max");
+  sMaj_min        = iConfig.getParameter<double> ("sMaj_min");
+  sMaj_max        = iConfig.getParameter<double> ("sMaj_max");
+  seedTimeMin     = iConfig.getParameter<double> ("seedTimeMin");
+  seedTimeMax     = iConfig.getParameter<double> ("seedTimeMax");
 
-  inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
+  inputToken_     = consumes<trigger::TriggerFilterObjectWithRefs> (inputTag_);
   rechitsEBToken_ = consumes<EcalRecHitCollection>(rechitsEB);
   rechitsEEToken_ = consumes<EcalRecHitCollection>(rechitsEE);
-  inputTrkToken_ = consumes<reco::TrackCollection>(inputTrk);
+  inputTrkToken_  = consumes<reco::TrackCollection>(inputTrk);
 
 }
 
@@ -56,25 +54,23 @@ void
 HLTDisplacedEgammaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
-   desc.add<edm::InputTag>("inputTag",edm::InputTag("hltEGRegionalL1SingleEG22"));
-   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-   desc.add<edm::InputTag>("RecHitsEB",edm::InputTag("hltEcalRecHit", "EcalRecHitsEB"));
-   desc.add<edm::InputTag>("RecHitsEE",edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
-   desc.add<edm::InputTag>("inputTrack",edm::InputTag("hltL1SeededEgammaRegionalCTFFinalFitWithMaterial"));
-   desc.add<bool>("relaxed",false);
-   desc.add<int>("ncandcut",1);
-   desc.add<bool>("EBOnly",false);
-   desc.add<double>("sMin_min",0.1);
-   desc.add<double>("sMin_max",0.4);
-   desc.add<double>("sMaj_min",0.0);
-   desc.add<double>("sMaj_max",999.0);
+   desc.add<edm::InputTag>("inputTag", edm::InputTag("hltEGRegionalL1SingleEG22"));
+   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
+   desc.add<edm::InputTag>("RecHitsEB", edm::InputTag("hltEcalRecHit", "EcalRecHitsEB"));
+   desc.add<edm::InputTag>("RecHitsEE", edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
+   desc.add<edm::InputTag>("inputTrack", edm::InputTag("hltL1SeededEgammaRegionalCTFFinalFitWithMaterial"));
+   desc.add<int>("ncandcut", 1);
+   desc.add<bool>("EBOnly", false);
+   desc.add<double>("sMin_min", 0.1);
+   desc.add<double>("sMin_max", 0.4);
+   desc.add<double>("sMaj_min", 0.0);
+   desc.add<double>("sMaj_max", 999.0);
    desc.add<double>("seedTimeMin", -25.0);
    desc.add<double>("seedTimeMax",  25.0);
    desc.add<int>("maxTrackCut", 0);
    desc.add<double>("trackPtCut", 3.0);
    desc.add<double>("trackdRCut", 0.5);
-   descriptions.add("hltDisplacedEgammaFilter",desc);
+   descriptions.add("hltDisplacedEgammaFilter", desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -86,8 +82,7 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
   // The filter object
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
 
   // Ref to Candidate object to be recorded in filter object

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
@@ -21,13 +21,11 @@
 //
 HLTEgammaDoubleEtDeltaPhiFilter::HLTEgammaDoubleEtDeltaPhiFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-   inputTag_ = iConfig.getParameter< edm::InputTag > ("inputTag");
-   etcut_  = iConfig.getParameter<double> ("etcut");
-   minDeltaPhi_ =   iConfig.getParameter<double> ("minDeltaPhi");
-   relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-   L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
-   inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
+   inputTag_    = iConfig.getParameter< edm::InputTag > ("inputTag");
+   etcut_       = iConfig.getParameter<double> ("etcut");
+   minDeltaPhi_ = iConfig.getParameter<double> ("minDeltaPhi");
+   l1EGTag_     = iConfig.getParameter< edm::InputTag > ("l1EGCand");
+   inputToken_  = consumes<trigger::TriggerFilterObjectWithRefs> (inputTag_);
 }
 
 HLTEgammaDoubleEtDeltaPhiFilter::~HLTEgammaDoubleEtDeltaPhiFilter(){}
@@ -36,13 +34,11 @@ void
 HLTEgammaDoubleEtDeltaPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
-   desc.add<edm::InputTag>("inputTag",edm::InputTag("hltDoublePhotonEt5L1MatchFilterRegional"));
-   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-   desc.addUntracked<bool>("relaxed",false);
+   desc.add<edm::InputTag>("inputTag", edm::InputTag("hltDoublePhotonEt5L1MatchFilterRegional"));
+   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
    desc.add<double>("etcut", 5.0);
    desc.add<double>("minDeltaPhi", 2.5);
-   descriptions.add("hltEgammaDoubleEtDeltaPhiFilter",desc);
+   descriptions.add("hltEgammaDoubleEtDeltaPhiFilter", desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -52,8 +48,7 @@ HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventS
    using namespace trigger;
    // The filter object
    if (saveTags()) {
-     filterproduct.addCollectionTag(L1IsoCollTag_);
-     if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+     filterproduct.addCollectionTag(l1EGTag_);
    }
 
    // get hold of filtered candidates

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
@@ -29,14 +29,12 @@ public:
 //
 HLTEgammaDoubleEtFilter::HLTEgammaDoubleEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-  candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
-  etcut1_  = iConfig.getParameter<double> ("etcut1");
-  etcut2_  = iConfig.getParameter<double> ("etcut2");
+  candTag_   = iConfig.getParameter< edm::InputTag > ("candTag");
+  etcut1_    = iConfig.getParameter<double> ("etcut1");
+  etcut2_    = iConfig.getParameter<double> ("etcut2");
   npaircut_  = iConfig.getParameter<int> ("npaircut");
-  relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
-  candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
+  l1EGTag_   = iConfig.getParameter< edm::InputTag > ("l1EGCand");
+  candToken_ = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
 }
 
 HLTEgammaDoubleEtFilter::~HLTEgammaDoubleEtFilter(){}
@@ -45,14 +43,12 @@ void
 HLTEgammaDoubleEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
-   desc.add<edm::InputTag>("candTag",edm::InputTag("hltTrackIsolFilter"));
-   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-   desc.addUntracked<bool>("relaxed",true);
+   desc.add<edm::InputTag>("candTag", edm::InputTag("hltTrackIsolFilter"));
+   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
    desc.add<double>("etcut1", 30.0);
    desc.add<double>("etcut2", 20.0);
    desc.add<int>("npaircut", 1);
-   descriptions.add("hltEgammaDoubleEtFilter",desc);
+   descriptions.add("hltEgammaDoubleEtFilter", desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -63,12 +59,11 @@ HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 
   // The filter object
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
   // Ref to Candidate object to be recorded in filter object
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (candToken_,PrevFilterOutput);
+  iEvent.getByToken (candToken_, PrevFilterOutput);
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> >  mysortedrecoecalcands;
   PrevFilterOutput->getObjects(TriggerPhoton,  mysortedrecoecalcands);

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
@@ -20,28 +20,24 @@
 //
 HLTEgammaEtFilter::HLTEgammaEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-  inputTag_ = iConfig.getParameter< edm::InputTag > ("inputTag");
-  etcutEB_  = iConfig.getParameter<double> ("etcutEB");
-  etcutEE_  = iConfig.getParameter<double> ("etcutEE");
-  ncandcut_  = iConfig.getParameter<int> ("ncandcut");
-  relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
-  inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
+  inputTag_   = iConfig.getParameter< edm::InputTag > ("inputTag");
+  etcutEB_    = iConfig.getParameter<double> ("etcutEB");
+  etcutEE_    = iConfig.getParameter<double> ("etcutEE");
+  ncandcut_   = iConfig.getParameter<int> ("ncandcut");
+  l1EGTag_    = iConfig.getParameter< edm::InputTag > ("l1EGCand");
+  inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs> (inputTag_);
 }
 
 void
 HLTEgammaEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
-   desc.add<edm::InputTag>("inputTag",edm::InputTag("HLTEgammaL1MatchFilter"));
-   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-   desc.addUntracked<bool>("relaxed",true);
+   desc.add<edm::InputTag>("inputTag", edm::InputTag("HLTEgammaL1MatchFilter"));
+   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
    desc.add<double>("etcutEB", 1.0);
    desc.add<double>("etcutEE", 1.0);
    desc.add<int>("ncandcut", 1);
-   descriptions.add("hltEgammaEtFilter",desc);
+   descriptions.add("hltEgammaEtFilter", desc);
 }
 
 HLTEgammaEtFilter::~HLTEgammaEtFilter(){}
@@ -55,8 +51,7 @@ HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
   // The filter object
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);;
   }
 
   // Ref to Candidate object to be recorded in filter object
@@ -65,7 +60,7 @@ HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   // get hold of filtered candidates
   //edm::Handle<reco::HLTFilterObjectWithRefs> recoecalcands;
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (inputToken_,PrevFilterOutput);
+  iEvent.getByToken (inputToken_, PrevFilterOutput);
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;                // vref with your specific C++ collection type
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
@@ -20,30 +20,26 @@
 //
 HLTEgammaEtFilterPairs::HLTEgammaEtFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-   inputTag_ = iConfig.getParameter< edm::InputTag > ("inputTag");
-   etcutEB1_  = iConfig.getParameter<double> ("etcut1EB");
-   etcutEE1_  = iConfig.getParameter<double> ("etcut1EE");
-   etcutEB2_  = iConfig.getParameter<double> ("etcut2EB");
-   etcutEE2_  = iConfig.getParameter<double> ("etcut2EE");
-   relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-   L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
-   inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
+   inputTag_   = iConfig.getParameter< edm::InputTag > ("inputTag");
+   etcutEB1_   = iConfig.getParameter<double> ("etcut1EB");
+   etcutEE1_   = iConfig.getParameter<double> ("etcut1EE");
+   etcutEB2_   = iConfig.getParameter<double> ("etcut2EB");
+   etcutEE2_   = iConfig.getParameter<double> ("etcut2EE");
+   l1EGTag_    = iConfig.getParameter< edm::InputTag > ("l1EGCand");
+   inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs> (inputTag_);
 }
 
 void
 HLTEgammaEtFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
-   desc.add<edm::InputTag>("inputTag",edm::InputTag("HLTEgammaL1MatchFilter"));
-   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-   desc.addUntracked<bool>("relaxed",true);
+   desc.add<edm::InputTag>("inputTag", edm::InputTag("HLTEgammaL1MatchFilter"));
+   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
    desc.add<double>("etcut1EB", 1.0);
    desc.add<double>("etcut1EE", 1.0);
    desc.add<double>("etcut2EB", 1.0);
    desc.add<double>("etcut2EE", 1.0);
-   descriptions.add("hltEgammaEtFilterPairs",desc);
+   descriptions.add("hltEgammaEtFilterPairs", desc);
 }
 
 HLTEgammaEtFilterPairs::~HLTEgammaEtFilterPairs(){}
@@ -56,12 +52,11 @@ HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
   using namespace trigger;
   // The filter object
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (inputToken_,PrevFilterOutput);
+  iEvent.getByToken (inputToken_, PrevFilterOutput);
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;                // vref with your specific C++ collection type
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -23,36 +23,34 @@
 // constructors and destructor
 //
 HLTEgammaGenericQuadraticEtaFilter::HLTEgammaGenericQuadraticEtaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig){
-  candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
-  isoTag_ = iConfig.getParameter< edm::InputTag > ("isoTag");
-  nonIsoTag_ = iConfig.getParameter< edm::InputTag > ("nonIsoTag");
+  candTag_         = iConfig.getParameter< edm::InputTag > ("candTag");
+  varTag_          = iConfig.getParameter< edm::InputTag > ("varTag");
 
-  lessThan_ = iConfig.getParameter<bool> ("lessThan");			
-  useEt_ = iConfig.getParameter<bool> ("useEt");			
-  etaBoundaryEB12_ = iConfig.getParameter<double> ("etaBoundaryEB12");	
-  etaBoundaryEE12_ = iConfig.getParameter<double> ("etaBoundaryEE12");	
-  thrRegularEB1_ = iConfig.getParameter<double> ("thrRegularEB1");	
-  thrRegularEE1_ = iConfig.getParameter<double> ("thrRegularEE1");	
-  thrOverEEB1_ = iConfig.getParameter<double> ("thrOverEEB1");		
-  thrOverEEE1_ = iConfig.getParameter<double> ("thrOverEEE1");		
-  thrOverE2EB1_ = iConfig.getParameter<double> ("thrOverE2EB1");		
-  thrOverE2EE1_ = iConfig.getParameter<double> ("thrOverE2EE1");		
-  thrRegularEB2_ = iConfig.getParameter<double> ("thrRegularEB2");	
-  thrRegularEE2_ = iConfig.getParameter<double> ("thrRegularEE2");	
-  thrOverEEB2_ = iConfig.getParameter<double> ("thrOverEEB2");		
-  thrOverEEE2_ = iConfig.getParameter<double> ("thrOverEEE2");		
-  thrOverE2EB2_ = iConfig.getParameter<double> ("thrOverE2EB2");		
-  thrOverE2EE2_ = iConfig.getParameter<double> ("thrOverE2EE2");		
-  				     	
-  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			
-  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		
+  lessThan_        = iConfig.getParameter<bool> ("lessThan");
+  useEt_           = iConfig.getParameter<bool> ("useEt");
+
+  etaBoundaryEB12_ = iConfig.getParameter<double> ("etaBoundaryEB12");
+  etaBoundaryEE12_ = iConfig.getParameter<double> ("etaBoundaryEE12");
+
+  thrRegularEB1_   = iConfig.getParameter<double> ("thrRegularEB1");
+  thrRegularEE1_   = iConfig.getParameter<double> ("thrRegularEE1");
+  thrOverEEB1_     = iConfig.getParameter<double> ("thrOverEEB1");
+  thrOverEEE1_     = iConfig.getParameter<double> ("thrOverEEE1");
+  thrOverE2EB1_    = iConfig.getParameter<double> ("thrOverE2EB1");
+  thrOverE2EE1_    = iConfig.getParameter<double> ("thrOverE2EE1");
+  thrRegularEB2_   = iConfig.getParameter<double> ("thrRegularEB2");
+  thrRegularEE2_   = iConfig.getParameter<double> ("thrRegularEE2");
+  thrOverEEB2_     = iConfig.getParameter<double> ("thrOverEEB2");
+  thrOverEEE2_     = iConfig.getParameter<double> ("thrOverEEE2");
+  thrOverE2EB2_    = iConfig.getParameter<double> ("thrOverE2EB2");
+  thrOverE2EE2_    = iConfig.getParameter<double> ("thrOverE2EE2");
+
+  ncandcut_        = iConfig.getParameter<int> ("ncandcut");
 			     				
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
+  l1EGTag_         = iConfig.getParameter< edm::InputTag > ("l1EGCand");
 
-  candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
-  isoToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(isoTag_);
-  if(!doIsolated_) nonIsoToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(nonIsoTag_);
+  candToken_       = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
+  varToken_        = consumes<reco::RecoEcalCandidateIsolationMap> (varTag_);
 
 //register your products
   produces<trigger::TriggerFilterObjectWithRefs>();
@@ -62,30 +60,27 @@ void
 HLTEgammaGenericQuadraticEtaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("candTag",edm::InputTag("hltEGIsolFilter"));
-  desc.add<edm::InputTag>("isoTag",edm::InputTag("hltEGIsol"));
-  desc.add<edm::InputTag>("nonIsoTag",edm::InputTag("hltEGNonIsol"));
-  desc.add<bool>("lessThan",true);
-  desc.add<bool>("useEt",true);
-  desc.add<double>("etaBoundaryEB12",1.0);
-  desc.add<double>("etaBoundaryEE12",2.0);
-  desc.add<double>("thrRegularEB1",4.0);
-  desc.add<double>("thrRegularEE1",6.0);
-  desc.add<double>("thrOverEEB1",0.0020);
-  desc.add<double>("thrOverEEE1",0.0020);
-  desc.add<double>("thrOverE2EB1",0.0);
-  desc.add<double>("thrOverE2EE1",0.0);
-  desc.add<double>("thrRegularEB2",6.0);
-  desc.add<double>("thrRegularEE2",4.0);
-  desc.add<double>("thrOverEEB2",0.0020);
-  desc.add<double>("thrOverEEE2",0.0020);
-  desc.add<double>("thrOverE2EB2",0.0);
-  desc.add<double>("thrOverE2EE2",0.0);
-  desc.add<int>("ncandcut",1);
-  desc.add<bool>("doIsolated",false);
-  desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-  desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-  descriptions.add("hltEgammaGenericQuadraticEtaFilter",desc);
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltEGIsolFilter"));
+  desc.add<edm::InputTag>("varTag", edm::InputTag("hltEGIsol"));
+  desc.add<bool>("lessThan", true);
+  desc.add<bool>("useEt", true);
+  desc.add<double>("etaBoundaryEB12", 1.0);
+  desc.add<double>("etaBoundaryEE12", 2.0);
+  desc.add<double>("thrRegularEB1", 4.0);
+  desc.add<double>("thrRegularEE1", 6.0);
+  desc.add<double>("thrOverEEB1", 0.0020);
+  desc.add<double>("thrOverEEE1", 0.0020);
+  desc.add<double>("thrOverE2EB1", 0.0);
+  desc.add<double>("thrOverE2EE1", 0.0);
+  desc.add<double>("thrRegularEB2", 6.0);
+  desc.add<double>("thrRegularEE2", 4.0);
+  desc.add<double>("thrOverEEB2", 0.0020);
+  desc.add<double>("thrOverEEE2", 0.0020);
+  desc.add<double>("thrOverE2EB2", 0.0);
+  desc.add<double>("thrOverE2EE2", 0.0);
+  desc.add<int>("ncandcut", 1);
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
+  descriptions.add("hltEgammaGenericQuadraticEtaFilter", desc);
 }
 
 HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter(){}
@@ -97,10 +92,7 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
 {
   using namespace trigger;
   if ( saveTags() ) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if ( not doIsolated_) {
-      filterproduct.addCollectionTag(L1NonIsoCollTag_);
-    }
+    filterproduct.addCollectionTag(l1EGTag_);
   }
   // Ref to Candidate object to be recorded in filter object
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
@@ -119,11 +111,7 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
 
   //get hold of isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
-  iEvent.getByToken (isoToken_,depMap);
-
-  //get hold of non-isolated association map
-  edm::Handle<reco::RecoEcalCandidateIsolationMap> depNonIsoMap;
-  if(!doIsolated_) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
+  iEvent.getByToken (varToken_,depMap);
 
   // look at all photons, check cuts and add to filter object
   int n = 0;
@@ -132,7 +120,6 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
 
     ref = recoecalcands[i];
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
-    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref );
 
     float vali = mapi->val;
     float energy = ref->superCluster()->energy();

--- a/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
@@ -26,17 +26,15 @@
 // constructors and destructor
 //
 HLTElectronEtFilter::HLTElectronEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
-  candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
-  EtEB_ = iConfig.getParameter<double> ("EtCutEB");
-  EtEE_ = iConfig.getParameter<double> ("EtCutEE");
+  candTag_   = iConfig.getParameter< edm::InputTag > ("candTag");
+  EtEB_      = iConfig.getParameter<double> ("EtCutEB");
+  EtEE_      = iConfig.getParameter<double> ("EtCutEE");
 
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
-  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");
 
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
+  l1EGTag_   = iConfig.getParameter< edm::InputTag > ("l1EGCand");
 
-  candToken_ =  consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
+  candToken_ =  consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
 }
 
 HLTElectronEtFilter::~HLTElectronEtFilter(){}
@@ -45,12 +43,12 @@ void
 HLTElectronEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("candTag",edm::InputTag("hltElectronPixelMatchFilter"));
-  desc.add<double>("EtCutEB",0.0);
-  desc.add<double>("EtCutEE",0.0);
-  desc.add<int>("ncandcut",1);
-  desc.add<bool>("doIsolated",true);
-  descriptions.add("hltElectronEtFilter",desc);
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltElectronPixelMatchFilter"));
+  desc.add<double>("EtCutEB", 0.0);
+  desc.add<double>("EtCutEE", 0.0);
+  desc.add<int>("ncandcut", 1);
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
+  descriptions.add("hltElectronEtFilter", desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -58,15 +56,14 @@ bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 {
   using namespace trigger;
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (not doIsolated_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
 
   // Ref to Candidate object to be recorded in filter object
   reco::ElectronRef ref;
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (candToken_,PrevFilterOutput);
+  iEvent.getByToken (candToken_, PrevFilterOutput);
 
   std::vector<edm::Ref<reco::ElectronCollection> > elecands;
   PrevFilterOutput->getObjects(TriggerElectron, elecands);

--- a/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
@@ -25,24 +25,20 @@
 // constructors and destructor
 //
 HLTElectronGenericFilter::HLTElectronGenericFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
-  candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
-  isoTag_ = iConfig.getParameter< edm::InputTag > ("isoTag");
-  nonIsoTag_ = iConfig.getParameter< edm::InputTag > ("nonIsoTag");
-  lessThan_ = iConfig.getParameter<bool> ("lessThan");
+  candTag_      = iConfig.getParameter< edm::InputTag > ("candTag");
+  varTag_       = iConfig.getParameter< edm::InputTag > ("varTag");
+  lessThan_     = iConfig.getParameter<bool> ("lessThan");
   thrRegularEB_ = iConfig.getParameter<double> ("thrRegularEB");
   thrRegularEE_ = iConfig.getParameter<double> ("thrRegularEE");
-  thrOverPtEB_ = iConfig.getParameter<double> ("thrOverPtEB");
-  thrOverPtEE_ = iConfig.getParameter<double> ("thrOverPtEE");
+  thrOverPtEB_  = iConfig.getParameter<double> ("thrOverPtEB");
+  thrOverPtEE_  = iConfig.getParameter<double> ("thrOverPtEE");
   thrTimesPtEB_ = iConfig.getParameter<double> ("thrTimesPtEB");
   thrTimesPtEE_ = iConfig.getParameter<double> ("thrTimesPtEE");
-  ncandcut_  = iConfig.getParameter<int> ("ncandcut");
-  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
+  ncandcut_     = iConfig.getParameter<int> ("ncandcut");
+  l1EGTag_      = iConfig.getParameter< edm::InputTag > ("l1EGCand");
 
-  candToken_ =  consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
-  isoToken_ = consumes<reco::ElectronIsolationMap>(isoTag_);
-  if(!doIsolated_) nonIsoToken_ = consumes<reco::ElectronIsolationMap>(nonIsoTag_);
+  candToken_    =  consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
+  varToken_     = consumes<reco::ElectronIsolationMap>(varTag_);
 }
 
 HLTElectronGenericFilter::~HLTElectronGenericFilter(){}
@@ -51,21 +47,18 @@ void
 HLTElectronGenericFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("candTag",edm::InputTag("hltSingleElectronOneOEMinusOneOPFilter"));
-  desc.add<edm::InputTag>("isoTag",edm::InputTag("hltSingleElectronTrackIsol"));
-  desc.add<edm::InputTag>("nonIsoTag",edm::InputTag("hltSingleElectronHcalTrackIsol"));
-  desc.add<bool>("lessThan",true);
-  desc.add<double>("thrRegularEB",0.0);
-  desc.add<double>("thrRegularEE",0.0);
-  desc.add<double>("thrOverPtEB",-1.0);
-  desc.add<double>("thrOverPtEE",-1.0);
-  desc.add<double>("thrTimesPtEB",-1.0);
-  desc.add<double>("thrTimesPtEE",-1.0);
-  desc.add<int>("ncandcut",1);
-  desc.add<bool>("doIsolated",true);
-  desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltPixelMatchElectronsL1Iso"));
-  desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltPixelMatchElectronsL1NonIso"));
-  descriptions.add("hltElectronGenericFilter",desc);
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltSingleElectronOneOEMinusOneOPFilter"));
+  desc.add<edm::InputTag>("varTag", edm::InputTag("hltSingleElectronTrackIsol"));
+  desc.add<bool>("lessThan", true);
+  desc.add<double>("thrRegularEB", 0.0);
+  desc.add<double>("thrRegularEE", 0.0);
+  desc.add<double>("thrOverPtEB", -1.0);
+  desc.add<double>("thrOverPtEE", -1.0);
+  desc.add<double>("thrTimesPtEB", -1.0);
+  desc.add<double>("thrTimesPtEE", -1.0);
+  desc.add<int>("ncandcut", 1);
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltPixelMatchElectronsL1Iso"));
+  descriptions.add("hltElectronGenericFilter", desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -75,15 +68,14 @@ HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   using namespace trigger;
 
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (not doIsolated_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
 
   // Ref to Candidate object to be recorded in filter object
   reco::ElectronRef ref;
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (candToken_,PrevFilterOutput);
+  iEvent.getByToken (candToken_, PrevFilterOutput);
 
   std::vector<edm::Ref<reco::ElectronCollection> > elecands;
   PrevFilterOutput->getObjects(TriggerElectron, elecands);
@@ -91,11 +83,7 @@ HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
   //get hold of isolated association map
   edm::Handle<reco::ElectronIsolationMap> depMap;
-  iEvent.getByToken (isoToken_,depMap);
-
-  //get hold of non-isolated association map
-  edm::Handle<reco::ElectronIsolationMap> depNonIsoMap;
-  if(!doIsolated_) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
+  iEvent.getByToken (varToken_,depMap);
 
   // look at all photons, check cuts and add to filter object
   int n = 0;
@@ -104,7 +92,6 @@ HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
     ref = elecands[i];
     reco::ElectronIsolationMap::const_iterator mapi = (*depMap).find( ref );
-    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref );
 
     float vali = mapi->val;
     float Pt = ref->pt();

--- a/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
@@ -5,19 +5,18 @@ template <typename T>
 HLTElectronPFMTFilter<T>::HLTElectronPFMTFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   // MHT parameters
-  inputMetTag_ = iConfig.getParameter< edm::InputTag > ("inputMetTag");
-  minMht_      = iConfig.getParameter<double> ("minMht");
-  // Electron parameters
-  inputEleTag_ = iConfig.getParameter< edm::InputTag > ("inputEleTag");
-  lowerMTCut_  = iConfig.getParameter<double> ("lowerMTCut");
-  upperMTCut_  = iConfig.getParameter<double> ("upperMTCut");
-  relaxed_     = iConfig.getParameter<bool> ("relaxed");
-  minN_        = iConfig.getParameter<int>("minN");
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  inputMetTag_   = iConfig.getParameter< edm::InputTag > ("inputMetTag");
+  minMht_        = iConfig.getParameter<double> ("minMht");
 
-  inputMetToken_ = consumes<reco::METCollection>(inputMetTag_);
-  inputEleToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputEleTag_);
+  // Electron parameters
+  inputEleTag_   = iConfig.getParameter< edm::InputTag > ("inputEleTag");
+  lowerMTCut_    = iConfig.getParameter<double> ("lowerMTCut");
+  upperMTCut_    = iConfig.getParameter<double> ("upperMTCut");
+  minN_          = iConfig.getParameter<int>("minN");
+  l1EGTag_       = iConfig.getParameter< edm::InputTag > ("l1EGCand");
+
+  inputMetToken_ = consumes<reco::METCollection> (inputMetTag_);
+  inputEleToken_ = consumes<trigger::TriggerFilterObjectWithRefs> (inputEleTag_);
 }
 
 template <typename T> 
@@ -27,15 +26,13 @@ template <typename T>
 void HLTElectronPFMTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("inputMetTag",edm::InputTag("hltPFMHT"));
-  desc.add<edm::InputTag>("inputEleTag",edm::InputTag("hltEle25CaloIdVTTrkIdTCaloIsoTTrkIsoTTrackIsolFilter"));
-  desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-  desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-  desc.add<bool>("relaxed",true);
-  desc.add<int>("minN",0);
-  desc.add<double>("minMht",0.0);
-  desc.add<double>("lowerMTCut",0.0);
-  desc.add<double>("upperMTCut",9999.0);
+  desc.add<edm::InputTag>("inputMetTag", edm::InputTag("hltPFMHT"));
+  desc.add<edm::InputTag>("inputEleTag", edm::InputTag("hltEle25CaloIdVTTrkIdTCaloIsoTTrkIsoTTrackIsolFilter"));
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
+  desc.add<int>("minN", 0);
+  desc.add<double>("minMht", 0.0);
+  desc.add<double>("lowerMTCut", 0.0);
+  desc.add<double>("upperMTCut", 9999.0);
   descriptions.add(defaultModuleLabel<HLTElectronPFMTFilter<T>>(), desc);
 }
 
@@ -49,8 +46,7 @@ bool  HLTElectronPFMTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSe
   // The filter object
   if (saveTags()) {
     filterproduct.addCollectionTag(inputMetTag_);
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
   
   // Get the Met collection
@@ -73,13 +69,13 @@ bool  HLTElectronPFMTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSe
   
   vector< Ref< vector<T> > > refEleCollection ;
 
-  PrevFilterOutput->getObjects(TriggerElectron,refEleCollection);
+  PrevFilterOutput->getObjects(TriggerElectron, refEleCollection);
   int trigger_type = trigger::TriggerElectron;
   if(refEleCollection.empty()){
-    PrevFilterOutput->getObjects(TriggerCluster,refEleCollection);
+    PrevFilterOutput->getObjects(TriggerCluster, refEleCollection);
     trigger_type = trigger::TriggerCluster;    
     if(refEleCollection.empty()){
-     PrevFilterOutput->getObjects(TriggerPhoton,refEleCollection);
+     PrevFilterOutput->getObjects(TriggerPhoton, refEleCollection);
      trigger_type = trigger::TriggerPhoton;
     }
   }    

--- a/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
@@ -33,33 +33,29 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 HLTElectronPixelMatchFilter::HLTElectronPixelMatchFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
-  candTag_                = iConfig.getParameter< edm::InputTag > ("candTag");
-  L1IsoPixelSeedsTag_     = iConfig.getParameter< edm::InputTag > ("L1IsoPixelSeedsTag");
-  L1NonIsoPixelSeedsTag_  = iConfig.getParameter< edm::InputTag > ("L1NonIsoPixelSeedsTag");
-  npixelmatchcut_         = iConfig.getParameter< double >        ("npixelmatchcut");
-  ncandcut_               = iConfig.getParameter< int >           ("ncandcut");
-  doIsolated_             = iConfig.getParameter< bool >          ("doIsolated");
-  L1IsoCollTag_           = iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_        = iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
+  candTag_           = iConfig.getParameter< edm::InputTag > ("candTag");
+  l1PixelSeedsTag_   = iConfig.getParameter< edm::InputTag > ("l1PixelSeedsTag");
+  npixelmatchcut_    = iConfig.getParameter< double >        ("npixelmatchcut");
+  ncandcut_          = iConfig.getParameter< int >           ("ncandcut");
+  l1EGTag_           = iConfig.getParameter< edm::InputTag > ("l1EGCand");
   
-  candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
-  L1IsoPixelSeedsToken_ = consumes<reco::ElectronSeedCollection>(L1IsoPixelSeedsTag_);
-  L1NonIsoPixelSeedsToken_= consumes<reco::ElectronSeedCollection>(L1NonIsoPixelSeedsTag_);
+  candToken_         = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
+  l1PixelSeedsToken_ = consumes<reco::ElectronSeedCollection> (l1PixelSeedsTag_);
   
-  sPhi1B_ = iConfig.getParameter< double >("s_a_phi1B") ;
-  sPhi1I_ = iConfig.getParameter< double >("s_a_phi1I") ;
-  sPhi1F_ = iConfig.getParameter< double >("s_a_phi1F") ;
-  sPhi2B_ = iConfig.getParameter< double >("s_a_phi2B") ;
-  sPhi2I_ = iConfig.getParameter< double >("s_a_phi2I") ;
-  sPhi2F_ = iConfig.getParameter< double >("s_a_phi2F") ;
-  sZ2B_    = iConfig.getParameter< double >("s_a_zB"   ) ;
-  sR2I_    = iConfig.getParameter< double >("s_a_rI"   ) ;
-  sR2F_    = iConfig.getParameter< double >("s_a_rF"   ) ;
-  s2BarrelThres_ = std::pow(std::atanh(iConfig.getParameter< double >("tanhSO10BarrelThres"))*10.,2);
-  s2InterThres_ = std::pow(std::atanh(iConfig.getParameter< double >("tanhSO10InterThres"))*10.,2);
-  s2ForwardThres_ = std::pow(std::atanh(iConfig.getParameter< double >("tanhSO10ForwardThres"))*10.,2);
+  sPhi1B_         = iConfig.getParameter< double >("s_a_phi1B") ;
+  sPhi1I_         = iConfig.getParameter< double >("s_a_phi1I") ;
+  sPhi1F_         = iConfig.getParameter< double >("s_a_phi1F") ;
+  sPhi2B_         = iConfig.getParameter< double >("s_a_phi2B") ;
+  sPhi2I_         = iConfig.getParameter< double >("s_a_phi2I") ;
+  sPhi2F_         = iConfig.getParameter< double >("s_a_phi2F") ;
+  sZ2B_           = iConfig.getParameter< double >("s_a_zB"   ) ;
+  sR2I_           = iConfig.getParameter< double >("s_a_rI"   ) ;
+  sR2F_           = iConfig.getParameter< double >("s_a_rF"   ) ;
+  s2BarrelThres_  = std::pow(std::atanh(iConfig.getParameter< double >("tanhSO10BarrelThres"))*10., 2);
+  s2InterThres_   = std::pow(std::atanh(iConfig.getParameter< double >("tanhSO10InterThres"))*10., 2);
+  s2ForwardThres_ = std::pow(std::atanh(iConfig.getParameter< double >("tanhSO10ForwardThres"))*10., 2);
   
-  isPixelVeto_ = iConfig.getParameter< bool >("pixelVeto" );
+  isPixelVeto_ = iConfig.getParameter< bool >("pixelVeto");
   useS_        = iConfig.getParameter< bool >("useS" );
 
 }
@@ -92,14 +88,11 @@ float HLTElectronPixelMatchFilter::calDZ2Sq(reco::ElectronSeedCollection::const_
 void HLTElectronPixelMatchFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("candTag",edm::InputTag("hltEgammaHcalIsolFilter"));
-  desc.add<edm::InputTag>("L1IsoPixelSeedsTag",edm::InputTag("electronPixelSeeds"));
-  desc.add<edm::InputTag>("L1NonIsoPixelSeedsTag",edm::InputTag("electronPixelSeeds"));
-  desc.add<double>("npixelmatchcut",1.0);
-  desc.add<int>("ncandcut",1);
-  desc.add<bool>("doIsolated",true);
-  desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-  desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltEgammaHcalIsolFilter"));
+  desc.add<edm::InputTag>("l1PixelSeedsTag", edm::InputTag("electronPixelSeeds"));
+  desc.add<double>("npixelmatchcut", 1.0);
+  desc.add<int>("ncandcut", 1);
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
   desc.add<double>("s_a_phi1B",    0.0069) ;
   desc.add<double>("s_a_phi1I",    0.0088) ;
   desc.add<double>("s_a_phi1F",    0.0076) ;
@@ -110,9 +103,9 @@ void HLTElectronPixelMatchFilter::fillDescriptions(edm::ConfigurationDescription
   desc.add<double>("s_a_rI"   ,    0.027) ;
   desc.add<double>("s_a_rF"   ,    0.040) ;
   desc.add<double>("s2_threshold", 0);
-  desc.add<double>("tanhSO10BarrelThres",0.35);
-  desc.add<double>("tanhSO10InterThres",1);
-  desc.add<double>("tanhSO10ForwardThres",1);
+  desc.add<double>("tanhSO10BarrelThres", 0.35);
+  desc.add<double>("tanhSO10InterThres", 1);
+  desc.add<double>("tanhSO10ForwardThres", 1);
   desc.add<bool>  ("useS"     , false);
   desc.add<bool>  ("pixelVeto", false);
 
@@ -123,8 +116,7 @@ bool HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::Event
   // The filter object
   using namespace trigger;
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (not doIsolated_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
   
   // Ref to Candidate object to be recorded in filter object
@@ -138,13 +130,8 @@ bool HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::Event
   if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);  //we dont know if its type trigger cluster or trigger photon
   
   //get hold of the pixel seed - supercluster association map
-  edm::Handle<reco::ElectronSeedCollection> L1IsoSeeds;
-  iEvent.getByToken(L1IsoPixelSeedsToken_,L1IsoSeeds);
-
-  edm::Handle<reco::ElectronSeedCollection> L1NonIsoSeeds;
-  if(!doIsolated_){
-    iEvent.getByToken(L1NonIsoPixelSeedsToken_,L1NonIsoSeeds);
-  }
+  edm::Handle<reco::ElectronSeedCollection> l1PixelSeeds;
+  iEvent.getByToken(l1PixelSeedsToken_, l1PixelSeeds);
   
   // look at all egammas,  check cuts and add to filter object
   int n = 0;
@@ -153,8 +140,7 @@ bool HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::Event
     ref = recoecalcands[i];
     reco::SuperClusterRef recr2 = ref->superCluster();
     
-    int nmatch = getNrOfMatches(L1IsoSeeds,recr2);
-    if(!doIsolated_) nmatch+=getNrOfMatches(L1NonIsoSeeds,recr2);
+    int nmatch = getNrOfMatches(l1PixelSeeds, recr2);
 
     if (!isPixelVeto_) {
       if ( nmatch >= npixelmatchcut_) {

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -15,19 +15,19 @@
 //
 HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-  candTag_            = iConfig.getParameter< edm::InputTag > ("candTag");
-  beamSpot_           = iConfig.getParameter< edm::InputTag > ("beamSpot");
-  lowerMassCut_       = iConfig.getParameter<double> ("lowerMassCut");
-  upperMassCut_       = iConfig.getParameter<double> ("upperMassCut");
-  nZcandcut_          = iConfig.getParameter<int> ("nZcandcut");
-  reqOppCharge_       = iConfig.getUntrackedParameter<bool> ("reqOppCharge",false);
-  isElectron1_ = iConfig.getUntrackedParameter<bool> ("isElectron1",true) ;
-  isElectron2_ = iConfig.getUntrackedParameter<bool> ("isElectron2",true) ;
-  relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
-  candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
-  beamSpotToken_ = consumes<reco::BeamSpot>(beamSpot_);
+  candTag_       = iConfig.getParameter< edm::InputTag > ("candTag");
+  beamSpot_      = iConfig.getParameter< edm::InputTag > ("beamSpot");
+  l1EGTag_       = iConfig.getParameter< edm::InputTag > ("l1EGCand");
+
+  lowerMassCut_  = iConfig.getParameter<double> ("lowerMassCut");
+  upperMassCut_  = iConfig.getParameter<double> ("upperMassCut");
+  nZcandcut_     = iConfig.getParameter<int> ("nZcandcut");
+  reqOppCharge_  = iConfig.getUntrackedParameter<bool> ("reqOppCharge",false);
+  isElectron1_   = iConfig.getUntrackedParameter<bool> ("isElectron1", true) ;
+  isElectron2_   = iConfig.getUntrackedParameter<bool> ("isElectron2", true) ;
+
+  candToken_     = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
+  beamSpotToken_ = consumes<reco::BeamSpot> (beamSpot_);
 }
 
 HLTPMMassFilter::~HLTPMMassFilter(){}
@@ -36,18 +36,16 @@ void
 HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("candTag",edm::InputTag("hltL1NonIsoDoublePhotonEt5UpsHcalIsolFilter"));
-  desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOfflineBeamSpot"));
-  desc.add<double>("lowerMassCut",8.0);
-  desc.add<double>("upperMassCut",11.0);
-  desc.add<int>("nZcandcut",1);
-  desc.addUntracked<bool>("reqOppCharge",true);
-  desc.addUntracked<bool>("isElectron1",false);
-  desc.addUntracked<bool>("isElectron2",false);
-  desc.addUntracked<bool>("relaxed",true);
-  desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-  desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-  descriptions.add("hltPMMassFilter",desc);
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltL1NonIsoDoublePhotonEt5UpsHcalIsolFilter"));
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOfflineBeamSpot"));
+  desc.add<double>("lowerMassCut", 8.0);
+  desc.add<double>("upperMassCut", 11.0);
+  desc.add<int>("nZcandcut", 1);
+  desc.addUntracked<bool>("reqOppCharge", true);
+  desc.addUntracked<bool>("isElectron1", false);
+  desc.addUntracked<bool>("isElectron2", false);
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
+  descriptions.add("hltPMMassFilter", desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -61,15 +59,14 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 
   // The filter object
   if (saveTags()) {
-    filterproduct.addCollectionTag(L1IsoCollTag_);
-    if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
+    filterproduct.addCollectionTag(l1EGTag_);
   }
 
   edm::ESHandle<MagneticField> theMagField;
   iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (candToken_,PrevFilterOutput);
+  iEvent.getByToken (candToken_, PrevFilterOutput);
 
   // beam spot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;

--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -1338,11 +1338,11 @@ EmDQM::makePSetForEgammaGenericFilter(const std::string& moduleName)
 
   // infer the type of filter by the type of the producer which
   // generates the collection used to cut on this
-  edm::InputTag isoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("isoTag");
-  edm::InputTag nonIsoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("nonIsoTag");
-  //std::cout << "isoTag.label " << isoTag.label() << " nonIsoTag.label " << nonIsoTag.label() << std::endl;
+  edm::InputTag varTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("varTag");
+  //edm::InputTag nonIsoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("");
+  //std::cout << "varTag.label " << varTag.label() << " nonIsoTag.label " << nonIsoTag.label() << std::endl;
 
-  std::string inputType = hltConfig_.moduleType(isoTag.label());
+  std::string inputType = hltConfig_.moduleType(varTag.label());
   //std::cout << "inputType " << inputType << " moduleName " << moduleName << std::endl;
 
   //--------------------
@@ -1355,7 +1355,7 @@ EmDQM::makePSetForEgammaGenericFilter(const std::string& moduleName)
   //  return retPSet;
   //}
   //if (inputType != hltConfig_.moduleType(nonIsoTag.label())) {
-  //  edm::LogError("EmDQM") << "C++ Type of isoTag '" << inputType << "' and nonIsoTag '" << hltConfig_.moduleType(nonIsoTag.label()) << "' are not the same for HLTEgammaGenericFilter '" << moduleName <<  "'.";
+  //  edm::LogError("EmDQM") << "C++ Type of varTag '" << inputType << "' and nonIsoTag '" << hltConfig_.moduleType(nonIsoTag.label()) << "' are not the same for HLTEgammaGenericFilter '" << moduleName <<  "'.";
   //  return retPSet;
   //}
   //--------------------
@@ -1367,9 +1367,9 @@ EmDQM::makePSetForEgammaGenericFilter(const std::string& moduleName)
      retPSet.addParameter<int>("theHLTOutputTypes", trigger::TriggerCluster);
 
   std::vector<edm::InputTag> isoCollections;
-  isoCollections.push_back(isoTag);
-  if (!nonIsoTag.label().empty())
-     isoCollections.push_back(nonIsoTag);
+  isoCollections.push_back(varTag);
+  //if (!nonIsoTag.label().empty())
+  //   isoCollections.push_back(nonIsoTag);
 
   //--------------------
   // the following cases seem to have identical PSets ?
@@ -1416,11 +1416,11 @@ EmDQM::makePSetForEgammaGenericQuadraticFilter(const std::string& moduleName)
 
   // infer the type of filter by the type of the producer which
   // generates the collection used to cut on this
-  edm::InputTag isoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("isoTag");
-  edm::InputTag nonIsoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("nonIsoTag");
-  //std::cout << "isoTag.label " << isoTag.label() << " nonIsoTag.label " << nonIsoTag.label() << std::endl;
+  edm::InputTag varTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("varTag");
+  //edm::InputTag nonIsoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("nonIsoTag");
+  //std::cout << "varTag.label " << varTag.label() << " nonIsoTag.label " << nonIsoTag.label() << std::endl;
 
-  std::string inputType = hltConfig_.moduleType(isoTag.label());
+  std::string inputType = hltConfig_.moduleType(varTag.label());
   //std::cout << "inputType " << inputType << " moduleName " << moduleName << std::endl;
 
   //--------------------
@@ -1433,7 +1433,7 @@ EmDQM::makePSetForEgammaGenericQuadraticFilter(const std::string& moduleName)
   //  return retPSet;
   //}
   //if (inputType != hltConfig_.moduleType(nonIsoTag.label())) {
-  //  edm::LogError("EmDQM") << "C++ Type of isoTag '" << inputType << "' and nonIsoTag '" << hltConfig_.moduleType(nonIsoTag.label()) << "' are not the same for HLTEgammaGenericFilter '" << moduleName <<  "'.";
+  //  edm::LogError("EmDQM") << "C++ Type of varTag '" << inputType << "' and nonIsoTag '" << hltConfig_.moduleType(nonIsoTag.label()) << "' are not the same for HLTEgammaGenericFilter '" << moduleName <<  "'.";
   //  return retPSet;
   //}
   //--------------------
@@ -1445,9 +1445,9 @@ EmDQM::makePSetForEgammaGenericQuadraticFilter(const std::string& moduleName)
      retPSet.addParameter<int>("theHLTOutputTypes", trigger::TriggerCluster);
 
   std::vector<edm::InputTag> isoCollections;
-  isoCollections.push_back(isoTag);
-  if (!nonIsoTag.label().empty())
-     isoCollections.push_back(nonIsoTag);
+  isoCollections.push_back(varTag);
+  //if (!nonIsoTag.label().empty())
+  //   isoCollections.push_back(nonIsoTag);
 
   //--------------------
   // the following cases seem to have identical PSets ?
@@ -1492,11 +1492,11 @@ EmDQM::makePSetForElectronGenericFilter(const std::string& moduleName)
 
   // infer the type of filter by the type of the producer which
   // generates the collection used to cut on this
-  edm::InputTag isoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("isoTag");
-  edm::InputTag nonIsoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("nonIsoTag");
-  //std::cout << "isoTag.label " << isoTag.label() << " nonIsoTag.label " << nonIsoTag.label() << std::endl;
+  edm::InputTag varTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("varTag");
+  //edm::InputTag nonIsoTag = hltConfig_.modulePSet(moduleName).getParameter<edm::InputTag>("nonIsoTag");
+  //std::cout << "varTag.label " << varTag.label() << " nonIsoTag.label " << nonIsoTag.label() << std::endl;
 
-  std::string inputType = hltConfig_.moduleType(isoTag.label());
+  std::string inputType = hltConfig_.moduleType(varTag.label());
   //std::cout << "inputType iso " << inputType << " inputType noniso " << hltConfig_.moduleType(nonIsoTag.label()) << " moduleName " << moduleName << std::endl;
 
   //--------------------
@@ -1507,7 +1507,7 @@ EmDQM::makePSetForElectronGenericFilter(const std::string& moduleName)
   //  return retPSet;
   //}
   //if (inputType != hltConfig_.moduleType(nonIsoTag.label())) {
-  //  edm::LogError("EmDQM") << "C++ Type of isoTag '" << inputType << "' and nonIsoTag '" << hltConfig_.moduleType(nonIsoTag.label()) << "' are not the same for HLTElectronGenericFilter '" << moduleName <<  "'.";
+  //  edm::LogError("EmDQM") << "C++ Type of varTag '" << inputType << "' and nonIsoTag '" << hltConfig_.moduleType(nonIsoTag.label()) << "' are not the same for HLTElectronGenericFilter '" << moduleName <<  "'.";
   //  return retPSet;
   //}
   //--------------------
@@ -1517,9 +1517,9 @@ EmDQM::makePSetForElectronGenericFilter(const std::string& moduleName)
   retPSet.addParameter<int>("theHLTOutputTypes", trigger::TriggerElectron);
 
   std::vector<edm::InputTag> isoCollections;
-  isoCollections.push_back(isoTag);
-  if (!nonIsoTag.label().empty())
-     isoCollections.push_back(nonIsoTag);
+  isoCollections.push_back(varTag);
+  //if (!nonIsoTag.label().empty())
+  //   isoCollections.push_back(nonIsoTag);
 
   //--------------------
   // the following cases seem to have identical PSets ?


### PR DESCRIPTION
Hi,

[Take 2]

This pull request is to propose a cleanup of some EG HLT filters removing the distinction of isolated/non-isolated L1 candidates (which is now assumed to be correctly filled by the new L1 interface).

On the HLT menu in ConfDB this implies several changes to the affected filters:
- Parameters L1IsoCand and L1NonIsoCand are merged into a single parameter l1EGCand
- Parameters isoTag and nonIsoTag are merged into a single parameter varTag
- The booleans relaxed and doIsolated are no longer needed and thus deleted

This has been checked to compile and the corresponding HLT config producing the same behavior in release 803pa1.

A similar PR for 80X will be submitted shortly.

Best regards,
Afiq
