### PR TITLE
Use std::shared_ptr and std::make_shared (EventSetup in Simulation)

### DIFF
--- a/SimGeneral/HepPDTESSource/interface/HepPDTESSource.h
+++ b/SimGeneral/HepPDTESSource/interface/HepPDTESSource.h
@@ -18,7 +18,6 @@
 //
 #include <memory>
 #include <fstream>
-#include "boost/shared_ptr.hpp"
 #include "HepPDT/TableBuilder.hh"
 #include "HepPDT/ParticleDataTable.hh"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.cc
@@ -5,7 +5,7 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h
+++ b/SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h
@@ -9,15 +9,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  CosmicParametersDefinerForTPESProducer: public edm::ESProducer{
-  typedef boost::shared_ptr<CosmicParametersDefinerForTP> ReturnType;
+  typedef std::shared_ptr<CosmicParametersDefinerForTP> ReturnType;
 
  public:
   CosmicParametersDefinerForTPESProducer(const edm::ParameterSet & p);
   virtual ~CosmicParametersDefinerForTPESProducer(); 
-  boost::shared_ptr<CosmicParametersDefinerForTP> produce(const TrackAssociatorRecord &);
+  std::shared_ptr<CosmicParametersDefinerForTP> produce(const TrackAssociatorRecord &);
 
 };
 

--- a/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.cc
@@ -5,7 +5,7 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h
+++ b/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h
@@ -9,15 +9,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  ParametersDefinerForTPESProducer: public edm::ESProducer{
-  typedef boost::shared_ptr<ParametersDefinerForTP> ReturnType;
+  typedef std::shared_ptr<ParametersDefinerForTP> ReturnType;
 
  public:
   ParametersDefinerForTPESProducer(const edm::ParameterSet & p);
   virtual ~ParametersDefinerForTPESProducer(); 
-  boost::shared_ptr<ParametersDefinerForTP> produce(const TrackAssociatorRecord &);
+  std::shared_ptr<ParametersDefinerForTP> produce(const TrackAssociatorRecord &);
 
   edm::ParameterSet pset_;
 

--- a/TrackPropagation/Geant4e/BuildFile.xml
+++ b/TrackPropagation/Geant4e/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="root"/>
 <use   name="geant4"/>
-<use   name="boost"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <use   name="TrackingTools/GeomPropagators"/>

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
@@ -22,7 +22,7 @@ GeantPropagatorESProducer::GeantPropagatorESProducer(const edm::ParameterSet & p
 
 GeantPropagatorESProducer::~GeantPropagatorESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 GeantPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -37,7 +37,7 @@ GeantPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  _propagator  = boost::shared_ptr<Propagator>(new Geant4ePropagator(&(*magfield),particleName,dir));
+  _propagator  = std::make_shared<Geant4ePropagator>(&(*magfield),particleName,dir);
   return _propagator;
 }
 

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 /*
  * GeantPropagatorESProducer
@@ -19,10 +19,10 @@ class GeantPropagatorESProducer: public edm::ESProducer{
   GeantPropagatorESProducer(const edm::ParameterSet & p);
   virtual ~GeantPropagatorESProducer() override; 
 
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
 
  private:
-  boost::shared_ptr<Propagator> _propagator;
+  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
@@ -24,7 +24,7 @@ SteppingHelixPropagatorESProducer::SteppingHelixPropagatorESProducer(const edm::
 
 SteppingHelixPropagatorESProducer::~SteppingHelixPropagatorESProducer() {}
 
-boost::shared_ptr<Propagator> 
+std::shared_ptr<Propagator> 
 SteppingHelixPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -106,6 +106,6 @@ SteppingHelixPropagatorESProducer::produce(const TrackingComponentsRecord & iRec
     shProp->setEndcapShiftsInZPosNeg(valPos, valNeg);
   }
 
-  _propagator  = boost::shared_ptr<Propagator>(shProp);
+  _propagator  = std::shared_ptr<Propagator>(shProp);
   return _propagator;
 }

--- a/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.h
+++ b/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.h
@@ -5,15 +5,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class  SteppingHelixPropagatorESProducer: public edm::ESProducer{
  public:
   SteppingHelixPropagatorESProducer(const edm::ParameterSet & p);
   virtual ~SteppingHelixPropagatorESProducer(); 
-  boost::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  boost::shared_ptr<Propagator> _propagator;
+  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for full simulation packages. Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation.
This PR is totally technical.
