### PR TITLE
E/g HLT Pixel Match Variable Producer

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
@@ -41,9 +41,50 @@ namespace egPM {
     }
     AbsEtaNrClus(float iEta,size_t iNrClus): //iEta= input eta
       x(std::abs(iEta)),y(iNrClus){}
-    
+
     bool pass(float absEtaMin,float absEtaMax,size_t nrClusMin,size_t nrClusMax)const{
       return x>=absEtaMin && x<absEtaMax && y>=nrClusMin && y<=nrClusMax;
+    }
+  };
+  struct AbsEtaNrClusPhi{
+    float x;
+    size_t y;
+    float z;
+
+    AbsEtaNrClusPhi(const reco::ElectronSeed& seed){
+      reco::SuperClusterRef scRef = seed.caloCluster().castTo<reco::SuperClusterRef>();
+      x = std::abs(scRef->eta());
+      y = scRef->clustersSize();
+      z = scRef->phi();
+    }
+    AbsEtaNrClusPhi(float iEta,size_t iNrClus,float iPhi): //iEta= input eta
+      x(std::abs(iEta)),y(iNrClus),z(iPhi){}
+
+    bool pass(float absEtaMin,float absEtaMax,size_t nrClusMin,size_t nrClusMax,
+	      float phiMin,float phiMax)const{
+      return x>=absEtaMin && x<absEtaMax && y>=nrClusMin && y<=nrClusMax 
+	&& z>=phiMin && z < phiMax;
+    }
+  };
+
+  struct AbsEtaNrClusEt {
+    float x;
+    size_t y;
+    float z;
+
+    AbsEtaNrClusEt(const reco::ElectronSeed& seed){
+      reco::SuperClusterRef scRef = seed.caloCluster().castTo<reco::SuperClusterRef>();
+      x = std::abs(scRef->eta());
+      y = scRef->clustersSize();
+      z = scRef->energy()*sin(scRef->position().Theta());
+    }
+    AbsEtaNrClusEt(float iEta,size_t iNrClus,float iEt): //iEta= input eta
+      x(std::abs(iEta)),y(iNrClus),z(iEt){}
+
+    bool pass(float absEtaMin,float absEtaMax,size_t nrClusMin,size_t nrClusMax,
+	      float etMin,float etMax)const{
+      return x>=absEtaMin && x<absEtaMax && y>=nrClusMin && y<=nrClusMax 
+	&& z>=etMin && z < etMax;
     }
   };
   

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
@@ -1,0 +1,146 @@
+//These objects allow an arbitary parameristisation to be used
+//design:
+// 1) the function and parameterisation can be changing without having to change the interface
+//    or breaking backwards compatibiltiy with existing configs.
+//    This is vital for the HLT and the main driving force behind the design which otherwise 
+//    could have been a lot simplier
+
+// 2) An intermediate object, "AbsEtaNrClus" is used to pass in the eta and nr cluster variables
+//    as it allows the function to accept either a reco::ElectronSeed or an eta/nrClus pair.
+//    The former simplies the accessing of the eta/nrClus from the seed object and the later
+//    simplifies unit testing as one can generate all possible values of eta/nrClus easily
+
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+
+namespace egPM {
+  
+  struct GausPlusConstFunc {
+    float constTerm_,norm_,mean_,sigma_;
+    constexpr static float kSqrt2Pi=std::sqrt(std::asin(1)*4);
+    GausPlusConstFunc(const edm::ParameterSet& config):
+      constTerm_(config.getParameter<double>("constTerm")),norm_(config.getParameter<double>("norm")),
+      mean_(config.getParameter<double>("mean")),sigma_(config.getParameter<double>("sigma")){}
+    float operator()(float x)const{return constTerm_+norm_*std::exp(-.5*(x-mean_)*(x-mean_)/(sigma_*sigma_))/(kSqrt2Pi*sigma_);}
+  };
+  
+  template<size_t order>
+  struct PolyFunc {
+    std::array<float,order+1> para_;
+    PolyFunc(const edm::ParameterSet& config){
+      for(size_t paraNr=0;paraNr<para_.size();paraNr++){
+	std::ostringstream paraName;
+	paraName<<"p"<<paraNr;
+	para_[paraNr]=config.getParameter<double>(paraName.str());
+      }
+    }
+    float operator()(float x)const{
+      float retVal=0.,xVal=1.;
+      for(size_t termOrder=0;termOrder<=order;termOrder++){
+	retVal+=xVal*para_[termOrder];
+	xVal*=x;
+      }
+      return retVal;
+    }
+  };
+
+  struct AbsEtaNrClus{
+    float absEta;
+    size_t nrClus;
+    
+    AbsEtaNrClus(const reco::ElectronSeed& seed){
+      reco::SuperClusterRef scRef = seed.caloCluster().castTo<reco::SuperClusterRef>();
+      absEta = std::abs(scRef->eta());
+      nrClus = scRef->clustersSize();
+    }
+    AbsEtaNrClus(float iEta,size_t iNrClus): //iEta= input eta
+      absEta(std::abs(iEta)),nrClus(iNrClus){}
+  };
+  
+  template<typename ParamType>
+  class ParamBin {
+  public:
+    ParamBin(){}
+    virtual ~ParamBin(){}
+    virtual bool pass(const ParamType&)const=0; 
+    virtual float operator()(const ParamType&)const=0;
+    static std::function<float(float)> makeParamFunc(const edm::ParameterSet& config){
+      std::string type = config.getParameter<std::string>("funcType");
+      if(type=="GausPlusConst") return egPM::GausPlusConstFunc(config);
+      else if(type=="Pol0") return egPM::PolyFunc<0>(config);
+      else if(type=="Pol1") return egPM::PolyFunc<1>(config);
+      else if(type=="Pol2") return egPM::PolyFunc<2>(config);
+      else if(type=="Pol3") return egPM::PolyFunc<3>(config);
+      else if(type=="Pol4") return egPM::PolyFunc<4>(config);
+      else throw cms::Exception("InvalidConfig") << " type "<<type<<" is not recognised, configuration is invalid and needs to be fixed"<<std::endl;
+    }
+  };
+   
+
+  class AbsEtaClusParamBin : public ParamBin<egPM::AbsEtaNrClus>  {
+    size_t minNrClus_; //inclusive
+    size_t maxNrClus_; //inclusive
+    float minEta_; //inclusive
+    float maxEta_;//exclusive
+    std::function<float(float)> etaFunc_; 
+  public:
+    
+    AbsEtaClusParamBin(const edm::ParameterSet& config) {
+      minNrClus_ = config.getParameter<int>("minNrClus");
+      maxNrClus_ = config.getParameter<int>("maxNrClus");
+      minEta_ = config.getParameter<double>("minEta");
+      maxEta_ = config.getParameter<double>("maxEta");
+      etaFunc_ = makeParamFunc(config.getParameter<edm::ParameterSet>("etaFunc"));
+    }
+
+    bool pass(const egPM::AbsEtaNrClus& seed)const override {
+      return seed.absEta>=minEta_ && seed.absEta<maxEta_ &&
+	seed.nrClus>=minNrClus_ && seed.nrClus<=maxNrClus_;
+    }
+    
+    float operator()(const egPM::AbsEtaNrClus& seed)const override{
+      if(!pass(seed)) return 0;
+      else return etaFunc_(seed.absEta);	
+    }
+  };
+
+  class AbsEtaClusWithClusCorrParamBin : public AbsEtaClusParamBin  {
+    float corrPerClus_;
+    int clusNrOffset_;
+  public:
+    AbsEtaClusWithClusCorrParamBin(const edm::ParameterSet& config): 
+      AbsEtaClusParamBin(config),
+      corrPerClus_(config.getParameter<double>("corrPerClus")),
+      clusNrOffset_(config.getParameter<int>("clusNrOffset")){}
+    float operator()(const egPM::AbsEtaNrClus& seed)const override{
+      return corrPerClus_*std::max(static_cast<int>(seed.nrClus)-clusNrOffset_,0)+AbsEtaClusParamBin::operator()(seed);
+    }
+  };
+
+
+  
+  template<typename ParamType>
+  class Param {
+    std::vector<std::unique_ptr<ParamBin<ParamType> > > bins_;
+  public:
+    Param(const edm::ParameterSet& config){
+      std::vector<edm::ParameterSet> binConfigs = config.getParameter<std::vector<edm::ParameterSet> >("bins");
+      for(auto& binConfig : binConfigs) bins_.emplace_back(createParamBin_(binConfig));
+      std::cout<<" "<<std::endl;
+      for(auto& binConfig : binConfigs) std::cout <<"paraSets.push_back(edm::ParameterSet(\""<<binConfig.toString()<<"\"));"<<std::endl;
+    }
+    float operator()(const ParamType& seed)const{
+      for(auto& bin : bins_){
+	if(bin->pass(seed)) return  (*bin)(seed);
+      }
+      return -1; //didnt find a suitable bin, just return -1 for now
+    } 
+	
+  private:
+    std::unique_ptr<ParamBin<ParamType> > createParamBin_(const edm::ParameterSet& config){
+      std::string type = config.getParameter<std::string>("binType");
+      if(type=="AbsEtaClusParamBin") return std::make_unique<AbsEtaClusParamBin>(config);
+      else if(type=="AbsEtaClusWithClusCorrParamBin") return std::make_unique<AbsEtaClusWithClusCorrParamBin>(config);
+      else throw cms::Exception("InvalidConfig") << " type "<<type<<" is not recognised, configuration is invalid and needs to be fixed"<<std::endl;
+    }
+  };
+}

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
@@ -16,35 +16,6 @@
 
 namespace egPM {
   
-  struct GausPlusConstFunc {
-    float constTerm_,norm_,mean_,sigma_;
-    constexpr static float kSqrt2Pi=std::sqrt(std::asin(1)*4);
-    GausPlusConstFunc(const edm::ParameterSet& config):
-      constTerm_(config.getParameter<double>("constTerm")),norm_(config.getParameter<double>("norm")),
-      mean_(config.getParameter<double>("mean")),sigma_(config.getParameter<double>("sigma")){}
-    float operator()(float x)const{return constTerm_+norm_*std::exp(-.5*(x-mean_)*(x-mean_)/(sigma_*sigma_))/(kSqrt2Pi*sigma_);}
-  };
-  
-  template<size_t order>
-  struct PolyFunc {
-    std::array<float,order+1> para_;
-    PolyFunc(const edm::ParameterSet& config){
-      for(size_t paraNr=0;paraNr<para_.size();paraNr++){
-	std::ostringstream paraName;
-	paraName<<"p"<<paraNr;
-	para_[paraNr]=config.getParameter<double>(paraName.str());
-      }
-    }
-    float operator()(float x)const{
-      float retVal=0.,xVal=1.;
-      for(size_t termOrder=0;termOrder<=order;termOrder++){
-	retVal+=xVal*para_[termOrder];
-	xVal*=x;
-      }
-      return retVal;
-    }
-  };
-
   struct AbsEtaNrClus{
     float absEta;
     size_t nrClus;
@@ -143,8 +114,8 @@ namespace egPM {
   private:
     std::unique_ptr<ParamBin<ParamType> > createParamBin_(const edm::ParameterSet& config){
       std::string type = config.getParameter<std::string>("binType");
-      if(type=="AbsEtaClusParamBin") return std::make_unique<AbsEtaClusParamBin>(config);
-      else if(type=="AbsEtaClusWithClusCorrParamBin") return std::make_unique<AbsEtaClusWithClusCorrParamBin>(config);
+      if(type=="AbsEtaClus") return std::make_unique<AbsEtaClusParamBin>(config);
+      else if(type=="AbsEtaClusWithClusCorr") return std::make_unique<AbsEtaClusWithClusCorrParamBin>(config);
       else throw cms::Exception("InvalidConfig") << " type "<<type<<" is not recognised, configuration is invalid and needs to be fixed"<<std::endl;
     }
   };

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
@@ -74,7 +74,31 @@ void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescripti
   
   edm::ParameterSetDescription varParamDesc;
   edm::ParameterSetDescription binParamDesc;
-  binParamDesc.setAllowAnything();
+  //binParamDesc.add<std::string>("binType");
+  
+  std::auto_ptr<edm::ParameterDescriptionCases<std::string>> binDescCases;
+  binDescCases = 
+    "AbsEtaClus" >> 
+    (edm::ParameterDescription<double>("minEta",0.0,true) and
+     edm::ParameterDescription<double>("maxEta",3.0,true) and
+     edm::ParameterDescription<double>("minNrClus",0,true) and
+     edm::ParameterDescription<double>("maxNrClus",99999,true) and
+     edm::ParameterDescription<std::string>("funcType","pol0",true) and
+     edm::ParameterDescription<std::vector<double>>("funcParams",{0.},true)) or
+    "AbsEtaClusWithClusCorr" >>
+    (edm::ParameterDescription<double>("minEta",0.0,true) and
+     edm::ParameterDescription<double>("maxEta",3.0,true) and
+     edm::ParameterDescription<double>("minNrClus",0,true) and
+     edm::ParameterDescription<double>("maxNrClus",99999,true) and
+     edm::ParameterDescription<std::string>("funcType","pol0",true) and
+     edm::ParameterDescription<std::vector<double> >("funcParams",{0.},true) and
+     edm::ParameterDescription<double>("corrPerClus",0.0,true) and
+     edm::ParameterDescription<double>("clusNrOffset",0.0,true));
+  
+    
+  binParamDesc.ifValue(edm::ParameterDescription<std::string>("binType","AbsEtaClus",true), binDescCases);
+  
+  
   varParamDesc.addVPSet("bins",binParamDesc);
   desc.add("dPhi1SParams",varParamDesc);
   desc.add("dPhi2SParams",varParamDesc);

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
@@ -40,9 +40,9 @@ private:
   const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandidateToken_;
   const edm::EDGetTokenT<reco::ElectronSeedCollection> pixelSeedsToken_;
 
-  egPM::Param<egPM::AbsEtaNrClus> dPhi1Para_;
-  egPM::Param<egPM::AbsEtaNrClus> dPhi2Para_;
-  egPM::Param<egPM::AbsEtaNrClus> dRZ2Para_;
+  egPM::Param<reco::ElectronSeed> dPhi1Para_;
+  egPM::Param<reco::ElectronSeed> dPhi2Para_;
+  egPM::Param<reco::ElectronSeed> dRZ2Para_;
 
 };
 
@@ -74,28 +74,39 @@ void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescripti
   
   edm::ParameterSetDescription varParamDesc;
   edm::ParameterSetDescription binParamDesc;
-  //binParamDesc.add<std::string>("binType");
+  // binParamDesc.add<std::string>("binType");
+  // binParamDesc.add<std::string>("funcType");
+  // binParamDesc.add<std::vector<double>>("funcParams");
+  // binParamDesc.add<double>("xMin");
+  // binParamDesc.add<double>("xMax");
+  // binParamDesc.add<double>("yMin");
+  // binParamDesc.add<double>("yMax");
+  
   
   std::auto_ptr<edm::ParameterDescriptionCases<std::string>> binDescCases;
   binDescCases = 
     "AbsEtaClus" >> 
-    (edm::ParameterDescription<double>("minEta",0.0,true) and
-     edm::ParameterDescription<double>("maxEta",3.0,true) and
-     edm::ParameterDescription<int>("minNrClus",0,true) and
-     edm::ParameterDescription<int>("maxNrClus",99999,true) and
+    (edm::ParameterDescription<double>("xMin",0.0,true) and
+     edm::ParameterDescription<double>("xMax",3.0,true) and
+     edm::ParameterDescription<int>("yMin",0,true) and
+     edm::ParameterDescription<int>("yMax",99999,true) and
      edm::ParameterDescription<std::string>("funcType","pol0",true) and
      edm::ParameterDescription<std::vector<double>>("funcParams",{0.},true)) or
-    "AbsEtaClusWithClusCorr" >>
-    (edm::ParameterDescription<double>("minEta",0.0,true) and
-     edm::ParameterDescription<double>("maxEta",3.0,true) and
-     edm::ParameterDescription<int>("minNrClus",0,true) and
-     edm::ParameterDescription<int>("maxNrClus",99999,true) and
+    "AbsEtaClusPhi" >>
+    (edm::ParameterDescription<double>("xMin",0.0,true) and
+     edm::ParameterDescription<double>("xMax",3.0,true) and
+     edm::ParameterDescription<int>("yMin",0,true) and
+     edm::ParameterDescription<int>("yMax",99999,true) and
      edm::ParameterDescription<std::string>("funcType","pol0",true) and
-     edm::ParameterDescription<std::vector<double> >("funcParams",{0.},true) and
-     edm::ParameterDescription<double>("corrPerClus",0.0,true) and
-     edm::ParameterDescription<int>("clusNrOffset",0.0,true));
+     edm::ParameterDescription<std::vector<double>>("funcParams",{0.},true)) or 
+     "AbsEtaClusEt" >>
+    (edm::ParameterDescription<double>("xMin",0.0,true) and
+     edm::ParameterDescription<double>("xMax",3.0,true) and
+     edm::ParameterDescription<int>("yMin",0,true) and
+     edm::ParameterDescription<int>("yMax",99999,true) and
+     edm::ParameterDescription<std::string>("funcType","pol0",true) and
+     edm::ParameterDescription<std::vector<double>>("funcParams",{0.},true));
   
-    
   binParamDesc.ifValue(edm::ParameterDescription<std::string>("binType","AbsEtaClus",true), binDescCases);
   
   

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
@@ -81,19 +81,19 @@ void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescripti
     "AbsEtaClus" >> 
     (edm::ParameterDescription<double>("minEta",0.0,true) and
      edm::ParameterDescription<double>("maxEta",3.0,true) and
-     edm::ParameterDescription<double>("minNrClus",0,true) and
-     edm::ParameterDescription<double>("maxNrClus",99999,true) and
+     edm::ParameterDescription<int>("minNrClus",0,true) and
+     edm::ParameterDescription<int>("maxNrClus",99999,true) and
      edm::ParameterDescription<std::string>("funcType","pol0",true) and
      edm::ParameterDescription<std::vector<double>>("funcParams",{0.},true)) or
     "AbsEtaClusWithClusCorr" >>
     (edm::ParameterDescription<double>("minEta",0.0,true) and
      edm::ParameterDescription<double>("maxEta",3.0,true) and
-     edm::ParameterDescription<double>("minNrClus",0,true) and
-     edm::ParameterDescription<double>("maxNrClus",99999,true) and
+     edm::ParameterDescription<int>("minNrClus",0,true) and
+     edm::ParameterDescription<int>("maxNrClus",99999,true) and
      edm::ParameterDescription<std::string>("funcType","pol0",true) and
      edm::ParameterDescription<std::vector<double> >("funcParams",{0.},true) and
      edm::ParameterDescription<double>("corrPerClus",0.0,true) and
-     edm::ParameterDescription<double>("clusNrOffset",0.0,true));
+     edm::ParameterDescription<int>("clusNrOffset",0.0,true));
   
     
   binParamDesc.ifValue(edm::ParameterDescription<std::string>("binType","AbsEtaClus",true), binDescCases);

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
@@ -43,7 +43,9 @@ private:
   egPM::Param<reco::ElectronSeed> dPhi1Para_;
   egPM::Param<reco::ElectronSeed> dPhi2Para_;
   egPM::Param<reco::ElectronSeed> dRZ2Para_;
-
+  
+  int productsToWrite_;
+  
 };
 
 EgammaHLTPixelMatchS2Producer::EgammaHLTPixelMatchS2Producer(const edm::ParameterSet& config) : 
@@ -51,14 +53,17 @@ EgammaHLTPixelMatchS2Producer::EgammaHLTPixelMatchS2Producer(const edm::Paramete
   pixelSeedsToken_(consumes<reco::ElectronSeedCollection>(config.getParameter<edm::InputTag>("pixelSeedsProducer"))),
   dPhi1Para_(config.getParameter<edm::ParameterSet>("dPhi1SParams")),
   dPhi2Para_(config.getParameter<edm::ParameterSet>("dPhi2SParams")),
-  dRZ2Para_(config.getParameter<edm::ParameterSet>("dRZ2SParams"))
+  dRZ2Para_(config.getParameter<edm::ParameterSet>("dRZ2SParams")),
+  productsToWrite_(config.getParameter<int>("productsToWrite"))
   
 {
-  //register your products
-  produces < reco::RecoEcalCandidateIsolationMap >("dPhi1BestS2");
-  produces < reco::RecoEcalCandidateIsolationMap >("dPhi2BestS2");
-  produces < reco::RecoEcalCandidateIsolationMap >("dzBestS2");
+  //register your products  
   produces < reco::RecoEcalCandidateIsolationMap >("s2");
+  if(productsToWrite_>=1){
+    produces < reco::RecoEcalCandidateIsolationMap >("dPhi1BestS2");
+    produces < reco::RecoEcalCandidateIsolationMap >("dPhi2BestS2");
+    produces < reco::RecoEcalCandidateIsolationMap >("dzBestS2");
+  }
 
 
 }
@@ -74,14 +79,6 @@ void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescripti
   
   edm::ParameterSetDescription varParamDesc;
   edm::ParameterSetDescription binParamDesc;
-  // binParamDesc.add<std::string>("binType");
-  // binParamDesc.add<std::string>("funcType");
-  // binParamDesc.add<std::vector<double>>("funcParams");
-  // binParamDesc.add<double>("xMin");
-  // binParamDesc.add<double>("xMax");
-  // binParamDesc.add<double>("yMin");
-  // binParamDesc.add<double>("yMax");
-  
   
   std::auto_ptr<edm::ParameterDescriptionCases<std::string>> binDescCases;
   binDescCases = 
@@ -114,6 +111,7 @@ void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescripti
   desc.add("dPhi1SParams",varParamDesc);
   desc.add("dPhi2SParams",varParamDesc);
   desc.add("dRZ2SParams",varParamDesc);
+  desc.add<int>("productsToWrite",0);
   descriptions.add(("hltEgammaHLTPixelMatchS2Producer"), desc);  
 }
 
@@ -155,17 +153,20 @@ void EgammaHLTPixelMatchS2Producer::produce(edm::StreamID sid, edm::Event& iEven
 
    
     s2Map->insert(candRef,bestS2[0]);
-    dPhi1BestS2Map->insert(candRef,bestS2[1]);
-    dPhi2BestS2Map->insert(candRef,bestS2[2]);
-    dzBestS2Map->insert(candRef,bestS2[3]);
+    if(productsToWrite_>=1){
+      dPhi1BestS2Map->insert(candRef,bestS2[1]);
+      dPhi2BestS2Map->insert(candRef,bestS2[2]);
+      dzBestS2Map->insert(candRef,bestS2[3]);
+    }
     
   }
 
   iEvent.put(s2Map,"s2");
-  iEvent.put(dPhi1BestS2Map,"dPhi1BestS2");
-  iEvent.put(dPhi2BestS2Map,"dPhi2BestS2");
-  iEvent.put(dzBestS2Map,"dzBestS2");
-  
+  if(productsToWrite_>=1){
+    iEvent.put(dPhi1BestS2Map,"dPhi1BestS2");
+    iEvent.put(dPhi2BestS2Map,"dPhi2BestS2");
+    iEvent.put(dzBestS2Map,"dzBestS2");
+  }
 }
 
 std::array<float,4> EgammaHLTPixelMatchS2Producer::calS2(const reco::ElectronSeed& seed,int charge)const

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchS2Producer.cc
@@ -1,0 +1,151 @@
+
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
+
+#include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h"
+
+class EgammaHLTPixelMatchS2Producer : public edm::global::EDProducer<> {
+public:
+
+  explicit EgammaHLTPixelMatchS2Producer(const edm::ParameterSet&);
+  ~EgammaHLTPixelMatchS2Producer();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
+  std::array<float,4> calS2(const reco::ElectronSeed& seed,int charge)const;
+
+private: 
+  // ----------member data ---------------------------
+  
+  const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandidateToken_;
+  const edm::EDGetTokenT<reco::ElectronSeedCollection> pixelSeedsToken_;
+
+  egPM::Param<egPM::AbsEtaNrClus> dPhi1Para_;
+  egPM::Param<egPM::AbsEtaNrClus> dPhi2Para_;
+  egPM::Param<egPM::AbsEtaNrClus> dRZ2Para_;
+
+};
+
+EgammaHLTPixelMatchS2Producer::EgammaHLTPixelMatchS2Producer(const edm::ParameterSet& config) : 
+  recoEcalCandidateToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
+  pixelSeedsToken_(consumes<reco::ElectronSeedCollection>(config.getParameter<edm::InputTag>("pixelSeedsProducer"))),
+  dPhi1Para_(config.getParameter<edm::ParameterSet>("dPhi1SParams")),
+  dPhi2Para_(config.getParameter<edm::ParameterSet>("dPhi2SParams")),
+  dRZ2Para_(config.getParameter<edm::ParameterSet>("dRZ2SParams"))
+  
+{
+  //register your products
+  produces < reco::RecoEcalCandidateIsolationMap >("dPhi1BestS2");
+  produces < reco::RecoEcalCandidateIsolationMap >("dPhi2BestS2");
+  produces < reco::RecoEcalCandidateIsolationMap >("dzBestS2");
+  produces < reco::RecoEcalCandidateIsolationMap >("s2");
+
+
+}
+
+EgammaHLTPixelMatchS2Producer::~EgammaHLTPixelMatchS2Producer()
+{}
+
+void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>(("recoEcalCandidateProducer"), edm::InputTag("hltL1SeededRecoEcalCandidate"));
+  desc.add<edm::InputTag>(("pixelSeedsProducer"), edm::InputTag("electronPixelSeeds"));
+  
+  edm::ParameterSetDescription varParamDesc;
+  edm::ParameterSetDescription binParamDesc;
+  binParamDesc.setAllowAnything();
+  varParamDesc.addVPSet("bins",binParamDesc);
+  desc.add("dPhi1SParams",varParamDesc);
+  desc.add("dPhi2SParams",varParamDesc);
+  desc.add("dRZ2SParams",varParamDesc);
+  descriptions.add(("hltEgammaHLTPixelMatchS2Producer"), desc);  
+}
+
+void EgammaHLTPixelMatchS2Producer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  
+  // Get the HLT filtered objects
+  edm::Handle<reco::RecoEcalCandidateCollection> recoEcalCandHandle;
+  iEvent.getByToken(recoEcalCandidateToken_,recoEcalCandHandle);
+
+
+  edm::Handle<reco::ElectronSeedCollection> pixelSeedsHandle;
+  iEvent.getByToken(pixelSeedsToken_,pixelSeedsHandle);
+
+  if(!recoEcalCandHandle.isValid() || !pixelSeedsHandle.isValid()) return;
+
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhi1BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhi2BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dzBestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> s2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  
+  for(unsigned int candNr = 0; candNr<recoEcalCandHandle->size(); candNr++) {
+    
+    reco::RecoEcalCandidateRef candRef(recoEcalCandHandle,candNr);
+    reco::SuperClusterRef candSCRef = candRef->superCluster();
+    
+    std::array<float,4> bestS2{{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}};
+    for(auto & seed : *pixelSeedsHandle){
+      edm::RefToBase<reco::CaloCluster> pixelClusterRef = seed.caloCluster() ;
+      reco::SuperClusterRef pixelSCRef = pixelClusterRef.castTo<reco::SuperClusterRef>() ;
+      if(&(*candSCRef) ==  &(*pixelSCRef)){
+	
+	std::array<float,4> s2Data = calS2(seed,-1);
+	std::array<float,4> s2DataPos = calS2(seed,+1);
+	if(s2Data[0]<bestS2[0]) bestS2=s2Data;
+	if(s2DataPos[0]<bestS2[0]) bestS2=s2DataPos;
+	
+      }
+    }
+
+   
+    s2Map->insert(candRef,bestS2[0]);
+    dPhi1BestS2Map->insert(candRef,bestS2[1]);
+    dPhi2BestS2Map->insert(candRef,bestS2[2]);
+    dzBestS2Map->insert(candRef,bestS2[3]);
+    
+  }
+
+  iEvent.put(s2Map,"s2");
+  iEvent.put(dPhi1BestS2Map,"dPhi1BestS2");
+  iEvent.put(dPhi2BestS2Map,"dPhi2BestS2");
+  iEvent.put(dzBestS2Map,"dzBestS2");
+  
+}
+
+std::array<float,4> EgammaHLTPixelMatchS2Producer::calS2(const reco::ElectronSeed& seed,int charge)const
+{
+  const float dPhi1Const = dPhi1Para_(seed);	
+  const float dPhi2Const = dPhi2Para_(seed);
+  const float dRZ2Const = dRZ2Para_(seed);
+  
+  float dPhi1 = (charge <0 ? seed.dPhi1() : seed.dPhi1Pos())/dPhi1Const;
+  float dPhi2 = (charge <0 ? seed.dPhi2() : seed.dPhi2Pos())/dPhi2Const;
+  float dRz2 = (charge <0 ? seed.dRz2() : seed.dRz2Pos())/dRZ2Const;
+  
+  float s2 = dPhi1*dPhi1+dPhi2*dPhi2+dRz2*dRz2;
+  return std::array<float,4>{{s2,dPhi1,dPhi2,dRz2}}; 
+}
+
+
+DEFINE_FWK_MODULE(EgammaHLTPixelMatchS2Producer);

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -24,11 +24,11 @@
 
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h"
 
-class EgammaHLTPixelMatchS2Producer : public edm::global::EDProducer<> {
+class EgammaHLTPixelMatchVarProducer : public edm::global::EDProducer<> {
 public:
 
-  explicit EgammaHLTPixelMatchS2Producer(const edm::ParameterSet&);
-  ~EgammaHLTPixelMatchS2Producer();
+  explicit EgammaHLTPixelMatchVarProducer(const edm::ParameterSet&);
+  ~EgammaHLTPixelMatchVarProducer();
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
@@ -48,7 +48,7 @@ private:
   
 };
 
-EgammaHLTPixelMatchS2Producer::EgammaHLTPixelMatchS2Producer(const edm::ParameterSet& config) : 
+EgammaHLTPixelMatchVarProducer::EgammaHLTPixelMatchVarProducer(const edm::ParameterSet& config) : 
   recoEcalCandidateToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
   pixelSeedsToken_(consumes<reco::ElectronSeedCollection>(config.getParameter<edm::InputTag>("pixelSeedsProducer"))),
   dPhi1Para_(config.getParameter<edm::ParameterSet>("dPhi1SParams")),
@@ -68,10 +68,10 @@ EgammaHLTPixelMatchS2Producer::EgammaHLTPixelMatchS2Producer(const edm::Paramete
 
 }
 
-EgammaHLTPixelMatchS2Producer::~EgammaHLTPixelMatchS2Producer()
+EgammaHLTPixelMatchVarProducer::~EgammaHLTPixelMatchVarProducer()
 {}
 
-void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void EgammaHLTPixelMatchVarProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>(("recoEcalCandidateProducer"), edm::InputTag("hltL1SeededRecoEcalCandidate"));
@@ -112,10 +112,10 @@ void EgammaHLTPixelMatchS2Producer::fillDescriptions(edm::ConfigurationDescripti
   desc.add("dPhi2SParams",varParamDesc);
   desc.add("dRZ2SParams",varParamDesc);
   desc.add<int>("productsToWrite",0);
-  descriptions.add(("hltEgammaHLTPixelMatchS2Producer"), desc);  
+  descriptions.add(("hltEgammaHLTPixelMatchVarProducer"), desc);  
 }
 
-void EgammaHLTPixelMatchS2Producer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   
   // Get the HLT filtered objects
   edm::Handle<reco::RecoEcalCandidateCollection> recoEcalCandHandle;
@@ -169,7 +169,7 @@ void EgammaHLTPixelMatchS2Producer::produce(edm::StreamID sid, edm::Event& iEven
   }
 }
 
-std::array<float,4> EgammaHLTPixelMatchS2Producer::calS2(const reco::ElectronSeed& seed,int charge)const
+std::array<float,4> EgammaHLTPixelMatchVarProducer::calS2(const reco::ElectronSeed& seed,int charge)const
 {
   const float dPhi1Const = dPhi1Para_(seed);	
   const float dPhi2Const = dPhi2Para_(seed);
@@ -184,4 +184,4 @@ std::array<float,4> EgammaHLTPixelMatchS2Producer::calS2(const reco::ElectronSee
 }
 
 
-DEFINE_FWK_MODULE(EgammaHLTPixelMatchS2Producer);
+DEFINE_FWK_MODULE(EgammaHLTPixelMatchVarProducer);


### PR DESCRIPTION
Dear All,

This is a new producer which makes new variables related to pixel matching for the E/gamma HLT and is a necessary module for the 2016 Z' trigger strategy. 

The core of it relies on parameterising the spread of the dPhi1, dPhi2 and dRZ2 (phi and R/Z matching of the supercluster trajectory to the 1st and 2nd pixel hits) for a given electron. This is done via an arbitrary function in arbitrary bins. While we know what function we want to apply, it has been designed to easily change this function in the future while maintaining the exact same python interface (ie old configs still work the same, no confdb reparse needed). Hence the rather abstract interface. Given this is a stream module, my understanding from replies on the fwcore hypernews that a TF1 / TF2 / TF3 is acceptable here. If its not, we can hard code the functions easily enough.

Martin, does this need to be backported to 80X as well for the HLT? 

Cheers,
Sam
