### PR TITLE
Fix phi range

### DIFF
--- a/DataFormats/GeometryVector/interface/EtaInterval.h
+++ b/DataFormats/GeometryVector/interface/EtaInterval.h
@@ -1,0 +1,22 @@
+#ifndef GeometryVector_EtaInterval_H
+#define GeometryVector_EtaInterval_H
+#include "DataFormats/GeometryVector/interface/Basic3DVector.h"
+
+class EtaInterval {
+public:
+  EtaInterval(float eta1, float eta2) : z1(::sinhf(eta1)), z2(::sinhf(eta2)){}
+
+  template<typename T>
+  bool inside(Basic3DVector<T> const & v) const {
+    auto z = v.z();
+    auto r = v.perp();
+    return (z>z1*r) & (z<z2*r);
+  }
+
+private:
+  float z1, z2;
+
+};
+
+#endif
+

--- a/DataFormats/GeometryVector/interface/PhiInterval.h
+++ b/DataFormats/GeometryVector/interface/PhiInterval.h
@@ -1,0 +1,45 @@
+#ifndef GeometryVector_PhiInterval_H
+#define GeometryVector_PhiInterval_H
+#include "DataFormats/GeometryVector/interface/Basic3DVector.h"
+#include "DataFormats/Math/interface/normalizedPhi.h"
+
+class PhiInterval {
+public:
+  PhiInterval(float phi1, float phi2) {
+    phi2 = proxim(phi2,phi1);
+    auto dphi = 0.5f*(phi2-phi1);
+    auto phi = phi1+dphi;
+    x = std::cos(phi);
+    y = std::sin(phi);
+    dcos = std::cos(dphi);
+  }
+
+  PhiInterval(float ix, float iy, float dphi) {
+    auto norm = 1.f/std::sqrt(ix*ix+iy*iy);
+    x = ix*norm;
+    y = iy*norm;
+    dcos = std::cos(dphi);
+  }
+
+  template<typename T>
+  bool inside(Basic3DVector<T> const & v) const {
+    return inside(v.x(),v.y());
+  }
+
+  bool inside(float ix, float iy) const {
+    auto norm = 1.f/std::sqrt(ix*ix+iy*iy);
+    ix *= norm;
+    iy *= norm;
+    
+    return ix*x+iy*y > dcos;
+
+  }
+
+private:
+  float x,y;
+  float dcos;
+
+};
+
+#endif
+

--- a/DataFormats/GeometryVector/interface/PhiInterval.h
+++ b/DataFormats/GeometryVector/interface/PhiInterval.h
@@ -7,6 +7,8 @@ class PhiInterval {
 public:
   PhiInterval(float phi1, float phi2) {
     phi2 = proxim(phi2,phi1);
+    constexpr float c1 = 2.*M_PI;
+    if (phi2<phi1) phi2+=c1;
     auto dphi = 0.5f*(phi2-phi1);
     auto phi = phi1+dphi;
     x = std::cos(phi);

--- a/DataFormats/GeometryVector/interface/PhiInterval.h
+++ b/DataFormats/GeometryVector/interface/PhiInterval.h
@@ -29,12 +29,7 @@ public:
   }
 
   bool inside(float ix, float iy) const {
-    auto norm = 1.f/std::sqrt(ix*ix+iy*iy);
-    ix *= norm;
-    iy *= norm;
-    
-    return ix*x+iy*y > dcos;
-
+    return ix*x+iy*y > dcos*std::sqrt(ix*ix+iy*iy);
   }
 
 private:

--- a/DataFormats/GeometryVector/test/BuildFile.xml
+++ b/DataFormats/GeometryVector/test/BuildFile.xml
@@ -1,4 +1,4 @@
 <use  name="DataFormats/GeometryVector"/>
 <bin  file="BasicVector_t.cpp" name="DataFormatsBasicVector_t"/>
 <bin  file="phiLess_t.cpp" name="GeomVectPhiLess_t"/>
-
+<bin  file="Intervals_t.cpp" name="DataFormatsIntervals_t"/>

--- a/DataFormats/GeometryVector/test/Intervals_t.cpp
+++ b/DataFormats/GeometryVector/test/Intervals_t.cpp
@@ -51,7 +51,7 @@ int main() {
     }
 
     //phi
-    for (float phi=-6;phi<6.5; phi+=0.2)
+    for (float phi=-6.001;phi<6.5; phi+=0.2)
     for (float dphi=-3.1;dphi<3.15; dphi+=0.2) {
       PhiInterval pi(phi,phi+dphi);
       auto in = pi.inside(p.basicVector());

--- a/DataFormats/GeometryVector/test/Intervals_t.cpp
+++ b/DataFormats/GeometryVector/test/Intervals_t.cpp
@@ -1,0 +1,94 @@
+#include "DataFormats/GeometryVector/interface/PhiInterval.h"
+#include "DataFormats/GeometryVector/interface/EtaInterval.h"
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+
+#include "DataFormats/Math/interface/PtEtaPhiMass.h"
+
+#include <cassert>
+
+
+
+int main() {
+
+  assert(!checkPhiInRange(-0.9f,1.f,-1.f));
+  assert(!checkPhiInRange(0.9f,1.f,-1.f));
+  assert(checkPhiInRange(-1.1f,1.f,-1.f));
+  assert(checkPhiInRange(1.1f,1.f,-1.f));
+
+  assert(checkPhiInRange(-0.9f,-1.f,1.f));
+  assert(checkPhiInRange(0.9f,-1.f,1.f));
+  assert(!checkPhiInRange(-1.1f,-1.f,1.f));
+  assert(!checkPhiInRange(1.1f,-1.f,1.f));
+
+
+  assert(checkPhiInRange(-2.9f,-3.f,3.f));
+  assert(checkPhiInRange(2.9f,-3.f,3.f));
+  assert(!checkPhiInRange(-3.1f,-3.f,3.f));
+  assert(!checkPhiInRange(3.1f,-3.f,3.f));
+
+  
+  assert(!checkPhiInRange(-2.9f,3.f,-3.f));
+  assert(!checkPhiInRange(2.9f,3.f,-3.f));
+  assert(checkPhiInRange(-3.1f,3.f,-3.f));
+  assert(checkPhiInRange(3.1f,3.f,-3.f));
+  
+
+  for (float x=-10;x<10;x+=1.)
+  for (float y=-10;y<10;y+=1.) 
+  for (float z=-10;z<10;z+=1.) {
+    if (x==0 && y==0) continue;
+    GlobalPoint p(x,y,z);
+
+    // eta
+    for (float eta=-4;eta<3.5; eta+=0.2)
+    for (float deta=0.1;deta<2.; deta+=0.2) {
+       EtaInterval ei(eta,eta+deta);
+       auto in = ei.inside(p.basicVector());       
+       auto e = etaFromXYZ(x,y,z);
+       auto in2 = (e>eta) & (e<eta+deta);
+       assert(in==in2);
+    }
+
+    //phi
+    for (float phi=-6;phi<6.5; phi+=0.2)
+    for (float dphi=-3.1;dphi<3.15; dphi+=0.2) {
+      PhiInterval pi(phi,phi+dphi);
+      auto in = pi.inside(p.basicVector());
+      auto ph = p.barePhi();
+      auto in2 = checkPhiInRange(ph,phi,phi+dphi);
+      assert(in==in2);      
+    }
+    {
+      PhiInterval pi(3.f,-3.f);
+      auto in = pi.inside(p.basicVector());
+      auto ph = p.barePhi();
+      auto it = ph>3.f || ph<-3.f;
+      assert(in==it);
+      auto in2 = checkPhiInRange(ph,3.f,-3.f);
+      assert(in2==it);
+    }
+    {
+      PhiInterval pi(3.f,4.f);
+      auto in = pi.inside(p.basicVector());
+      auto ph = p.barePhi();
+      auto it = ph>3.f || ph< 4-2*M_PI; ;
+      assert(in==it);
+      auto in2 = checkPhiInRange(ph,3.f,4.f);
+      assert(in2==it);
+    }
+
+    {
+      PhiInterval pi(-1.f,1.f);
+      auto in = pi.inside(p.basicVector());
+      auto ph = p.barePhi();
+      auto it = std::abs(ph)<1;
+      assert(in==it);
+      auto in2 = checkPhiInRange(ph,-1.f,1.f);
+      assert(in2==it);
+    }
+
+
+  } 
+  return 0;
+}

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -17,6 +17,18 @@ T proxim(T b, T a) {
         return b+c1*std::round(c2*(a-b));
 }
 
+#include<iostream>
+
+// smallest range
+template<typename T>
+inline
+bool checkPhiInSymRange(T phi, T phi1, T phi2, float maxDphi=float(M_PI)) {
+  // symmetrize
+  if (phi2<phi1) std::swap(phi1,phi2);
+  return checkPhiInRange(phi,phi1,phi2,maxDphi);
+}
+
+// counterclock-wise range
 template<typename T>
 inline
 bool checkPhiInRange(T phi, T phi1, T phi2, float maxDphi=float(M_PI)) {
@@ -28,7 +40,7 @@ bool checkPhiInRange(T phi, T phi1, T phi2, float maxDphi=float(M_PI)) {
     phi = proxim(phi,phiA);
     return std::abs(phiA-phi)<dphi;
 
-    /*
+    /* old "alternative algo"
     constexpr T c1 = 2.*M_PI;
     phi1 = normalizedPhi(phi1);
     phi2 = proxim(phi2,phi1);

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -1,6 +1,7 @@
 #ifndef Math_notmalizedPhi_h
 #define Math_notmalizedPhi_h
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include <algorithm>
 
 // return a value of phi into interval [-pi,+pi]
 template<typename T>
@@ -22,9 +23,11 @@ bool checkPhiInRange(T phi, T phi1, T phi2) {
     constexpr T c1 = 2.*M_PI;
     phi1 = normalizedPhi(phi1);
     phi2 = proxim(phi2,phi1);
+    if (phi2<phi1) std::swap(phi1,phi2);
     // phi & phi1 are in [-pi,pi] range...
-    return ( (phi1 <= phi) && (phi <= phi2) ) ||
-           ( (phi1 <= phi-c1) && (phi-c1 <= phi2) );
+    return ( (phi1 <= phi) & (phi <= phi2) )
+           || ( (phi1 <= phi-c1) & (phi-c1 <= phi2) )
+           || ( (phi1 <= phi+c1) & (phi+c1 <= phi2) );
 }
 
 #endif

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -19,7 +19,16 @@ T proxim(T b, T a) {
 
 template<typename T>
 inline
-bool checkPhiInRange(T phi, T phi1, T phi2) {
+bool checkPhiInRange(T phi, T phi1, T phi2, float maxDphi=float(M_PI)) {
+    phi2 = proxim(phi2,phi1);
+    constexpr float c1 = 2.*M_PI;
+    if (phi2<phi1) phi2+=c1;
+    auto dphi = std::min(maxDphi,0.5f*(phi2-phi1));
+    auto phiA = phi1+dphi;
+    phi = proxim(phi,phiA);
+    return std::abs(phiA-phi)<dphi;
+
+    /*
     constexpr T c1 = 2.*M_PI;
     phi1 = normalizedPhi(phi1);
     phi2 = proxim(phi2,phi1);
@@ -28,6 +37,7 @@ bool checkPhiInRange(T phi, T phi1, T phi2) {
     return ( (phi1 <= phi) & (phi <= phi2) )
 //           || ( (phi1 <= phi-c1) & (phi-c1 <= phi2) )
            || ( (phi1 <= phi+c1) & (phi+c1 <= phi2) );
+    */
 }
 
 #endif

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -23,10 +23,10 @@ bool checkPhiInRange(T phi, T phi1, T phi2) {
     constexpr T c1 = 2.*M_PI;
     phi1 = normalizedPhi(phi1);
     phi2 = proxim(phi2,phi1);
-    if (phi2<phi1) std::swap(phi1,phi2);
+    if (phi2<phi1) phi2+=c1;
     // phi & phi1 are in [-pi,pi] range...
     return ( (phi1 <= phi) & (phi <= phi2) )
-           || ( (phi1 <= phi-c1) & (phi-c1 <= phi2) )
+//           || ( (phi1 <= phi-c1) & (phi-c1 <= phi2) )
            || ( (phi1 <= phi+c1) & (phi+c1 <= phi2) );
 }
 

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -24,7 +24,7 @@ bool checkPhiInRange(T phi, T phi1, T phi2) {
     phi2 = proxim(phi2,phi1);
     // phi & phi1 are in [-pi,pi] range...
     return ( (phi1 <= phi) && (phi <= phi2) ) ||
-           ( (phi1 <= phi+c1) && (phi+c1 <= phi2) );
+           ( (phi1 <= phi-c1) && (phi-c1 <= phi2) );
 }
 
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -286,12 +286,14 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 	if (crossingRange.empty())  continue;
 	
 	float ir = 1.f/hits.rv(KDdata);
-	float phiErr = nSigmaPhi * hits.drphi[KDdata]*ir;
+        // limit error to 90 degree
+        constexpr float maxPhiErr = 0.5*M_PI;
+	float phiErr = std::min(maxPhiErr, nSigmaPhi * hits.drphi[KDdata]*ir);
         bool nook=true;
 	for (int icharge=-1; icharge <=1; icharge+=2) {
 	  Range rangeRPhi = predictionRPhi(hits.rv(KDdata), icharge);
 	  correction.correctRPhiRange(rangeRPhi);
-	  if (checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr)) {
+	  if (checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr,maxPhiErr)) {
 	    // insert here check with comparitor
 	    OrderedHitTriplet hittriplet( doublets.hit(ip,HitDoublets::inner), doublets.hit(ip,HitDoublets::outer), hits.theHits[KDdata].hit());
 	    if (!theComparitor  || theComparitor->compatible(hittriplet,region) ) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -288,10 +288,12 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 	float ir = 1.f/hits.rv(KDdata);
         // limit error to 90 degree
         constexpr float maxPhiErr = 0.5*M_PI;
-	float phiErr = std::min(maxPhiErr, nSigmaPhi * hits.drphi[KDdata]*ir);
+	float phiErr = nSigmaPhi * hits.drphi[KDdata]*ir;
+        phiErr = std::min(maxPhiErr, phiErr);
         bool nook=true;
 	for (int icharge=-1; icharge <=1; icharge+=2) {
 	  Range rangeRPhi = predictionRPhi(hits.rv(KDdata), icharge);
+          if(rangeRPhi.first>rangeRPhi.second) continue; // range is empty
 	  correction.correctRPhiRange(rangeRPhi);
 	  if (checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr,maxPhiErr)) {
 	    // insert here check with comparitor

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -41,7 +41,7 @@ namespace {
 }
 
 constexpr double nSigmaRZ = 3.4641016151377544; // sqrt(12.)
-constexpr double nSigmaPhi = 3.;
+constexpr float nSigmaPhi = 3.;
 constexpr float fnSigmaRZ = nSigmaRZ;
 
 
@@ -329,8 +329,10 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 	correction.correctRPhiRange(rangeRPhi);
 
 	float ir = 1.f/p3_r;
-	float phiErr = nSigmaPhi *  hits.drphi[KDdata]*ir;
-	if (!checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr))
+        // limit error to 90 degree
+        constexpr float maxPhiErr = 0.5*M_PI;
+        float phiErr = std::min(maxPhiErr, nSigmaPhi * hits.drphi[KDdata]*ir);
+	if (!checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr, maxPhiErr))
 	  continue;
 	
 	Basic2DVector<double> thc(p3.x(), p3.y());

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -331,7 +331,8 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 	float ir = 1.f/p3_r;
         // limit error to 90 degree
         constexpr float maxPhiErr = 0.5*M_PI;
-        float phiErr = std::min(maxPhiErr, nSigmaPhi * hits.drphi[KDdata]*ir);
+        float phiErr = nSigmaPhi * hits.drphi[KDdata]*ir;
+        phiErr = std::min(maxPhiErr, phiErr);
 	if (!checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr, maxPhiErr))
 	  continue;
 	

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
@@ -79,6 +79,7 @@ ThirdHitCorrection::init(
   };
 
   theMultScattCorrRPhi = 3.f*sigmaRPhi(pt, line.cotLine(), point2(), layer2.seqNum());
+  
 }
 
 void ThirdHitCorrection::init( 

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvParabola.cc
@@ -89,16 +89,16 @@ ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius, int icharge) const
   Scalar phi1 = f_phi(theRotation.rotateBack(Point2D(u[0],v[0])));
   Scalar phi2 = phi1+(v[1]-v[0]); 
   
+  if (phi2<phi1) std::swap(phi1, phi2);
+
   if (ip.empty()) {
     Range r1(phi1*radius-theTolerance, phi1*radius+theTolerance); 
     Range r2(phi2*radius-theTolerance, phi2*radius+theTolerance); 
-    return r1.intersection(r2);
+    return r1.intersection(r2); // this range can be empty
   }
 
-  if (phi2<phi1) std::swap(phi1, phi2); 
   return Range(radius*phi1-theTolerance, radius*phi2+theTolerance);
   
-
 }
 
 
@@ -107,14 +107,15 @@ ThirdHitPredictionFromInvParabola::rangeRPhi(Scalar radius) const
 {
 
   auto getRange = [&](Scalar phi1, Scalar phi2, bool empty)->RangeD {
-    
+  
+    if (phi2<phi1) std::swap(phi1, phi2);  
     if (empty) {
       RangeD r1(phi1*radius-theTolerance, phi1*radius+theTolerance); 
       RangeD r2(phi2*radius-theTolerance, phi2*radius+theTolerance); 
       return r1.intersection(r2);
     }
     
-    return RangeD(radius*std::min(phi1,phi2)-theTolerance, radius*std::max(phi1,phi2)+theTolerance);
+    return RangeD(radius*phi1-theTolerance, radius*phi2+theTolerance);
   };
 
 


### PR DESCRIPTION
there was a bug in checkPhiInRange and other in PixelTripletHLTGenerator.cc (accepting empty ranges).
Added also a test and two optimized implementations of phi and eta intervals.

regression expected in particular at low-pt
http://innocent.home.cern.ch/innocent/RelVal/pu35_81_fixRP/plots_highPurity/effandfake1.pdf
