### PR TITLE
Fix compilation under EDM_ML_DEBUG

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
@@ -154,7 +154,7 @@ DuplicateRecHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	    detidstr << ttrh->det()->geographicalId().rawId();
 	    m_nduplmod->Fill(detidstr.str().c_str(),1.);
 	    LogDebug("DuplicateHitFinder") << "Track with " << it->recHitsSize() << " RecHits";
-	    LogTrace("DuplicateHitFinder") << "Duplicate found " << ttrh->det()->geographicalId() << " " << pxrh->cluster().index();
+	    LogTrace("DuplicateHitFinder") << "Duplicate found " << ttrh->det()->geographicalId().rawId() << " " << pxrh->cluster().index();
 	  }
 	  clusters.insert(pxrh->cluster().index());
 	}

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonLinksProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonLinksProducer.cc
@@ -80,7 +80,13 @@ CosmicMuonLinksProducer::produce(Event& iEvent, const EventSetup& iSetup)
   unsigned int counter= 0; ///DAMN I cannot read the label of the TOKEN so I need to do this stupid thing to create the labels of the products!
   for(std::vector<std::pair<edm::EDGetTokenT<reco::TrackCollection>,edm::EDGetTokenT<reco::TrackCollection> > >::const_iterator iLink = theTrackLinks.begin();
      iLink != theTrackLinks.end(); iLink++){
-    LogDebug(category_) << "making map between " << (*iLink).first<<" and "<< (*iLink).second;
+#ifdef EDM_ML_DEBUG
+    edm::EDConsumerBase::Labels labels_first;
+    edm::EDConsumerBase::Labels labels_second;
+    labelsForToken(iLink->first, labels_first);
+    labelsForToken(iLink->second, labels_second);
+    LogDebug(category_) << "making map between " << labels_first.module <<" and "<< labels_second.module;
+#endif
     std::string mapname = theTrackLinkNames[counter].first + "To" + theTrackLinkNames[counter].second;
     reco::TrackToTrackMap ttmap;
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.cc
@@ -72,7 +72,7 @@ void TrackListCombiner::produce(edm::StreamID, edm::Event& ev, const edm::EventS
 
 #ifdef EDM_ML_DEBUG
     edm::EDConsumerBase::Labels labels;
-    labelsForToken(trackProducer->trajectory_, labels);
+    labelsForToken(trackProducer->trajectory, labels);
 
     LogTrace("MinBiasTracking")
       << " [TrackListCombiner] " << labels.module


### PR DESCRIPTION
I encountered some compilation failures while compiling large bunch of code with `-DEDM_ML_DEBUG`. Here is a suggestion to fix them.

Tested in CMSSW_8_1_X_2016-03-27-1100, no changes expected.
