### PR TITLE
use std::shared_ptr and std::make_shared (EventSetup in Calibration)

### DIFF
--- a/CalibCalorimetry/CastorCalib/BuildFile.xml
+++ b/CalibCalorimetry/CastorCalib/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="root"/>
 <use   name="clhep"/>
 <use   name="FWCore/Framework"/>

--- a/CalibCalorimetry/CastorCalib/plugins/BuildFile.xml
+++ b/CalibCalorimetry/CastorCalib/plugins/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
 <use   name="Geometry/CaloTopology"/>
-<use   name="boost"/>
 <library   file="*.cc" name="CalibCalorimetryCastorPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.cc
@@ -75,7 +75,7 @@ CastorDbProducer::~CastorDbProducer()
 //
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<CastorDbService> CastorDbProducer::produce( const CastorDbRecord&)
+std::shared_ptr<CastorDbService> CastorDbProducer::produce( const CastorDbRecord&)
 {
   return mService;
 }

--- a/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.h
@@ -1,6 +1,5 @@
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -22,7 +21,7 @@ class CastorDbProducer : public edm::ESProducer {
   CastorDbProducer( const edm::ParameterSet& );
   ~CastorDbProducer();
   
-  boost::shared_ptr<CastorDbService> produce( const CastorDbRecord& );
+  std::shared_ptr<CastorDbService> produce( const CastorDbRecord& );
 
   // callbacks
   void pedestalsCallback (const CastorPedestalsRcd& fRecord);
@@ -35,7 +34,7 @@ class CastorDbProducer : public edm::ESProducer {
 
    private:
       // ----------member data ---------------------------
-  boost::shared_ptr<CastorDbService> mService;
+  std::shared_ptr<CastorDbService> mService;
   std::vector<std::string> mDumpRequest;
   std::ostream* mDumpStream;
 };

--- a/CalibCalorimetry/EcalCorrectionModules/src/EcalGlobalShowerContainmentCorrectionsVsEtaESProducer.cc
+++ b/CalibCalorimetry/EcalCorrectionModules/src/EcalGlobalShowerContainmentCorrectionsVsEtaESProducer.cc
@@ -14,7 +14,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/CalibCalorimetry/EcalCorrectionModules/src/EcalShowerContainmentCorrectionsESProducer.cc
+++ b/CalibCalorimetry/EcalCorrectionModules/src/EcalShowerContainmentCorrectionsESProducer.cc
@@ -15,7 +15,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.cc
@@ -56,7 +56,7 @@ EcalLaserCorrectionService::~EcalLaserCorrectionService()
 //
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<EcalLaserDbService> EcalLaserCorrectionService::produce( const EcalLaserDbRecord& )
+std::shared_ptr<EcalLaserDbService> EcalLaserCorrectionService::produce( const EcalLaserDbRecord& )
 {
   return mService_;
 }

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.h
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -24,7 +23,7 @@ public:
   EcalLaserCorrectionService( const edm::ParameterSet& );
   ~EcalLaserCorrectionService();
   
-  boost::shared_ptr<EcalLaserDbService> produce( const EcalLaserDbRecord& );
+  std::shared_ptr<EcalLaserDbService> produce( const EcalLaserDbRecord& );
   
   // callbacks
   void alphaCallback (const EcalLaserAlphasRcd& fRecord);
@@ -34,7 +33,7 @@ public:
   
 private:
   // ----------member data ---------------------------
-  boost::shared_ptr<EcalLaserDbService> mService_;
+  std::shared_ptr<EcalLaserDbService> mService_;
   //  std::vector<std::string> mDumpRequest;
   //  std::ostream* mDumpStream;
 };

--- a/CalibCalorimetry/HcalPlugins/BuildFile.xml
+++ b/CalibCalorimetry/HcalPlugins/BuildFile.xml
@@ -11,5 +11,4 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
 <use   name="Geometry/CaloTopology"/>
-<use   name="boost"/>
 <flags   EDM_PLUGIN="1"/>

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -89,7 +89,7 @@ HcalDbProducer::~HcalDbProducer()
 //
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<HcalDbService> HcalDbProducer::produce( const HcalDbRecord&)
+std::shared_ptr<HcalDbService> HcalDbProducer::produce( const HcalDbRecord&)
 {
   return mService;
 }
@@ -113,12 +113,12 @@ void HcalDbProducer::pedestalsCallback (const HcalPedestalsRcd& fRecord) {
   }
 }
 
-boost::shared_ptr<HcalChannelQuality> HcalDbProducer::produceChannelQualityWithTopo(const HcalChannelQualityRcd& fRecord)
+std::shared_ptr<HcalChannelQuality> HcalDbProducer::produceChannelQualityWithTopo(const HcalChannelQualityRcd& fRecord)
 {
   edm::ESHandle <HcalChannelQuality> item;
   fRecord.get (item);
 
-  boost::shared_ptr<HcalChannelQuality> channelQuality( new HcalChannelQuality(*item) );
+  auto channelQuality = std::make_shared<HcalChannelQuality>(*item);
 
   edm::ESHandle<HcalTopology> htopo;
   fRecord.getRecord<HcalRecNumberingRecord>().get(htopo);

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -37,9 +36,9 @@ class HcalDbProducer : public edm::ESProducer {
   HcalDbProducer( const edm::ParameterSet& );
   ~HcalDbProducer();
   
-  boost::shared_ptr<HcalDbService> produce( const HcalDbRecord& );
+  std::shared_ptr<HcalDbService> produce( const HcalDbRecord& );
 
-  boost::shared_ptr<HcalChannelQuality> produceChannelQualityWithTopo( const HcalChannelQualityRcd&);
+  std::shared_ptr<HcalChannelQuality> produceChannelQualityWithTopo( const HcalChannelQualityRcd&);
 
   // callbacks
   void pedestalsCallback (const HcalPedestalsRcd& fRecord);
@@ -60,7 +59,7 @@ class HcalDbProducer : public edm::ESProducer {
 
    private:
       // ----------member data ---------------------------
-  boost::shared_ptr<HcalDbService> mService;
+  std::shared_ptr<HcalDbService> mService;
   std::vector<std::string> mDumpRequest;
   std::ostream* mDumpStream;
 

--- a/CalibCalorimetry/HcalPlugins/test/BuildFile.xml
+++ b/CalibCalorimetry/HcalPlugins/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use   name="boost"/>
   <use   name="CalibFormats/HcalObjects"/>
   <library   file="HcalDbAnalyzer.cc" name="HcalDbAnalyzer">
     <flags   EDM_PLUGIN="1"/>

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -20,7 +20,6 @@
 // system include files
 #include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 
@@ -43,7 +42,7 @@ public:
   HcalTPGCoderULUT(const edm::ParameterSet&);
   ~HcalTPGCoderULUT();
      
-  typedef boost::shared_ptr<HcalTPGCoder> ReturnType;
+  typedef std::shared_ptr<HcalTPGCoder> ReturnType;
   void dbRecordCallback(const HcalDbRecord&);
 
   ReturnType produce(const HcalTPGRecord&);

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
@@ -2,7 +2,6 @@
 #define CSCChannelMapperESProducer_H
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include "FWCore/Framework/interface/ESProducer.h"
 
@@ -12,7 +11,7 @@
 class CSCChannelMapperESProducer : public edm::ESProducer {
 
  public:
-  typedef boost::shared_ptr<CSCChannelMapperBase> BSP_TYPE;
+  typedef std::shared_ptr<CSCChannelMapperBase> BSP_TYPE;
 
   CSCChannelMapperESProducer(const edm::ParameterSet&);
   ~CSCChannelMapperESProducer();

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h
@@ -16,7 +16,6 @@
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"
 #include "CondFormats/DataRecord/interface/CSCDBCrosstalkRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <boost/shared_ptr.hpp>
 
 class CSCFakeDBCrosstalk: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
@@ -25,7 +24,7 @@ class CSCFakeDBCrosstalk: public edm::ESProducer, public edm::EventSetupRecordIn
 
       inline static CSCDBCrosstalk * prefillDBCrosstalk(); 
 
-      typedef  boost::shared_ptr<CSCDBCrosstalk> Pointer;
+      typedef  std::shared_ptr<CSCDBCrosstalk> Pointer;
 
       Pointer produceDBCrosstalk(const CSCDBCrosstalkRcd&);
 

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBGains.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBGains.h
@@ -17,8 +17,6 @@
 #include "CondFormats/DataRecord/interface/CSCDBGainsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-#include <boost/shared_ptr.hpp>
-
 class CSCFakeDBGains: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeDBGains(const edm::ParameterSet&);
@@ -26,7 +24,7 @@ class CSCFakeDBGains: public edm::ESProducer, public edm::EventSetupRecordInterv
 
       inline static CSCDBGains* prefillDBGains(); 
 
-      typedef boost::shared_ptr<CSCDBGains> Pointer;
+      typedef std::shared_ptr<CSCDBGains> Pointer;
       Pointer produceDBGains(const CSCDBGainsRcd&);
 
    private:

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h
@@ -16,7 +16,6 @@
 #include "CondFormats/CSCObjects/interface/CSCDBNoiseMatrix.h"
 #include "CondFormats/DataRecord/interface/CSCDBNoiseMatrixRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <boost/shared_ptr.hpp>
 
 class CSCFakeDBNoiseMatrix: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
@@ -25,7 +24,7 @@ class CSCFakeDBNoiseMatrix: public edm::ESProducer, public edm::EventSetupRecord
 
       inline static CSCDBNoiseMatrix * prefillDBNoiseMatrix(); 
 
-      typedef boost::shared_ptr<CSCDBNoiseMatrix> Pointer;
+      typedef std::shared_ptr<CSCDBNoiseMatrix> Pointer;
 
       Pointer produceDBNoiseMatrix(const CSCDBNoiseMatrixRcd&);
 

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h
@@ -16,7 +16,6 @@
 #include "CondFormats/CSCObjects/interface/CSCDBPedestals.h"
 #include "CondFormats/DataRecord/interface/CSCDBPedestalsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <boost/shared_ptr.hpp>
 
 class CSCFakeDBPedestals: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
@@ -25,7 +24,7 @@ class CSCFakeDBPedestals: public edm::ESProducer, public edm::EventSetupRecordIn
       
        inline static CSCDBPedestals * prefillDBPedestals();
 
-      typedef  boost::shared_ptr<CSCDBPedestals> Pointer;
+      typedef  std::shared_ptr<CSCDBPedestals> Pointer;
 
       Pointer produceDBPedestals(const CSCDBPedestalsRcd&);
 

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
@@ -2,7 +2,6 @@
 #define CSCIndexerESProducer_H
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include "FWCore/Framework/interface/ESProducer.h"
 
@@ -12,7 +11,7 @@
 class CSCIndexerESProducer : public edm::ESProducer {
 
  public:
-  typedef boost::shared_ptr<CSCIndexerBase> BSP_TYPE;
+  typedef std::shared_ptr<CSCIndexerBase> BSP_TYPE;
 
   CSCIndexerESProducer(const edm::ParameterSet&);
   ~CSCIndexerESProducer();

--- a/CalibMuon/CSCCalibration/plugins/CSCBadChambersConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCBadChambersConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCBadStripsConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCBadStripsConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCBadStrips.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCBadWiresConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCBadWiresConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCBadWires.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCChipSpeedCorrectionDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCChipSpeedCorrectionDBConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDBChipSpeedCorrection.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCCrosstalkDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCCrosstalkDBConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBCrosstalk.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBCrosstalk.cc
@@ -7,7 +7,7 @@ CSCFakeDBCrosstalk::CSCFakeDBCrosstalk(const edm::ParameterSet& iConfig)
 {
   //the following line is needed to tell the framework what
   // data is being produced
-  cndbCrosstalk = boost::shared_ptr<CSCDBCrosstalk> ( prefillDBCrosstalk() );
+  cndbCrosstalk = std::shared_ptr<CSCDBCrosstalk> ( prefillDBCrosstalk() );
   setWhatProduced(this,&CSCFakeDBCrosstalk::produceDBCrosstalk);
   findingRecord<CSCDBCrosstalkRcd>();
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBGains.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBGains.cc
@@ -5,7 +5,7 @@
 
 CSCFakeDBGains::CSCFakeDBGains(const edm::ParameterSet& iConfig)
 {
-  cndbGains = boost::shared_ptr<CSCDBGains>( prefillDBGains() );
+  cndbGains = std::shared_ptr<CSCDBGains>( prefillDBGains() );
 
   // the following line is needed to tell the framework what
   // data is being produced

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBNoiseMatrix.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBNoiseMatrix.cc
@@ -5,7 +5,7 @@
 
 CSCFakeDBNoiseMatrix::CSCFakeDBNoiseMatrix(const edm::ParameterSet& iConfig)
 {
-  cndbNoiseMatrix = boost::shared_ptr<CSCDBNoiseMatrix> ( prefillDBNoiseMatrix() );  
+  cndbNoiseMatrix = std::shared_ptr<CSCDBNoiseMatrix> ( prefillDBNoiseMatrix() );  
   //tell the framework what data is being produced
   setWhatProduced(this,&CSCFakeDBNoiseMatrix::produceDBNoiseMatrix);  
   findingRecord<CSCDBNoiseMatrixRcd>();

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBPedestals.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBPedestals.cc
@@ -5,7 +5,7 @@
 
 CSCFakeDBPedestals::CSCFakeDBPedestals(const edm::ParameterSet& iConfig)
 {
-  cndbPedestals = boost::shared_ptr<CSCDBPedestals> ( prefillDBPedestals() );
+  cndbPedestals = std::shared_ptr<CSCDBPedestals> ( prefillDBPedestals() );
 
   //the following line is needed to tell the framework what
   // data is being produced

--- a/CalibMuon/CSCCalibration/plugins/CSCGainsDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCGainsDBConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDBGains.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCGasGainCorrectionDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCGasGainCorrectionDBConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDBGasGainCorrection.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCL1TPParameters.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCL1TPParameters.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCL1TPParameters.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixDBConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDBNoiseMatrix.h"

--- a/CalibMuon/CSCCalibration/plugins/CSCPedestalsDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCPedestalsDBConditions.cc
@@ -1,5 +1,4 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDBPedestals.h"

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -6,7 +6,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h"

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -9,7 +9,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/SourceFactory.h"

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.cc
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.cc
@@ -16,12 +16,10 @@ PixelToFEDAssociateFromAsciiESProducer::
     ~PixelToFEDAssociateFromAsciiESProducer()
 { }
 
-boost::shared_ptr<PixelToFEDAssociate> PixelToFEDAssociateFromAsciiESProducer::
+std::shared_ptr<PixelToFEDAssociate> PixelToFEDAssociateFromAsciiESProducer::
     produce(const TrackerDigiGeometryRecord & r)
 {
-  theAssociator = boost::shared_ptr<PixelToFEDAssociate>(
-     new PixelToFEDAssociateFromAscii(
-             theConfig.getParameter<std::string>("fileName")));
+  theAssociator = std::make_shared<PixelToFEDAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
   return theAssociator;
 }
 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
@@ -3,7 +3,7 @@
 
 #include  "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h"
@@ -12,9 +12,9 @@ class PixelToFEDAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
   PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet & p);
   virtual ~PixelToFEDAssociateFromAsciiESProducer();
-  boost::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
+  std::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
 private:
-  boost::shared_ptr<PixelToFEDAssociate> theAssociator;
+  std::shared_ptr<PixelToFEDAssociate> theAssociator;
   edm::ParameterSet theConfig;
 };
 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.cc
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.cc
@@ -16,12 +16,10 @@ PixelToLNKAssociateFromAsciiESProducer::
     ~PixelToLNKAssociateFromAsciiESProducer()
 { }
 
-boost::shared_ptr<PixelToFEDAssociate> PixelToLNKAssociateFromAsciiESProducer::
+std::shared_ptr<PixelToFEDAssociate> PixelToLNKAssociateFromAsciiESProducer::
     produce(const TrackerDigiGeometryRecord & r)
 {
-  theAssociator = boost::shared_ptr<PixelToFEDAssociate>(
-     new PixelToLNKAssociateFromAscii(
-             theConfig.getParameter<std::string>("fileName")));
+  theAssociator = std::make_shared<PixelToLNKAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
   return theAssociator;
 }
 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
@@ -3,7 +3,7 @@
 
 #include  "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelConnectivity/interface/PixelToLNKAssociateFromAscii.h"
@@ -12,9 +12,9 @@ class PixelToLNKAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
   PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet & p);
   virtual ~PixelToLNKAssociateFromAsciiESProducer();
-  boost::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
+  std::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
 private:
-  boost::shared_ptr<PixelToFEDAssociate> theAssociator;
+  std::shared_ptr<PixelToFEDAssociate> theAssociator;
   edm::ParameterSet theConfig;
 };
 

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
@@ -2,7 +2,6 @@
 #define CalibTracker_SiPixelESProducers_SiPixelFakeCPEGenericErrorParmESSource_h
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
@@ -2,7 +2,6 @@
 #define CalibTracker_SiPixelESProducers_SiPixelFakeGenErrorDBObjectESSource_h
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
@@ -2,7 +2,6 @@
 #define CalibTracker_SiPixelESProducers_SiPixelFakeTemplateDBObjectESSource_h
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGenErrorDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGenErrorDBObjectESProducer.h
@@ -28,6 +28,6 @@ public:
 
 	SiPixelGenErrorDBObjectESProducer(const edm::ParameterSet& iConfig);
   ~SiPixelGenErrorDBObjectESProducer();
-	boost::shared_ptr<SiPixelGenErrorDBObject> produce(const SiPixelGenErrorDBObjectESProducerRcd &);
+	std::shared_ptr<SiPixelGenErrorDBObject> produce(const SiPixelGenErrorDBObjectESProducerRcd &);
  };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
@@ -28,6 +28,6 @@ public:
 
 	SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
   ~SiPixelTemplateDBObjectESProducer();
-	boost::shared_ptr<SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd &);
+	std::shared_ptr<SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd &);
  };
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelGenErrorDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelGenErrorDBObjectESProducer.cc
@@ -12,7 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/do_nothing_deleter.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "boost/mpl/vector.hpp"
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -31,7 +31,7 @@ SiPixelGenErrorDBObjectESProducer::~SiPixelGenErrorDBObjectESProducer(){
 
 
 
-boost::shared_ptr<SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::produce(const SiPixelGenErrorDBObjectESProducerRcd & iRecord) {
+std::shared_ptr<SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::produce(const SiPixelGenErrorDBObjectESProducerRcd & iRecord) {
 	
 	ESHandle<MagneticField> magfield;
 	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
@@ -56,7 +56,7 @@ boost::shared_ptr<SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::pr
 	if(std::fabs(theMagField-dbobject->sVector()[22])>0.1)
 		edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixelGenError") << "Magnetic field is " << theMagField << " GenError Magnetic field is " << dbobject->sVector()[22];
 	
-	return boost::shared_ptr<SiPixelGenErrorDBObject>(const_cast<SiPixelGenErrorDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
+	return std::shared_ptr<SiPixelGenErrorDBObject>(const_cast<SiPixelGenErrorDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixelGenErrorDBObjectESProducer);

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
@@ -12,7 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/do_nothing_deleter.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "boost/mpl/vector.hpp"
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -31,7 +31,7 @@ SiPixelTemplateDBObjectESProducer::~SiPixelTemplateDBObjectESProducer(){
 
 
 
-boost::shared_ptr<SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::produce(const SiPixelTemplateDBObjectESProducerRcd & iRecord) {
+std::shared_ptr<SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::produce(const SiPixelTemplateDBObjectESProducerRcd & iRecord) {
 	
 	ESHandle<MagneticField> magfield;
 	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
@@ -56,7 +56,7 @@ boost::shared_ptr<SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::pr
 	if(std::fabs(theMagField-dbobject->sVector()[22])>0.1)
 		edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixelTemplate") << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject->sVector()[22];
 	
-	return boost::shared_ptr<SiPixelTemplateDBObject>(const_cast<SiPixelTemplateDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
+	return std::shared_ptr<SiPixelTemplateDBObject>(const_cast<SiPixelTemplateDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixelTemplateDBObjectESProducer);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateDepFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateDepFakeESSource.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateFakeESSource.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
@@ -32,7 +32,7 @@ SiStripBackPlaneCorrectionDepESProducer::SiStripBackPlaneCorrectionDepESProducer
 }
 
 
-boost::shared_ptr<SiStripBackPlaneCorrection> SiStripBackPlaneCorrectionDepESProducer::produce(const SiStripBackPlaneCorrectionDepRcd& iRecord)
+std::shared_ptr<SiStripBackPlaneCorrection> SiStripBackPlaneCorrectionDepESProducer::produce(const SiStripBackPlaneCorrectionDepRcd& iRecord)
 {
 
   edm::LogInfo("SiStripBackPlaneCorrectionDepESProducer") << "Producer called" << std::endl;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -24,7 +23,7 @@ class SiStripBackPlaneCorrectionDepESProducer : public edm::ESProducer {
   SiStripBackPlaneCorrectionDepESProducer(const edm::ParameterSet&);
   ~SiStripBackPlaneCorrectionDepESProducer(){};
   
-  boost::shared_ptr<SiStripBackPlaneCorrection> produce(const SiStripBackPlaneCorrectionDepRcd&);
+  std::shared_ptr<SiStripBackPlaneCorrection> produce(const SiStripBackPlaneCorrectionDepRcd&);
    
  private:
 
@@ -37,7 +36,7 @@ class SiStripBackPlaneCorrectionDepESProducer : public edm::ESProducer {
   edm::ParameterSet getPeak;
   edm::ParameterSet getDeconv;
 
-  boost::shared_ptr<SiStripBackPlaneCorrection> siStripBPC_;
+  std::shared_ptr<SiStripBackPlaneCorrection> siStripBPC_;
 
 };
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
@@ -34,7 +34,7 @@ SiStripDelayESProducer::SiStripDelayESProducer(const edm::ParameterSet& iConfig)
 }
 
 
-boost::shared_ptr<SiStripDelay> SiStripDelayESProducer::produce(const SiStripDelayRcd& iRecord)
+std::shared_ptr<SiStripDelay> SiStripDelayESProducer::produce(const SiStripDelayRcd& iRecord)
 {
   edm::LogInfo("SiStripDelayESProducer") << "produce called" << std::endl;
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -23,7 +22,7 @@ class SiStripDelayESProducer : public edm::ESProducer {
   SiStripDelayESProducer(const edm::ParameterSet&);
   ~SiStripDelayESProducer(){};
   
-  boost::shared_ptr<SiStripDelay> produce(const SiStripDelayRcd&);
+  std::shared_ptr<SiStripDelay> produce(const SiStripDelayRcd&);
    
  private:
 
@@ -34,7 +33,7 @@ class SiStripDelayESProducer : public edm::ESProducer {
   typedef std::vector< edm::ParameterSet > Parameters;
   Parameters toGet;
 
-  boost::shared_ptr<SiStripDelay> delay;
+  std::shared_ptr<SiStripDelay> delay;
 };
 
 #endif

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducerTemplate.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducerTemplate.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <utility>
 
 // user include files

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
@@ -34,7 +34,7 @@ SiStripLorentzAngleDepESProducer::SiStripLorentzAngleDepESProducer(const edm::Pa
 }
 
 
-boost::shared_ptr<SiStripLorentzAngle> SiStripLorentzAngleDepESProducer::produce(const SiStripLorentzAngleDepRcd& iRecord)
+std::shared_ptr<SiStripLorentzAngle> SiStripLorentzAngleDepESProducer::produce(const SiStripLorentzAngleDepRcd& iRecord)
 {
 
   edm::LogInfo("SiStripLorentzAngleDepESProducer") << "Producer called" << std::endl;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -24,7 +23,7 @@ class SiStripLorentzAngleDepESProducer : public edm::ESProducer {
   SiStripLorentzAngleDepESProducer(const edm::ParameterSet&);
   ~SiStripLorentzAngleDepESProducer(){};
   
-  boost::shared_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleDepRcd&);
+  std::shared_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleDepRcd&);
    
  private:
 
@@ -37,7 +36,7 @@ class SiStripLorentzAngleDepESProducer : public edm::ESProducer {
   edm::ParameterSet getPeak;
   edm::ParameterSet getDeconv;
 
-  boost::shared_ptr<SiStripLorentzAngle> siStripLA_;
+  std::shared_ptr<SiStripLorentzAngle> siStripLA_;
 
 };
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -35,7 +35,7 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
 }
 
 
-boost::shared_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord)
+std::shared_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord)
 {
   
   edm::LogInfo("SiStripQualityESProducer") << "produce called" << std::endl;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -23,7 +22,7 @@ class SiStripQualityESProducer : public edm::ESProducer {
   SiStripQualityESProducer(const edm::ParameterSet&);
   ~SiStripQualityESProducer(){};
   
-  boost::shared_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
+  std::shared_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
    
  private:
 
@@ -34,7 +33,7 @@ class SiStripQualityESProducer : public edm::ESProducer {
   typedef std::vector< edm::ParameterSet > Parameters;
   Parameters toGet;
 
-  boost::shared_ptr<SiStripQuality>  quality;
+  std::shared_ptr<SiStripQuality>  quality;
 };
 
 #endif

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
@@ -45,9 +45,9 @@ MeasureLA::MeasureLA(const edm::ParameterSet& conf) :
 }
 
 
-boost::shared_ptr<SiStripLorentzAngle> MeasureLA::
+std::shared_ptr<SiStripLorentzAngle> MeasureLA::
 produce(const SiStripLorentzAngleRcd& ) {
-  boost::shared_ptr<SiStripLorentzAngle> lorentzAngle(new SiStripLorentzAngle());
+  auto lorentzAngle = std::make_shared<SiStripLorentzAngle>();
   /*
   std::map<uint32_t,LA_Filler_Fitter::Result> 
     module_results = LA_Filler_Fitter::module_results(book, LA_Filler_Fitter::SQRTVAR);

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.h
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.h
@@ -9,6 +9,8 @@
 #include "CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h"
 #include "CalibTracker/SiStripCommon/interface/Book.h"
 
+#include <memory>
+
 namespace sistrip {
 
 class MeasureLA : public edm::ESProducer {
@@ -16,7 +18,7 @@ class MeasureLA : public edm::ESProducer {
  public:
 
   explicit MeasureLA(const edm::ParameterSet&);
-  boost::shared_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleRcd&);
+  std::shared_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleRcd&);
   
  private:
 

--- a/Calibration/EcalCalibAlgos/interface/ZeeCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/ZeeCalibration.h
@@ -98,7 +98,7 @@ class ZeeCalibration : public edm::ESProducerLooper {
   virtual Status duringLoop( const edm::Event&, const edm::EventSetup& );
   
   /// Produce Ecal interCalibrations
-  virtual boost::shared_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& iRecord );
+  virtual std::shared_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& iRecord );
 
  private:
 
@@ -192,7 +192,7 @@ class ZeeCalibration : public edm::ESProducerLooper {
   float calibCoeffError[nMaxChannels];
    float initCalibCoeff[nMaxChannels];
 
-  boost::shared_ptr<EcalIntercalibConstants> ical;
+  std::shared_ptr<EcalIntercalibConstants> ical;
   
   ZIterativeAlgorithmWithFit* theAlgorithm_;
 

--- a/Calibration/EcalCalibAlgos/src/ZeeCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/ZeeCalibration.cc
@@ -180,7 +180,7 @@ ZeeCalibration::~ZeeCalibration()
 
 //_____________________________________________________________________________
 // Produce EcalIntercalibConstants
-boost::shared_ptr<EcalIntercalibConstants>
+std::shared_ptr<EcalIntercalibConstants>
 ZeeCalibration::produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& iRecord )
 {
   std::cout << "@SUB=ZeeCalibration::produceEcalIntercalibConstants" << std::endl;
@@ -747,7 +747,7 @@ ZeeCalibration::duringLoop( const edm::Event& iEvent, const edm::EventSetup& iSe
 	  }
       }
 
-    ical = boost::shared_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+    ical = std::make_shared<EcalIntercalibConstants>();
   
     for(int k = 0; k < theAlgorithm_->getNumberOfChannels(); k++)
       {


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for Calibration packages.
Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation.
This PR is totally technical.
