### PR TITLE
Fix Puppi MET and smearing MET correction, add central test for the MET tool

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,7 +12,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '80X_mcRun2_design_v9',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_Candidate_2016_04_07_12_27_27',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v11',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '80X_mcRun2_asymptotic_v9',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,7 +12,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '80X_mcRun2_design_v9',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v9',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_Candidate_2016_04_07_12_27_27',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '80X_mcRun2_asymptotic_v9',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -253,6 +253,7 @@ def miniAOD_customizeCommon(process):
                                         pfCandColl=cms.InputTag("puppiForMET"),
                                         jetCollUnskimmed="slimmedJetsPuppi",
                                         recoMetFromPFCs=True,
+                                        jetFlavor="AK4PFPuppi",
                                         postfix="Puppi"
                                         )
     

--- a/PhysicsTools/PatAlgos/test/patTuple_updateMet_fromMiniAOD_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_updateMet_fromMiniAOD_cfg.py
@@ -1,0 +1,43 @@
+## import skeleton process
+from PhysicsTools.PatAlgos.patTemplate_cfg import *
+## switch to uncheduled mode
+process.options.allowUnscheduled = cms.untracked.bool(True)
+
+#process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+#process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
+#process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
+
+# apply type I PFMEt corrections to pat::MET object
+# and estimate systematic uncertainties on MET
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+runMetCorAndUncFromMiniAOD(process)
+    
+
+## ------------------------------------------------------
+#  In addition you usually want to change the following
+#  parameters:
+## ------------------------------------------------------
+#
+#   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
+#                                         ##
+## switch to RECO input
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+#                                         ##
+process.maxEvents.input = 10
+#                                         ##
+#   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
+#    
+  
+from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
+process.out.outputCommands = MINIAODSIMEventContent.outputCommands
+process.out.outputCommands.append("keep *_slimmedMETs_*_*")
+process.out.outputCommands.append("keep *_patPFMet_*_*")
+process.out.outputCommands.append("keep *_patPFMetT1_*_*")
+process.out.outputCommands.append("keep *_patPFMetT1JetResDown_*_*")
+process.out.outputCommands.append("keep *_patPFMetT1JetResUp_*_*")
+                                   ##
+process.out.fileName = 'patTuple_updateMet_fromMiniAOD.root'
+#                                         ##
+#   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)

--- a/PhysicsTools/PatAlgos/test/produceMETFromAOD.py
+++ b/PhysicsTools/PatAlgos/test/produceMETFromAOD.py
@@ -1,24 +1,8 @@
-import FWCore.ParameterSet.Config as cms
-
-# Define the CMSSW process
-process = cms.Process("RERUN")
-
-# Load the standard set of configuration modules
-process.load('Configuration.StandardSequences.Services_cff')
-process.load('Configuration.StandardSequences.GeometryDB_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-
-# Message Logger settings
-process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.destinations = ['cout', 'cerr']
-process.MessageLogger.cerr.FwkReport.reportEvery = 1
+from PhysicsTools.PatAlgos.patTemplate_cfg import cms, process
 
 # Set the process options -- Display summary at the end, enable unscheduled execution
-process.options = cms.untracked.PSet( 
-    allowUnscheduled = cms.untracked.bool(True),
-    wantSummary = cms.untracked.bool(False) 
-)
+process.options.allowUnscheduled = cms.untracked.bool(True)
+process.options.wantSummary = cms.untracked.bool(False) 
 
 # How many events to process
 process.maxEvents = cms.untracked.PSet( 
@@ -34,11 +18,7 @@ redoPuppi=False # rebuild puppiMET
 
 
 ### External JECs =====================================================================================================
-
-#from Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff import *
-#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-#from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 from Configuration.AlCa.autoCond import autoCond
 if runOnData:
   process.GlobalTag.globaltag = autoCond['run2_data']
@@ -97,64 +77,47 @@ if not useHFCandidates:
 #jets are rebuilt from those candidates by the tools, no need to do anything else
 ### =================================================================================
 
-from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMETCorrectionsAndUncertainties
 
 #default configuration for miniAOD reprocessing, change the isData flag to run on data
 #for a full met computation, remove the pfCandColl input
-runMetCorAndUncFromMiniAOD(process,
-                           isData=runOnData,
+runMETCorrectionsAndUncertainties(process,
+                           #isData=runOnData,
                            )
 
 if not useHFCandidates:
-    runMetCorAndUncFromMiniAOD(process,
-                               isData=runOnData,
-                               pfCandColl=cms.InputTag("noHFCands"),
-                               reclusterJets=True, #needed for NoHF
-                               recoMetFromPFCs=True, #needed for NoHF
-                               postfix="NoHF"
-                               )
+  runMETCorrectionsAndUncertainties(process,
+                                    #isData=runOnData,
+                                    pfCandColl=cms.InputTag("noHFCands"),
+                                    reclusterJets=True, #needed for NoHF
+                                    recoMetFromPFCs=True, #needed for NoHF
+                                    postfix="NoHF"
+                                    )
 
 if redoPuppi:
   from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
   makePuppiesFromMiniAOD( process );
 
-  runMetCorAndUncFromMiniAOD(process,
-                             isData=runOnData,
+  runMETCorrectionsAndUncertainties(process,
+                             #isData=runOnData,
                              pfCandColl=cms.InputTag("puppiForMET"),
-                             recoMetFromPFCs=True,
+                             recoMetFromPFCs=True, 
                              reclusterJets=True,
                              jetFlavor="AK4PFPuppi",
                              postfix="Puppi"
                              )
 
-
-process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
-    compressionLevel = cms.untracked.int32(4),
-    compressionAlgorithm = cms.untracked.string('LZMA'),
-    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
-    outputCommands = cms.untracked.vstring( "keep *_slimmedMETs_*_RERUN",
-                                            "keep *_slimmedMETsNoHF_*_*",
-                                            "keep *_patPFMet_*_*",
-                                            "keep *_patPFMetT1_*_*",
-                                            "keep *_patPFMetT1JetResDown_*_*",
-                                            "keep *_patPFMetT1JetResUp_*_*",
-                                            "keep *_patPFMetT1Smear_*_*",
-                                            "keep *_patPFMetT1SmearJetResDown_*_*",
-                                            "keep *_patPFMetT1SmearJetResUp_*_*",
-                                            "keep *_puppiForMET_*_*",
-                                            "keep *_puppi_*_*",
-                                            "keep *_patPFMetT1Puppi_*_*",
-                                            "keep *_slimmedMETsPuppi_*_*",
-                                            ),
-    fileName = cms.untracked.string('corMETMiniAOD.root'),
-    dataset = cms.untracked.PSet(
-        filterName = cms.untracked.string(''),
-        dataTier = cms.untracked.string('')
-    ),
-    dropMetaData = cms.untracked.string('ALL'),
-    fastCloning = cms.untracked.bool(False),
-    overrideInputFileSplitLevels = cms.untracked.bool(True)
-)
+if runOnData:
+  from PhysicsTools.PatAlgos.tools.coreTools import runOnData
+  runOnData( process )
 
 
-process.MINIAODSIMoutput_step = cms.EndPath(process.MINIAODSIMoutput)
+process.out.outputCommands = cms.untracked.vstring( "keep *_slimmedMETs_*_*",
+                                                    "keep *_slimmedMETsNoHF_*_*",
+                                                    "keep *_slimmedMETsPuppi_*_*",
+                                                    )
+process.out.fileName = cms.untracked.string('corMETMiniAOD.root')
+  
+
+
+process.MINIAODSIMoutput_step = cms.EndPath(process.out)

--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -31,6 +31,8 @@ cmsRun ${LOCAL_TEST_DIR}/patTuple_fastsim_cfg.py || die 'Failure using patTuple_
 
 cmsRun ${LOCAL_TEST_DIR}/patTuple_metUncertainties_cfg.py || die 'Failure using patTuple_metUncertainties_cfg.py' $?
 
+cmsRun ${LOCAL_TEST_DIR}/patTuple_updateMet_fromMiniAOD_cfg.py || die 'Failure using patTuple_updateMet_fromMiniAOD_cfg.py' $?
+
 cmsRun ${LOCAL_TEST_DIR}/patTuple_updateJets_fromMiniAOD_cfg.py || die 'Failure using patTuple_updateJets_fromMiniAOD_cfg.py' $?
 
 #---- disabled while the release is still open and changes to AOD event content are still allowed

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -202,8 +202,8 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
 
             for (const auto& jet: jets) {
 
-                if (! m_enabled) {
-                    // Module disabled. Simply copy the input jet.
+                if ((! m_enabled) || (jet.pt() == 0)) {
+                    // Module disabled or invalid p4. Simply copy the input jet.
                     smearedJets->push_back(jet);
 
                     continue;

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -247,7 +247,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     }
 
                     std::normal_distribution<> d(0, sigma);
-                    smearFactor = 1. + d(m_random_generator) / jet.pt();
+                    smearFactor = 1. + d(m_random_generator);
                 } else if (m_debug) {
                     std::cout << "Impossible to smear this jet" << std::endl;
                 }

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -233,12 +233,12 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                         std::cout << "gen jet:  pt: " << genJet->pt() << "  eta: " << genJet->eta() << "  phi: " << genJet->phi() << "  e: " << genJet->energy() << std::endl;
                     }
 
-                    double dE = jet.energy() - genJet->energy();
-                    smearFactor = 1 + (jer_sf - 1.) * dE / jet.energy();
+                    double dPt = jet.pt() - genJet->pt();
+                    smearFactor = 1 + (jer_sf - 1.) * dPt / jet.pt();
 
                 } else if (jer_sf > 1) {
                     /*
-                     * Case 2: we don't have a gen jet. Smear jet energy using a random gaussian variation
+                     * Case 2: we don't have a gen jet. Smear jet pt using a random gaussian variation
                      */
 
                     double sigma = jet_resolution * std::sqrt(jer_sf * jer_sf - 1);
@@ -247,7 +247,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     }
 
                     std::normal_distribution<> d(0, sigma);
-                    smearFactor = 1. + d(m_random_generator) / jet.energy();
+                    smearFactor = 1. + d(m_random_generator) / jet.pt();
                 } else if (m_debug) {
                     std::cout << "Impossible to smear this jet" << std::endl;
                 }

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.cc
@@ -40,7 +40,7 @@ ShiftedParticleProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
   for(CandidateView::const_iterator originalParticle = originalParticles->begin();
       originalParticle != originalParticles->end(); ++originalParticle ) {
-    
+
     double uncertainty = getUncShift(originalParticle);
     double shift = shiftBy_*uncertainty;
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h
@@ -60,11 +60,12 @@ class ShiftedParticleProducer : public edm::stream::EDProducer<>
     }
   binningEntryType(const edm::ParameterSet& cfg, std::string moduleLabel)
   : binSelection_(new StringCutObjectSelector<reco::Candidate>(cfg.getParameter<std::string>("binSelection"))),
-      //binUncertainty_(cfg.getParameter<double>("binUncertainty")),
-      binUncertainty_(cfg.getParameter<std::string>("binUncertainty"))
+      binUncertainty_(cfg.getParameter<std::string>("binUncertainty")),
+      energyDep_(false)
     {
       binUncFormula_ = std::unique_ptr<TF2>(new TF2(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() ) );
-      if(cfg.exists("energyDep") ) energyDep_=cfg.getParameter<bool>("energyDependency");
+      if(cfg.exists("energyDependency") ) {energyDep_=cfg.getParameter<bool>("energyDependency");
+      }
     }
     ~binningEntryType()
     {

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -741,19 +741,19 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                     cms.PSet(
                         binSelection = cms.string('pdgId==130'),
                         energyDependency = cms.bool(True),
-                        binUncertainty = cms.string('((abs(y)<1.3)?(max(0.25,sqrt(pow(0.8/sqrt(x), 2)+0.05*0.05))):(max(0.30,sqrt(pow(1.0/sqrt(x),2)+0.04*0.04))))')
+                        binUncertainty = cms.string('((abs(y)<1.3)?(min(0.25,sqrt(0.64/x+0.0025))):(min(0.30,sqrt(1.0/x+0.0016))))')
                         ),
                     # photon - ECAL resolution
                     cms.PSet(
                         binSelection = cms.string('pdgId==22'),
                         energyDependency = cms.bool(True),
-                        binUncertainty = cms.string('sqrt(pow(0.03/sqrt(x),2)+0.001*0.001)+0*y')
+                        binUncertainty = cms.string('sqrt(0.0009/x+0.000001)+0*y')
                         ),
                     # HF particules - HF resolution
                     cms.PSet(
                         binSelection = cms.string('pdgId==1 || pdgId==2'),
                         energyDependency = cms.bool(True),
-                        binUncertainty = cms.string('sqrt(pow(1/sqrt(x),2)+0.05*0.05)+0*y')
+                        binUncertainty = cms.string('sqrt(1./x+0.0025)+0*y')
                         ),
                     ),
                                              shiftBy = cms.double(+1.*varyByNsigmas)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -741,19 +741,19 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                     cms.PSet(
                         binSelection = cms.string('pdgId==130'),
                         energyDependency = cms.bool(True),
-                        binUncertainty = cms.string('((abs(y)<1.3)?(1/sqrt(x)+0.07):(1.5/sqrt(x)+0.04))')
+                        binUncertainty = cms.string('((abs(y)<1.3)?(max(0.25,sqrt(pow(0.8/sqrt(x), 2)+0.05*0.05))):(max(0.30,sqrt(pow(1.0/sqrt(x),2)+0.04*0.04))))')
                         ),
                     # photon - ECAL resolution
                     cms.PSet(
                         binSelection = cms.string('pdgId==22'),
                         energyDependency = cms.bool(True),
-                        binUncertainty = cms.string('(0.03/sqrt(x)+0.003)+0*y')
+                        binUncertainty = cms.string('sqrt(pow(0.03/sqrt(x),2)+0.001*0.001)+0*y')
                         ),
                     # HF particules - HF resolution
                     cms.PSet(
                         binSelection = cms.string('pdgId==1 || pdgId==2'),
                         energyDependency = cms.bool(True),
-                        binUncertainty = cms.string('(2/sqrt(x)+0.1)+0*y')
+                        binUncertainty = cms.string('sqrt(pow(1/sqrt(x),2)+0.05*0.05)+0*y')
                         ),
                     ),
                                              shiftBy = cms.double(+1.*varyByNsigmas)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -63,7 +63,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.addParameter(self._defaultParameters, 'mvaMetLeptons',["Electrons","Muons"],
                           "Leptons to be used for recoil computation in the MVA MET, available values are: Electrons, Muons, Taus, Photons", allowedValues=["Electrons","Muons","Taus","Photons",""])
 
-        self.addParameter(self._defaultParameters, 'addToPatDefaultSequence', True,
+        self.addParameter(self._defaultParameters, 'addToPatDefaultSequence', False,
                           "Flag to enable/disable that metUncertaintySequence is inserted into patDefaultSequence", Type=bool)
         self.addParameter(self._defaultParameters, 'manualJetConfig', False,
                   "Enable jet configuration options", Type=bool)
@@ -211,8 +211,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('onMiniAOD',onMiniAOD),
         self.setParameter('postfix',postfix),
 
-        #if mva MET, autoswitch to std jets
-        if metType == "MVA":
+        #if mva/puppi MET, autoswitch to std jets
+        if metType == "MVA" or 'Puppi' in postfix:
             self.setParameter('CHS',False),
 
         #jet energy scale uncertainty needs
@@ -226,10 +226,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.jetConfiguration()
         
         #met reprocessing and jet reclustering
-        #ZD: puppi jet reclustering breaks the puppi jets
-        if recoMetFromPFCs and postfix != 'Puppi': 
+        if recoMetFromPFCs:
             self.setParameter('reclusterJets',True)
         
+        #ZD: puppi jet reclustering breaks the puppi jets
+        #overwriting of jet reclustering parameter for puppi
+        if 'Puppi' in postfix and not onMiniAOD:
+            self.setParameter('reclusterJets',False)
+
         #jet collection overloading for automatic jet reclustering or JEC application
         if reclusterJets:
             self.setParameter('jetCollectionUnskimmed',cms.InputTag('patJets'))
@@ -278,9 +282,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                          onMiniAOD,
                                          patMetModuleSequence,
                                          postfix)
-            #ZD:puppi jet reclustering breaks puppi jets
-            if postfix != 'Puppi':
-                reclusterJets = True
+            
         elif onMiniAOD: #raw MET extraction if running on miniAODs
             self.extractMET(process, "raw", patMetModuleSequence, postfix)
 
@@ -325,10 +327,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #fix the default jets for the type1 computation to those used to compute the uncertainties
         #in order to be consistent with what is done in the correction and uncertainty step
         #particularly true for miniAODs
-        #ZD:puppi currently doesn't have the L1 corrections in the GT
         if "T1" in metModName:
             getattr(process,"patPFMetT1T2Corr"+postfix).src = cms.InputTag(jetCollection.value()+postfix)
             getattr(process,"patPFMetT2Corr"+postfix).src = cms.InputTag(jetCollection.value()+postfix)
+            #ZD:puppi currently doesn't have the L1 corrections in the GT
             if 'Puppi' in postfix:
                 getattr(process,"patPFMetT1T2Corr"+postfix).offsetCorrLabel = cms.InputTag("")
                 getattr(process,"patPFMetT2Corr"+postfix).offsetCorrLabel = cms.InputTag("")
@@ -473,7 +475,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             corrections.append(corTags["T2Smear"])
             correctionSequence.append(corModules["T2Smear"])
 
-
+        #if both are here, consider smeared corJets for the full T1+Smear correction
+        if "T1" in correctionLevel and "Smear" in correctionLevel:
+            corrections.remove(corTags["T1"])
+            
         #Txy parameter tuning
         if "Txy" in correctionLevel:
             self.tuneTxyParameters(process, corScheme, postfix)
@@ -1266,7 +1271,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             
 
         jetColName+=postfix
-
         if not hasattr(process, jetColName):
             process.load("RecoJets.JetProducers.ak4PFJets_cfi")
             
@@ -1379,6 +1383,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.setParameter("CHS",True)
             jetCorLabelUpToL3Name += "CHS" #chs
             jetCorLabelL3ResName += "CHS"
+        elif "Puppi" in jetFlavor:
+            self.setParameter("CHS",False)
+            
         else:
             self.setParameter("CHS",False)
 
@@ -1474,6 +1481,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                         jetCleaning="LepClean",
                                         jetSelection="pt>15 && abs(eta)<9.9",
                                         jecUnFile="",
+                                        jetFlavor="AK4PFchs",
                                         recoMetFromPFCs=False,
                                         postfix=""):
 
@@ -1494,6 +1502,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       autoJetCleaning=jetCleaning,
                                       jecUncertaintyFile=jecUnFile,
                                       jetSelection=jetSelection,
+                                      jetFlavor=jetFlavor,
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix
                                       )
@@ -1513,6 +1522,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       autoJetCleaning=jetCleaning,
                                       jecUncertaintyFile=jecUnFile,
                                       jetSelection=jetSelection,
+                                      jetFlavor=jetFlavor,
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix
                                       )
@@ -1532,6 +1542,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       autoJetCleaning=jetCleaning,
                                       jecUncertaintyFile=jecUnFile,
                                       jetSelection=jetSelection,
+                                      jetFlavor=jetFlavor,
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix,
                                       )
@@ -1547,16 +1558,17 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                muonColl="slimmedMuons",
                                tauColl="slimmedTaus",
                                pfCandColl = "packedPFCandidates",
-                               jetFlav="AK4PFchs",
+                               jetFlavor="AK4PFchs",
                                jetCleaning="LepClean",
                                isData=False,
-                               jetConfig=False,
+                               manualJetConfig=False,
                                reclusterJets=False,
                                jetSelection="pt>15 && abs(eta)<9.9",
                                recoMetFromPFCs=False,
                                jetCorLabelL3="ak4PFCHSL1FastL2L3Corrector",
                                jetCorLabelRes="ak4PFCHSL1FastL2L3ResidualCorrector",
 ##                               jecUncFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
+                               CHS=False,
                                jecUncFile="",
                                postfix=""):
 
@@ -1580,11 +1592,12 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jetSelection=jetSelection,
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       autoJetCleaning=jetCleaning,
-                                      manualJetConfig=jetConfig,
-                                      jetFlavor=jetFlav,
+                                      manualJetConfig=manualJetConfig,
+                                      jetFlavor=jetFlavor,
                                       jetCorLabelUpToL3=jetCorLabelL3,
                                       jetCorLabelL3Res=jetCorLabelRes,
                                       jecUncertaintyFile=jecUncFile,
+                                      CHS=CHS,
                                       postfix=postfix,
                                       )
     
@@ -1606,11 +1619,12 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jetSelection=jetSelection,
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       autoJetCleaning=jetCleaning,
-                                      manualJetConfig=jetConfig,
-                                      jetFlavor=jetFlav,
+                                      manualJetConfig=manualJetConfig,
+                                      jetFlavor=jetFlavor,
                                       jetCorLabelUpToL3=jetCorLabelL3,
                                       jetCorLabelL3Res=jetCorLabelRes,
                                       jecUncertaintyFile=jecUncFile,
+                                      CHS=CHS,
                                       postfix=postfix,
                                       )
     #MET T1+Smear + uncertainties
@@ -1631,10 +1645,11 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jetSelection=jetSelection,
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       autoJetCleaning=jetCleaning,
-                                      manualJetConfig=jetConfig,
-                                      jetFlavor=jetFlav,
+                                      manualJetConfig=manualJetConfig,
+                                      jetFlavor=jetFlavor,
                                       jetCorLabelUpToL3=jetCorLabelL3,
                                       jetCorLabelL3Res=jetCorLabelRes,
                                       jecUncertaintyFile=jecUncFile,
+                                      CHS=CHS,
                                       postfix=postfix,
                                       )


### PR DESCRIPTION
This PR fixes only configuration : the computation of the puppiMET in the miniAOD production, now using the proper jet energy corrections for the puppiMET and a small inconsistency in the MET smearing correction have been also added.
A central test for the MET tool has been added, in order to avoid conflicts such as the one seen with the update of the PAT names few weeks ago.
Few internal variable names were also modified.

The miniAOD to miniAOD MET reprocessing example test file has been updated and a test file for the MET production from AOD has been added.

Packages impacted by this PR : 
- PhysicsTools/PatAlgos
- PhysicsTools/PatUtils

Changes :
- puppiMET will change due to the modification of the jet energy corrections used
- the smeared T1 PFMET is changing, no other change expected for the slimmedMET content
- no modification of the CPU/memory performances for the miniAOD production sequence
- fix MET unclustered uncertainty bug
- fix jet smearing bug
