### PR TITLE
Added zdc unpacker to 81x and fixed digi->reco step

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -29,7 +29,7 @@ import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
 muonRPCDigis = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone()
 
 from EventFilter.CastorRawToDigi.CastorRawToDigi_cff import *
-castorDigis = EventFilter.CastorRawToDigi.CastorRawToDigi_cfi.castorDigis.clone( FEDs = cms.untracked.vint32(690,691,692) )
+castorDigis = EventFilter.CastorRawToDigi.CastorRawToDigi_cfi.castorDigis.clone( FEDs = cms.untracked.vint32(690,691,692, 693,722) )
 
 from EventFilter.ScalersRawToDigi.ScalersRawToDigi_cfi import *
 

--- a/EventFilter/CastorRawToDigi/interface/CastorRawCollections.h
+++ b/EventFilter/CastorRawToDigi/interface/CastorRawCollections.h
@@ -21,6 +21,7 @@ public:
    CastorRawCollections();
    ~CastorRawCollections();
     std::vector<CastorDataFrame>* castorCont;
+    std::vector<ZDCDataFrame>* zdcCont;
     std::vector<HcalCalibDataFrame>* calibCont;
     std::vector<CastorTriggerPrimitiveDigi>* tpCont;
 	std::vector<HcalTTPDigi>* ttp;

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -5,16 +5,23 @@ using namespace std;
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Run.h"
-
+#include <fstream>
 #include "CalibFormats/CastorObjects/interface/CastorDbService.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include "EventFilter/CastorRawToDigi/interface/CastorRawCollections.h"
+#include "CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
 
 CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   dataTag_(conf.getParameter<edm::InputTag>("InputLabel")),
   unpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
+  zdcunpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
   ctdcunpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
   filter_(conf.getParameter<bool>("FilterDataQuality"),conf.getParameter<bool>("FilterDataQuality"),false,0,0,-1),
   fedUnpackList_(conf.getUntrackedParameter<std::vector<int> >("FEDs",std::vector<int>())),
@@ -22,6 +29,7 @@ CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   complainEmptyData_(conf.getUntrackedParameter<bool>("ComplainEmptyData",false)),
   usingctdc_(conf.getParameter<bool>("CastorCtdc")),
   unpackTTP_(conf.getParameter<bool>("UnpackTTP")),
+  unpackZDC_(conf.getParameter<bool>("UnpackZDC")),
   silent_(conf.getUntrackedParameter<bool>("silent",true)),
   usenominalOrbitMessageTime_(conf.getParameter<bool>("UseNominalOrbitMessageTime")),
   expectedOrbitMessageTime_(conf.getParameter<int>("ExpectedOrbitMessageTime"))
@@ -40,6 +48,7 @@ CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
     
   // products produced...
   produces<CastorDigiCollection>();
+  produces<ZDCDigiCollection>();
   produces<CastorTrigPrimDigiCollection>();
   produces<HcalUnpackerReport>();
   if (unpackTTP_)
@@ -65,6 +74,7 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   
   // Step B: Create empty output  : three vectors for three classes...
   std::vector<CastorDataFrame> castor;
+  std::vector<ZDCDataFrame> zdc;
   std::vector<HcalTTPDigi> ttp;
   std::vector<CastorTriggerPrimitiveDigi> htp;
 
@@ -72,37 +82,93 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
 
   CastorRawCollections colls;
   colls.castorCont=&castor;
+  colls.zdcCont=&zdc;
   if (unpackTTP_) colls.ttp=&ttp;
   colls.tpCont=&htp;
  
   // Step C: unpack all requested FEDs
+  const FEDRawData& fed722 = rawraw->FEDData(722);
+  const int fed722size = fed722.size();
+  const FEDRawData& fed693 = rawraw->FEDData(693);
+  const int fed693size = fed693.size();
   for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) {
     const FEDRawData& fed = rawraw->FEDData(*i);
-    if (fed.size()==0) {
-      if (complainEmptyData_) {
-	edm::LogWarning("EmptyData") << "No data for FED " << *i;
-	report->addError(*i);
-      }
-    } else if (fed.size()<8*3) {
-      edm::LogWarning("EmptyData") << "Tiny data " << fed.size() << " for FED " << *i;
-      report->addError(*i);
-    } else {
-      try {
-		  if ( usingctdc_ ) { 
-			  ctdcunpacker_.unpack(fed,*readoutMap,colls, *report);
-		  } else {
-			  unpacker_.unpack(fed,*readoutMap,colls, *report);
+    //std::cout<<"Fed number "<<*i<<"is being worked on"<<std::endl;
+    if (*i == 693 && fed693size == 0 && fed722size != 0)
+      continue;
+    if (*i == 722 && fed722size == 0 && fed693size != 0)
+      continue;      
+      
+    if (*i!=693 && *i!=722)
+      {
+	if (fed.size()==0) 
+	  {
+	    if (complainEmptyData_) 
+	      {
+		edm::LogWarning("EmptyData") << "No data for FED " << *i;
+		report->addError(*i);
 	      }
-	      report->addUnpacked(*i);
-      } catch (cms::Exception& e) {
-	edm::LogWarning("Unpacking error") << e.what();
-	report->addError(*i);
-      } catch (...) {
-	edm::LogWarning("Unpacking exception");
-	report->addError(*i);
+	  } 
+	else if (fed.size()<8*3) 
+	  {
+	    edm::LogWarning("EmptyData") << "Tiny data " << fed.size() << " for FED " << *i;
+	    report->addError(*i);
+	  } 
+	else 
+	  {
+	    try 
+	      {
+		if ( usingctdc_ ) 
+		  { 
+		    ctdcunpacker_.unpack(fed,*readoutMap,colls, *report);
+		  } 
+		else 
+		  {
+		    unpacker_.unpack(fed,*readoutMap,colls, *report);
+		  }
+		report->addUnpacked(*i);
+	      } 
+	    catch (cms::Exception& e) 
+	      {
+		edm::LogWarning("Unpacking error") << e.what();
+		report->addError(*i);
+	      } catch (...) 
+	      {
+		edm::LogWarning("Unpacking exception");
+		report->addError(*i);
+	      }
+	  }
       }
-    }
-  }
+
+    if (*i==693 && unpackZDC_)
+      {
+	if (fed.size()==0)
+	  {
+	    edm::LogWarning("EmptyData") << "No data for FED "<< *i;
+	    report->addError(*i);
+	  }
+	if (fed.size()!=0)
+	  {
+	    zdcunpacker_.unpack(fed,*readoutMap,colls,*report);
+	    report->addUnpacked(*i); 
+	  }
+      }
+      
+    if (*i==722 && unpackZDC_)
+      {
+	if (fed.size()==0)
+	  {
+	    edm::LogWarning("EmptyData") << "No data for FED "<< *i;
+	    report->addError(*i);
+	  }
+	if (fed.size()!=0)
+	  {
+	    zdcunpacker_.unpack(fed,*readoutMap,colls,*report);
+	    report->addUnpacked(*i);
+	  }
+      }      
+
+  }//end of loop over feds
 
   // Step B: encapsulate vectors in actual collections
   std::auto_ptr<CastorDigiCollection> castor_prod(new CastorDigiCollection()); 
@@ -116,16 +182,25 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
     CastorDigiCollection filtered_castor=filter_.filter(*castor_prod,*report);
     
     castor_prod->swap(filtered_castor);
-  }
-
-  // Step D: Put outputs into event
-  // just until the sorting is proven
-  castor_prod->sort();
-  htp_prod->sort();
-
-  e.put(castor_prod);
-  e.put(htp_prod);
-
+   }
+   
+   // Step D: Put outputs into event
+   // just until the sorting is proven
+   castor_prod->sort();
+   htp_prod->sort();
+   
+   if(unpackZDC_)
+     {
+       std::auto_ptr<ZDCDigiCollection> zdc_prod(new ZDCDigiCollection());
+       zdc_prod->swap_contents(zdc);
+       
+       zdc_prod->sort();
+       e.put(zdc_prod);
+     }
+   
+   e.put(castor_prod);
+   e.put(htp_prod);
+   
   if (unpackTTP_) {
     std::auto_ptr<HcalTTPDigiCollection> prod(new HcalTTPDigiCollection());
     prod->swap_contents(ttp);

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -25,6 +25,12 @@
 #include "EventFilter/CastorRawToDigi/interface/CastorUnpacker.h"
 #include "EventFilter/CastorRawToDigi/interface/CastorCtdcUnpacker.h"
 #include "EventFilter/CastorRawToDigi/interface/CastorDataFrameFilter.h"
+#include "DataFormats/HcalDigi/interface/ZDCDataFrame.h"
+#include "EventFilter/CastorRawToDigi/interface/ZdcUnpacker.h"
+#include "CondFormats/DataRecord/interface/HcalAllRcds.h"
+#include <map>
+//#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+
 
 class CastorRawToDigi : public edm::stream::EDProducer<>
 {
@@ -37,6 +43,7 @@ public:
 private:
   edm::InputTag dataTag_;
   CastorUnpacker unpacker_;
+  ZdcUnpacker zdcunpacker_;
   CastorCtdcUnpacker ctdcunpacker_;
   CastorDataFrameFilter filter_;
   std::vector<int> fedUnpackList_;
@@ -44,11 +51,13 @@ private:
   bool complainEmptyData_;
   bool usingctdc_;
   bool unpackTTP_;
+  bool unpackZDC_;
   bool silent_;
   bool usenominalOrbitMessageTime_;
   int expectedOrbitMessageTime_;
+  std::auto_ptr<HcalElectronicsMap> myEMap;
   edm::EDGetTokenT<FEDRawDataCollection> tok_input_;
-
+  edm::ParameterSet zdcemap;
 };
 
 #endif

--- a/EventFilter/CastorRawToDigi/python/CastorRawToDigi_cfi.py
+++ b/EventFilter/CastorRawToDigi/python/CastorRawToDigi_cfi.py
@@ -8,9 +8,10 @@ castorDigis = cms.EDProducer("CastorRawToDigi",
     # Number of the first CASTOR FED.  If this is not specified, the
     # default from FEDNumbering is used.
     CastorFirstFED = cms.int32(690),
+    ZDCFirstFED = cms.int32(693),                         
     # FED numbers to unpack.  If this is not specified, all FEDs from
     # FEDNumbering will be unpacked.
-    FEDs = cms.untracked.vint32( 690, 691, 692 ),
+    FEDs = cms.untracked.vint32( 690, 691, 692, 693, 722),
     # Do not complain about missing FEDs
     ExceptionEmptyData = cms.untracked.bool(False),
     # Do not complain about missing FEDs
@@ -28,5 +29,7 @@ castorDigis = cms.EDProducer("CastorRawToDigi",
     InputLabel = cms.InputTag("rawDataCollector"),
     CastorCtdc = cms.bool(False),
     UseNominalOrbitMessageTime = cms.bool(True),
-    ExpectedOrbitMessageTime = cms.int32(-1)
-)
+    ExpectedOrbitMessageTime = cms.int32(-1),
+    UnpackZDC = cms.bool(True),
+
+   )

--- a/EventFilter/CastorRawToDigi/src/CastorRawCollections.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorRawCollections.cc
@@ -2,6 +2,7 @@
 
 CastorRawCollections::CastorRawCollections() {
   castorCont=0;
+  zdcCont=0;
   tpCont=0;
   calibCont=0;
   ttp=0;

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
@@ -32,6 +32,7 @@ RecoLocalCaloRECO = cms.PSet(
                                            'keep HFRecHitsSorted_hfrecoMB_*_*',
                                            #'keep ZDCDataFramesSorted_*Digis_*_*',
                                            'keep ZDCDataFramesSorted_hcalDigis_*_*',
+                                           'keep ZDCDataFramesSorted_castorDigis_*_*',
                                            'keep ZDCRecHitsSorted_*_*_*',
                                            'keep *_reducedHcalRecHits_*_*',
                                            'keep *_castorreco_*_*',

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_zdc_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_zdc_cfi.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 zdcreco = cms.EDProducer(
     "ZdcHitReconstructor",
     correctionPhaseNS = cms.double(0.0),
-    digiLabel = cms.InputTag("hcalDigis"),
+    digiLabelhcal = cms.InputTag("hcalDigis"),
+    digiLabelcastor = cms.InputTag("castorDigis"),
     Subdetector = cms.string('ZDC'),
     correctForPhaseContainment = cms.bool(False),
     correctForTimeslew = cms.bool(False),

--- a/RecoLocalCalo/HcalRecProducers/python/HcalSimpleReconstructor_zdc_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalSimpleReconstructor_zdc_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 zdcreco = cms.EDProducer("ZdcSimpleReconstructor",
     correctionPhaseNS = cms.double(0.0),
-    digiLabel = cms.InputTag("hcalDigis"),
+    digiLabelhcal = cms.InputTag("hcalDigis"),
+    digiLabelcastor = cms.InputTag("castorDigis"),
     Subdetector = cms.string('ZDC'),
     correctForPhaseContainment = cms.bool(False),
     correctForTimeslew = cms.bool(False),

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
@@ -34,7 +34,8 @@ ZdcHitReconstructor::ZdcHitReconstructor(edm::ParameterSet const& conf):
   theTopology(0)
   
 { 
-  tok_input_ = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabel"));
+  tok_input_hcal = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelhcal"));
+  tok_input_castor = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelcastor"));
 
   std::sort(AuxTSvec_.begin(),AuxTSvec_.end()); // sort vector in ascending TS order
   std::string subd=conf.getParameter<std::string>("Subdetector");
@@ -97,8 +98,14 @@ void ZdcHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSet
   
    if (det_==DetId::Calo && subdet_==HcalZDCDetId::SubdetectorId) {
      edm::Handle<ZDCDigiCollection> digi;
-     e.getByToken(tok_input_,digi);
+     e.getByToken(tok_input_castor,digi);
      
+     if(digi->size() == 0) {
+       e.getByToken(tok_input_hcal,digi);
+       if(digi->size() != 0) std::cout<<"No ZDC info in castorDigis, using hcalDigis. This is normal for all Run1 datasets"<<std::endl;
+       else std::cout<<"No ZDC info in either castorDigis or hcalDigis"<<std::endl;
+     }
+        
      // create empty output
      std::auto_ptr<ZDCRecHitCollection> rec(new ZDCRecHitCollection);
      rec->reserve(digi->size());

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.h
@@ -53,7 +53,8 @@ class HcalTopology;
       DetId::Detector det_;
       int subdet_;
       HcalOtherSubdetector subdetOther_;
-      edm::EDGetTokenT<ZDCDigiCollection> tok_input_;
+      edm::EDGetTokenT<ZDCDigiCollection> tok_input_hcal;
+      edm::EDGetTokenT<ZDCDigiCollection> tok_input_castor;
       //std::vector<std::string> channelStatusToDrop_;
       bool correctTiming_; // turn on/off Ken Rossato's algorithm to fix timing
       bool setNoiseFlags_; // turn on/off basic noise flags

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc
@@ -20,7 +20,9 @@ ZdcSimpleReconstructor::ZdcSimpleReconstructor(edm::ParameterSet const& conf):
   det_(DetId::Hcal),
   dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed"))
 {
-  tok_input_ = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabel"));
+  tok_input_castor = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelcastor"));
+  tok_input_castor = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelhcal"));
+
 
   std::string subd=conf.getParameter<std::string>("Subdetector");
   if (!strcasecmp(subd.c_str(),"ZDC")) {
@@ -60,7 +62,13 @@ void ZdcSimpleReconstructor::produce(edm::Event& e, const edm::EventSetup& event
   
   if (det_==DetId::Calo && subdet_==HcalZDCDetId::SubdetectorId) {
     edm::Handle<ZDCDigiCollection> digi;
-    e.getByToken(tok_input_,digi);
+    e.getByToken(tok_input_castor,digi);
+     
+     if(digi->size() == 0) {
+       e.getByToken(tok_input_hcal,digi);
+       if(digi->size() != 0) std::cout<<"No ZDC info in castorDigis, using hcalDigis. This is normal for all Run1 datasets"<<std::endl;
+       else std::cout<<"No ZDC info in either castorDigis or hcalDigis"<<std::endl;
+     }
     
     // create empty output
     std::auto_ptr<ZDCRecHitCollection> rec(new ZDCRecHitCollection);

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
@@ -31,7 +31,8 @@
       DetId::Detector det_;
       int subdet_;
       HcalOtherSubdetector subdetOther_;
-      edm::EDGetTokenT<ZDCDigiCollection> tok_input_;
+      edm::EDGetTokenT<ZDCDigiCollection> tok_input_castor;
+      edm::EDGetTokenT<ZDCDigiCollection> tok_input_hcal;
 
       bool dropZSmarkedPassed_; // turn on/off dropping of zero suppression marked and passed digis
       


### PR DESCRIPTION
Hello,

I've updated the zdc unpacker, which was implemented in 75X for the HI run, but not in subsequent releases. Additionally, I've updated digi->reco functionality so that reco level ZDC objects are generated.

Cheers,
Chris Ferraioli
