### PR TITLE
Use std::shared_ptr and std::make_shared (EventSetup in FastSim)

### DIFF
--- a/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.cc
+++ b/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.cc
@@ -19,7 +19,7 @@ MagneticFieldMapESProducer::MagneticFieldMapESProducer(const edm::ParameterSet &
 
 MagneticFieldMapESProducer::~MagneticFieldMapESProducer() {}
 
-boost::shared_ptr<MagneticFieldMap> 
+std::shared_ptr<MagneticFieldMap>
 MagneticFieldMapESProducer::produce(const MagneticFieldMapRecord & iRecord){ 
 
   edm::ESHandle<TrackerInteractionGeometry> theInteractionGeometry;
@@ -28,8 +28,7 @@ MagneticFieldMapESProducer::produce(const MagneticFieldMapRecord & iRecord){
   iRecord.getRecord<TrackerInteractionGeometryRecord>().get(_label, theInteractionGeometry );
   iRecord.getRecord<IdealMagneticFieldRecord>().get(theMagneticField );
 
-  _map = boost::shared_ptr<MagneticFieldMap>
-    (new MagneticFieldMap(&(*theMagneticField),&(*theInteractionGeometry)));
+  _map = std::make_shared<MagneticFieldMap>(&(*theMagneticField),&(*theInteractionGeometry));
 
   return _map;
 

--- a/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.h
+++ b/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.h
@@ -4,16 +4,16 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FastSimulation/ParticlePropagator/interface/MagneticFieldMapRecord.h"
 #include "FastSimulation/ParticlePropagator/interface/MagneticFieldMap.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 class  MagneticFieldMapESProducer: public edm::ESProducer{
  public:
   MagneticFieldMapESProducer(const edm::ParameterSet & p);
   virtual ~MagneticFieldMapESProducer(); 
-  boost::shared_ptr<MagneticFieldMap> produce(const MagneticFieldMapRecord &);
+  std::shared_ptr<MagneticFieldMap> produce(const MagneticFieldMapRecord &);
  private:
-  boost::shared_ptr<MagneticFieldMap> _map;
+  std::shared_ptr<MagneticFieldMap> _map;
   std::string _label;
 };
 

--- a/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.cc
+++ b/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.cc
@@ -17,14 +17,13 @@ TrackerInteractionGeometryESProducer::TrackerInteractionGeometryESProducer(const
 
 TrackerInteractionGeometryESProducer::~TrackerInteractionGeometryESProducer() {}
 
-boost::shared_ptr<TrackerInteractionGeometry> 
+std::shared_ptr<TrackerInteractionGeometry>
 TrackerInteractionGeometryESProducer::produce(const TrackerInteractionGeometryRecord & iRecord){ 
 
   edm::ESHandle<GeometricSearchTracker> theGeomSearchTracker;
   
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(_label, theGeomSearchTracker );
-  _tracker = boost::shared_ptr<TrackerInteractionGeometry>
-    (new TrackerInteractionGeometry(theTrackerMaterial,&(*theGeomSearchTracker)));
+  _tracker = std::make_shared<TrackerInteractionGeometry>(theTrackerMaterial,&(*theGeomSearchTracker));
   return _tracker;
 
 }

--- a/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.h
+++ b/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.h
@@ -5,16 +5,16 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FastSimulation/TrackerSetup/interface/TrackerInteractionGeometryRecord.h"
 #include "FastSimulation/TrackerSetup/interface/TrackerInteractionGeometry.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 class  TrackerInteractionGeometryESProducer: public edm::ESProducer{
  public:
   TrackerInteractionGeometryESProducer(const edm::ParameterSet & p);
   virtual ~TrackerInteractionGeometryESProducer(); 
-  boost::shared_ptr<TrackerInteractionGeometry> produce(const TrackerInteractionGeometryRecord &);
+  std::shared_ptr<TrackerInteractionGeometry> produce(const TrackerInteractionGeometryRecord &);
  private:
-  boost::shared_ptr<TrackerInteractionGeometry> _tracker;
+  std::shared_ptr<TrackerInteractionGeometry> _tracker;
   std::string _label;
   edm::ParameterSet theTrackerMaterial;
 };


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for FastSim packages.
Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation.
This PR is totally technical.
