### PR TITLE
Fix JEC updater for MET correction in 76X

### DIFF
--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -28,7 +28,7 @@ process.maxEvents = cms.untracked.PSet(
 #configurable options =======================================================================
 runOnData=False #data/MC switch
 usePrivateSQlite=False #use external JECs (sqlite file)
-useHFCandidates=False #create an additionnal NoHF slimmed MET collection if the option is set to false
+useHFCandidates=True #create an additionnal NoHF slimmed MET collection if the option is set to false
 applyResiduals=True #application of residual corrections. Have to be set to True once the 13 TeV residual corrections are available. False to be kept meanwhile. Can be kept to False later for private tests or for analysis checks and developments (not the official recommendation!).
 #===================================================================
 
@@ -85,7 +85,8 @@ if runOnData:
 else:
   #75X file : root://eoscms.cern.ch//store/relval/CMSSW_7_5_0/RelValTTbar_13/MINIAODSIM/75X_mcRun2_asymptotic_v1-v1/00000/92A928E7-842A-E511-87CC-0025905A60E0.root
   #74X file : root://eoscms.cern.ch//store/mc/RunIISpring15DR74/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v2/60000/001C7571-0511-E511-9B8E-549F35AE4FAF.root
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_7_5_3/RelValZEE_13/MINIAODSIM/75X_mcRun2_asymptotic_v5-v1/00000/F8C5D3F4-A861-E511-BA41-002618943906.root'
+#  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_7_5_3/RelValZEE_13/MINIAODSIM/75X_mcRun2_asymptotic_v5-v1/00000/F8C5D3F4-A861-E511-BA41-002618943906.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_7_6_4/RelValZMM_13/MINIAODSIM/76X_mcRun2_asymptotic_v14_reHLTref-v1/00000/28DBC5FA-D7EF-E511-AE1E-0CC47A78A426.root'
   
 # Define the input source
 process.source = cms.Source("PoolSource", 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1192,16 +1192,16 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 
     def updateJECs(self,process,jetCollection, patMetModuleSequence, postfix):
-        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetCorrFactorsUpdated
-        patJetCorrFactorsReapplyJEC = patJetCorrFactorsUpdated.clone(
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
+        patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
             src = jetCollection,
             levels = ['L1FastJet', 
                       'L2Relative', 
                       'L3Absolute'],
             payload = 'AK4PFchs' ) # always CHS from miniAODs
         
-        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetsUpdated
-        patJetsReapplyJEC = patJetsUpdated.clone(
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
+        patJetsReapplyJEC = updatedPatJets.clone(
             jetSource = cms.InputTag("slimmedJets"),
             jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"))
             )


### PR DESCRIPTION
This fix allows the MET tool to run in 76X after the changes of name made in 
https://github.com/cms-sw/cmssw/pull/12890
https://github.com/cms-sw/cmssw/pull/12950

Changes in production chain : none
Packages changed : 
PhysicsTools/PatUtils
PhysicsTools/PatAlgos (for the test config file)

This PR does NOT correct the bugs found in 74X and addressed in 80X with #13115 as the backport of it would require a change of dataformat and production chain. The plan is to backport 80X to 76X in a private branch that users can get with a merge-topic if needed.
