### PR TITLE
Change auto_ptr to unique_ptr in text

### DIFF
--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -23,9 +23,9 @@ namespace edm {
     template <typename T>
     class IndirectHolder : public BaseHolder<T> {
     public:
-      // It may be better to use auto_ptr<RefHolderBase> in
+      // It may be better to use unique_ptr<RefHolderBase> in
       // this constructor, so that the cloning can be avoided. I'm not
-      // sure if use of auto_ptr here causes any troubles elsewhere.
+      // sure if use of unique_ptr here causes any troubles elsewhere.
       IndirectHolder() : BaseHolder<T>(), helper_( nullptr ) { }
       IndirectHolder(std::shared_ptr<RefHolderBase> p);
       template< typename U>

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -97,7 +97,7 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
       virtual void registerProxies(const eventsetup::EventSetupRecordKey& iRecord ,
                                     KeyedProxies& aProxyList) ;
 
-      /** \param iFactory auto_ptr holding a new instance of a Factory
+      /** \param iFactory unique_ptr holding a new instance of a Factory
          \param iLabel extra string label used to get data (optional)
          Producer takes ownership of the Factory and uses it create the appropriate
          Proxy which is then registered with the EventSetup.  If used, this method should

--- a/FWCore/MessageLogger/doc/MessageLoggerDesign.txt
+++ b/FWCore/MessageLogger/doc/MessageLoggerDesign.txt
@@ -106,7 +106,7 @@ struct MessageLoggerScribe {
     case LOG:
     {
      MessageLoggerSlot m = static_cast<MessageLoggerSlot> m;
-     auto_ptr<ErrorObj> ep (m->ep);
+     unique_ptr<ErrorObj> ep (m->ep);
      (*errlogp) << *ep;
     } break;
     case SETUP_USING_PARAMETERS:
@@ -209,7 +209,7 @@ MessageSender LogWarning (const char* id)
      constructs.  The MessageSender class contains an ErrorObj*, which
      the ctor initializes to point to an ErrorObj on the heap, constructed
      from ELwarning and myid.  This ErrorObj, though allocated via new,
-     will not be deleted explicitly by MessageSender - instead, an auto_ptr
+     will not be deleted explicitly by MessageSender - instead, a unique_ptr
      will be formed to pass that duty onward.
 
   g) The messageSender now has a couple of invocations of operator<<().  It
@@ -220,8 +220,8 @@ MessageSender LogWarning (const char* id)
 
   i) The dtor of MessageSender obtains a slot in the queue obtained by
      messageLoggerQ().  It casts this unstructured slot into form for taking
-     a command and an auto_ptr to an ErrorObj.  It then fills that structure
-     with the command LOG and an auto_ptr to the on-the-heap ErrorObj
+     a command and a unique_ptr to an ErrorObj.  It then fills that structure
+     with the command LOG and a unique_ptr to the on-the-heap ErrorObj
      (at this point, it is relieved of responsibility for deleting the
      ErrorObj).
 
@@ -233,9 +233,9 @@ MessageSender LogWarning (const char* id)
      command member of that struct is examined and found (in this case) to
      be LOG.
 
-  l) An auto_ptr<ErrorObj> is formed from the pointer sitting in the
+  l) An unique_ptr<ErrorObj> is formed from the pointer sitting in the
      raw slot.  This is done by casting the raw memory into its Message
-     SenderSlot form.  This is crucial because we had "lost" the auto_ptr
+     SenderSlot form.  This is crucial because we had "lost" the unique_ptr
      nature of that pointer.
 
   m) The activate() is a member function of MessageLoggerScribe; it has
@@ -243,7 +243,7 @@ MessageSender LogWarning (const char* id)
      error logger.  Thus the message is formated and comes out in all
      the destinations -- in this case just cerr -- attached to the logger.
 
-  n) At the end of the LOG case, the auto_ptr goes out of scope, thus deleting
+  n) At the end of the LOG case, the unique_ptr goes out of scope, thus deleting
      the ErrorObj so that the memory on the heap is properly freed.
 
   o) At the end of the switch on command, the buffer is replaced into the pool.

--- a/FWCore/MessageService/doc/Design_and_maintenance.txt
+++ b/FWCore/MessageService/doc/Design_and_maintenance.txt
@@ -44,8 +44,8 @@ Server side:
 ------------------------------------------------
 						     
 LogInfo is a functor -- a class that has an operator() so that
-it can look like a function.   It has one  data member - an 
-auto_ptr to a MessageSender, which is named ap.  When you say
+it can look like a function.   It has one  data member - a
+unique_ptr to a MessageSender, which is named ap.  When you say
 
 LogInfo("myCategory") << x; 
 
@@ -56,8 +56,8 @@ When the << x is encountered, that merely sends << x to the MessageSender.
 In the line        LogInfo("myCategory") << x; 
 one has created a **temporary** instance of LogInfo -- this gets 
 destructed upon completion of the statement.  The whole working of LogInfo 
-is in that destruction:  Since LogInfo has an auto_ptr to the Message
-Sender, when LogInfo goes away, the auto_ptr goes away, and this causes
+is in that destruction:  Since LogInfo has a unique_ptr to the Message
+Sender, when LogInfo goes away, the unique_ptr goes away, and this causes
 a delete of the MessageSender.  The destructor of MessageSender is where
 all the action -- at the client side -- happens.  
 

--- a/FWCore/MessageService/doc/flush-and-end.txt
+++ b/FWCore/MessageService/doc/flush-and-end.txt
@@ -28,7 +28,7 @@ Very early in main() of cmsRun, theMessageServicePresence is instantiated.
 The ctor of MessageServicePresence instantiates scribe, which is a 
 boost::thread, instructing it to execute runMessageLoggerScribe.
 
-Just after that, the jobReport is created on the heap and an auto_ptr to 
+Just after that, the jobReport is created on the heap and a unique_ptr to 
 JobReport is given to ServiceRegistry, retaining jobReportToken.
 
 Next, the services are pushed onto defaultServices, with MessageLogger first.
@@ -36,7 +36,7 @@ Then the forcedServises are created; JobReport is the first of those.
 
 Then black magic happens leading to the CFG command to the logger.  It
 happens in the statement 
-std::auto_ptr<edm::EventProcessor> 
+std::unique_ptr<edm::EventProcessor> 
          procP(new 
                edm::EventProcessor(processDesc, jobReportToken, 
                               edm::serviceregistry::kTokenOverrides));

--- a/FWCore/MessageService/doc/suppression.txt
+++ b/FWCore/MessageService/doc/suppression.txt
@@ -159,7 +159,7 @@ and how modification policy is established.
 
 The variable obtained by edm::MessageDrop::instance()->infoEnabled 
 is the relevant suppression boolean.  It is used in the ctor of LogInfo
-to decide whether to initialize an auto_ptr to a MessageSender with
+to decide whether to initialize a unique_ptr to a MessageSender with
 an actual MessageSender, or with 0.  
 
 In MessageLogger/interface/MessageLogger.h:
@@ -174,7 +174,7 @@ public:
 }
 
 The act of destroying the MessageSender, which occurs when in the dtor of
-LogInfo this auto_ptr is destructed, is what triggers preparation of the
+LogInfo this unique_ptr is destructed, is what triggers preparation of the
 ErrorObject and placing that ErrorObject onto the MessageLoggerQueue.  
 That is, if the MessageSender is constructed, then INEVITABLY the message 
 will appear on the queue, and such a message by definition was not suppressed.

--- a/FWCore/ParameterSet/interface/ParameterDescriptionCases.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionCases.h
@@ -18,11 +18,8 @@
 
 // If one decided to save the value then one should be aware
 // the class has been optimized to minimize the number of copies made
-// while evaluating such an expression.  It contains an auto_ptr and
-// the class has copy semantics like an auto_ptr.  If you tried to use
-// this class directly you must be aware that if a copy is
-// made the original contains a null pointer. Then it would
-// be easy to write code that dereferences that null pointer.
+// while evaluating such an expression.  It contains a unique_ptr and
+// the class has move semantics like a unique_ptr.
 
 #include "FWCore/Utilities/interface/value_ptr.h"
 #include "FWCore/ParameterSet/interface/ParameterDescriptionNode.h"

--- a/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
@@ -42,7 +42,7 @@ class __class__ : public edm::ESProducerLooper {
     if  len(__datatypes__) > 1:
         datatypes = []
         for dtype in __datatypes__:
-            datatypes.append("boost::auto_ptr<%s>" % dtype)
+            datatypes.append("std::unique_ptr<%s>" % dtype)
         print "      typedef edm::ESProducts<%s> ReturnType;" % ','.join(datatypes)
     elif len(__datatypes__) == 1:
         print "      typedef std::shared_ptr<%s> ReturnType;" % __datatypes__[0]


### PR DESCRIPTION
Trivial.
A recent PR #13820 replaced nearly all uses of std::auto_ptr in the framework with std::unique_ptr.
However, the documentation files (*.txt), a few comments in the C++ code, and an example script in FWCore/Skeletons were missed in that PR. This PR changes std::auto_ptr to std::unique_ptr in the documentation, comments, and the example script.
Should not affect anything, but since some of the comments are in C++ header files, it will cause a big rebuild.
