### PR TITLE
use std::make_shared in framework (again)

### DIFF
--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -156,16 +156,15 @@ class ESProducer : public ESProxyFactoryProducer
                               TReturn (T ::* iMethod)(const TRecord&),
                               const TArg& iDec,
                               const es::Label& iLabel = es::Label()) {
-            std::shared_ptr<eventsetup::Callback<T,TReturn,TRecord, typename eventsetup::DecoratorFromArg<T, TRecord, TArg>::Decorator_t > >
-            callback(new eventsetup::Callback<T,
+            auto callback = std::make_shared<eventsetup::Callback<T,
                                           TReturn,
                                           TRecord, 
-                                          typename eventsetup::DecoratorFromArg<T,TRecord,TArg>::Decorator_t>(
+                                          typename eventsetup::DecoratorFromArg<T,TRecord,TArg>::Decorator_t>>(
                                                                iThis, 
                                                                iMethod, 
                                                                createDecoratorFrom(iThis, 
                                                                                     static_cast<const TRecord*>(nullptr),
-                                                                                    iDec)));
+                                                                                    iDec));
             registerProducts(callback,
                              static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
                              static_cast<const TRecord*>(nullptr),

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -456,7 +456,7 @@ testGlobalModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& i
 
 void testGlobalModule::basicTest()
 {
-  std::shared_ptr<BasicProd> testProd = std::make_shared<BasicProd>();
+  auto testProd = std::make_shared<BasicProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent});
@@ -464,7 +464,7 @@ void testGlobalModule::basicTest()
 
 void testGlobalModule::streamTest()
 {
-  std::shared_ptr<StreamProd> testProd = std::make_shared<StreamProd>();
+  auto testProd = std::make_shared<StreamProd>();
   edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(testProd,nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
   
@@ -475,7 +475,7 @@ void testGlobalModule::streamTest()
 
 void testGlobalModule::runTest()
 {
-  std::shared_ptr<RunProd> testProd = std::make_shared<RunProd>();
+  auto testProd = std::make_shared<RunProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
@@ -483,7 +483,7 @@ void testGlobalModule::runTest()
 
 void testGlobalModule::runSummaryTest()
 {
-  std::shared_ptr<RunSummaryProd> testProd = std::make_shared<RunSummaryProd>();
+  auto testProd = std::make_shared<RunSummaryProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
@@ -491,7 +491,7 @@ void testGlobalModule::runSummaryTest()
 
 void testGlobalModule::lumiTest()
 {
-  std::shared_ptr<LumiProd> testProd = std::make_shared<LumiProd>();
+  auto testProd = std::make_shared<LumiProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
@@ -499,7 +499,7 @@ void testGlobalModule::lumiTest()
 
 void testGlobalModule::lumiSummaryTest()
 {
-  std::shared_ptr<LumiSummaryProd> testProd{ new LumiSummaryProd };
+  auto testProd = std::make_shared<LumiSummaryProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
@@ -507,7 +507,7 @@ void testGlobalModule::lumiSummaryTest()
 
 void testGlobalModule::beginRunProdTest()
 {
-  std::shared_ptr<BeginRunProd> testProd{ new BeginRunProd };
+  auto testProd = std::make_shared<BeginRunProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent});
@@ -515,7 +515,7 @@ void testGlobalModule::beginRunProdTest()
 
 void testGlobalModule::beginLumiProdTest()
 {
-  std::shared_ptr<BeginLumiProd> testProd{ new BeginLumiProd };
+  auto testProd = std::make_shared<BeginLumiProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
@@ -523,7 +523,7 @@ void testGlobalModule::beginLumiProdTest()
 
 void testGlobalModule::endRunProdTest()
 {
-  std::shared_ptr<EndRunProd> testProd{ new EndRunProd };
+  auto testProd = std::make_shared<EndRunProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent});
@@ -531,7 +531,7 @@ void testGlobalModule::endRunProdTest()
 
 void testGlobalModule::endLumiProdTest()
 {
-  std::shared_ptr<EndLumiProd> testProd{ new EndLumiProd };
+  auto testProd = std::make_shared<EndLumiProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
@@ -539,7 +539,7 @@ void testGlobalModule::endLumiProdTest()
 
 void testGlobalModule::endRunSummaryProdTest()
 {
-  std::shared_ptr<EndRunSummaryProd> testProd{ new EndRunSummaryProd };
+  auto testProd = std::make_shared<EndRunSummaryProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
@@ -547,7 +547,7 @@ void testGlobalModule::endRunSummaryProdTest()
 
 void testGlobalModule::endLumiSummaryProdTest()
 {
-  std::shared_ptr<EndLumiSummaryProd> testProd{ new EndLumiSummaryProd };
+  auto testProd = std::make_shared<EndLumiSummaryProd>();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -291,7 +291,7 @@ void testGlobalOutputModule::basicTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::shared_ptr<BasicOutputModule> testProd{ new BasicOutputModule(pset) };
+  auto testProd = std::make_shared<BasicOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
@@ -303,7 +303,7 @@ void testGlobalOutputModule::fileTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::shared_ptr<FileOutputModule> testProd = std::make_shared<FileOutputModule>(pset);
+  auto testProd = std::make_shared<FileOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -369,7 +369,7 @@ void testOneOutputModule::basicTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::shared_ptr<BasicOutputModule> testProd{ new BasicOutputModule(pset) };
+  auto testProd = std::make_shared<BasicOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
@@ -381,7 +381,7 @@ void testOneOutputModule::runTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::shared_ptr<RunOutputModule> testProd{ new RunOutputModule(pset) };
+  auto testProd = std::make_shared<RunOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalEndRun});
@@ -393,7 +393,7 @@ void testOneOutputModule::lumiTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::shared_ptr<LumiOutputModule> testProd{ new LumiOutputModule(pset) };
+  auto testProd = std::make_shared<LumiOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
@@ -405,7 +405,7 @@ void testOneOutputModule::fileTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::shared_ptr<FileOutputModule> testProd = std::make_shared<FileOutputModule>(pset);
+  auto testProd = std::make_shared<FileOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
@@ -417,7 +417,7 @@ void testOneOutputModule::resourceTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::shared_ptr<ResourceOutputModule> testProd{ new ResourceOutputModule(pset) };
+  auto testProd = std::make_shared<ResourceOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -460,7 +460,7 @@ namespace {
   template<typename T>
   std::shared_ptr<edm::stream::EDProducerAdaptorBase> createModule() {
     edm::ParameterSet pset;
-    std::shared_ptr<edm::stream::EDProducerAdaptorBase> retValue(new edm::stream::EDProducerAdaptor<T>(pset));
+    std::shared_ptr<edm::stream::EDProducerAdaptorBase> retValue = std::make_shared<edm::stream::EDProducerAdaptor<T>>(pset);
     edm::maker::ModuleHolderT<edm::stream::EDProducerAdaptorBase> h(retValue,nullptr);
     h.preallocate(edm::PreallocationConfiguration{});
     return retValue;


### PR DESCRIPTION
This little PR implements the use of std::make_shared in the very few places in the framework that were somehow missed in previous PRs. Also, in a few related assignments in files being modified anyway, the type of the left hand operand (a shared pointer) was simplfied to "auto".
