### PR TITLE
use std::shared_ptr and std::make_shared (EventSetup in Reco)

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -35,7 +34,7 @@ public:
       EcalRegionCablingESProducer(const edm::ParameterSet&);
   ~EcalRegionCablingESProducer();
 
-  typedef boost::shared_ptr<EcalRegionCabling> ReturnType;
+  typedef std::shared_ptr<EcalRegionCabling> ReturnType;
 
   ReturnType produce(const EcalRegionCablingRecord&);
 private:

--- a/RecoBTag/PerformanceDB/plugins/BtagPerformanceESProducer.cc
+++ b/RecoBTag/PerformanceDB/plugins/BtagPerformanceESProducer.cc
@@ -24,7 +24,7 @@ BtagPerformanceESProducer::BtagPerformanceESProducer(const edm::ParameterSet & p
 
 BtagPerformanceESProducer::~BtagPerformanceESProducer() {}
 
-boost::shared_ptr<BtagPerformance> 
+std::shared_ptr<BtagPerformance> 
 BtagPerformanceESProducer::produce(const BTagPerformanceRecord & iRecord){ 
    ESHandle<PerformancePayload> pl;
    //ESHandle<PhysicsPerformancePayload> pl;
@@ -41,8 +41,8 @@ BtagPerformanceESProducer::produce(const BTagPerformanceRecord & iRecord){
    
    
    
-   _perf  = boost::shared_ptr<BtagPerformance>(new BtagPerformance(*((pl.product())), *((wp.product()))));
-   //    _perf  = boost::shared_ptr<BtagPerformance>(new BtagPerformance(*((pl.product())), wp));
+   _perf  = std::make_shared<BtagPerformance>(*((pl.product())), *((wp.product())));
+   //    _perf  = std::make_shared<BtagPerformance>(*((pl.product())), wp);
    return _perf;
 }
 

--- a/RecoBTag/PerformanceDB/plugins/BtagPerformanceESProducer.h
+++ b/RecoBTag/PerformanceDB/plugins/BtagPerformanceESProducer.h
@@ -7,15 +7,15 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  BtagPerformanceESProducer : public edm::ESProducer{
  public:
   BtagPerformanceESProducer(const edm::ParameterSet & p);
   virtual ~BtagPerformanceESProducer(); 
-  boost::shared_ptr<BtagPerformance> produce(const  BTagPerformanceRecord &);
+  std::shared_ptr<BtagPerformance> produce(const  BTagPerformanceRecord &);
  private:
-  boost::shared_ptr<BtagPerformance> _perf;
+  std::shared_ptr<BtagPerformance> _perf;
   edm::ParameterSet pset_;
   std::string mypl;
   std::string mywp;

--- a/RecoBTag/PerformanceDB/plugins/BuildFile.xml
+++ b/RecoBTag/PerformanceDB/plugins/BuildFile.xml
@@ -14,5 +14,4 @@
   <use   name="CondCore/DBOutputService"/>
   <use   name="PhysicsTools/CondLiteIO"/>
   <use   name="PhysicsTools/UtilAlgos"/>
-  <use   name="boost"/>
 </library>

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
@@ -4,8 +4,7 @@
 #include <string>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,20 +21,20 @@ public:
   JetTagComputerESProducer(const edm::ParameterSet & pset) : m_pset(pset) {
     setWhatProduced(this, m_pset.getParameter<std::string>("@module_label") );
 
-    m_jetTagComputer = boost::make_shared<ConcreteJetTagComputer>(m_pset);
+    m_jetTagComputer = std::make_shared<ConcreteJetTagComputer>(m_pset);
   }
   
   virtual ~JetTagComputerESProducer() {
   }
 
-  boost::shared_ptr<JetTagComputer> produce(const JetTagComputerRecord & record) {
+  std::shared_ptr<JetTagComputer> produce(const JetTagComputerRecord & record) {
     m_jetTagComputer->initialize(record);
     m_jetTagComputer->setupDone();
     return m_jetTagComputer;
   }
 
 private:
-  boost::shared_ptr<JetTagComputer> m_jetTagComputer;
+  std::shared_ptr<JetTagComputer> m_jetTagComputer;
   edm::ParameterSet m_pset;
 };
 

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.cc
@@ -2,7 +2,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 // user include files
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoEcal/EgammaCoreTools/plugins/EcalNextToDeadChannelESProducer.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalNextToDeadChannelESProducer.cc
@@ -1,6 +1,6 @@
 
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -26,7 +26,7 @@ class EcalNextToDeadChannelESProducer : public edm::ESProducer {
 public:
   EcalNextToDeadChannelESProducer(const edm::ParameterSet& iConfig);
   
-  typedef boost::shared_ptr<EcalNextToDeadChannel> ReturnType;
+  typedef std::shared_ptr<EcalNextToDeadChannel> ReturnType;
   
   ReturnType produce(const EcalNextToDeadChannelRcd& iRecord);
   

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h
@@ -24,7 +24,6 @@
 #include <memory>
 #include <fstream>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 #include "RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h"
 #include "RecoEgamma/ElectronIdentification/interface/LikelihoodSwitches.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
+++ b/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
@@ -1,4 +1,4 @@
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -21,7 +21,7 @@ class EcalSeverityLevelESProducer : public edm::ESProducer {
 public:
   EcalSeverityLevelESProducer(const edm::ParameterSet& iConfig);
   
-  typedef boost::shared_ptr<EcalSeverityLevelAlgo> ReturnType;
+  typedef std::shared_ptr<EcalSeverityLevelAlgo> ReturnType;
   
   ReturnType produce(const EcalSeverityLevelAlgoRcd& iRecord);
   

--- a/RecoLocalCalo/EcalRecProducers/test/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecProducers/test/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="FWCore/Framework"/>
 <use   name="DQMServices/Core"/>
-<use   name="boost"/>
 <use   name="root"/>
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/DataRecord"/>

--- a/RecoLocalCalo/EcalRecProducers/test/stubs/EcalSampleMaskRecordESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/test/stubs/EcalSampleMaskRecordESProducer.cc
@@ -1,4 +1,4 @@
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -21,7 +21,7 @@ class EcalSampleMaskRecordESProducer : public edm::ESProducer {
 public:
   EcalSampleMaskRecordESProducer(const edm::ParameterSet& iConfig);
   
-  typedef boost::shared_ptr<EcalSampleMask> ReturnType;
+  typedef std::shared_ptr<EcalSampleMask> ReturnType;
   
   ReturnType produce(const EcalSampleMaskRcd& iRecord);
   

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -43,7 +42,7 @@ class HcalRecAlgoESProducer : public edm::ESProducer {
 
       ~HcalRecAlgoESProducer();
 
-      typedef boost::shared_ptr<HcalSeverityLevelComputer> ReturnType;
+      typedef std::shared_ptr<HcalSeverityLevelComputer> ReturnType;
 
       ReturnType produce(const HcalSeverityLevelComputerRcd&);
    private:

--- a/RecoLocalMuon/RPCRecHit/src/CSCObjectMapESProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCObjectMapESProducer.cc
@@ -1,7 +1,5 @@
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -21,8 +19,8 @@ public:
   ~CSCObjectMapESProducer() {
   }
 
-  boost::shared_ptr<CSCObjectMap> produce(MuonGeometryRecord const& record) {
-    return boost::make_shared<CSCObjectMap>(record);
+  std::shared_ptr<CSCObjectMap> produce(MuonGeometryRecord const& record) {
+    return std::make_shared<CSCObjectMap>(record);
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalMuon/RPCRecHit/src/DTObjectMapESProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTObjectMapESProducer.cc
@@ -1,7 +1,5 @@
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -21,8 +19,8 @@ public:
   ~DTObjectMapESProducer() {
   }
 
-  boost::shared_ptr<DTObjectMap> produce(MuonGeometryRecord const& record) {
-    return boost::make_shared<DTObjectMap>(record);
+  std::shared_ptr<DTObjectMap> produce(MuonGeometryRecord const& record) {
+    return std::make_shared<DTObjectMap>(record);
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -8,8 +8,6 @@
 
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <memory>
 #include <map>
 
@@ -18,7 +16,7 @@ class Phase2StripCPEESProducer: public edm::ESProducer {
     public:
     
         Phase2StripCPEESProducer(const edm::ParameterSet&);
-        boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > produce(const TkStripCPERecord & iRecord);
+        std::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > produce(const TkStripCPERecord & iRecord);
 
     private:
 
@@ -27,7 +25,7 @@ class Phase2StripCPEESProducer: public edm::ESProducer {
 
         CPE_t cpeNum_;
         edm::ParameterSet pset_;
-        boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe_;
+        std::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe_;
 
 };
 
@@ -43,12 +41,12 @@ Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet & p) 
   setWhatProduced(this, name);
 }
 
-boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripCPEESProducer::produce(const TkStripCPERecord & iRecord) {
+std::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripCPEESProducer::produce(const TkStripCPERecord & iRecord) {
 
   switch(cpeNum_) {
 
     case TRIVIAL:
-      cpe_ = boost::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> >(new Phase2StripCPETrivial());
+      cpe_ = std::make_shared<Phase2StripCPETrivial>();
       break;
 
   }

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/BuildFile.xml
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="root"/>
 <use   name="classlib"/>
 <use   name="clhep"/>

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  PixelCPEGenericESProducer: public edm::ESProducer{
  public:
   PixelCPEGenericESProducer(const edm::ParameterSet & p);
   virtual ~PixelCPEGenericESProducer(); 
-  boost::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
-  boost::shared_ptr<PixelClusterParameterEstimator> cpe_;
+  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   edm::ESInputTag magname_;
   bool useLAWidthFromDB_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  PixelCPETemplateRecoESProducer: public edm::ESProducer{
  public:
   PixelCPETemplateRecoESProducer(const edm::ParameterSet & p);
   virtual ~PixelCPETemplateRecoESProducer(); 
-  boost::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
-  boost::shared_ptr<PixelClusterParameterEstimator> cpe_;
+  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   bool DoLorentz_;
 };

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -47,7 +47,7 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p
 
 PixelCPEGenericESProducer::~PixelCPEGenericESProducer() {}
 
-boost::shared_ptr<PixelClusterParameterEstimator>
+std::shared_ptr<PixelClusterParameterEstimator>
 PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -86,10 +86,10 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
     //} else {
     //std::cout<<" pass an empty GenError pointer"<<std::endl;
   }
-  cpe_  = boost::shared_ptr<PixelClusterParameterEstimator>
-    (new PixelCPEGeneric(pset_,magfield.product(),*pDD.product(),
+  cpe_  = std::make_shared<PixelCPEGeneric>(
+                         pset_,magfield.product(),*pDD.product(),
 			 *hTT.product(),lorentzAngle.product(),
-			 genErrorDBObjectProduct,lorentzAngleWidthProduct) );
+			 genErrorDBObjectProduct,lorentzAngleWidthProduct);
 
 #else  // old full templates, not used anymore  
   // Errors can be used from tempaltes or from GenError, for testing only
@@ -104,9 +104,9 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
   ESHandle<SiPixelTemplateDBObject> templateDBobject;
   iRecord.getRecord<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
 
-  cpe_  = boost::shared_ptr<PixelClusterParameterEstimator>(new PixelCPEGeneric(
-										pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngle.product(),genErrorDBObjectProduct,
-										templateDBobject.product(),lorentzAngleWidthProduct) );
+  cpe_  = std::make_shared<PixelCPEGeneric>(
+					pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngle.product(),genErrorDBObjectProduct,
+					templateDBobject.product(),lorentzAngleWidthProduct);
 #endif
 
   return cpe_;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -35,7 +35,7 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
 
 PixelCPETemplateRecoESProducer::~PixelCPETemplateRecoESProducer() {}
 
-boost::shared_ptr<PixelClusterParameterEstimator> 
+std::shared_ptr<PixelClusterParameterEstimator> 
 PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -60,8 +60,8 @@ PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){
   ESHandle<SiPixelTemplateDBObject> templateDBobject;
   iRecord.getRecord<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
 
-  //  cpe_  = boost::shared_ptr<PixelClusterParameterEstimator>(new PixelCPETemplateReco(pset_,magfield.product(),lorentzAngle.product(),templateDBobject.product() ));
-  cpe_  = boost::shared_ptr<PixelClusterParameterEstimator>(new PixelCPETemplateReco(pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngleProduct,templateDBobject.product() ));
+  //  cpe_  = std::make_shared<PixelCPETemplateReco>(pset_,magfield.product(),lorentzAngle.product(),templateDBobject.product() );
+  cpe_  = std::make_shared<PixelCPETemplateReco>(pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngleProduct,templateDBobject.product() );
   return cpe_;
 }
 

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.cc
@@ -6,11 +6,11 @@ ClusterizerUnitTesterESProducer(const edm::ParameterSet& conf) :
   noises(new SiStripNoises())
 {
   edm::FileInPath testInfo(("RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTestDetInfo.dat"));
-  quality = boost::shared_ptr<SiStripQuality>(new SiStripQuality(testInfo));
+  quality = std::make_shared<SiStripQuality>(testInfo);
 
   extractNoiseGainQuality(conf);
 
-  gain = boost::shared_ptr<SiStripGain>(new SiStripGain(*apvGain,1));
+  gain = std::make_shared<SiStripGain>(*apvGain,1);
 
   quality->cleanUp();
   quality->fillBadComponents();

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.h
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.h
@@ -13,7 +13,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class ClusterizerUnitTesterESProducer: public edm::ESProducer {
   typedef edm::ParameterSet PSet;
@@ -22,9 +22,9 @@ class ClusterizerUnitTesterESProducer: public edm::ESProducer {
  public:
   ClusterizerUnitTesterESProducer(const PSet&);
   ~ClusterizerUnitTesterESProducer(){}
-  boost::shared_ptr<SiStripGain> produceGainRcd(const SiStripGainRcd&) { return gain;}
-  boost::shared_ptr<SiStripNoises> produceNoisesRcd(const SiStripNoisesRcd&) { return noises;}
-  boost::shared_ptr<SiStripQuality> produceQualityRcd(const SiStripQualityRcd&) {return quality;}
+  std::shared_ptr<SiStripGain> produceGainRcd(const SiStripGainRcd&) { return gain;}
+  std::shared_ptr<SiStripNoises> produceNoisesRcd(const SiStripNoisesRcd&) { return noises;}
+  std::shared_ptr<SiStripQuality> produceQualityRcd(const SiStripQualityRcd&) {return quality;}
  private:
   
   void extractNoiseGainQuality(const PSet&);
@@ -33,9 +33,9 @@ class ClusterizerUnitTesterESProducer: public edm::ESProducer {
   void setNoises(uint32_t, std::vector<std::pair<uint16_t,float> >&);
   void setGains( uint32_t, std::vector<std::pair<uint16_t,float> >&);
 
-  boost::shared_ptr<SiStripApvGain> apvGain;
-  boost::shared_ptr<SiStripGain> gain;
-  boost::shared_ptr<SiStripNoises>  noises;
-  boost::shared_ptr<SiStripQuality> quality;
+  std::shared_ptr<SiStripApvGain> apvGain;
+  std::shared_ptr<SiStripGain> gain;
+  std::shared_ptr<SiStripNoises>  noises;
+  std::shared_ptr<SiStripQuality> quality;
 };
 #endif

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitMatcherESProducer.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitMatcherESProducer.cc
@@ -12,10 +12,10 @@ SiStripRecHitMatcherESProducer::SiStripRecHitMatcherESProducer(const edm::Parame
   setWhatProduced(this,name);
 }
 
-boost::shared_ptr<SiStripRecHitMatcher> SiStripRecHitMatcherESProducer::
+std::shared_ptr<SiStripRecHitMatcher> SiStripRecHitMatcherESProducer::
 produce(const TkStripCPERecord & iRecord)
 { 
-  matcher_  = boost::shared_ptr<SiStripRecHitMatcher>(new SiStripRecHitMatcher(pset_));
+  matcher_  = std::make_shared<SiStripRecHitMatcher>(pset_);
   return matcher_;
 }
 

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitMatcherESProducer.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitMatcherESProducer.h
@@ -5,14 +5,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class SiStripRecHitMatcherESProducer: public edm::ESProducer {
  public:
   SiStripRecHitMatcherESProducer(const edm::ParameterSet&);
-  boost::shared_ptr<SiStripRecHitMatcher> produce(const TkStripCPERecord&);
+  std::shared_ptr<SiStripRecHitMatcher> produce(const TkStripCPERecord&);
  private:
-  boost::shared_ptr<SiStripRecHitMatcher> matcher_;
+  std::shared_ptr<SiStripRecHitMatcher> matcher_;
   edm::ParameterSet pset_;
 };
 #endif

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
@@ -32,7 +32,7 @@ StripCPEESProducer::StripCPEESProducer(const edm::ParameterSet & p)
   setWhatProduced(this,name);
 }
 
-boost::shared_ptr<StripClusterParameterEstimator> StripCPEESProducer::
+std::shared_ptr<StripClusterParameterEstimator> StripCPEESProducer::
 produce(const TkStripCPERecord & iRecord) 
 { 
   edm::ESHandle<TrackerGeometry> pDD;  iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );
@@ -49,19 +49,19 @@ produce(const TkStripCPERecord & iRecord)
   switch(cpeNum) {
 
   case SIMPLE:     
-    cpe = boost::shared_ptr<StripClusterParameterEstimator>(new StripCPE( parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency ));  
+    cpe = std::make_shared<StripCPE>( parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency );
     break;
     
   case TRACKANGLE: 
-    cpe = boost::shared_ptr<StripClusterParameterEstimator>(new StripCPEfromTrackAngle( parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency )); 
+    cpe = std::make_shared<StripCPEfromTrackAngle>( parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency );
     break;
     
   case GEOMETRIC:  
-    cpe = boost::shared_ptr<StripClusterParameterEstimator>(new StripCPEgeometric(parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency )); 
+    cpe = std::make_shared<StripCPEgeometric>(parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency ); 
     break;  
 
   case TEMPLATE: 
-    cpe = boost::shared_ptr<StripClusterParameterEstimator>(new StripCPEfromTemplate( parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency )); 
+    cpe = std::make_shared<StripCPEfromTemplate>( parametersPSet, *magfield, *pDD, *lorentzAngle, *backPlaneCorrection, *confObj, *latency ); 
     break;
 
   }

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.h
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <map>
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
@@ -16,7 +16,7 @@ class  StripCPEESProducer: public edm::ESProducer {
  public:
 
   StripCPEESProducer(const edm::ParameterSet&);
-  boost::shared_ptr<StripClusterParameterEstimator> produce(const TkStripCPERecord&);
+  std::shared_ptr<StripClusterParameterEstimator> produce(const TkStripCPERecord&);
 
  private:
 
@@ -25,7 +25,7 @@ class  StripCPEESProducer: public edm::ESProducer {
 
   CPE_t cpeNum;
   edm::ParameterSet parametersPSet;
-  boost::shared_ptr<StripClusterParameterEstimator> cpe;
+  std::shared_ptr<StripClusterParameterEstimator> cpe;
 
 };
 #endif

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
@@ -8,7 +8,6 @@ Description: A essource/esproducer for lumi values from DIP via runtime logger D
 */
 
 //#include <memory>
-//#include "boost/shared_ptr.hpp"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -75,7 +74,7 @@ DIPLumiProducer::produceSummary(const DIPLuminosityRcd&)
   unsigned int currentrun=m_pcurrentTime->eventID().run();
   unsigned int currentls=m_pcurrentTime->luminosityBlockNumber();
   if(currentls==0||currentls==4294967295){ 
-    return  boost::shared_ptr<DIPLumiSummary>(new DIPLumiSummary());
+    return std::make_shared<DIPLumiSummary>();
   }
   if(m_summarycachedrun!=currentrun){//i'm in a new run
     fillsummarycache(currentrun,currentls);//starting ls
@@ -85,11 +84,11 @@ DIPLumiProducer::produceSummary(const DIPLuminosityRcd&)
     }
   }
   if(m_summarycache.empty()){
-    return boost::shared_ptr<DIPLumiSummary>(new DIPLumiSummary());
+    return std::make_shared<DIPLumiSummary>();
   }
   if(m_summarycache.find(currentls)==m_summarycache.end()){
     std::vector<unsigned int> v;
-    for(std::map<unsigned int,boost::shared_ptr<DIPLumiSummary> >::iterator it=m_summarycache.begin();it!=m_summarycache.end();++it){
+    for(std::map<unsigned int,std::shared_ptr<DIPLumiSummary> >::iterator it=m_summarycache.begin();it!=m_summarycache.end();++it){
       v.push_back(it->first);
     }
     m_summaryresult=m_summarycache[v.back()];
@@ -97,7 +96,7 @@ DIPLumiProducer::produceSummary(const DIPLuminosityRcd&)
     m_summaryresult=m_summarycache[currentls];
   }
   if(m_summaryresult.get()==0){
-    return boost::shared_ptr<DIPLumiSummary>(new DIPLumiSummary());
+    return std::make_shared<DIPLumiSummary>();
   }
   return m_summaryresult;
 }
@@ -107,7 +106,7 @@ DIPLumiProducer::produceDetail(const DIPLuminosityRcd&)
   unsigned int currentrun=m_pcurrentTime->eventID().run();
   unsigned int currentls=m_pcurrentTime->luminosityBlockNumber();
   if(currentls==0||currentls==4294967295){ 
-    return  boost::shared_ptr<DIPLumiDetail>(new DIPLumiDetail());
+    return std::make_shared<DIPLumiDetail>();
   }
   if(m_detailcachedrun!=currentrun){//i'm in a new run
     filldetailcache(currentrun,currentls);//starting ls
@@ -117,11 +116,11 @@ DIPLumiProducer::produceDetail(const DIPLuminosityRcd&)
     }
   }
   if(m_detailcache.empty()){
-    return boost::shared_ptr<DIPLumiDetail>(new DIPLumiDetail());
+    return std::make_shared<DIPLumiDetail>();
   }
   if(m_detailcache.find(currentls)==m_detailcache.end()){
     std::vector<unsigned int> v;
-    for(std::map<unsigned int,boost::shared_ptr<DIPLumiDetail> >::iterator it=m_detailcache.begin();it!=m_detailcache.end();++it){
+    for(std::map<unsigned int,std::shared_ptr<DIPLumiDetail> >::iterator it=m_detailcache.begin();it!=m_detailcache.end();++it){
       v.push_back(it->first);
     }
     m_detailresult=m_detailcache[v.back()];
@@ -129,7 +128,7 @@ DIPLumiProducer::produceDetail(const DIPLuminosityRcd&)
     m_detailresult=m_detailcache[currentls];
   }
   if(m_detailresult.get()==0){
-    return boost::shared_ptr<DIPLumiDetail>(new DIPLumiDetail());
+    return std::make_shared<DIPLumiDetail>();
   }
   return m_detailresult;
 }
@@ -226,7 +225,7 @@ DIPLumiProducer::fillsummarycache(unsigned int runnumber,unsigned int currentlsn
       if(!row["CMS_ACTIVE"].isNull()){
 	cmsalive=row["CMS_ACTIVE"].data<unsigned short>();
       }
-      boost::shared_ptr<DIPLumiSummary> tmpls(new DIPLumiSummary(instlumi,intgdellumi,intgreclumi,cmsalive));
+      auto tmpls = std::make_shared<DIPLumiSummary>(instlumi,intgdellumi,intgreclumi,cmsalive);
       tmpls->setOrigin(m_summarycachedrun,lsnum);
       //std::cout<<"filling "<<lsnum<<std::endl;
       m_summarycache.insert(std::make_pair(lsnum,tmpls));
@@ -324,7 +323,7 @@ DIPLumiProducer::filldetailcache(unsigned int runnumber,unsigned int currentlsnu
       const coral::AttributeList& row=lumidetailcursor.currentRow();
       unsigned int lsnum=row["LUMISECTION"].data<unsigned int>();
       if(m_detailcache.find(lsnum)==m_detailcache.end()){
-	m_detailcache.insert(std::make_pair(lsnum,boost::shared_ptr<DIPLumiDetail>(new DIPLumiDetail)));
+	m_detailcache.insert(std::make_pair(lsnum,std::make_shared<DIPLumiDetail>()));
 	m_detailcache[lsnum]->setOrigin(m_detailcachedrun,lsnum);
       }
       if(!row["BUNCH"].isNull()){

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 namespace edm{
   class IOVSyncValue;
 }
@@ -22,9 +22,9 @@ class DIPLumiDetail;
 class DIPLumiProducer: public edm::ESProducer , public edm::EventSetupRecordIntervalFinder{
  public:
   DIPLumiProducer(const edm::ParameterSet&);
-  typedef boost::shared_ptr<DIPLumiSummary> ReturnSummaryType;
+  typedef std::shared_ptr<DIPLumiSummary> ReturnSummaryType;
   ReturnSummaryType produceSummary(const DIPLuminosityRcd&);
-  typedef boost::shared_ptr<DIPLumiDetail> ReturnDetailType;
+  typedef std::shared_ptr<DIPLumiDetail> ReturnDetailType;
   ReturnDetailType produceDetail(const DIPLuminosityRcd&);
   ~DIPLumiProducer();
 
@@ -36,14 +36,14 @@ class DIPLumiProducer: public edm::ESProducer , public edm::EventSetupRecordInte
   unsigned int maxavailableLSforRun(coral::ISchema& schema,const std::string&tablename,unsigned int runnumber);
  private:
   std::string m_connectStr;
-  std::map< unsigned int,boost::shared_ptr<DIPLumiSummary> > m_summarycache;
-  std::map< unsigned int,boost::shared_ptr<DIPLumiDetail> > m_detailcache;
+  std::map< unsigned int,std::shared_ptr<DIPLumiSummary> > m_summarycache;
+  std::map< unsigned int,std::shared_ptr<DIPLumiDetail> > m_detailcache;
   bool m_isNullRun; //if lumi data exist for this run
   unsigned int m_summarycachedrun;
   unsigned int m_detailcachedrun;
   unsigned int m_cachesize;
-  boost::shared_ptr<DIPLumiSummary> m_summaryresult;
-  boost::shared_ptr<DIPLumiDetail> m_detailresult;
+  std::shared_ptr<DIPLumiSummary> m_summaryresult;
+  std::shared_ptr<DIPLumiDetail> m_detailresult;
   const edm::IOVSyncValue* m_pcurrentTime;
  private:
   void fillsummarycache(unsigned int runnumber,unsigned int startlsnum);

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -9,7 +9,6 @@ Description: A essource/esproducer for lumi correction factor and run parameters
 */
 
 //#include <memory>
-//#include "boost/shared_ptr.hpp"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -206,7 +205,7 @@ LumiCorrectionSource::produceLumiCorrectionParam(const LumiCorrectionParamRcd&)
 { 
   unsigned int currentrun=m_pcurrentTime->eventID().run();
   if(currentrun==0||currentrun==4294967295){ 
-    return  boost::shared_ptr<LumiCorrectionParam>(new LumiCorrectionParam());
+    return std::make_shared<LumiCorrectionParam>();
   }
   if(m_paramcachedrun!=currentrun){//i'm in a new run
     fillparamcache(currentrun);//fill cache
@@ -216,11 +215,11 @@ LumiCorrectionSource::produceLumiCorrectionParam(const LumiCorrectionParamRcd&)
     }
   }
   if(m_paramcache.empty()){
-    return boost::shared_ptr<LumiCorrectionParam>(new LumiCorrectionParam());
+    return std::make_shared<LumiCorrectionParam>();
   }
   m_paramresult=m_paramcache[currentrun];
   if(m_paramresult.get()==0){
-    return boost::shared_ptr<LumiCorrectionParam>(new LumiCorrectionParam());
+    return std::make_shared<LumiCorrectionParam>();
   }
   return m_paramresult;
 }
@@ -271,7 +270,7 @@ LumiCorrectionSource::fillparamcache(unsigned int runnumber){
   tconverter.setCppTypeForSqlType(std::string("float"),std::string("FLOAT(63)"));
   tconverter.setCppTypeForSqlType(std::string("unsigned int"),std::string("NUMBER(10)"));
   tconverter.setCppTypeForSqlType(std::string("unsigned short"),std::string("NUMBER(1)"));
-  boost::shared_ptr<LumiCorrectionParam> result(new LumiCorrectionParam(LumiCorrectionParam::HF));
+  auto result = std::make_shared<LumiCorrectionParam>(LumiCorrectionParam::HF);
   try{
     session->transaction().start(true);
     coral::ISchema& schema=session->nominalSchema();

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include "FWCore/Concurrency/interface/Xerces.h"
@@ -25,7 +25,7 @@ class LumiCorrectionParam;
 class LumiCorrectionSource: public edm::ESProducer , public edm::EventSetupRecordIntervalFinder{
  public:
   LumiCorrectionSource(const edm::ParameterSet&);
-  typedef boost::shared_ptr<LumiCorrectionParam> ReturnParamType;
+  typedef std::shared_ptr<LumiCorrectionParam> ReturnParamType;
   ReturnParamType produceLumiCorrectionParam(const LumiCorrectionParamRcd&);
   ~LumiCorrectionSource();
  protected:
@@ -46,11 +46,11 @@ class LumiCorrectionSource: public edm::ESProducer , public edm::EventSetupRecor
   std::string m_globaltag;
   std::string m_normtag;
   std::string m_siteconfpath;
-  std::map< unsigned int,boost::shared_ptr<LumiCorrectionParam> > m_paramcache;
+  std::map< unsigned int,std::shared_ptr<LumiCorrectionParam> > m_paramcache;
   bool m_isNullRun; //if lumi data exist for this run
   unsigned int m_paramcachedrun;
   unsigned int m_cachesize;
-  boost::shared_ptr<LumiCorrectionParam> m_paramresult;
+  std::shared_ptr<LumiCorrectionParam> m_paramresult;
   const edm::IOVSyncValue* m_pcurrentTime;
  private:
   void fillparamcache(unsigned int runnumber);

--- a/RecoMuon/DetLayers/plugins/BuildFile.xml
+++ b/RecoMuon/DetLayers/plugins/BuildFile.xml
@@ -9,6 +9,5 @@
   <use   name="Geometry/Records"/>
   <use   name="RecoMuon/DetLayers"/>
   <use   name="RecoMuon/Records"/>
-  <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
@@ -39,7 +39,7 @@ MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::Parame
 MuonDetLayerGeometryESProducer::~MuonDetLayerGeometryESProducer(){}
 
 
-boost::shared_ptr<MuonDetLayerGeometry>
+std::shared_ptr<MuonDetLayerGeometry>
 MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
 
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonDetLayerGeometryESProducer";
@@ -95,5 +95,5 @@ MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
   // Sort layers properly
   muonDetLayerGeometry->sortLayers();
 
-  return boost::shared_ptr<MuonDetLayerGeometry>(muonDetLayerGeometry);
+  return std::shared_ptr<MuonDetLayerGeometry>(muonDetLayerGeometry);
 }

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.h
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.h
@@ -12,7 +12,7 @@
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <RecoMuon/Records/interface/MuonRecoGeometryRecord.h>
 #include <RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 class  MuonDetLayerGeometryESProducer: public edm::ESProducer{
@@ -24,7 +24,7 @@ class  MuonDetLayerGeometryESProducer: public edm::ESProducer{
   virtual ~MuonDetLayerGeometryESProducer(); 
 
   /// Produce MuonDeLayerGeometry.
-  boost::shared_ptr<MuonDetLayerGeometry> produce(const MuonRecoGeometryRecord & record);
+  std::shared_ptr<MuonDetLayerGeometry> produce(const MuonRecoGeometryRecord & record);
 
  private:
 };

--- a/RecoMuon/TransientTrackingRecHit/plugins/BuildFile.xml
+++ b/RecoMuon/TransientTrackingRecHit/plugins/BuildFile.xml
@@ -6,6 +6,5 @@
   <use   name="RecoMuon/TransientTrackingRecHit"/>
   <use   name="TrackingTools/Records"/>
   <use   name="TrackingTools/TransientTrackingRecHit"/>
-  <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.cc
@@ -11,6 +11,8 @@
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
+#include<memory>
+
 using namespace edm;
 using namespace std;
     
@@ -22,14 +24,14 @@ MuonTransientTrackingRecHitBuilderESProducer::MuonTransientTrackingRecHitBuilder
 MuonTransientTrackingRecHitBuilderESProducer::~MuonTransientTrackingRecHitBuilderESProducer() {}
 
     
-boost::shared_ptr<TransientTrackingRecHitBuilder> 
+std::shared_ptr<TransientTrackingRecHitBuilder> 
 MuonTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord& iRecord){ 
   
 
   ESHandle<GlobalTrackingGeometry> trackingGeometry;
   iRecord.getRecord<GlobalTrackingGeometryRecord>().get(trackingGeometry);
   
-  return boost::shared_ptr<TransientTrackingRecHitBuilder>(new MuonTransientTrackingRecHitBuilder(trackingGeometry));
+  return std::make_shared<MuonTransientTrackingRecHitBuilder>(trackingGeometry);
 }
     
     

--- a/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.h
@@ -13,7 +13,7 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace edm {class ParameterSet;}
 
@@ -28,7 +28,7 @@ public:
   virtual ~MuonTransientTrackingRecHitBuilderESProducer();
 
   // Operations
-  boost::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord&);
+  std::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord&);
 
 protected:
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
@@ -24,7 +24,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <library   file="ClusterShapeExtractor.cc" name="ClusterShapeExtractor">
-<use   name="boost"/>
 <use   name="root"/>
 <use   name="FWCore/Framework"/>
 <use   name="Geometry/CommonDetUnit"/>

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
@@ -31,7 +31,7 @@ TrackerRecoGeometryESProducer::TrackerRecoGeometryESProducer(const edm::Paramete
 
 TrackerRecoGeometryESProducer::~TrackerRecoGeometryESProducer() {}
 
-boost::shared_ptr<GeometricSearchTracker> 
+std::shared_ptr<GeometricSearchTracker> 
 TrackerRecoGeometryESProducer::produce(const TrackerRecoGeometryRecord & iRecord){ 
 
 
@@ -43,7 +43,7 @@ TrackerRecoGeometryESProducer::produce(const TrackerRecoGeometryRecord & iRecord
   const TrackerTopology *tTopo=tTopoHand.product();
 
   GeometricSearchTrackerBuilder builder;
-  _tracker  = boost::shared_ptr<GeometricSearchTracker>(builder.build( tG->trackerDet(), &(*tG), tTopo ));
+  _tracker  = std::shared_ptr<GeometricSearchTracker>(builder.build( tG->trackerDet(), &(*tG), tTopo ));
   return _tracker;
 }
 

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
@@ -6,15 +6,15 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  TrackerRecoGeometryESProducer: public edm::ESProducer{
  public:
   TrackerRecoGeometryESProducer(const edm::ParameterSet & p);
   virtual ~TrackerRecoGeometryESProducer(); 
-  boost::shared_ptr<GeometricSearchTracker> produce(const TrackerRecoGeometryRecord &);
+  std::shared_ptr<GeometricSearchTracker> produce(const TrackerRecoGeometryRecord &);
  private:
- boost::shared_ptr<GeometricSearchTracker> _tracker;
+ std::shared_ptr<GeometricSearchTracker> _tracker;
  std::string geoLabel;
 };
 

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -96,7 +96,7 @@ bool Chi2ChargeMeasurementEstimator::preFilter(const TrajectoryStateOnSurface& t
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -110,10 +110,10 @@ class  Chi2ChargeMeasurementEstimatorESProducer: public edm::ESProducer{
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & p);
   virtual ~Chi2ChargeMeasurementEstimatorESProducer(); 
-  boost::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
 
  private:
-  boost::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
+  std::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
   const edm::ParameterSet m_pset;
 };
 
@@ -145,7 +145,7 @@ Chi2ChargeMeasurementEstimatorESProducer::Chi2ChargeMeasurementEstimatorESProduc
 
 Chi2ChargeMeasurementEstimatorESProducer::~Chi2ChargeMeasurementEstimatorESProducer() {}
 
-boost::shared_ptr<Chi2MeasurementEstimatorBase> 
+std::shared_ptr<Chi2MeasurementEstimatorBase> 
 Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 
   auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
@@ -157,9 +157,9 @@ Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord
   auto minGoodStripCharge  =  clusterChargeCut(m_pset);
   auto pTChargeCutThreshold=   m_pset.getParameter<double>("pTChargeCutThreshold");
 
-  m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(
-	new Chi2ChargeMeasurementEstimator(minGoodPixelCharge, minGoodStripCharge, pTChargeCutThreshold,
-                                            maxChi2,nSigma, maxDis, maxSag, minTol) ); 
+  m_estimator = std::make_shared<Chi2ChargeMeasurementEstimator>(
+                                            minGoodPixelCharge, minGoodStripCharge, pTChargeCutThreshold,
+                                            maxChi2,nSigma, maxDis, maxSag, minTol);
 
   return m_estimator;
 }

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -43,7 +43,7 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
 
 MeasurementTrackerESProducer::~MeasurementTrackerESProducer() {}
 
-boost::shared_ptr<MeasurementTracker> 
+std::shared_ptr<MeasurementTracker> 
 MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
   std::string pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
@@ -126,19 +126,19 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   iRecord.getRecord<TrackerDigiGeometryRecord>().get(trackerGeom);
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
   
-  _measurementTracker  = boost::shared_ptr<MeasurementTracker>(new MeasurementTrackerImpl(pset_,
-										      pixelCPE.product(),
-										      stripCPE.product(),
-										      hitMatcher.product(),
-										      trackerGeom.product(),
-										      geometricSearchTracker.product(),
-										      ptr_stripQuality,
-                                                                                      stripQualityFlags,
-                                                                                      stripQualityDebugFlags,
-										      ptr_pixelQuality,
-										      ptr_pixelCabling,
-                                                                                      pixelQualityFlags,
-                                                                                      pixelQualityDebugFlags) ); 
+  _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
+							          pixelCPE.product(),
+							          stripCPE.product(),
+							          hitMatcher.product(),
+							          trackerGeom.product(),
+							          geometricSearchTracker.product(),
+							          ptr_stripQuality,
+                                                                  stripQualityFlags,
+                                                                  stripQualityDebugFlags,
+							          ptr_pixelQuality,
+							          ptr_pixelCabling,
+                                                                  pixelQualityFlags,
+                                                                  pixelQualityDebugFlags); 
   return _measurementTracker;
 }
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  dso_hidden MeasurementTrackerESProducer: public edm::ESProducer{
  public:
   MeasurementTrackerESProducer(const edm::ParameterSet & p);
   virtual ~MeasurementTrackerESProducer(); 
-  boost::shared_ptr<MeasurementTracker> produce(const CkfComponentsRecord &);
+  std::shared_ptr<MeasurementTracker> produce(const CkfComponentsRecord &);
  private:
-  boost::shared_ptr<MeasurementTracker> _measurementTracker;
+  std::shared_ptr<MeasurementTracker> _measurementTracker;
   edm::ParameterSet pset_;
 };
 

--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.cc
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.cc
@@ -30,7 +30,7 @@ MultiRecHitCollectorESProducer::MultiRecHitCollectorESProducer(const edm::Parame
 
 MultiRecHitCollectorESProducer::~MultiRecHitCollectorESProducer() {}
 
-boost::shared_ptr<MultiRecHitCollector> 
+std::shared_ptr<MultiRecHitCollector> 
 MultiRecHitCollectorESProducer::produce(const MultiRecHitRecord& iRecord){
   std::string mode = "Grouped";
   if (conf_.getParameter<std::string>("Mode")=="Simple") mode = "Simple"; 
@@ -55,17 +55,17 @@ MultiRecHitCollectorESProducer::produce(const MultiRecHitRecord& iRecord){
 	std::string propagatorOppositeName = conf_.getParameter<std::string>("propagatorOpposite");  
 	ESHandle<Propagator>  propagatorOppositehandle;
   	iRecord.getRecord<CkfComponentsRecord>().getRecord<TrackingComponentsRecord>().get(propagatorOppositeName, propagatorOppositehandle); 
-  	collector_ = boost::shared_ptr<MultiRecHitCollector>(new GroupedDAFHitCollector(measurementhandle.product(),
-									         mrhuhandle.product(),
-										 estimatorhandle.product(),
-										 propagatorhandle.product(),
-										 propagatorOppositehandle.product(), debug));
+  	collector_ = std::make_shared<GroupedDAFHitCollector>(measurementhandle.product(),
+						         mrhuhandle.product(),
+							 estimatorhandle.product(),
+							 propagatorhandle.product(),
+							 propagatorOppositehandle.product(), debug);
   } 
   else {
-	collector_ = boost::shared_ptr<MultiRecHitCollector>(new SimpleDAFHitCollector(measurementhandle.product(),
-                                                                                 mrhuhandle.product(),
-                                                                                 estimatorhandle.product(),
-                                                                                 propagatorhandle.product(), debug));
+	collector_ = std::make_shared<SimpleDAFHitCollector>(measurementhandle.product(),
+                                                             mrhuhandle.product(),
+                                                             estimatorhandle.product(),
+                                                             propagatorhandle.product(), debug);
   }
   	
   return collector_;

--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
@@ -14,19 +14,19 @@
 #include "RecoTracker/Record/interface/MultiRecHitRecord.h"
 #include "RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  MultiRecHitCollectorESProducer: public edm::ESProducer{
  public:
   MultiRecHitCollectorESProducer(const edm::ParameterSet& iConfig);
   virtual ~MultiRecHitCollectorESProducer(); 
-  boost::shared_ptr<MultiRecHitCollector> produce(const MultiRecHitRecord &);
+  std::shared_ptr<MultiRecHitCollector> produce(const MultiRecHitRecord &);
 
   // Set parameter set
   void setConf(const edm::ParameterSet& conf){ conf_ = conf; }
  
  private:
-  boost::shared_ptr<MultiRecHitCollector> collector_;
+  std::shared_ptr<MultiRecHitCollector> collector_;
   edm::ParameterSet conf_;
 
 };

--- a/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.cc
+++ b/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.cc
@@ -21,7 +21,7 @@ SiTrackerMultiRecHitUpdatorESProducer::SiTrackerMultiRecHitUpdatorESProducer(con
 
 SiTrackerMultiRecHitUpdatorESProducer::~SiTrackerMultiRecHitUpdatorESProducer() {}
 
-boost::shared_ptr<SiTrackerMultiRecHitUpdator> 
+std::shared_ptr<SiTrackerMultiRecHitUpdator> 
 SiTrackerMultiRecHitUpdatorESProducer::produce(const MultiRecHitRecord & iRecord){ 
   std::vector<double> annealingProgram = pset_.getParameter<std::vector<double> >("AnnealingProgram");
   float Chi2Cut1D = pset_.getParameter<double>("ChiSquareCut1D");
@@ -35,9 +35,9 @@ SiTrackerMultiRecHitUpdatorESProducer::produce(const MultiRecHitRecord & iRecord
   iRecord.getRecord<CkfComponentsRecord>().getRecord<TrackingComponentsRecord>().get(hitpropagator, hhitpropagator);		
 
   bool debug = pset_.getParameter<bool>("Debug");
-  //_updator  = boost::shared_ptr<SiTrackerMultiRecHitUpdator>(new SiTrackerMultiRecHitUpdator(pDD.product(), pp, sp, mp, annealingProgram));
-  _updator  = boost::shared_ptr<SiTrackerMultiRecHitUpdator>(new SiTrackerMultiRecHitUpdator(hbuilder.product(),hhitpropagator.product(), Chi2Cut1D, Chi2Cut2D, annealingProgram, debug));
-   // _updator  = boost::shared_ptr<SiTrackerMultiRecHitUpdator>(new SiTrackerMultiRecHitUpdator(hhitpropagator.product(),annealingProgram));
+  //_updator  = std::make_shared<SiTrackerMultiRecHitUpdator>(pDD.product(), pp, sp, mp, annealingProgram);
+  _updator  = std::make_shared<SiTrackerMultiRecHitUpdator>(hbuilder.product(),hhitpropagator.product(), Chi2Cut1D, Chi2Cut2D, annealingProgram, debug);
+   // _updator  = std::make_shared<SiTrackerMultiRecHitUpdator>(hhitpropagator.product(),annealingProgram);
   return _updator;
 }
 

--- a/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
@@ -6,15 +6,15 @@
 #include "RecoTracker/Record/interface/MultiRecHitRecord.h"
 #include "RecoTracker/SiTrackerMRHTools/interface/SiTrackerMultiRecHitUpdator.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  SiTrackerMultiRecHitUpdatorESProducer: public edm::ESProducer{
  public:
   SiTrackerMultiRecHitUpdatorESProducer(const edm::ParameterSet & p);
   virtual ~SiTrackerMultiRecHitUpdatorESProducer(); 
-  boost::shared_ptr<SiTrackerMultiRecHitUpdator> produce(const MultiRecHitRecord &);
+  std::shared_ptr<SiTrackerMultiRecHitUpdator> produce(const MultiRecHitRecord &);
  private:
-  boost::shared_ptr<SiTrackerMultiRecHitUpdator> _updator;
+  std::shared_ptr<SiTrackerMultiRecHitUpdator> _updator;
   edm::ParameterSet pset_;
 };
 

--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -337,7 +337,6 @@ SkippingLayerCosmicNavigationSchool::SkippingLayerCosmicNavigationSchool(const G
 #include <FWCore/Utilities/interface/ESInputTag.h>
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -365,7 +364,7 @@ class dso_hidden SkippingLayerCosmicNavigationSchoolESProducer final : public ed
 
   ~SkippingLayerCosmicNavigationSchoolESProducer(){}
 
-   typedef boost::shared_ptr<NavigationSchool> ReturnType;
+   typedef std::shared_ptr<NavigationSchool> ReturnType;
 
 
   ReturnType produce(const NavigationSchoolRecord&);
@@ -373,7 +372,7 @@ class dso_hidden SkippingLayerCosmicNavigationSchoolESProducer final : public ed
   // ----------member data ---------------------------
   edm::ParameterSet theNavigationPSet;
   std::string theNavigationSchoolName;
-  boost::shared_ptr<NavigationSchool> theNavigationSchool ;
+  std::shared_ptr<NavigationSchool> theNavigationSchool ;
 
 
 };

--- a/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
+++ b/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
@@ -1,7 +1,6 @@
 #include <FWCore/Utilities/interface/ESInputTag.h>
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -21,14 +20,14 @@ public:
   NavigationSchoolESProducer(const edm::ParameterSet&);
   ~NavigationSchoolESProducer();
   
-  typedef boost::shared_ptr<NavigationSchool> ReturnType;
+  typedef std::shared_ptr<NavigationSchool> ReturnType;
 
   virtual ReturnType produce(const NavigationSchoolRecord&);
  protected:
   // ----------member data ---------------------------
   edm::ParameterSet theNavigationPSet;
   std::string theNavigationSchoolName;
-  boost::shared_ptr<NavigationSchool> theNavigationSchool ;
+  std::shared_ptr<NavigationSchool> theNavigationSchool ;
 };
 
 //

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -25,7 +25,7 @@ TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESPr
 
 TkTransientTrackingRecHitBuilderESProducer::~TkTransientTrackingRecHitBuilderESProducer() {}
 
-boost::shared_ptr<TransientTrackingRecHitBuilder> 
+std::shared_ptr<TransientTrackingRecHitBuilder> 
 TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -76,7 +76,7 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
   edm::ESHandle<TrackerGeometry> pDD;
   iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );     
   
-  _builder  = boost::shared_ptr<TransientTrackingRecHitBuilder>(new TkTransientTrackingRecHitBuilder(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk));
+  _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
   return _builder;
 }
 

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
@@ -9,15 +9,15 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoLocalTracker/Records//interface/TrackerCPERecord.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  TkTransientTrackingRecHitBuilderESProducer: public edm::ESProducer{
  public:
   TkTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet & p);
   virtual ~TkTransientTrackingRecHitBuilderESProducer(); 
-  boost::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
+  std::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
  private:
-  boost::shared_ptr<TransientTrackingRecHitBuilder> _builder;
+  std::shared_ptr<TransientTrackingRecHitBuilder> _builder;
   edm::ParameterSet pset_;
 };
 

--- a/RecoTracker/TransientTrackingRecHit/test/BuildFile.xml
+++ b/RecoTracker/TransientTrackingRecHit/test/BuildFile.xml
@@ -6,7 +6,6 @@
 <use   name="RecoLocalTracker/SiStripRecHitConverter"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="clhep"/>
-<use   name="boost"/>
 <use   name="root"/>
 <library   file="*.cc" name="TTRHBuilderTest">
 <flags   EDM_PLUGIN="1"/>

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
@@ -8,8 +8,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 #include <TClass.h>
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -26,7 +24,7 @@
 
 class BeamSpotFakeConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
-	typedef boost::shared_ptr<BeamSpotObjects> ReturnType;
+	typedef std::shared_ptr<BeamSpotObjects> ReturnType;
 	BeamSpotFakeConditions(const edm::ParameterSet &params);
 	virtual ~BeamSpotFakeConditions();
 	ReturnType produce(const BeamSpotObjectsRcd &record);

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="CondFormats/BeamSpotObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/DBOutputService"/>
-<use   name="boost"/>
 
 <use   name="root"/>
 <use   name="rootminuit"/>

--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -6,7 +6,6 @@
 <use   name="CondFormats/BeamSpotObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/DBOutputService"/>
-<use   name="boost"/>
 
 <use   name="root"/>
 <use   name="rootminuit"/>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags   CXXFLAGS="-Ofast -funroll-all-loops"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>

--- a/TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdatorESProducer.h
@@ -11,15 +11,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  KFSwitching1DUpdatorESProducer: public edm::ESProducer{
  public:
   KFSwitching1DUpdatorESProducer(const edm::ParameterSet & p);
   virtual ~KFSwitching1DUpdatorESProducer(); 
-  boost::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
  private:
-  boost::shared_ptr<TrajectoryStateUpdator> _updator;
+  std::shared_ptr<TrajectoryStateUpdator> _updator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/KalmanUpdators/interface/KFUpdatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/KFUpdatorESProducer.h
@@ -11,15 +11,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  KFUpdatorESProducer: public edm::ESProducer{
  public:
   KFUpdatorESProducer(const edm::ParameterSet & p);
   virtual ~KFUpdatorESProducer(); 
-  boost::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
  private:
-  boost::shared_ptr<TrajectoryStateUpdator> _updator;
+  std::shared_ptr<TrajectoryStateUpdator> _updator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagatorESProducer.h
@@ -6,15 +6,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  TrackingRecHitPropagatorESProducer: public edm::ESProducer{
  public:
   TrackingRecHitPropagatorESProducer(const edm::ParameterSet & p);
   virtual ~TrackingRecHitPropagatorESProducer(); 
-  boost::shared_ptr<TrackingRecHitPropagator> produce(const TrackingComponentsRecord&);
+  std::shared_ptr<TrackingRecHitPropagator> produce(const TrackingComponentsRecord&);
  private:
-  boost::shared_ptr<TrackingRecHitPropagator> theHitPropagator;
+  std::shared_ptr<TrackingRecHitPropagator> theHitPropagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
@@ -11,7 +11,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace {
 
@@ -19,13 +19,13 @@ class  Chi2MeasurementEstimatorESProducer: public edm::ESProducer{
  public:
   Chi2MeasurementEstimatorESProducer(const edm::ParameterSet & p);
   virtual ~Chi2MeasurementEstimatorESProducer();
-  boost::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   //  static edm::ParameterSetDescription getFilledConfigurationDescription();
 
  private:
-  boost::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
+  std::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
   edm::ParameterSet const m_pset;
 };
 
@@ -37,7 +37,7 @@ Chi2MeasurementEstimatorESProducer::Chi2MeasurementEstimatorESProducer(const edm
 
 Chi2MeasurementEstimatorESProducer::~Chi2MeasurementEstimatorESProducer() {}
 
-boost::shared_ptr<Chi2MeasurementEstimatorBase> 
+std::shared_ptr<Chi2MeasurementEstimatorBase> 
 Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
   auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
   auto nSigma  = m_pset.getParameter<double>("nSigma");
@@ -45,7 +45,7 @@ Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRe
   auto maxSag  = m_pset.getParameter<double>("MaxSagitta");
   auto minTol = m_pset.getParameter<double>("MinimalTolerance");
    
-  m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(new Chi2MeasurementEstimator(maxChi2,nSigma, maxDis, maxSag, minTol));
+  m_estimator = std::make_shared<Chi2MeasurementEstimator>(maxChi2,nSigma, maxDis, maxSag, minTol);
   return m_estimator;
 }
 

--- a/TrackingTools/KalmanUpdators/plugins/KFSwitching1DUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFSwitching1DUpdatorESProducer.cc
@@ -21,14 +21,14 @@ KFSwitching1DUpdatorESProducer::KFSwitching1DUpdatorESProducer(const edm::Parame
 
 KFSwitching1DUpdatorESProducer::~KFSwitching1DUpdatorESProducer() {}
 
-boost::shared_ptr<TrajectoryStateUpdator> 
+std::shared_ptr<TrajectoryStateUpdator> 
 KFSwitching1DUpdatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_updator){
 //     delete _updator;
 //     _updator = 0;
 //   }
   
-  _updator  = boost::shared_ptr<TrajectoryStateUpdator>(new KFSwitching1DUpdator(&pset_));
+  _updator  = std::make_shared<KFSwitching1DUpdator>(&pset_);
   return _updator;
 }
 

--- a/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
@@ -21,14 +21,14 @@ KFUpdatorESProducer::KFUpdatorESProducer(const edm::ParameterSet & p)
 
 KFUpdatorESProducer::~KFUpdatorESProducer() {}
 
-boost::shared_ptr<TrajectoryStateUpdator> 
+std::shared_ptr<TrajectoryStateUpdator> 
 KFUpdatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_updator){
 //     delete _updator;
 //     _updator = 0;
 //   }
   
-  _updator  = boost::shared_ptr<TrajectoryStateUpdator>(new KFUpdator());
+  _updator = std::make_shared<KFUpdator>();
   return _updator;
 }
 

--- a/TrackingTools/KalmanUpdators/plugins/MRHChi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/MRHChi2MeasurementEstimatorESProducer.cc
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/KalmanUpdators/interface/MRHChi2MeasurementEstimator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace {
 
@@ -13,9 +13,9 @@ class  MRHChi2MeasurementEstimatorESProducer: public edm::ESProducer{
  public:
   MRHChi2MeasurementEstimatorESProducer(const edm::ParameterSet & p);
   virtual ~MRHChi2MeasurementEstimatorESProducer();
-  boost::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord&);
+  std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord&);
  private:
-  boost::shared_ptr<Chi2MeasurementEstimatorBase> _estimator;
+  std::shared_ptr<Chi2MeasurementEstimatorBase> _estimator;
   edm::ParameterSet pset_;
 };
 
@@ -28,12 +28,12 @@ MRHChi2MeasurementEstimatorESProducer::MRHChi2MeasurementEstimatorESProducer(con
 
 MRHChi2MeasurementEstimatorESProducer::~MRHChi2MeasurementEstimatorESProducer() {}
 
-boost::shared_ptr<Chi2MeasurementEstimatorBase> 
+std::shared_ptr<Chi2MeasurementEstimatorBase> 
 MRHChi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
   
   double maxChi2 = pset_.getParameter<double>("MaxChi2");
   double nSigma = pset_.getParameter<double>("nSigma");
-  _estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(new MRHChi2MeasurementEstimator(maxChi2,nSigma));
+  _estimator = std::make_shared<MRHChi2MeasurementEstimator>(maxChi2,nSigma);
   return _estimator;
 }
 

--- a/TrackingTools/KalmanUpdators/plugins/TrackingRecHitPropagatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/TrackingRecHitPropagatorESProducer.cc
@@ -20,7 +20,7 @@ TrackingRecHitPropagatorESProducer::TrackingRecHitPropagatorESProducer(const edm
 
 TrackingRecHitPropagatorESProducer::~TrackingRecHitPropagatorESProducer() {}
 
-boost::shared_ptr<TrackingRecHitPropagator> 
+std::shared_ptr<TrackingRecHitPropagator> 
 TrackingRecHitPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
    ESHandle<MagneticField> magfield;
    std::string mfName = "";
@@ -29,7 +29,7 @@ TrackingRecHitPropagatorESProducer::produce(const TrackingComponentsRecord& iRec
    iRecord.getRecord<IdealMagneticFieldRecord>().get(mfName,magfield);
    //   edm::ESInputTag mfESInputTag(mfName);
    //   iRecord.getRecord<IdealMagneticFieldRecord>().get(mfESInputTag,magfield);
-   theHitPropagator= boost::shared_ptr<TrackingRecHitPropagator>(new TrackingRecHitPropagator(magfield.product()));
+   theHitPropagator = std::make_shared<TrackingRecHitPropagator>(magfield.product());
    return theHitPropagator;
 }
 

--- a/TrackingTools/KalmanUpdators/test/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/test/BuildFile.xml
@@ -4,7 +4,6 @@
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
 <use   name="MagneticField/Engine"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <bin   file="KFUpdator_t.cpp">
 </bin>

--- a/TrackingTools/MaterialEffects/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackPropagation/RungeKutta"/>
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
-<use   name="boost"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
@@ -23,7 +23,7 @@ PropagatorWithMaterialESProducer::PropagatorWithMaterialESProducer(const edm::Pa
 
 PropagatorWithMaterialESProducer::~PropagatorWithMaterialESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 PropagatorWithMaterialESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -53,9 +53,9 @@ PropagatorWithMaterialESProducer::produce(const TrackingComponentsRecord & iReco
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  _propagator  = boost::shared_ptr<Propagator>(new PropagatorWithMaterial(dir, mass, &(*magfield),
-									  maxDPhi,useRK,ptMin,
-									  useOldAnalPropLogic));
+  _propagator = std::make_shared<PropagatorWithMaterial>(dir, mass, &(*magfield),
+									maxDPhi,useRK,ptMin,
+									useOldAnalPropLogic);
   return _propagator;
 }
 

--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.h
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.h
@@ -11,15 +11,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  PropagatorWithMaterialESProducer: public edm::ESProducer{
  public:
   PropagatorWithMaterialESProducer(const edm::ParameterSet & p);
   virtual ~PropagatorWithMaterialESProducer(); 
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  boost::shared_ptr<Propagator> _propagator;
+  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc
+++ b/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc
@@ -7,7 +7,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -28,7 +27,7 @@ class TSCBLBuilderNoMaterialESProducer : public edm::ESProducer {
       TSCBLBuilderNoMaterialESProducer(const edm::ParameterSet&);
       ~TSCBLBuilderNoMaterialESProducer();
 
-      typedef boost::shared_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
+      typedef std::shared_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
 
       ReturnType produce(const TrackingComponentsRecord&);
    private:

--- a/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc
+++ b/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc
@@ -7,7 +7,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -28,7 +27,7 @@ class TSCBLBuilderWithPropagatorESProducer : public edm::ESProducer {
       TSCBLBuilderWithPropagatorESProducer(const edm::ParameterSet&);
       ~TSCBLBuilderWithPropagatorESProducer();
 
-      typedef boost::shared_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
+      typedef std::shared_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
 
       ReturnType produce(const TrackingComponentsRecord&);
    private:

--- a/TrackingTools/Producers/BuildFile.xml
+++ b/TrackingTools/Producers/BuildFile.xml
@@ -9,5 +9,4 @@
 <use   name="RecoTracker/Record"/>
 <use   name="TrackingTools/TrajectoryCleaning"/>
 <use   name="TrackingTools/TrajectoryFiltering"/>
-<use   name="boost"/>
 <flags   EDM_PLUGIN="1"/>

--- a/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  AnalyticalPropagatorESProducer: public edm::ESProducer{
  public:
   AnalyticalPropagatorESProducer(const edm::ParameterSet & p);
   virtual ~AnalyticalPropagatorESProducer(); 
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  boost::shared_ptr<Propagator> _propagator;
+  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
@@ -12,7 +12,7 @@
 #include "TrackingTools/GeomPropagators/interface/BeamHaloPropagator.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
   
 
 namespace edm {class ParameterSet;}
@@ -30,10 +30,10 @@ class  BeamHaloPropagatorESProducer: public edm::ESProducer{
   virtual ~BeamHaloPropagatorESProducer(); 
   
   // Operations
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
   
  private:
-  boost::shared_ptr<Propagator> thePropagator;
+  std::shared_ptr<Propagator> thePropagator;
   PropagationDirection thePropagationDirection;
   std::string myname;
   std::string theEndCapTrackerPropagatorName;

--- a/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
@@ -12,7 +12,7 @@
 #include "TrackingTools/GeomPropagators/interface/SmartPropagator.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
   
 
 namespace edm {class ParameterSet;}
@@ -30,10 +30,10 @@ class  SmartPropagatorESProducer: public edm::ESProducer{
   virtual ~SmartPropagatorESProducer(); 
   
   // Operations
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
   
  private:
-  boost::shared_ptr<Propagator> thePropagator;
+  std::shared_ptr<Propagator> thePropagator;
   PropagationDirection thePropagationDirection;
   std::string theTrackerPropagatorName;
   std::string theMuonPropagatorName;

--- a/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/GeomPropagators/interface/StraightLinePropagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  StraightLinePropagatorESProducer: public edm::ESProducer{
  public:
   StraightLinePropagatorESProducer(const edm::ParameterSet & p);
   virtual ~StraightLinePropagatorESProducer(); 
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  boost::shared_ptr<Propagator> _propagator;
+  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h
+++ b/TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -35,7 +34,7 @@ class TrajectoryCleanerESProducer : public edm::ESProducer {
       TrajectoryCleanerESProducer(const edm::ParameterSet&);
       ~TrajectoryCleanerESProducer();
 
-  typedef boost::shared_ptr<TrajectoryCleaner> ReturnType;
+  typedef std::shared_ptr<TrajectoryCleaner> ReturnType;
 
       ReturnType produce(const  TrackingComponentsRecord&);
    private:

--- a/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
@@ -22,7 +22,7 @@ AnalyticalPropagatorESProducer::AnalyticalPropagatorESProducer(const edm::Parame
 
 AnalyticalPropagatorESProducer::~AnalyticalPropagatorESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -45,7 +45,7 @@ AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  _propagator  = boost::shared_ptr<Propagator>(new AnalyticalPropagator(&(*magfield), dir,dphiCut));
+  _propagator = std::make_shared<AnalyticalPropagator>(&(*magfield), dir,dphiCut);
   return _propagator;
 }
 

--- a/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
@@ -44,7 +44,7 @@ BeamHaloPropagatorESProducer::BeamHaloPropagatorESProducer(const ParameterSet& p
 
 BeamHaloPropagatorESProducer::~BeamHaloPropagatorESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
 
   ESHandle<MagneticField> magField;
@@ -60,8 +60,8 @@ BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){
 				<<"\n with EndCap Propagator: "<<theEndCapTrackerPropagatorName
 				<<"\n with Crossing Propagator: "<<theCrossingTrackerPropagatorName;
 
-  thePropagator  = boost::shared_ptr<Propagator>(new BeamHaloPropagator(*endcapPropagator,*crossPropagator,
-									&*magField,
-									thePropagationDirection));
+  thePropagator = std::make_shared<BeamHaloPropagator>(*endcapPropagator,*crossPropagator,
+							&*magField,
+							thePropagationDirection);
   return thePropagator;
 }

--- a/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
@@ -46,7 +46,7 @@ SmartPropagatorESProducer::SmartPropagatorESProducer(const ParameterSet& paramet
 
 SmartPropagatorESProducer::~SmartPropagatorESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
 
   ESHandle<MagneticField> magField;
@@ -59,9 +59,9 @@ SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){
   iRecord.get(theMuonPropagatorName,muonPropagator);
   
   
-  thePropagator  = boost::shared_ptr<Propagator>(new SmartPropagator(*trackerPropagator, *muonPropagator,
-								     &*magField,
-								     thePropagationDirection, 
-								     theEpsilon));
+  thePropagator = std::make_shared<SmartPropagator>(*trackerPropagator, *muonPropagator,
+						     &*magField,
+						     thePropagationDirection, 
+						     theEpsilon);
   return thePropagator;
 }

--- a/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
@@ -21,7 +21,7 @@ StraightLinePropagatorESProducer::StraightLinePropagatorESProducer(const edm::Pa
 
 StraightLinePropagatorESProducer::~StraightLinePropagatorESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -37,7 +37,7 @@ StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iReco
     if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
     if (pdir == "alongMomentum") dir = alongMomentum;
     if (pdir == "anyDirection") dir = anyDirection;
-  _propagator  = boost::shared_ptr<Propagator>(new StraightLinePropagator(&(*magfield),dir));
+  _propagator = std::make_shared<StraightLinePropagator>(&(*magfield),dir);
   return _propagator;
 }
 

--- a/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.cc
@@ -19,11 +19,11 @@ DetLayerGeometryESProducer::DetLayerGeometryESProducer(const edm::ParameterSet &
  
 DetLayerGeometryESProducer::~DetLayerGeometryESProducer() {}
 
-boost::shared_ptr<DetLayerGeometry> 
+std::shared_ptr<DetLayerGeometry> 
 DetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){ 
 
 
-  geometry_  = boost::shared_ptr<DetLayerGeometry>(new DetLayerGeometry());
+  geometry_ = std::make_shared<DetLayerGeometry>();
   return geometry_;
 }
 

--- a/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h"
 #include "TrackingTools/DetLayers/interface/DetLayerGeometry.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  DetLayerGeometryESProducer: public edm::ESProducer{
  public:
   DetLayerGeometryESProducer(const edm::ParameterSet & p);
   virtual ~DetLayerGeometryESProducer(); 
-  boost::shared_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
+  std::shared_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
  private:
-  boost::shared_ptr<DetLayerGeometry> geometry_;
+  std::shared_ptr<DetLayerGeometry> geometry_;
 };
 
 

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
@@ -18,7 +18,7 @@ GlobalDetLayerGeometryESProducer::GlobalDetLayerGeometryESProducer(const edm::Pa
  
 GlobalDetLayerGeometryESProducer::~GlobalDetLayerGeometryESProducer() {}
 
-boost::shared_ptr<DetLayerGeometry> 
+std::shared_ptr<DetLayerGeometry> 
 GlobalDetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){ 
   
   edm::ESHandle<GeometricSearchTracker> tracker;  
@@ -27,8 +27,7 @@ GlobalDetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(tracker);
   iRecord.getRecord<MuonRecoGeometryRecord>().get(muon);
 
-  geometry_  = boost::shared_ptr<DetLayerGeometry>(new GlobalDetLayerGeometry(tracker.product(),
-									      muon.product() ));
+  geometry_ = std::make_shared<GlobalDetLayerGeometry>(tracker.product(), muon.product());
   return geometry_;
 }
 

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h"
 #include "TrackingTools/RecoGeometry/interface/GlobalDetLayerGeometry.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  GlobalDetLayerGeometryESProducer: public edm::ESProducer{
  public:
   GlobalDetLayerGeometryESProducer(const edm::ParameterSet & p);
   virtual ~GlobalDetLayerGeometryESProducer(); 
-  boost::shared_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
+  std::shared_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
  private:
-  boost::shared_ptr<DetLayerGeometry> geometry_;
+  std::shared_ptr<DetLayerGeometry> geometry_;
 };
 
 

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -40,7 +39,7 @@ public:
   DetIdAssociatorESProducer(const edm::ParameterSet&);
   ~DetIdAssociatorESProducer();
   
-  typedef boost::shared_ptr<DetIdAssociator> ReturnType;
+  typedef std::shared_ptr<DetIdAssociator> ReturnType;
   
   ReturnType produce(const DetIdAssociatorRecord&);
 private:

--- a/TrackingTools/TrackFitters/plugins/FlexibleKFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/FlexibleKFFittingSmootherESProducer.cc
@@ -84,7 +84,7 @@ namespace {
       descriptions.add("FlexibleKFFittingSmoother", desc);
     }
     
-    boost::shared_ptr<TrajectoryFitter> 
+    std::shared_ptr<TrajectoryFitter> 
     produce(const TrajectoryFitterRecord & iRecord){ 
       
       edm::ESHandle<TrajectoryFitter> standardFitter;
@@ -93,7 +93,7 @@ namespace {
       iRecord.get(pset_.getParameter<std::string>("standardFitter"),standardFitter);
       iRecord.get(pset_.getParameter<std::string>("looperFitter"),looperFitter);
       
-      return boost::shared_ptr<TrajectoryFitter>(new FlexibleKFFittingSmoother(*standardFitter.product(),
+      return std::shared_ptr<TrajectoryFitter>(new FlexibleKFFittingSmoother(*standardFitter.product(),
 									       *looperFitter.product())
 						 );
     }

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -37,7 +37,7 @@ namespace {
     
     ~KFFittingSmootherESProducer() {}
     
-    boost::shared_ptr<TrajectoryFitter> 
+    std::shared_ptr<TrajectoryFitter> 
     produce(const TrajectoryFitterRecord & iRecord){ 
       
       
@@ -47,7 +47,7 @@ namespace {
       iRecord.get(pset_.getParameter<std::string>("Fitter"), fit);
       iRecord.get(pset_.getParameter<std::string>("Smoother"), smooth);
       
-     return boost::shared_ptr<TrajectoryFitter>(new KFFittingSmoother(*fit.product(), *smooth.product(),pset_));
+     return std::shared_ptr<TrajectoryFitter>(new KFFittingSmoother(*fit.product(), *smooth.product(),pset_));
     }
 
   private:

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.h
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.h
@@ -11,15 +11,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h"
 #include "TrackingTools/TrackFitters/interface/KFFittingSmoother.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  KFFittingSmootherESProducer: public edm::ESProducer{
  public:
   KFFittingSmootherESProducer(const edm::ParameterSet & p);
   virtual ~KFFittingSmootherESProducer(); 
-  boost::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
+  std::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
  private:
-  boost::shared_ptr<TrajectoryFitter> _fitter;
+  std::shared_ptr<TrajectoryFitter> _fitter;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/TrackFitters/plugins/KFTrajectoryFitterESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFTrajectoryFitterESProducer.cc
@@ -17,7 +17,7 @@
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace {
 
@@ -25,7 +25,7 @@ namespace {
   public:
     KFTrajectoryFitterESProducer(const edm::ParameterSet & p);
     ~KFTrajectoryFitterESProducer(); 
-    boost::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
+    std::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
     
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
@@ -52,7 +52,7 @@ namespace {
   
   KFTrajectoryFitterESProducer::~KFTrajectoryFitterESProducer() {}
   
-  boost::shared_ptr<TrajectoryFitter> 
+  std::shared_ptr<TrajectoryFitter>
   KFTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
     
     std::string pname = pset_.getParameter<std::string>("Propagator");
@@ -71,11 +71,11 @@ namespace {
     iRecord.getRecord<TrackingComponentsRecord>().get(ename, est);
     iRecord.getRecord<RecoGeometryRecord>().get(gname,geo);
 
-    return boost::shared_ptr<TrajectoryFitter>(new KFTrajectoryFitter(prop.product(),
-								      upd.product(),
-								      est.product(),
-								      minHits,
-								      geo.product() ));
+    return std::make_shared<KFTrajectoryFitter>(prop.product(),
+				                upd.product(),
+				                est.product(),
+				                minHits,
+				                geo.product());
   }
 
 }

--- a/TrackingTools/TrackFitters/plugins/KFTrajectorySmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFTrajectorySmootherESProducer.cc
@@ -16,7 +16,7 @@
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectorySmoother.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 namespace {
@@ -25,7 +25,7 @@ namespace {
   public:
     KFTrajectorySmootherESProducer(const edm::ParameterSet & p);
     ~KFTrajectorySmootherESProducer(); 
-    boost::shared_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
+    std::shared_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
@@ -54,7 +54,7 @@ namespace {
   
   KFTrajectorySmootherESProducer::~KFTrajectorySmootherESProducer() {}
   
-  boost::shared_ptr<TrajectorySmoother> 
+  std::shared_ptr<TrajectorySmoother> 
     KFTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
     
     std::string pname = pset_.getParameter<std::string>("Propagator");
@@ -75,12 +75,12 @@ namespace {
     iRecord.getRecord<TrackingComponentsRecord>().get(ename, est);
     iRecord.getRecord<RecoGeometryRecord>().get(gname,geo);
     
-    return boost::shared_ptr<TrajectorySmoother>(new KFTrajectorySmoother(prop.product(),
-									  upd.product(),
-									  est.product(),
-									  rescaleFactor,
-									  minHits,
-									  geo.product() ));
+    return std::make_shared<KFTrajectorySmoother>(prop.product(),
+						  upd.product(),
+						  est.product(),
+						  rescaleFactor,
+						  minHits,
+						  geo.product());
     
   }
 }

--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
@@ -20,7 +20,7 @@ TransientTrackBuilderESProducer::TransientTrackBuilderESProducer(const edm::Para
 
 TransientTrackBuilderESProducer::~TransientTrackBuilderESProducer() {}
 
-boost::shared_ptr<TransientTrackBuilder> 
+std::shared_ptr<TransientTrackBuilder> 
 TransientTrackBuilderESProducer::produce(const TransientTrackRecord & iRecord){ 
 
   edm::ESHandle<MagneticField> magfield;
@@ -28,8 +28,7 @@ TransientTrackBuilderESProducer::produce(const TransientTrackRecord & iRecord){
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   iRecord.getRecord<GlobalTrackingGeometryRecord>().get(theTrackingGeometry); 
 
-  _builder  = boost::shared_ptr<TransientTrackBuilder>(
-	new TransientTrackBuilder(magfield.product(), theTrackingGeometry ));
+  _builder  = std::make_shared<TransientTrackBuilder>(magfield.product(), theTrackingGeometry);
   return _builder;
 
 }

--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.h
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.h
@@ -8,15 +8,15 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  TransientTrackBuilderESProducer: public edm::ESProducer{
  public:
   TransientTrackBuilderESProducer(const edm::ParameterSet & p);
   virtual ~TransientTrackBuilderESProducer(); 
-  boost::shared_ptr<TransientTrackBuilder> produce(const TransientTrackRecord &);
+  std::shared_ptr<TransientTrackBuilder> produce(const TransientTrackRecord &);
  private:
-  boost::shared_ptr<TransientTrackBuilder> _builder;
+  std::shared_ptr<TransientTrackBuilder> _builder;
   edm::ParameterSet pset_;
 };
 


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for Reco packages.
Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation.
Packages TrackingTools/Gsf\* are not done in this PR because there is another PR from Vincenzo Innocente making some of the same changes, and I wish to avoid a confluct with that PR.
This PR is totally technical.
