### PR TITLE
era-based run1 tracking setup and T0 Data processing update

### DIFF
--- a/Configuration/DataProcessing/python/Impl/HeavyIons.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIons.py
@@ -18,7 +18,7 @@ class HeavyIons(Reco):
         Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='HeavyIons'
-        self.promptCustoms='Configuration/DataProcessing/RecoTLR.customisePromptHI'
+        self.promptCustoms= [ 'Configuration/DataProcessing/RecoTLR.customisePromptHI' ]
         self.expressCustoms= [ ]
         self.expressModifiers = modifyExpressHI
         self.visCustoms= [ ]

--- a/Configuration/DataProcessing/python/Impl/HeavyIons.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIons.py
@@ -11,7 +11,7 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.DataProcessing.RecoTLR import modifyExpressHI
+from Configuration.DataProcessing.Modifiers import modifyExpressHI
 
 class HeavyIons(Reco):
     def __init__(self):

--- a/Configuration/DataProcessing/python/Impl/HeavyIons.py
+++ b/Configuration/DataProcessing/python/Impl/HeavyIons.py
@@ -11,6 +11,7 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.RecoTLR import modifyExpressHI
 
 class HeavyIons(Reco):
     def __init__(self):
@@ -18,8 +19,10 @@ class HeavyIons(Reco):
         self.recoSeq=''
         self.cbSc='HeavyIons'
         self.promptCustoms='Configuration/DataProcessing/RecoTLR.customisePromptHI'
-        self.expressCustoms='Configuration/DataProcessing/RecoTLR.customiseExpressHI'
-        self.visCustoms='Configuration/DataProcessing/RecoTLR.customiseExpressHI'
+        self.expressCustoms= [ ]
+        self.expressModifiers = modifyExpressHI
+        self.visCustoms= [ ]
+        self.visModifiers = modifyExpressHI
     """
     _HeavyIons_
 
@@ -55,7 +58,8 @@ class HeavyIons(Reco):
         if not 'customs' in args:
             args['customs']=[ ]
 
-        args['customs'].append(self.promptCustoms)
+        for c in self.promptCustoms:
+            args['customs'].append(c)
 
         process = Reco.promptReco(self,globalTag, **args)
 
@@ -78,7 +82,8 @@ class HeavyIons(Reco):
         if not 'customs' in args:
             args['customs']=[ ]
 
-        args['customs'].append( self.expressCustoms )
+        for c in self.expressCustoms:
+            args['customs'].append(c)
 
         process = Reco.expressProcessing(self,globalTag, **args)
         
@@ -97,7 +102,8 @@ class HeavyIons(Reco):
         if not 'customs' in args:
             args['customs']=[ ]
 
-        args['customs'].append( self.visCustoms )
+        for c in self.visCustoms:
+            args['customs'].append(c)
 
         process = Reco.visualizationProcessing(self,globalTag, **args)
         

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -11,7 +11,7 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.DataProcessing.RecoTLR import modifyExpress
+from Configuration.DataProcessing.Modifiers import modifyExpress
 
 class pp(Reco):
     def __init__(self):

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -11,6 +11,7 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.RecoTLR import modifyExpress
 
 class pp(Reco):
     def __init__(self):
@@ -18,8 +19,10 @@ class pp(Reco):
         self.recoSeq=''
         self.cbSc='pp'
         self.promptCustoms= [ 'Configuration/DataProcessing/RecoTLR.customisePrompt' ]
-        self.expressCustoms=[ 'Configuration/DataProcessing/RecoTLR.customiseExpress' ]
-        self.visCustoms=[ 'Configuration/DataProcessing/RecoTLR.customiseExpress' ]
+        self.expressCustoms=[ ]
+        self.expressModifiers = modifyExpress
+        self.visCustoms=[ ]
+        self.visModifiers = modifyExpress
     """
     _pp_
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016_trackingLowPU.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016_trackingLowPU.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2016_trackingLowPU_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+import Configuration.StandardSequences.Eras as eras
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2016_trackingLowPU(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=eras.eras.Run2_2016_trackingLowPU
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+    """
+    _ppEra_Run2_2016_trackingLowPU_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/pplowpu.py
+++ b/Configuration/DataProcessing/python/Impl/pplowpu.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+_pplowpu_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class pplowpu(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.cbSc='pp'
+        cCustoms = [ 'RecoTracker/Configuration/customiseForRunI.customiseForRunI' ]
+        self.promptCustoms += cCustoms
+        self.expressCustoms += cCustoms
+        self.visCustoms += cCustoms
+    """
+    _pplowpu_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/pplowpuEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/pplowpuEra_Run2_2016.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_pplowpuEra_Run2_2016_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+import Configuration.StandardSequences.Eras as eras
+
+from Configuration.DataProcessing.Impl.pplowpu import pplowpu
+
+class pplowpuEra_Run2_2016(pplowpu):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=eras.eras.Run2_2016
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
+    """
+    _pplowpuEra_Run2_2016_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/pplowpuEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/pplowpuEra_Run2_2016.py
@@ -17,7 +17,7 @@ from Configuration.DataProcessing.Impl.pplowpu import pplowpu
 
 class pplowpuEra_Run2_2016(pplowpu):
     def __init__(self):
-        pp.__init__(self)
+        pplowpu.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
         self.eras=eras.eras.Run2_2016

--- a/Configuration/DataProcessing/python/Modifiers.py
+++ b/Configuration/DataProcessing/python/Modifiers.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+modifyPPData = cms.ModifierChain()
+
+modifyCosmicData = cms.ModifierChain()
+
+import RecoVertex.BeamSpotProducer.Modifiers as _modsBS
+modifyExpress = cms.ModifierChain(modifyPPData, _modsBS.offlineToOnlineBeamSpotSwap)
+
+modifyCommonHI = cms.ModifierChain()
+
+modifyExpressHI = cms.ModifierChain(modifyCommonHI, _modsBS.offlineToOnlineBeamSpotSwap)
+

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -19,6 +19,9 @@ class Reco(Scenario):
         Scenario.__init__(self)
         self.recoSeq=''
         self.cbSc=self.__class__.__name__
+        self.promptModifiers = cms.ModifierChain()
+        self.expressModifiers = cms.ModifierChain()
+        self.visModifiers = cms.ModifierChain()
     """
     _pp_
 
@@ -81,7 +84,7 @@ class Reco(Scenario):
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
         
-        process = cms.Process('RECO', self.eras)
+        process = cms.Process('RECO', cms.ModifierChain(self.eras, self.promptModifiers) )
         cb = ConfigBuilder(options, process = process, with_output = True)
 
         # Input source
@@ -121,10 +124,12 @@ class Reco(Scenario):
         options.step = 'RAW2DIGI,L1Reco,RECO'+eiStep+step+',DQM'+dqmStep+',ENDJOB'
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
+
+        
         options.filein = 'tobeoverwritten.xyz'
         if 'inputSource' in args:
             options.filetype = args['inputSource']
-        process = cms.Process('RECO', self.eras)
+        process = cms.Process('RECO', cms.ModifierChain(self.eras, self.expressModifiers) )
 
         if 'customs' in args:
             options.customisation_file=args['customs']
@@ -175,7 +180,7 @@ class Reco(Scenario):
 
         print "Using %s source"%options.filetype            
 
-        process = cms.Process('RECO', self.eras)
+        process = cms.Process('RECO', cms.ModifierChain(self.eras, self.visModifiers) )
 
         if 'customs' in args:
             options.customisation_file=args['customs']

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -51,7 +51,6 @@ def customisePPData(process):
     #left as a place holder to alter production sequences in case of emergencies
     return process
 
-modifyPPData = cms.ModifierChain()
 
 ##############################################################################
 def customisePPMC(process):
@@ -63,7 +62,6 @@ def customisePPMC(process):
 def customiseCosmicData(process):
     return process
 
-modifyCosmicData = cms.ModifierChain()
 
 ##############################################################################
 def customiseCosmicMC(process):
@@ -83,9 +81,6 @@ def customiseExpress(process):
     process = _swapOfflineBSwithOnline(process)
     return process
 
-import RecoVertex.BeamSpotProducer.Modifiers as modsBS
-modifyExpress = cms.ModifierChain(modifyPPData, modsBS.offlineToOnlineBeamSpotSwap)
-
 ##############################################################################
 def customisePrompt(process):
     process= customisePPData(process)
@@ -100,8 +95,6 @@ def customisePrompt(process):
 def customiseCommonHI(process):
     return process
 
-modifyCommonHI = cms.ModifierChain()
-
 ##############################################################################
 def customiseExpressHI(process):
     process = customiseCommonHI(process)
@@ -109,7 +102,6 @@ def customiseExpressHI(process):
     
     return process
 
-modifyExpressHI = cms.ModifierChain(modifyCommonHI, modsBS.offlineToOnlineBeamSpotSwap)
 ##############################################################################
 def customisePromptHI(process):
     process = customiseCommonHI(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoTracker.Configuration.customiseForRunI import customiseForRunI
-
 ##############################################################################
 # common utilities
 ##############################################################################
@@ -53,6 +51,7 @@ def customisePPData(process):
     #left as a place holder to alter production sequences in case of emergencies
     return process
 
+modifyPPData = cms.ModifierChain()
 
 ##############################################################################
 def customisePPMC(process):
@@ -64,7 +63,7 @@ def customisePPMC(process):
 def customiseCosmicData(process):
     return process
 
-
+modifyCosmicData = cms.ModifierChain()
 
 ##############################################################################
 def customiseCosmicMC(process):
@@ -82,8 +81,10 @@ def customiseVALSKIM(process):
 def customiseExpress(process):
     process= customisePPData(process)
     process = _swapOfflineBSwithOnline(process)
-    
     return process
+
+import RecoVertex.BeamSpotProducer.Modifiers as modsBS
+modifyExpress = cms.ModifierChain(modifyPPData, modsBS.offlineToOnlineBeamSpotSwap)
 
 ##############################################################################
 def customisePrompt(process):
@@ -99,6 +100,8 @@ def customisePrompt(process):
 def customiseCommonHI(process):
     return process
 
+modifyCommonHI = cms.ModifierChain()
+
 ##############################################################################
 def customiseExpressHI(process):
     process = customiseCommonHI(process)
@@ -106,6 +109,7 @@ def customiseExpressHI(process):
     
     return process
 
+modifyExpressHI = cms.ModifierChain(modifyCommonHI, modsBS.offlineToOnlineBeamSpotSwap)
 ##############################################################################
 def customisePromptHI(process):
     process = customiseCommonHI(process)
@@ -202,6 +206,7 @@ def customiseExpressRun2Deprecated_50ns(process):
     return process
 
 def customiseExpressRun2DeprecatedB0T(process):
+    from RecoTracker.Configuration.customiseForRunI import customiseForRunI
     process=customiseForRunI(process)
     process=customiseExpressRun2Deprecated(process)
     return process
@@ -218,6 +223,7 @@ def customisePromptRun2Deprecated_50ns(process):
     return process
 
 def customisePromptRun2DeprecatedB0T(process):
+    from RecoTracker.Configuration.customiseForRunI import customiseForRunI
     process=customiseForRunI(process)
     process=customisePromptRun2Deprecated(process)
     return process

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "pplowpuEra_Run2_2016" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" )
+declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016" )
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "pplowpuEra_Run2_2016" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "pplowpuEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppRun2" "HeavyIons" "HeavyIonsRun2" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016" )
+declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "pplowpuEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -31,7 +31,15 @@ class Eras (object):
         self.phase2dev_tracker = cms.Modifier()
         self.phase2dev_hgc = cms.Modifier()
         self.phase2dev_muon = cms.Modifier()
-        
+
+
+        # These eras are used to specify the tracking configuration
+        # when it should differ from the default (which is Run2). This
+        # way the tracking configuration is decoupled from the
+        # detector geometry to allow e.g. running Run2 tracking on
+        # phase1Pixel detector.
+        self.trackingLowPU = cms.Modifier()
+
         # This era should not be set by the user with the "--era" command, it's
         # activated automatically if the "--fast" command is used.
         self.fastSim = cms.Modifier()
@@ -55,6 +63,9 @@ class Eras (object):
         # Phase2dev is everything for the 2023 (2026?) detector that is still in development.
         self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.phase2dev_hgc, self.phase2dev_muon )
         
+        # Scenarios with low-PU tracking (for B=0T reconstruction)
+        self.Run2_2016_trackingLowPU = cms.ModifierChain(self.Run2_2016, self.trackingLowPU)
+
         # The only thing this collection is used for is for cmsDriver to
         # warn the user if they specify an era that is discouraged from being
         # set directly. It also stops these eras being printed in the error
@@ -67,7 +78,8 @@ class Eras (object):
                                 self.phase2_common, self.phase2_tracker,
                                 self.phase2_hgc, self.phase2_muon,
                                 self.phase2dev_common, self.phase2dev_tracker,
-                                self.phase2dev_hgc, self.phase2dev_muon
+                                self.phase2dev_hgc, self.phase2dev_muon,
+                                self.trackingLowPU
                                ]
 
 eras=Eras()

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
@@ -58,6 +59,10 @@ globalreco_tracking = cms.Sequence(offlineBeamSpot*
                           standalonemuontracking*
                           trackingGlobalReco*
                           vertexreco)
+_globalreco_trackingLowPU = globalreco_tracking.copy()
+_globalreco_trackingLowPU.replace(trackingGlobalReco, recopixelvertexing+trackingGlobalReco)
+eras.trackingLowPU.toReplaceWith(globalreco_tracking, _globalreco_trackingLowPU)
+
 globalreco = cms.Sequence(globalreco_tracking*
                           hcalGlobalRecoSequence*
                           particleFlowCluster*
@@ -117,6 +122,9 @@ noTrackingAndDependent.append(siPixelClusters)
 noTrackingAndDependent.append(clusterSummaryProducer)
 noTrackingAndDependent.append(siPixelRecHitsPreSplitting)
 noTrackingAndDependent.append(MeasurementTrackerEventPreSplitting)
+noTrackingAndDependent.append(PixelLayerTriplets)
+noTrackingAndDependent.append(pixelTracks)
+noTrackingAndDependent.append(pixelVertices)
 modulesToRemove.append(dt1DRecHits)
 modulesToRemove.append(dt1DCosmicRecHits)
 modulesToRemove.append(csc2DRecHits)

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ### load which are the tracks collection 2 be monitored
 from DQM.TrackingMonitorSource.TrackCollections2monitor_cff import *
@@ -172,6 +173,7 @@ for tracks in selectedTracks :
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
     TrackingDQMSourceTier0 += cms.Sequence(locals()[label])
+eras.trackingLowPU.toReplaceWith(TrackingDQMSourceTier0, TrackingDQMSourceTier0.copyAndExclude([TrackSeedMonjetCoreRegionalStep]))
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
@@ -192,6 +194,7 @@ for tracks in selectedTracks :
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
     TrackingDQMSourceTier0Common += cms.Sequence(locals()[label])
+eras.trackingLowPU.toReplaceWith(TrackingDQMSourceTier0Common, TrackingDQMSourceTier0Common.copyAndExclude([TrackSeedMonjetCoreRegionalStep]))
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
@@ -213,6 +216,7 @@ for tracks in selectedTracks :
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
     TrackingDQMSourceTier0MinBias += cms.Sequence(locals()[label])
+eras.trackingLowPU.toReplaceWith(TrackingDQMSourceTier0MinBias, TrackingDQMSourceTier0MinBias.copyAndExclude([TrackSeedMonjetCoreRegionalStep]))
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonMB'

--- a/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
+++ b/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
@@ -1,9 +1,13 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
 caloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbheprereco'))
 ak4CaloJetsForTrk = ak4CaloJets.clone(srcPVs = cms.InputTag('firstStepPrimaryVertices'), src= cms.InputTag('caloTowerForTrk'))
+eras.trackingLowPU.toModify(ak4CaloJetsForTrk,
+    srcPVs = "pixelVertices"
+)
 
 caloJetsForTrk = cms.Sequence(caloTowerForTrk*ak4CaloJetsForTrk)
 

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
@@ -3,25 +3,5 @@ import FWCore.ParameterSet.Config as cms
 
 #
 from CondTools.SiPixel.SiPixelGainCalibrationService_cfi import *
-siPixelClustersPreSplitting = cms.EDProducer("SiPixelClusterProducer",
-    SiPixelGainCalibrationServiceParameters,
-    src = cms.InputTag("siPixelDigis"),
-    ChannelThreshold = cms.int32(1000),
-    MissCalibrate = cms.untracked.bool(True),
-    SplitClusters = cms.bool(False),
-    VCaltoElectronGain = cms.int32(65),
-    VCaltoElectronOffset = cms.int32(-414),
-    # **************************************
-    # ****  payLoadType Options         ****
-    # ****  HLT - column granularity    ****
-    # ****  Offline - gain:col/ped:pix  ****
-    # **************************************
-    payloadType = cms.string('Offline'),
-    SeedThreshold = cms.int32(1000),
-    ClusterThreshold = cms.double(4000.0),
-    # **************************************
-    maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
-)
-
-
-
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+siPixelClustersPreSplitting = _siPixelClusters.clone()

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
@@ -17,6 +17,5 @@ SiStripClusterChargeCutTight = cms.PSet(
     value     = cms.double(1945.0) 
 )
 
-eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTiny, SiStripClusterChargeCutNone)
-eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutLoose, SiStripClusterChargeCutNone)
-eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTight, SiStripClusterChargeCutNone)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutLoose, SiStripClusterChargeCutTiny)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTight, SiStripClusterChargeCutTiny)

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 SiStripClusterChargeCutNone = cms.PSet(
     value     = cms.double(-1.0)
@@ -16,3 +17,6 @@ SiStripClusterChargeCutTight = cms.PSet(
     value     = cms.double(1945.0) 
 )
 
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTiny, SiStripClusterChargeCutNone)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutLoose, SiStripClusterChargeCutNone)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTight, SiStripClusterChargeCutNone)

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -19,7 +19,7 @@ mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.Tra
 
 
 #for displaced global muons
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 duplicateDisplacedTrackClassifier = TrackCutClassifier.clone()
 duplicateDisplacedTrackClassifier.src='mergedDuplicateDisplacedTracks'
 duplicateDisplacedTrackClassifier.mva.minPixelHits = [0,0,0]

--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 #
@@ -8,3 +9,11 @@ from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
 recopixelvertexing = cms.Sequence(PixelLayerTriplets*pixelTracks*pixelVertices)
 
+# For LowPU tracking
+PixelLayerTripletsPreSplitting = PixelLayerTriplets.clone(
+    BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+    FPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+)
+_recopixelvertexing_trackingLowPU = recopixelvertexing.copy()
+_recopixelvertexing_trackingLowPU.replace(PixelLayerTriplets, PixelLayerTripletsPreSplitting)
+eras.trackingLowPU.toReplaceWith(recopixelvertexing, _recopixelvertexing_trackingLowPU)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoPixelVertexing.PixelTrackFitting.PixelFitterByHelixProjections_cfi import *
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
@@ -34,3 +35,9 @@ PixelTrackReconstructionBlock = cms.PSet (
     )
 )
 
+eras.trackingLowPU.toModify(PixelTrackReconstructionBlock,
+    OrderedHitsFactoryPSet = dict(
+        SeedingLayers = "PixelLayerTripletsPreSplitting",
+        GeneratorPSet = dict(SeedComparitorPSet = dict(clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"))
+    ),
+)

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
@@ -207,6 +208,7 @@ photonConvTrajSeedFromSingleLeg.TrackRefitter = cms.InputTag('generalTracks')
 photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrimaryVertices')
 #photonConvTrajSeedFromQuadruplets.TrackRefitter = cms.InputTag('generalTracks')
 #photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertices')
+eras.trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = "pixelVertices")
 
 
 # TRACKER DATA CONTROL

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 photonConvTrajSeedFromSingleLeg  = cms.EDProducer("PhotonConversionTrajectorySeedProducerFromSingleLeg",
                                                   TrackRefitter        = cms.InputTag('TrackRefitter',''),
@@ -44,3 +45,11 @@ photonConvTrajSeedFromSingleLeg  = cms.EDProducer("PhotonConversionTrajectorySee
                                                       TTRHBuilder = cms.string('WithTrackAngle')
                                                       )
                                                   )
+eras.trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg,
+    OrderedHitsFactoryPSet = dict(maxElement = 10000),
+    ClusterCheckPSet = dict(
+        MaxNumberOfCosmicClusters = 150000,
+        MaxNumberOfPixelClusters = 20000,
+        cut = "strip < 150000 && pixel < 20000 && (strip < 20000 + 7* pixel)"
+    )
+)

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -13,7 +13,7 @@ mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduce
 mergedDuplicateTracks.src = cms.InputTag("duplicateTrackCandidates","candidates")
 mergedDuplicateTracks.Fitter='RKFittingSmoother' # no outlier rejection!
 
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 duplicateTrackClassifier = TrackCutClassifier.clone()
 duplicateTrackClassifier.src='mergedDuplicateTracks'
 duplicateTrackClassifier.mva.minPixelHits = [0,0,0]

--- a/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
@@ -1,0 +1,5 @@
+from Configuration.StandardSequences.Eras import eras
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+eras.trackingLowPU.toModify(TrackCutClassifier,
+    vertices = "pixelVertices"
+)

--- a/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
@@ -1,4 +1,4 @@
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
@@ -21,3 +22,24 @@ earlyGeneralTracks.inputClassifiers =["initialStep",
                                       "pixelLessStep",
                                       "tobTecStep"
                                       ]
+
+eras.trackingLowPU.toModify(earlyGeneralTracks,
+    trackProducers = [
+        'initialStepTracks',
+        'lowPtTripletStepTracks',
+        'pixelPairStepTracks',
+        'detachedTripletStepTracks',
+        'mixedTripletStepTracks',
+        'pixelLessStepTracks',
+        'tobTecStepTracks'
+    ],
+    inputClassifiers = [
+        "initialStepSelector",
+        "lowPtTripletStepSelector",
+        "pixelPairStepSelector",
+        "detachedTripletStep",
+        "mixedTripletStep",
+        "pixelLessStepSelector",
+        "tobTecStep"
+    ]
+)

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 looseMTS = cms.PSet(
     preFilterName=cms.string(''),
@@ -89,3 +90,6 @@ multiTrackSelector = cms.EDProducer("MultiTrackSelector",
                                tightMTS,
                                highpurityMTS)
  ) 
+eras.trackingLowPU.toModify(multiTrackSelector,
+    vertices = "pixelVertices"
+)

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -89,9 +89,6 @@ detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEst
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
-eras.trackingLowPU.toModify(detachedTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ###############################################
 # Low pT and detached tracks from pixel triplets
@@ -6,17 +7,25 @@ import FWCore.ParameterSet.Config as cms
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-detachedTripletStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_detachedTripletStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("initialStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag(""),
-    trackClassifier                          = cms.InputTag('initialStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+detachedTripletStepClusters = _detachedTripletStepClustersBase.clone(
+   trackClassifier                          = cms.InputTag('initialStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(detachedTripletStepClusters, _detachedTripletStepClustersBase.clone(
+    trajectories                             = "pixelPairStepTracks",
+    oldClusterRemovalInfo                    = "pixelPairStepClusters",
+    overrideTrkQuals                         = "pixelPairStepSelector:QualityMasks",
+))
+
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
@@ -48,14 +57,20 @@ detachedTripletStepSeeds.SeedComparitorPSet = cms.PSet(
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
 #    maxLostHitsFraction = cms.double(1./10.),
 #    constantValueForLostHitsFractionFilter = cms.double(0.701),
     minimumNumberOfHits = 3,
     minPt = 0.075,
+    )
+detachedTripletStepTrajectoryFilterBase = _detachedTripletStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
-    )
+)
+eras.trackingLowPU.toReplaceWith(detachedTripletStepTrajectoryFilterBase, _detachedTripletStepTrajectoryFilterBase.clone(
+    maxLostHitsFraction = 1./10.,
+    constantValueForLostHitsFractionFilter = 0.701,
+))
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 detachedTripletStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
 detachedTripletStepTrajectoryFilter = cms.PSet(
@@ -74,6 +89,9 @@ detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEst
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
+eras.trackingLowPU.toModify(detachedTripletStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -86,6 +104,10 @@ detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
+eras.trackingLowPU.toModify(detachedTripletStepTrajectoryBuilder,
+    maxCand = 2,
+    alwaysUseInvalidHits = False,
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -107,7 +129,7 @@ detachedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits
             allowSharedFirstHit = cms.bool(True)
             )
 detachedTripletStepTrackCandidates.TrajectoryCleaner = 'detachedTripletStepTrajectoryCleanerBySharedHits'
-
+eras.trackingLowPU.toModify(detachedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
@@ -135,6 +157,99 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 detachedTripletStep = ClassifierMerger.clone()
 detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+detachedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='detachedTripletStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter3'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedTripletStepVtxLoose',
+            chi2n_par = 1.6,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 1.2, 3.0 ),
+            dz_par1 = ( 1.2, 3.0 ),
+            d0_par2 = ( 1.3, 3.0 ),
+            dz_par2 = ( 1.3, 3.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedTripletStepTrkLoose',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 1.6, 4.0 ),
+            dz_par1 = ( 1.6, 4.0 ),
+            d0_par2 = ( 1.6, 4.0 ),
+            dz_par2 = ( 1.6, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedTripletStepVtxTight',
+            preFilterName = 'detachedTripletStepVtxLoose',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.95, 3.0 ),
+            dz_par1 = ( 0.9, 3.0 ),
+            d0_par2 = ( 1.0, 3.0 ),
+            dz_par2 = ( 1.0, 3.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedTripletStepTrkTight',
+            preFilterName = 'detachedTripletStepTrkLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedTripletStepVtx',
+            preFilterName = 'detachedTripletStepVtxTight',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.85, 3.0 ),
+            dz_par1 = ( 0.8, 3.0 ),
+            d0_par2 = ( 0.9, 3.0 ),
+            dz_par2 = ( 0.9, 3.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedTripletStepTrk',
+            preFilterName = 'detachedTripletStepTrkTight',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 1.0, 4.0 ),
+            dz_par1 = ( 1.0, 4.0 ),
+            d0_par2 = ( 1.0, 4.0 ),
+            dz_par2 = ( 1.0, 4.0 )
+            )
+        ),
+    vertices = cms.InputTag("pixelVertices") #end of vpset
+    ) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+eras.trackingLowPU.toReplaceWith(detachedTripletStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers = cms.VInputTag(cms.InputTag('detachedTripletStepTracks'),
+                                   cms.InputTag('detachedTripletStepTracks')),
+    hasSelector=cms.vint32(1,1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("detachedTripletStepSelector","detachedTripletStepVtx"),
+                                       cms.InputTag("detachedTripletStepSelector","detachedTripletStepTrk")),
+    setsToMerge = cms.VPSet(cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )),
+    writeOnlyTrkQuals=cms.bool(True)
+))
 
 DetachedTripletStep = cms.Sequence(detachedTripletStepClusters*
                                    detachedTripletStepSeedLayers*
@@ -143,3 +258,6 @@ DetachedTripletStep = cms.Sequence(detachedTripletStepClusters*
                                    detachedTripletStepTracks*
                                    detachedTripletStepClassifier1*detachedTripletStepClassifier2*
                                    detachedTripletStep)
+_DetachedTripletStep_LowPU = DetachedTripletStep.copyAndExclude([detachedTripletStepClassifier2])
+_DetachedTripletStep_LowPU.replace(detachedTripletStepClassifier1, detachedTripletStepSelector)
+eras.trackingLowPU.toReplaceWith(DetachedTripletStep, _DetachedTripletStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ### STEP 0 ###
 
@@ -141,3 +142,25 @@ InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
                                        MeasurementTrackerEvent*
                                        siPixelClusterShapeCache)
 
+# Although InitialStepPreSplitting is not really part of LowPU/Run1/Phase1PU70
+# tracking, we use it to get siPixelClusters and siPixelRecHits
+# collections for non-splitted pixel clusters. All modules before
+# iterTracking sequence use siPixelClustersPreSplitting and
+# siPixelRecHitsPreSplitting for that purpose.
+#
+# If siPixelClusters would be defined in
+# RecoLocalTracker.Configuration.RecoLocalTracker_cff, we would have a
+# situation where
+# - LowPU/Phase1PU70 has siPixelClusters defined in RecoLocalTracker_cff
+# - everything else has siPixelClusters defined here
+# and this leads to a mess. The way it is done here we have only
+# one place (within Reconstruction_cff) where siPixelClusters
+# module is defined.
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+eras.trackingLowPU.toReplaceWith(siPixelClusters, _siPixelClusters)
+eras.trackingLowPU.toReplaceWith(InitialStepPreSplitting, cms.Sequence(
+    siPixelClusters +
+    siPixelRecHits +
+    MeasurementTrackerEvent +
+    siPixelClusterShapeCache
+))

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -165,6 +165,6 @@ InitialStep = cms.Sequence(initialStepSeedLayers*
                            firstStepPrimaryVertices*
                            initialStepClassifier1*initialStepClassifier2*initialStepClassifier3*
                            initialStep)
-_InitialStep_LowPU = InitialStep.copyAndExclude([initialStepSeedLayers, firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
+_InitialStep_LowPU = InitialStep.copyAndExclude([firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
 _InitialStep_LowPU.replace(initialStep, initialStepSelector)
 eras.trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -62,9 +62,6 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_c
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
-eras.trackingLowPU.toModify(initialStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-)
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ### STEP 0 ###
 
@@ -29,15 +30,19 @@ initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+eras.trackingLowPU.toModify(initialStepSeeds, OrderedHitsFactoryPSet = dict(GeneratorPSet = dict(maxElement = 100000)))
 
 # building
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.2,
+    )
+initialStepTrajectoryFilterBase = _initialStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
-    )
+)
+eras.trackingLowPU.toReplaceWith(initialStepTrajectoryFilterBase, _initialStepTrajectoryFilterBase)
 
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 initialStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
@@ -57,6 +62,9 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_c
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
+eras.trackingLowPU.toModify(initialStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
@@ -67,6 +75,7 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
     )
+eras.trackingLowPU.toModify(initialStepTrajectoryBuilder, maxCand = 5)
 
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
@@ -125,6 +134,27 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 initialStep = ClassifierMerger.clone()
 initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+initialStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='initialStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter0'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'initialStepLoose',
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'initialStepTight',
+            preFilterName = 'initialStepLoose',
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'initialStepTight',
+        ),
+    ), #end of vpset
+    vertices = cms.InputTag("pixelVertices")
+) #end of clone
 
 
 # Final sequence
@@ -135,3 +165,6 @@ InitialStep = cms.Sequence(initialStepSeedLayers*
                            firstStepPrimaryVertices*
                            initialStepClassifier1*initialStepClassifier2*initialStepClassifier3*
                            initialStep)
+_InitialStep_LowPU = InitialStep.copyAndExclude([initialStepSeedLayers, firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
+_InitialStep_LowPU.replace(initialStep, initialStepSelector)
+eras.trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -148,7 +148,7 @@ from RecoTracker.IterativeTracking.InitialStep_cff import initialStepClassifier1
 #jetCoreRegionalStep.inputClassifiers=['jetCoreRegionalStepClassifier1','jetCoreRegionalStepClassifier2']
 
 
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 jetCoreRegionalStep = TrackCutClassifier.clone()
 jetCoreRegionalStep.src='jetCoreRegionalStepTracks'
 jetCoreRegionalStep.mva.minPixelHits = [1,1,1]

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -72,9 +72,6 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
-eras.trackingLowPU.toModify(lowPtTripletStepChi2Est, 
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -1,17 +1,24 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-lowPtTripletStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_lowPtTripletStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("detachedTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
-    oldClusterRemovalInfo                    = cms.InputTag("detachedTripletStepClusters"),
-    trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+lowPtTripletStepClusters = _lowPtTripletStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
+    oldClusterRemovalInfo                    = cms.InputTag("detachedTripletStepClusters"),
+)
+eras.trackingLowPU.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
+    trajectories                             = "initialStepTracks",
+    overrideTrkQuals                         = "initialStepSelector:QualityMasks",
+))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
@@ -41,13 +48,15 @@ lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = 
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_lowPtTripletStepStandardTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.075,
+    )
+lowPtTripletStepStandardTrajectoryFilter = _lowPtTripletStepStandardTrajectoryFilterBase.clone(
     maxCCCLostHits = 1,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
-    )
-
+)
+eras.trackingLowPU.toReplaceWith(lowPtTripletStepStandardTrajectoryFilter, _lowPtTripletStepStandardTrajectoryFilterBase)
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
 # Composite filter
 lowPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
@@ -63,6 +72,9 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
+eras.trackingLowPU.toModify(lowPtTripletStepChi2Est, 
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -76,6 +88,7 @@ lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
+eras.trackingLowPU.toModify(lowPtTripletStepTrajectoryBuilder, maxCand = 3)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -106,6 +119,7 @@ lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
             allowSharedFirstHit = cms.bool(True)
             )
 lowPtTripletStepTrackCandidates.TrajectoryCleaner = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 # Final selection
 
@@ -118,6 +132,28 @@ lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='lowPtTripletStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter1'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'lowPtTripletStepLoose',
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'lowPtTripletStepTight',
+            preFilterName = 'lowPtTripletStepLoose',
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'lowPtTripletStepTight',
+        ),
+    ),
+    vertices = cms.InputTag("pixelVertices")#end of vpset
+) #end of clone
+
 
 # Final sequence
 LowPtTripletStep = cms.Sequence(lowPtTripletStepClusters*
@@ -126,3 +162,6 @@ LowPtTripletStep = cms.Sequence(lowPtTripletStepClusters*
                                 lowPtTripletStepTrackCandidates*
                                 lowPtTripletStepTracks*
                                 lowPtTripletStep)
+_LowPtTripletStep_LowPU = LowPtTripletStep.copy()
+_LowPtTripletStep_LowPU.replace(lowPtTripletStep, lowPtTripletStepSelector)
+eras.trackingLowPU.toReplaceWith(LowPtTripletStep, _LowPtTripletStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -70,9 +70,7 @@ eras.trackingLowPU.toModify(mixedTripletStepSeedLayersA,
         'FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg',
         'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'
     ],
-    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
-    FPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
-    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
 )
 
 # SEEDS
@@ -124,8 +122,7 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
 )
 eras.trackingLowPU.toModify(mixedTripletStepSeedLayersB,
     layerList = ['BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'],
-    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
-    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
 )
 
 # SEEDS
@@ -196,7 +193,7 @@ mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 eras.trackingLowPU.toModify(mixedTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ###############################################################
 # Large impact parameter Tracking using mixed-triplet seeding #
@@ -12,18 +13,25 @@ chargeCut2069Clusters =  cms.EDProducer("ClusterChargeMasker",
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-mixedTripletStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_mixedTripletStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("pixelPairStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
 #    oldClusterRemovalInfo                    = cms.InputTag("pixelPairStepClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("chargeCut2069Clusters"),
-    trackClassifier                          = cms.InputTag('pixelPairStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+mixedTripletStepClusters = _mixedTripletStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('pixelPairStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(mixedTripletStepClusters, _mixedTripletStepClustersBase.clone(
+    trajectories                             = "detachedTripletStepTracks",
+    oldClusterRemovalInfo                    = "detachedTripletStepClusters",
+    overrideTrkQuals                         = "detachedTripletStep",
+))
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
@@ -52,6 +60,19 @@ mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(1),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
+)
+eras.trackingLowPU.toModify(mixedTripletStepSeedLayersA,
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg',
+        'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'
+    ],
+    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
+    FPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
 )
 
 # SEEDS
@@ -82,6 +103,10 @@ mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
+eras.trackingLowPU.toModify(mixedTripletStepSeedsA,
+    RegionFactoryPSet = dict(RegionPSet = dict(originHalfLength = 10.0)),
+    SeedComparitorPSet = dict(ClusterShapeHitFilterName = 'ClusterShapeHitFilter')
+)
 
 # SEEDING LAYERS
 mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
@@ -96,6 +121,11 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
+)
+eras.trackingLowPU.toModify(mixedTripletStepSeedLayersB,
+    layerList = ['BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'],
+    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
 )
 
 # SEEDS
@@ -119,6 +149,7 @@ mixedTripletStepSeedsB.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
+eras.trackingLowPU.toModify(mixedTripletStepSeedsB, SeedComparitorPSet = dict(ClusterShapeHitFilterName = 'ClusterShapeHitFilter'))
 
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 mixedTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
@@ -129,12 +160,17 @@ mixedTripletStepSeeds.seedCollections = cms.VInputTag(
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-mixedTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_mixedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
 #    maxLostHits = 0,
-    constantValueForLostHitsFractionFilter = 1.4,
     minimumNumberOfHits = 3,
     minPt = 0.1
     )
+mixedTripletStepTrajectoryFilter = _mixedTripletStepTrajectoryFilterBase.clone(
+    constantValueForLostHitsFractionFilter = 1.4,
+)
+eras.trackingLowPU.toReplaceWith(mixedTripletStepTrajectoryFilter, _mixedTripletStepTrajectoryFilterBase.clone(
+    maxLostHits = 0,
+))
 
 # Propagator taking into account momentum uncertainty in multiple scattering calculation.
 import TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff
@@ -158,6 +194,9 @@ mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingLowPU.toModify(mixedTripletStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
 # TRACK BUILDING
@@ -195,6 +234,7 @@ mixedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
             allowSharedFirstHit = cms.bool(True)
             )
 mixedTripletStepTrackCandidates.TrajectoryCleaner = 'mixedTripletStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 
 # TRACK FITTING
@@ -221,6 +261,103 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 mixedTripletStep = ClassifierMerger.clone()
 mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+mixedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='mixedTripletStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter4'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'mixedTripletStepVtxLoose',
+            chi2n_par = 1.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.2, 3.0 ),
+            dz_par1 = ( 1.2, 3.0 ),
+            d0_par2 = ( 1.3, 3.0 ),
+            dz_par2 = ( 1.3, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'mixedTripletStepTrkLoose',
+            chi2n_par = 0.6,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.2, 4.0 ),
+            dz_par1 = ( 1.2, 4.0 ),
+            d0_par2 = ( 1.2, 4.0 ),
+            dz_par2 = ( 1.2, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'mixedTripletStepVtxTight',
+            preFilterName = 'mixedTripletStepVtxLoose',
+            chi2n_par = 0.6,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 3.0 ),
+            dz_par1 = ( 1.1, 3.0 ),
+            d0_par2 = ( 1.2, 3.0 ),
+            dz_par2 = ( 1.2, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'mixedTripletStepTrkTight',
+            preFilterName = 'mixedTripletStepTrkLoose',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'mixedTripletStepVtx',
+            preFilterName = 'mixedTripletStepVtxTight',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 3.0 ),
+            dz_par1 = ( 1.1, 3.0 ),
+            d0_par2 = ( 1.2, 3.0 ),
+            dz_par2 = ( 1.2, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'mixedTripletStepTrk',
+            preFilterName = 'mixedTripletStepTrkTight',
+            chi2n_par = 0.3,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 0.9, 4.0 ),
+            dz_par1 = ( 0.9, 4.0 ),
+            d0_par2 = ( 0.9, 4.0 ),
+            dz_par2 = ( 0.9, 4.0 )
+        )
+    ),
+    vertices = cms.InputTag("pixelVertices") #end of vpset
+) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+eras.trackingLowPU.toReplaceWith(mixedTripletStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers = cms.VInputTag(cms.InputTag('mixedTripletStepTracks'),
+                                   cms.InputTag('mixedTripletStepTracks')),
+    hasSelector=cms.vint32(1,1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("mixedTripletStepSelector","mixedTripletStepVtx"),
+                                       cms.InputTag("mixedTripletStepSelector","mixedTripletStepTrk")),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )),
+    writeOnlyTrkQuals=cms.bool(True)
+))
 
 
 
@@ -235,3 +372,6 @@ MixedTripletStep = cms.Sequence(chargeCut2069Clusters*mixedTripletStepClusters*
                                 mixedTripletStepTracks*
                                 mixedTripletStepClassifier1*mixedTripletStepClassifier2*
                                 mixedTripletStep)
+_MixedTripletStep_LowPU = MixedTripletStep.copyAndExclude([chargeCut2069Clusters, mixedTripletStepClassifier1])
+_MixedTripletStep_LowPU.replace(mixedTripletStepClassifier2, mixedTripletStepSelector)
+eras.trackingLowPU.toReplaceWith(MixedTripletStep, _MixedTripletStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -117,7 +117,7 @@ muonSeededTracksInOut = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduce
 
 
 # Final Classifier
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 muonSeededTracksInOutClassifier = TrackCutClassifier.clone()
 muonSeededTracksInOutClassifier.src='muonSeededTracksInOut'
 muonSeededTracksInOutClassifier.mva.minPixelHits = [0,0,0]

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -94,8 +94,7 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(3)
     )
 )
-eras.trackingLowPU.toModify(
-    pixelLessStepSeedLayers,
+eras.trackingLowPU.toModify(pixelLessStepSeedLayers,
     layerList = [
         'TIB1+TIB2',
         'TID1_pos+TID2_pos','TID2_pos+TID3_pos',
@@ -103,9 +102,9 @@ eras.trackingLowPU.toModify(
         'TID1_neg+TID2_neg','TID2_neg+TID3_neg',
         'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg','TEC4_neg+TEC5_neg'
     ],
-    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
-    TID = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
-    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
+    TID = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
     MTIB = None,
     MTID = None,
     MTEC = None,
@@ -188,7 +187,7 @@ pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 eras.trackingLowPU.toModify(pixelLessStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -1,20 +1,26 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ##########################################################################
 # Large impact parameter tracking using TIB/TID/TEC stereo layer seeding #
 ##########################################################################
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-pixelLessStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_pixelLessStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("mixedTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("mixedTripletStepClusters"),
-    trackClassifier                          = cms.InputTag('mixedTripletStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+pixelLessStepClusters = _pixelLessStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('mixedTripletStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(pixelLessStepClusters, _pixelLessStepClustersBase.clone(
+    overrideTrkQuals                         = "mixedTripletStep",
+))
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
@@ -88,6 +94,22 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(3)
     )
 )
+eras.trackingLowPU.toModify(
+    pixelLessStepSeedLayers,
+    layerList = [
+        'TIB1+TIB2',
+        'TID1_pos+TID2_pos','TID2_pos+TID3_pos',
+        'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos','TEC4_pos+TEC5_pos',
+        'TID1_neg+TID2_neg','TID2_neg+TID3_neg',
+        'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg','TEC4_neg+TEC5_neg'
+    ],
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TID = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    MTIB = None,
+    MTID = None,
+    MTEC = None,
+)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
@@ -127,15 +149,36 @@ pixelLessStepSeeds.SeedComparitorPSet = cms.PSet(
             RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
         )
     )
+import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+eras.trackingLowPU.toReplaceWith(pixelLessStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
+    OrderedHitsFactoryPSet = dict(SeedingLayers = 'pixelLessStepSeedLayers'),
+    RegionFactoryPSet = dict(RegionPSet = dict(
+        ptMin = 0.7,
+        originHalfLength = 10.0,
+        originRadius = 2.0,
+    )),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(False),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    )
+))
+
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-pixelLessStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_pixelLessStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     maxLostHits = 0,
     minimumNumberOfHits = 4,
-    seedPairPenalty = 1,
     minPt = 0.1
     )
+pixelLessStepTrajectoryFilter = _pixelLessStepTrajectoryFilterBase.clone(
+    seedPairPenalty = 1,
+)
+eras.trackingLowPU.toReplaceWith(pixelLessStepTrajectoryFilter, _pixelLessStepTrajectoryFilterBase)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -143,6 +186,9 @@ pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingLowPU.toModify(pixelLessStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
 # TRACK BUILDING
@@ -176,6 +222,7 @@ pixelLessStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone
     allowSharedFirstHit = cms.bool(True)
     )
 pixelLessStepTrackCandidates.TrajectoryCleaner = 'pixelLessStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(pixelLessStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 
 # TRACK FITTING
@@ -204,6 +251,54 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 pixelLessStep = ClassifierMerger.clone()
 pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='pixelLessStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter5'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'pixelLessStepLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.3, 4.0 ),
+            dz_par1 = ( 1.3, 4.0 ),
+            d0_par2 = ( 1.3, 4.0 ),
+            dz_par2 = ( 1.3, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'pixelLessStepTight',
+            preFilterName = 'pixelLessStepLoose',
+            chi2n_par = 0.35,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'pixelLessStepTight',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.9, 4.0 ),
+            dz_par1 = ( 0.9, 4.0 ),
+            d0_par2 = ( 0.9, 4.0 ),
+            dz_par2 = ( 0.9, 4.0 )
+        ),
+    ),
+    vertices = cms.InputTag("pixelVertices")#end of vpset
+) #end of clone
 
 
 PixelLessStep = cms.Sequence(pixelLessStepClusters*
@@ -213,3 +308,6 @@ PixelLessStep = cms.Sequence(pixelLessStepClusters*
                              pixelLessStepTracks*
                              pixelLessStepClassifier1*pixelLessStepClassifier2*
                              pixelLessStep)
+_PixelLessStep_LowPU = PixelLessStep.copyAndExclude([pixelLessStepClassifier1, pixelLessStepClassifier2])
+_PixelLessStep_LowPU.replace(pixelLessStep, pixelLessStepSelector)
+eras.trackingLowPU.toReplaceWith(PixelLessStep, _PixelLessStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -97,7 +97,7 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     pTChargeCutThreshold = cms.double(15.)
 )
 eras.trackingLowPU.toModify(pixelPairStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
 )
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -1,18 +1,25 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-pixelPairStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_pixelPairStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("lowPtTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("lowPtTripletStepClusters"),
-    trackClassifier                          = cms.InputTag('lowPtTripletStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+pixelPairStepClusters = _pixelPairStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('lowPtTripletStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
+    overrideTrkQuals                         = "lowPtTripletStepSelector:QualityMasks",
+))
+
 
 # SEEDING LAYERS
 pixelPairStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
@@ -50,16 +57,25 @@ pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache'),
     )
+eras.trackingLowPU.toModify(pixelPairStepSeeds,
+    RegionFactoryPSet = dict(RegionPSet = dict(
+        VertexCollection = 'pixelVertices',
+        useMultipleScattering = False
+    ))
+)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    seedPairPenalty =0,
     minPt = 0.1,
+    )
+pixelPairStepTrajectoryFilterBase = _pixelPairStepTrajectoryFilterBase.clone(
+    seedPairPenalty =0,
     maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
-    )
+)
+eras.trackingLowPU.toReplaceWith(pixelPairStepTrajectoryFilterBase, _pixelPairStepTrajectoryFilterBase)
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 pixelPairStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
 pixelPairStepTrajectoryFilter = cms.PSet(
@@ -80,7 +96,9 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
-
+eras.trackingLowPU.toModify(pixelPairStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
@@ -91,6 +109,7 @@ pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
+eras.trackingLowPU.toModify(pixelPairStepTrajectoryBuilder, maxCand = 2)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -120,6 +139,29 @@ pixelPairStep.src = 'pixelPairStepTracks'
 pixelPairStep.GBRForestLabel = 'MVASelectorIter2_13TeV'
 pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
 
+# For LowPU
+import RecoTracker.IterativeTracking.LowPtTripletStep_cff
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+pixelPairStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='pixelPairStepTracks',
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('MVASelectorIter2'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'pixelPairStepLoose',
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'pixelPairStepTight',
+            preFilterName = 'pixelPairStepLoose',
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'pixelPairStepTight',
+        ),
+    ),
+    vertices = cms.InputTag("pixelVertices")#end of vpset
+) #end of clone
+
 
 # Final sequence
 PixelPairStep = cms.Sequence(pixelPairStepClusters*
@@ -128,3 +170,6 @@ PixelPairStep = cms.Sequence(pixelPairStepClusters*
                          pixelPairStepTrackCandidates*
                          pixelPairStepTracks*
                          pixelPairStep)
+_PixelPairStep_LowPU = PixelPairStep.copy()
+_PixelPairStep_LowPU.replace(pixelPairStep, pixelPairStepSelector)
+eras.trackingLowPU.toReplaceWith(PixelPairStep, _PixelPairStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -186,7 +186,7 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 eras.trackingLowPU.toModify(tobTecStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 # TRACK BUILDING
@@ -395,7 +395,7 @@ tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         skipClusters = cms.InputTag('tobTecStepClusters'),
-        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny'))
     ),
 
     TEC = cms.PSet(
@@ -403,7 +403,7 @@ tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('tobTecStepClusters'),
         #    untracked bool useSimpleRphiHitsCleaner = false
         useRingSlector = cms.bool(True),
-        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
         minRing = cms.int32(5),
         maxRing = cms.int32(5)
     )

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -210,10 +210,10 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
 # chose to "fix" the behaviour here, so the era is not fully
 # equivalent to the customize. To restore the customize behaviour,
 # uncomment the following lines
-eras.trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
-    inOutTrajectoryFilter = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.inOutTrajectoryFilter.clone(),
-    inOutTrajectoryFilterName = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter'))
-)
+#eras.trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
+#    inOutTrajectoryFilter = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.inOutTrajectoryFilter.clone(),
+#    inOutTrajectoryFilterName = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter'))
+#)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -1,20 +1,26 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 #######################################################################
 # Very large impact parameter tracking using TOB + TEC ring 5 seeding #
 #######################################################################
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-tobTecStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_tobTecStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("pixelLessStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("pixelLessStepClusters"),
-    trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+tobTecStepClusters = _tobTecStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(tobTecStepClusters, _tobTecStepClustersBase.clone(
+    overrideTrkQuals                         = "pixelLessStepSelector:QualityMasks",
+))
 
 # TRIPLET SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
@@ -141,25 +147,36 @@ tobTecStepSeedsPair.SeedComparitorPSet = cms.PSet(
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
 tobTecStepSeeds.seedCollections = cms.VInputTag(cms.InputTag('tobTecStepSeedsTripl'),cms.InputTag('tobTecStepSeedsPair'))
+# LowPU
+import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+eras.trackingLowPU.toReplaceWith(tobTecStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
+    OrderedHitsFactoryPSet = dict(SeedingLayers = 'tobTecStepSeedLayers'),
+    RegionFactoryPSet = dict(RegionPSet = dict(
+        ptMin = 0.6,
+        originHalfLength = 30.0,
+        originRadius = 6.0,
+    ))
+))
 
 # QUALITY CUTS DURING TRACK BUILDING (for inwardss and outwards track building steps)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 
-tobTecStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_tobTecStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     maxLostHits = 0,
     minimumNumberOfHits = 5,
-    seedPairPenalty = 1,
     minPt = 0.1,
     minHitsMinPt = 3
     )
+tobTecStepTrajectoryFilter = _tobTecStepTrajectoryFilterBase.clone(
+    seedPairPenalty = 1,
+)
+eras.trackingLowPU.toReplaceWith(tobTecStepTrajectoryFilter, _tobTecStepTrajectoryFilterBase.clone(
+    minimumNumberOfHits = 6,
+))
 
 tobTecStepInOutTrajectoryFilter = tobTecStepTrajectoryFilter.clone(
-    maxLostHits = 0,
     minimumNumberOfHits = 4,
-    seedPairPenalty = 1,
-    minPt = 0.1,
-    minHitsMinPt = 3
-    )
+)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -167,6 +184,9 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingLowPU.toModify(tobTecStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
 # TRACK BUILDING
@@ -184,6 +204,16 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
     )
+# Important note for LowPU: in RunI_TobTecStep the
+# inOutTrajectoryFilter parameter is spelled as
+# inOutTrajectoryFilterName, and I suspect it has no effect there. I
+# chose to "fix" the behaviour here, so the era is not fully
+# equivalent to the customize. To restore the customize behaviour,
+# uncomment the following lines
+eras.trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
+    inOutTrajectoryFilter = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.inOutTrajectoryFilter.clone(),
+    inOutTrajectoryFilterName = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter'))
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -207,6 +237,7 @@ tobTecStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
     allowSharedFirstHit = cms.bool(True)
     )
 tobTecStepTrackCandidates.TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 # TRACK FITTING AND SMOOTHING OPTIONS
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
@@ -217,6 +248,7 @@ tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFi
     Fitter = cms.string('tobTecStepRKFitter'),
     Smoother = cms.string('tobTecStepRKSmoother')
     )
+eras.trackingLowPU.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
 
 tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
     ComponentName = 'tobTecStepFitterSmootherForLoopers',
@@ -229,6 +261,8 @@ tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.
     ComponentName = cms.string('tobTecStepRKFitter'),
     minHits = 7
 )
+eras.trackingLowPU.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
+
 tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
     ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -239,6 +273,8 @@ tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cf
     errorRescaling = 10.0,
     minHits = 7
 )
+eras.trackingLowPU.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
+
 tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
     ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -279,6 +315,53 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 tobTecStep = ClassifierMerger.clone()
 tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
 
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+eras.trackingLowPU.toReplaceWith(tobTecStep, RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='tobTecStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter6'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'tobTecStepLoose',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 2.0, 4.0 ),
+            dz_par1 = ( 1.8, 4.0 ),
+            d0_par2 = ( 2.0, 4.0 ),
+            dz_par2 = ( 1.8, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'tobTecStepTight',
+            preFilterName = 'tobTecStepLoose',
+            chi2n_par = 0.3,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.5, 4.0 ),
+            dz_par1 = ( 1.4, 4.0 ),
+            d0_par2 = ( 1.5, 4.0 ),
+            dz_par2 = ( 1.4, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'tobTecStepTight',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.4, 4.0 ),
+            dz_par1 = ( 1.3, 4.0 ),
+            d0_par2 = ( 1.4, 4.0 ),
+            dz_par2 = ( 1.3, 4.0 )
+        ),
+    ),
+    vertices = cms.InputTag("pixelVertices") #end of vpset
+)) #end of clone
 
 
 
@@ -293,3 +376,45 @@ TobTecStep = cms.Sequence(tobTecStepClusters*
                           tobTecStepClassifier1*tobTecStepClassifier2*
                           tobTecStep)
 
+
+
+### Following are specific for LowPU, they're collected here to
+### not to interfere too much with the default configuration
+
+# SEEDING LAYERS
+tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('TOB1+TOB2',
+        'TOB1+TEC1_pos', 'TOB1+TEC1_neg',
+        'TEC1_pos+TEC2_pos', 'TEC2_pos+TEC3_pos',
+        'TEC3_pos+TEC4_pos', 'TEC4_pos+TEC5_pos',
+        'TEC5_pos+TEC6_pos', 'TEC6_pos+TEC7_pos',
+        'TEC1_neg+TEC2_neg', 'TEC2_neg+TEC3_neg',
+        'TEC3_neg+TEC4_neg', 'TEC4_neg+TEC5_neg',
+        'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'),
+
+    TOB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('tobTecStepClusters'),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        skipClusters = cms.InputTag('tobTecStepClusters'),
+        #    untracked bool useSimpleRphiHitsCleaner = false
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        minRing = cms.int32(5),
+        maxRing = cms.int32(5)
+    )
+)
+
+
+eras.trackingLowPU.toReplaceWith(TobTecStep, cms.Sequence(
+    tobTecStepClusters*
+    tobTecStepSeedLayers*
+    tobTecStepSeeds*
+    tobTecStepTrackCandidates*
+    tobTecStepTracks*
+    tobTecStep
+))

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -32,3 +32,21 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
                             ConvStep*
                             conversionStepTracks
                             )
+
+from Configuration.StandardSequences.Eras import eras
+eras.trackingLowPU.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStep*
+    LowPtTripletStep*
+    PixelPairStep*
+    DetachedTripletStep*
+    MixedTripletStep*
+    PixelLessStep*
+    TobTecStep*
+    earlyGeneralTracks*
+    muonSeededStep*
+    preDuplicateMergingGeneralTracks*
+    generalTracksSequence*
+    ConvStep*
+    conversionStepTracks
+))
+

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -35,6 +35,7 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
 
 from Configuration.StandardSequences.Eras import eras
 eras.trackingLowPU.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStepPreSplitting*
     InitialStep*
     LowPtTripletStep*
     PixelPairStep*

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 RegionPSetWithVerticesBlock = cms.PSet(
     RegionPSet = cms.PSet(
@@ -16,4 +17,6 @@ RegionPSetWithVerticesBlock = cms.PSet(
         nSigmaZ = cms.double(4.0)
     )
 )
-
+eras.trackingLowPU.toModify(RegionPSetWithVerticesBlock,
+    RegionPSet = dict(VertexCollection = "pixelVertices")
+)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+import RecoVertex.BeamSpotProducer.Modifiers as mods
+
 offlineBeamSpot = cms.EDProducer("BeamSpotProducer")
 
-
+import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
+_onlineBeamSpotProducer = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+mods.offlineToOnlineBeamSpotSwap.toReplaceWith(offlineBeamSpot, _onlineBeamSpotProducer)

--- a/RecoVertex/BeamSpotProducer/python/Modifiers.py
+++ b/RecoVertex/BeamSpotProducer/python/Modifiers.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+offlineToOnlineBeamSpotSwap = cms.Modifier()


### PR DESCRIPTION
- Run2_2016_trackingLowPU  is added by @makortel to replace functionality earlier available from RecoTracker/Configuration/customiseForRunI.customiseForRunI

DataProcessing setup has a matching ppEra_Run2_2016_trackingLowPU scenario

This PR also includes an attempt to revive the setup with old customization function: it is available with pplowpuEra_Run2_2016 data processing scenario. However, the customization is out of date and while the code configures, it doesn't run.
With the customization, detachedTripletStepChi2Est  is  a Chi2MeasurementEstimatorESProducer (compared to Chi2ChargeMeasurementEstimatorESProducer with the era). The PSet for the former requires no clusterChargeCut is present and PSet validation fails.

@makortel @VinInn @rovere  in case there is some need to support this customization function, it needs an update.
A better choice is to live with the era-based setup.
