### PR TITLE
use std::shared_ptr and std::make_shared (EventSetup in Analysis)

### DIFF
--- a/JetMETCorrections/FFTJetModules/interface/FFTJetESParameterParser.h
+++ b/JetMETCorrections/FFTJetModules/interface/FFTJetESParameterParser.h
@@ -14,10 +14,10 @@
 
 // Parser for the adjuster of the adjustable :-)
 template<class Jet, class Adjustable>
-boost::shared_ptr<AbsFFTJetAdjuster<Jet, Adjustable> >
+std::shared_ptr<AbsFFTJetAdjuster<Jet, Adjustable> >
 parseFFTJetAdjuster(const edm::ParameterSet& ps, const bool /* verbose */)
 {
-    typedef boost::shared_ptr<AbsFFTJetAdjuster<Jet,Adjustable> > Result;
+    typedef std::shared_ptr<AbsFFTJetAdjuster<Jet,Adjustable> > Result;
 
     const std::string& adjuster_type = ps.getParameter<std::string>("Class");
 
@@ -39,12 +39,12 @@ parseFFTJetAdjuster(const edm::ParameterSet& ps, const bool /* verbose */)
 
 // Parser for the mapper/scaler
 template<class Jet, class Adjustable>
-boost::shared_ptr<AbsFFTJetScaleCalculator<Jet, Adjustable> >
+std::shared_ptr<AbsFFTJetScaleCalculator<Jet, Adjustable> >
 parseFFTJetScaleCalculator(const edm::ParameterSet& ps,
                            gs::StringArchive& ar,
                            const bool verbose)
 {
-    typedef boost::shared_ptr<AbsFFTJetScaleCalculator<Jet,Adjustable> > Result;
+    typedef std::shared_ptr<AbsFFTJetScaleCalculator<Jet,Adjustable> > Result;
 
     std::string mapper_type(ps.getParameter<std::string>("Class"));
 
@@ -102,18 +102,18 @@ Corrector parseFFTJetCorrector(const edm::ParameterSet& ps,
 
     // "adjuster" is a PSet
     const edm::ParameterSet& adjuster = ps.getParameter<edm::ParameterSet>("adjuster");
-    boost::shared_ptr<const AbsFFTJetAdjuster<MyJet,Adjustable> > adj = 
+    std::shared_ptr<const AbsFFTJetAdjuster<MyJet,Adjustable> > adj = 
         parseFFTJetAdjuster<MyJet,Adjustable>(adjuster, verbose);
 
     // "scalers" is a VPSet
     const std::vector<edm::ParameterSet>& scalers = 
         ps.getParameter<std::vector<edm::ParameterSet> >("scalers");
     const unsigned nScalers = scalers.size();
-    std::vector<boost::shared_ptr<const AbsFFTJetScaleCalculator<MyJet,Adjustable> > > sVec;
+    std::vector<std::shared_ptr<const AbsFFTJetScaleCalculator<MyJet,Adjustable> > > sVec;
     sVec.reserve(nScalers);
     for (unsigned i=0; i<nScalers; ++i)
     {
-        boost::shared_ptr<AbsFFTJetScaleCalculator<MyJet,Adjustable> > s = 
+        std::shared_ptr<AbsFFTJetScaleCalculator<MyJet,Adjustable> > s = 
             parseFFTJetScaleCalculator<MyJet,Adjustable>(scalers[i], ar, verbose);
         sVec.push_back(s);
     }

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectionESProducer.h
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectionESProducer.h
@@ -23,7 +23,7 @@
 // system include files
 #include <sstream>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "Alignment/Geners/interface/CompressedIO.hh"
 
@@ -50,7 +50,7 @@
 // record types.
 //
 template<class CorrectorSequence>
-static boost::shared_ptr<CorrectorSequence>
+static std::shared_ptr<CorrectorSequence>
 buildCorrectorSequence(
     const FFTJetCorrectorParameters& tablePars,
     const std::vector<edm::ParameterSet>& sequence,
@@ -70,7 +70,7 @@ buildCorrectorSequence(
     }
 
     // Create an empty corrector sequence
-    boost::shared_ptr<CorrectorSequence> ptr(new CorrectorSequence());
+    auto ptr = std::make_shared<CorrectorSequence>();
 
     // Go over the parameter sets in the VPSet and
     // configure all correction levels. Add each new
@@ -113,7 +113,7 @@ public:
         FFTJetCorrectorTransientFromJet,
         FFTJetCorrectorResultFromTransient
     > CorrectorSequence;
-    typedef boost::shared_ptr<CorrectorSequence> ReturnType;
+    typedef std::shared_ptr<CorrectorSequence> ReturnType;
     typedef FFTJetCorrectorSequenceRcd<CT> MyRecord;
     typedef FFTJetCorrectorParametersRcd<CT> ParentRecord;
 

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <utility>
 
+#include <memory>
 #include "boost/shared_ptr.hpp"
 
 #include "Alignment/Geners/interface/CompressedIO.hh"
@@ -52,7 +53,7 @@ static void insertLUTItem(FFTJetLookupTableSequence& seq,
     it->second.insert(std::make_pair(name, fptr));
 }
 
-static boost::shared_ptr<FFTJetLookupTableSequence>
+static std::shared_ptr<FFTJetLookupTableSequence>
 buildLookupTables(
     const FFTJetCorrectorParameters& tablePars,
     const std::vector<edm::ParameterSet>& tableDefs,
@@ -68,8 +69,7 @@ buildLookupTables(
             ar = gs::read_item<gs::StringArchive>(is);
     }
 
-    boost::shared_ptr<FFTJetLookupTableSequence> ptr(
-        new FFTJetLookupTableSequence());
+    auto ptr = std::make_shared<FFTJetLookupTableSequence>();
 
     // Avoid loading the same item more than once
     std::set<unsigned long long> loadedSet;
@@ -112,7 +112,7 @@ template<typename CT>
 class FFTJetLookupTableESProducer : public edm::ESProducer
 {
 public:
-    typedef boost::shared_ptr<FFTJetLookupTableSequence> ReturnType;
+    typedef std::shared_ptr<FFTJetLookupTableSequence> ReturnType;
     typedef FFTJetLookupTableRcd<CT> MyRecord;
     typedef FFTJetCorrectorParametersRcd<CT> ParentRecord;
 

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrector.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrector.h
@@ -1,8 +1,8 @@
 #ifndef JetMETCorrections_FFTJetObjects_FFTJetCorrector_h
 #define JetMETCorrections_FFTJetObjects_FFTJetCorrector_h
 
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 #include "JetMETCorrections/FFTJetObjects/interface/AbsFFTJetAdjuster.h"
 #include "JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h"
@@ -17,8 +17,8 @@ public:
     typedef AbsFFTJetScaleCalculator<jet_type, adjustable_type> AbsScaler;
     typedef AbsFFTJetAdjuster<jet_type, adjustable_type> AbsAdjuster;
 
-    inline FFTJetCorrector(boost::shared_ptr<const AbsAdjuster> adjuster,
-                           const std::vector<boost::shared_ptr<const AbsScaler> >& scalers,
+    inline FFTJetCorrector(std::shared_ptr<const AbsAdjuster> adjuster,
+                           const std::vector<std::shared_ptr<const AbsScaler> >& scalers,
                            const unsigned i_level, const FFTJetCorrectorApp a)
         : adjuster_(adjuster), scalers_(scalers),
           level_(i_level), app_(a) {}
@@ -56,8 +56,8 @@ public:
     inline FFTJetCorrectorApp app() const {return app_;}
 
 private:
-    boost::shared_ptr<const AbsAdjuster> adjuster_;
-    std::vector<boost::shared_ptr<const AbsScaler> > scalers_;
+    std::shared_ptr<const AbsAdjuster> adjuster_;
+    std::vector<std::shared_ptr<const AbsScaler> > scalers_;
     unsigned level_;
     FFTJetCorrectorApp app_;
 };

--- a/JetMETCorrections/Modules/interface/JetCorrectionESChain.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESChain.h
@@ -9,8 +9,8 @@
 //
 
 #include <string>
+#include <memory>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 #include "FWCore/Framework/interface/ESProducer.h"
 
@@ -25,10 +25,10 @@ public:
   JetCorrectionESChain(edm::ParameterSet const& fParameters);
   ~JetCorrectionESChain();
 
-  boost::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& );
+  std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& );
 
 private:
   std::vector <std::string> mCorrectors;
-  boost::shared_ptr<JetCorrector> mChainCorrector;
+  std::shared_ptr<JetCorrector> mChainCorrector;
 };
 #endif

--- a/JetMETCorrections/Modules/interface/JetCorrectionESProducer.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESProducer.h
@@ -7,7 +7,7 @@
 //
 
 #include <string>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -42,13 +42,12 @@ public:
 
   ~JetCorrectionESProducer() {}
 
-  boost::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord) 
+  std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord)
   {
     edm::ESHandle<JetCorrectorParametersCollection> JetCorParColl;
     iRecord.get(mAlgo,JetCorParColl); 
     JetCorrectorParameters const& JetCorPar = (*JetCorParColl)[mLevel];
-    boost::shared_ptr<JetCorrector> mCorrector(new Corrector(JetCorPar, mParameterSet));
-    return mCorrector;
+    return std::make_shared<Corrector>(JetCorPar, mParameterSet);
   }
 };
 #endif

--- a/JetMETCorrections/Modules/interface/JetCorrectionESSource.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESSource.h
@@ -6,7 +6,7 @@
 // Created:  Dec. 28, 2006 (originally JetCorrectionService, renamed in 2011)
 //
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 #include <iostream>
 
@@ -60,7 +60,7 @@ public:
 
   ~JetCorrectionESSource() {}
 
-  boost::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord) 
+  std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord) 
   {
     std::string fileName("CondFormats/JetMETObjects/data/");
     if (!mEra.empty())
@@ -74,8 +74,7 @@ public:
       std::cout << "Parameter File: " << fileName << std::endl;
     edm::FileInPath fip(fileName);
     JetCorrectorParameters *tmpJetCorPar = new JetCorrectorParameters(fip.fullPath(), mSection);
-    boost::shared_ptr<JetCorrector> mCorrector(new Corrector(*tmpJetCorPar, mParameterSet));
-    return mCorrector;
+    return std::make_shared<Corrector>(*tmpJetCorPar, mParameterSet);
   }
 
   void setIntervalFor(edm::eventsetup::EventSetupRecordKey const&, edm::IOVSyncValue const&, edm::ValidityInterval& fIOV)

--- a/JetMETCorrections/Modules/interface/JetResolutionESProducer.h
+++ b/JetMETCorrections/Modules/interface/JetResolutionESProducer.h
@@ -6,7 +6,7 @@
 //
 
 #include <string>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -31,7 +31,7 @@ class JetResolutionESProducer : public edm::ESProducer
 
         ~JetResolutionESProducer() {}
 
-        boost::shared_ptr<JME::JetResolution> produce(JetResolutionRcd const& iRecord) {
+        std::shared_ptr<JME::JetResolution> produce(JetResolutionRcd const& iRecord) {
             
             // Get object from record
             edm::ESHandle<JME::JetResolutionObject> jerObjectHandle;
@@ -39,7 +39,7 @@ class JetResolutionESProducer : public edm::ESProducer
 
             // Convert this object to a JetResolution object
             JME::JetResolutionObject const& jerObject = (*jerObjectHandle);
-            return boost::shared_ptr<JME::JetResolution>(new JME::JetResolution(jerObject));
+            return std::make_shared<JME::JetResolution>(jerObject);
         }
 };
 
@@ -57,7 +57,7 @@ class JetResolutionScaleFactorESProducer : public edm::ESProducer
 
         ~JetResolutionScaleFactorESProducer() {}
 
-        boost::shared_ptr<JME::JetResolutionScaleFactor> produce(JetResolutionScaleFactorRcd const& iRecord) {
+        std::shared_ptr<JME::JetResolutionScaleFactor> produce(JetResolutionScaleFactorRcd const& iRecord) {
             
             // Get object from record
             edm::ESHandle<JME::JetResolutionObject> jerObjectHandle;
@@ -65,7 +65,7 @@ class JetResolutionScaleFactorESProducer : public edm::ESProducer
 
             // Convert this object to a JetResolution object
             JME::JetResolutionObject const& jerObject = (*jerObjectHandle);
-            return boost::shared_ptr<JME::JetResolutionScaleFactor>(new JME::JetResolutionScaleFactor(jerObject));
+            return std::make_shared<JME::JetResolutionScaleFactor>(jerObject);
         }
 };
 #endif

--- a/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
+++ b/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -22,7 +21,7 @@ class QGLikelihoodESProducer : public edm::ESProducer{
       QGLikelihoodESProducer(const edm::ParameterSet&);
       ~QGLikelihoodESProducer(){};
 
-      boost::shared_ptr<QGLikelihoodObject> produce(const QGLikelihoodRcd&);
+      std::shared_ptr<QGLikelihoodObject> produce(const QGLikelihoodRcd&);
       void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);
 
    private:

--- a/JetMETCorrections/Modules/interface/QGLikelihoodSystematicsESProducer.h
+++ b/JetMETCorrections/Modules/interface/QGLikelihoodSystematicsESProducer.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -22,7 +21,7 @@ class QGLikelihoodSystematicsESProducer : public edm::ESProducer{
       QGLikelihoodSystematicsESProducer(const edm::ParameterSet&);
       ~QGLikelihoodSystematicsESProducer(){};
 
-      boost::shared_ptr<QGLikelihoodSystematicsObject> produce(const QGLikelihoodSystematicsRcd&);
+      std::shared_ptr<QGLikelihoodSystematicsObject> produce(const QGLikelihoodSystematicsRcd&);
       void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);
    private:
       std::string mAlgo;

--- a/JetMETCorrections/Modules/src/JetCorrectionESChain.cc
+++ b/JetMETCorrections/Modules/src/JetCorrectionESChain.cc
@@ -27,7 +27,7 @@ JetCorrectionESChain::JetCorrectionESChain(edm::ParameterSet const& fParameters)
 
 JetCorrectionESChain::~JetCorrectionESChain() {}
 
-boost::shared_ptr<JetCorrector> JetCorrectionESChain::produce(JetCorrectionsRecord const& fRecord) {
+std::shared_ptr<JetCorrector> JetCorrectionESChain::produce(JetCorrectionsRecord const& fRecord) {
   ChainedJetCorrector* corrector = dynamic_cast<ChainedJetCorrector*>(&*mChainCorrector);
   corrector->clear ();
   for (size_t i = 0; i < mCorrectors.size(); ++i) {

--- a/JetMETCorrections/Modules/src/JetResolution.cc
+++ b/JetMETCorrections/Modules/src/JetResolution.cc
@@ -12,11 +12,11 @@
 namespace JME {
 
     JetResolution::JetResolution(const std::string& filename) {
-        m_object = std::shared_ptr<JetResolutionObject>(new JetResolutionObject(filename));
+        m_object = std::make_shared<JetResolutionObject>(filename);
     }
 
     JetResolution::JetResolution(const JetResolutionObject& object) {
-        m_object = std::shared_ptr<JetResolutionObject>(new JetResolutionObject(object));
+        m_object = std::make_shared<JetResolutionObject>(object);
     }
 
 #ifndef STANDALONE
@@ -37,11 +37,11 @@ namespace JME {
     }
 
     JetResolutionScaleFactor::JetResolutionScaleFactor(const std::string& filename) {
-        m_object = std::shared_ptr<JetResolutionObject>(new JetResolutionObject(filename));
+        m_object = std::make_shared<JetResolutionObject>(filename);
     }
 
     JetResolutionScaleFactor::JetResolutionScaleFactor(const JetResolutionObject& object) {
-        m_object = std::shared_ptr<JetResolutionObject>(new JetResolutionObject(object));
+        m_object = std::make_shared<JetResolutionObject>(object);
     }
 
 #ifndef STANDALONE

--- a/JetMETCorrections/Modules/src/QGLikelihoodESProducer.cc
+++ b/JetMETCorrections/Modules/src/QGLikelihoodESProducer.cc
@@ -25,10 +25,9 @@ void QGLikelihoodESProducer::setIntervalFor(const edm::eventsetup::EventSetupRec
 }
 
 // Produce the data
-boost::shared_ptr<QGLikelihoodObject> QGLikelihoodESProducer::produce(const QGLikelihoodRcd& iRecord){
+std::shared_ptr<QGLikelihoodObject> QGLikelihoodESProducer::produce(const QGLikelihoodRcd& iRecord){
    edm::ESHandle<QGLikelihoodObject> qglObj;
    iRecord.get(mAlgo, qglObj);
 
-   boost::shared_ptr<QGLikelihoodObject> pMyType(new QGLikelihoodObject(*qglObj));
-   return pMyType;
+   return std::make_shared<QGLikelihoodObject>(*qglObj);
 }

--- a/JetMETCorrections/Modules/src/QGLikelihoodSystematicsESProducer.cc
+++ b/JetMETCorrections/Modules/src/QGLikelihoodSystematicsESProducer.cc
@@ -27,10 +27,9 @@ void QGLikelihoodSystematicsESProducer::setIntervalFor(const edm::eventsetup::Ev
 }
 
 // Produce the data
-boost::shared_ptr<QGLikelihoodSystematicsObject> QGLikelihoodSystematicsESProducer::produce(const QGLikelihoodSystematicsRcd& iRecord){
+std::shared_ptr<QGLikelihoodSystematicsObject> QGLikelihoodSystematicsESProducer::produce(const QGLikelihoodSystematicsRcd& iRecord){
    edm::ESHandle<QGLikelihoodSystematicsObject> qglObj;
    iRecord.get(mAlgo, qglObj);
 
-   boost::shared_ptr<QGLikelihoodSystematicsObject> pMyType(new QGLikelihoodSystematicsObject(*qglObj));
-   return pMyType;
+   return std::make_shared<QGLikelihoodSystematicsObject>(*qglObj);
 }

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -267,7 +267,7 @@ FWLiteESRecordWriterAnalyzer::update(const edm::EventSetup& iSetup)
             }
             dataInfos.push_back(DataInfo(tt,itData->second));
          }
-         m_handlers.push_back( std::shared_ptr<RecordHandler>( new RecordHandler(rKey,m_file,dataInfos) ) );
+         m_handlers.push_back( std::make_shared<RecordHandler>(rKey,m_file,dataInfos) );
       }
    }
    

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
@@ -205,7 +205,7 @@ FWLiteESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRec
       if(tt != HCTypeTag() ) {
          edm::eventsetup::DataKey dk(tt,edm::eventsetup::IdTags(it->second.c_str()));
          aProxyList.push_back(std::make_pair(dk,
-                                             std::shared_ptr<edm::eventsetup::DataProxy>(new FWLiteProxy(TypeID(tt.value()),&rec))));
+                                             std::make_shared<FWLiteProxy>(TypeID(tt.value()),&rec)));
       } else {
          LogDebug("UnknownESType")<<"The type '"<<it->first<<"' is unknown in this job";
          std::cout <<"    *****FAILED*****"<<std::endl;

--- a/PhysicsTools/MVAComputer/interface/MVAComputerESSourceBase.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputerESSourceBase.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <map>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,7 +16,7 @@ namespace PhysicsTools {
 
 class MVAComputerESSourceBase : public edm::ESProducer {
     public:
-	typedef boost::shared_ptr<Calibration::MVAComputerContainer> ReturnType;
+	typedef std::shared_ptr<Calibration::MVAComputerContainer> ReturnType;
 
 	MVAComputerESSourceBase(const edm::ParameterSet &params);
 	virtual ~MVAComputerESSourceBase();

--- a/PhysicsTools/MVAComputer/src/MVAComputerESSourceBase.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputerESSourceBase.cc
@@ -4,8 +4,6 @@
 #include <vector>
 #include <map>
 
-#include <boost/shared_ptr.hpp>
-
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for Analysis packages.
Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation.
This PR is totally technical.
