### PR TITLE
PreMixing era switch for Stage 2 L1 configuration

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
@@ -8,11 +8,18 @@ simDtTriggerPrimitiveDigis.digiTag = 'mixData'
 simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag("mixData","MuonCSCComparatorDigisDM")
 simCscTriggerPrimitiveDigis.CSCWireDigiProducer = cms.InputTag("mixData","MuonCSCWireDigisDM")
 #
-#simRpcTriggerDigis.label = cms.InputTag("simMuonRPCDigis")
-simRpcTriggerDigis.label = 'mixData'
+#
 simRpcTechTrigDigis.RPCDigiLabel = 'mixData'
+#
 simHcalTechTrigDigis.ttpDigiCollection = "DMHcalTTPDigis"
-simRctDigis.hcalDigis=cms.VInputTag(cms.InputTag("DMHcalTriggerPrimitiveDigis"))
-simRctDigis.ecalDigis=cms.VInputTag(cms.InputTag("DMEcalTriggerPrimitiveDigis"))
+#
 
-
+if not eras.stage2L1Trigger.isChosen():
+    simRpcTriggerDigis.label = 'mixData'
+    simRctDigis.hcalDigis=cms.VInputTag(cms.InputTag("DMHcalTriggerPrimitiveDigis"))   
+    simRctDigis.ecalDigis=cms.VInputTag(cms.InputTag("DMEcalTriggerPrimitiveDigis"))   
+else:
+    simTwinMuxDigis.RPC_Source = cms.InputTag('mixData')
+    simOmtfDigis.srcRPC = cms.InputTag('mixData')
+    simCaloStage2Layer1Digis.ecalToken = cms.InputTag("DMEcalTriggerPrimitiveDigis")
+    simCaloStage2Layer1Digis.hcalToken = cms.InputTag("DMHcalTriggerPrimitiveDigis")


### PR DESCRIPTION
add an era-based switch to the PreMixing configuration so that the phase 2 L1 gets the correct input collections from the PreMixing framework.
