### PR TITLE
Updating L1 Menu and HLT JECs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,31 +10,31 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v9',
+    'run2_design'       :   '80X_mcRun2_design_v10',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v9',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v10',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v9',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v10',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v8',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v9',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v8',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v9',
+    'run1_data'         :   '80X_dataRun2_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v9',
+    'run2_data'         :   '80X_dataRun2_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v8',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v8',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v7',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '80X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v10',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v10',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run2 HLT for HI: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,13 +24,13 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '80X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v6',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,31 +10,31 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v10',
+    'run2_design'       :   '80X_mcRun2_design_v11',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v10',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v11',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v10',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v9',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v10',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v8',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v10',
+    'run1_data'         :   '80X_dataRun2_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v10',
+    'run2_data'         :   '80X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v9',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v10',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v9',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v10',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v8',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v11) as [80X_mcRun2_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v11/80X_mcRun2_design_v9): 
  - updated JEC for HLT (v11) 
  - updated L1 menu for Stage-2 (dev v4)
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v10) as [80X_mcRun2cosmics_startup_peak_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v10/80X_mcRun2cosmics_startup_peak_v8): 
  - updated JEC for HLT (v10) 
  - fixed version of correction level string in JEC for HLT payloads
  - latest version of the L1 menu (dev v4)
  - Ecal readout setting for 2016
  - Strip bad components for 2016
  - JEC resolutions and PF corrections as in pp 
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v11) as [80X_mcRun2_asymptotic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v11/80X_mcRun2_asymptotic_v9): 
  - updated JEC for HLT (v11) 
  - updated L1 menu for Stage-2 (dev v4)
- **RunII Startup scenario** : [80X_mcRun2_startup_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v11) as [80X_mcRun2_startup_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v11/80X_mcRun2_startup_v9): 
  - updated L1 menu for Stage-2 (dev v4)
  - adding JEC uncertainties for 50ns for all algorithms
## RunI data
- **RunI Offline processing** : [80X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v11) as [80X_dataRun2_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v11/80X_dataRun2_v9): 
  - updated JEC for HLT (v11) 
  - added e/gamma regressions for HLT (needed for HLT+RECO step)
- **RunI HLT processing** : [80X_dataRun1_HLT_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun1_HLT_frozen_v10) as [80X_dataRun1_HLT_frozen_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun1_HLT_frozen_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun1_HLT_frozen_v10/80X_dataRun1_HLT_frozen_v8): 
  - updated JEC for HLT (v11) 
  - adding 7 payloads for GBRWrapperRcd for tracking MVA
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v11) as [80X_dataRun2_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v10/80X_dataRun2_v9): 
  - updated JEC for HLT (v11) 
  - added e/gamma regressions for HLT (needed for HLT+RECO step)
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v7) as [80X_dataRun2_HLT_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v7/80X_dataRun2_HLT_relval_v4): 
  - updated JEC for HLT (v11) 
  - updated L1 menu for Stage-2 (dev v4)
  - adding 7 payloads for GBRWrapperRcd for tracking MVA
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v11) as [80X_dataRun2_HLT_frozen_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v10/80X_dataRun2_HLT_frozen_v8): 
  - updated JEC for HLT (v11) 
  - Adding 7 payloads for GBRWrapperRcd for tracking MVA
- **RunII Offline relval processing** : [80X_dataRun2_relval_v56(https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v6) as [80X_dataRun2_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v6/80X_dataRun2_relval_v4): 
  - updated JEC for HLT (v11) 
  - updated L1 menu for Stage-2 (dev v4)
  - added e/gamma regressions for HLT (needed for HLT+RECO step)
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v10) as [80X_upgrade2017_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v10/80X_upgrade2017_design_v8): 
  - updated JEC for HLT (v11) 
  - updated L1 menu for Stage-2 (dev v4)
