### PR TITLE
bsunanda:Run2-hcx76 Remove wrong warnings

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -56,8 +56,10 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
     for(std::vector<DetId>::iterator i=allChannels.begin(); i!=allChannels.end(); ++i){
 
 	if (not HcalGenericDetId(*i).isHcalTrigTowerDetId()) {
-	    if (not HcalGenericDetId(*i).isHcalDetId())
-		edm::LogWarning("CaloTPGTranscoderULUT") << "Encountered invalid HcalDetId " << HcalGenericDetId(*i);
+	  if ((not HcalGenericDetId(*i).isHcalDetId()) and
+	      (not HcalGenericDetId(*i).isHcalZDCDetId()) and
+	      (not HcalGenericDetId(*i).isHcalCastorDetId()))
+	    edm::LogWarning("CaloTPGTranscoderULUT") << "Encountered invalid HcalDetId " << HcalGenericDetId(*i);
 	    continue;
 	}
 	

--- a/CondFormats/HcalObjects/src/HcalCondObjectContainerBase.cc
+++ b/CondFormats/HcalObjects/src/HcalCondObjectContainerBase.cc
@@ -13,9 +13,9 @@ HcalCondObjectContainerBase::HcalCondObjectContainerBase(const HcalTopology* top
 }
 
 void HcalCondObjectContainerBase::setTopo(const HcalTopology* topo) {
-  if (topo && !topo->denseIdConsistent(packedIndexVersion_)) {
+  if ((topo) && (packedIndexVersion_ != 0) &&
+      (!topo->denseIdConsistent(packedIndexVersion_)))
     edm::LogError("HCAL") << std::string("Inconsistent dense packing between current topology (") << topo->topoVersion() << ") and calibration object (" << packedIndexVersion_ << ")";
-  }
   topo_=topo;
 }
 


### PR DESCRIPTION
Wrong warnings in HcalCondObjectContainer and CaloTPGTranscoderULUT are removed
