### PR TITLE
8x Fireworks: move clipping cone apex in 3D region view 

### DIFF
--- a/Fireworks/Core/interface/FW3DViewBase.h
+++ b/Fireworks/Core/interface/FW3DViewBase.h
@@ -97,6 +97,7 @@ private:
    FWDoubleParameter m_clipPhi;
    FWDoubleParameter m_clipDelta1;
    FWDoubleParameter m_clipDelta2;
+   FWLongParameter   m_clipAppexOffset;
 
 
    FW3DViewDistanceMeasureTool* m_DMT;


### PR DESCRIPTION
Add option to move apex from origin (0, 0, 0) for a given offset in eta, phi direction.
## clipping without offset

![off0](https://cloud.githubusercontent.com/assets/2516492/14091029/99b5f64a-f4f2-11e5-8bc7-8bcef34b7389.png)
## clipping 5cm offset

![off5](https://cloud.githubusercontent.com/assets/2516492/14091049/b62d986e-f4f2-11e5-808a-3450aa4fa93a.png)
## editor

![offedi](https://cloud.githubusercontent.com/assets/2516492/14091058/c299feda-f4f2-11e5-9ec5-3e64a863aea5.png)
