### PR TITLE
Default initialize PTrajectoryStateOnDet members

### DIFF
--- a/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
+++ b/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
@@ -79,9 +79,9 @@ public:
 private:
 
   LocalTrajectoryParameters theLocalParameters;
-  float theLocalErrors[15];
-  float thePt;
-  unsigned int thePack;
+  float theLocalErrors[15] = {};
+  float thePt = 0;
+  unsigned int thePack = 0;
 
 };
 


### PR DESCRIPTION
GCC 6.0.0 (r234661) we might create PTrajectoryStateOnDet without
initialized members. The patch adds the defaults which later can be
modified by member initializer list in ctor.

```
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[0]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[10]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[11]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[12]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[13]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[14]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[1]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[2]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[3]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[4]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[5]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[6]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[7]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[8]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::theLocalErrors[9]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc:282:20: error: 'seedVoid.TrajectorySeed::tsos_.PTrajectoryStateOnDet::thePt' may be used uninitialized in this function [-Werror=maybe-uninitialized]
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
