### PR TITLE
Fix evaluation of function arguments for FormulaEvaluator

### DIFF
--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -484,7 +484,7 @@ namespace {
     //account for closing parenthesis
     ++info.nextParseIndex;
 
-    info.evaluator = std::make_shared<reco::formula::FunctionOneArgEvaluator>(std::move(argEvaluatorInfo.evaluator),
+    info.evaluator = std::make_shared<reco::formula::FunctionOneArgEvaluator>(std::move(argEvaluatorInfo.top),
                                                                               op);
     info.top = info.evaluator;
     return info;
@@ -552,8 +552,8 @@ namespace {
     //account for closing parenthesis
     ++info.nextParseIndex;
 
-    info.evaluator = std::make_shared<reco::formula::FunctionTwoArgsEvaluator>(std::move(arg1EvaluatorInfo.evaluator),
-                                                                               std::move(arg2EvaluatorInfo.evaluator),
+    info.evaluator = std::make_shared<reco::formula::FunctionTwoArgsEvaluator>(std::move(arg1EvaluatorInfo.top),
+                                                                               std::move(arg2EvaluatorInfo.top),
                                                                                op);
     info.top = info.evaluator;
     return info;

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -729,4 +729,37 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     }
   }
 
+  {
+    //Tests that pick proper evaluator for argument of function
+    reco::FormulaEvaluator f("exp([4]*(log10(x)-[5])*(log10(x)-[5]))");
+    std::vector<double> x = {10.};
+
+    std::vector<double> v = {0.88524, 28.4947, 4.89135, -19.0245, 0.0227809, -6.97308};
+    std::vector<double> xValues = {10.};
+
+    auto func =[&v](double x) {return std::exp(v[4]*(std::log(x)/std::log(10)-v[5])*(std::log(x)/std::log(10)-v[5])); }; 
+
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
+    }
+  }
+
+  {
+    reco::FormulaEvaluator f("max(0.0001,[0]+[1]/(pow(log10(x),2)+[2])+[3]*exp(-1*([4]*((log10(x)-[5])*(log10(x)-[5])))))");
+
+    std::vector<double> x = {10.};
+
+    std::vector<double> v = {0.88524, 28.4947, 4.89135, -19.0245, 0.0227809, -6.97308};
+    std::vector<double> xValues = {10.};
+
+
+    auto func =[&v](double x) {return std::max(0.0001,v[0]+v[1]/(std::pow(std::log(x)/std::log(10), 2)+v[2])+v[3]*std::exp(-1*v[4]*(std::log(x)/std::log(10)-v[5])*(std::log(x)/std::log(10)-v[5]))); };
+
+    for(auto const xv: xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
+    }
+  }
+
 }


### PR DESCRIPTION
The FormulaEvaluator was not using the proper evaluator for the argument
passed to a function if the argument was a complex expression.
Added unit tests for the failing cases.
