### PR TITLE
add code for phase1 raw2digi

### DIFF
--- a/CondFormats/SiPixelObjects/interface/FrameConversion.h
+++ b/CondFormats/SiPixelObjects/interface/FrameConversion.h
@@ -6,6 +6,7 @@
 
 class PixelEndcapName;
 class PixelBarrelName;
+class TrackerTopology;
 
 namespace sipixelobjects {
 
@@ -17,6 +18,8 @@ public:
   FrameConversion( int rowOffset, int rowSlopeSign, int colOffset, int colSlopeSign)
     : theRowConversion( LinearConversion(rowOffset,rowSlopeSign) ),
     theCollumnConversion( LinearConversion(colOffset, colSlopeSign) ) {}
+  // for phase1
+  FrameConversion(bool bpix, int side, int rocIdInDetUnit);
 
   const sipixelobjects::LinearConversion & row() const { return theRowConversion; }
   const sipixelobjects::LinearConversion & collumn() const { return theCollumnConversion;}

--- a/CondFormats/SiPixelObjects/interface/PixelROC.h
+++ b/CondFormats/SiPixelObjects/interface/PixelROC.h
@@ -17,6 +17,7 @@
  * The Global coordinates are row and column in DetUnit.
  */
 
+//class TrackerTopology;
 
 namespace sipixelobjects {
 
@@ -62,10 +63,18 @@ public:
     return result;
   }
 
+  // recognise the detector side 
+  int bpixSidePhase0(uint32_t rawId) const;
+  int fpixSidePhase0(uint32_t rawId) const;
+  int bpixSidePhase1(uint32_t rawId) const;
+  int fpixSidePhase1(uint32_t rawId) const;
+
   /// printout for debug
   std::string print(int depth = 0) const;
 
   void initFrameConversion();
+  void initFrameConversionPhase1();
+  //void initFrameConversion(const TrackerTopology *tt, bool phase1=false);
 
 private:
   uint32_t theDetUnit;

--- a/CondFormats/SiPixelObjects/src/FrameConversion.cc
+++ b/CondFormats/SiPixelObjects/src/FrameConversion.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -9,6 +10,93 @@ using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
+FrameConversion::FrameConversion(bool bpix, int side, int rocIdInDetUnit) {
+  const bool PRINT = false;
+  if(PRINT) cout<<"FrameConversion - for phase1  "<<endl;
+
+  int slopeRow =0;
+  int slopeCol = 0;
+  int  rowOffset = 0;
+  int  colOffset = 0; 
+ 
+  if (bpix ) { // bpix 
+    if(PRINT) cout<<" for bpix, side "<<side<<" "<< rocIdInDetUnit<<endl;
+    
+    if (side==-1) {  // -Z side
+
+      if (rocIdInDetUnit <8) {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;	
+      } else {
+	slopeRow = -1;
+	slopeCol = 1;      
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+      } // if roc
+      
+    } else {  // +Z side
+      
+      if (rocIdInDetUnit <8) {
+	slopeRow = -1;
+	slopeCol = 1;
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc; 
+      } else {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (16-rocIdInDetUnit)*LocalPixel::numColsInRoc-1; 
+      }
+      
+    } // end if +-Z
+
+
+
+  } else { // fpix 
+
+    if(PRINT) cout<<" for fpix, side "<<side<<endl;
+    // for fpix follow Urs's code for pilot blade
+    // no difference between panels
+    if(side==-1) { // pannel 1
+      if (rocIdInDetUnit < 8) {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+      } else {
+	slopeRow = -1;
+	slopeCol = 1;
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+      }
+    } else { // pannel 2 
+      if (rocIdInDetUnit < 8) {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+      } else {
+	slopeRow = -1;
+	slopeCol = 1;
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+      }
+      
+    } // side 
+
+  } // bpix/fpix
+
+
+  if(PRINT)  cout<<slopeRow<<" "<<slopeCol<<" "<<rowOffset<<" "<<colOffset<<endl;
+
+  theRowConversion      = LinearConversion(rowOffset,slopeRow);
+  theCollumnConversion =  LinearConversion(colOffset, slopeCol);
+  
+}
+
+// OLD method for phase0 bpix
 FrameConversion::FrameConversion( const PixelBarrelName & name, int rocIdInDetUnit)
 {
   int slopeRow =0;
@@ -75,6 +163,7 @@ FrameConversion::FrameConversion( const PixelBarrelName & name, int rocIdInDetUn
   theCollumnConversion =  LinearConversion(colOffset, slopeCol);
 
 }
+// OLD method for phase0 fpix
 FrameConversion::FrameConversion( const PixelEndcapName & name, int rocIdInDetUnit)
 {
   int slopeRow =0;

--- a/CondFormats/SiPixelObjects/src/FrameConversion.cc
+++ b/CondFormats/SiPixelObjects/src/FrameConversion.cc
@@ -2,8 +2,6 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
@@ -11,16 +9,12 @@ using namespace edm;
 using namespace sipixelobjects;
 
 FrameConversion::FrameConversion(bool bpix, int side, int rocIdInDetUnit) {
-  const bool PRINT = false;
-  if(PRINT) cout<<"FrameConversion - for phase1  "<<endl;
-
   int slopeRow =0;
   int slopeCol = 0;
   int  rowOffset = 0;
   int  colOffset = 0; 
  
   if (bpix ) { // bpix 
-    if(PRINT) cout<<" for bpix, side "<<side<<" "<< rocIdInDetUnit<<endl;
     
     if (side==-1) {  // -Z side
 
@@ -56,7 +50,6 @@ FrameConversion::FrameConversion(bool bpix, int side, int rocIdInDetUnit) {
 
   } else { // fpix 
 
-    if(PRINT) cout<<" for fpix, side "<<side<<endl;
     // for fpix follow Urs's code for pilot blade
     // no difference between panels
     if(side==-1) { // pannel 1
@@ -87,9 +80,6 @@ FrameConversion::FrameConversion(bool bpix, int side, int rocIdInDetUnit) {
     } // side 
 
   } // bpix/fpix
-
-
-  if(PRINT)  cout<<slopeRow<<" "<<slopeCol<<" "<<rowOffset<<" "<<colOffset<<endl;
 
   theRowConversion      = LinearConversion(rowOffset,slopeRow);
   theCollumnConversion =  LinearConversion(colOffset, slopeCol);

--- a/CondFormats/SiPixelObjects/src/PixelROC.cc
+++ b/CondFormats/SiPixelObjects/src/PixelROC.cc
@@ -13,9 +13,9 @@ using namespace sipixelobjects;
 // Constructor with transformation frame initilization - NEVER CALLED
 PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
   : theDetUnit(du), theIdDU(idDU), theIdLk(idLk) {
-  cout<<" is this ever called "<<endl;
+  //cout<<" is this ever called "<<endl;
   initFrameConversion();
-  cout<<" no "<<endl;
+  //cout<<" no "<<endl;
 }
 
 
@@ -96,29 +96,29 @@ PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
 
 // works for phase 1, find det side from the local method
 void PixelROC::initFrameConversionPhase1() {
-  const bool PRINT = false;
-
-  if(PRINT) cout<<"PixelROC::initFramConversion - for phase1 "<<endl;
+  //const bool PRINT = false;
+  //if(PRINT) cout<<"PixelROC::initFramConversion - for phase1 "<<endl;
 
   int side = 0;
   bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
   if(isBarrel) {
     side = bpixSidePhase1(theDetUnit); // find the side for phase1
-    if(PRINT) cout<<" bpix, side "<<side<<endl;
+    //if(PRINT) cout<<" bpix, side "<<side<<endl;
   } else {
     side = fpixSidePhase1(theDetUnit);
-    if(PRINT) cout<<" fpix, side "<<side<<endl;
+    //if(PRINT) cout<<" fpix, side "<<side<<endl;
   }
 
   theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
 
-  if(PRINT) cout<<" init FrameConversion "
-      <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
-      <<" "<<theFrameConverter.row().offset()
-      <<" "<<theFrameConverter.row().slope()
-      <<" "<<theFrameConverter.collumn().offset()
-      <<" "<<theFrameConverter.collumn().slope()
-      <<endl;
+  // if(PRINT) cout<<" init FrameConversion "
+  //     <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
+  //     <<" "<<theFrameConverter.row().offset()
+  //     <<" "<<theFrameConverter.row().slope()
+  //     <<" "<<theFrameConverter.collumn().offset()
+  //     <<" "<<theFrameConverter.collumn().slope()
+  //     <<endl;
+
 }
 
 // Works only for phase0, uses the fixed pixel id

--- a/CondFormats/SiPixelObjects/src/PixelROC.cc
+++ b/CondFormats/SiPixelObjects/src/PixelROC.cc
@@ -3,38 +3,282 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <sstream>
 #include <algorithm>
 using namespace std;
 using namespace sipixelobjects;
 
+// Constructor with transformation frame initilization - NEVER CALLED
 PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
-  : theDetUnit(du), theIdDU(idDU), theIdLk(idLk)
-{initFrameConversion();}
-
-void PixelROC::initFrameConversion()
-{
-  if ( PixelModuleName::isBarrel(theDetUnit) ) {
-    PixelBarrelName barrelName(theDetUnit); 
-    theFrameConverter = FrameConversion(barrelName, theIdDU);
-  } else {
-    PixelEndcapName endcapName(theDetUnit);
-    theFrameConverter =  FrameConversion(endcapName, theIdDU); 
-  }
+  : theDetUnit(du), theIdDU(idDU), theIdLk(idLk) {
+  cout<<" is this ever called "<<endl;
+  initFrameConversion();
+  cout<<" no "<<endl;
 }
 
-string PixelROC::print(int depth) const
-{
+
+// // for testing, uses topology fot det id, it works but I cannot pass topology here
+// // not used  
+// void PixelROC::initFrameConversion(const TrackerTopology *tt, bool phase1) {
+//   const bool PRINT = false;
+//   const bool TEST = false;
+
+//   if(PRINT) cout<<"PixelROC::initFramConversion - using topology, phase1 "<<phase1<<endl;
+
+//   if(phase1) { // phase1
+//     if(PRINT) cout<<" new initFrameConversion for phase 1 "<<phase1<<endl;
+
+//     if(PRINT) cout<<hex<<theDetUnit<<dec<<endl;
+
+//     bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
+//     int side = 0;
+//     if(isBarrel) {
+//       // Barrel Z-index=1,8
+//       if((tt->pxbModule(theDetUnit))<5) side=-1;
+//       else side=1;
+
+//       if(PRINT) cout<<" bpix, side "<<side<<endl;
+
+//       if(TEST) {
+// 	// phase0 code 
+// 	PXBDetId det(theDetUnit);
+// 	cout<<det.layer()<<" "<<det.ladder()<<" "<<det.module()<<endl;
+// 	unsigned  int module = bpixSidePhase0(theDetUnit);
+// 	if(!phase1 && (tt->pxbModule(theDetUnit) != module) ) 
+// 	  cout<<" ERRROR: Stop "<<module<<endl;
+// 	// phase1 code
+// 	cout<<tt->pxbLayer(theDetUnit)<<" "<<tt->pxbLadder(theDetUnit)<<" "
+// 	    <<tt->pxbModule(theDetUnit)<<endl;
+// 	unsigned  int module1 = bpixSidePhase1(theDetUnit);
+// 	if( tt->pxbModule(theDetUnit) != module1 ) cout<<" ERROR: Stop "<<module1<<endl;
+//       }
+
+//     } else {
+
+//       // Endcaps, use the panel to find the direction 
+//       if((tt->pxfPanel(theDetUnit))==1) side=-1; // panel 1
+//       else side =1; // panel 2
+
+//       if(PRINT) cout<<" fpix, side "<<side<<endl;
+
+//       if(TEST) {
+// 	// code -phase0
+// 	PXFDetId det(theDetUnit);      
+// 	cout<<det.side()<<" "<<det.disk()<<" "<<det.blade()<<" "<<det.panel()<<" "<<det.module()<<endl;
+// 	unsigned int module = fpixSidePhase0(theDetUnit);
+// 	if(!phase1 && (tt->pxfPanel(theDetUnit) != module) ) cout<<" ERRROR: Stop "<<module<<endl;
+	
+// 	// phase1 code
+// 	unsigned int module1 = fpixSidePhase1(theDetUnit);
+// 	cout<<tt->pxfSide(theDetUnit)<<" "<<tt->pxfDisk(theDetUnit)<<" "
+// 	    <<tt->pxfBlade(theDetUnit)<<" "<<tt->pxfPanel(theDetUnit)<<" "
+// 	  <<tt->pxfModule(theDetUnit)<<endl;
+// 	if( tt->pxfPanel(theDetUnit) != module1 ) cout<<" ERROR: Stop "<<module1<<endl;
+//       }
+//     }
+
+//     theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
+
+//   } else { // phase0
+//     initFrameConversion();  // old code for phase0
+//   }
+
+//   if(PRINT) cout<<" init FrameConversion "<<phase1
+//       <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
+//       <<" "<<theFrameConverter.row().offset()
+//       <<" "<<theFrameConverter.row().slope()
+//       <<" "<<theFrameConverter.collumn().offset()
+//       <<" "<<theFrameConverter.collumn().slope()
+//       <<endl;
+// }
+
+// works for phase 1, find det side from the local method
+void PixelROC::initFrameConversionPhase1() {
+  const bool PRINT = false;
+
+  if(PRINT) cout<<"PixelROC::initFramConversion - for phase1 "<<endl;
+
+  int side = 0;
+  bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
+  if(isBarrel) {
+    side = bpixSidePhase1(theDetUnit); // find the side for phase1
+    if(PRINT) cout<<" bpix, side "<<side<<endl;
+  } else {
+    side = fpixSidePhase1(theDetUnit);
+    if(PRINT) cout<<" fpix, side "<<side<<endl;
+  }
+
+  theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
+
+  if(PRINT) cout<<" init FrameConversion "
+      <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
+      <<" "<<theFrameConverter.row().offset()
+      <<" "<<theFrameConverter.row().slope()
+      <<" "<<theFrameConverter.collumn().offset()
+      <<" "<<theFrameConverter.collumn().slope()
+      <<endl;
+}
+
+// Works only for phase0, uses the fixed pixel id
+void PixelROC::initFrameConversion() {
+
+    if ( PixelModuleName::isBarrel(theDetUnit) ) {
+      PixelBarrelName barrelName(theDetUnit);
+      //cout<<" bpix mod "<<barrelName.name()<<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk<<endl;
+      theFrameConverter = FrameConversion(barrelName, theIdDU);
+    } else {
+      PixelEndcapName endcapName(theDetUnit);
+      theFrameConverter =  FrameConversion(endcapName, theIdDU); 
+    }
+    // } // end phase 
+
+  // cout<<" init FrameConversion "
+  //     <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
+  //     <<" "<<theFrameConverter.row().offset()
+  //     <<" "<<theFrameConverter.row().slope()
+  //     <<" "<<theFrameConverter.collumn().offset()
+  //     <<" "<<theFrameConverter.collumn().slope()
+  //     <<endl;
+
+}
+
+// These are methods to find the module side.
+// The are hardwired for phase0 and phase1
+// Will not work for phase2 or when the detid coding changes.
+int PixelROC::bpixSidePhase0(uint32_t rawId) const {
+  int side = 1;
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  //const unsigned int layerStartBit_=   16;
+  //const unsigned int ladderStartBit_=   8;
+  const unsigned int moduleStartBit_=   2;
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  //const unsigned int layerMask_=       0xF;
+  //const unsigned int ladderMask_=      0xFF;
+  const unsigned int moduleMask_=      0x3F;
+
+  /// layer id
+  //unsigned int layer = (rawId>>layerStartBit_) & layerMask_;
+  /// ladder  id
+  //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
+  /// det id
+  unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
+  //cout<<layer<<" "<<ladder<<" "<<module<<endl;
+
+  if(module<5) side=-1; // modules 1-4 are on -z
+  return side;
+}
+int PixelROC::bpixSidePhase1(uint32_t rawId) const {
+  int side = 1;
+
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  //const unsigned int layerStartBit_=   20;
+  //const unsigned int ladderStartBit_=  12;
+  const unsigned int moduleStartBit_=   2;
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  //const unsigned int layerMask_=       0xF;
+  //const unsigned int ladderMask_=      0xFF;
+  const unsigned int moduleMask_=      0x3FF;
+
+  /// layer id
+  //unsigned int layer = (rawId>>layerStartBit_) & layerMask_;
+  /// ladder  id
+  //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
+  /// det id
+  unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
+  //cout<<layer<<" "<<ladder<<" "<<module<<endl;
+
+  if(module<5) side=-1; // modules 1-4 are on -z
+  return side;
+}
+
+int PixelROC::fpixSidePhase0(uint32_t rawId) const {
+  int side = 1;
+
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  //const unsigned int sideStartBit_=   23;
+  //const unsigned int diskStartBit_=   16;
+  //const unsigned int bladeStartBit_=  10;
+  const unsigned int panelStartBit_=  8;
+  //const unsigned int moduleStartBit_= 2;
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  
+  //const unsigned int sideMask_=     0x3;
+  //const unsigned int diskMask_=     0xF;
+  //const unsigned int bladeMask_=    0x3F;
+  const unsigned int panelMask_=    0x3;
+  //const unsigned int moduleMask_=   0x3F;
+
+  /// positive or negative id
+  //unsigned int sides = int((rawId>>sideStartBit_) & sideMask_);
+  /// disk id
+  //unsigned int disk = int((rawId>>diskStartBit_) & diskMask_);
+  /// blade id
+  //unsigned int blade = ((rawId>>bladeStartBit_) & bladeMask_);
+  /// panel id
+  unsigned int panel = ((rawId>>panelStartBit_) & panelMask_);
+  /// det id
+  //unsigned int module = ((rawId>>moduleStartBit_) & moduleMask_);
+
+  //cout<<sides<<" "<<disk<<" "<<blade<<" "<<panel<<" "<<module<<endl;
+
+  if(panel==1) side=-1; // panel 1 faces -z (is this true for all disks?)
+  return side;
+}
+int PixelROC::fpixSidePhase1(uint32_t rawId) const {
+  int side = 1;
+
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  //const unsigned int sideStartBit_=   23;
+  //const unsigned int diskStartBit_=   18;
+  //const unsigned int bladeStartBit_=  12;
+  const unsigned int panelStartBit_=  10;
+  //const unsigned int moduleStartBit_= 2;
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  
+  //const unsigned int sideMask_=     0x3;
+  //const unsigned int diskMask_=     0xF;
+  //const unsigned int bladeMask_=    0x3F;
+  const unsigned int panelMask_=    0x3;
+  //const unsigned int moduleMask_=   0xFF;
+
+  //cout<<hex<<rawId<<dec<<endl;
+
+  /// positive or negative id
+  //unsigned int sides = int((rawId>>sideStartBit_) & sideMask_);
+  /// disk id
+  //unsigned int disk = int((rawId>>diskStartBit_) & diskMask_);
+  
+  /// blade id
+  //unsigned int blade = ((rawId>>bladeStartBit_) & bladeMask_);
+  
+ /// panel id 1 or 2
+  unsigned int panel = ((rawId>>panelStartBit_) & panelMask_);
+
+  /// det id
+  //unsigned int module = ((rawId>>moduleStartBit_) & moduleMask_);
+
+
+  //cout<<sides<<" "<<disk<<" "<<blade<<" "<<panel<<" "<<module<<endl;
+
+  if(panel==1) side=-1; // panel 1 faces -z (is this true for all disks?)
+  return side;
+}
+
+
+string PixelROC::print(int depth) const {
 
   ostringstream out;
   bool barrel = PixelModuleName::isBarrel(theDetUnit);
   DetId detId(theDetUnit);
   if (depth-- >=0 ) {
     out <<"======== PixelROC ";
-    out <<" unit: ";
-    if (barrel) out << PixelBarrelName(detId).name();
-    else        out << PixelEndcapName(detId).name(); 
+    //out <<" unit: ";
+    //if (barrel) out << PixelBarrelName(detId).name();
+    //else        out << PixelEndcapName(detId).name(); 
+    if (barrel) out << " barrel ";
+    else        out << " endcap "; 
     out <<" ("<<theDetUnit<<")"
         <<" idInDU: "<<theIdDU
         <<" idInLk: "<<theIdLk

--- a/CondFormats/SiPixelObjects/src/PixelROC.cc
+++ b/CondFormats/SiPixelObjects/src/PixelROC.cc
@@ -3,7 +3,6 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <sstream>
 #include <algorithm>
@@ -13,111 +12,57 @@ using namespace sipixelobjects;
 // Constructor with transformation frame initilization - NEVER CALLED
 PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
   : theDetUnit(du), theIdDU(idDU), theIdLk(idLk) {
-  //cout<<" is this ever called "<<endl;
   initFrameConversion();
-  //cout<<" no "<<endl;
 }
-
 
 // // for testing, uses topology fot det id, it works but I cannot pass topology here
 // // not used  
 // void PixelROC::initFrameConversion(const TrackerTopology *tt, bool phase1) {
-//   const bool PRINT = false;
 //   const bool TEST = false;
-
-//   if(PRINT) cout<<"PixelROC::initFramConversion - using topology, phase1 "<<phase1<<endl;
-
 //   if(phase1) { // phase1
-//     if(PRINT) cout<<" new initFrameConversion for phase 1 "<<phase1<<endl;
-
-//     if(PRINT) cout<<hex<<theDetUnit<<dec<<endl;
-
 //     bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
 //     int side = 0;
 //     if(isBarrel) {
 //       // Barrel Z-index=1,8
 //       if((tt->pxbModule(theDetUnit))<5) side=-1;
 //       else side=1;
-
-//       if(PRINT) cout<<" bpix, side "<<side<<endl;
-
 //       if(TEST) {
 // 	// phase0 code 
 // 	PXBDetId det(theDetUnit);
-// 	cout<<det.layer()<<" "<<det.ladder()<<" "<<det.module()<<endl;
 // 	unsigned  int module = bpixSidePhase0(theDetUnit);
 // 	if(!phase1 && (tt->pxbModule(theDetUnit) != module) ) 
-// 	  cout<<" ERRROR: Stop "<<module<<endl;
 // 	// phase1 code
-// 	cout<<tt->pxbLayer(theDetUnit)<<" "<<tt->pxbLadder(theDetUnit)<<" "
-// 	    <<tt->pxbModule(theDetUnit)<<endl;
 // 	unsigned  int module1 = bpixSidePhase1(theDetUnit);
-// 	if( tt->pxbModule(theDetUnit) != module1 ) cout<<" ERROR: Stop "<<module1<<endl;
 //       }
-
 //     } else {
-
 //       // Endcaps, use the panel to find the direction 
 //       if((tt->pxfPanel(theDetUnit))==1) side=-1; // panel 1
 //       else side =1; // panel 2
-
-//       if(PRINT) cout<<" fpix, side "<<side<<endl;
-
 //       if(TEST) {
 // 	// code -phase0
 // 	PXFDetId det(theDetUnit);      
-// 	cout<<det.side()<<" "<<det.disk()<<" "<<det.blade()<<" "<<det.panel()<<" "<<det.module()<<endl;
 // 	unsigned int module = fpixSidePhase0(theDetUnit);
-// 	if(!phase1 && (tt->pxfPanel(theDetUnit) != module) ) cout<<" ERRROR: Stop "<<module<<endl;
-	
 // 	// phase1 code
 // 	unsigned int module1 = fpixSidePhase1(theDetUnit);
-// 	cout<<tt->pxfSide(theDetUnit)<<" "<<tt->pxfDisk(theDetUnit)<<" "
-// 	    <<tt->pxfBlade(theDetUnit)<<" "<<tt->pxfPanel(theDetUnit)<<" "
-// 	  <<tt->pxfModule(theDetUnit)<<endl;
-// 	if( tt->pxfPanel(theDetUnit) != module1 ) cout<<" ERROR: Stop "<<module1<<endl;
 //       }
 //     }
-
 //     theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
-
 //   } else { // phase0
 //     initFrameConversion();  // old code for phase0
 //   }
-
-//   if(PRINT) cout<<" init FrameConversion "<<phase1
-//       <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
-//       <<" "<<theFrameConverter.row().offset()
-//       <<" "<<theFrameConverter.row().slope()
-//       <<" "<<theFrameConverter.collumn().offset()
-//       <<" "<<theFrameConverter.collumn().slope()
-//       <<endl;
 // }
 
 // works for phase 1, find det side from the local method
 void PixelROC::initFrameConversionPhase1() {
-  //const bool PRINT = false;
-  //if(PRINT) cout<<"PixelROC::initFramConversion - for phase1 "<<endl;
-
   int side = 0;
   bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
   if(isBarrel) {
     side = bpixSidePhase1(theDetUnit); // find the side for phase1
-    //if(PRINT) cout<<" bpix, side "<<side<<endl;
   } else {
     side = fpixSidePhase1(theDetUnit);
-    //if(PRINT) cout<<" fpix, side "<<side<<endl;
   }
 
   theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
-
-  // if(PRINT) cout<<" init FrameConversion "
-  //     <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
-  //     <<" "<<theFrameConverter.row().offset()
-  //     <<" "<<theFrameConverter.row().slope()
-  //     <<" "<<theFrameConverter.collumn().offset()
-  //     <<" "<<theFrameConverter.collumn().slope()
-  //     <<endl;
 
 }
 
@@ -126,21 +71,11 @@ void PixelROC::initFrameConversion() {
 
     if ( PixelModuleName::isBarrel(theDetUnit) ) {
       PixelBarrelName barrelName(theDetUnit);
-      //cout<<" bpix mod "<<barrelName.name()<<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk<<endl;
       theFrameConverter = FrameConversion(barrelName, theIdDU);
     } else {
       PixelEndcapName endcapName(theDetUnit);
       theFrameConverter =  FrameConversion(endcapName, theIdDU); 
     }
-    // } // end phase 
-
-  // cout<<" init FrameConversion "
-  //     <<" "<<theDetUnit<<" "<<theIdDU<<" "<<theIdLk
-  //     <<" "<<theFrameConverter.row().offset()
-  //     <<" "<<theFrameConverter.row().slope()
-  //     <<" "<<theFrameConverter.collumn().offset()
-  //     <<" "<<theFrameConverter.collumn().slope()
-  //     <<endl;
 
 }
 
@@ -164,7 +99,6 @@ int PixelROC::bpixSidePhase0(uint32_t rawId) const {
   //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
   /// det id
   unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
-  //cout<<layer<<" "<<ladder<<" "<<module<<endl;
 
   if(module<5) side=-1; // modules 1-4 are on -z
   return side;
@@ -187,7 +121,6 @@ int PixelROC::bpixSidePhase1(uint32_t rawId) const {
   //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
   /// det id
   unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
-  //cout<<layer<<" "<<ladder<<" "<<module<<endl;
 
   if(module<5) side=-1; // modules 1-4 are on -z
   return side;
@@ -221,8 +154,6 @@ int PixelROC::fpixSidePhase0(uint32_t rawId) const {
   /// det id
   //unsigned int module = ((rawId>>moduleStartBit_) & moduleMask_);
 
-  //cout<<sides<<" "<<disk<<" "<<blade<<" "<<panel<<" "<<module<<endl;
-
   if(panel==1) side=-1; // panel 1 faces -z (is this true for all disks?)
   return side;
 }
@@ -243,8 +174,6 @@ int PixelROC::fpixSidePhase1(uint32_t rawId) const {
   const unsigned int panelMask_=    0x3;
   //const unsigned int moduleMask_=   0xFF;
 
-  //cout<<hex<<rawId<<dec<<endl;
-
   /// positive or negative id
   //unsigned int sides = int((rawId>>sideStartBit_) & sideMask_);
   /// disk id
@@ -258,9 +187,6 @@ int PixelROC::fpixSidePhase1(uint32_t rawId) const {
 
   /// det id
   //unsigned int module = ((rawId>>moduleStartBit_) & moduleMask_);
-
-
-  //cout<<sides<<" "<<disk<<" "<<blade<<" "<<panel<<" "<<module<<endl;
 
   if(panel==1) side=-1; // panel 1 faces -z (is this true for all disks?)
   return side;

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -1,19 +1,61 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <vector>
 #include <iostream>
 #include <algorithm>
-
 #include <iostream>
+
+//#define OLD_RAW2DIGI
 
 using namespace sipixelobjects;
 
-
 void SiPixelFedCablingMap::initializeRocs() {
-  //  std::cout << "initialize PixelRocs" << std::endl;
-  for (auto & v : theMap) v.second.initFrameConversion();
+  const bool PRINT = false;
+  if(PRINT) std::cout<<"SiPixelFedCablingMap::initializeRocs - cabling version "
+		     <<theVersion<<" "<<version()<<std::endl;
 
+#ifdef OLD_RAW2DIGI
+
+  if(PRINT) std::cout << "initialize PixelRocs works only for phase0" << std::endl;
+  for (auto & v : theMap) v.second.initFrameConversion(); 
+
+#else 
+
+  // Decide if it is phase0 or phase1 based on the first fed, 0-phase0, 1200-phase1
+  unsigned int fedId = (theMap.begin())->first.fed; // get the first fed
+  if(PRINT) std::cout << "initialize PixelRocs works for phase0 & phase1 1st fed " 
+		      <<fedId<< std::endl;
+
+  if(fedId>=1200) { // phase1
+    for (auto & v : theMap) v.second.initFrameConversionPhase1(); // works
+  } else { // phase0
+    for (auto & v : theMap) v.second.initFrameConversion(); // works
+  }
+
+  
+  if(0) {  // for testing 
+  for (Map::iterator im = theMap.begin(); im != theMap.end(); im++) {
+    unsigned int fedId = im->first.fed;
+    unsigned int linkId = im->first.link;
+    unsigned int rocId = im->first.roc;
+    auto rawDetID = im->second.rawId();
+    auto idInDetUnit = im->second.idInDetUnit();
+    auto idInLink = im->second.idInLink();
+    if(0) std::cout<<" roc in map "<<fedId<<" "<<linkId<<" "<<rocId<<" "<<rawDetID<<" "
+	     <<idInDetUnit<<" "<<idInLink<<std::endl;
+    //auto v = *im;
+    if(fedId>=1200) {
+      //v.second.initFrameConversionPhase1(); //  
+      im->second.initFrameConversionPhase1(); // 
+    } else {
+      im->second.initFrameConversion();
+    }
+  } //  
+  } 
+#endif
+  if(PRINT) std::cout<<"SiPixelFedCablingMap::initializeRocs - END "<<std::endl;
 }
 
 
@@ -34,8 +76,10 @@ bool SiPixelFedCablingMap::Key::operator < (const Key & other) const
 SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab) 
   : theVersion(cab->version())
 {
-// std::cout << "HERE --- SiPixelFedCablingMap CTOR" << std::endl;
-  
+
+  std::cout << "HERE --- SiPixelFedCablingMap CTOR- NEVER CALLED " << std::endl;
+
+  // Never called  
   std::vector<const PixelFEDCabling *> fedList = cab->fedList();
   for (std::vector<const PixelFEDCabling *>::const_iterator ifed=fedList.begin();
    ifed != fedList.end(); ifed++) {
@@ -48,6 +92,10 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
       if (linkId != 0 && linkId!= link) 
           std::cout << "PROBLEM WITH LINK NUMBER!!!!" << std::endl;
       unsigned int numberROC = pLink->numberOfROCs(); 
+
+      //std::cout<<"  cabling map "<<fed<<" "<<linkId<<" "<<link<<" "
+      //       <<numberROC<<std::endl;
+
       for (unsigned int roc=1; roc <= numberROC; roc++) {
         const PixelROC * pROC = pLink->roc(roc);
         if (pROC==0) continue;
@@ -57,11 +105,13 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
         theMap[key] = (*pROC);
       }
     } 
-  }  
+  } // fed loop   
+ 
+  std::cout<<" SiPixelFedCablingMap CTOR: end"<<std::endl;
 }
 
-std::unique_ptr<SiPixelFedCablingTree>  SiPixelFedCablingMap::cablingTree() const
-{
+std::unique_ptr<SiPixelFedCablingTree>  SiPixelFedCablingMap::cablingTree() const {
+
   std::unique_ptr<SiPixelFedCablingTree>  tree(new SiPixelFedCablingTree(theVersion)); 
   for (Map::const_iterator im = theMap.begin(); im != theMap.end(); im++) {
     const sipixelobjects::PixelROC & roc = im->second;
@@ -72,8 +122,7 @@ std::unique_ptr<SiPixelFedCablingTree>  SiPixelFedCablingMap::cablingTree() cons
   return tree;
 }
 
-std::vector<unsigned int> SiPixelFedCablingMap::fedIds() const
-{
+std::vector<unsigned int> SiPixelFedCablingMap::fedIds() const {
   std::vector<unsigned int> result;
   for (Map::const_iterator im = theMap.begin(); im != theMap.end(); im++) {
     unsigned int fedId = im->first.fed;
@@ -83,8 +132,7 @@ std::vector<unsigned int> SiPixelFedCablingMap::fedIds() const
 }
 
 const sipixelobjects::PixelROC* SiPixelFedCablingMap::findItem(
-    const sipixelobjects::CablingPathToDetUnit & path) const
-{
+    const sipixelobjects::CablingPathToDetUnit & path) const {
   const PixelROC* roc = 0;
   Key key = {path.fed, path.link, path.roc};
   Map::const_iterator inMap = theMap.find(key);
@@ -93,8 +141,8 @@ const sipixelobjects::PixelROC* SiPixelFedCablingMap::findItem(
 }
 
 std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingMap::pathToDetUnit(
-      uint32_t rawDetId) const
-{
+      uint32_t rawDetId) const {
+
   std::vector<sipixelobjects::CablingPathToDetUnit> result;
   for (Map::const_iterator im = theMap.begin(); im != theMap.end(); ++im) {
     if(im->second.rawId()==rawDetId ) {

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -1,61 +1,47 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
 #include <vector>
 #include <iostream>
 #include <algorithm>
 #include <iostream>
 
-//#define OLD_RAW2DIGI
-
 using namespace sipixelobjects;
 
 void SiPixelFedCablingMap::initializeRocs() {
-  const bool PRINT = false;
-  if(PRINT) std::cout<<"SiPixelFedCablingMap::initializeRocs - cabling version "
-		     <<theVersion<<" "<<version()<<std::endl;
 
-#ifdef OLD_RAW2DIGI
-
-  if(PRINT) std::cout << "initialize PixelRocs works only for phase0" << std::endl;
-  for (auto & v : theMap) v.second.initFrameConversion(); 
-
-#else 
+  // OLD Method 
+  //for (auto & v : theMap) v.second.initFrameConversion(); 
+  // below is the new code, works for phase0 and phase1
 
   // Decide if it is phase0 or phase1 based on the first fed, 0-phase0, 1200-phase1
   unsigned int fedId = (theMap.begin())->first.fed; // get the first fed
-  if(PRINT) std::cout << "initialize PixelRocs works for phase0 & phase1 1st fed " 
-		      <<fedId<< std::endl;
 
-  if(fedId>=1200) { // phase1
+  if(fedId>=FEDNumbering::MINSiPixeluTCAFEDID) { // phase1 >= 1200
     for (auto & v : theMap) v.second.initFrameConversionPhase1(); // works
   } else { // phase0
     for (auto & v : theMap) v.second.initFrameConversion(); // works
   }
-
   
-  if(0) {  // for testing 
-  for (Map::iterator im = theMap.begin(); im != theMap.end(); im++) {
-    unsigned int fedId = im->first.fed;
-    unsigned int linkId = im->first.link;
-    unsigned int rocId = im->first.roc;
-    auto rawDetID = im->second.rawId();
-    auto idInDetUnit = im->second.idInDetUnit();
-    auto idInLink = im->second.idInLink();
-    if(0) std::cout<<" roc in map "<<fedId<<" "<<linkId<<" "<<rocId<<" "<<rawDetID<<" "
-	     <<idInDetUnit<<" "<<idInLink<<std::endl;
-    //auto v = *im;
-    if(fedId>=1200) {
-      //v.second.initFrameConversionPhase1(); //  
-      im->second.initFrameConversionPhase1(); // 
-    } else {
-      im->second.initFrameConversion();
-    }
-  } //  
-  } 
-#endif
-  if(PRINT) std::cout<<"SiPixelFedCablingMap::initializeRocs - END "<<std::endl;
+  // if(0) {  // for testing 
+  //   for (Map::iterator im = theMap.begin(); im != theMap.end(); im++) {
+  //     unsigned int fedId = im->first.fed;
+  //     unsigned int linkId = im->first.link;
+  //     unsigned int rocId = im->first.roc;
+  //     auto rawDetID = im->second.rawId();
+  //     auto idInDetUnit = im->second.idInDetUnit();
+  //     auto idInLink = im->second.idInLink();
+  //     //auto v = *im;
+  //     if(fedId>=1200) {
+  // 	//v.second.initFrameConversionPhase1(); //  
+  // 	im->second.initFrameConversionPhase1(); // 
+  //     } else {
+  // 	im->second.initFrameConversion();
+  //     }
+  //   } //  
+  // } // end if(0)
+
 }
 
 
@@ -77,8 +63,6 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
   : theVersion(cab->version())
 {
 
-  std::cout << "HERE --- SiPixelFedCablingMap CTOR- NEVER CALLED " << std::endl;
-
   // Never called  
   std::vector<const PixelFEDCabling *> fedList = cab->fedList();
   for (std::vector<const PixelFEDCabling *>::const_iterator ifed=fedList.begin();
@@ -88,26 +72,22 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
     for (unsigned int link=1; link <= numLink; link++) {
       const PixelFEDLink * pLink = (**ifed).link(link); 
       if (pLink==0) continue;
-      unsigned int linkId = pLink->id();
-      if (linkId != 0 && linkId!= link) 
-          std::cout << "PROBLEM WITH LINK NUMBER!!!!" << std::endl;
+      //unsigned int linkId = pLink->id();
+      //if (linkId != 0 && linkId!= link) 
+      //  std::cout << "PROBLEM WITH LINK NUMBER!!!!" << std::endl;
       unsigned int numberROC = pLink->numberOfROCs(); 
-
-      //std::cout<<"  cabling map "<<fed<<" "<<linkId<<" "<<link<<" "
-      //       <<numberROC<<std::endl;
 
       for (unsigned int roc=1; roc <= numberROC; roc++) {
         const PixelROC * pROC = pLink->roc(roc);
         if (pROC==0) continue;
-        if (pROC->idInLink() != roc) 
-            std::cout << "PROBLEM WITH ROC NUMBER!!!!" << std::endl;
+        //if (pROC->idInLink() != roc) 
+	//  std::cout << "PROBLEM WITH ROC NUMBER!!!!" << std::endl;
         Key key = {fed, link, roc}; 
         theMap[key] = (*pROC);
       }
     } 
   } // fed loop   
  
-  std::cout<<" SiPixelFedCablingMap CTOR: end"<<std::endl;
 }
 
 std::unique_ptr<SiPixelFedCablingTree>  SiPixelFedCablingMap::cablingTree() const {


### PR DESCRIPTION
Modify 3 classes in CondFormats/SiPixelObjects to handle phase1 pixel raw2digi.
The switch between phase0 and phase1 is based on FED-ID, feds 0-40 are phase 0,
feds >=1200 are phase1.
Tested on MC muons for phase1 pixel geometry.
Tested for phase0 geometry for MC single muons and cosmic data from 2016.
The correctness of the module rotations for phase1 can only be tested with real data.
Special calibration runs, e.g. PixelAlive with a non-symmetric pattern can be also used. 
