### PR TITLE
Add TimingTask sequence. Add TTF plots.

### DIFF
--- a/DQM/EcalMonitorClient/python/TimingClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TimingClient_cfi.py
@@ -11,6 +11,7 @@ minTowerEntriesFwd = 160
 toleranceMeanFwd = 6.
 toleranceRMSFwd = 12.
 tailPopulThreshold = 0.4
+timeWindow = 25. 
 
 ecalTimingClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
@@ -68,16 +69,16 @@ ecalTimingClient = cms.untracked.PSet(
         FwdvBkwd = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             yaxis = cms.untracked.PSet(
-                high = cms.untracked.double(25.0),
+                high = cms.untracked.double(timeWindow),
                 nbins = cms.untracked.int32(50),
-                low = cms.untracked.double(-25.0),
+                low = cms.untracked.double(-timeWindow),
                 title = cms.untracked.string('time (ns)')
             ),
             otype = cms.untracked.string('Ecal2P'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(25.0),
+                high = cms.untracked.double(timeWindow),
                 nbins = cms.untracked.int32(50),
-                low = cms.untracked.double(-25.0)
+                low = cms.untracked.double(-timeWindow)
             ),
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing %(prefix)s+ vs %(prefix)s-'),
@@ -100,9 +101,9 @@ ecalTimingClient = cms.untracked.PSet(
             ),
             otype = cms.untracked.string('SM'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(25.0),
+                high = cms.untracked.double(timeWindow),
                 nbins = cms.untracked.int32(100),
-                low = cms.untracked.double(-25.0)
+                low = cms.untracked.double(-timeWindow)
             ),
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingClient/%(prefix)sTMT timing mean %(sm)s'),
@@ -137,9 +138,9 @@ ecalTimingClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH1F'),
             otype = cms.untracked.string('Ecal3P'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(25.0),
+                high = cms.untracked.double(timeWindow),
                 nbins = cms.untracked.int32(100),
-                low = cms.untracked.double(-25.0),
+                low = cms.untracked.double(-timeWindow),
                 title = cms.untracked.string('time (ns)')
             ),
             btype = cms.untracked.string('User'),

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -13,7 +13,9 @@ ecalTrigPrimClient = cms.untracked.PSet(
     ),
     sources = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,
-        MatchedIndex = ecalTrigPrimTask.MEs.MatchedIndex
+        MatchedIndex = ecalTrigPrimTask.MEs.MatchedIndex,
+        TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
+        TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll
     ),
     MEs = cms.untracked.PSet(
         NonSingleSummary = cms.untracked.PSet(
@@ -42,6 +44,13 @@ ecalTrigPrimClient = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('TriggerTower'),
             description = cms.untracked.string('Emulator TP timing where the largest number of events had Et matches. Towers with entries less than ' + str(minEntries) + ' are not considered.')
+        ),
+        TTF4vMask = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT TTF4 vs Masking Status%(suffix)s'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('TriggerTower'),
+            description = cms.untracked.string('Summarizes whether a TT was masked in the TPGRecords, or had an instance of TT Flag=4.<br/>GRAY: Masked, no TTF4,<br/>BLACK: Masked, with TTF4,<br/>BLUE: Not Masked, with TTF4.')
         )
     )
 )

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -72,7 +72,31 @@ namespace ecaldqm
       else
         meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
     }
-  }
+
+    // Fill TTF4 v Masking ME
+    // NOT an occupancy plot: only tells you if non-zero TTF4 occupancy was seen
+    // without giving info about how many were seen
+    MESet& meTTF4vMask(MEs_.at("TTF4vMask"));
+    MESet const& sTTFlags4(sources_.at("TTFlags4"));
+    MESet const& sTTMaskMapAll(sources_.at("TTMaskMapAll"));
+    
+    // Loop over all TTs
+    for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
+      EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
+      bool isMasked( sTTMaskMapAll.getBinContent(ttid) > 0. );
+      bool hasTTF4( sTTFlags4.getBinContent(ttid) > 0. );
+      if ( isMasked ) { 
+        if ( hasTTF4 )
+          meTTF4vMask.setBinContent( ttid,12 ); // Masked, has TTF4
+        else
+          meTTF4vMask.setBinContent( ttid,11 ); // Masked, no TTF4
+      } else {
+        if ( hasTTF4 )
+          meTTF4vMask.setBinContent( ttid,13 ); // not Masked, has TTF4
+      }   
+    } // TT loop 
+
+  } // TrigPrimClient::producePlots()
 
   DEFINE_ECALDQM_WORKER(TrigPrimClient);
 }

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -5,6 +5,11 @@
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
+
 namespace ecaldqm {
 
   class TrigPrimTask : public DQWorkerTask {
@@ -16,6 +21,7 @@ namespace ecaldqm {
 
     bool analyze(void const*, Collections) override;
 
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void beginEvent(edm::Event const&, edm::EventSetup const&) override;
 
     void runOnRealTPs(EcalTrigPrimDigiCollection const&);
@@ -42,6 +48,10 @@ namespace ecaldqm {
     double bxBin_;
 
     std::map<uint32_t, unsigned> towerReadouts_;
+
+    edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
+    edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
+
   };
 
   inline bool TrigPrimTask::analyze(void const* _p, Collections _collection){

--- a/DQM/EcalMonitorTasks/python/EcalMonitorTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTask_cfi.py
@@ -26,6 +26,7 @@ ecalMonitorTask = cms.EDAnalyzer("EcalDQMonitorTask",
         "PresampleTask",
         "RawDataTask",
         "RecoSummaryTask",
+        "TimingTask",
         "TrigPrimTask"
     ),
     # task parameters (included from indivitual cfis)

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -149,12 +149,26 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('DCC'),
             description = cms.untracked.string('Distribution of the trigger tower flags.')
         ),
+        TTFlags4 = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT TTF4 Occupancy%(suffix)s'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('TriggerTower'),
+            description = cms.untracked.string('Occupancy for TP digis with TTF=4.')
+        ),
         TTMaskMap = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/TTStatus/%(prefix)sTTT TT Masking Status%(sm)s'),
             kind = cms.untracked.string('TProfile2D'),
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('PseudoStrip'),
             description = cms.untracked.string('Trigger tower and pseudo-strip masking status: a TT or strip is red if it is masked')
+        ),
+        TTMaskMapAll = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT TT Masking Status%(suffix)s'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('TriggerTower'),
+            description = cms.untracked.string('Trigger tower masking status: a TT is red if it is masked.')
         ),
         TTFMismatch = cms.untracked.PSet(
 #            path = cms.untracked.string('Ecal/Errors/TriggerPrimitives/FlagMismatch/'),


### PR DESCRIPTION
-     Add TimingTask sequence to EcalMonitorTask (for offline dqm)
-     Consolidate timing windows in Timing Client As requested by ECAL trigger group:
-     Add TTF4 Occupancy plot
-     Add TT Masking status plot
-     Add TTF4 v Masking status plot
-     Include TT records for EE masking

Based on 80X PR https://github.com/cms-sw/cmssw/pull/13917
