### PR TITLE
fix HF TP transcoder crash.

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -55,8 +55,8 @@ public:
   // Member Variables
   double nominal_gain_;
   double lsb_factor_;
-  int rct_factor_;
-  int nct_factor_;
+  double rct_factor_;
+  double nct_factor_;
   std::string compressionFile_;
   std::string decompressionFile_;
   std::vector<int> ietal;
@@ -64,6 +64,7 @@ public:
   std::vector<int> ZS;
   std::vector<int> LUTfactor;
 
+  unsigned int size; 
   std::vector<std::vector<LUT> > outputLUT_;
   std::vector<RCTdecompression> hcaluncomp_;
 };


### PR DESCRIPTION
Fix LUT transcoder crashing when running on 2010 data. 
Discussed in #13803

With this compression LUTs can be adjusted in either direction (e.g. can be made 2:1 or 1:2).
The change should only affect 2010 data, where RCTlsb was 0.25 GeV. 

Also, throw an exception when the output LUT for a channel is not available (instead of seg fault).
