### PR TITLE
Bug fix for Electron Tracker Isolation used by HEEP  

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h
@@ -45,7 +45,7 @@ class ElectronTkIsolation {
   drb_(drb),
   trackCollection_(trackCollection),
   beamPoint_(beamPoint) {
-
+        setAlgosToReject();
         setDzOption("vz");
 
   }
@@ -70,7 +70,7 @@ class ElectronTkIsolation {
   drb_(drb),
   trackCollection_(trackCollection),
   beamPoint_(beamPoint) {
-
+        setAlgosToReject();
         setDzOption("vz");
 
   }
@@ -106,7 +106,9 @@ class ElectronTkIsolation {
   std::pair<int,double>getIso(const reco::Track*) const ;
 
  private:
-    
+
+  bool passAlgo(const reco::TrackBase& trk)const;
+  void setAlgosToReject();
   double extRadius_ ;
   double intRadiusBarrel_ ;
   double intRadiusEndcap_ ;
@@ -115,6 +117,7 @@ class ElectronTkIsolation {
   double ptLow_ ;
   double lip_ ;
   double drb_;
+  std::vector<int> algosToReject_; //vector is sorted
   const reco::TrackCollection *trackCollection_ ;
   reco::TrackBase::Point beamPoint_;
 

--- a/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
@@ -45,6 +45,7 @@ ElectronTkIsolation::ElectronTkIsolation (double extRadius,
   trackCollection_(trackCollection),
   beamPoint_(beamPoint)
 {
+    setAlgosToReject();
     setDzOption(dzOptionString);
 }
 
@@ -86,19 +87,13 @@ std::pair<int,double> ElectronTkIsolation::getIso(const reco::Track* tmpTrack) c
     if (fabs( (*itrTr).dxy(beamPoint_) ) > drb_   ) continue;
     double dr = ROOT::Math::VectorUtil::DeltaR(itrTr->momentum(),tmpElectronMomentumAtVtx) ;
     double deta = (*itrTr).eta() - tmpElectronEtaAtVertex;
-    if (fabs(tmpElectronEtaAtVertex) < 1.479) { 
-    	if ( fabs(dr) < extRadius_ && fabs(dr) >= intRadiusBarrel_ && fabs(deta) >= stripBarrel_)
-      	{
-	    ++counter ;
-	    ptSum += this_pt;
-      	}
-    }
-    else {
-        if ( fabs(dr) < extRadius_ && fabs(dr) >= intRadiusEndcap_ && fabs(deta) >= stripEndcap_)
-        {
-            ++counter ;
-            ptSum += this_pt;
-        }
+    bool isBarrel = std::abs(tmpElectronEtaAtVertex) < 1.479;
+    double intRadius = isBarrel ? intRadiusBarrel_ : intRadiusEndcap_;
+    double strip = isBarrel ? stripBarrel_ : stripEndcap_;
+    if(dr < extRadius_ && dr>=intRadius && std::abs(deta) >=strip && passAlgo(*itrTr)){
+        
+        ++counter ;
+        ptSum += this_pt;
     }
 
   }//end loop over tracks                 
@@ -122,3 +117,17 @@ double ElectronTkIsolation::getPtTracks (const reco::GsfElectron* electron) cons
   return getIso(electron).second ;
 }
 
+
+bool ElectronTkIsolation::passAlgo(const reco::TrackBase& trk)const
+{
+  int algo = trk.algo();
+  bool rejAlgo=std::binary_search(algosToReject_.begin(),algosToReject_.end(),algo);
+  return rejAlgo==false;
+}
+
+
+void ElectronTkIsolation::setAlgosToReject()
+{
+  algosToReject_={reco::TrackBase::jetCoreRegionalStep};
+  std::sort(algosToReject_.begin(),algosToReject_.end());
+}


### PR DESCRIPTION
Dear All,

In 76X, the HEEP ID efficiency dropped by ~4% above 100 GeV. This was tracked to the selection on tracks with algo ID jetCoreRegionStep changing so tracks from pileup were included.

After some thought and studies, I have removed tracks with algo jetCoreRegionalStep from the electron tracker isolation. I have decided that because these tracks only appear for jets with Et>100 GeV that these tracks are harmful to the HEEP electron ID regardless if they improve sig vs bkg discrimination. Therefore rather than attempting to restore the old quality cuts on these tracks, I have taken the step to remove them all together

Further more, I have concluded that using these tracks are not a good idea any conceivable usage of the tracker isolation variables and so its removed for all instances of electron tracker isolation. 

This fixes the problem reported about the HEEP ID losing 4% efficiency above 100 GeV at higher masses. 

I have briefly run this argument past @matteosan1 and he concurred (but tagging him just to make sure I was clear what I was actually done). 

Cheers,
Sam
