### PR TITLE
DQM GCC 6.0.0 (r234661) cleanup (address used as a pointer, std::fabs)

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -84,11 +84,6 @@ namespace cscdqm {
 
     config->incNUnpackedCSC();
 
-    if (&data == 0) {
-      LOG_ERROR << "Zero pointer. DMB data are not available for unpacking"; //KK is->are
-      return;
-    }
-
     int FEBunpacked   = 0;
     int alct_unpacked = 0;
     int tmb_unpacked  = 0;

--- a/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
+++ b/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
@@ -356,7 +356,7 @@ void EwkMuLumiMonitorDQM::analyze(const Event& ev, const EventSetup&) {
     } else {
       name = fullname;
     }
-    if (&toc != 0) {
+    if (!toc.empty()) {
       const trigger::Keys& k = handleTriggerEvent->filterKeys(ia);
       for (trigger::Keys::const_iterator ki = k.begin(); ki != k.end(); ++ki) {
         // looking at all the single muon l3 trigger present, for example

--- a/DQM/SiStripCommissioningSummary/src/DaqScopeModeSummaryFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/DaqScopeModeSummaryFactory.cc
@@ -87,14 +87,6 @@ void SummaryHistogramFactory<DaqScopeModeAnalysis>::fill( TH1& summary_histo ) {
     return;
   }
 
-  // Check if instance of generator class exists
-  if ( !(&summary_histo) ) { 
-    edm::LogWarning(mlSummaryPlots_)
-      << "[SummaryHistogramFactory::" << __func__ << "]" 
-      << " NULL pointer to SummaryGenerator object!";
-    return;
-  }
-
   // Check if std::map is filled
   if ( !generator_->size() ) { 
     edm::LogWarning(mlSummaryPlots_)

--- a/DQM/SiStripCommissioningSummary/src/FedTimingSummaryFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/FedTimingSummaryFactory.cc
@@ -104,13 +104,6 @@ void SummaryHistogramFactory<FedTimingAnalysis>::fill( TH1& summary_histo ) {
     return;
   }
 
-  // Check if instance of generator class exists
-  if ( !(&summary_histo) ) { 
-    edm::LogWarning(mlSummaryPlots_) << "[SummaryHistogramFactory::" << __func__ << "]" 
-	 << " NULL pointer to SummaryGenerator object!";
-    return;
-  }
-
   // Check if std::map is filled
   if ( !generator_->size() ) { 
     edm::LogWarning(mlSummaryPlots_) << "[SummaryHistogramFactory::" << __func__ << "]" 

--- a/DQM/SiStripCommissioningSummary/src/SummaryHistogramFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/SummaryHistogramFactory.cc
@@ -99,13 +99,6 @@ void SummaryHistogramFactory<T>::fill( TH1& summary_histo ) {
     return;
   }
 
-  // Check if instance of generator class exists
-  if ( !(&summary_histo) ) { 
-    edm::LogWarning(mlSummaryPlots_) << "[SummaryHistogramFactory::" << __func__ << "]" 
-	 << " NULL pointer to SummaryGenerator object!";
-    return;
-  }
-
   // Check if std::map is filled
   if ( !generator_->size() ) { 
     edm::LogWarning(mlSummaryPlots_) << "[SummaryHistogramFactory::" << __func__ << "]" 

--- a/DQM/SiStripCommissioningSummary/src/SummaryPlotFactoryBase.cc
+++ b/DQM/SiStripCommissioningSummary/src/SummaryPlotFactoryBase.cc
@@ -127,14 +127,6 @@ void SummaryPlotFactoryBase::fill( TH1& summary_histo ) {
     return; 
   } 
   
-  // Check if instance of generator class exists
-  if ( !(&summary_histo) ) { 
-    edm::LogWarning(mlSummaryPlots_)
-      << "[SummaryPlotFactoryBase::" << __func__ << "]" 
-      << " NULL pointer to TH1 object!";
-    return;
-  }
-  
   // Print contents of map for histogram
   //generator_->printMap();
   

--- a/DQMOffline/JetMET/interface/SusyDQM/HT.h
+++ b/DQMOffline/JetMET/interface/SusyDQM/HT.h
@@ -15,6 +15,7 @@
 #include "TVector2.h"
 #include <vector>
 #include <iostream>
+#include <cmath>
 
 template<class T>
 class HT {
@@ -35,7 +36,7 @@ private:
   {
     typedef typename T::const_iterator Iter;
     for (Iter jet = jetcoll->begin(); jet!=jetcoll->end(); ++jet){
-      if ((jet->pt()>ptThreshold) && (abs(jet->eta())<maxAbsEta)){
+      if ((jet->pt()>ptThreshold) && (std::fabs(jet->eta())<maxAbsEta)){
 	njet++;
 	Hx += jet->px();
 	Hy += jet->py();
@@ -45,11 +46,5 @@ private:
     v=TVector2(Hx,Hy);
   }
 };
-
-
-
-
-
-
 
 #endif

--- a/DQMOffline/JetMET/src/HTMHTAnalyzer.cc
+++ b/DQMOffline/JetMET/src/HTMHTAnalyzer.cc
@@ -82,44 +82,35 @@ void HTMHTAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   // ==========================================================  
   // Trigger information 
   //
-  if(&triggerResults) {   
 
-    /////////// Analyzing HLT Trigger Results (TriggerResults) //////////
+  /////////// Analyzing HLT Trigger Results (TriggerResults) //////////
 
-    //
-    //
-    // Check how many HLT triggers are in triggerResults 
-    int ntrigs = triggerResults.size();
-    if (_verbose) std::cout << "ntrigs=" << ntrigs << std::endl;
-    
-    //
-    //
-    // If index=ntrigs, this HLT trigger doesn't exist in the HLT table for this data.
-    const edm::TriggerNames & triggerNames = iEvent.triggerNames(triggerResults);
-    
-    //
-    //
-    // count number of requested Jet or MB HLT paths which have fired
-    for (unsigned int i=0; i!=HLTPathsJetMBByName_.size(); i++) {
-      unsigned int triggerIndex = triggerNames.triggerIndex(HLTPathsJetMBByName_[i]);
-      if (triggerIndex<triggerResults.size()) {
-	if (triggerResults.accept(triggerIndex)) {
-	  _trig_JetMB++;
-	}
+  //
+  //
+  // Check how many HLT triggers are in triggerResults 
+  int ntrigs = triggerResults.size();
+  if (_verbose) std::cout << "ntrigs=" << ntrigs << std::endl;
+  
+  //
+  //
+  // If index=ntrigs, this HLT trigger doesn't exist in the HLT table for this data.
+  const edm::TriggerNames & triggerNames = iEvent.triggerNames(triggerResults);
+  
+  //
+  //
+  // count number of requested Jet or MB HLT paths which have fired
+  for (unsigned int i=0; i!=HLTPathsJetMBByName_.size(); i++) {
+    unsigned int triggerIndex = triggerNames.triggerIndex(HLTPathsJetMBByName_[i]);
+    if (triggerIndex<triggerResults.size()) {
+      if (triggerResults.accept(triggerIndex)) {
+        _trig_JetMB++;
       }
     }
-    // for empty input vectors (n==0), take all HLT triggers!
-    if (HLTPathsJetMBByName_.size()==0) _trig_JetMB=triggerResults.size()-1;
-
-    if (_trig_JetMB==0) return;
-
-  } else {
-
-    edm::LogInfo("CaloMetAnalyzer") << "TriggerResults::HLT not found, "
-      "automatically select events"; 
-    //return;
-    
   }
+  // for empty input vectors (n==0), take all HLT triggers!
+  if (HLTPathsJetMBByName_.size()==0) _trig_JetMB=triggerResults.size()-1;
+
+  if (_trig_JetMB==0) return;
    
   // ==========================================================
 

--- a/DQMOffline/PFTau/src/Benchmark.cc
+++ b/DQMOffline/PFTau/src/Benchmark.cc
@@ -22,49 +22,37 @@ void Benchmark::setDirectory(TDirectory* dir) {
 
 TH1F* Benchmark::book1D(DQMStore::IBooker& b, const char* histname, const char* title, 
 			int nbins, float xmin, float xmax) {
-  if( &b ) {
-    edm::LogInfo("Benchmark") << " Benchmark::book1D " << "booking "<<histname;
-    return b.book1D(histname,title,nbins,xmin,xmax)->getTH1F();
-  }
-  else assert(0);
+  edm::LogInfo("Benchmark") << " Benchmark::book1D " << "booking "<<histname;
+  return b.book1D(histname,title,nbins,xmin,xmax)->getTH1F();
 }
 
 TH2F* Benchmark::book2D(DQMStore::IBooker& b, const char* histname, const char* title, 
 			int nbinsx, float xmin, float xmax,
 			int nbinsy, float ymin, float ymax ) {
-  if( &b ) {
-    edm::LogInfo("Benchmark") << " Benchmark::book2D "<<"booked "<<histname;
-    return b.book2D(histname,title,nbinsx,xmin, xmax, nbinsy, ymin, ymax)->getTH2F();
-  }
-  else assert(0);
+  edm::LogInfo("Benchmark") << " Benchmark::book2D "<<"booked "<<histname;
+  return b.book2D(histname,title,nbinsx,xmin, xmax, nbinsy, ymin, ymax)->getTH2F();
 }
 
 TH2F* Benchmark::book2D(DQMStore::IBooker& b, const char* histname, const char* title, 
 			int nbinsx, float* xbins,
 			int nbinsy, float ymin, float ymax ) {
-  if( &b ) {
-    edm::LogInfo("Benchmark") << " Benchmark::book2D " << " booked "<<histname;
-    
-    // need to build the y bin array manually, due to a missing function in DQMStore
-    vector<float> ybins( nbinsy+1 );
-    double binsize = (ymax - ymin) / nbinsy;
-    for(int i=0; i<=nbinsy; ++i) {
-      ybins[i] = ymin + i*binsize;
-    } 
-    
-    return b.book2D(histname,title,nbinsx, xbins, nbinsy, &ybins[0])->getTH2F();
-  }
-  else assert(0);
+  edm::LogInfo("Benchmark") << " Benchmark::book2D " << " booked "<<histname;
+  
+  // need to build the y bin array manually, due to a missing function in DQMStore
+  vector<float> ybins( nbinsy+1 );
+  double binsize = (ymax - ymin) / nbinsy;
+  for(int i=0; i<=nbinsy; ++i) {
+    ybins[i] = ymin + i*binsize;
+  } 
+  
+  return b.book2D(histname,title,nbinsx, xbins, nbinsy, &ybins[0])->getTH2F();
 }
 
 TProfile* Benchmark::bookProfile(DQMStore::IBooker& b, const char* histname, const char* title,
 				 int nbinsx, float xmin, float xmax,
 				 float ymin, float ymax, const char* option ) {
-  if( &b ) {
-    edm::LogInfo("Benchmark") << " Benchmark::bookProfile "<<"booked "<<histname;
-    return b.bookProfile(histname, title, nbinsx, xmin, xmax, 0.0, 0.0, option )->getTProfile();
-  }
-  else assert(0);
+  edm::LogInfo("Benchmark") << " Benchmark::bookProfile "<<"booked "<<histname;
+  return b.bookProfile(histname, title, nbinsx, xmin, xmax, 0.0, 0.0, option )->getTProfile();
 }
 
 TProfile* Benchmark::bookProfile(DQMStore::IBooker& b, const char* histname, const char* title,
@@ -77,11 +65,8 @@ TProfile* Benchmark::bookProfile(DQMStore::IBooker& b, const char* histname, con
     xbinsd[i] = xbins[i];
   }
 
-  if( &b ) {
-    edm::LogInfo("Benchmark") << " Benchmark::bookProfile "<<"booked "<<histname;
-    return b.bookProfile(histname, title, nbinsx, &xbinsd[0], ymin, ymax, option)->getTProfile();
-  }
-  else assert(0);
+  edm::LogInfo("Benchmark") << " Benchmark::bookProfile "<<"booked "<<histname;
+  return b.bookProfile(histname, title, nbinsx, &xbinsd[0], ymin, ymax, option)->getTProfile();
 }
 
 


### PR DESCRIPTION
The following are last pieces to cleanup DQM with GCC 6.0.0 (r234661). In majority cases it's about using address as a pointer. Compiler can always assume that address is not `0/NULL/nullptr`, thus it can always assume that condition is `true` or `false` at compile time. Cleanup such places. There is one place there such comparison was replaced to `!std:vector::empty()` check for same. There is one instance where `abs` was replace by `std::fabs` and `<cmath>` header added.

Errors are available in commit messages.

Please, review.
