### PR TITLE
VID MVA headers in plugin directory - 80X version

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
@@ -1,4 +1,4 @@
-#include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2Phys14NonTrig.h"
+#include "RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -349,3 +349,6 @@ void ElectronMVAEstimatorRun2Phys14NonTrig::constrainMVAVariables(AllVariables& 
     vars.kfchi2 = 10.;
 }
 
+DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
+		  ElectronMVAEstimatorRun2Phys14NonTrig,
+		  "ElectronMVAEstimatorRun2Phys14NonTrig");

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.h
@@ -108,8 +108,4 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   
 };
 
-DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
-		  ElectronMVAEstimatorRun2Phys14NonTrig,
-		  "ElectronMVAEstimatorRun2Phys14NonTrig");
-
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
@@ -1,4 +1,4 @@
-#include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2Spring15NonTrig.h"
+#include "RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -464,3 +464,6 @@ void ElectronMVAEstimatorRun2Spring15NonTrig::constrainMVAVariables(AllVariables
 
 }
 
+DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
+		  ElectronMVAEstimatorRun2Spring15NonTrig,
+		  "ElectronMVAEstimatorRun2Spring15NonTrig");

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.h
@@ -144,8 +144,4 @@ class ElectronMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   
 };
 
-DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
-		  ElectronMVAEstimatorRun2Spring15NonTrig,
-		  "ElectronMVAEstimatorRun2Spring15NonTrig");
-
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
@@ -1,4 +1,4 @@
-#include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2Spring15Trig.h"
+#include "RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -412,3 +412,6 @@ void ElectronMVAEstimatorRun2Spring15Trig::constrainMVAVariables(AllVariables& a
 
 }
 
+DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
+		  ElectronMVAEstimatorRun2Spring15Trig,
+		  "ElectronMVAEstimatorRun2Spring15Trig");

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.h
@@ -140,8 +140,4 @@ class ElectronMVAEstimatorRun2Spring15Trig : public AnyMVAEstimatorRun2Base{
   
 };
 
-DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
-		  ElectronMVAEstimatorRun2Spring15Trig,
-		  "ElectronMVAEstimatorRun2Spring15Trig");
-
 #endif

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -1,4 +1,4 @@
-#include "RecoEgamma/PhotonIdentification/interface/PhotonMVAEstimatorRun2Phys14NonTrig.h"
+#include "RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.h"
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
@@ -377,3 +377,7 @@ void PhotonMVAEstimatorRun2Phys14NonTrig::setConsumes(edm::ConsumesCollector&& c
   cc.consumes<edm::ValueMap<float> >( _phoWorstChargedIsolationLabel);
   cc.consumes<double>(_rhoLabel);
 }
+
+DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
+		  PhotonMVAEstimatorRun2Phys14NonTrig,
+		  "PhotonMVAEstimatorRun2Phys14NonTrig");

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.h
@@ -1,5 +1,5 @@
-#ifndef RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Spring15NonTrig_H
-#define RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Spring15NonTrig_H
+#ifndef RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Phys14NonTrig_H
+#define RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Phys14NonTrig_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -18,7 +18,7 @@
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 
-class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
+class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   
  public:
 
@@ -32,8 +32,7 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   };
 
   // Define the struct that contains all necessary for MVA variables
-  struct AllVariables {
-    
+  struct AllVariables {    
     float varPhi;
     float varR9;
     float varSieie;
@@ -56,37 +55,40 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
     // Spectators
     float varPt;
     float varEta;
+
   };
   
   // Constructor and destructor
-  PhotonMVAEstimatorRun2Spring15NonTrig(const edm::ParameterSet& conf);
-  ~PhotonMVAEstimatorRun2Spring15NonTrig();
+  PhotonMVAEstimatorRun2Phys14NonTrig(const edm::ParameterSet& conf);
+  ~PhotonMVAEstimatorRun2Phys14NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
+  float mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
  
   // Utility functions
-  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
-  
-  virtual int getNCategories() const { return nCategories; }
+  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile) ;
+
+  virtual int getNCategories() const override final {return nCategories;};
   bool isEndcapCategory( int category ) const;
   virtual const std::string& getName() const override final { return _name; }
   virtual const std::string& getTag() const override final { return _tag; }
   
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
-  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const override;
-  int findCategory( const edm::Ptr<reco::Candidate>& particle ) const override;
+  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
+  int findCategory(const edm::Ptr<reco::Candidate>& particle) const;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
-  void constrainMVAVariables(AllVariables&) const;
+  void constrainMVAVariables(AllVariables& vars) const;
 
   // Call this function once after the constructor to declare
   // the needed event content pieces to the framework
+  // DEPRECATED
   void setConsumes(edm::ConsumesCollector&&) const override;
   // Call this function once per event to retrieve all needed
   // event content pices
-  //void getEventContent(const edm::Event& iEvent) override;
+  // DEPRECATED
+  // void getEventContent(const edm::Event& iEvent) const override;
 
   
  private:
@@ -94,15 +96,14 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   // MVA name. This is a unique name for this MVA implementation.
   // It will be used as part of ValueMap names.
   // For simplicity, keep it set to the class name.
-  const std::string _name = "PhotonMVAEstimatorRun2Spring15NonTrig";
-
+  const std::string _name = "PhotonMVAEstimatorRun2Phys14NonTrig";
   // MVA tag. This is an additional string variable to distinguish
   // instances of the estimator of this class configured with different
   // weight files.
   std::string _tag;
 
   // Data members
-  std::vector< std::unique_ptr<const GBRForest> > _gbrForests;
+  std::vector<std::unique_ptr<const GBRForest> > _gbrForests;
 
   // All variables needed by this MVA
   const std::string _MethodName;
@@ -127,11 +128,8 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   const edm::InputTag _phoChargedIsolationLabel; 
   const edm::InputTag _phoPhotonIsolationLabel; 
   const edm::InputTag _phoWorstChargedIsolationLabel; 
+  // token for rho
   const edm::InputTag _rhoLabel;
 };
-
-DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
-		  PhotonMVAEstimatorRun2Spring15NonTrig,
-		  "PhotonMVAEstimatorRun2Spring15NonTrig");
 
 #endif

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -1,4 +1,4 @@
-#include "RecoEgamma/PhotonIdentification/interface/PhotonMVAEstimatorRun2Spring15NonTrig.h"
+#include "RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.h"
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
@@ -389,3 +389,6 @@ void PhotonMVAEstimatorRun2Spring15NonTrig::setConsumes(edm::ConsumesCollector&&
   cc.consumes<double>(_rhoLabel);
 }
 
+DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
+		  PhotonMVAEstimatorRun2Spring15NonTrig,
+		  "PhotonMVAEstimatorRun2Spring15NonTrig");

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.h
@@ -1,5 +1,5 @@
-#ifndef RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Phys14NonTrig_H
-#define RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Phys14NonTrig_H
+#ifndef RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Spring15NonTrig_H
+#define RecoEgamma_PhotonIdentification_PhotonMVAEstimatorRun2Spring15NonTrig_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -18,7 +18,7 @@
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 
-class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
+class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   
  public:
 
@@ -32,7 +32,8 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   };
 
   // Define the struct that contains all necessary for MVA variables
-  struct AllVariables {    
+  struct AllVariables {
+    
     float varPhi;
     float varR9;
     float varSieie;
@@ -55,40 +56,37 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
     // Spectators
     float varPt;
     float varEta;
-
   };
   
   // Constructor and destructor
-  PhotonMVAEstimatorRun2Phys14NonTrig(const edm::ParameterSet& conf);
-  ~PhotonMVAEstimatorRun2Phys14NonTrig();
+  PhotonMVAEstimatorRun2Spring15NonTrig(const edm::ParameterSet& conf);
+  ~PhotonMVAEstimatorRun2Spring15NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
+  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
  
   // Utility functions
-  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile) ;
-
-  virtual int getNCategories() const override final {return nCategories;};
+  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
+  
+  virtual int getNCategories() const { return nCategories; }
   bool isEndcapCategory( int category ) const;
   virtual const std::string& getName() const override final { return _name; }
   virtual const std::string& getTag() const override final { return _tag; }
   
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
-  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
-  int findCategory(const edm::Ptr<reco::Candidate>& particle) const;
+  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const override;
+  int findCategory( const edm::Ptr<reco::Candidate>& particle ) const override;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
-  void constrainMVAVariables(AllVariables& vars) const;
+  void constrainMVAVariables(AllVariables&) const;
 
   // Call this function once after the constructor to declare
   // the needed event content pieces to the framework
-  // DEPRECATED
   void setConsumes(edm::ConsumesCollector&&) const override;
   // Call this function once per event to retrieve all needed
   // event content pices
-  // DEPRECATED
-  // void getEventContent(const edm::Event& iEvent) const override;
+  //void getEventContent(const edm::Event& iEvent) override;
 
   
  private:
@@ -96,14 +94,15 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   // MVA name. This is a unique name for this MVA implementation.
   // It will be used as part of ValueMap names.
   // For simplicity, keep it set to the class name.
-  const std::string _name = "PhotonMVAEstimatorRun2Phys14NonTrig";
+  const std::string _name = "PhotonMVAEstimatorRun2Spring15NonTrig";
+
   // MVA tag. This is an additional string variable to distinguish
   // instances of the estimator of this class configured with different
   // weight files.
   std::string _tag;
 
   // Data members
-  std::vector<std::unique_ptr<const GBRForest> > _gbrForests;
+  std::vector< std::unique_ptr<const GBRForest> > _gbrForests;
 
   // All variables needed by this MVA
   const std::string _MethodName;
@@ -128,12 +127,7 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   const edm::InputTag _phoChargedIsolationLabel; 
   const edm::InputTag _phoPhotonIsolationLabel; 
   const edm::InputTag _phoWorstChargedIsolationLabel; 
-  // token for rho
   const edm::InputTag _rhoLabel;
 };
-
-DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
-		  PhotonMVAEstimatorRun2Phys14NonTrig,
-		  "PhotonMVAEstimatorRun2Phys14NonTrig");
 
 #endif


### PR DESCRIPTION
This is related to this hypernews thread:

https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3321.html

Loading the plugin in the .cc file and moving the .h file to the plugin directory. Similar PR will be done for 76X and 81X
