### PR TITLE
use std::shared_ptr and std::make_shared (EventSetup in Geometry/Alignment/Visualization)

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -158,9 +158,9 @@ AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       iSetup.get<MuonNumberingRecord>().get(mdc);
       DTGeometryBuilderFromDDD DTGeometryBuilder;
       CSCGeometryBuilderFromDDD CSCGeometryBuilder;
-      boost::shared_ptr<DTGeometry> theMuonDT(new DTGeometry);
+      auto theMuonDT = std::make_shared<DTGeometry>();
       DTGeometryBuilder.build(theMuonDT, &(*cpv), *mdc);
-      boost::shared_ptr<CSCGeometry> theMuonCSC(new CSCGeometry);
+      auto theMuonCSC = std::make_shared<CSCGeometry>();
       CSCGeometryBuilder.build(theMuonCSC, &(*cpv), *mdc);
       
       edm::ESHandle<Alignments> globalPositionRcd;

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
@@ -168,7 +168,7 @@ AlignmentProducer::~AlignmentProducer()
 
 //_____________________________________________________________________________
 // Produce tracker geometry
-boost::shared_ptr<TrackerGeometry>
+std::shared_ptr<TrackerGeometry>
 AlignmentProducer::produceTracker( const TrackerDigiGeometryRecord& iRecord )
 {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::produceTracker";
@@ -177,7 +177,7 @@ AlignmentProducer::produceTracker( const TrackerDigiGeometryRecord& iRecord )
 
 //_____________________________________________________________________________
 // Produce muonDT geometry
-boost::shared_ptr<DTGeometry>
+std::shared_ptr<DTGeometry>
 AlignmentProducer::produceDT( const MuonGeometryRecord& iRecord )
 {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::produceDT";
@@ -186,7 +186,7 @@ AlignmentProducer::produceDT( const MuonGeometryRecord& iRecord )
 
 //_____________________________________________________________________________
 // Produce muonCSC geometry
-boost::shared_ptr<CSCGeometry>
+std::shared_ptr<CSCGeometry>
 AlignmentProducer::produceCSC( const MuonGeometryRecord& iRecord )
 {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::produceCSC";
@@ -658,7 +658,7 @@ void AlignmentProducer::createGeometries_( const edm::EventSetup& iSetup )
      const TrackerTopology* const tTopo = tTopoHandle.product();
 
      TrackerGeomBuilderFromGeometricDet trackerBuilder;
-     theTracker = boost::shared_ptr<TrackerGeometry>( trackerBuilder.build(&(*geometricDet), *ptp, tTopo ));
+     theTracker = std::shared_ptr<TrackerGeometry>( trackerBuilder.build(&(*geometricDet), *ptp, tTopo ));
    }
 
    if (doMuon_) {
@@ -666,9 +666,9 @@ void AlignmentProducer::createGeometries_( const edm::EventSetup& iSetup )
      iSetup.get<MuonNumberingRecord>().get(mdc);
      DTGeometryBuilderFromDDD DTGeometryBuilder;
      CSCGeometryBuilderFromDDD CSCGeometryBuilder;
-     theMuonDT = boost::shared_ptr<DTGeometry>(new DTGeometry );
+     theMuonDT = std::make_shared<DTGeometry>();
      DTGeometryBuilder.build( theMuonDT, &(*cpv), *mdc);
-     theMuonCSC = boost::shared_ptr<CSCGeometry>( new CSCGeometry );
+     theMuonCSC = std::make_shared<CSCGeometry>();
      CSCGeometryBuilder.build( theMuonCSC, &(*cpv), *mdc );
    }
 }

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -11,6 +11,7 @@
 ///  last update: $Date: 2012/06/13 16:23:30 $
 ///  by         : $Author: yana $
 
+#include <memory>
 #include <vector>
 
 // Framework
@@ -71,11 +72,11 @@ class AlignmentProducer : public edm::ESProducerLooper
   ~AlignmentProducer();
 
   /// Produce the tracker geometry
-  virtual boost::shared_ptr<TrackerGeometry> produceTracker( const TrackerDigiGeometryRecord& iRecord );
+  virtual std::shared_ptr<TrackerGeometry> produceTracker( const TrackerDigiGeometryRecord& iRecord );
   /// Produce the muon DT geometry
-  virtual boost::shared_ptr<DTGeometry>      produceDT( const MuonGeometryRecord& iRecord );
+  virtual std::shared_ptr<DTGeometry>      produceDT( const MuonGeometryRecord& iRecord );
   /// Produce the muon CSC geometry
-  virtual boost::shared_ptr<CSCGeometry>     produceCSC( const MuonGeometryRecord& iRecord );
+  virtual std::shared_ptr<CSCGeometry>     produceCSC( const MuonGeometryRecord& iRecord );
 
   /// Called at beginning of job
   virtual void beginOfJob(const edm::EventSetup&);
@@ -163,9 +164,9 @@ class AlignmentProducer : public edm::ESProducerLooper
   AlignableTracker* theAlignableTracker;
   AlignableMuon* theAlignableMuon;
 
-  boost::shared_ptr<TrackerGeometry> theTracker;
-  boost::shared_ptr<DTGeometry> theMuonDT;
-  boost::shared_ptr<CSCGeometry> theMuonCSC;
+  std::shared_ptr<TrackerGeometry> theTracker;
+  std::shared_ptr<DTGeometry> theMuonDT;
+  std::shared_ptr<CSCGeometry> theMuonCSC;
   /// GlobalPositions that might be read from DB, NULL otherwise
   const Alignments *globalPositions_;
 

--- a/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
@@ -17,7 +17,6 @@
   <use   name="CondFormats/AlignmentRecord"/>
   <use   name="CondFormats/GeometryObjects"/>
   <use   name="FWCore/ServiceRegistry"/>
-  <use   name="boost"/>
 </library>
 <library   name="AlignmentPCLTrackerAlignmentProducerPlugin" file="PCLTrackerAlProducer.cc">
   <use   name="Alignment/CommonAlignment"/>
@@ -31,7 +30,6 @@
   <use   name="CondFormats/AlignmentRecord"/>
   <use   name="CondFormats/GeometryObjects"/>
   <use   name="FWCore/ServiceRegistry"/>
-  <use   name="boost"/>
 </library>
 <library   name="CommonAlignmentProducerSelectors" file="Alignment*SelectorModule.cc,AlignmentMuonHIPTrajectorySelector.cc">
   <use   name="Alignment/CommonAlignmentProducer"/>

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -506,7 +506,7 @@ void PCLTrackerAlProducer
     edm::ESHandle<PTrackerParameters> ptp;
     setup.get<PTrackerParametersRcd>().get( ptp );
 
-    theTrackerGeometry = boost::shared_ptr<TrackerGeometry>(
+    theTrackerGeometry = std::shared_ptr<TrackerGeometry>(
         trackerBuilder.build(&(*geometricDet), *ptp, tTopo )
     );
   }
@@ -518,8 +518,8 @@ void PCLTrackerAlProducer
     setup.get<IdealGeometryRecord>().get(cpv);
     setup.get<MuonNumberingRecord>().get(mdc);
 
-    theMuonDTGeometry  = boost::shared_ptr<DTGeometry> (new DTGeometry);
-    theMuonCSCGeometry = boost::shared_ptr<CSCGeometry>(new CSCGeometry);
+    theMuonDTGeometry  = std::make_shared<DTGeometry>();
+    theMuonCSCGeometry = std::make_shared<CSCGeometry>();
 
     DTGeometryBuilderFromDDD  DTGeometryBuilder;
     CSCGeometryBuilderFromDDD CSCGeometryBuilder;

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
@@ -228,10 +228,9 @@ class PCLTrackerAlProducer : public edm::EDAnalyzer {
     /// GlobalPositions that might be read from DB, NULL otherwise
     const Alignments* globalPositions_;
 
-    // TODO: Change pointers to std::shared_ptr
-    boost::shared_ptr<TrackerGeometry> theTrackerGeometry;
-    boost::shared_ptr<DTGeometry>      theMuonDTGeometry;
-    boost::shared_ptr<CSCGeometry>     theMuonCSCGeometry;
+    std::shared_ptr<TrackerGeometry> theTrackerGeometry;
+    std::shared_ptr<DTGeometry>      theMuonDTGeometry;
+    std::shared_ptr<CSCGeometry>     theMuonCSCGeometry;
 
     int nevent_;
 

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h
@@ -20,7 +20,7 @@
 //
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -45,8 +45,8 @@ class MuonAlignmentInputMethod {
       virtual AlignableMuon *newAlignableMuon(const edm::EventSetup &iSetup) const;
 
    protected:
-      boost::shared_ptr<DTGeometry> idealDTGeometry(const edm::EventSetup &iSetup) const;
-      boost::shared_ptr<CSCGeometry> idealCSCGeometry(const edm::EventSetup &iSetup) const;
+      std::shared_ptr<DTGeometry> idealDTGeometry(const edm::EventSetup &iSetup) const;
+      std::shared_ptr<CSCGeometry> idealCSCGeometry(const edm::EventSetup &iSetup) const;
 
    private:
       MuonAlignmentInputMethod(const MuonAlignmentInputMethod&); // stop default

--- a/Alignment/MuonAlignment/plugins/MisalignedMuonESProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MisalignedMuonESProducer.cc
@@ -35,7 +35,6 @@
 #include "Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h"
 #include "Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.h"
 
-#include <boost/shared_ptr.hpp>
 #include <memory>
 
 
@@ -50,8 +49,8 @@ public:
   virtual ~MisalignedMuonESProducer(); 
   
   /// Produce the misaligned Muon geometry and store it
-  edm::ESProducts< boost::shared_ptr<DTGeometry>,
- 				   boost::shared_ptr<CSCGeometry> > produce( const MuonGeometryRecord&  );
+  edm::ESProducts< std::shared_ptr<DTGeometry>,
+ 				   std::shared_ptr<CSCGeometry> > produce( const MuonGeometryRecord&  );
 
   /// Save alignemnts and error to database
   void saveToDB();
@@ -63,8 +62,8 @@ private:
   std::string theDTAlignRecordName, theDTErrorRecordName;
   std::string theCSCAlignRecordName, theCSCErrorRecordName;
   
-  boost::shared_ptr<DTGeometry> theDTGeometry;
-  boost::shared_ptr<CSCGeometry> theCSCGeometry;
+  std::shared_ptr<DTGeometry> theDTGeometry;
+  std::shared_ptr<CSCGeometry> theCSCGeometry;
 
   Alignments*      dt_Alignments;
   AlignmentErrorsExtended* dt_AlignmentErrorsExtended;
@@ -98,7 +97,7 @@ MisalignedMuonESProducer::~MisalignedMuonESProducer() {}
 
 
 //__________________________________________________________________________________________________
-edm::ESProducts< boost::shared_ptr<DTGeometry>, boost::shared_ptr<CSCGeometry> >
+edm::ESProducts< std::shared_ptr<DTGeometry>, std::shared_ptr<CSCGeometry> >
 MisalignedMuonESProducer::produce( const MuonGeometryRecord& iRecord )
 { 
 
@@ -115,9 +114,9 @@ MisalignedMuonESProducer::produce( const MuonGeometryRecord& iRecord )
   DTGeometryBuilderFromDDD  DTGeometryBuilder;
   CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
-  theDTGeometry = boost::shared_ptr<DTGeometry>(new DTGeometry );
+  theDTGeometry = std::make_shared<DTGeometry>();
   DTGeometryBuilder.build(theDTGeometry,  &(*cpv), *mdc );
-  theCSCGeometry  = boost::shared_ptr<CSCGeometry>( new CSCGeometry );
+  theCSCGeometry  = std::make_shared<CSCGeometry>();
   CSCGeometryBuilder.build( theCSCGeometry,  &(*cpv), *mdc );
 
 

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputDB.cc
@@ -65,8 +65,8 @@ MuonAlignmentInputDB::~MuonAlignmentInputDB() {}
 //
 
 AlignableMuon *MuonAlignmentInputDB::newAlignableMuon(const edm::EventSetup& iSetup) const {
-   boost::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
-   boost::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
+   std::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
+   std::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
 
    edm::ESHandle<Alignments> dtAlignments;
    edm::ESHandle<AlignmentErrorsExtended> dtAlignmentErrorsExtended;

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
@@ -60,13 +60,13 @@ MuonAlignmentInputMethod::~MuonAlignmentInputMethod() {}
 //
 
 AlignableMuon *MuonAlignmentInputMethod::newAlignableMuon(const edm::EventSetup& iSetup) const {
-   boost::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
-   boost::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
+   std::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
+   std::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
 
    return new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
 }
 
-boost::shared_ptr<DTGeometry> MuonAlignmentInputMethod::idealDTGeometry(const edm::EventSetup& iSetup) const {
+std::shared_ptr<DTGeometry> MuonAlignmentInputMethod::idealDTGeometry(const edm::EventSetup& iSetup) const {
    edm::ESTransientHandle<DDCompactView> cpv;
    iSetup.get<IdealGeometryRecord>().get(cpv);
 
@@ -74,13 +74,13 @@ boost::shared_ptr<DTGeometry> MuonAlignmentInputMethod::idealDTGeometry(const ed
    iSetup.get<MuonNumberingRecord>().get(mdc);
    DTGeometryBuilderFromDDD DTGeometryBuilder;
 
-   boost::shared_ptr<DTGeometry> boost_dtGeometry(new DTGeometry );
+   auto boost_dtGeometry = std::make_shared<DTGeometry>();
    DTGeometryBuilder.build(boost_dtGeometry, &(*cpv), *mdc);
 
    return boost_dtGeometry;
 }
 
-boost::shared_ptr<CSCGeometry> MuonAlignmentInputMethod::idealCSCGeometry(const edm::EventSetup& iSetup) const {
+std::shared_ptr<CSCGeometry> MuonAlignmentInputMethod::idealCSCGeometry(const edm::EventSetup& iSetup) const {
    edm::ESTransientHandle<DDCompactView> cpv;
    iSetup.get<IdealGeometryRecord>().get(cpv);
 
@@ -88,7 +88,7 @@ boost::shared_ptr<CSCGeometry> MuonAlignmentInputMethod::idealCSCGeometry(const 
    iSetup.get<MuonNumberingRecord>().get(mdc);
    CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
-   boost::shared_ptr<CSCGeometry> boost_cscGeometry(new CSCGeometry);
+   auto boost_cscGeometry = std::make_shared<CSCGeometry>();
    CSCGeometryBuilder.build(boost_cscGeometry, &(*cpv), *mdc);
 
    return boost_cscGeometry;

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
@@ -63,8 +63,8 @@ MuonAlignmentInputSurveyDB::~MuonAlignmentInputSurveyDB() {}
 //
 
 AlignableMuon *MuonAlignmentInputSurveyDB::newAlignableMuon(const edm::EventSetup& iSetup) const {
-   boost::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
-   boost::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
+   std::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
+   std::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
 
    edm::ESHandle<Alignments> dtSurvey;
    edm::ESHandle<SurveyErrors> dtSurveyError;

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -244,8 +244,8 @@ void MuonAlignmentInputXML::fillAliToIdeal(std::map<Alignable*, Alignable*> &ali
 }
 
 AlignableMuon *MuonAlignmentInputXML::newAlignableMuon(const edm::EventSetup& iSetup) const {
-   boost::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
-   boost::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
+   std::shared_ptr<DTGeometry> dtGeometry = idealDTGeometry(iSetup);
+   std::shared_ptr<CSCGeometry> cscGeometry = idealCSCGeometry(iSetup);
 
    AlignableMuon *alignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
    std::map<unsigned int, Alignable*> alignableNavigator;  // real AlignableNavigators don't have const methods

--- a/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
@@ -130,10 +130,10 @@ void MuonAlignmentOutputXML::write(AlignableMuon *alignableMuon, const edm::Even
       DTGeometryBuilderFromDDD DTGeometryBuilder;
       CSCGeometryBuilderFromDDD CSCGeometryBuilder;
  
-      boost::shared_ptr<DTGeometry> dtGeometry(new DTGeometry );
+      auto dtGeometry = std::shared_ptr<DTGeometry>();
       DTGeometryBuilder.build(dtGeometry, &(*cpv), *mdc);
 
-      boost::shared_ptr<CSCGeometry> boost_cscGeometry(new CSCGeometry);
+      auto boost_cscGeometry = std::make_shared<CSCGeometry>();
       CSCGeometryBuilder.build(boost_cscGeometry, &(*cpv), *mdc);
 
       AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*boost_cscGeometry));

--- a/Alignment/MuonAlignment/test/TestReader.cpp
+++ b/Alignment/MuonAlignment/test/TestReader.cpp
@@ -7,6 +7,7 @@
 
 
 // system include files
+#include <memory>
 #include <string>
 #include <TTree.h>
 #include <TRotMatrix.h>
@@ -121,9 +122,9 @@ TestMuonReader::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup
   DTGeometryBuilderFromDDD DTGeometryBuilder;
   CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
-  boost::shared_ptr<DTGeometry> dtGeometry(new DTGeometry );
+  auto dtGeometry = std::make_shared<DTGeometry>();
   DTGeometryBuilder.build(dtGeometry, &(*cpv), *mdc);
-  boost::shared_ptr<CSCGeometry> cscGeometry(new CSCGeometry);
+  auto cscGeometry = std::make_shared<CSCGeometry>();
   CSCGeometryBuilder.build(cscGeometry, &(*cpv), *mdc);
 
   AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry));

--- a/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
+++ b/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
@@ -24,7 +24,6 @@
 #include "Alignment/CommonAlignment/interface/Alignable.h" 
 
 // C++
-#include <boost/shared_ptr.hpp>
 #include <memory>
 #include <algorithm>
 
@@ -46,7 +45,7 @@ public:
   virtual ~MisalignedTrackerESProducer(); 
   
   /// Produce the misaligned tracker geometry and store it
-  boost::shared_ptr<TrackerGeometry> produce(const TrackerDigiGeometryRecord& iRecord);
+  std::shared_ptr<TrackerGeometry> produce(const TrackerDigiGeometryRecord& iRecord);
 
 private:
   const bool theSaveToDB; /// whether or not writing to DB
@@ -54,7 +53,7 @@ private:
   const edm::ParameterSet theScenario; /// misalignment scenario
   const std::string theAlignRecordName, theErrorRecordName;
   
-  boost::shared_ptr<TrackerGeometry> theTracker;
+  std::shared_ptr<TrackerGeometry> theTracker;
 };
 
 //__________________________________________________________________________________________________
@@ -81,7 +80,7 @@ MisalignedTrackerESProducer::~MisalignedTrackerESProducer() {}
 
 
 //__________________________________________________________________________________________________
-boost::shared_ptr<TrackerGeometry> 
+std::shared_ptr<TrackerGeometry> 
 MisalignedTrackerESProducer::produce( const TrackerDigiGeometryRecord& iRecord )
 { 
   //Retrieve tracker topology from geometry
@@ -97,7 +96,7 @@ MisalignedTrackerESProducer::produce( const TrackerDigiGeometryRecord& iRecord )
   edm::ESHandle<PTrackerParameters> ptp;
   iRecord.getRecord<PTrackerParametersRcd>().get( ptp );
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
-  theTracker  = boost::shared_ptr<TrackerGeometry>( trackerBuilder.build(&(*gD), *ptp, tTopo));
+  theTracker  = std::shared_ptr<TrackerGeometry>( trackerBuilder.build(&(*gD), *ptp, tTopo));
  
   // Create the alignable hierarchy
   std::auto_ptr<AlignableTracker> theAlignableTracker(new AlignableTracker( &(*theTracker), tTopo ) );

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -1,7 +1,7 @@
 #ifndef GEOMETRY_FWRECO_GEOMETRY_ES_PRODUCER_H
 # define GEOMETRY_FWRECO_GEOMETRY_ES_PRODUCER_H
 
-# include "boost/shared_ptr.hpp"
+# include <memory>
 
 # include "FWCore/Framework/interface/ESProducer.h"
 # include "FWCore/Framework/interface/ESHandle.h"
@@ -26,7 +26,7 @@ public:
   FWRecoGeometryESProducer( const edm::ParameterSet& );
   virtual ~FWRecoGeometryESProducer( void );
   
-  boost::shared_ptr<FWRecoGeometry> produce( const FWRecoGeometryRecord& );
+  std::shared_ptr<FWRecoGeometry> produce( const FWRecoGeometryRecord& );
 
 private:
   FWRecoGeometryESProducer( const FWRecoGeometryESProducer& );
@@ -53,7 +53,7 @@ private:
   edm::ESHandle<CaloGeometry>                m_caloGeom;
   std::vector<edm::ESHandle<HGCalGeometry> > m_hgcalGeoms;
   const TrackerGeometry*                     m_trackerGeom;
-  boost::shared_ptr<FWRecoGeometry>          m_fwGeometry;
+  std::shared_ptr<FWRecoGeometry>          m_fwGeometry;
   
   unsigned int m_current;
   bool m_tracker;

--- a/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
@@ -1,7 +1,7 @@
 #ifndef GEOMETRY_FWTGEORECO_GEOMETRY_ES_PRODUCER_H
 # define GEOMETRY_FWTGEORECO_GEOMETRY_ES_PRODUCER_H
 
-# include "boost/shared_ptr.hpp"
+# include <memory>
 
 # include "FWCore/Framework/interface/ESProducer.h"
 # include "FWCore/Framework/interface/ESHandle.h"
@@ -36,7 +36,7 @@ public:
    FWTGeoRecoGeometryESProducer( const edm::ParameterSet& );
    virtual ~FWTGeoRecoGeometryESProducer( void );
   
-   boost::shared_ptr<FWTGeoRecoGeometry> produce( const FWTGeoRecoGeometryRecord& );
+   std::shared_ptr<FWTGeoRecoGeometry> produce( const FWTGeoRecoGeometryRecord& );
 
 private:
    FWTGeoRecoGeometryESProducer( const FWTGeoRecoGeometryESProducer& );
@@ -76,7 +76,7 @@ private:
    edm::ESHandle<CaloGeometry>           m_caloGeom;
    const TrackerGeometry* m_trackerGeom;
   
-   boost::shared_ptr<FWTGeoRecoGeometry> m_fwGeometry;
+   std::shared_ptr<FWTGeoRecoGeometry> m_fwGeometry;
 
    TGeoMedium* m_dummyMedium;
 

--- a/Fireworks/Geometry/interface/TGeoMgrFromDdd.h
+++ b/Fireworks/Geometry/interface/TGeoMgrFromDdd.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <map>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -50,7 +50,7 @@ public:
    TGeoMgrFromDdd(const edm::ParameterSet&);
    virtual ~TGeoMgrFromDdd();
 
-   typedef boost::shared_ptr<TGeoManager> ReturnType;
+   typedef std::shared_ptr<TGeoManager> ReturnType;
 
    // ---------- const member functions ---------------------
 

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -84,12 +84,12 @@ FWRecoGeometryESProducer::FWRecoGeometryESProducer( const edm::ParameterSet& pse
 FWRecoGeometryESProducer::~FWRecoGeometryESProducer( void )
 {}
 
-boost::shared_ptr<FWRecoGeometry> 
+std::shared_ptr<FWRecoGeometry> 
 FWRecoGeometryESProducer::produce( const FWRecoGeometryRecord& record )
 {
   using namespace edm;
 
-  m_fwGeometry =  boost::shared_ptr<FWRecoGeometry>( new FWRecoGeometry );
+  m_fwGeometry = std::make_shared<FWRecoGeometry>();
 
   record.getRecord<GlobalTrackingGeometryRecord>().get( m_geomRecord );
   

--- a/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
@@ -257,12 +257,12 @@ FWTGeoRecoGeometryESProducer::GetMedium(ERecoDet det)
 
 
 
-boost::shared_ptr<FWTGeoRecoGeometry> 
+std::shared_ptr<FWTGeoRecoGeometry> 
 FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
 {
    using namespace edm;
 
-   m_fwGeometry = boost::shared_ptr<FWTGeoRecoGeometry>( new FWTGeoRecoGeometry );
+   m_fwGeometry = std::make_shared<FWTGeoRecoGeometry>();
    record.getRecord<GlobalTrackingGeometryRecord>().get( m_geomRecord );
   
    DetId detId( DetId::Tracker, 0 );
@@ -287,7 +287,7 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
   
    if( 0 == top )
    {
-      return boost::shared_ptr<FWTGeoRecoGeometry>();
+      return std::shared_ptr<FWTGeoRecoGeometry>();
    }
    geom->SetTopVolume( top );
    // ROOT chokes unless colors are assigned

--- a/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
@@ -93,7 +93,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
    iRecord.getRecord<IdealGeometryRecord>().get(viewH);
 
    if ( ! viewH.isValid()) {
-      return boost::shared_ptr<TGeoManager>();
+      return std::shared_ptr<TGeoManager>();
    }
 
    TGeoManager *geo_mgr = new TGeoManager("cmsGeo","CMS Detector");
@@ -111,14 +111,14 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
    // geometry AND the magnetic field volumes!
    walker.firstChild();
    if( ! walker.firstChild()) {
-      return boost::shared_ptr<TGeoManager>();
+      return std::shared_ptr<TGeoManager>();
    }
 
    TGeoVolume *top = createVolume(info.first.name().fullname(),
 				  info.first.solid(),
                                   info.first.material());
    if (top == 0) {
-      return boost::shared_ptr<TGeoManager>();
+      return std::shared_ptr<TGeoManager>();
    }
 
    geo_mgr->SetTopVolume(top);
@@ -209,7 +209,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
    nameToMaterial_.clear();
    nameToMedium_.clear();
 
-   return boost::shared_ptr<TGeoManager>(geo_mgr);
+   return std::shared_ptr<TGeoManager>(geo_mgr);
 }
 
 

--- a/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
@@ -9,7 +9,6 @@
  <use name="Geometry/MuonNumbering"/>
  <use name="Geometry/Records"/>
  <use name="Geometry/TrackingGeometryAligner"/>
- <use name="boost"/>
 <library file="CSCGeometryESModule.cc">
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -88,7 +88,7 @@ CSCGeometryESModule::CSCGeometryESModule(const edm::ParameterSet & p)
 CSCGeometryESModule::~CSCGeometryESModule(){}
 
 
-boost::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryRecord& record) {
+std::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryRecord& record) {
 
   initCSCGeometry_(record);
 
@@ -134,8 +134,8 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record )
 
   // Updates whenever a dependent Record was changed
 
-  cscGeometry = boost::shared_ptr<CSCGeometry>( new CSCGeometry( debugV, useGangedStripsInME1a, useOnlyWiresInME1a, useRealWireGeometry,
-								 useCentreTIOffsets ) );
+  cscGeometry = std::make_shared<CSCGeometry>( debugV, useGangedStripsInME1a, useOnlyWiresInME1a, useRealWireGeometry,
+								 useCentreTIOffsets );
 
   //  cscGeometry->setUseRealWireGeometry( useRealWireGeometry );
   //  cscGeometry->setOnlyWiresInME1a( useOnlyWiresInME1a );
@@ -153,7 +153,7 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record )
     record.getRecord<IdealGeometryRecord>().get(cpv);
     record.getRecord<MuonNumberingRecord>().get( mdc );
     CSCGeometryBuilderFromDDD builder;
-    //    _cscGeometry = boost::shared_ptr<CSCGeometry>(builder.build(_cscGeometry, &(*cpv), *mdc));
+    //    _cscGeometry = std::shared_ptr<CSCGeometry>(builder.build(_cscGeometry, &(*cpv), *mdc));
     builder.build(cscGeometry, &(*cpv), *mdc);
   } else {
     edm::ESHandle<RecoIdealGeometry> rig;
@@ -161,7 +161,7 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record )
     record.getRecord<CSCRecoGeometryRcd>().get(rig);
     record.getRecord<CSCRecoDigiParametersRcd>().get(rdp);
     CSCGeometryBuilder cscgb;
-    //    _cscGeometry = boost::shared_ptr<CSCGeometry>(cscgb.build(_cscGeometry, *rig, *rdp));
+    //    _cscGeometry = std::shared_ptr<CSCGeometry>(cscgb.build(_cscGeometry, *rig, *rdp));
     cscgb.build(cscGeometry, *rig, *rdp);
   }
   recreateGeometry_=false;

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
@@ -12,8 +12,8 @@
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
-#include <boost/shared_ptr.hpp>
 
+#include <memory>
 #include <string>
 
 class CSCGeometryESModule : public edm::ESProducer {
@@ -25,7 +25,7 @@ public:
   virtual ~CSCGeometryESModule();
 
   /// Produce CSCGeometry
-  boost::shared_ptr<CSCGeometry> produce(const MuonGeometryRecord& record);
+  std::shared_ptr<CSCGeometry> produce(const MuonGeometryRecord& record);
 
 private:  
 
@@ -35,7 +35,7 @@ private:
   void cscRecoDigiParametersChanged_( const CSCRecoDigiParametersRcd& );
 
   void initCSCGeometry_(const MuonGeometryRecord& );
-  boost::shared_ptr<CSCGeometry> cscGeometry;
+  std::shared_ptr<CSCGeometry> cscGeometry;
   bool recreateGeometry_;
 
   // Flags for controlling geometry modelling during build of CSCGeometry

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.cc
@@ -16,7 +16,7 @@ CSCGeometryBuilder::CSCGeometryBuilder() : myName("CSCGeometryBuilder"){}
 CSCGeometryBuilder::~CSCGeometryBuilder(){}
 
 
-void CSCGeometryBuilder::build( boost::shared_ptr<CSCGeometry> theGeometry
+void CSCGeometryBuilder::build( std::shared_ptr<CSCGeometry> theGeometry
 				, const RecoIdealGeometry& rig
 				, const CSCRecoDigiParameters& cscpars ) {
 
@@ -117,7 +117,7 @@ void CSCGeometryBuilder::build( boost::shared_ptr<CSCGeometry> theGeometry
 }
 
 void CSCGeometryBuilder::buildChamber (  
-				       boost::shared_ptr<CSCGeometry> theGeometry // the geometry container
+				       std::shared_ptr<CSCGeometry> theGeometry // the geometry container
 				       , CSCDetId chamberId                         // the DetId for this chamber
 				       , const std::vector<float>& fpar           // volume parameters hB, hT. hD, hH	
 				       , const std::vector<float>& fupar          // user parameters 

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h
@@ -15,7 +15,7 @@
 
 #include <string>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class CSCGeometry;
 
@@ -28,7 +28,7 @@ public:
   virtual ~CSCGeometryBuilder();
 
   /// Build the geometry
-  void build( boost::shared_ptr<CSCGeometry> theGeometry
+  void build( std::shared_ptr<CSCGeometry> theGeometry
 		      , const RecoIdealGeometry& rig
 		      , const CSCRecoDigiParameters& cscpars ) ;
 
@@ -37,7 +37,7 @@ protected:
 private:
   /// Build one CSC chamber, and its component layers, and add them to the geometry
   void buildChamber (  
-		     boost::shared_ptr<CSCGeometry> theGeometry        // the geometry container
+		     std::shared_ptr<CSCGeometry> theGeometry        // the geometry container
 		     , CSCDetId chamberId              // the DetId of this chamber
 		     , const std::vector<float>& fpar  // volume parameters
 		     , const std::vector<float>& fupar // user parameters

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.cc
@@ -14,7 +14,7 @@ CSCGeometryBuilderFromDDD::CSCGeometryBuilderFromDDD() : myName("CSCGeometryBuil
 CSCGeometryBuilderFromDDD::~CSCGeometryBuilderFromDDD(){}
 
 
-void CSCGeometryBuilderFromDDD::build(boost::shared_ptr<CSCGeometry> geom, const DDCompactView* cview, const MuonDDDConstants& muonConstants){
+void CSCGeometryBuilderFromDDD::build(std::shared_ptr<CSCGeometry> geom, const DDCompactView* cview, const MuonDDDConstants& muonConstants){
 
   RecoIdealGeometry rig;
   CSCRecoDigiParameters rdp;

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.h
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.h
@@ -9,7 +9,7 @@
  */
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 class DDCompactView;
@@ -25,7 +25,7 @@ public:
   virtual ~CSCGeometryBuilderFromDDD();
 
   /// Build the geometry
-  void build(boost::shared_ptr<CSCGeometry> geom, const DDCompactView* fv, const MuonDDDConstants& muonConstants);
+  void build(std::shared_ptr<CSCGeometry> geom, const DDCompactView* fv, const MuonDDDConstants& muonConstants);
 
 protected:
 

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.h
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.h
@@ -10,7 +10,6 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <string>
-#include <boost/shared_ptr.hpp>
 
 class CSCGeometry;
 class DDCompactView;

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -43,7 +42,7 @@ class CaloGeometryDBEP : public edm::ESProducer
       typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
       typedef CaloCellGeometry::Tr3D     Tr3D     ;
 
-      typedef boost::shared_ptr< CaloSubdetectorGeometry > PtrType ;
+      typedef std::shared_ptr<CaloSubdetectorGeometry > PtrType ;
       typedef CaloSubdetectorGeometry::TrVec  TrVec      ;
       typedef CaloSubdetectorGeometry::DimVec DimVec     ;
       typedef CaloSubdetectorGeometry::IVec   IVec       ;

--- a/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
@@ -27,7 +27,7 @@ public:
 
   typedef std::vector< double > ParmVec ;
 
-  typedef boost::shared_ptr< CaloSubdetectorGeometry > PtrType ;
+  typedef std::shared_ptr<CaloSubdetectorGeometry > PtrType ;
 
   typedef CaloSubdetectorGeometry::ParVec    ParVec ;
   typedef CaloSubdetectorGeometry::ParVecVec ParVecVec ;

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -38,7 +37,7 @@ class CaloGeometryBuilder : public edm::ESProducer
 {
    public:
 
-      typedef boost::shared_ptr<CaloGeometry> ReturnType;
+      typedef std::shared_ptr<CaloGeometry> ReturnType;
 
       typedef edm::ESHandle<CaloSubdetectorGeometry> SubdType ;
 

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -38,7 +37,7 @@ class CaloTopologyBuilder : public edm::ESProducer
       CaloTopologyBuilder( const edm::ParameterSet& iP );
       ~CaloTopologyBuilder() ;
 
-      typedef boost::shared_ptr< CaloTopology > ReturnType;
+      typedef std::shared_ptr< CaloTopology > ReturnType;
 
       ReturnType produceCalo(  const CaloTopologyRecord&  );
 

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
@@ -20,7 +20,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/Geometry/CaloEventSetup/plugins/FakeCaloAlignmentEP.cc
+++ b/Geometry/CaloEventSetup/plugins/FakeCaloAlignmentEP.cc
@@ -61,8 +61,8 @@ class FakeCaloAlignmentEP : public edm::ESProducer
 {
    public:
 
-      typedef boost::shared_ptr<Alignments>      ReturnAli    ;
-      typedef boost::shared_ptr<AlignmentErrors> ReturnAliErr ;
+      typedef std::shared_ptr<Alignments>      ReturnAli    ;
+      typedef std::shared_ptr<AlignmentErrors> ReturnAliErr ;
 
       typedef AlignTransform::Translation Trl ;
       typedef AlignTransform::Rotation    Rot ;

--- a/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include <FWCore/Framework/interface/ModuleFactory.h>
@@ -45,7 +44,7 @@ public:
   HGCalTopologyBuilder( const edm::ParameterSet& iP );
   ~HGCalTopologyBuilder() ;
 
-  typedef boost::shared_ptr< HGCalTopology > ReturnType;
+  typedef std::shared_ptr< HGCalTopology > ReturnType;
 
   ReturnType produce(const IdealGeometryRecord&);
 

--- a/Geometry/CaloEventSetup/plugins/TestCaloAlignmentEP.cc
+++ b/Geometry/CaloEventSetup/plugins/TestCaloAlignmentEP.cc
@@ -61,8 +61,8 @@ class TestCaloAlignmentEP : public edm::ESProducer
 {
    public:
 
-      typedef boost::shared_ptr<Alignments>      ReturnAli    ;
-      typedef boost::shared_ptr<AlignmentErrors> ReturnAliErr ;
+      typedef std::shared_ptr<Alignments>      ReturnAli    ;
+      typedef std::shared_ptr<AlignmentErrors> ReturnAliErr ;
 
       typedef AlignTransform::Translation Trl ;
       typedef AlignTransform::Rotation    Rot ;

--- a/Geometry/DTGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/DTGeometryBuilder/plugins/BuildFile.xml
@@ -9,7 +9,6 @@
  <use name="Geometry/Records"/>
  <use name="Geometry/TrackingGeometryAligner"/>
  <use name="Geometry/DTGeometryBuilder"/>
- <use name="boost"/>
 
 <library file="DTGeometryESModule.cc">
  <flags EDM_PLUGIN="1"/>

--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.cc
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.cc
@@ -53,7 +53,7 @@ DTGeometryESModule::DTGeometryESModule(const edm::ParameterSet & p)
 
 DTGeometryESModule::~DTGeometryESModule(){}
 
-boost::shared_ptr<DTGeometry> 
+std::shared_ptr<DTGeometry> 
 DTGeometryESModule::produce(const MuonGeometryRecord & record) {
 
   //
@@ -91,7 +91,7 @@ void DTGeometryESModule::geometryCallback_( const MuonNumberingRecord& record ) 
   // Called whenever the muon numbering (or ideal geometry) changes
   //
 
-  _dtGeometry = boost::shared_ptr<DTGeometry>(new DTGeometry );
+  _dtGeometry = std::make_shared<DTGeometry>();
   edm::ESHandle<MuonDDDConstants> mdc;
   record.get( mdc );
 
@@ -108,7 +108,7 @@ void DTGeometryESModule::dbGeometryCallback_( const DTRecoGeometryRcd& record ) 
   // Called whenever the muon numbering (or ideal geometry) changes
   //
 
-  _dtGeometry = boost::shared_ptr<DTGeometry>(new DTGeometry );
+  _dtGeometry = std::make_shared<DTGeometry>();
   edm::ESHandle<RecoIdealGeometry> rig;
   record.get(rig);
   

--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
@@ -14,6 +14,7 @@
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <Geometry/DTGeometry/interface/DTGeometry.h>
 
+#include <memory>
 #include <string>
 
 class DTGeometryESModule : public edm::ESProducer {
@@ -25,12 +26,12 @@ public:
   virtual ~DTGeometryESModule();
 
   /// Produce DTGeometry.
-  boost::shared_ptr<DTGeometry> produce(const MuonGeometryRecord& record);
+  std::shared_ptr<DTGeometry> produce(const MuonGeometryRecord& record);
 
 private:  
   void geometryCallback_( const MuonNumberingRecord& record ) ;
   void dbGeometryCallback_( const DTRecoGeometryRcd& record ) ;
-  boost::shared_ptr<DTGeometry> _dtGeometry;
+  std::shared_ptr<DTGeometry> _dtGeometry;
 
   bool applyAlignment_; // Switch to apply alignment corrections
   const std::string alignmentsLabel_;

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.cc
@@ -38,7 +38,7 @@ DTGeometryBuilderFromCondDB::~DTGeometryBuilderFromCondDB() {
 
 /* Operations */ 
 void
-DTGeometryBuilderFromCondDB::build(boost::shared_ptr<DTGeometry> theGeometry,
+DTGeometryBuilderFromCondDB::build(std::shared_ptr<DTGeometry> theGeometry,
                                    const RecoIdealGeometry& rig) {
   //  cout << "DTGeometryBuilderFromCondDB " << endl;
   const std::vector<DetId>& detids(rig.detIds());

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
@@ -25,7 +25,7 @@ class DetId;
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
 /* C++ Headers */
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 /* ====================================================================== */
@@ -43,7 +43,7 @@ class DTGeometryBuilderFromCondDB{
     virtual ~DTGeometryBuilderFromCondDB() ;
 
 /* Operations */ 
-    void build(boost::shared_ptr<DTGeometry> theGeometry,
+    void build(std::shared_ptr<DTGeometry> theGeometry,
                const RecoIdealGeometry& rig);
 
   private:

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -33,7 +33,7 @@ DTGeometryBuilderFromDDD::DTGeometryBuilderFromDDD() {}
 DTGeometryBuilderFromDDD::~DTGeometryBuilderFromDDD(){}
 
 
-void DTGeometryBuilderFromDDD::build(boost::shared_ptr<DTGeometry> theGeometry,
+void DTGeometryBuilderFromDDD::build(std::shared_ptr<DTGeometry> theGeometry,
                                      const DDCompactView* cview,
                                      const MuonDDDConstants& muonConstants){
   //  cout << "DTGeometryBuilderFromDDD::build" << endl;
@@ -58,7 +58,7 @@ void DTGeometryBuilderFromDDD::build(boost::shared_ptr<DTGeometry> theGeometry,
 }
 
 
-void DTGeometryBuilderFromDDD::buildGeometry(boost::shared_ptr<DTGeometry> theGeometry,
+void DTGeometryBuilderFromDDD::buildGeometry(std::shared_ptr<DTGeometry> theGeometry,
                                              DDFilteredView& fv,
                                              const MuonDDDConstants& muonConstants) const {
   // static const string t0 = "DTGeometryBuilderFromDDD::buildGeometry";

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
@@ -10,8 +10,8 @@
  */
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 class DTGeometry;
 class DDCompactView;
@@ -31,7 +31,7 @@ class DTGeometryBuilderFromDDD {
     virtual ~DTGeometryBuilderFromDDD();
 
     // Operations
-    void build(boost::shared_ptr<DTGeometry> theGeometry,
+    void build(std::shared_ptr<DTGeometry> theGeometry,
                const DDCompactView* cview, 
                const MuonDDDConstants& muonConstants);
 
@@ -61,7 +61,7 @@ class DTGeometryBuilderFromDDD {
     RCPPlane plane(const DDFilteredView& fv, 
                    Bounds * bounds) const ;
 
-    void buildGeometry(boost::shared_ptr<DTGeometry> theGeometry,
+    void buildGeometry(std::shared_ptr<DTGeometry> theGeometry,
                        DDFilteredView& fv,
                        const MuonDDDConstants& muonConstants) const;
 

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.h
@@ -10,7 +10,6 @@
 
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 class DTGeometry;
 class DDCompactView;

--- a/Geometry/EcalAlgo/interface/WriteESAlignments.h
+++ b/Geometry/EcalAlgo/interface/WriteESAlignments.h
@@ -1,8 +1,6 @@
 #ifndef SOMEPACKAGE_WRITEESALIGNMENTS_H
 #define SOMEPACKAGE_WRITEESALIGNMENTS_H 1
 
-#include "boost/shared_ptr.hpp"
-
 namespace edm
 {
    class EventSetup ;

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/EcalTestBeam/plugins/BuildFile.xml
+++ b/Geometry/EcalTestBeam/plugins/BuildFile.xml
@@ -11,7 +11,6 @@
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/EcalTestBeam"/>
 <use   name="Geometry/EcalTestBeam"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <library   file="*.cc" name="GeometryEcalTestBeamPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryEPtest.h
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryEPtest.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.h
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.h
@@ -7,6 +7,7 @@
 #include "CondFormats/Alignment/interface/Alignments.h"
 
 #include "CLHEP/Geometry/Transform3D.h"
+#include <memory>
 #include <vector>
 
 /** \class EcalGeometryLoader
@@ -24,7 +25,7 @@ class CaloGeometryLoaderTest
 
       typedef std::vector< double > ParmVec ;
 
-      typedef boost::shared_ptr< CaloSubdetectorGeometry > PtrType ;
+      typedef std::shared_ptr< CaloSubdetectorGeometry > PtrType ;
 
       typedef CaloSubdetectorGeometry::ParVec    ParVec ;
       typedef CaloSubdetectorGeometry::ParVecVec ParVecVec ;

--- a/Geometry/ForwardGeometry/interface/ZdcHardcodeGeometryLoader.h
+++ b/Geometry/ForwardGeometry/interface/ZdcHardcodeGeometryLoader.h
@@ -3,7 +3,6 @@
 
 #include "Geometry/CaloGeometry/interface/CaloVGeometryLoader.h"
 #include "Geometry/ForwardGeometry/interface/ZdcTopology.h"
-#include <boost/shared_ptr.hpp>
 
 class CaloCellGeometry;
 class CaloSubdetectorGeometry;

--- a/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.h
+++ b/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/ForwardGeometry/plugins/ZdcHardcodeGeometryEP.h
+++ b/Geometry/ForwardGeometry/plugins/ZdcHardcodeGeometryEP.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -24,7 +23,7 @@ class ZdcHardcodeGeometryEP : public edm::ESProducer
       ZdcHardcodeGeometryEP(const edm::ParameterSet&);
       ~ZdcHardcodeGeometryEP();
 
-      typedef boost::shared_ptr<CaloSubdetectorGeometry> ReturnType;
+      typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
 
       ReturnType produce( const ZDCGeometryRecord&   ) ;
 

--- a/Geometry/GEMGeometryBuilder/plugins/GEMGeometryESModule.cc
+++ b/Geometry/GEMGeometryBuilder/plugins/GEMGeometryESModule.cc
@@ -34,7 +34,7 @@ GEMGeometryESModule::GEMGeometryESModule(const edm::ParameterSet & p)
 GEMGeometryESModule::~GEMGeometryESModule(){}
 
 
-boost::shared_ptr<GEMGeometry>
+std::shared_ptr<GEMGeometry>
 GEMGeometryESModule::produce(const MuonGeometryRecord & record) 
 {
   if(useDDD){
@@ -43,12 +43,12 @@ GEMGeometryESModule::produce(const MuonGeometryRecord & record)
     edm::ESHandle<MuonDDDConstants> mdc;
     record.getRecord<MuonNumberingRecord>().get(mdc);
     GEMGeometryBuilderFromDDD builder;
-    return boost::shared_ptr<GEMGeometry>(builder.build(&(*cpv), *mdc));
+    return std::shared_ptr<GEMGeometry>(builder.build(&(*cpv), *mdc));
   }else{
     edm::ESHandle<RecoIdealGeometry> riggem;
     record.getRecord<GEMRecoGeometryRcd>().get(riggem);
     GEMGeometryBuilderFromCondDB builder;
-    return boost::shared_ptr<GEMGeometry>(builder.build(*riggem));
+    return std::shared_ptr<GEMGeometry>(builder.build(*riggem));
   }
 }
 

--- a/Geometry/GEMGeometryBuilder/plugins/GEMGeometryESModule.h
+++ b/Geometry/GEMGeometryBuilder/plugins/GEMGeometryESModule.h
@@ -13,7 +13,7 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class GEMGeometryESModule : public edm::ESProducer 
 {
@@ -25,7 +25,7 @@ class GEMGeometryESModule : public edm::ESProducer
   virtual ~GEMGeometryESModule();
   
   /// Produce GEMGeometry.
-  boost::shared_ptr<GEMGeometry>  produce(const MuonGeometryRecord & record);
+  std::shared_ptr<GEMGeometry>  produce(const MuonGeometryRecord & record);
   
  private:  
   // use the DDD as Geometry source

--- a/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.cc
+++ b/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.cc
@@ -34,7 +34,7 @@ ME0GeometryESModule::ME0GeometryESModule(const edm::ParameterSet & p)
 ME0GeometryESModule::~ME0GeometryESModule(){}
 
 
-boost::shared_ptr<ME0Geometry>
+std::shared_ptr<ME0Geometry>
 ME0GeometryESModule::produce(const MuonGeometryRecord & record) 
 {
   if(useDDD){
@@ -43,12 +43,12 @@ ME0GeometryESModule::produce(const MuonGeometryRecord & record)
     edm::ESHandle<MuonDDDConstants> mdc;
     record.getRecord<MuonNumberingRecord>().get(mdc);
     ME0GeometryBuilderFromDDD builder;
-    return boost::shared_ptr<ME0Geometry>(builder.build(&(*cpv), *mdc));
+    return std::shared_ptr<ME0Geometry>(builder.build(&(*cpv), *mdc));
   }else{
     edm::ESHandle<RecoIdealGeometry> rigme0;
     record.getRecord<ME0RecoGeometryRcd>().get(rigme0);
     ME0GeometryBuilderFromCondDB builder;
-    return boost::shared_ptr<ME0Geometry>(builder.build(*rigme0));
+    return std::shared_ptr<ME0Geometry>(builder.build(*rigme0));
   }
 }
 

--- a/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.h
+++ b/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.h
@@ -13,7 +13,7 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class ME0GeometryESModule : public edm::ESProducer 
 {
@@ -25,7 +25,7 @@ class ME0GeometryESModule : public edm::ESProducer
   virtual ~ME0GeometryESModule();
   
   /// Produce ME0Geometry.
-  boost::shared_ptr<ME0Geometry>  produce(const MuonGeometryRecord & record);
+  std::shared_ptr<ME0Geometry>  produce(const MuonGeometryRecord & record);
   
  private:  
   // use the DDD as Geometry source

--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
@@ -23,7 +23,7 @@ GlobalTrackingGeometryESProducer::GlobalTrackingGeometryESProducer(const edm::Pa
 
 GlobalTrackingGeometryESProducer::~GlobalTrackingGeometryESProducer(){}
 
-boost::shared_ptr<GlobalTrackingGeometry>
+std::shared_ptr<GlobalTrackingGeometry>
 GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& record) {
 
   TrackerGeometry const* tk = nullptr;
@@ -92,7 +92,7 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
   }
 
   GlobalTrackingGeometryBuilder builder;
-  return boost::shared_ptr<GlobalTrackingGeometry>(builder.build(tk, dt, csc, rpc, gem, me0));
+  return std::shared_ptr<GlobalTrackingGeometry>(builder.build(tk, dt, csc, rpc, gem, me0));
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(GlobalTrackingGeometryESProducer);

--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.h
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.h
@@ -12,7 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 class GlobalTrackingGeometry;
@@ -27,7 +27,7 @@ public:
   virtual ~GlobalTrackingGeometryESProducer();
 
   /// Produce GlobalTrackingGeometry
-  boost::shared_ptr<GlobalTrackingGeometry> produce(const GlobalTrackingGeometryRecord& record);
+  std::shared_ptr<GlobalTrackingGeometry> produce(const GlobalTrackingGeometryRecord& record);
 
 private:  
 

--- a/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 // user include files
 #include <FWCore/Framework/interface/ModuleFactory.h>

--- a/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
@@ -8,7 +8,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalParametersFromDD.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 //#define DeugLog
 
@@ -17,7 +17,7 @@ public:
   HGCalParametersESModule( const edm::ParameterSet & );
   ~HGCalParametersESModule( void );
   
-  typedef boost::shared_ptr<HGCalParameters> ReturnType;
+  typedef std::shared_ptr<HGCalParameters> ReturnType;
   
   ReturnType produce( const IdealGeometryRecord&);
 

--- a/Geometry/HGCalGeometry/BuildFile.xml
+++ b/Geometry/HGCalGeometry/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
-<use   name="boost"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Geometry/HGCalGeometry/plugins/BuildFile.xml
+++ b/Geometry/HGCalGeometry/plugins/BuildFile.xml
@@ -5,6 +5,5 @@
   <use   name="Geometry/CaloTopology"/>
   <use   name="Geometry/Records"/>
   <use   name="CondFormats/GeometryObjects"/>
-  <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/HGCalGeometry/plugins/HGCalGeometryESProducer.cc
+++ b/Geometry/HGCalGeometry/plugins/HGCalGeometryESProducer.cc
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -42,7 +41,7 @@ public:
   HGCalGeometryESProducer( const edm::ParameterSet& iP );
   virtual ~HGCalGeometryESProducer() ;
 
-  typedef boost::shared_ptr<HGCalGeometry> ReturnType;
+  typedef std::shared_ptr<HGCalGeometry> ReturnType;
 
   ReturnType produce(const IdealGeometryRecord&);
 

--- a/Geometry/HcalCommonData/plugins/BuildFile.xml
+++ b/Geometry/HcalCommonData/plugins/BuildFile.xml
@@ -4,6 +4,5 @@
   <use   name="Geometry/Records"/>
   <use   name="Geometry/HcalCommonData"/>
   <use   name="CondFormats/GeometryObjects"/>
-  <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
@@ -20,7 +20,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 // user include files
 #include <FWCore/Framework/interface/ModuleFactory.h>
@@ -41,7 +40,7 @@ public:
   HcalDDDRecConstantsESModule(const edm::ParameterSet&);
   ~HcalDDDRecConstantsESModule();
 
-  typedef boost::shared_ptr<HcalDDDRecConstants> ReturnType;
+  typedef std::shared_ptr<HcalDDDRecConstants> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & );
 

--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 // user include files
 #include <FWCore/Framework/interface/ModuleFactory.h>
@@ -37,7 +36,7 @@ public:
   HcalDDDSimConstantsESModule(const edm::ParameterSet&);
   ~HcalDDDSimConstantsESModule();
 
-  typedef boost::shared_ptr<HcalDDDSimConstants> ReturnType;
+  typedef std::shared_ptr<HcalDDDSimConstants> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & );
 

--- a/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
@@ -10,7 +10,7 @@
 #include "Geometry/Records/interface/HcalParametersRcd.h"
 #include "Geometry/HcalCommonData/interface/HcalParametersFromDD.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
  
 
 class  HcalParametersESModule : public edm::ESProducer {
@@ -18,7 +18,7 @@ public:
   HcalParametersESModule( const edm::ParameterSet & );
   ~HcalParametersESModule( void );
   
-  typedef boost::shared_ptr<HcalParameters> ReturnType;
+  typedef std::shared_ptr<HcalParameters> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & );
   

--- a/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
+++ b/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -30,7 +29,7 @@ public:
   CaloTowerTopologyEP(const edm::ParameterSet&);
   ~CaloTowerTopologyEP();
 
-  typedef boost::shared_ptr<CaloTowerTopology> ReturnType;
+  typedef std::shared_ptr<CaloTowerTopology> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & descriptions );
     

--- a/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
@@ -21,8 +21,8 @@ class HcalAlignmentEP : public edm::ESProducer {
 
 public:
 
-  typedef boost::shared_ptr<Alignments>      ReturnAli    ;
-  typedef boost::shared_ptr<AlignmentErrors> ReturnAliErr ;
+  typedef std::shared_ptr<Alignments>      ReturnAli    ;
+  typedef std::shared_ptr<AlignmentErrors> ReturnAliErr ;
 
   typedef AlignTransform::Translation Trl ;
   typedef AlignTransform::Rotation    Rot ;

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -28,7 +27,7 @@ public:
   HcalDDDGeometryEP(const edm::ParameterSet&);
   ~HcalDDDGeometryEP();
 
-  typedef boost::shared_ptr<CaloSubdetectorGeometry> ReturnType;
+  typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
  
   void idealRecordCallBack(const HcalRecNumberingRecord&) {}
 

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -20,7 +19,7 @@ public:
   HcalHardcodeGeometryEP(const edm::ParameterSet&);
   virtual ~HcalHardcodeGeometryEP();
 
-  typedef boost::shared_ptr<CaloSubdetectorGeometry> ReturnType;
+  typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
 
   ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord& );

--- a/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
@@ -4,7 +4,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -29,7 +28,7 @@ public:
   HcalTopologyIdealEP(const edm::ParameterSet&);
   ~HcalTopologyIdealEP();
 
-  typedef boost::shared_ptr<HcalTopology> ReturnType;
+  typedef std::shared_ptr<HcalTopology> ReturnType;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/Geometry/HcalTowerAlgo/plugins/BuildFile.xml
+++ b/Geometry/HcalTowerAlgo/plugins/BuildFile.xml
@@ -4,6 +4,5 @@
   <use   name="Geometry/Records"/>
   <use   name="Geometry/HcalTowerAlgo"/>
   <use   name="CondFormats/GeometryObjects"/>
-  <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -12,14 +12,13 @@ HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::Par
 HcalTrigTowerGeometryESProducer::~HcalTrigTowerGeometryESProducer( void ) 
 {}
 
-boost::shared_ptr<HcalTrigTowerGeometry>
+std::shared_ptr<HcalTrigTowerGeometry>
 HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 {
     edm::ESHandle<HcalTopology> hcalTopology;
     iRecord.getRecord<HcalRecNumberingRecord>().get( hcalTopology );
 
-    m_hcalTrigTowerGeom =
-	boost::shared_ptr<HcalTrigTowerGeometry>( new HcalTrigTowerGeometry( &*hcalTopology));
+    m_hcalTrigTowerGeom = std::make_shared<HcalTrigTowerGeometry>( &*hcalTopology);
     HcalTopologyMode::TriggerMode tmode=hcalTopology->triggerMode();
     bool enableRCTHF=(tmode==HcalTopologyMode::tm_LHC_RCT || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
     bool enable1x1HF=(tmode==HcalTopologyMode::tm_LHC_1x1 || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -1,7 +1,7 @@
 #ifndef HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H
 # define HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H
 
-# include "boost/shared_ptr.hpp"
+# include <memory>
 
 # include "FWCore/Framework/interface/ESProducer.h"
 # include "Geometry/Records/interface/CaloGeometryRecord.h"
@@ -17,12 +17,12 @@ public:
   HcalTrigTowerGeometryESProducer( const edm::ParameterSet & conf );
   virtual ~HcalTrigTowerGeometryESProducer( void );
 
-  boost::shared_ptr<HcalTrigTowerGeometry> produce( const CaloGeometryRecord & );
+  std::shared_ptr<HcalTrigTowerGeometry> produce( const CaloGeometryRecord & );
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  boost::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
+  std::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
 };
 
 #endif // HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H

--- a/Geometry/HcalTowerAlgo/test/BuildFile.xml
+++ b/Geometry/HcalTowerAlgo/test/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/PythonParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <use   name="Geometry/Records"/>
-<use   name="boost"/>
 <library   file="CaloTowerGeometryAnalyzer.cc" name="testCaloTowerGeometryESProducer">
  <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
@@ -17,7 +17,6 @@
 //
 
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.cc
+++ b/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.cc
@@ -36,7 +36,7 @@ RPCGeometryESModule::RPCGeometryESModule(const edm::ParameterSet & p){
 RPCGeometryESModule::~RPCGeometryESModule(){}
 
 
-boost::shared_ptr<RPCGeometry>
+std::shared_ptr<RPCGeometry>
 RPCGeometryESModule::produce(const MuonGeometryRecord & record) {
   if(useDDD){
     edm::ESTransientHandle<DDCompactView> cpv;
@@ -44,12 +44,12 @@ RPCGeometryESModule::produce(const MuonGeometryRecord & record) {
     edm::ESHandle<MuonDDDConstants> mdc;
     record.getRecord<MuonNumberingRecord>().get(mdc);
     RPCGeometryBuilderFromDDD builder(comp11);
-    return boost::shared_ptr<RPCGeometry>(builder.build(&(*cpv), *mdc));
+    return std::shared_ptr<RPCGeometry>(builder.build(&(*cpv), *mdc));
   }else{
     edm::ESHandle<RecoIdealGeometry> rigrpc;
     record.getRecord<RPCRecoGeometryRcd>().get(rigrpc);
     RPCGeometryBuilderFromCondDB builder(comp11);
-    return boost::shared_ptr<RPCGeometry>(builder.build(*rigrpc));
+    return std::shared_ptr<RPCGeometry>(builder.build(*rigrpc));
   }
 
 }

--- a/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.h
+++ b/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.h
@@ -12,7 +12,7 @@
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class RPCGeometryESModule : public edm::ESProducer {
 public:
@@ -23,7 +23,7 @@ public:
   virtual ~RPCGeometryESModule();
 
   /// Produce RPCGeometry.
-  boost::shared_ptr<RPCGeometry>  produce(const MuonGeometryRecord & record);
+  std::shared_ptr<RPCGeometry>  produce(const MuonGeometryRecord & record);
 
 private:  
 

--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
@@ -1,8 +1,6 @@
 #ifndef Geometry_TrackerGeometryBuilder_PixelGeomDetUnit_H
 #define Geometry_TrackerGeometryBuilder_PixelGeomDetUnit_H
 
-#include <boost/shared_ptr.hpp>
-
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h"

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
@@ -1,8 +1,6 @@
 #ifndef Geometry_TrackerGeometryBuilder_StripGeomDetUnit_H
 #define Geometry_TrackerGeometryBuilder_StripGeomDetUnit_H
 
-#include <boost/shared_ptr.hpp>
-
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h"

--- a/Geometry/TrackerGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/plugins/BuildFile.xml
@@ -9,6 +9,5 @@
   <use   name="Geometry/Records"/>
   <use   name="Geometry/TrackerGeometryBuilder"/>
   <use   name="Geometry/TrackerNumberingBuilder"/>
-  <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
@@ -67,7 +67,7 @@ TrackerDigiGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions & d
 }
 
 //__________________________________________________________________
-boost::shared_ptr<TrackerGeometry> 
+std::shared_ptr<TrackerGeometry> 
 TrackerDigiGeometryESModule::produce(const TrackerDigiGeometryRecord & iRecord)
 { 
   //
@@ -84,7 +84,7 @@ TrackerDigiGeometryESModule::produce(const TrackerDigiGeometryRecord & iRecord)
   iRecord.getRecord<PTrackerParametersRcd>().get( ptp );
   
   TrackerGeomBuilderFromGeometricDet builder;
-  _tracker  = boost::shared_ptr<TrackerGeometry>(builder.build(&(*gD), *ptp, tTopo));
+  _tracker  = std::shared_ptr<TrackerGeometry>(builder.build(&(*gD), *ptp, tTopo));
 
   if (applyAlignment_) {
     // Since fake is fully working when checking for 'empty', we should get rid of applyAlignment_!

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.h
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.h
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <string>
 
@@ -17,13 +17,13 @@ class  TrackerDigiGeometryESModule: public edm::ESProducer{
  public:
   TrackerDigiGeometryESModule(const edm::ParameterSet & p);
   virtual ~TrackerDigiGeometryESModule(); 
-  boost::shared_ptr<TrackerGeometry> produce(const TrackerDigiGeometryRecord &);
+  std::shared_ptr<TrackerGeometry> produce(const TrackerDigiGeometryRecord &);
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
  private:
   /// Called when geometry description changes
-  boost::shared_ptr<TrackerGeometry> _tracker;
+  std::shared_ptr<TrackerGeometry> _tracker;
   const std::string alignmentsLabel_;
   const std::string myLabel_;
   bool applyAlignment_; // Switch to apply alignment corrections

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.h
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.h
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -18,7 +18,7 @@ class  TrackerParametersESModule: public edm::ESProducer
   TrackerParametersESModule( const edm::ParameterSet & );
   ~TrackerParametersESModule( void );
 
-  typedef boost::shared_ptr<PTrackerParameters> ReturnType;
+  typedef std::shared_ptr<PTrackerParameters> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & );
   

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetExtraESModule.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetExtraESModule.cc
@@ -29,9 +29,9 @@ TrackerGeometricDetExtraESModule::TrackerGeometricDetExtraESModule(const edm::Pa
 
 TrackerGeometricDetExtraESModule::~TrackerGeometricDetExtraESModule() {}
 
-boost::shared_ptr<std::vector<GeometricDetExtra> >
+std::shared_ptr<std::vector<GeometricDetExtra> >
 TrackerGeometricDetExtraESModule::produce(const IdealGeometryRecord & iRecord) {
-  boost::shared_ptr<std::vector<GeometricDetExtra> > gde (new std::vector<GeometricDetExtra>);
+  auto gde = std::make_shared<std::vector<GeometricDetExtra> >();
   // get the GeometricDet which has a nav_type
   edm::ESHandle<GeometricDet> gd;
   iRecord.get ( gd );
@@ -175,7 +175,7 @@ TrackerGeometricDetExtraESModule::produce(const IdealGeometryRecord & iRecord) {
 				       , pgdes[i]._material, nm));
     }
   }
-  return boost::shared_ptr<std::vector<GeometricDetExtra> >(gde);
+  return std::shared_ptr<std::vector<GeometricDetExtra> >(gde);
 }
 
 void TrackerGeometricDetExtraESModule::putOne(std::vector<GeometricDetExtra> & gde, const GeometricDet* gd, const DDExpandedView& ev, int lev ) {

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetExtraESModule.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetExtraESModule.h
@@ -12,7 +12,7 @@ class  TrackerGeometricDetExtraESModule: public edm::ESProducer {
  public:
   TrackerGeometricDetExtraESModule(const edm::ParameterSet & p);
   virtual ~TrackerGeometricDetExtraESModule(); 
-  boost::shared_ptr<std::vector<GeometricDetExtra> > produce(const IdealGeometryRecord &);
+  std::shared_ptr<std::vector<GeometricDetExtra> > produce(const IdealGeometryRecord &);
 
  protected:
 

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerTopologyEP.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerTopologyEP.h
@@ -1,7 +1,7 @@
 #ifndef GEOMETRY_TRACKERNUMBERINGBUILDER_TRACKERTOPOLOGYEP_H
 #define GEOMETRY_TRACKERNUMBERINGBUILDER_TRACKERTOPOLOGYEP_H 1
 
-#include "boost/shared_ptr.hpp"
+#include "memory"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
@@ -17,7 +17,7 @@ public:
   TrackerTopologyEP( const edm::ParameterSet & );
   ~TrackerTopologyEP( void );
 
-  typedef boost::shared_ptr<TrackerTopology> ReturnType;
+  typedef std::shared_ptr<TrackerTopology> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & descriptions );
     

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
@@ -1,5 +1,3 @@
-#include "boost/shared_ptr.hpp"
-
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for geometry, alignment, and visualization packages. Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation. The changes to geometry and alignment were not independent, so they are being done in a single PR.
This PR is totally technical.
