### PR TITLE
Split up GEM and ME0 customizations

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -20,6 +20,7 @@ class Eras (object):
         # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to
         # "run2_common" over the whole python tree). In practice, I don't think it's worth
         # it, and this also gives the flexibilty to take it out easily.
+        self.run3_GEM = cms.Modifier()
 
         # Phase 2 sub-eras for stable features
         self.phase2_common = cms.Modifier()
@@ -59,9 +60,11 @@ class Eras (object):
         self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger, self.run2_HF_2016 )
         self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.trackingPhase1 )
         # Scenarios further afield.
+        # Run3 includes the GE1/1 upgrade
+        self.Run3 = cms.ModifierChain( self.Run2_2017,self.run3_GEM )
         # Phase2 is everything for the 2023 (2026?) detector that works so far in this release.
         # include phase 1 stuff until phase 2 tracking is fully defined....
-        self.Phase2 = cms.ModifierChain( self.phase2_common, self.phase2_tracker, self.phase2_hgcal, self.phase2_muon )
+        self.Phase2 = cms.ModifierChain( self.phase2_common, self.phase2_tracker, self.phase2_hgcal, self.phase2_muon, self.run3_GEM )
         # Phase2dev is everything for the 2023 (2026?) detector that is still in development.
         self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.phase2dev_hgcal, self.phase2dev_muon )
 
@@ -81,7 +84,7 @@ class Eras (object):
                                 self.run2_50ns_specific, self.run2_HI_specific,
                                 self.stage1L1Trigger, self.fastSim,
                                 self.run2_HF_2016, self.stage2L1Trigger,
-                                self.phase1Pixel,
+                                self.phase1Pixel, self.run3_GEM,
                                 self.phase2_common, self.phase2_tracker,
                                 self.phase2_hgcal, self.phase2_muon,
                                 self.phase2dev_common, self.phase2dev_tracker,

--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -170,10 +170,10 @@ RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
 randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify(RandomNumberGeneratorService, simMuonGEMDigis = dict(
+eras.run3_GEM.toModify(RandomNumberGeneratorService, simMuonGEMDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('HepJamesRandom')) )
 
-eras.phase2_muon.toModify(RandomNumberGeneratorService, simMuonME0Digis = dict(
+eras.phase2_muon.toModify(RandomNumberGeneratorService, simMuonME0Digis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('HepJamesRandom')) )

--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -169,15 +169,18 @@ RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
 
 randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
-def _modifyRandomNumberGeneratorServiceForPhase2( object ):
+def _modifyRandomNumberGeneratorServiceForRun3( object ):
     object.simMuonGEMDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('HepJamesRandom')
     )
+
+def _modifyRandomNumberGeneratorServiceForPhase2( object ):
     object.simMuonME0Digis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('HepJamesRandom')
     )
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( RandomNumberGeneratorService, func=_modifyRandomNumberGeneratorServiceForRun3 )
 eras.phase2_muon.toModify( RandomNumberGeneratorService, func=_modifyRandomNumberGeneratorServiceForPhase2 )

--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -169,18 +169,11 @@ RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
 
 randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
-def _modifyRandomNumberGeneratorServiceForRun3( object ):
-    object.simMuonGEMDigis = cms.PSet(
-        initialSeed = cms.untracked.uint32(1234567),
-        engineName = cms.untracked.string('HepJamesRandom')
-    )
-
-def _modifyRandomNumberGeneratorServiceForPhase2( object ):
-    object.simMuonME0Digis = cms.PSet(
-        initialSeed = cms.untracked.uint32(1234567),
-        engineName = cms.untracked.string('HepJamesRandom')
-    )
-
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( RandomNumberGeneratorService, func=_modifyRandomNumberGeneratorServiceForRun3 )
-eras.phase2_muon.toModify( RandomNumberGeneratorService, func=_modifyRandomNumberGeneratorServiceForPhase2 )
+eras.run3_GEM.toModify(RandomNumberGeneratorService, simMuonGEMDigis = dict(
+        initialSeed = cms.untracked.uint32(1234567),
+        engineName = cms.untracked.string('HepJamesRandom')) )
+
+eras.phase2_muon.toModify(RandomNumberGeneratorService, simMuonME0Digis = dict(
+        initialSeed = cms.untracked.uint32(1234567),
+        engineName = cms.untracked.string('HepJamesRandom')) )

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -29,16 +29,10 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_rpcRecHits_*_*')
 )
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( RecoLocalMuonFEVT, outputCommands = RecoLocalMuonFEVT.outputCommands + ['keep *_gemRecHits_*_*'] )
-eras.run3_GEM.toModify( RecoLocalMuonRECO, outputCommands = RecoLocalMuonRECO.outputCommands + ['keep *_gemRecHits_*_*'] )
-eras.run3_GEM.toModify( RecoLocalMuonAOD, outputCommands = RecoLocalMuonAOD.outputCommands + ['keep *_gemRecHits_*_*'] )
+def _updateOutput( era, outputPSets, commands):
+   for o in outputPSets:
+      era.toModify( o, outputCommands = o.outputCommands + commands )
 
-eras.phase2_muon.toModify( RecoLocalMuonFEVT, outputCommands = RecoLocalMuonFEVT.outputCommands + ['keep *_me0RecHits_*_*'] )
-eras.phase2_muon.toModify( RecoLocalMuonRECO, outputCommands = RecoLocalMuonRECO.outputCommands + ['keep *_me0RecHits_*_*'] )
-eras.phase2_muon.toModify( RecoLocalMuonAOD, outputCommands = RecoLocalMuonAOD.outputCommands + ['keep *_me0RecHits_*_*'] )
-
-eras.phase2_muon.toModify( RecoLocalMuonFEVT, outputCommands = RecoLocalMuonFEVT.outputCommands + ['keep *_me0Segments_*_*'] )
-eras.phase2_muon.toModify( RecoLocalMuonRECO, outputCommands = RecoLocalMuonRECO.outputCommands + ['keep *_me0Segments_*_*'] )
-eras.phase2_muon.toModify( RecoLocalMuonAOD, outputCommands = RecoLocalMuonAOD.outputCommands + ['keep *_me0Segments_*_*'] )
-
-
+_outputs = [RecoLocalMuonFEVT, RecoLocalMuonRECO, RecoLocalMuonAOD]
+_updateOutput( eras.run3_GEM, _outputs, ['keep *_gemRecHits_*_*'] )
+_updateOutput(eras.phase2_muon, _outputs, ['keep *_me0RecHits_*_*', 'keep *_me0Segments_*_*'])

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -28,19 +28,17 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_cscSegments_*_*', 
         'keep *_rpcRecHits_*_*')
 )
-
-def _modifyRecoLocalMuonEventContentForRun3( object ):
-    object.outputCommands.append('keep *_gemRecHits_*_*')
-
-def _modifyRecoLocalMuonEventContentForPhase2( object ):
-    object.outputCommands.append('keep *_me0RecHits_*_*')
-    object.outputCommands.append('keep *_me0Segments_*_*')
-
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( RecoLocalMuonFEVT, func=_modifyRecoLocalMuonEventContentForRun3 )
-eras.run3_GEM.toModify( RecoLocalMuonRECO, func=_modifyRecoLocalMuonEventContentForRun3 )
-eras.run3_GEM.toModify( RecoLocalMuonAOD,  func=_modifyRecoLocalMuonEventContentForRun3 )
+eras.run3_GEM.toModify( RecoLocalMuonFEVT, outputCommands = RecoLocalMuonFEVT.outputCommands + ['keep *_gemRecHits_*_*'] )
+eras.run3_GEM.toModify( RecoLocalMuonRECO, outputCommands = RecoLocalMuonRECO.outputCommands + ['keep *_gemRecHits_*_*'] )
+eras.run3_GEM.toModify( RecoLocalMuonAOD, outputCommands = RecoLocalMuonAOD.outputCommands + ['keep *_gemRecHits_*_*'] )
 
-eras.phase2_muon.toModify( RecoLocalMuonFEVT, func=_modifyRecoLocalMuonEventContentForPhase2 )
-eras.phase2_muon.toModify( RecoLocalMuonRECO, func=_modifyRecoLocalMuonEventContentForPhase2 )
-eras.phase2_muon.toModify( RecoLocalMuonAOD,  func=_modifyRecoLocalMuonEventContentForPhase2 )
+eras.phase2_muon.toModify( RecoLocalMuonFEVT, outputCommands = RecoLocalMuonFEVT.outputCommands + ['keep *_me0RecHits_*_*'] )
+eras.phase2_muon.toModify( RecoLocalMuonRECO, outputCommands = RecoLocalMuonRECO.outputCommands + ['keep *_me0RecHits_*_*'] )
+eras.phase2_muon.toModify( RecoLocalMuonAOD, outputCommands = RecoLocalMuonAOD.outputCommands + ['keep *_me0RecHits_*_*'] )
+
+eras.phase2_muon.toModify( RecoLocalMuonFEVT, outputCommands = RecoLocalMuonFEVT.outputCommands + ['keep *_me0Segments_*_*'] )
+eras.phase2_muon.toModify( RecoLocalMuonRECO, outputCommands = RecoLocalMuonRECO.outputCommands + ['keep *_me0Segments_*_*'] )
+eras.phase2_muon.toModify( RecoLocalMuonAOD, outputCommands = RecoLocalMuonAOD.outputCommands + ['keep *_me0Segments_*_*'] )
+
+

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -29,12 +29,18 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_rpcRecHits_*_*')
 )
 
-def _modifyRecoLocalMuonEventContentForPhase2( object ):
+def _modifyRecoLocalMuonEventContentForRun3( object ):
     object.outputCommands.append('keep *_gemRecHits_*_*')
+
+def _modifyRecoLocalMuonEventContentForPhase2( object ):
     object.outputCommands.append('keep *_me0RecHits_*_*')
     object.outputCommands.append('keep *_me0Segments_*_*')
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( RecoLocalMuonFEVT, func=_modifyRecoLocalMuonEventContentForRun3 )
+eras.run3_GEM.toModify( RecoLocalMuonRECO, func=_modifyRecoLocalMuonEventContentForRun3 )
+eras.run3_GEM.toModify( RecoLocalMuonAOD,  func=_modifyRecoLocalMuonEventContentForRun3 )
+
 eras.phase2_muon.toModify( RecoLocalMuonFEVT, func=_modifyRecoLocalMuonEventContentForPhase2 )
 eras.phase2_muon.toModify( RecoLocalMuonRECO, func=_modifyRecoLocalMuonEventContentForPhase2 )
 eras.phase2_muon.toModify( RecoLocalMuonAOD,  func=_modifyRecoLocalMuonEventContentForPhase2 )

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -37,7 +37,7 @@ muonlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegments+cscloca
 # DT, CSC and RPC together (correct sequence for the standard path)
 muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
 
-from RecoLocalMuon.GEMRecHit.gemRecHits_cfi import gemRecHits
+from RecoLocalMuon.GEMRecHit.gemRecHits_cfi import *
 from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import *
 
 _run3_muonlocalreco = muonlocalreco.copy()

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -37,14 +37,15 @@ muonlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegments+cscloca
 # DT, CSC and RPC together (correct sequence for the standard path)
 muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
 
-def _modifyRecoLocalMuonForRun3( theProcess ):
-    theProcess.load("RecoLocalMuon.GEMRecHit.gemRecHits_cfi")
-    theProcess.muonlocalreco += theProcess.gemRecHits
+from RecoLocalMuon.GEMRecHit.gemRecHits_cfi import gemRecHits
+from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import me0LocalReco
 
-def _modifyRecoLocalMuonForPhase2( theProcess ):
-    theProcess.load("RecoLocalMuon.GEMRecHit.me0LocalReco_cff")
-    theProcess.muonlocalreco += theProcess.me0LocalReco
+_run3_muonlocalreco = muonlocalreco.copy()
+_run3_muonlocalreco += gemRecHits
+
+_phase2_muonlocalreco = _run3_muonlocalreco.copy()
+_phase2_muonlocalreco += me0LocalReco
 
 from Configuration.StandardSequences.Eras import eras
-modifyConfigurationStandardSequencesRecoLocalMuonForRun3_ = eras.run3_GEM.makeProcessModifier( _modifyRecoLocalMuonForRun3 )
-modifyConfigurationStandardSequencesRecoLocalMuonForPhase2_ = eras.phase2_muon.makeProcessModifier( _modifyRecoLocalMuonForPhase2 )
+eras.run3_GEM.toReplaceWith( muonlocalreco , _run3_muonlocalreco )
+eras.phase2_muon.toReplaceWith( muonlocalreco , _phase2_muonlocalreco )

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -38,7 +38,7 @@ muonlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegments+cscloca
 muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
 
 from RecoLocalMuon.GEMRecHit.gemRecHits_cfi import gemRecHits
-from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import me0LocalReco
+from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import *
 
 _run3_muonlocalreco = muonlocalreco.copy()
 _run3_muonlocalreco += gemRecHits

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -37,11 +37,14 @@ muonlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegments+cscloca
 # DT, CSC and RPC together (correct sequence for the standard path)
 muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
 
-def _modifyRecoLocalMuonForPhase2( theProcess ):
+def _modifyRecoLocalMuonForRun3( theProcess ):
     theProcess.load("RecoLocalMuon.GEMRecHit.gemRecHits_cfi")
-    theProcess.load("RecoLocalMuon.GEMRecHit.me0LocalReco_cff")
     theProcess.muonlocalreco += theProcess.gemRecHits
+
+def _modifyRecoLocalMuonForPhase2( theProcess ):
+    theProcess.load("RecoLocalMuon.GEMRecHit.me0LocalReco_cff")
     theProcess.muonlocalreco += theProcess.me0LocalReco
 
 from Configuration.StandardSequences.Eras import eras
+modifyConfigurationStandardSequencesRecoLocalMuonForRun3_ = eras.run3_GEM.makeProcessModifier( _modifyRecoLocalMuonForRun3 )
 modifyConfigurationStandardSequencesRecoLocalMuonForPhase2_ = eras.phase2_muon.makeProcessModifier( _modifyRecoLocalMuonForPhase2 )

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -84,23 +84,29 @@ muonGlobalReco = cms.Sequence(globalmuontracking*muonIdProducerSequence*muonSele
 
 ########################################################
 
-def _modifyRecoMuonPPonlyForRun3( object ):
-    object.STATrajBuilderParameters.FilterParameters.EnableGEMMeasurement = cms.bool(True)
-    object.STATrajBuilderParameters.BWFilterParameters.EnableGEMMeasurement = cms.bool(True)
+_run3_standAloneMuons = standAloneMuons.clone()
+_run3_standAloneMuons.STATrajBuilderParameters.FilterParameters.EnableGEMMeasurement = cms.bool(True)
+_run3_standAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableGEMMeasurement = cms.bool(True)
 
-def _modifyRecoMuonPPonlyForPhase2( object ):
-    object.STATrajBuilderParameters.FilterParameters.EnableME0Measurement = cms.bool(True)
-    object.STATrajBuilderParameters.BWFilterParameters.EnableME0Measurement = cms.bool(True)
+_run3_refittedStandAloneMuons = refittedStandAloneMuons.clone()
+_run3_refittedStandAloneMuons.STATrajBuilderParameters.FilterParameters.EnableGEMMeasurement = cms.bool(True)
+_run3_refittedStandAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableGEMMeasurement = cms.bool(True)
+
+_phase2_standAloneMuons = _run3_standAloneMuons.clone()
+_phase2_standAloneMuons.STATrajBuilderParameters.FilterParameters.EnableME0Measurement = cms.bool(True)
+_phase2_standAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableME0Measurement = cms.bool(True)
+
+_phase2_refittedStandAloneMuons = _run3_refittedStandAloneMuons.clone()
+_phase2_refittedStandAloneMuons.STATrajBuilderParameters.FilterParameters.EnableME0Measurement = cms.bool(True)
+_phase2_refittedStandAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableME0Measurement = cms.bool(True)
+
+from RecoMuon.MuonIdentification.me0MuonReco_cff import me0MuonReco
+_phase2_muonGlobalReco = muonGlobalReco.copy()
+_phase2_muonGlobalReco += me0MuonReco
 
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( standAloneMuons, func=_modifyRecoMuonPPonlyForRun3 )
-eras.run3_GEM.toModify( refittedStandAloneMuons, func=_modifyRecoMuonPPonlyForRun3 )
-eras.phase2_muon.toModify( standAloneMuons, func=_modifyRecoMuonPPonlyForPhase2 )
-eras.phase2_muon.toModify( refittedStandAloneMuons, func=_modifyRecoMuonPPonlyForPhase2 )
-
-def _modifyRecoMuonPPonlyForPhase2_addME0Muon( theProcess ):
-    theProcess.load("RecoMuon.MuonIdentification.me0MuonReco_cff")
-    theProcess.muonGlobalReco += theProcess.me0MuonReco
-
-modifyConfigurationStandardSequencesRecoMuonPPonlyPhase2_ = eras.phase2_muon.makeProcessModifier( _modifyRecoMuonPPonlyForPhase2_addME0Muon )
-    
+eras.run3_GEM.toReplaceWith( standAloneMuons, _run3_standAloneMuons )
+eras.run3_GEM.toReplaceWith( refittedStandAloneMuons, _run3_refittedStandAloneMuons )
+eras.phase2_muon.toReplaceWith( standAloneMuons, _phase2_standAloneMuons )
+eras.phase2_muon.toReplaceWith( refittedStandAloneMuons, _phase2_refittedStandAloneMuons )
+eras.phase2_muon.toReplaceWith( muonGlobalReco, _phase2_muonGlobalReco )

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -101,7 +101,7 @@ eras.phase2_muon.toModify( refittedStandAloneMuons, STATrajBuilderParameters = d
     FilterParameters = _enableME0Measurement,
     BWFilterParameters = _enableME0Measurement ) )
 
-from RecoMuon.MuonIdentification.me0MuonReco_cff import me0MuonReco
+from RecoMuon.MuonIdentification.me0MuonReco_cff import *
 _phase2_muonGlobalReco = muonGlobalReco.copy()
 _phase2_muonGlobalReco += me0MuonReco
 eras.phase2_muon.toReplaceWith( muonGlobalReco, _phase2_muonGlobalReco )

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -84,29 +84,25 @@ muonGlobalReco = cms.Sequence(globalmuontracking*muonIdProducerSequence*muonSele
 
 ########################################################
 
-_run3_standAloneMuons = standAloneMuons.clone()
-_run3_standAloneMuons.STATrajBuilderParameters.FilterParameters.EnableGEMMeasurement = cms.bool(True)
-_run3_standAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableGEMMeasurement = cms.bool(True)
+_enableGEMMeasurement = dict( EnableGEMMeasurement = cms.bool(True) )
+eras.run3_GEM.toModify( standAloneMuons, STATrajBuilderParameters = dict(
+    FilterParameters = _enableGEMMeasurement, 
+    BWFilterParameters = _enableGEMMeasurement ) )
+eras.run3_GEM.toModify( refittedStandAloneMuons, STATrajBuilderParameters = dict(
+    FilterParameters = _enableGEMMeasurement,
+    BWFilterParameters = _enableGEMMeasurement ) )
 
-_run3_refittedStandAloneMuons = refittedStandAloneMuons.clone()
-_run3_refittedStandAloneMuons.STATrajBuilderParameters.FilterParameters.EnableGEMMeasurement = cms.bool(True)
-_run3_refittedStandAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableGEMMeasurement = cms.bool(True)
-
-_phase2_standAloneMuons = _run3_standAloneMuons.clone()
-_phase2_standAloneMuons.STATrajBuilderParameters.FilterParameters.EnableME0Measurement = cms.bool(True)
-_phase2_standAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableME0Measurement = cms.bool(True)
-
-_phase2_refittedStandAloneMuons = _run3_refittedStandAloneMuons.clone()
-_phase2_refittedStandAloneMuons.STATrajBuilderParameters.FilterParameters.EnableME0Measurement = cms.bool(True)
-_phase2_refittedStandAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableME0Measurement = cms.bool(True)
+_enableME0Measurement = dict( EnableME0Measurement = cms.bool(True) )
+eras.phase2_muon.toModify( standAloneMuons, STATrajBuilderParameters = dict(
+    FilterParameters = _enableME0Measurement,
+    BWFilterParameters = _enableME0Measurement ) )
+eras.phase2_muon.toModify( refittedStandAloneMuons, STATrajBuilderParameters = dict(
+    FilterParameters = _enableME0Measurement,
+    BWFilterParameters = _enableME0Measurement ) )
 
 from RecoMuon.MuonIdentification.me0MuonReco_cff import me0MuonReco
 _phase2_muonGlobalReco = muonGlobalReco.copy()
 _phase2_muonGlobalReco += me0MuonReco
 
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toReplaceWith( standAloneMuons, _run3_standAloneMuons )
-eras.run3_GEM.toReplaceWith( refittedStandAloneMuons, _run3_refittedStandAloneMuons )
-eras.phase2_muon.toReplaceWith( standAloneMuons, _phase2_standAloneMuons )
-eras.phase2_muon.toReplaceWith( refittedStandAloneMuons, _phase2_refittedStandAloneMuons )
 eras.phase2_muon.toReplaceWith( muonGlobalReco, _phase2_muonGlobalReco )

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -84,13 +84,17 @@ muonGlobalReco = cms.Sequence(globalmuontracking*muonIdProducerSequence*muonSele
 
 ########################################################
 
-def _modifyRecoMuonPPonlyForPhase2( object ):
+def _modifyRecoMuonPPonlyForRun3( object ):
     object.STATrajBuilderParameters.FilterParameters.EnableGEMMeasurement = cms.bool(True)
     object.STATrajBuilderParameters.BWFilterParameters.EnableGEMMeasurement = cms.bool(True)
+
+def _modifyRecoMuonPPonlyForPhase2( object ):
     object.STATrajBuilderParameters.FilterParameters.EnableME0Measurement = cms.bool(True)
     object.STATrajBuilderParameters.BWFilterParameters.EnableME0Measurement = cms.bool(True)
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( standAloneMuons, func=_modifyRecoMuonPPonlyForRun3 )
+eras.run3_GEM.toModify( refittedStandAloneMuons, func=_modifyRecoMuonPPonlyForRun3 )
 eras.phase2_muon.toModify( standAloneMuons, func=_modifyRecoMuonPPonlyForPhase2 )
 eras.phase2_muon.toModify( refittedStandAloneMuons, func=_modifyRecoMuonPPonlyForPhase2 )
 

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -84,6 +84,7 @@ muonGlobalReco = cms.Sequence(globalmuontracking*muonIdProducerSequence*muonSele
 
 ########################################################
 
+from Configuration.StandardSequences.Eras import eras
 _enableGEMMeasurement = dict( EnableGEMMeasurement = cms.bool(True) )
 eras.run3_GEM.toModify( standAloneMuons, STATrajBuilderParameters = dict(
     FilterParameters = _enableGEMMeasurement, 
@@ -103,6 +104,4 @@ eras.phase2_muon.toModify( refittedStandAloneMuons, STATrajBuilderParameters = d
 from RecoMuon.MuonIdentification.me0MuonReco_cff import me0MuonReco
 _phase2_muonGlobalReco = muonGlobalReco.copy()
 _phase2_muonGlobalReco += me0MuonReco
-
-from Configuration.StandardSequences.Eras import eras
 eras.phase2_muon.toReplaceWith( muonGlobalReco, _phase2_muonGlobalReco )

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -222,11 +222,18 @@ mixPCFHepMCProducts = cms.PSet(
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( theMixObjects,
+    mixSH = dict(
+        input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","MuonGEMHits") ],
+        subdets = theMixObjects.mixSH.subdets + [ 'MuonGEMHits' ],
+        crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonGEMHits' ]
+    )
+)
 eras.phase2_muon.toModify( theMixObjects,
-    mixSH = dict( 
-        input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","MuonGEMHits"), cms.InputTag("g4SimHits","MuonME0Hits") ],
-        subdets = theMixObjects.mixSH.subdets + [ 'MuonGEMHits', 'MuonME0Hits' ],
-        crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonGEMHits', 'MuonME0Hits' ]
+    mixSH = dict(
+        input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","MuonME0Hits") ],
+        subdets = theMixObjects.mixSH.subdets + [ 'MuonME0Hits' ],
+        crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonME0Hits' ]
     )
 )
 eras.phase2_hgcal.toModify( theMixObjects,
@@ -237,5 +244,5 @@ eras.phase2_hgcal.toModify( theMixObjects,
         subdets = theMixObjects.mixCH.subdets + [ hgceeDigitizer.hitCollection.value(),
                                                   hgchebackDigitizer.hitCollection.value(),
                                                   hgchefrontDigitizer.hitCollection.value() ]
-    ) 
+    )
 )

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -238,5 +238,4 @@ eras.phase2_hgcal.toModify( theMixObjects,
                                                   hgchebackDigitizer.hitCollection.value(),
                                                   hgchefrontDigitizer.hitCollection.value() ]
     ) 
-
 )

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -53,7 +53,7 @@ if eras.fastSim.isChosen():
 
 from Configuration.StandardSequences.Eras import eras
 eras.run3_GEM.toModify(trackingParticles, simHitCollections = dict(
-        muon = trackingParticles.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonGEMHits"))))
+        muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonGEMHits")]))
 
 eras.phase2_muon.toModify( trackingParticles, simHitCollections = dict(
-        muon = trackingParticles.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonME0Hits"))))
+        muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonME0Hits")]))

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -51,12 +51,9 @@ if eras.fastSim.isChosen():
     trackingParticles.simTrackCollection = cms.InputTag('famosSimHits')
     trackingParticles.simVertexCollection = cms.InputTag('famosSimHits')
 
-def _modifyTrackingParticlesForRun3( object ):
-    object.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonGEMHits"))
-
-def _modifyTrackingParticlesForPhase2( object ):
-    object.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonME0Hits"))
-
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( trackingParticles, func=_modifyTrackingParticlesForRun3 )
-eras.phase2_muon.toModify( trackingParticles, func=_modifyTrackingParticlesForPhase2 )
+eras.run3_GEM.toModify(trackingParticles, simHitCollections = dict(
+        muon = trackingParticles.simHitCollections.muon+cmsInputTag("g4SimHits","MuonGEMHits")))
+
+eras.phase2_muon.toModify( trackingParticles, simHitCollections = dict(
+        muon = trackingParticles.simHitCollections.muon+cmsInputTag("g4SimHits","MuonME0Hits")))

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -51,9 +51,12 @@ if eras.fastSim.isChosen():
     trackingParticles.simTrackCollection = cms.InputTag('famosSimHits')
     trackingParticles.simVertexCollection = cms.InputTag('famosSimHits')
 
-def _modifyTrackingParticlesForPhase2( object ):
+def _modifyTrackingParticlesForRun3( object ):
     object.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonGEMHits"))
+
+def _modifyTrackingParticlesForPhase2( object ):
     object.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonME0Hits"))
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( trackingParticles, func=_modifyTrackingParticlesForRun3 )
 eras.phase2_muon.toModify( trackingParticles, func=_modifyTrackingParticlesForPhase2 )

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -53,7 +53,7 @@ if eras.fastSim.isChosen():
 
 from Configuration.StandardSequences.Eras import eras
 eras.run3_GEM.toModify(trackingParticles, simHitCollections = dict(
-        muon = trackingParticles.simHitCollections.muon+cmsInputTag("g4SimHits","MuonGEMHits")))
+        muon = trackingParticles.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonGEMHits"))))
 
 eras.phase2_muon.toModify( trackingParticles, simHitCollections = dict(
-        muon = trackingParticles.simHitCollections.muon+cmsInputTag("g4SimHits","MuonME0Hits")))
+        muon = trackingParticles.simHitCollections.muon.append(cms.InputTag("g4SimHits","MuonME0Hits"))))

--- a/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
@@ -60,7 +60,7 @@ trackingParticleSelection = cms.Sequence(mergedtruth)
 
 from Configuration.StandardSequences.Eras import eras
 eras.run3_GEM.toModify(trackingParticleSelection, simHitCollections = dict(
-        muon = trackingParticleSelection.simHitCollections.muon.append("g4SimHitsMuonGEMHits")))
+        muon = trackingParticleSelection.simHitCollections.muon+["g4SimHitsMuonGEMHits"]))
 
 eras.phase2_muon.toModify( trackingParticleSelection, simHitCollections = dict(
-        muon = trackingParticleSelection.simHitCollections.muon.append("g4SimHitsMuonME0Hits")))
+        muon = trackingParticleSelection.simHitCollections.muon+["g4SimHitsMuonME0Hits"]))

--- a/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
@@ -58,9 +58,12 @@ mergedtruth = cms.EDProducer("TrackingTruthProducer",
 
 trackingParticleSelection = cms.Sequence(mergedtruth)
 
-def _modifyTrackingParticleSelectionForPhase2( object ):
+def _modifyTrackingParticleSelectionForRun3( object ):
     object.simHitCollections.muon.append('g4SimHitsMuonGEMHits')
+
+def _modifyTrackingParticleSelectionForPhase2( object ):
     object.simHitCollections.muon.append('g4SimHitsMuonME0Hits')
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( trackingParticleSelection, func=_modifyTrackingParticleSelectionForRun3 )
 eras.phase2_muon.toModify( trackingParticleSelection, func=_modifyTrackingParticleSelectionForPhase2 )

--- a/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
@@ -60,7 +60,7 @@ trackingParticleSelection = cms.Sequence(mergedtruth)
 
 from Configuration.StandardSequences.Eras import eras
 eras.run3_GEM.toModify(trackingParticleSelection, simHitCollections = dict(
-        muon = trackingParticleSelection.simHitCollections.muon+("g4SimHitsMuonGEMHits")))
+        muon = trackingParticleSelection.simHitCollections.muon.append("g4SimHitsMuonGEMHits")))
 
 eras.phase2_muon.toModify( trackingParticleSelection, simHitCollections = dict(
-        muon = trackingParticleSelection.simHitCollections.muon+("g4SimHitsMuonME0Hits")))
+        muon = trackingParticleSelection.simHitCollections.muon.append("g4SimHitsMuonME0Hits")))

--- a/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
@@ -58,12 +58,9 @@ mergedtruth = cms.EDProducer("TrackingTruthProducer",
 
 trackingParticleSelection = cms.Sequence(mergedtruth)
 
-def _modifyTrackingParticleSelectionForRun3( object ):
-    object.simHitCollections.muon.append('g4SimHitsMuonGEMHits')
-
-def _modifyTrackingParticleSelectionForPhase2( object ):
-    object.simHitCollections.muon.append('g4SimHitsMuonME0Hits')
-
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( trackingParticleSelection, func=_modifyTrackingParticleSelectionForRun3 )
-eras.phase2_muon.toModify( trackingParticleSelection, func=_modifyTrackingParticleSelectionForPhase2 )
+eras.run3_GEM.toModify(trackingParticleSelection, simHitCollections = dict(
+        muon = trackingParticleSelection.simHitCollections.muon+("g4SimHitsMuonGEMHits")))
+
+eras.phase2_muon.toModify( trackingParticleSelection, simHitCollections = dict(
+        muon = trackingParticleSelection.simHitCollections.muon+("g4SimHitsMuonME0Hits")))

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -39,15 +39,18 @@ SimMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 
-def _modifySimMuonEventContentFEVTDEBUGForPhase2( object ):
+def _modifySimMuonEventContentFEVTDEBUGForRun3( object ):
     object.outputCommands.append('keep *_simMuonGEMDigis_*_*')
     object.outputCommands.append('keep *_simMuonGEMPadDigis_*_*')
-    object.outputCommands.append('keep *_simMuonME0Digis_*_*')
 
-def _modifySimMuonEventContentRAWRECOForPhase2( object ):
+def _modifySimMuonEventContentRAWRECOForRun3( object ):
     object.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*')
 
+def _modifySimMuonEventContentFEVTDEBUGForPhase2( object ):
+    object.outputCommands.append('keep *_simMuonME0Digis_*_*')
+
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toModify( SimMuonFEVTDEBUG, func=_modifySimMuonEventContentFEVTDEBUGForRun3 )
+eras.run3_GEM.toModify( SimMuonRAW, func=_modifySimMuonEventContentRAWRECOForRun3 )
+eras.run3_GEM.toModify( SimMuonRECO, func=_modifySimMuonEventContentRAWRECOForRun3 )
 eras.phase2_muon.toModify( SimMuonFEVTDEBUG, func=_modifySimMuonEventContentFEVTDEBUGForPhase2 )
-eras.phase2_muon.toModify( SimMuonRAW, func=_modifySimMuonEventContentRAWRECOForPhase2 )
-eras.phase2_muon.toModify( SimMuonRECO, func=_modifySimMuonEventContentRAWRECOForPhase2 )

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -39,18 +39,8 @@ SimMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 
-def _modifySimMuonEventContentFEVTDEBUGForRun3( object ):
-    object.outputCommands.append('keep *_simMuonGEMDigis_*_*')
-    object.outputCommands.append('keep *_simMuonGEMPadDigis_*_*')
-
-def _modifySimMuonEventContentRAWRECOForRun3( object ):
-    object.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*')
-
-def _modifySimMuonEventContentFEVTDEBUGForPhase2( object ):
-    object.outputCommands.append('keep *_simMuonME0Digis_*_*')
-
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( SimMuonFEVTDEBUG, func=_modifySimMuonEventContentFEVTDEBUGForRun3 )
-eras.run3_GEM.toModify( SimMuonRAW, func=_modifySimMuonEventContentRAWRECOForRun3 )
-eras.run3_GEM.toModify( SimMuonRECO, func=_modifySimMuonEventContentRAWRECOForRun3 )
-eras.phase2_muon.toModify( SimMuonFEVTDEBUG, func=_modifySimMuonEventContentFEVTDEBUGForPhase2 )
+eras.run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*', 'keep *_simMuonGEMPadDigis_*_*'] )
+eras.run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+eras.run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+eras.phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0Digis_*_*'] )

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -19,8 +19,10 @@ from CondCore.DBCommon.CondDBCommon_cfi import *
 from SimMuon.GEMDigitizer.muonGEMDigi_cff import *
 from SimMuon.GEMDigitizer.muonME0DigisPreReco_cfi import *
 
-_phase2_muonDigi = muonDigi.copy()
-_phase2_muonDigi += muonGEMDigi
+_run3_muonDigi = muonDigi.copy()
+_run3_muonDigi += muonGEMDigi
+
+_phase2_muonDigi = _run3_muonDigi.copy()
 _phase2_muonDigi += simMuonME0Digis
 
 def _modifySimMuonForPhase2( theProcess ):
@@ -41,5 +43,6 @@ def _modifySimMuonForPhase2( theProcess ):
     theProcess.rpcphase2recovery_esprefer = cms.ESPrefer("PoolDBESSource","rpcphase2recovery_essource")
 
 from Configuration.StandardSequences.Eras import eras
+eras.run3_GEM.toReplaceWith( muonDigi, _run3_muonDigi )
 eras.phase2_muon.toReplaceWith( muonDigi, _phase2_muonDigi )
 modifyConfigurationStandardSequencesSimMuonPhase2_ = eras.phase2_muon.makeProcessModifier( _modifySimMuonForPhase2 )

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -140,4 +140,4 @@ muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.phase2_muon.toModify( muonAssociatorByHits, useGEMs = cms.bool(True) )
+eras.run3_GEM.toModify( muonAssociatorByHits, useGEMs = cms.bool(True) )

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -120,11 +120,14 @@ globalPrevalidationTrackingOnly = cms.Sequence(
 )
 globalValidationTrackingOnly = cms.Sequence()
 
-def _modifyGlobalValidationForPhase2( theProcess ):
+def _modifyGlobalValidationForRun3( theProcess ):
     theProcess.load('Validation.Configuration.gemSimValid_cff')
-    theProcess.load('Validation.Configuration.me0SimValid_cff')
     theProcess.globalValidation += theProcess.gemSimValid
+
+def _modifyGlobalValidationForPhase2( theProcess ):
+    theProcess.load('Validation.Configuration.me0SimValid_cff')
     theProcess.globalValidation += theProcess.me0SimValid
 
 from Configuration.StandardSequences.Eras import eras
+modifyConfigurationStandardSequencesGlobalValidationForRun3_ = eras.run3_GEM.makeProcessModifier( _modifyGlobalValidationForRun3 )
 modifyConfigurationStandardSequencesGlobalValidationForPhase2_ = eras.phase2_muon.makeProcessModifier( _modifyGlobalValidationForPhase2 )

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -120,14 +120,15 @@ globalPrevalidationTrackingOnly = cms.Sequence(
 )
 globalValidationTrackingOnly = cms.Sequence()
 
-def _modifyGlobalValidationForRun3( theProcess ):
-    theProcess.load('Validation.Configuration.gemSimValid_cff')
-    theProcess.globalValidation += theProcess.gemSimValid
+from Validation.Configuration.gemSimValid_cff import gemSimValid
+from Validation.Configuration.me0SimValid_cff import me0SimValid
 
-def _modifyGlobalValidationForPhase2( theProcess ):
-    theProcess.load('Validation.Configuration.me0SimValid_cff')
-    theProcess.globalValidation += theProcess.me0SimValid
+_run3_globalValidation = globalValidation.copy()
+_run3_globalValidation += gemSimValid
+
+_phase2_globalValidation = _run3_globalValidation.copy()
+_phase2_globalValidation += me0SimValid
 
 from Configuration.StandardSequences.Eras import eras
-modifyConfigurationStandardSequencesGlobalValidationForRun3_ = eras.run3_GEM.makeProcessModifier( _modifyGlobalValidationForRun3 )
-modifyConfigurationStandardSequencesGlobalValidationForPhase2_ = eras.phase2_muon.makeProcessModifier( _modifyGlobalValidationForPhase2 )
+eras.run3_GEM.toReplaceWith( globalValidation, _run3_globalValidation )
+eras.phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -120,8 +120,8 @@ globalPrevalidationTrackingOnly = cms.Sequence(
 )
 globalValidationTrackingOnly = cms.Sequence()
 
-from Validation.Configuration.gemSimValid_cff import gemSimValid
-from Validation.Configuration.me0SimValid_cff import me0SimValid
+from Validation.Configuration.gemSimValid_cff import *
+from Validation.Configuration.me0SimValid_cff import *
 
 _run3_globalValidation = globalValidation.copy()
 _run3_globalValidation += gemSimValid

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -73,7 +73,7 @@ postValidationMiniAOD = cms.Sequence(
     electronPostValidationSequenceMiniAOD
 )
 
-def _modifyPostValidationForPhase2( theProcess ):
+def _modifyPostValidationForRun3( theProcess ):
     theProcess.load('Validation.MuonGEMHits.PostProcessor_cff')
     theProcess.load('Validation.MuonGEMDigis.PostProcessor_cff')
     theProcess.load('Validation.MuonGEMRecHits.PostProcessor_cff')
@@ -84,4 +84,4 @@ def _modifyPostValidationForPhase2( theProcess ):
     theProcess.postValidation += theProcess.hgcalPostProcessor
 
 from Configuration.StandardSequences.Eras import eras
-modifyConfigurationStandardSequencesPostValidationForPhase2_ = eras.phase2_muon.makeProcessModifier( _modifyPostValidationForPhase2 )
+modifyConfigurationStandardSequencesPostValidationForRun3_ = eras.run3_GEM.makeProcessModifier( _modifyPostValidationForRun3 )

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -82,7 +82,10 @@ _run3_postValidation = postValidation.copy()
 _run3_postValidation += MuonGEMHitsPostProcessors
 _run3_postValidation += MuonGEMDigisPostProcessors
 _run3_postValidation += MuonGEMRecHitsPostProcessors
-_run3_postValidation += hgcalPostProcessor
+
+_phase2_postValidation = _run3_postValidation.copy()
+_phase2_postValidation += hgcalPostProcessor
 
 from Configuration.StandardSequences.Eras import eras
 eras.run3_GEM.toReplaceWith( postValidation, _run3_postValidation )
+eras.phase2_hgcal.toReplaceWith( postValidation, _phase2_postValidation )

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -73,15 +73,16 @@ postValidationMiniAOD = cms.Sequence(
     electronPostValidationSequenceMiniAOD
 )
 
-def _modifyPostValidationForRun3( theProcess ):
-    theProcess.load('Validation.MuonGEMHits.PostProcessor_cff')
-    theProcess.load('Validation.MuonGEMDigis.PostProcessor_cff')
-    theProcess.load('Validation.MuonGEMRecHits.PostProcessor_cff')
-    theProcess.load('Validation.HGCalValidation.HGCalPostProcessor_cff')
-    theProcess.postValidation += theProcess.MuonGEMHitsPostProcessors
-    theProcess.postValidation += theProcess.MuonGEMDigisPostProcessors
-    theProcess.postValidation += theProcess.MuonGEMRecHitsPostProcessors
-    theProcess.postValidation += theProcess.hgcalPostProcessor
+from Validation.MuonGEMHits.PostProcessor_cff import *
+from Validation.MuonGEMDigis.PostProcessor_cff import *
+from Validation.MuonGEMRecHits.PostProcessor_cff import *
+from Validation.HGCalValidation.HGCalPostProcessor_cff import *
+
+_run3_postValidation = postValidation.copy()
+_run3_postValidation += MuonGEMHitsPostProcessors
+_run3_postValidation += MuonGEMDigisPostProcessors
+_run3_postValidation += MuonGEMRecHitsPostProcessors
+_run3_postValidation += hgcalPostProcessor
 
 from Configuration.StandardSequences.Eras import eras
-modifyConfigurationStandardSequencesPostValidationForRun3_ = eras.run3_GEM.makeProcessModifier( _modifyPostValidationForRun3 )
+eras.run3_GEM.toReplaceWith( postValidation, _run3_postValidation )

--- a/Validation/RecoMuon/python/MuonTrackValidator_cfi.py
+++ b/Validation/RecoMuon/python/MuonTrackValidator_cfi.py
@@ -115,4 +115,4 @@ muonTrackValidator = cms.EDAnalyzer("MuonTrackValidator",
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.phase2_muon.toModify( muonTrackValidator, useGEMs = cms.bool(True) )
+eras.run3_GEM.toModify( muonTrackValidator, useGEMs = cms.bool(True) )


### PR DESCRIPTION
As requested by @slava77 in https://github.com/cms-sw/cmssw/pull/13880#issuecomment-204594636 this PR splits up the GEM and ME0 customizations. GEMs will be enabled starting Run3 (GE1/1), with (possibly) an extension in Phase2 (GE2/1). ME0 will only be enabled starting Phase2. Including GEMs in the Run2_2017 era may be done in the future if the GE1/1 slice test goes well. 
- This PR is purely technical
- It introduces "Run3" and "Run3_GEM" in which GE1/1 customizations are applied
- Phase2 and Phase2_dev include "Run3_GEM" and ME0 customizations
- The baseline or other eras should not be affected. 

HGCal and DT fail at the DIGI and L1 step respectively in the simulation unfortunately. However, the simple cmsDriver command below does produce a syntactically correct configuration (see https://github.com/cms-sw/cmssw/pull/13880#issuecomment-204279041)

<PRE>
cmsDriver.py SingleMuPt100_cfi  \
--conditions auto:upgradePLS3 \
-n 10 \
--eventcontent FEVTDEBUGHLT \
-s GEN,SIM,DIGI:pdigi_valid,L1,DIGI2RAW,RAW2DIGI,L1Reco,RECO,VALIDATION \
--datatier GEN-SIM-RECO-RAW-VALIDATION \
--geometry Extended2023Muon,Extended2023MuonReco \
--era Phase2 \
--magField 38T_PostLS1 \
--no_exec \
--fileout file:out_all.root
</PRE>


@calabria, @jshlee
