### PR TITLE
Use std::shared_ptr in EventSetup interface (L1 and DB)

### DIFF
--- a/CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc
@@ -5,6 +5,7 @@
 
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 
+#include <memory>
 #include <sstream>
 
 namespace {
@@ -34,7 +35,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("Run","x");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
+	std::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
 	jprint.append(boost::lexical_cast<std::string>( iov.since ),
 		      boost::lexical_cast<std::string>( obj->GetX() ),
 		      boost::lexical_cast<std::string>( obj->GetXError() ) );
@@ -68,7 +69,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("Run","y");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
+	std::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
 	jprint.append(boost::lexical_cast<std::string>( iov.since ),
 		      boost::lexical_cast<std::string>( obj->GetY() ),
 		      boost::lexical_cast<std::string>( obj->GetYError() ) );
@@ -102,7 +103,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("x","y");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
+	std::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
 	jprint.append(boost::lexical_cast<std::string>( obj->GetX() ), 
 		      boost::lexical_cast<std::string>( obj->GetY() ) );
       }

--- a/CondCore/CSCPlugins/src/plugin.cc
+++ b/CondCore/CSCPlugins/src/plugin.cc
@@ -58,10 +58,11 @@
 
 //
 #include "CondCore/CondDB/interface/Serialization.h"
+#include <memory>
 
 
 namespace cond {
-  template <> boost::shared_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
+  template <> std::shared_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
 										   const Binary& payloadData,
 										   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( CSCReadoutMapping ); abstract
@@ -69,7 +70,7 @@ namespace cond {
     // here we come if none of the deserializations above match the payload type:
     throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
   }
-  template <> boost::shared_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
+  template <> std::shared_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
 													   const Binary& payloadData,
 													   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( CSCReadoutMappingForSliceTest ); abstract

--- a/CondCore/CalibPlugins/src/plugin.cc
+++ b/CondCore/CalibPlugins/src/plugin.cc
@@ -22,7 +22,7 @@
 
 
 namespace cond {
-  template <> boost::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+  template <> std::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
                                                                                      const Binary& payloadData,
                                                                                      const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( condex::Efficiency ); abstract 
@@ -36,7 +36,7 @@ namespace cond {
 
 
 namespace cond {
-  template <> boost::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+  template <> std::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
 								   const Binary& payloadData,
 								   const Binary& streamerInfoData ){
     DESERIALIZE_BASE_CASE( BaseKeyed );

--- a/CondCore/CondDB/interface/Binary.h
+++ b/CondCore/CondDB/interface/Binary.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <memory>
 // temporarely
-#include <boost/shared_ptr.hpp>
 // 
 
 namespace coral {

--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -43,10 +43,10 @@ namespace cond {
       void configure();
       Session createSession( const std::string& connectionString, bool writeCapable = false );
       Session createReadOnlySession( const std::string& connectionString, const std::string& transactionId );
-      boost::shared_ptr<coral::ISessionProxy> createCoralSession( const std::string& connectionString, bool writeCapable = false );
+      std::shared_ptr<coral::ISessionProxy> createCoralSession( const std::string& connectionString, bool writeCapable = false );
       
     private:
-      boost::shared_ptr<coral::ISessionProxy> createCoralSession( const std::string& connectionString, 
+      std::shared_ptr<coral::ISessionProxy> createCoralSession( const std::string& connectionString, 
                                                                   const std::string& transactionId, 
                                                                   bool writeCapable = false );
       Session createSession( const std::string& connectionString, 

--- a/CondCore/CondDB/interface/CredentialStore.h
+++ b/CondCore/CondDB/interface/CredentialStore.h
@@ -4,8 +4,8 @@
 #include "CondCore/CondDB/interface/DecodingKey.h"
 //
 #include <map>
+#include <memory>
 #include <string>
-#include <boost/shared_ptr.hpp>
 //
 #include "CoralBase/MessageStream.h"
 
@@ -160,8 +160,8 @@ namespace cond {
 
     private:
 
-      boost::shared_ptr<coral::IConnection> m_connection;
-      boost::shared_ptr<coral::ISession> m_session;
+      std::shared_ptr<coral::IConnection> m_connection;
+      std::shared_ptr<coral::ISession> m_session;
 
       int m_principalId;
       std::string m_principalKey;

--- a/CondCore/CondDB/interface/KeyList.h
+++ b/CondCore/CondDB/interface/KeyList.h
@@ -8,6 +8,7 @@
 #include "CondFormats/Common/interface/BaseKeyed.h"
 //
 #include<map>
+#include<memory>
 #include<vector>
 #include<string>
 
@@ -36,7 +37,7 @@ namespace cond {
       void load( const std::vector<unsigned long long>& keys );
       
       template<typename T> 
-      boost::shared_ptr<T> get(size_t n) const {
+      std::shared_ptr<T> get(size_t n) const {
 	if( n >= size() ) throwException( "Index outside the bounds of the key array.", 
 					  "KeyList::get");
 	if( !m_objects[n] ){
@@ -49,7 +50,7 @@ namespace cond {
 			    "KeyList::get");
 	  }
 	}
-	return boost::static_pointer_cast<T>( m_objects[n] );
+	return std::static_pointer_cast<T>( m_objects[n] );
       }
 
       size_t size() const { return m_objects.size();}
@@ -59,7 +60,7 @@ namespace cond {
       IOVProxy m_proxy;
       // the key selection: 
       mutable std::map<size_t,std::pair<std::string,std::pair<cond::Binary,cond::Binary> > > m_data;
-      mutable std::vector<boost::shared_ptr<void> > m_objects;
+      mutable std::vector<std::shared_ptr<void> > m_objects;
       
     };
 

--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -123,7 +123,7 @@ namespace cond {
       }
       
     private:
-      boost::shared_ptr<DataT> m_data;
+      std::shared_ptr<DataT> m_data;
       Hash m_currentPayloadId;
     };
     

--- a/CondCore/CondDB/interface/PayloadReader.h
+++ b/CondCore/CondDB/interface/PayloadReader.h
@@ -52,7 +52,7 @@ namespace cond {
       void close();
       
       //
-      template <typename T> boost::shared_ptr<T> fetch( const cond::Hash& payloadHash );
+      template <typename T> std::shared_ptr<T> fetch( const cond::Hash& payloadHash );
       
    private:
       
@@ -60,8 +60,8 @@ namespace cond {
       Session m_session;
     };
         
-    template <typename T> inline boost::shared_ptr<T> PayloadReader::fetch( const cond::Hash& payloadHash ){
-      boost::shared_ptr<T> ret;
+    template <typename T> inline std::shared_ptr<T> PayloadReader::fetch( const cond::Hash& payloadHash ){
+      std::shared_ptr<T> ret;
       if(m_session.connectionString().empty()) open( PRODUCTION_DB );
       m_session.transaction().start( true );
       ret = m_session.fetchPayload<T>( payloadHash );

--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -18,9 +18,9 @@
 //
 #include <sstream>
 #include <iostream>
+#include <memory>
 //
 // temporarely
-#include <boost/shared_ptr.hpp>
 
 #include "CondFormats/Serialization/interface/Archive.h"
 
@@ -70,10 +70,10 @@ namespace cond {
   }
 
   // generates an instance of T from the binary serialized data. 
-  template <typename T> boost::shared_ptr<T> default_deserialize( const std::string& payloadType, 
+  template <typename T> std::shared_ptr<T> default_deserialize( const std::string& payloadType, 
 								  const Binary& payloadData, 
 								  const Binary& streamerInfoData ){
-    boost::shared_ptr<T> payload;
+    std::shared_ptr<T> payload;
     std::stringbuf sstreamerInfoBuf;
     sstreamerInfoBuf.pubsetbuf( static_cast<char*>(const_cast<void*>(streamerInfoData.data())), streamerInfoData.size() );
     std::string streamerInfo = sstreamerInfoBuf.str();
@@ -102,7 +102,7 @@ namespace cond {
   }
 
   // default specialization
-  template <typename T> boost::shared_ptr<T> deserialize( const std::string& payloadType, 
+  template <typename T> std::shared_ptr<T> deserialize( const std::string& payloadType, 
 							  const Binary& payloadData, 
 							  const Binary& streamerInfoData ){
     return default_deserialize<T>( payloadType, payloadData, streamerInfoData );
@@ -117,7 +117,7 @@ namespace cond {
 
 #define DESERIALIZE_POLIMORPHIC_CASE( BASETYPENAME, DERIVEDTYPENAME )	\
   if( payloadType == #DERIVEDTYPENAME ){ \
-    return boost::dynamic_pointer_cast<BASETYPENAME>( default_deserialize<DERIVEDTYPENAME>( payloadType, payloadData, streamerInfoData ) ); \
+    return std::dynamic_pointer_cast<BASETYPENAME>( default_deserialize<DERIVEDTYPENAME>( payloadType, payloadData, streamerInfoData ) ); \
   }
  
 #endif

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -22,7 +22,6 @@
 #include "CondCore/CondDB/interface/Utils.h"
 // 
 // temporarely
-#include <boost/shared_ptr.hpp>
 
 // TO BE REMOVED AFTER THE TRANSITION
 namespace coral {
@@ -129,7 +128,7 @@ namespace cond {
       // functions to store a payload in the database. return the identifier of the item in the db. 
       template <typename T> cond::Hash storePayload( const T& payload, 
 						     const boost::posix_time::ptime& creationTime = boost::posix_time::microsec_clock::universal_time() );
-      template <typename T> boost::shared_ptr<T> fetchPayload( const cond::Hash& payloadHash );
+      template <typename T> std::shared_ptr<T> fetchPayload( const cond::Hash& payloadHash );
       
       // low-level function to access the payload data as a blob. mainly used for the data migration and testing.
       // the version for ROOT 
@@ -187,14 +186,14 @@ namespace cond {
       return ret;
     }
     
-    template <typename T> inline boost::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
+    template <typename T> inline std::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
       cond::Binary payloadData;
       cond::Binary streamerInfoData;
       std::string payloadType;
       if(! fetchPayloadData( payloadHash, payloadType, payloadData, streamerInfoData ) ) 
 	throwException( "Payload with id "+payloadHash+" has not been found in the database.",
 			"Session::fetchPayload" );
-      boost::shared_ptr<T> ret;
+      std::shared_ptr<T> ret;
       try{ 
 	ret = deserialize<T>(  payloadType, payloadData, streamerInfoData );
       } catch ( const cond::persistency::Exception& e ){

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -134,7 +134,7 @@ namespace cond {
       configure( connServ.configuration() );
     }
 
-    boost::shared_ptr<coral::ISessionProxy> ConnectionPool::createCoralSession( const std::string& connectionString, 
+    std::shared_ptr<coral::ISessionProxy> ConnectionPool::createCoralSession( const std::string& connectionString, 
                                                                                 const std::string& transactionId,
                                                                                 bool writeCapable ){
       coral::ConnectionService connServ;
@@ -147,7 +147,7 @@ namespace cond {
         connServ.webCacheControl().setTableTimeToLive( fullConnectionPars.second, PAYLOAD::tname, 3 );
       }
 
-      return boost::shared_ptr<coral::ISessionProxy>( connServ.connect( fullConnectionPars.first, 
+      return std::shared_ptr<coral::ISessionProxy>( connServ.connect( fullConnectionPars.first, 
 									writeCapable ? auth::COND_WRITER_ROLE : auth::COND_READER_ROLE,
 									writeCapable ? coral::Update : coral::ReadOnly ) ); 
     }
@@ -155,9 +155,8 @@ namespace cond {
     Session ConnectionPool::createSession( const std::string& connectionString, 
                                            const std::string& transactionId, 
                                            bool writeCapable ){
-      boost::shared_ptr<coral::ISessionProxy> coralSession = createCoralSession( connectionString, transactionId, writeCapable );
-      std::shared_ptr<SessionImpl> impl( new SessionImpl( coralSession, connectionString ) );  
-      return Session( impl );
+      std::shared_ptr<coral::ISessionProxy> coralSession = createCoralSession( connectionString, transactionId, writeCapable );
+      return Session( std::make_shared<SessionImpl>( coralSession, connectionString ));
     }
 
     Session ConnectionPool::createSession( const std::string& connectionString, bool writeCapable ){
@@ -168,7 +167,7 @@ namespace cond {
       return createSession( connectionString, transactionId );
     }
 
-    boost::shared_ptr<coral::ISessionProxy> ConnectionPool::createCoralSession( const std::string& connectionString, 
+    std::shared_ptr<coral::ISessionProxy> ConnectionPool::createCoralSession( const std::string& connectionString, 
                                                                                 bool writeCapable ){
       return createCoralSession( connectionString, "", writeCapable );
     }

--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -40,7 +40,6 @@
 #include <map>
 #include <memory>
 //
-#include <boost/shared_ptr.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 // macros for the schema definition

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -12,7 +12,7 @@ namespace cond {
 
     class CondDBTransaction : public ITransaction {
     public:
-      CondDBTransaction( const boost::shared_ptr<coral::ISessionProxy>& coralSession ):
+      CondDBTransaction( const std::shared_ptr<coral::ISessionProxy>& coralSession ):
 	m_session( coralSession ){
       }
       virtual ~CondDBTransaction(){}
@@ -29,14 +29,14 @@ namespace cond {
 	return m_session->transaction().isActive();
       }
     private: 
-      boost::shared_ptr<coral::ISessionProxy> m_session;
+      std::shared_ptr<coral::ISessionProxy> m_session;
     };
 
     SessionImpl::SessionImpl():
       coralSession(){
     }
 
-    SessionImpl::SessionImpl( boost::shared_ptr<coral::ISessionProxy>& session, 
+    SessionImpl::SessionImpl( std::shared_ptr<coral::ISessionProxy>& session, 
 			      const std::string& connectionStr ):
       coralSession( session ),
       connectionString( connectionStr ){

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -10,7 +10,6 @@
 //
 #include <memory>
 // temporarely
-#include <boost/shared_ptr.hpp>
 
 namespace coral {
   class ISessionProxy;
@@ -40,7 +39,7 @@ namespace cond {
       typedef enum { THROW, DO_NOT_THROW, CREATE } FailureOnOpeningPolicy;
     public:
       SessionImpl();
-      SessionImpl( boost::shared_ptr<coral::ISessionProxy>& session, 
+      SessionImpl( std::shared_ptr<coral::ISessionProxy>& session, 
 		   const std::string& connectionString );
 
       ~SessionImpl();
@@ -62,7 +61,7 @@ namespace cond {
       
     public:
       // allows for session shared among more services. To be changed to unique_ptr when we stop needing this feature.
-      boost::shared_ptr<coral::ISessionProxy> coralSession;
+      std::shared_ptr<coral::ISessionProxy> coralSession;
       // not really useful outside the ORA bridging...
       std::string connectionString;
       std::unique_ptr<ITransaction> transaction;

--- a/CondCore/CondDB/test/testConditionDatabase_0.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_0.cpp
@@ -89,7 +89,7 @@ int run( const std::string& connectionString ){
     } else {
       cond::Iov_t val = *iovIt;
       std::cout <<"#[0] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay0 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay0 = session.fetchPayload<MyTestData>( val.payloadId );
       pay0->print();
       iovIt++;
     }
@@ -98,7 +98,7 @@ int run( const std::string& connectionString ){
     } else {
       cond::Iov_t val =*iovIt;
       std::cout <<"#[1] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay1 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay1 = session.fetchPayload<MyTestData>( val.payloadId );
       pay1->print();
     }
     iovIt = proxy.find( 176 );
@@ -107,7 +107,7 @@ int run( const std::string& connectionString ){
     } else {
       cond::Iov_t val = *iovIt;
       std::cout <<"#[2] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay2 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay2 = session.fetchPayload<MyTestData>( val.payloadId );
       pay2->print();
       iovIt++;
     }
@@ -116,7 +116,7 @@ int run( const std::string& connectionString ){
     } else {
       cond::Iov_t val =*iovIt;
       std::cout <<"#[3] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay3 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay3 = session.fetchPayload<MyTestData>( val.payloadId );
       pay3->print();
     }
 
@@ -127,7 +127,7 @@ int run( const std::string& connectionString ){
     } else {
       cond::Iov_t val =*iov2It;
       std::cout <<"#[4] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<std::string> pay4 = session.fetchPayload<std::string>( val.payloadId );
+      std::shared_ptr<std::string> pay4 = session.fetchPayload<std::string>( val.payloadId );
       std::cout <<"#pay4="<<*pay4<<std::endl;
     }
     session.transaction().commit();

--- a/CondCore/CondDB/test/testConditionDatabase_1.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_1.cpp
@@ -25,7 +25,7 @@ void readTag( const std::string& tag, Session& session, const boost::posix_time:
   } else {
     cond::Iov_t val = *iovIt;
     std::cout <<"#[0] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-    boost::shared_ptr<std::string> pay0 = session.fetchPayload<std::string>( val.payloadId );
+    std::shared_ptr<std::string> pay0 = session.fetchPayload<std::string>( val.payloadId );
     std::cout <<"#[0] payload="<<*pay0<<std::endl;
   }
   iovIt = proxy.find( 235 );
@@ -34,7 +34,7 @@ void readTag( const std::string& tag, Session& session, const boost::posix_time:
   } else {
     cond::Iov_t val = *iovIt;
     std::cout <<"#[1] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-    boost::shared_ptr<std::string> pay0 = session.fetchPayload<std::string>( val.payloadId );
+    std::shared_ptr<std::string> pay0 = session.fetchPayload<std::string>( val.payloadId );
     std::cout <<"#[1] payload="<<*pay0<<std::endl;
   }
 }

--- a/CondCore/CondDB/test/testConnectionPool.cpp
+++ b/CondCore/CondDB/test/testConnectionPool.cpp
@@ -21,7 +21,6 @@
 #include "CoralBase/AttributeList.h"
 #include "CoralBase/Attribute.h"
 //BOOST includes
-#include <boost/shared_ptr.hpp>
 //
 #include <array>
 #include <cstdlib>
@@ -29,7 +28,7 @@
 #include <memory>
 
 void testCreateCoralSession( cond::persistency::ConnectionPool & connPool, std::string const & connectionString, bool const writeCapable ) {
-  boost::shared_ptr<coral::ISessionProxy> session = connPool.createCoralSession( connectionString, writeCapable );
+  std::shared_ptr<coral::ISessionProxy> session = connPool.createCoralSession( connectionString, writeCapable );
   session->transaction().start( true );
   coral::ISchema& schema = session->nominalSchema();
   std::string tagTable( "TAG" );

--- a/CondCore/CondDB/test/testReadWritePayloads.cpp
+++ b/CondCore/CondDB/test/testReadWritePayloads.cpp
@@ -122,7 +122,7 @@ int doRead( const std::string& connectionString ){
     } else {
       cond::Iov_t val = *iovIt;
       std::cout <<"#[0] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay0 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay0 = session.fetchPayload<MyTestData>( val.payloadId );
       pay0->print();
       if ( *pay0 != MyTestData(iVal0) ){
 	nFail++;
@@ -135,7 +135,7 @@ int doRead( const std::string& connectionString ){
     } else {
       cond::Iov_t val =*iovIt;
       std::cout <<"#[1] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay1 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay1 = session.fetchPayload<MyTestData>( val.payloadId );
       pay1->print();
       if ( *pay1 != MyTestData(iVal1) ){
 	nFail++;
@@ -148,7 +148,7 @@ int doRead( const std::string& connectionString ){
     } else {
       cond::Iov_t val = *iovIt;
       std::cout <<"#[2] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay2 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay2 = session.fetchPayload<MyTestData>( val.payloadId );
       pay2->print();
       if ( *pay2 != MyTestData(iVal1) ){
 	nFail++;
@@ -161,7 +161,7 @@ int doRead( const std::string& connectionString ){
     } else {
       cond::Iov_t val =*iovIt;
       std::cout <<"#[3] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<MyTestData> pay3 = session.fetchPayload<MyTestData>( val.payloadId );
+      std::shared_ptr<MyTestData> pay3 = session.fetchPayload<MyTestData>( val.payloadId );
       pay3->print();
       if ( *pay3 != MyTestData(iVal1) ){
 	nFail++;
@@ -176,7 +176,7 @@ int doRead( const std::string& connectionString ){
     } else {
       cond::Iov_t val =*iov2It;
       std::cout <<"#[4] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-      boost::shared_ptr<std::string> pay4 = session.fetchPayload<std::string>( val.payloadId );
+      std::shared_ptr<std::string> pay4 = session.fetchPayload<std::string>( val.payloadId );
       std::cout <<"#pay4="<<*pay4<<std::endl;
       if ( *pay4 != sVal ){
 	nFail++;
@@ -191,7 +191,7 @@ int doRead( const std::string& connectionString ){
 //     } else {
 //       cond::Iov_t val =*iov3It;
 //       std::cout <<"#[5] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-//       boost::shared_ptr<ArrayPayload> pay5 = session.fetchPayload<ArrayPayload>( val.payloadId );
+//       std::shared_ptr<ArrayPayload> pay5 = session.fetchPayload<ArrayPayload>( val.payloadId );
 //       // std::cout << "#pay5=" << (*pay5==arrayPl ? "OK" : "NOT OK") << std::endl;
 //     }
 // 
@@ -202,7 +202,7 @@ int doRead( const std::string& connectionString ){
 //     } else {
 //       cond::Iov_t val =*iov4It;
 //       std::cout <<"#[6] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
-//       boost::shared_ptr<SimplePayload> pay5 = session.fetchPayload<SimplePayload>( val.payloadId );
+//       std::shared_ptr<SimplePayload> pay5 = session.fetchPayload<SimplePayload>( val.payloadId );
 //       // std::cout << "#pay6=" << (*pay6==simplePl ? "OK" : "NOT OK") << std::endl;
 //     }
 

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -49,9 +49,10 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 #include "CondFormats/External/interface/DetID.h"
 
+#include <memory>
 
 namespace cond {
-  template <> boost::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+  template <> std::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
 						 const Binary& payloadData,
 						 const Binary& streamerInfoData ){
     DESERIALIZE_BASE_CASE( BaseKeyed );                                                                                                                                                                                                             

--- a/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
+++ b/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
@@ -14,7 +14,7 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 namespace cond {
-  template <> boost::shared_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType, 
+  template <> std::shared_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType, 
 										     const Binary& payloadData, 
 										     const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( PerformancePayload );  abstract 

--- a/CondCore/PopCon/interface/PopConSourceHandler.h
+++ b/CondCore/PopCon/interface/PopConSourceHandler.h
@@ -6,6 +6,7 @@
 
 #include <boost/bind.hpp>
 #include <algorithm>
+#include <memory>
 #include <vector>
 #include <string>
 
@@ -82,7 +83,7 @@ namespace popcon {
     private:
       
       cond::persistency::Session m_dbsession;
-      boost::shared_ptr<T> m_d;
+      std::shared_ptr<T> m_d;
     };
     
     

--- a/CondCore/PopCon/test/stubs/EffSourceHandler.cc
+++ b/CondCore/PopCon/test/stubs/EffSourceHandler.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 //#include<iostream>
+#include<memory>
 #include<sstream>
 #include<vector>
 #include<string>
@@ -13,7 +14,7 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 namespace cond {
-  template <> boost::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+  template <> std::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
                                                                                      const Binary& payloadData,
                                                                                      const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( condex::Efficiency );  abstract

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -5,6 +5,7 @@
 
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
 
+#include <memory>
 #include <sstream>
 
 namespace {
@@ -35,7 +36,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("Time","nLVOff");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<SiStripDetVOff> obj = reader.fetch<SiStripDetVOff>( iov.payloadId );
+	std::shared_ptr<SiStripDetVOff> obj = reader.fetch<SiStripDetVOff>( iov.payloadId );
 	jprint.append(boost::lexical_cast<std::string>( iov.since ),
 		      boost::lexical_cast<std::string>( obj->getLVoffCounts() ),
 		      boost::lexical_cast<std::string>( 0. ) );
@@ -70,7 +71,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("Time","nHVOff");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<SiStripDetVOff> obj = reader.fetch<SiStripDetVOff>( iov.payloadId );
+	std::shared_ptr<SiStripDetVOff> obj = reader.fetch<SiStripDetVOff>( iov.payloadId );
 	jprint.append(boost::lexical_cast<std::string>( iov.since ),
 		      boost::lexical_cast<std::string>( obj->getHVoffCounts() ),
 		      boost::lexical_cast<std::string>( 0. ) );

--- a/CondCore/Utilities/interface/CondDBImport.h
+++ b/CondCore/Utilities/interface/CondDBImport.h
@@ -3,6 +3,7 @@
 
 #include "CondCore/CondDB/interface/Types.h"
 #include "CondCore/CondDB/interface/Session.h"
+#include <memory>
 //
 
 namespace cond {
@@ -11,8 +12,8 @@ namespace cond {
 
     cond::Hash import( Session& source, const cond::Hash& sourcePayloadId, const std::string& inputTypeName, const void* inputPtr, Session& destination );
 
-    std::pair<std::string,boost::shared_ptr<void> > fetch( const cond::Hash& payloadId, Session& session );
-    std::pair<std::string, boost::shared_ptr<void> > fetchOne( const std::string &payloadTypeName, const cond::Binary &data, const cond::Binary &streamerInfo, boost::shared_ptr<void> payloadPtr );
+    std::pair<std::string, std::shared_ptr<void> > fetch( const cond::Hash& payloadId, Session& session );
+    std::pair<std::string, std::shared_ptr<void> > fetchOne( const std::string &payloadTypeName, const cond::Binary &data, const cond::Binary &streamerInfo, std::shared_ptr<void> payloadPtr );
 
   }
 

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -3,6 +3,7 @@
 #include "CondFormats/Common/interface/BasicPayload.h"
 #include "CondCore/CondDB/interface/Time.h"
 #include "CondCore/CondDB/interface/PayloadReader.h"
+#include <memory>
 #include <sstream>
 
 namespace {
@@ -32,7 +33,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("Run","data0");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<cond::BasicPayload> obj = reader.fetch<cond::BasicPayload>( iov.payloadId );
+	std::shared_ptr<cond::BasicPayload> obj = reader.fetch<cond::BasicPayload>( iov.payloadId );
 	jprint.append(boost::lexical_cast<std::string>(iov.since),boost::lexical_cast<std::string>(obj->m_data0 ));
       }
       return jprint.print();
@@ -64,7 +65,7 @@ namespace {
       cond::utilities::JsonPrinter jprint("Run","data1");
       for( int i=0; i< len( iovs ); i++ ) {
 	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
-	boost::shared_ptr<cond::BasicPayload> obj = reader.fetch<cond::BasicPayload>( iov.payloadId );
+	std::shared_ptr<cond::BasicPayload> obj = reader.fetch<cond::BasicPayload>( iov.payloadId );
         jprint.append(boost::lexical_cast<std::string>(iov.since),boost::lexical_cast<std::string>(obj->m_data1 ));
       }
       return jprint.print();

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -14,13 +14,14 @@
 #include "CondFormats.h"
 
 //
+#include <memory>
 #include <sstream>
 
 namespace cond {
 
   namespace persistency {
 
-    std::pair<std::string, boost::shared_ptr<void> > fetchOne( const std::string &payloadTypeName, const cond::Binary &data, const cond::Binary &streamerInfo, boost::shared_ptr<void> payloadPtr ){
+    std::pair<std::string, std::shared_ptr<void> > fetchOne( const std::string &payloadTypeName, const cond::Binary &data, const cond::Binary &streamerInfo, std::shared_ptr<void> payloadPtr ){
 
       bool match = false;
       FETCH_PAYLOAD_CASE( std::string ) 
@@ -308,8 +309,8 @@ namespace cond {
       return std::make_pair( payloadTypeName, payloadPtr );
     }
 
-    std::pair<std::string,boost::shared_ptr<void> > fetch( const cond::Hash& payloadId, Session& session ){
-      boost::shared_ptr<void> payloadPtr;
+    std::pair<std::string,std::shared_ptr<void> > fetch( const cond::Hash& payloadId, Session& session ){
+      std::shared_ptr<void> payloadPtr;
       cond::Binary data;
       cond::Binary streamerInfo;
       std::string payloadTypeName;

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -15,21 +15,22 @@
 #include "CondFormats.h"
 
 //
+#include <memory>
 #include <sstream>
 
 namespace cond {
 
   namespace persistency {
 
-    std::pair<std::string,boost::shared_ptr<void> > fetchIfExists( const cond::Hash& payloadId, Session& session, bool& exists ){
-      boost::shared_ptr<void> payloadPtr;
+    std::pair<std::string,std::shared_ptr<void> > fetchIfExists( const cond::Hash& payloadId, Session& session, bool& exists ){
+      std::shared_ptr<void> payloadPtr;
       cond::Binary data;
       cond::Binary streamerInfo;
       std::string payloadTypeName;
       exists = session.fetchPayloadData( payloadId, payloadTypeName, data, streamerInfo );
       if( exists ) {
 	return fetchOne(payloadTypeName, data, streamerInfo, payloadPtr );
-      } else return std::make_pair( std::string(""), boost::shared_ptr<void>() );
+      } else return std::make_pair( std::string(""), std::shared_ptr<void>() );
     }
 
     cond::Hash import( Session& source, const cond::Hash& sourcePayloadId, const std::string& inputTypeName, const void* inputPtr, Session& destination ){

--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -7,6 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 #include <boost/bind.hpp>
+#include <memory>
 
 namespace cond {
 
@@ -62,7 +63,7 @@ namespace cond {
 	sinces.insert( iov.since );
 	// make sure that we import the payload _IN_USE_
 	auto usedIov = p.getInterval( iov.since );
-	std::pair<std::string,boost::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
+	std::pair<std::string,std::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
 	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
 	editor.insert( iov.since, ph );
 	pids.insert( ph );
@@ -139,7 +140,7 @@ namespace cond {
 	sinces.insert( newSince );
 	// make sure that we import the payload _IN_USE_
 	auto usedIov = p.getInterval( newSince );
-	std::pair<std::string,boost::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
+	std::pair<std::string,std::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
 	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
 	editor.insert( newSince, ph );
 	pids.insert( ph );

--- a/CondFormats/RPCObjects/interface/L1RPCConeBuilder.h
+++ b/CondFormats/RPCObjects/interface/L1RPCConeBuilder.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <cstdlib>
 #include "CondFormats/L1TObjects/interface/L1RPCConeDefinition.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 class L1RPCConeBuilder
@@ -116,10 +116,10 @@ class L1RPCConeBuilder
       virtual ~L1RPCConeBuilder();
 
             
-      void setConeConnectionMap(const boost::shared_ptr< TConMap > connMap) 
+      void setConeConnectionMap(const std::shared_ptr< TConMap > connMap) 
                       { m_coneConnectionMap = connMap;};
                       
-      void setCompressedConeConnectionMap(const boost::shared_ptr< TCompressedConMap >
+      void setCompressedConeConnectionMap(const std::shared_ptr< TCompressedConMap >
                                               cmpConnMap) 
       {  
             m_compressedConeConnectionMap = cmpConnMap;
@@ -141,8 +141,8 @@ class L1RPCConeBuilder
      int m_firstTower;
      int m_lastTower;
 
-     boost::shared_ptr< TConMap > m_coneConnectionMap; 
-     boost::shared_ptr< TCompressedConMap >  m_compressedConeConnectionMap;
+     std::shared_ptr< TConMap > m_coneConnectionMap; 
+     std::shared_ptr< TCompressedConMap >  m_compressedConeConnectionMap;
 
    COND_SERIALIZABLE;
 };

--- a/CondTools/DT/interface/DTKeyedConfigHandler.h
+++ b/CondTools/DT/interface/DTKeyedConfigHandler.h
@@ -22,6 +22,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
+#include <memory>
 #include <string>
 
 namespace coral {
@@ -79,7 +80,7 @@ class DTKeyedConfigHandler: public popcon::PopConSourceHandler<DTCCBConfig> {
   DTCCBConfig* ccbConfig;
   
   cond::persistency::ConnectionPool connection;
-  boost::shared_ptr<coral::ISessionProxy> isession;
+  std::shared_ptr<coral::ISessionProxy> isession;
   void chkConfigList();
   static bool sameConfigList( const std::vector<DTConfigKey>& cfgl,
                               const std::vector<DTConfigKey>& cfgr );

--- a/CondTools/DT/interface/DTUserKeyedConfigHandler.h
+++ b/CondTools/DT/interface/DTUserKeyedConfigHandler.h
@@ -22,6 +22,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
+#include <memory>
 #include <string>
 
 namespace coral {
@@ -77,7 +78,7 @@ class DTUserKeyedConfigHandler: public popcon::PopConSourceHandler<DTCCBConfig> 
   DTCCBConfig* ccbConfig;
   
   cond::persistency::ConnectionPool connection;
-  boost::shared_ptr<coral::ISessionProxy> isession;
+  std::shared_ptr<coral::ISessionProxy> isession;
   void chkConfigList( const std::map<int,bool>& userBricks );
   bool userDiscardedKey( int key );
   static bool sameConfigList( const std::vector<DTConfigKey>& cfgl,

--- a/CondTools/DT/plugins/DTKeyedConfigDBDump.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigDBDump.cc
@@ -25,6 +25,7 @@
 // C++ Headers --
 //---------------
 #include <iostream>
+#include <memory>
 
 //-------------------
 // Initializations --
@@ -72,7 +73,7 @@ void DTKeyedConfigDBDump::analyze( const edm::Event& e,
   std::cout << "now load" << std::endl;
   kp->load( nkeys );
   std::cout << "now get" << std::endl;
-  boost::shared_ptr<DTKeyedConfig> pkc = kp->get<DTKeyedConfig>(0);
+  std::shared_ptr<DTKeyedConfig> pkc = kp->get<DTKeyedConfig>(0);
   std::cout << "now check" << std::endl;
   if ( pkc.get() ) std::cout << pkc->getId() << " "
                             << *( pkc->dataBegin() ) << std::endl;

--- a/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
 #include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
+#include <memory>
 
 //typedef popcon::PopConAnalyzer<DTKeyedConfigHandler> DTKeyedConfigPopConAnalyzer;
 class DTKeyedConfigPopConAnalyzer: public popcon::PopConAnalyzer<DTKeyedConfigHandler> {
@@ -27,7 +28,7 @@ class DTKeyedConfigPopConAnalyzer: public popcon::PopConAnalyzer<DTKeyedConfigHa
     cond::persistency::KeyList const &  kl= *klh.product();
     cond::persistency::KeyList* list = const_cast<cond::persistency::KeyList*>( &kl );
     for ( size_t i = 0; i < list->size(); i++ ) {
-      boost::shared_ptr<DTKeyedConfig> kelem = list->get<DTKeyedConfig>( i );
+      std::shared_ptr<DTKeyedConfig> kelem = list->get<DTKeyedConfig>( i );
       if ( kelem.get() )
            std::cout << kelem->getId() << std::endl;
     }

--- a/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
 #include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
+#include <memory>
 
 //typedef popcon::PopConAnalyzer<DTUserKeyedConfigHandler> DTUserKeyedConfigPopConAnalyzer;
 class DTUserKeyedConfigPopConAnalyzer: public popcon::PopConAnalyzer<DTUserKeyedConfigHandler> {
@@ -22,7 +23,7 @@ class DTUserKeyedConfigPopConAnalyzer: public popcon::PopConAnalyzer<DTUserKeyed
     cond::persistency::KeyList const &  kl= *klh.product();
     cond::persistency::KeyList* list = const_cast<cond::persistency::KeyList*>( &kl );
     for ( size_t i = 0; i < list->size(); i++ ) {
-      boost::shared_ptr<DTKeyedConfig> kentry = list->get<DTKeyedConfig>( i );
+      std::shared_ptr<DTKeyedConfig> kentry = list->get<DTKeyedConfig>( i );
       if ( kentry.get() )
            std::cout << kentry->getId() << std::endl;
     }

--- a/CondTools/DT/src/DTKeyedConfigCache.cc
+++ b/CondTools/DT/src/DTKeyedConfigCache.cc
@@ -23,8 +23,7 @@
 #include "CondCore/CondDB/interface/KeyList.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include <boost/shared_ptr.hpp>
-
+#include <memory>
 //-------------------
 // Initializations --
 //-------------------
@@ -100,7 +99,7 @@ int DTKeyedConfigCache::get( const DTKeyedConfigListRcd& keyRecord,
   if ( keyList == 0 ) return 999;
 
   std::vector<unsigned long long> checkedKeys;
-  boost::shared_ptr<DTKeyedConfig> kBrick;
+  std::shared_ptr<DTKeyedConfig> kBrick;
   checkedKeys.push_back( cfgId );
   bool brickFound = false;
   try {

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -36,6 +36,7 @@
 //---------------
 
 #include <iostream>
+#include <memory>
 
 //-------------------
 // Initializations --
@@ -547,7 +548,7 @@ void DTKeyedConfigHandler::chkConfigList() {
     bool brickFound = false;
     try {
       keyList->load( checkedKeys );
-      boost::shared_ptr<DTKeyedConfig> brickCheck = keyList->get<DTKeyedConfig>( 0 );
+      std::shared_ptr<DTKeyedConfig> brickCheck = keyList->get<DTKeyedConfig>( 0 );
       if ( brickCheck.get() ) brickFound =
                              ( brickCheck->getId() == brickConfigId );
     }

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -37,6 +37,7 @@
 //---------------
 
 #include <iostream>
+#include <memory>
 
 //-------------------
 // Initializations --
@@ -363,7 +364,7 @@ void DTUserKeyedConfigHandler::chkConfigList(
       std::cout << "key list " <<  keyList << std::endl;
       keyList->load( checkedKeys );
       std::cout << "get brick..." << std::endl;
-      boost::shared_ptr<DTKeyedConfig> brickCheck =
+      std::shared_ptr<DTKeyedConfig> brickCheck =
                            keyList->get<DTKeyedConfig>( 0 );
       if ( brickCheck.get() ) {
 	brickFound = ( brickCheck->getId() == brickConfigId );

--- a/CondTools/Hcal/interface/BufferedBoostIOESProducer.h
+++ b/CondTools/Hcal/interface/BufferedBoostIOESProducer.h
@@ -21,7 +21,7 @@
 //
 
 #include <sstream>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -34,7 +34,7 @@ template<class DataType, class MyRecord>
 class BufferedBoostIOESProducer : public edm::ESProducer
 {
 public:
-    typedef boost::shared_ptr<DataType> ReturnType;
+    typedef std::shared_ptr<DataType> ReturnType;
 
     inline BufferedBoostIOESProducer(const edm::ParameterSet&)
         {setWhatProduced(this);}

--- a/CondTools/L1Trigger/interface/DataWriter.h
+++ b/CondTools/L1Trigger/interface/DataWriter.h
@@ -90,7 +90,7 @@ void DataWriter::readObject( const std::string& payloadToken,
   session.transaction().start(true);
  
   // Get object from CondDB
-  boost::shared_ptr<T> ref = session.fetchPayload<T>(payloadToken) ;
+  std::shared_ptr<T> ref = session.fetchPayload<T>(payloadToken) ;
   outputObject = *ref ;
   session.transaction().commit ();
 }

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -23,7 +23,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -55,9 +54,9 @@ class L1ConfigOnlineProdBase : public edm::ESProducer {
       L1ConfigOnlineProdBase(const edm::ParameterSet&);
       ~L1ConfigOnlineProdBase();
 
-      virtual boost::shared_ptr< TData > produce(const TRcd& iRecord);
+      virtual std::shared_ptr< TData > produce(const TRcd& iRecord);
 
-      virtual boost::shared_ptr< TData > newObject(
+      virtual std::shared_ptr< TData > newObject(
 	const std::string& objectKey ) = 0 ;
 
    private:
@@ -72,7 +71,7 @@ class L1ConfigOnlineProdBase : public edm::ESProducer {
       // If bool is false, produce method should throw
       // DataAlreadyPresentException.
       bool getObjectKey( const TRcd& record,
-                         boost::shared_ptr< TData > data,
+                         std::shared_ptr< TData > data,
                          std::string& objectKey ) ;
 
       // For reading object directly from a CondDB w/o PoolDBOutputService
@@ -126,11 +125,11 @@ L1ConfigOnlineProdBase<TRcd, TData>::~L1ConfigOnlineProdBase()
 }
 
 template< class TRcd, class TData >
-boost::shared_ptr< TData >
+std::shared_ptr< TData >
 L1ConfigOnlineProdBase<TRcd, TData>::produce( const TRcd& iRecord )
 {
    using namespace edm::es;
-   boost::shared_ptr< TData > pData ;
+   std::shared_ptr< TData > pData ;
 
    // Get object key and check if already in ORCON
    std::string key ;
@@ -172,7 +171,7 @@ L1ConfigOnlineProdBase<TRcd, TData>::produce( const TRcd& iRecord )
        }
 
      //     if( pData.get() == 0 )
-     if( pData == boost::shared_ptr< TData >() )
+     if( pData == std::shared_ptr< TData >() )
        {
 	 std::string dataType = edm::typelookup::className<TData>();
 
@@ -197,7 +196,7 @@ template< class TRcd, class TData >
 bool 
 L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(
   const TRcd& record,
-  boost::shared_ptr< TData > data,
+  std::shared_ptr< TData > data,
   std::string& objectKey )
 {
    // Get L1TriggerKey

--- a/CondTools/L1Trigger/interface/L1ObjectKeysOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ObjectKeysOnlineProdBase.h
@@ -23,7 +23,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -42,7 +41,7 @@ class L1ObjectKeysOnlineProdBase : public edm::ESProducer {
       L1ObjectKeysOnlineProdBase(const edm::ParameterSet&);
       ~L1ObjectKeysOnlineProdBase();
 
-      typedef boost::shared_ptr<L1TriggerKey> ReturnType;
+      typedef std::shared_ptr<L1TriggerKey> ReturnType;
 
       ReturnType produce(const L1TriggerKeyRcd&);
 

--- a/CondTools/L1Trigger/interface/OMDSReader.h
+++ b/CondTools/L1Trigger/interface/OMDSReader.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "CondTools/L1Trigger/interface/DataManager.h"

--- a/CondTools/L1Trigger/interface/WriterProxy.h
+++ b/CondTools/L1Trigger/interface/WriterProxy.h
@@ -76,7 +76,7 @@ class WriterProxyT : public WriterProxy
 	    // if throw transaction will unroll
 	    tr.start(false);
 
-	    boost::shared_ptr<Type> pointer(new Type (*(handle.product ())));
+	    auto pointer = std::make_shared<Type>(*(handle.product ()));
 	    std::string payloadToken =  session.storePayload( *pointer );
 	    tr.commit();
 	    return payloadToken ;

--- a/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
@@ -81,7 +81,7 @@ L1SubsystemKeysOnlineProd::ReturnType
 L1SubsystemKeysOnlineProd::produce(const L1TriggerKeyRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1TriggerKey> pL1TriggerKey ;
+   std::shared_ptr<L1TriggerKey> pL1TriggerKey ;
 
    // Get L1TriggerKeyList
    L1TriggerKeyList keyList ;
@@ -97,8 +97,7 @@ L1SubsystemKeysOnlineProd::produce(const L1TriggerKeyRcd& iRecord)
        m_forceGeneration )
      {
        // Instantiate new L1TriggerKey
-       pL1TriggerKey = boost::shared_ptr< L1TriggerKey >(
-	 new L1TriggerKey() ) ;
+       pL1TriggerKey = std::make_shared< L1TriggerKey >() ;
        pL1TriggerKey->setTSCKey( m_tscKey ) ;
 
        edm::LogVerbatim( "L1-O2O" ) << "TSC KEY " << m_tscKey ;

--- a/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.h
+++ b/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -40,7 +39,7 @@ class L1SubsystemKeysOnlineProd : public edm::ESProducer {
       L1SubsystemKeysOnlineProd(const edm::ParameterSet&);
       ~L1SubsystemKeysOnlineProd();
 
-      typedef boost::shared_ptr<L1TriggerKey> ReturnType;
+      typedef std::shared_ptr<L1TriggerKey> ReturnType;
 
       ReturnType produce(const L1TriggerKeyRcd&);
    private:

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyDummyProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyDummyProd.cc
@@ -106,12 +106,8 @@ L1TriggerKeyDummyProd::ReturnType
 L1TriggerKeyDummyProd::produce(const L1TriggerKeyRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1TriggerKey> pL1TriggerKey ;
 
-   pL1TriggerKey = boost::shared_ptr< L1TriggerKey >(
-      new L1TriggerKey( m_key ) ) ;
-
-   return pL1TriggerKey ;
+   return std::make_shared< L1TriggerKey >(m_key) ;
 }
 
 //define this as a plug-in

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyDummyProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyDummyProd.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -39,7 +38,7 @@ class L1TriggerKeyDummyProd : public edm::ESProducer {
       L1TriggerKeyDummyProd(const edm::ParameterSet&);
       ~L1TriggerKeyDummyProd();
 
-      typedef boost::shared_ptr<L1TriggerKey> ReturnType;
+      typedef std::shared_ptr<L1TriggerKey> ReturnType;
 
       ReturnType produce(const L1TriggerKeyRcd&);
    private:

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.cc
@@ -66,10 +66,9 @@ L1TriggerKeyListDummyProd::ReturnType
 L1TriggerKeyListDummyProd::produce(const L1TriggerKeyListRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1TriggerKeyList> pL1TriggerKeyList ;
+   std::shared_ptr<L1TriggerKeyList> pL1TriggerKeyList ;
 
-   pL1TriggerKeyList = boost::shared_ptr< L1TriggerKeyList >(
-      new L1TriggerKeyList() ) ;
+   pL1TriggerKeyList = std::make_shared< L1TriggerKeyList >() ;
 
    return pL1TriggerKeyList ;
 }

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -38,7 +37,7 @@ class L1TriggerKeyListDummyProd : public edm::ESProducer {
       L1TriggerKeyListDummyProd(const edm::ParameterSet&);
       ~L1TriggerKeyListDummyProd();
 
-      typedef boost::shared_ptr<L1TriggerKeyList> ReturnType;
+      typedef std::shared_ptr<L1TriggerKeyList> ReturnType;
 
       ReturnType produce(const L1TriggerKeyListRcd&);
    private:

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
@@ -86,9 +86,8 @@ L1TriggerKeyOnlineProd::produce(const L1TriggerKeyRcd& iRecord)
        throw ex ;
      }
 
-   boost::shared_ptr<L1TriggerKey> pL1TriggerKey ;
-   pL1TriggerKey = boost::shared_ptr< L1TriggerKey >(
-     new L1TriggerKey( *subsystemKeys ) ) ;
+   std::shared_ptr<L1TriggerKey> pL1TriggerKey ;
+   pL1TriggerKey = std::make_shared< L1TriggerKey >( *subsystemKeys ) ;
 
   // Collate object keys
   std::vector< std::string >::const_iterator itr = m_subsystemLabels.begin() ;

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
@@ -23,7 +23,6 @@
 #include <memory>
 #include <vector>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -40,7 +39,7 @@ class L1TriggerKeyOnlineProd : public edm::ESProducer {
       L1TriggerKeyOnlineProd(const edm::ParameterSet&);
       ~L1TriggerKeyOnlineProd();
 
-      typedef boost::shared_ptr<L1TriggerKey> ReturnType;
+      typedef std::shared_ptr<L1TriggerKey> ReturnType;
 
       ReturnType produce(const L1TriggerKeyRcd&);
    private:

--- a/CondTools/L1Trigger/src/DataWriter.cc
+++ b/CondTools/L1Trigger/src/DataWriter.cc
@@ -71,7 +71,7 @@ DataWriter::writeKeyList( L1TriggerKeyList* keyList,
   tr.start( false );
 
   // Write L1TriggerKeyList payload and save payload token before committing
-  boost::shared_ptr<L1TriggerKeyList> pointer(keyList);
+  std::shared_ptr<L1TriggerKeyList> pointer(keyList);
   std::string payloadToken = session.storePayload(*pointer );
 			
   // Commit before calling updateIOV(), otherwise PoolDBOutputService gets

--- a/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
+++ b/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
@@ -95,9 +95,8 @@ L1ObjectKeysOnlineProdBase::produce(const L1TriggerKeyRcd& iRecord)
     }
 
   // Copy L1TriggerKey to new object.
-  boost::shared_ptr<L1TriggerKey> pL1TriggerKey ;
-  pL1TriggerKey = boost::shared_ptr< L1TriggerKey >(
-    new L1TriggerKey( *subsystemKeys ) ) ;
+  std::shared_ptr<L1TriggerKey> pL1TriggerKey ;
+  pL1TriggerKey = std::make_shared< L1TriggerKey >( *subsystemKeys ) ;
 
   // Get object keys.
   fillObjectKeys( pL1TriggerKey ) ;

--- a/L1Trigger/L1TCalorimeter/interface/Stage1Layer2FirmwareFactory.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage1Layer2FirmwareFactory.h
@@ -11,7 +11,7 @@
 #ifndef CALOSTAGE1JETALGORITHMFACTORY_H
 #define CALOSTAGE1JETALGORITHMFACTORY_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
 
@@ -23,7 +23,7 @@ namespace l1t {
 
   class Stage1Layer2FirmwareFactory {
   public:
-    typedef boost::shared_ptr<Stage1Layer2MainProcessor> ReturnType;
+    typedef std::shared_ptr<Stage1Layer2MainProcessor> ReturnType;
 
     // ReturnType create(const FirmwareVersion & fwv /*,const CaloParamsHelper & dbPars*/);
     ReturnType create(const int fwv ,CaloParamsHelper* dbPars);

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer1FirmwareFactory.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer1FirmwareFactory.h
@@ -11,7 +11,7 @@
 #ifndef Stage2Layer1FirmwareFactory_h
 #define Stage2Layer1FirmwareFactory_h
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "L1Trigger/L1TCalorimeter/interface/Stage2PreProcessor.h"
 
@@ -22,7 +22,7 @@ namespace l1t {
 
   class Stage2Layer1FirmwareFactory {
   public:
-    typedef boost::shared_ptr<Stage2PreProcessor> ReturnType;
+    typedef std::shared_ptr<Stage2PreProcessor> ReturnType;
 
     ReturnType create(unsigned fwv, CaloParamsHelper* params);
 

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer2FirmwareFactory.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer2FirmwareFactory.h
@@ -11,7 +11,7 @@
 #ifndef Stage2Layer2FirmwareFactory_h
 #define Stage2Layer2FirmwareFactory_h
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "L1Trigger/L1TCalorimeter/interface/Stage2MainProcessor.h"
 
@@ -24,7 +24,7 @@ namespace l1t {
 
   class Stage2Layer2FirmwareFactory {
   public:
-    typedef boost::shared_ptr<Stage2MainProcessor> ReturnType;
+    typedef std::shared_ptr<Stage2MainProcessor> ReturnType;
 
     ReturnType create(unsigned fwv, CaloParamsHelper* params);
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
@@ -10,7 +10,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <iostream>
 #include <fstream>
 
@@ -40,7 +39,7 @@ public:
   L1TCaloConfigESProducer(const edm::ParameterSet&);
   ~L1TCaloConfigESProducer();
 
-  typedef boost::shared_ptr<CaloConfig> ReturnType;
+  typedef std::shared_ptr<CaloConfig> ReturnType;
 
   ReturnType produce(const L1TCaloConfigRcd&);
 
@@ -91,9 +90,7 @@ L1TCaloConfigESProducer::ReturnType
 L1TCaloConfigESProducer::produce(const L1TCaloConfigRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<CaloConfig> pCaloConfig ;
-   pCaloConfig = boost::shared_ptr< CaloConfig >(new CaloConfig(m_params));
-   return pCaloConfig;
+   return std::make_shared<CaloConfig>(m_params);
 }
 
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <iostream>
 #include <fstream>
 
@@ -47,7 +46,7 @@ public:
   L1TCaloParamsESProducer(const edm::ParameterSet&);
   ~L1TCaloParamsESProducer();
 
-  typedef boost::shared_ptr<CaloParams> ReturnType;
+  typedef std::shared_ptr<CaloParams> ReturnType;
 
   ReturnType produce(const L1TCaloParamsRcd&);
 
@@ -102,7 +101,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
 
   edm::FileInPath egTrimmingLUTFile = conf.getParameter<edm::FileInPath>("egTrimmingLUTFile");
   std::ifstream egTrimmingLUTStream(egTrimmingLUTFile.fullPath());
-  std::shared_ptr<LUT> egTrimmingLUT( new LUT(egTrimmingLUTStream) );
+  auto egTrimmingLUT = std::make_shared<LUT>(egTrimmingLUTStream);
   m_params_helper.setEgTrimmingLUT(*egTrimmingLUT);
 
   m_params_helper.setEgMaxHcalEt(conf.getParameter<double>("egMaxHcalEt"));
@@ -115,19 +114,19 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
 
   edm::FileInPath egMaxHOverELUTFile = conf.getParameter<edm::FileInPath>("egMaxHOverELUTFile");
   std::ifstream egMaxHOverELUTStream(egMaxHOverELUTFile.fullPath());
-  std::shared_ptr<LUT> egMaxHOverELUT( new LUT(egMaxHOverELUTStream) );
+  auto egMaxHOverELUT = std::make_shared<LUT>(egMaxHOverELUTStream);
   m_params_helper.setEgMaxHOverELUT(*egMaxHOverELUT);
 
   edm::FileInPath egCompressShapesLUTFile = conf.getParameter<edm::FileInPath>("egCompressShapesLUTFile");
   std::ifstream egCompressShapesLUTStream(egCompressShapesLUTFile.fullPath());
-  std::shared_ptr<LUT> egCompressShapesLUT( new LUT(egCompressShapesLUTStream) );
+  auto egCompressShapesLUT = std::make_shared<LUT>(egCompressShapesLUTStream);
   m_params_helper.setEgCompressShapesLUT(*egCompressShapesLUT);
 
   m_params_helper.setEgShapeIdType(conf.getParameter<std::string>("egShapeIdType"));
   m_params_helper.setEgShapeIdVersion(conf.getParameter<unsigned>("egShapeIdVersion"));
   edm::FileInPath egShapeIdLUTFile = conf.getParameter<edm::FileInPath>("egShapeIdLUTFile");
   std::ifstream egShapeIdLUTStream(egShapeIdLUTFile.fullPath());
-  std::shared_ptr<LUT> egShapeIdLUT( new LUT(egShapeIdLUTStream) );
+  auto egShapeIdLUT = std::make_shared<LUT>(egShapeIdLUTStream);
   m_params_helper.setEgShapeIdLUT(*egShapeIdLUT);
 
   m_params_helper.setEgPUSType(conf.getParameter<std::string>("egPUSType"));
@@ -135,17 +134,17 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setEgIsolationType(conf.getParameter<std::string>("egIsolationType"));
   edm::FileInPath egIsoLUTFile = conf.getParameter<edm::FileInPath>("egIsoLUTFile");
   std::ifstream egIsoLUTStream(egIsoLUTFile.fullPath());
-  std::shared_ptr<LUT> egIsoLUT( new LUT(egIsoLUTStream) );
+  auto egIsoLUT = std::make_shared<LUT>(egIsoLUTStream);
   m_params_helper.setEgIsolationLUT(*egIsoLUT);
 
   //edm::FileInPath egIsoLUTFileBarrel = conf.getParameter<edm::FileInPath>("egIsoLUTFileBarrel");
   //std::ifstream egIsoLUTBarrelStream(egIsoLUTFileBarrel.fullPath());
-  //std::shared_ptr<LUT> egIsoLUTBarrel( new LUT(egIsoLUTBarrelStream) );
+  //auto egIsoLUTBarrel = std::make_shared<LUT>(egIsoLUTBarrelStream);
   //m_params_helper.setEgIsolationLUTBarrel(egIsoLUTBarrel);
 
   //edm::FileInPath egIsoLUTFileEndcaps = conf.getParameter<edm::FileInPath>("egIsoLUTFileEndcaps");
   //std::ifstream egIsoLUTEndcapsStream(egIsoLUTFileEndcaps.fullPath());
-  //std::shared_ptr<LUT> egIsoLUTEndcaps( new LUT(egIsoLUTEndcapsStream) );
+  //auto egIsoLUTEndcaps = std::make_shared<LUT>(egIsoLUTEndcapsStream);
   //m_params_helper.setEgIsolationLUTEndcaps(egIsoLUTEndcaps);
 
 
@@ -161,7 +160,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setEgCalibrationVersion(conf.getParameter<unsigned>("egCalibrationVersion"));
   edm::FileInPath egCalibrationLUTFile = conf.getParameter<edm::FileInPath>("egCalibrationLUTFile");
   std::ifstream egCalibrationLUTStream(egCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> egCalibrationLUT( new LUT(egCalibrationLUTStream) );
+  auto egCalibrationLUT = std::make_shared<LUT>(egCalibrationLUTStream);
   m_params_helper.setEgCalibrationLUT(*egCalibrationLUT);
 
   // tau
@@ -180,22 +179,22 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
 
   edm::FileInPath tauIsoLUTFile = conf.getParameter<edm::FileInPath>("tauIsoLUTFile");
   std::ifstream tauIsoLUTStream(tauIsoLUTFile.fullPath());
-  std::shared_ptr<LUT> tauIsoLUT( new LUT(tauIsoLUTStream) );
+  auto tauIsoLUT = std::make_shared<LUT>(tauIsoLUTStream);
   m_params_helper.setTauIsolationLUT(*tauIsoLUT);
 
   edm::FileInPath tauCalibrationLUTFile = conf.getParameter<edm::FileInPath>("tauCalibrationLUTFile");
   std::ifstream tauCalibrationLUTStream(tauCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> tauCalibrationLUT( new LUT(tauCalibrationLUTStream) );
+  auto tauCalibrationLUT = std::make_shared<LUT>(tauCalibrationLUTStream);
   m_params_helper.setTauCalibrationLUT(*tauCalibrationLUT);
 
   edm::FileInPath tauCompressLUTFile = conf.getParameter<edm::FileInPath>("tauCompressLUTFile");
   std::ifstream tauCompressLUTStream(tauCompressLUTFile.fullPath());
-  std::shared_ptr<LUT> tauCompressLUT( new LUT(tauCompressLUTStream) );
+  auto tauCompressLUT = std::make_shared<LUT>(tauCompressLUTStream);
   m_params_helper.setTauCompressLUT(*tauCompressLUT);
 
   edm::FileInPath tauEtToHFRingEtLUTFile = conf.getParameter<edm::FileInPath>("tauEtToHFRingEtLUTFile");
   std::ifstream tauEtToHFRingEtLUTStream(tauEtToHFRingEtLUTFile.fullPath());
-  std::shared_ptr<LUT> tauEtToHFRingEtLUT( new LUT(tauEtToHFRingEtLUTStream) );
+  auto tauEtToHFRingEtLUT = std::make_shared<LUT>(tauEtToHFRingEtLUTStream);
   m_params_helper.setTauEtToHFRingEtLUT(*tauEtToHFRingEtLUT);
 
   m_params_helper.setIsoTauEtaMin(conf.getParameter<int> ("isoTauEtaMin"));
@@ -213,7 +212,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setJetCalibrationParams(conf.getParameter<std::vector<double> >("jetCalibrationParams"));
   edm::FileInPath jetCalibrationLUTFile = conf.getParameter<edm::FileInPath>("jetCalibrationLUTFile");
   std::ifstream jetCalibrationLUTStream(jetCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> jetCalibrationLUT( new LUT(jetCalibrationLUTStream) );
+  auto jetCalibrationLUT = std::make_shared<LUT>(jetCalibrationLUTStream);
   m_params_helper.setJetCalibrationLUT(*jetCalibrationLUT);
 
   // sums
@@ -237,7 +236,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   // HI centrality trigger
   edm::FileInPath centralityLUTFile = conf.getParameter<edm::FileInPath>("centralityLUTFile");
   std::ifstream centralityLUTStream(centralityLUTFile.fullPath());
-  std::shared_ptr<LUT> centralityLUT( new LUT(centralityLUTStream) );
+  auto centralityLUT = std::make_shared<LUT>(centralityLUTStream);
   m_params_helper.setCentralityLUT(*centralityLUT);
   m_params_helper.setCentralityRegionMask(conf.getParameter<int>("centralityRegionMask"));
   std::vector<int> minbiasThresholds = conf.getParameter<std::vector<int> >("minimumBiasThresholds");
@@ -250,7 +249,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   // HI Q2 trigger
   edm::FileInPath q2LUTFile = conf.getParameter<edm::FileInPath>("q2LUTFile");
   std::ifstream q2LUTStream(q2LUTFile.fullPath());
-  std::shared_ptr<LUT> q2LUT( new LUT(q2LUTStream) );
+  auto q2LUT = std::make_shared<LUT>(q2LUTStream);
   m_params_helper.setQ2LUT(*q2LUT);
 
   m_params = (CaloParams)m_params_helper;
@@ -275,10 +274,7 @@ L1TCaloParamsESProducer::ReturnType
 L1TCaloParamsESProducer::produce(const L1TCaloParamsRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<CaloParams> pCaloParams ;
-
-   pCaloParams = boost::shared_ptr< CaloParams >(new CaloParams(m_params));
-   return pCaloParams;
+   return std::make_shared<CaloParams>(m_params);
 }
 
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloRCTToUpgradeConverter.h
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloRCTToUpgradeConverter.h
@@ -24,7 +24,6 @@
 #include <memory>
 
 // system include files
-#include <boost/shared_ptr.hpp>
 
 // user include files
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -12,7 +12,7 @@
 
 
 #include "L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
 #include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h
@@ -12,7 +12,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TPhysicalEtAdder.h
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TPhysicalEtAdder.h
@@ -10,7 +10,6 @@
 #include <memory>
 
 // system include files
-#include <boost/shared_ptr.hpp>
 
 // user include files
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage1Layer2Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage1Layer2Producer.cc
@@ -9,7 +9,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -88,7 +88,7 @@ using namespace l1t;
     CaloConfigHelper m_config;
 
 
-    boost::shared_ptr<Stage1Layer2MainProcessor> m_fw; // Firmware to run per event, depends on database parameters.
+    std::shared_ptr<Stage1Layer2MainProcessor> m_fw; // Firmware to run per event, depends on database parameters.
 
     Stage1Layer2FirmwareFactory m_factory; // Factory to produce algorithms based on DB parameters
 
@@ -342,10 +342,10 @@ void L1TStage1Layer2Producer::beginRun(Run const&iR, EventSetup const&iE){
 
     // LenA move the setting of the firmware version to the L1TStage1Layer2Producer constructor
 
-    //m_params = boost::shared_ptr<const CaloParams>(parameters.product());
-    //m_fwv = boost::shared_ptr<const FirmwareVersion>(new FirmwareVersion());
+    //m_params = std::shared_ptr<const CaloParams>(parameters.product());
+    //m_fwv = std::shared_ptr<const FirmwareVersion>(new FirmwareVersion());
     //printf("Begin.\n");
-    //m_fwv = boost::shared_ptr<FirmwareVersion>(new FirmwareVersion()); //not const during testing
+    //m_fwv = std::make_shared<FirmwareVersion>(); //not const during testing
     //printf("Success m_fwv.\n");
     //m_fwv->setFirmwareVersion(1); //hardcode for now, 1=HI, 2=PP
     //printf("Success m_fwv version set.\n");
@@ -368,7 +368,7 @@ void L1TStage1Layer2Producer::beginRun(Run const&iR, EventSetup const&iE){
 
     int ifwv=m_config.fwv();
     //cout << "DEBUG:  ifwv is " << ifwv << "\n";
-    //m_fwv = boost::shared_ptr<FirmwareVersion>(new FirmwareVersion()); //not const during testing
+    //m_fwv = std::make_shared<FirmwareVersion>(); //not const during testing
     if (ifwv == 1){
       LogDebug("l1t|stage1firmware") << "L1TStage1Layer2Producer -- Running HI implementation\n";
       //std::cout << "L1TStage1Layer2Producer -- Running HI implementation\n";

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer1Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer1Producer.cc
@@ -18,7 +18,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -96,7 +96,7 @@ using namespace l1t;
 
     // the processor
     Stage2Layer1FirmwareFactory factory_;
-    boost::shared_ptr<Stage2PreProcessor> processor_;
+    std::shared_ptr<Stage2PreProcessor> processor_;
 
   };
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer2Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer2Producer.cc
@@ -18,7 +18,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -82,7 +82,7 @@ using namespace l1t;
 
     // the processor
     Stage2Layer2FirmwareFactory m_factory;
-    boost::shared_ptr<Stage2MainProcessor> m_processor;
+    std::shared_ptr<Stage2MainProcessor> m_processor;
 
   };
 

--- a/L1Trigger/L1TGlobal/plugins/BXVectorInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/BXVectorInputProducer.cc
@@ -13,7 +13,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -77,9 +77,9 @@ namespace l1t {
 
     // ----------member data ---------------------------
     unsigned long long m_paramsCacheId; // Cache-ID from current parameters, to check if needs to be updated.
-    //boost::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
-    //boost::shared_ptr<const FirmwareVersion> m_fwv;
-    //boost::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
+    //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
+    //std::shared_ptr<const FirmwareVersion> m_fwv;
+    //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
 
     // BX parameters
     int bxFirst_;

--- a/L1Trigger/L1TGlobal/plugins/FakeInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/FakeInputProducer.cc
@@ -10,7 +10,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -59,9 +59,9 @@ namespace l1t {
 
     // ----------member data ---------------------------
     unsigned long long m_paramsCacheId; // Cache-ID from current parameters, to check if needs to be updated.
-    //boost::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
-    //boost::shared_ptr<const FirmwareVersion> m_fwv;
-    //boost::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
+    //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
+    //std::shared_ptr<const FirmwareVersion> m_fwv;
+    //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
 
     // Parameters for EG
     std::vector<int> fEgBx;

--- a/L1Trigger/L1TGlobal/plugins/GenToInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/GenToInputProducer.cc
@@ -10,7 +10,7 @@
 
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -77,9 +77,9 @@ namespace l1t {
 
     // ----------member data ---------------------------
     unsigned long long m_paramsCacheId; // Cache-ID from current parameters, to check if needs to be updated.
-    //boost::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
-    //boost::shared_ptr<const FirmwareVersion> m_fwv;
-    //boost::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
+    //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
+    //std::shared_ptr<const FirmwareVersion> m_fwv;
+    //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
 
     TRandom3* gRandom;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuESProducer.cc
@@ -10,7 +10,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include <iostream>
 #include <fstream>
 #include <unistd.h>
@@ -48,7 +47,7 @@ public:
   L1TUtmTriggerMenuESProducer(const edm::ParameterSet&);
   ~L1TUtmTriggerMenuESProducer();
 
-  typedef boost::shared_ptr<L1TUtmTriggerMenu> ReturnType;
+  typedef std::shared_ptr<L1TUtmTriggerMenu> ReturnType;
 
   ReturnType produce(const L1TUtmTriggerMenuRcd&);
 
@@ -112,8 +111,8 @@ L1TUtmTriggerMenuESProducer::produce(const L1TUtmTriggerMenuRcd& iRecord)
   L1TUtmTriggerMenu * menu = const_cast<L1TUtmTriggerMenu *>(cmenu);
 
   using namespace edm::es;
-  boost::shared_ptr<L1TUtmTriggerMenu> pMenu ;
-  pMenu = boost::shared_ptr< L1TUtmTriggerMenu >(menu);
+  std::shared_ptr<L1TUtmTriggerMenu> pMenu ;
+  pMenu = std::shared_ptr< L1TUtmTriggerMenu >(menu);
   return pMenu;
 }
 

--- a/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.cc
@@ -17,8 +17,6 @@
 #include <memory>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
-
 // user include files
 //   base class
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -117,12 +115,11 @@ StableParametersTrivialProducer::~StableParametersTrivialProducer() {
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<GlobalStableParameters> 
+std::shared_ptr<GlobalStableParameters> 
     StableParametersTrivialProducer::produceGtStableParameters(
         const L1TGlobalStableParametersRcd& iRecord) {
 
-    boost::shared_ptr<GlobalStableParameters> pL1uGtStableParameters =
-        boost::shared_ptr<GlobalStableParameters>(new GlobalStableParameters());
+    auto pL1uGtStableParameters = std::make_shared<GlobalStableParameters>();
 
     // set the number of physics trigger algorithms
     pL1uGtStableParameters->setGtNumberPhysTriggers(m_numberPhysTriggers);

--- a/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.h
@@ -20,7 +20,6 @@
 
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
 #include <boost/cstdint.hpp>
 
 // user include files
@@ -50,7 +49,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    boost::shared_ptr<GlobalStableParameters> produceGtStableParameters(
+    std::shared_ptr<GlobalStableParameters> produceGtStableParameters(
         const L1TGlobalStableParametersRcd&);
 
 private:

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuXmlProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuXmlProducer.cc
@@ -15,8 +15,6 @@
 // system include files
 #include <memory>
 
-#include "boost/shared_ptr.hpp"
-
 
 // user include files
 //   base class
@@ -97,7 +95,7 @@ l1t::TriggerMenuXmlProducer::~TriggerMenuXmlProducer()
 
 
 // method called to produce the data
-boost::shared_ptr<TriggerMenu> l1t::TriggerMenuXmlProducer::produceGtTriggerMenu(
+std::shared_ptr<TriggerMenu> l1t::TriggerMenuXmlProducer::produceGtTriggerMenu(
     const L1TGlobalTriggerMenuRcd& l1MenuRecord)
 {
 
@@ -212,8 +210,8 @@ boost::shared_ptr<TriggerMenu> l1t::TriggerMenuXmlProducer::produceGtTriggerMenu
     
     // transfer the condition map and algorithm map from parser to L1uGtTriggerMenu
 
-    boost::shared_ptr<TriggerMenu> pL1uGtTriggerMenu = boost::shared_ptr<TriggerMenu>(
-                new TriggerMenu(gtXmlParser.gtTriggerMenuName(), numberConditionChips,
+    auto pL1uGtTriggerMenu = std::make_shared<TriggerMenu>(
+                        gtXmlParser.gtTriggerMenuName(), numberConditionChips,
                         gtXmlParser.vecMuonTemplate(),
                         gtXmlParser.vecCaloTemplate(),
                         gtXmlParser.vecEnergySumTemplate(),
@@ -221,7 +219,7 @@ boost::shared_ptr<TriggerMenu> l1t::TriggerMenuXmlProducer::produceGtTriggerMenu
                         gtXmlParser.vecCorrelationTemplate(),
                         gtXmlParser.corMuonTemplate(),
                         gtXmlParser.corCaloTemplate(),
-                        gtXmlParser.corEnergySumTemplate()) );
+                        gtXmlParser.corEnergySumTemplate());
 
  
     pL1uGtTriggerMenu->setGtTriggerMenuInterface(gtXmlParser.gtTriggerMenuInterface());

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuXmlProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuXmlProducer.h
@@ -21,7 +21,6 @@
 #include <memory>
 #include <string>
 
-#include "boost/shared_ptr.hpp"
 #include <boost/cstdint.hpp>
 
 // user include files
@@ -54,7 +53,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    boost::shared_ptr<TriggerMenu> produceGtTriggerMenu(
+    std::shared_ptr<TriggerMenu> produceGtTriggerMenu(
         const L1TGlobalTriggerMenuRcd&);
 
 private:

--- a/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -40,7 +39,7 @@ class L1TMuonGlobalParamsESProducer : public edm::ESProducer {
       L1TMuonGlobalParamsESProducer(const edm::ParameterSet&);
       ~L1TMuonGlobalParamsESProducer();
 
-      typedef boost::shared_ptr<L1TMuonGlobalParams> ReturnType;
+      typedef std::shared_ptr<L1TMuonGlobalParams> ReturnType;
 
       ReturnType produce(const L1TMuonGlobalParamsRcd&);
    private:
@@ -172,10 +171,8 @@ L1TMuonGlobalParamsESProducer::ReturnType
 L1TMuonGlobalParamsESProducer::produce(const L1TMuonGlobalParamsRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1TMuonGlobalParams> pMicroGMTParams;
 
-   pMicroGMTParams = boost::shared_ptr<L1TMuonGlobalParams>(new L1TMuonGlobalParams(m_params));
-   return pMicroGMTParams;
+   return std::make_shared<L1TMuonGlobalParams>(m_params);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelParamsESProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelParamsESProducer.cc
@@ -10,7 +10,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -39,7 +38,7 @@ class L1TMuonBarrelParamsESProducer : public edm::ESProducer {
       int load_ext(std::vector<L1TMuonBarrelParams::LUTParams::extLUT>&, unsigned short int, unsigned short int );
       //void print(std::vector<LUT>& , std::vector<int>& ) const;
       int getPtLutThreshold(int ,std::vector<int>& ) const;
-      typedef boost::shared_ptr<L1TMuonBarrelParams> ReturnType;
+      typedef std::shared_ptr<L1TMuonBarrelParams> ReturnType;
 
       ReturnType produce(const L1TMuonBarrelParamsRcd&);
    private:
@@ -504,10 +503,8 @@ L1TMuonBarrelParamsESProducer::ReturnType
 L1TMuonBarrelParamsESProducer::produce(const L1TMuonBarrelParamsRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1TMuonBarrelParams> pBMTFParams;
 
-   pBMTFParams = boost::shared_ptr<L1TMuonBarrelParams>(new L1TMuonBarrelParams(m_params));
-   return pBMTFParams;
+   return std::make_shared<L1TMuonBarrelParams>(m_params);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.cc
@@ -88,10 +88,8 @@ L1TMuonOverlapParamsESProducer::ReturnType
 L1TMuonOverlapParamsESProducer::produce(const L1TMuonOverlapParamsRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1TMuonOverlapParams> aL1TMTFOverlapParams;
   
-   aL1TMTFOverlapParams = boost::shared_ptr<L1TMuonOverlapParams>(new L1TMuonOverlapParams(m_params));
-   return aL1TMTFOverlapParams;
+   return std::make_shared<L1TMuonOverlapParams>(m_params);
 }
 ///////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.h
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.h
@@ -1,6 +1,5 @@
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -19,7 +18,7 @@ class L1TMuonOverlapParamsESProducer : public edm::ESProducer {
       L1TMuonOverlapParamsESProducer(const edm::ParameterSet&);
       ~L1TMuonOverlapParamsESProducer();
 
-      typedef boost::shared_ptr<L1TMuonOverlapParams> ReturnType;
+      typedef std::shared_ptr<L1TMuonOverlapParams> ReturnType;
 
       ReturnType produce(const L1TMuonOverlapParamsRcd&);
 

--- a/L1Trigger/RPCTrigger/interface/RPCConeBuilder.h
+++ b/L1Trigger/RPCTrigger/interface/RPCConeBuilder.h
@@ -18,7 +18,6 @@
 //         Created:  Mon Feb 25 12:06:44 CET 2008
 //
 #include <memory>
-#include "boost/shared_ptr.hpp"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
@@ -39,7 +38,7 @@ class RPCConeBuilder : public edm::ESProducer {
       RPCConeBuilder(const edm::ParameterSet&);
       ~RPCConeBuilder() {};
 
-      typedef boost::shared_ptr<L1RPCConeBuilder> ReturnType;
+      typedef std::shared_ptr<L1RPCConeBuilder> ReturnType;
       
 
       ReturnType produce(const L1RPCConeBuilderRcd&);

--- a/L1Trigger/RPCTrigger/interface/RPCStripsRing.h
+++ b/L1Trigger/RPCTrigger/interface/RPCStripsRing.h
@@ -54,7 +54,7 @@ class RPCStripsRing : public std::map<float, TStrip >
       
             
       RPCStripsRing(const RPCRoll * roll, 
-                    boost::shared_ptr<L1RPCConeBuilder::TConMap > cmap);
+                    std::shared_ptr<L1RPCConeBuilder::TConMap > cmap);
                     
       RPCStripsRing();
       virtual ~RPCStripsRing() {};
@@ -83,10 +83,10 @@ class RPCStripsRing : public std::map<float, TStrip >
       int getTowerForRefRing();
       
       void compressConnections();
-      boost::shared_ptr<L1RPCConeBuilder::TConMap > getConnectionsMap() 
+      std::shared_ptr<L1RPCConeBuilder::TConMap > getConnectionsMap() 
               { return m_connectionsMap;};
               
-      boost::shared_ptr<L1RPCConeBuilder::TCompressedConMap> getCompressedConnectionsMap() 
+      std::shared_ptr<L1RPCConeBuilder::TCompressedConMap> getCompressedConnectionsMap() 
       { 
         return m_compressedConnectionMap;
       };
@@ -102,8 +102,8 @@ class RPCStripsRing : public std::map<float, TStrip >
       bool m_didVirtuals; // m_isRefPlane previously
       bool m_didFiltering;    
       
-      boost::shared_ptr<L1RPCConeBuilder::TConMap > m_connectionsMap;  
-      boost::shared_ptr<L1RPCConeBuilder::TCompressedConMap > m_compressedConnectionMap;
+      std::shared_ptr<L1RPCConeBuilder::TConMap > m_connectionsMap;  
+      std::shared_ptr<L1RPCConeBuilder::TCompressedConMap > m_compressedConnectionMap;
 };
 
 

--- a/L1Trigger/RPCTrigger/interface/RPCTriggerBoard.h
+++ b/L1Trigger/RPCTrigger/interface/RPCTriggerBoard.h
@@ -15,7 +15,7 @@
 #include "L1Trigger/RPCTrigger/interface/RPCTBGhostBuster.h"
 #include "L1Trigger/RPCTrigger/interface/RPCTriggerConfiguration.h"
 #include "L1Trigger/RPCTrigger/interface/RPCPac.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 //---------------------------------------------------------------------------
 class RPCTriggerBoard {
 public:

--- a/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
+++ b/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
@@ -121,7 +121,7 @@ RPCConeBuilder::produce(const L1RPCConeBuilderRcd& iRecord)
   
    //std::cout << " RPCConeBuilder::produce called " << std::endl;
    using namespace edm::es;
-   boost::shared_ptr<L1RPCConeBuilder> pL1RPCConeBuilder( ( new L1RPCConeBuilder ) );
+   auto pL1RPCConeBuilder = std::make_shared<L1RPCConeBuilder>();
    
    pL1RPCConeBuilder->setFirstTower(m_towerBeg);
    pL1RPCConeBuilder->setLastTower(m_towerEnd);
@@ -188,8 +188,7 @@ void RPCConeBuilder::buildCones(const edm::ESHandle<RPCGeometry> & rpcGeom ){
   //std::cout << "    ---> buildCones called " << std::endl; 
   
   // fetch geometricall data
-  boost::shared_ptr<L1RPCConeBuilder::TConMap > uncompressedCons
-        = boost::shared_ptr<L1RPCConeBuilder::TConMap >(new L1RPCConeBuilder::TConMap());
+  auto uncompressedCons = std::make_shared<L1RPCConeBuilder::TConMap>();
   
   
   int rolls = 0;

--- a/L1Trigger/RPCTrigger/src/RPCStripsRing.cc
+++ b/L1Trigger/RPCTrigger/src/RPCStripsRing.cc
@@ -32,7 +32,7 @@ RPCStripsRing::RPCStripsRing() :
 }
 
 RPCStripsRing::RPCStripsRing(const RPCRoll * roll,
-                             boost::shared_ptr<L1RPCConeBuilder::TConMap > cmap) :
+                             std::shared_ptr<L1RPCConeBuilder::TConMap > cmap) :
     m_didVirtuals(false),
     m_didFiltering(false),
     m_connectionsMap(cmap)
@@ -516,12 +516,9 @@ void RPCStripsRing::compressConnections(){
   
   L1RPCConeBuilder::TConMap::iterator itChamber = m_connectionsMap->begin();
   
-  boost::shared_ptr<L1RPCConeBuilder::TConMap > uncompressedConsLeft
-  = boost::shared_ptr<L1RPCConeBuilder::TConMap >(new L1RPCConeBuilder::TConMap());
+  auto uncompressedConsLeft = std::make_shared<L1RPCConeBuilder::TConMap>();
   
-  m_compressedConnectionMap =        
-               boost::shared_ptr<L1RPCConeBuilder::TCompressedConMap >
-               (new L1RPCConeBuilder::TCompressedConMap());
+  m_compressedConnectionMap = std::make_shared<L1RPCConeBuilder::TCompressedConMap>();
   
   
   int compressedCons = 0, uncompressedConsBefore = 0, uncompressedConsAfter = 0;

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFAlignmentOnlineProd.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFAlignmentOnlineProd.h
@@ -7,7 +7,7 @@ class CSCTFAlignmentOnlineProd : public L1ConfigOnlineProdBase< L1MuCSCTFAlignme
       CSCTFAlignmentOnlineProd(const edm::ParameterSet& iConfig)
          : L1ConfigOnlineProdBase< L1MuCSCTFAlignmentRcd, L1MuCSCTFAlignment >( iConfig ) {}
       ~CSCTFAlignmentOnlineProd() {}
-      virtual boost::shared_ptr< L1MuCSCTFAlignment > newObject( const std::string& objectKey ) ;
+      virtual std::shared_ptr< L1MuCSCTFAlignment > newObject( const std::string& objectKey ) ;
    private:
 };
 

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFConfigOnlineProd.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFConfigOnlineProd.h
@@ -8,7 +8,7 @@ class CSCTFConfigOnlineProd : public L1ConfigOnlineProdBase< L1MuCSCTFConfigurat
          : L1ConfigOnlineProdBase< L1MuCSCTFConfigurationRcd, L1MuCSCTFConfiguration >( iConfig ) {}
       ~CSCTFConfigOnlineProd() {}
 
-      virtual boost::shared_ptr< L1MuCSCTFConfiguration > newObject( const std::string& objectKey ) ;
+      virtual std::shared_ptr< L1MuCSCTFConfiguration > newObject( const std::string& objectKey ) ;
    private:
 };
 

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCPtLutConfigOnlineProd.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCPtLutConfigOnlineProd.h
@@ -8,7 +8,7 @@ class L1MuCSCPtLutConfigOnlineProd : public L1ConfigOnlineProdBase< L1MuCSCPtLut
          : L1ConfigOnlineProdBase< L1MuCSCPtLutRcd, L1MuCSCPtLut >( iConfig ) {}
       ~L1MuCSCPtLutConfigOnlineProd() {}
 
-      virtual boost::shared_ptr< L1MuCSCPtLut > newObject( const std::string& objectKey ) ;
+      virtual std::shared_ptr< L1MuCSCPtLut > newObject( const std::string& objectKey ) ;
    private:
 };
 

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFAlignmentOnlineProd.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFAlignmentOnlineProd.cc
@@ -1,6 +1,6 @@
 #include "L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFAlignmentOnlineProd.h"
 
-boost::shared_ptr< L1MuCSCTFAlignment >
+std::shared_ptr< L1MuCSCTFAlignment >
 CSCTFAlignmentOnlineProd::newObject( const std::string& objectKey )
 {
    // Execute SQL queries to get data from OMDS (using key) and make C++ object
@@ -35,7 +35,7 @@ CSCTFAlignmentOnlineProd::newObject( const std::string& objectKey )
    if( results.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "Problem with CSCTF_ALIGN_PARAM query." ;
-      return boost::shared_ptr< L1MuCSCTFAlignment >( new L1MuCSCTFAlignment( ) ) ;
+      return std::make_shared<L1MuCSCTFAlignment>() ;
    }
 
 // oracle doesn't support double so some tweaks
@@ -66,7 +66,7 @@ CSCTFAlignmentOnlineProd::newObject( const std::string& objectKey )
 	edm::LogInfo( "algn_par queried" ) << par_align[i] ;
 	par_align_double[i]=par_align[i] ;
    }
-   return boost::shared_ptr< L1MuCSCTFAlignment >( new L1MuCSCTFAlignment(par_align_double) ) ;
+   return std::make_shared<L1MuCSCTFAlignment>(par_align_double) ;
 }
 
 

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigOnlineProd.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigOnlineProd.cc
@@ -2,7 +2,7 @@
 //#include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include <cstdio>
 
-boost::shared_ptr< L1MuCSCTFConfiguration >
+std::shared_ptr< L1MuCSCTFConfiguration >
 CSCTFConfigOnlineProd::newObject( const std::string& objectKey )
 {
   
@@ -43,7 +43,7 @@ CSCTFConfigOnlineProd::newObject( const std::string& objectKey )
       {
 	edm::LogError( "L1-O2O" ) << "Problem with L1CSCTFParameters key." ;
 	// return empty configuration
-	return boost::shared_ptr< L1MuCSCTFConfiguration >( new L1MuCSCTFConfiguration() ) ;
+	return std::make_shared<L1MuCSCTFConfiguration>() ;
       }
   
 
@@ -141,7 +141,7 @@ CSCTFConfigOnlineProd::newObject( const std::string& objectKey )
   }  
   
   // return the final object with the configuration for all CSCTF
-  return boost::shared_ptr< L1MuCSCTFConfiguration >( new L1MuCSCTFConfiguration(csctfreg) ) ;    
+  return std::make_shared<L1MuCSCTFConfiguration>(csctfreg) ;    
 
 }
 

--- a/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCPtLutConfigOnlineProd.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCPtLutConfigOnlineProd.cc
@@ -1,6 +1,6 @@
 #include "L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCPtLutConfigOnlineProd.h"
 
-boost::shared_ptr< L1MuCSCPtLut >
+std::shared_ptr< L1MuCSCPtLut >
 L1MuCSCPtLutConfigOnlineProd::newObject( const std::string& objectKey )
 {
 
@@ -24,7 +24,7 @@ L1MuCSCPtLutConfigOnlineProd::newObject( const std::string& objectKey )
     {
       edm::LogError( "L1-O2O" ) << "Problem with L1MuCSCPtLutParameters key" ;
       // return empty object
-      return boost::shared_ptr< L1MuCSCPtLut >() ;
+      return std::shared_ptr< L1MuCSCPtLut >() ;
     }
   
   
@@ -40,7 +40,7 @@ L1MuCSCPtLutConfigOnlineProd::newObject( const std::string& objectKey )
   L1MuCSCPtLut* CSCTFPtLut = new L1MuCSCPtLut();
   CSCTFPtLut->readFromDBS(ptlut);
 
-  return boost::shared_ptr< L1MuCSCPtLut >( CSCTFPtLut ) ;
+  return std::shared_ptr< L1MuCSCPtLut >( CSCTFPtLut ) ;
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(L1MuCSCPtLutConfigOnlineProd);

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.h
@@ -22,7 +22,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 // user include files

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.h
@@ -22,7 +22,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 // user include files

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTrackFinderConfig.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTrackFinderConfig.h
@@ -34,7 +34,6 @@
 #include "CondFormats/DataRecord/interface/L1MuDTTFMasksRcd.h"
 
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 

--- a/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutOnlineProd.cc
@@ -39,7 +39,7 @@ class DTEtaPatternLutOnlineProd :
       DTEtaPatternLutOnlineProd(const edm::ParameterSet&);
       ~DTEtaPatternLutOnlineProd();
 
-  virtual boost::shared_ptr< L1MuDTEtaPatternLut > newObject(
+  virtual std::shared_ptr< L1MuDTEtaPatternLut > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -77,13 +77,13 @@ DTEtaPatternLutOnlineProd::~DTEtaPatternLutOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTEtaPatternLut >
+std::shared_ptr< L1MuDTEtaPatternLut >
 DTEtaPatternLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTEtaPatternLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1MuDTEtaPatternLut >() ;
+  return std::shared_ptr< L1MuDTEtaPatternLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTExtLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTExtLutOnlineProd.cc
@@ -39,7 +39,7 @@ class DTExtLutOnlineProd :
       DTExtLutOnlineProd(const edm::ParameterSet&);
       ~DTExtLutOnlineProd();
 
-  virtual boost::shared_ptr< L1MuDTExtLut > newObject(
+  virtual std::shared_ptr< L1MuDTExtLut > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -77,13 +77,13 @@ DTExtLutOnlineProd::~DTExtLutOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTExtLut >
+std::shared_ptr< L1MuDTExtLut >
 DTExtLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTExtLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1MuDTExtLut >() ;
+  return std::shared_ptr< L1MuDTExtLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTPhiLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPhiLutOnlineProd.cc
@@ -39,7 +39,7 @@ class DTPhiLutOnlineProd :
       DTPhiLutOnlineProd(const edm::ParameterSet&);
       ~DTPhiLutOnlineProd();
 
-  virtual boost::shared_ptr< L1MuDTPhiLut > newObject(
+  virtual std::shared_ptr< L1MuDTPhiLut > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -77,13 +77,13 @@ DTPhiLutOnlineProd::~DTPhiLutOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTPhiLut >
+std::shared_ptr< L1MuDTPhiLut >
 DTPhiLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTPhiLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1MuDTPhiLut >() ;
+  return std::shared_ptr< L1MuDTPhiLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTPtaLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPtaLutOnlineProd.cc
@@ -39,7 +39,7 @@ class DTPtaLutOnlineProd :
       DTPtaLutOnlineProd(const edm::ParameterSet&);
       ~DTPtaLutOnlineProd();
 
-  virtual boost::shared_ptr< L1MuDTPtaLut > newObject(
+  virtual std::shared_ptr< L1MuDTPtaLut > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -77,13 +77,13 @@ DTPtaLutOnlineProd::~DTPtaLutOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTPtaLut >
+std::shared_ptr< L1MuDTPtaLut >
 DTPtaLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTPtaLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1MuDTPtaLut >() ;
+  return std::shared_ptr< L1MuDTPtaLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutOnlineProd.cc
@@ -39,7 +39,7 @@ class DTQualPatternLutOnlineProd :
       DTQualPatternLutOnlineProd(const edm::ParameterSet&);
       ~DTQualPatternLutOnlineProd();
 
-  virtual boost::shared_ptr< L1MuDTQualPatternLut > newObject(
+  virtual std::shared_ptr< L1MuDTQualPatternLut > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -77,13 +77,13 @@ DTQualPatternLutOnlineProd::~DTQualPatternLutOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTQualPatternLut >
+std::shared_ptr< L1MuDTQualPatternLut >
 DTQualPatternLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTQualPatternLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1MuDTQualPatternLut >() ;
+  return std::shared_ptr< L1MuDTQualPatternLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFMasksOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFMasksOnlineProd.cc
@@ -36,7 +36,7 @@ class DTTFMasksOnlineProd :
       DTTFMasksOnlineProd(const edm::ParameterSet&);
       ~DTTFMasksOnlineProd();
 
-      virtual boost::shared_ptr< L1MuDTTFMasks > newObject(
+      virtual std::shared_ptr< L1MuDTTFMasks > newObject(
         const std::string& objectKey ) override ;
 
    private:
@@ -66,13 +66,12 @@ DTTFMasksOnlineProd::~DTTFMasksOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTTFMasks >
+std::shared_ptr< L1MuDTTFMasks >
 DTTFMasksOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
 
-     boost::shared_ptr< L1MuDTTFMasks > pDTTFMasks(
-       new L1MuDTTFMasks() ) ;
+     auto pDTTFMasks = std::make_shared< L1MuDTTFMasks >() ;
 
      pDTTFMasks->reset() ;
 
@@ -105,7 +104,7 @@ DTTFMasksOnlineProd::newObject( const std::string& objectKey )
        {
 	 edm::LogError( "L1-O2O" )
 	   << "Problem with L1MuDTTFMasks key " << objectKey ;
-	 return boost::shared_ptr< L1MuDTTFMasks >() ;
+	 return std::shared_ptr< L1MuDTTFMasks >() ;
        }
 
      // Cache crate masks

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFParametersOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFParametersOnlineProd.cc
@@ -36,7 +36,7 @@ class DTTFParametersOnlineProd :
       DTTFParametersOnlineProd(const edm::ParameterSet&);
       ~DTTFParametersOnlineProd();
 
-      virtual boost::shared_ptr< L1MuDTTFParameters > newObject(
+      virtual std::shared_ptr< L1MuDTTFParameters > newObject(
         const std::string& objectKey ) override ;
 
    private:
@@ -66,13 +66,12 @@ DTTFParametersOnlineProd::~DTTFParametersOnlineProd()
 
 }
 
-boost::shared_ptr< L1MuDTTFParameters >
+std::shared_ptr< L1MuDTTFParameters >
 DTTFParametersOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
 
-     boost::shared_ptr< L1MuDTTFParameters > pDTTFParameters(
-       new L1MuDTTFParameters() ) ;
+     auto pDTTFParameters = std::make_shared< L1MuDTTFParameters >() ;
 
      pDTTFParameters->reset() ;
 
@@ -99,7 +98,7 @@ DTTFParametersOnlineProd::newObject( const std::string& objectKey )
        {
 	 edm::LogError( "L1-O2O" )
 	   << "Problem with L1MuDTTFParameters key " << objectKey ;
-	 return boost::shared_ptr< L1MuDTTFParameters >() ;
+	 return std::shared_ptr< L1MuDTTFParameters >() ;
        }
 
      // print crate keys -- delete when done debugging
@@ -181,7 +180,7 @@ DTTFParametersOnlineProd::newObject( const std::string& objectKey )
 		   {
 		     edm::LogError( "L1-O2O" )
 		       << "Problem with WEDGE_CRATE_CONF key." ;
-		     return boost::shared_ptr< L1MuDTTFParameters >() ;
+		     return std::shared_ptr< L1MuDTTFParameters >() ;
 		   }
 		 
 		 std::string dummy ;
@@ -201,7 +200,7 @@ DTTFParametersOnlineProd::newObject( const std::string& objectKey )
 		       {
 			 edm::LogError( "L1-O2O" )
 			   << "Problem with PHTF_CONF key." ;
-			 return boost::shared_ptr< L1MuDTTFParameters >() ;
+			 return std::shared_ptr< L1MuDTTFParameters >() ;
 		       }
 		     
 		     long long tmp ;

--- a/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersOnlineProducer.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersOnlineProducer.h
@@ -15,7 +15,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 // user include files
 
@@ -34,7 +33,7 @@ public:
   ~L1MuGMTParametersOnlineProducer();
   
   /// The method that actually implements the production of the parameter objects
-  virtual boost::shared_ptr<L1MuGMTParameters> newObject( const std::string& objectKey );
+  virtual std::shared_ptr<L1MuGMTParameters> newObject( const std::string& objectKey );
  protected:
 
   void checkCMSSWVersion(const coral::AttributeList& configRecord);

--- a/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersProducer.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersProducer.h
@@ -14,7 +14,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTChannelMaskOnlineProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTChannelMaskOnlineProducer.cc
@@ -8,11 +8,11 @@ class L1MuGMTChannelMaskOnlineProducer : public L1ConfigOnlineProdBase< L1MuGMTC
          : L1ConfigOnlineProdBase< L1MuGMTChannelMaskRcd, L1MuGMTChannelMask >( iConfig ) {}
       ~L1MuGMTChannelMaskOnlineProducer() {}
 
-      virtual boost::shared_ptr< L1MuGMTChannelMask > newObject( const std::string& objectKey ) override ;
+      virtual std::shared_ptr< L1MuGMTChannelMask > newObject( const std::string& objectKey ) override ;
    private:
 };
 
-boost::shared_ptr< L1MuGMTChannelMask >
+std::shared_ptr< L1MuGMTChannelMask >
 L1MuGMTChannelMaskOnlineProducer::newObject( const std::string& objectKey )
 {
 
@@ -35,7 +35,7 @@ L1MuGMTChannelMaskOnlineProducer::newObject( const std::string& objectKey )
    if( results.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "L1MuGMTChannelMaskOnlineProducer: Problem getting " << objectKey << " key from GMT_RUN_SETTING." ;
-      return boost::shared_ptr< L1MuGMTChannelMask >() ;
+      return std::shared_ptr< L1MuGMTChannelMask >() ;
    }
 
    unsigned mask = 0;
@@ -49,7 +49,7 @@ L1MuGMTChannelMaskOnlineProducer::newObject( const std::string& objectKey )
    results.fillVariable( "ENABLE_RPCF", maskaux ) ;
    if(!maskaux) mask|=8;
 
-   boost::shared_ptr< L1MuGMTChannelMask > gmtchanmask = boost::shared_ptr< L1MuGMTChannelMask >( new L1MuGMTChannelMask() );
+   auto gmtchanmask = std::make_shared< L1MuGMTChannelMask >();
 
    gmtchanmask->setSubsystemMask(mask);
    

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersOnlineProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersOnlineProducer.cc
@@ -31,7 +31,7 @@ RH_ASSIGN_GROUP(L1MuGMTParameters, TGlobalTriggerGroup)
  *  Query the CMS_GMT.GMT_SOFTWARE_CONFIG table with a key determined by the "master" config table
  *  and return the matching record.
  */
-boost::shared_ptr<L1MuGMTParameters> L1MuGMTParametersOnlineProducer::newObject( const std::string& objectKey )
+std::shared_ptr<L1MuGMTParameters> L1MuGMTParametersOnlineProducer::newObject( const std::string& objectKey )
 {
   using namespace edm::es;
 
@@ -83,7 +83,7 @@ boost::shared_ptr<L1MuGMTParameters> L1MuGMTParametersOnlineProducer::newObject(
   ADD_FIELD(helper, L1MuGMTParameters, VersionSortRankEtaQLUT);
   ADD_FIELD(helper, L1MuGMTParameters, VersionLUTs);
 
-  boost::shared_ptr<L1MuGMTParameters> ptrResult(new L1MuGMTParameters);
+  auto ptrResult = std::make_shared<L1MuGMTParameters>();
 
   std::vector<std::string> resultColumns = helper.getColumnList();
   resultColumns.push_back("CMSSW_VERSION");

--- a/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
+++ b/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include<vector>
 
@@ -52,8 +51,8 @@ class L1GctConfigProducers : public edm::ESProducer {
   L1GctConfigProducers(const edm::ParameterSet&);
   ~L1GctConfigProducers();
   
-  typedef boost::shared_ptr<L1GctJetFinderParams>          JfParamsReturnType;
-  typedef boost::shared_ptr<L1GctChannelMask>          ChanMaskReturnType;
+  typedef std::shared_ptr<L1GctJetFinderParams>          JfParamsReturnType;
+  typedef std::shared_ptr<L1GctChannelMask>          ChanMaskReturnType;
   
   JfParamsReturnType produceJfParams(const L1GctJetFinderParamsRcd&);
   ChanMaskReturnType produceChanMask(const L1GctChannelMaskRcd&);

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctChannelMaskOnlineProd.cc
@@ -8,11 +8,11 @@ class L1GctChannelMaskOnlineProd : public L1ConfigOnlineProdBase< L1GctChannelMa
          : L1ConfigOnlineProdBase< L1GctChannelMaskRcd, L1GctChannelMask >( iConfig ) {}
       ~L1GctChannelMaskOnlineProd() {}
 
-      virtual boost::shared_ptr< L1GctChannelMask > newObject( const std::string& objectKey ) override ;
+      virtual std::shared_ptr< L1GctChannelMask > newObject( const std::string& objectKey ) override ;
    private:
 };
 
-boost::shared_ptr< L1GctChannelMask >
+std::shared_ptr< L1GctChannelMask >
 L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
 { 
   // get EM mask data
@@ -26,7 +26,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
   
   if( emMaskResults.queryFailed() ) { // check if query was successful
     edm::LogError( "L1-O2O" ) << "Problem with L1GctChannelMask EM mask for key "  << objectKey;
-    return boost::shared_ptr< L1GctChannelMask >() ;
+    return std::shared_ptr< L1GctChannelMask >() ;
   }
   
   int emMask = -1;
@@ -43,7 +43,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
   
   if( rgnMaskKeyResults.queryFailed() ) { // check if query was successful
     edm::LogError( "L1-O2O" ) << "Problem with L1GctChannelMask region mask for key "  << objectKey;
-    return boost::shared_ptr< L1GctChannelMask >() ;
+    return std::shared_ptr< L1GctChannelMask >() ;
   }
 
   std::string rgnKey;
@@ -89,7 +89,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
   
   if( esumMaskKeyResults.queryFailed() ) { // check if query was successful
     edm::LogError( "L1-O2O" ) << "Problem with L1GctChannelMask energy sum mask for key "  << objectKey;
-    return boost::shared_ptr< L1GctChannelMask >() ;
+    return std::shared_ptr< L1GctChannelMask >() ;
   }
 
   std::string esumKey;
@@ -111,7 +111,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
 
 
   // create masks object
-  boost::shared_ptr< L1GctChannelMask > masks( new L1GctChannelMask() );
+  auto masks = std::make_shared< L1GctChannelMask >();
   
   // set EM masks
   for (int i=0; i<18; i++) {

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctConfigProducers.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctConfigProducers.cc
@@ -129,8 +129,7 @@ L1GctConfigProducers::produceJfParams(const L1GctJetFinderParamsRcd& aRcd)
   geomRcd.get( geom ) ;
   
   // construct jet finder params object
-  boost::shared_ptr<L1GctJetFinderParams> pL1GctJetFinderParams =
-    boost::shared_ptr<L1GctJetFinderParams> (new L1GctJetFinderParams(m_rgnEtLsb,
+  auto pL1GctJetFinderParams = std::make_shared<L1GctJetFinderParams>(m_rgnEtLsb,
 								      m_htLsb,
 								      m_CenJetSeed,
 								      m_FwdJetSeed,
@@ -143,7 +142,7 @@ L1GctConfigProducers::produceJfParams(const L1GctJetFinderParamsRcd& aRcd)
 								      m_jetCalibFunc,
 								      m_tauCalibFunc,
 								      m_convertToEnergy,
-								      etToEnergyConversion(geom.product())) );
+								      etToEnergyConversion(geom.product()));
   
   return pL1GctJetFinderParams ;
 
@@ -161,7 +160,7 @@ L1GctConfigProducers::produceChanMask(const L1GctChannelMaskRcd&) {
     if (((m_thtEtaMask>>ieta)&0x1)==1) mask->maskTotalHt(ieta);
   }
 
-  return boost::shared_ptr<L1GctChannelMask>(mask);
+  return std::shared_ptr<L1GctChannelMask>(mask);
 
 }
 

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctJetFinderParamsOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctJetFinderParamsOnlineProd.cc
@@ -8,11 +8,11 @@ class L1GctJetFinderParamsOnlineProd : public L1ConfigOnlineProdBase< L1GctJetFi
          : L1ConfigOnlineProdBase< L1GctJetFinderParamsRcd, L1GctJetFinderParams >( iConfig ) {}
       ~L1GctJetFinderParamsOnlineProd() {}
 
-      virtual boost::shared_ptr< L1GctJetFinderParams > newObject( const std::string& objectKey ) override ;
+      virtual std::shared_ptr< L1GctJetFinderParams > newObject( const std::string& objectKey ) override ;
    private:
 };
 
-boost::shared_ptr< L1GctJetFinderParams >
+std::shared_ptr< L1GctJetFinderParams >
 L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
 {
    // Execute SQL queries to get data from OMDS (using key) and make C++ object
@@ -42,7 +42,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
    if( results.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "Problem with L1GctJetFinderParams key." ;
-      return boost::shared_ptr< L1GctJetFinderParams >() ;
+      return std::shared_ptr< L1GctJetFinderParams >() ;
    }
 
    // fill values
@@ -112,7 +112,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
    if( jetCorrResults.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "Problem getting L1 jet corrections" ;
-      return boost::shared_ptr< L1GctJetFinderParams >() ;
+      return std::shared_ptr< L1GctJetFinderParams >() ;
    }
 
    // fill jet corr type
@@ -162,7 +162,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
      if( results.queryFailed() ) // check if query was successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem getting L1 jet correction coefficients" ;
-	 return boost::shared_ptr< L1GctJetFinderParams >() ;
+	 return std::shared_ptr< L1GctJetFinderParams >() ;
        }
 
      // fill coeffs - TODO
@@ -176,7 +176,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
      else if (corrType == 5) nCoeffs=6;  // PF
      else {
        edm::LogError( "L1-O2O" ) << "Unsupported jet correction type : " << corrType ;
-       return boost::shared_ptr< L1GctJetFinderParams >() ;
+       return std::shared_ptr< L1GctJetFinderParams >() ;
      }
 
      for (unsigned j=0; j< nCoeffs; ++j) {
@@ -198,23 +198,22 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
    
    
 
-   return boost::shared_ptr< L1GctJetFinderParams >( 
-						    new L1GctJetFinderParams( rgnEtLsb,
-									      htLsb,
-									      cJetSeed,
-									      fJetSeed,
-									      tJetSeed,
-									      tauIsoEtThresh,
-									      htJetEtThresh,
-									      mhtJetEtThresh,
-									      etaBoundary,
-									      corrType,
-									      jetCorrCoeffs,
-									      tauCorrCoeffs,
-									      convertToEnergy,
-									      energyConvCoeffs
+   return std::make_shared< L1GctJetFinderParams >( 
+						   rgnEtLsb,
+						   htLsb,
+						   cJetSeed,
+						   fJetSeed,
+						   tJetSeed,
+						   tauIsoEtThresh,
+						   htJetEtThresh,
+						   mhtJetEtThresh,
+						   etaBoundary,
+						   corrType,
+						   jetCorrCoeffs,
+						   tauCorrCoeffs,
+						   convertToEnergy,
+						   energyConvCoeffs
 
- )
 						    );
 
 }

--- a/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.cc
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.cc
@@ -117,7 +117,7 @@ L1CSCTriggerPrimitivesConfigProducer::~L1CSCTriggerPrimitivesConfigProducer() {
 std::auto_ptr<CSCDBL1TPParameters>
 L1CSCTriggerPrimitivesConfigProducer::produce(const CSCDBL1TPParametersRcd& iRecord) {
   using namespace edm::es;
-  //boost::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> pL1CSCTPConfigProducer;
+  //std::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> pL1CSCTPConfigProducer;
 
   // Create empty collection of CSCTPParameters.
   std::auto_ptr<CSCDBL1TPParameters> pL1CSCTPParams(new CSCDBL1TPParameters);

--- a/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.h
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.h
@@ -13,7 +13,6 @@
 
 // system include files
 #include <memory>
-//#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -27,7 +26,7 @@ class L1CSCTriggerPrimitivesConfigProducer : public edm::ESProducer {
   L1CSCTriggerPrimitivesConfigProducer(const edm::ParameterSet&);
   ~L1CSCTriggerPrimitivesConfigProducer();
 
-  //typedef boost::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> ReturnType;
+  //typedef std::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> ReturnType;
 
   std::auto_ptr<CSCDBL1TPParameters> produce(const CSCDBL1TPParametersRcd&);
 

--- a/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryProd.cc
+++ b/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryProd.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "L1TriggerConfig/L1GeometryProducers/interface/L1CaloGeometryProd.h"

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -47,7 +46,7 @@ public:
     /// public methods
 
     /// produce mappings of the L1 GT boards
-    boost::shared_ptr<L1GtBoardMaps> produceBoardMaps(
+    std::shared_ptr<L1GtBoardMaps> produceBoardMaps(
         const L1GtBoardMapsRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 
 // user include files
@@ -42,7 +42,7 @@ public:
     ~L1GtParametersConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtParameters> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtParameters> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
 #include <boost/cstdint.hpp>
 
 // user include files
@@ -49,7 +48,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    boost::shared_ptr<L1GtParameters> produceGtParameters(
+    std::shared_ptr<L1GtParameters> produceGtParameters(
         const L1GtParametersRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 
 // user include files
@@ -42,7 +42,7 @@ public:
     ~L1GtPrescaleFactorsAlgoTrigConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -47,7 +46,7 @@ public:
 
     /// public methods
 
-    boost::shared_ptr<L1GtPrescaleFactors> producePrescaleFactors(
+    std::shared_ptr<L1GtPrescaleFactors> producePrescaleFactors(
             const L1GtPrescaleFactorsAlgoTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 
 // user include files
@@ -42,7 +42,7 @@ public:
     ~L1GtPrescaleFactorsTechTrigConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -47,7 +46,7 @@ public:
 
     /// public methods
 
-    boost::shared_ptr<L1GtPrescaleFactors> producePrescaleFactors(
+    std::shared_ptr<L1GtPrescaleFactors> producePrescaleFactors(
             const L1GtPrescaleFactorsTechTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -45,7 +45,7 @@ public:
     ~L1GtPsbSetupConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtPsbSetup> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtPsbSetup> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -47,7 +46,7 @@ public:
     /// public methods
 
     /// produce the setup for L1 GT PSB boards
-    boost::shared_ptr<L1GtPsbSetup> producePsbSetup(
+    std::shared_ptr<L1GtPsbSetup> producePsbSetup(
         const L1GtPsbSetupRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
@@ -20,7 +20,6 @@
 
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
 #include <boost/cstdint.hpp>
 
 // user include files
@@ -50,7 +49,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    boost::shared_ptr<L1GtStableParameters> produceGtStableParameters(
+    std::shared_ptr<L1GtStableParameters> produceGtStableParameters(
         const L1GtStableParametersRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 
 // user include files
@@ -42,7 +42,7 @@ public:
     ~L1GtTriggerMaskAlgoTrigConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -48,7 +47,7 @@ public:
 
     /// public methods
 
-    boost::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskAlgoTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 
 // user include files
@@ -42,7 +42,7 @@ public:
     ~L1GtTriggerMaskTechTrigConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -48,7 +47,7 @@ public:
 
     /// public methods
 
-    boost::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskTechTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -48,7 +47,7 @@ public:
 
     /// public methods
 
-    boost::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskVetoAlgoTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.h
@@ -16,7 +16,7 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 
 // user include files
@@ -42,7 +42,7 @@ public:
     ~L1GtTriggerMaskVetoTechTrigConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigTrivialProducer.h
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -48,7 +47,7 @@ public:
 
     /// public methods
 
-    boost::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskVetoTechTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuConfigOnlineProd.h
@@ -16,9 +16,9 @@
  */
 
 // system include files
-#include "boost/shared_ptr.hpp"
 #include "boost/lexical_cast.hpp"
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <iomanip>
@@ -58,7 +58,7 @@ public:
     ~L1GtTriggerMenuConfigOnlineProd();
 
     /// public methods
-    virtual boost::shared_ptr<L1GtTriggerMenu> newObject(const std::string& objectKey);
+    virtual std::shared_ptr<L1GtTriggerMenu> newObject(const std::string& objectKey);
 
     /// initialize the class (mainly reserve/resize)
     void init(const int numberConditionChips);

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 
-#include "boost/shared_ptr.hpp"
 #include <boost/cstdint.hpp>
 
 // user include files
@@ -50,7 +49,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    boost::shared_ptr<L1GtTriggerMenu> produceGtTriggerMenu(
+    std::shared_ptr<L1GtTriggerMenu> produceGtTriggerMenu(
         const L1GtTriggerMenuRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <string>
 
@@ -473,14 +472,13 @@ L1GtBoardMapsTrivialProducer::~L1GtBoardMapsTrivialProducer()
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtBoardMaps> L1GtBoardMapsTrivialProducer::produceBoardMaps(
+std::shared_ptr<L1GtBoardMaps> L1GtBoardMapsTrivialProducer::produceBoardMaps(
     const L1GtBoardMapsRcd& iRecord)
 {
 
     using namespace edm::es;
 
-    boost::shared_ptr<L1GtBoardMaps> pL1GtBoardMaps =
-        boost::shared_ptr<L1GtBoardMaps>( new L1GtBoardMaps() );
+    auto pL1GtBoardMaps = std::make_shared<L1GtBoardMaps>();
 
     pL1GtBoardMaps->setGtBoardMaps(m_gtBoardMaps);
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersConfigOnlineProd.cc
@@ -38,12 +38,11 @@ L1GtParametersConfigOnlineProd::~L1GtParametersConfigOnlineProd() {
 
 // public methods
 
-boost::shared_ptr<L1GtParameters> L1GtParametersConfigOnlineProd::newObject(
+std::shared_ptr<L1GtParameters> L1GtParametersConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // shared pointer for L1GtParameters
-    boost::shared_ptr<L1GtParameters> pL1GtParameters = boost::shared_ptr<L1GtParameters>(
-            new L1GtParameters());
+    auto pL1GtParameters = std::make_shared<L1GtParameters>();
 
     // l1GtParameters: parameters in table GTFE_SETUP_FK
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
@@ -18,7 +18,6 @@
 // system include files
 #include <memory>
 
-#include "boost/shared_ptr.hpp"
 #include <boost/cstdint.hpp>
 
 
@@ -94,15 +93,14 @@ L1GtParametersTrivialProducer::~L1GtParametersTrivialProducer()
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtParameters> L1GtParametersTrivialProducer::produceGtParameters(
+std::shared_ptr<L1GtParameters> L1GtParametersTrivialProducer::produceGtParameters(
     const L1GtParametersRcd& iRecord)
 {
 
     using namespace edm::es;
 
 
-    boost::shared_ptr<L1GtParameters> pL1GtParameters =
-        boost::shared_ptr<L1GtParameters>( new L1GtParameters() );
+    auto pL1GtParameters = std::make_shared<L1GtParameters>();
 
 
     // set total Bx's in the event

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.cc
@@ -42,15 +42,14 @@ L1GtPrescaleFactorsAlgoTrigConfigOnlineProd::~L1GtPrescaleFactorsAlgoTrigConfigO
 
 // public methods
 
-boost::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigConfigOnlineProd::newObject(
+std::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // FIXME seems to not work anymore in constructor...
     m_isDebugEnabled = edm::isDebugEnabled();
 
     // shared pointer for L1GtPrescaleFactors
-    boost::shared_ptr<L1GtPrescaleFactors> pL1GtPrescaleFactors =
-            boost::shared_ptr<L1GtPrescaleFactors>(new L1GtPrescaleFactors());
+    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>();
 
     // Procedure:
     // objectKey received as input is GT_RUN_SETTINGS_FK

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -67,12 +66,10 @@ L1GtPrescaleFactorsAlgoTrigTrivialProducer::~L1GtPrescaleFactorsAlgoTrigTrivialP
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigTrivialProducer::producePrescaleFactors(
+std::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigTrivialProducer::producePrescaleFactors(
         const L1GtPrescaleFactorsAlgoTrigRcd& iRecord) {
 
-    boost::shared_ptr<L1GtPrescaleFactors> pL1GtPrescaleFactors =
-            boost::shared_ptr<L1GtPrescaleFactors>(
-                    new L1GtPrescaleFactors(m_prescaleFactors) );
+    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>(m_prescaleFactors);
 
     return pL1GtPrescaleFactors;
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigConfigOnlineProd.cc
@@ -42,15 +42,14 @@ L1GtPrescaleFactorsTechTrigConfigOnlineProd::~L1GtPrescaleFactorsTechTrigConfigO
 
 // public methods
 
-boost::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsTechTrigConfigOnlineProd::newObject(
+std::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsTechTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // FIXME seems to not work anymore in constructor...
     m_isDebugEnabled = edm::isDebugEnabled();
 
     // shared pointer for L1GtPrescaleFactors
-    boost::shared_ptr<L1GtPrescaleFactors> pL1GtPrescaleFactors =
-            boost::shared_ptr<L1GtPrescaleFactors>(new L1GtPrescaleFactors());
+    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>();
 
     // Procedure:
     // objectKey received as input is GT_RUN_SETTINGS_FK

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -69,14 +68,12 @@ L1GtPrescaleFactorsTechTrigTrivialProducer::~L1GtPrescaleFactorsTechTrigTrivialP
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtPrescaleFactors> 
+std::shared_ptr<L1GtPrescaleFactors> 
     L1GtPrescaleFactorsTechTrigTrivialProducer::producePrescaleFactors(
         const L1GtPrescaleFactorsTechTrigRcd& iRecord)
 {
 
-    boost::shared_ptr<L1GtPrescaleFactors> pL1GtPrescaleFactors =
-            boost::shared_ptr<L1GtPrescaleFactors>(
-                    new L1GtPrescaleFactors(m_prescaleFactors) );
+    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>(m_prescaleFactors);
 
     return pL1GtPrescaleFactors;
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupConfigOnlineProd.cc
@@ -40,12 +40,11 @@ L1GtPsbSetupConfigOnlineProd::~L1GtPsbSetupConfigOnlineProd() {
 
 // public methods
 
-boost::shared_ptr<L1GtPsbSetup> L1GtPsbSetupConfigOnlineProd::newObject(
+std::shared_ptr<L1GtPsbSetup> L1GtPsbSetupConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // shared pointer for L1GtPsbSetup
-    boost::shared_ptr<L1GtPsbSetup> pL1GtPsbSetup = boost::shared_ptr<L1GtPsbSetup>(
-            new L1GtPsbSetup());
+    auto pL1GtPsbSetup = std::make_shared<L1GtPsbSetup>();
 
     const std::string gtSchema = "CMS_GT";
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -114,14 +113,13 @@ L1GtPsbSetupTrivialProducer::~L1GtPsbSetupTrivialProducer()
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtPsbSetup> L1GtPsbSetupTrivialProducer::producePsbSetup(
+std::shared_ptr<L1GtPsbSetup> L1GtPsbSetupTrivialProducer::producePsbSetup(
         const L1GtPsbSetupRcd& iRecord)
 {
 
     using namespace edm::es;
 
-    boost::shared_ptr<L1GtPsbSetup> pL1GtPsbSetup = boost::shared_ptr<
-            L1GtPsbSetup>(new L1GtPsbSetup());
+    auto pL1GtPsbSetup = std::make_shared<L1GtPsbSetup>();
 
     pL1GtPsbSetup->setGtPsbSetup(m_gtPsbSetup);
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTrivialProducer.cc
@@ -19,8 +19,6 @@
 #include <memory>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
-
 // user include files
 //   base class
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -119,12 +117,11 @@ L1GtStableParametersTrivialProducer::~L1GtStableParametersTrivialProducer() {
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtStableParameters> 
+std::shared_ptr<L1GtStableParameters> 
     L1GtStableParametersTrivialProducer::produceGtStableParameters(
         const L1GtStableParametersRcd& iRecord) {
 
-    boost::shared_ptr<L1GtStableParameters> pL1GtStableParameters =
-        boost::shared_ptr<L1GtStableParameters>(new L1GtStableParameters());
+    auto pL1GtStableParameters = std::make_shared<L1GtStableParameters>();
 
     // set the number of physics trigger algorithms
     pL1GtStableParameters->setGtNumberPhysTriggers(m_numberPhysTriggers);

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigConfigOnlineProd.cc
@@ -42,12 +42,11 @@ L1GtTriggerMaskAlgoTrigConfigOnlineProd::~L1GtTriggerMaskAlgoTrigConfigOnlinePro
 
 // public methods
 
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigConfigOnlineProd::newObject(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // shared pointer for L1GtTriggerMask
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask());
+    auto pL1GtTriggerMask = std::make_shared<L1GtTriggerMask>();
 
     // l1GtTriggerMaskAlgoTrig: FINOR_ALGO_FK key in GT_PARTITION_FINOR_ALGO
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -58,11 +57,8 @@ L1GtTriggerMaskAlgoTrigTrivialProducer::~L1GtTriggerMaskAlgoTrigTrivialProducer(
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigTrivialProducer::produceTriggerMask(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskAlgoTrigRcd& iRecord)
 {
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask(m_triggerMask) );
-
-    return pL1GtTriggerMask ;
+    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigConfigOnlineProd.cc
@@ -41,12 +41,11 @@ L1GtTriggerMaskTechTrigConfigOnlineProd::~L1GtTriggerMaskTechTrigConfigOnlinePro
 
 // public methods
 
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigConfigOnlineProd::newObject(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // shared pointer for L1GtTriggerMask
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask());
+    auto pL1GtTriggerMask = std::make_shared<L1GtTriggerMask>();
 
     // l1GtTriggerMaskTechTrig: FINOR_TT_FK key in GT_PARTITION_FINOR_TT
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -58,11 +57,8 @@ L1GtTriggerMaskTechTrigTrivialProducer::~L1GtTriggerMaskTechTrigTrivialProducer(
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigTrivialProducer::produceTriggerMask(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskTechTrigRcd& iRecord)
 {
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask(m_triggerMask) );
-
-    return pL1GtTriggerMask ;
+    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -58,11 +57,8 @@ L1GtTriggerMaskVetoAlgoTrigTrivialProducer::~L1GtTriggerMaskVetoAlgoTrigTrivialP
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoAlgoTrigTrivialProducer::produceTriggerMask(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoAlgoTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskVetoAlgoTrigRcd& iRecord)
 {
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask(m_triggerMask) );
-
-    return pL1GtTriggerMask ;
+    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.cc
@@ -40,12 +40,11 @@ L1GtTriggerMaskVetoTechTrigConfigOnlineProd::~L1GtTriggerMaskVetoTechTrigConfigO
 
 // public methods
 
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigConfigOnlineProd::newObject(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // shared pointer for L1GtTriggerMask
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask());
+    auto pL1GtTriggerMask = std::make_shared<L1GtTriggerMask>();
 
     // l1GtTriggerMaskVetoTechTrig: VETO_TT_FK key in GT_PARTITION_VETO_TT
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigTrivialProducer.cc
@@ -17,7 +17,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include <vector>
 
@@ -58,11 +57,8 @@ L1GtTriggerMaskVetoTechTrigTrivialProducer::~L1GtTriggerMaskVetoTechTrigTrivialP
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigTrivialProducer::produceTriggerMask(
+std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskVetoTechTrigRcd& iRecord)
 {
-    boost::shared_ptr<L1GtTriggerMask> pL1GtTriggerMask = boost::shared_ptr<L1GtTriggerMask>(
-            new L1GtTriggerMask(m_triggerMask) );
-
-    return pL1GtTriggerMask ;
+    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuConfigOnlineProd.cc
@@ -79,15 +79,14 @@ void L1GtTriggerMenuConfigOnlineProd::init(const int numberConditionChips) {
 
 }
 
-boost::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
+std::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // FIXME seems to not work anymore in constructor...
     m_isDebugEnabled = edm::isDebugEnabled();
 
     // shared pointer for L1GtTriggerMenu - empty menu
-    boost::shared_ptr<L1GtTriggerMenu> pL1GtTriggerMenuEmpty =
-            boost::shared_ptr<L1GtTriggerMenu>(new L1GtTriggerMenu());
+    auto pL1GtTriggerMenuEmpty = std::make_shared<L1GtTriggerMenu>();
 
     // FIXME get it from L1GtStableParameters?
     //       initialize once, from outside
@@ -153,8 +152,8 @@ boost::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
     addConditions();
 
     // fill the record
-    boost::shared_ptr<L1GtTriggerMenu> pL1GtTriggerMenu = boost::shared_ptr<L1GtTriggerMenu>(
-                new L1GtTriggerMenu(menuName, numberConditionChips,
+    auto pL1GtTriggerMenu = std::make_shared<L1GtTriggerMenu>(
+                        menuName, numberConditionChips,
                         m_vecMuonTemplate,
                         m_vecCaloTemplate,
                         m_vecEnergySumTemplate,
@@ -167,7 +166,7 @@ boost::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
                         m_vecCorrelationTemplate,
                         m_corMuonTemplate,
                         m_corCaloTemplate,
-                        m_corEnergySumTemplate) );
+                        m_corEnergySumTemplate);
 
     pL1GtTriggerMenu->setGtTriggerMenuInterface(m_tableMenuGeneral.menuInterface);
     pL1GtTriggerMenu->setGtTriggerMenuImplementation(m_tableMenuGeneral.menuImplementation);

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlProducer.cc
@@ -18,8 +18,6 @@
 // system include files
 #include <memory>
 
-#include "boost/shared_ptr.hpp"
-
 
 // user include files
 //   base class
@@ -99,7 +97,7 @@ L1GtTriggerMenuXmlProducer::~L1GtTriggerMenuXmlProducer()
 // member functions
 
 // method called to produce the data
-boost::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerMenu(
+std::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerMenu(
     const L1GtTriggerMenuRcd& l1MenuRecord)
 {
 
@@ -130,8 +128,8 @@ boost::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerM
 
     // transfer the condition map and algorithm map from parser to L1GtTriggerMenu
 
-    boost::shared_ptr<L1GtTriggerMenu> pL1GtTriggerMenu = boost::shared_ptr<L1GtTriggerMenu>(
-                new L1GtTriggerMenu(gtXmlParser.gtTriggerMenuName(), numberConditionChips,
+    auto pL1GtTriggerMenu = std::make_shared<L1GtTriggerMenu>(
+                        gtXmlParser.gtTriggerMenuName(), numberConditionChips,
                         gtXmlParser.vecMuonTemplate(),
                         gtXmlParser.vecCaloTemplate(),
                         gtXmlParser.vecEnergySumTemplate(),
@@ -144,7 +142,7 @@ boost::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerM
                         gtXmlParser.vecCorrelationTemplate(),
                         gtXmlParser.corMuonTemplate(),
                         gtXmlParser.corCaloTemplate(),
-                        gtXmlParser.corEnergySumTemplate()) );
+                        gtXmlParser.corEnergySumTemplate());
 
 
     pL1GtTriggerMenu->setGtTriggerMenuInterface(gtXmlParser.gtTriggerMenuInterface());

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesProducer.h
@@ -20,7 +20,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -39,11 +38,11 @@ class L1CaloInputScalesProducer : public edm::ESProducer {
       L1CaloInputScalesProducer(const edm::ParameterSet&);
       ~L1CaloInputScalesProducer();
 
-      //typedef boost::shared_ptr<L1CaloInputScale> ReturnType;
+      //typedef std::shared_ptr<L1CaloInputScale> ReturnType;
 
-      boost::shared_ptr<L1CaloEcalScale>
+      std::shared_ptr<L1CaloEcalScale>
 	produceEcalScale(const L1CaloEcalScaleRcd&);
-      boost::shared_ptr<L1CaloHcalScale>
+      std::shared_ptr<L1CaloHcalScale>
 	produceHcalScale(const L1CaloHcalScaleRcd&);
    private:
       // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuGMTScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuGMTScalesProducer.h
@@ -14,7 +14,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 // user include files

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleOnlineProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleOnlineProducer.h
@@ -35,7 +35,7 @@ public:
   L1MuTriggerPtScaleOnlineProducer(const edm::ParameterSet&);
   ~L1MuTriggerPtScaleOnlineProducer();
   
-  boost::shared_ptr<L1MuTriggerPtScale> newObject(const std::string& objectKey);
+  std::shared_ptr<L1MuTriggerPtScale> newObject(const std::string& objectKey);
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleProducer.h
@@ -14,7 +14,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 // user include files

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesOnlineProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesOnlineProducer.h
@@ -37,7 +37,7 @@ public:
   L1MuTriggerScalesOnlineProducer(const edm::ParameterSet&);
   ~L1MuTriggerScalesOnlineProducer();
 
-  virtual boost::shared_ptr<L1MuTriggerScales> newObject(
+  virtual std::shared_ptr<L1MuTriggerScales> newObject(
 	const std::string& objectKey ) ;
 
 private:

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesProducer.h
@@ -14,7 +14,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 // user include files

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTrivialProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTrivialProducer.h
@@ -22,7 +22,6 @@
 
 // system include files
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 // user include files

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloEcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloEcalScaleConfigOnlineProd.cc
@@ -41,7 +41,7 @@ class L1CaloEcalScaleConfigOnlineProd :
       L1CaloEcalScaleConfigOnlineProd(const edm::ParameterSet&);
       ~L1CaloEcalScaleConfigOnlineProd();
 
-  virtual boost::shared_ptr< L1CaloEcalScale > newObject(
+  virtual std::shared_ptr< L1CaloEcalScale > newObject(
     const std::string& objectKey ) override ;
 
 
@@ -89,7 +89,7 @@ L1CaloEcalScaleConfigOnlineProd::~L1CaloEcalScaleConfigOnlineProd()
 
 }
 
-boost::shared_ptr< L1CaloEcalScale >
+std::shared_ptr< L1CaloEcalScale >
 L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
@@ -97,11 +97,11 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
      std:: cout << "object Key " << objectKey <<std::endl;
 
      if(objectKey == "NULL" || objectKey == "")  // return default blank ecal scale	 
-        return boost::shared_ptr< L1CaloEcalScale >( ecalScale );
+        return std::shared_ptr< L1CaloEcalScale >( ecalScale );
      if(objectKey == "IDENTITY"){  // return identity ecal scale  
        ecalScale = 0;
        ecalScale = new L1CaloEcalScale(1);
-       return boost::shared_ptr< L1CaloEcalScale >( ecalScale);
+       return std::shared_ptr< L1CaloEcalScale >( ecalScale);
      }
      
 
@@ -136,7 +136,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	|| (paramResults.numberRows()==0) ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloEcalScale key.  Unable to find lutparam dat table" ;
-	 return boost::shared_ptr< L1CaloEcalScale >() ;
+	 return std::shared_ptr< L1CaloEcalScale >() ;
        }
 
     
@@ -168,7 +168,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	 ee_lsb = etSat/1024;
        else {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloEcalScale  LOGIC_ID.  unable to find channel view with appropiate logic id" ;
-	 return boost::shared_ptr< L1CaloEcalScale >() ;
+	 return std::shared_ptr< L1CaloEcalScale >() ;
        }
 
      }
@@ -191,7 +191,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	|| (lutGrpResults.numberRows()%1024 !=0) ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloEcalScale key.  No group info" ;
-	 return boost::shared_ptr< L1CaloEcalScale >() ;
+	 return std::shared_ptr< L1CaloEcalScale >() ;
        }
 
 
@@ -253,7 +253,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	|| (grpMapResults.numberRows()==0) ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloEcalScale key. No fe_config_lut_dat info" ;
-	 return boost::shared_ptr< L1CaloEcalScale >() ;
+	 return std::shared_ptr< L1CaloEcalScale >() ;
        }
 
      nEntries = grpMapResults.numberRows();
@@ -276,7 +276,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   || (paramResults.numberRows()==0) ) // check query successful
 	 {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloEcalScale key.  Unable to find logic_id channel view" ;
-	 return boost::shared_ptr< L1CaloEcalScale >() ;
+	 return std::shared_ptr< L1CaloEcalScale >() ;
        }
        for(int j = 0; j < IDResults.numberRows(); j++){
 
@@ -361,7 +361,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 
  
 // ------------ method called to produce the data  ------------
-     return boost::shared_ptr< L1CaloEcalScale >( ecalScale );
+     return std::shared_ptr< L1CaloEcalScale >( ecalScale );
 }
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(L1CaloEcalScaleConfigOnlineProd);

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -43,9 +43,9 @@ class L1CaloHcalScaleConfigOnlineProd :
       L1CaloHcalScaleConfigOnlineProd(const edm::ParameterSet& iConfig);
       ~L1CaloHcalScaleConfigOnlineProd();
 
-  boost::shared_ptr< L1CaloHcalScale > produce(const L1CaloHcalScaleRcd& iRecord) override ;
+  std::shared_ptr< L1CaloHcalScale > produce(const L1CaloHcalScaleRcd& iRecord) override ;
 
-  virtual boost::shared_ptr< L1CaloHcalScale > newObject(
+  virtual std::shared_ptr< L1CaloHcalScale > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -94,7 +94,7 @@ L1CaloHcalScaleConfigOnlineProd::~L1CaloHcalScaleConfigOnlineProd()
     delete caloTPG;
 }
 
-boost::shared_ptr< L1CaloHcalScale >
+std::shared_ptr< L1CaloHcalScale >
 L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 {
   assert( theTrigTowerGeometry != nullptr );
@@ -104,14 +104,14 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
      edm::LogInfo("L1CaloHcalScaleConfigOnlineProd") << "object Key " << objectKey;
 
      if(objectKey == "NULL" || objectKey == "")  // return default blank ecal scale	 
-       return boost::shared_ptr< L1CaloHcalScale >( hcalScale );
+       return std::shared_ptr< L1CaloHcalScale >( hcalScale );
      if(objectKey == "IDENTITY"){  // return identity ecal scale  
        
        delete hcalScale;
        
        hcalScale = new L1CaloHcalScale(1);
        
-       return boost::shared_ptr< L1CaloHcalScale >( hcalScale);
+       return std::shared_ptr< L1CaloHcalScale >( hcalScale);
      }
   
      std::vector<unsigned int> analyticalLUT(1024, 0);
@@ -162,7 +162,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	|| (paramResults.numberRows()!=1) ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloHcalScale key.  Unable to find lutparam dat table" ;
-	 return boost::shared_ptr< L1CaloHcalScale >() ;
+	 return std::shared_ptr< L1CaloHcalScale >() ;
        }
         
     double hcalLSB, nominal_gain;
@@ -238,7 +238,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	|| (chanResults.numberRows()==0) ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1CaloHcalScale key.  Unable to find lutparam dat table nrows" << chanResults.numberRows() ;
-	 return boost::shared_ptr< L1CaloHcalScale >() ;
+	 return std::shared_ptr< L1CaloHcalScale >() ;
        }
 
 
@@ -335,11 +335,11 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
      hcalScale->print(s);
      edm::LogInfo("L1CaloHcalScaleConfigOnlineProd") << s.str();
 // ------------ method called to produce the data  ------------
-     return boost::shared_ptr< L1CaloHcalScale >( hcalScale );
+     return std::shared_ptr< L1CaloHcalScale >( hcalScale );
 
 }
 
-boost::shared_ptr< L1CaloHcalScale >
+std::shared_ptr< L1CaloHcalScale >
 L1CaloHcalScaleConfigOnlineProd::produce( const L1CaloHcalScaleRcd& iRecord )
 {
   edm::ESHandle<HcalTrigTowerGeometry> pG;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
@@ -72,12 +72,11 @@ L1CaloInputScalesProducer::~L1CaloInputScalesProducer()
 //
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<L1CaloEcalScale>
+std::shared_ptr<L1CaloEcalScale>
 L1CaloInputScalesProducer::produceEcalScale(const L1CaloEcalScaleRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1CaloEcalScale> pL1CaloEcalScale =
-     boost::shared_ptr<L1CaloEcalScale>( new L1CaloEcalScale ) ;
+   auto pL1CaloEcalScale = std::make_shared<L1CaloEcalScale>() ;
 
    std::vector< double >::const_iterator posItr =
      m_ecalEtThresholdsPosEta.begin() ;
@@ -104,12 +103,11 @@ L1CaloInputScalesProducer::produceEcalScale(const L1CaloEcalScaleRcd& iRecord)
 }
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<L1CaloHcalScale>
+std::shared_ptr<L1CaloHcalScale>
 L1CaloInputScalesProducer::produceHcalScale(const L1CaloHcalScaleRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1CaloHcalScale> pL1CaloHcalScale =
-     boost::shared_ptr<L1CaloHcalScale>( new L1CaloHcalScale ) ;
+   auto pL1CaloHcalScale = std::make_shared<L1CaloHcalScale>() ;
 
    std::vector< double >::const_iterator posItr =
      m_hcalEtThresholdsPosEta.begin() ;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1EmEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1EmEtScaleOnlineProd.cc
@@ -36,7 +36,7 @@ class L1EmEtScaleOnlineProd :
       L1EmEtScaleOnlineProd(const edm::ParameterSet&);
       ~L1EmEtScaleOnlineProd();
 
-  virtual boost::shared_ptr< L1CaloEtScale > newObject(
+  virtual std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 
@@ -74,7 +74,7 @@ L1EmEtScaleOnlineProd::~L1EmEtScaleOnlineProd()
 
 }
 
-boost::shared_ptr< L1CaloEtScale >
+std::shared_ptr< L1CaloEtScale >
 L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
@@ -170,7 +170,7 @@ L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 	 scaleResults.numberRows() != 1 ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1EmEtScale key." ;
-	 return boost::shared_ptr< L1CaloEtScale >() ;
+	 return std::shared_ptr< L1CaloEtScale >() ;
        }
      std::vector<double> m_thresholds;
 
@@ -192,7 +192,7 @@ L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 	 lsbResults.numberRows() != 1 ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1EmEtScale key." ;
-	 return boost::shared_ptr< L1CaloEtScale >() ;
+	 return std::shared_ptr< L1CaloEtScale >() ;
        }
 
      double m_lsb = 0.;
@@ -204,7 +204,7 @@ L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 
      // Default objects for Lindsey 
 
-     return boost::shared_ptr< L1CaloEtScale >( new L1CaloEtScale( m_lsb,m_thresholds ) );
+     return std::make_shared<L1CaloEtScale>(m_lsb,m_thresholds);
 }
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1HfRingEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1HfRingEtScaleOnlineProd.cc
@@ -36,7 +36,7 @@ class L1HfRingEtScaleOnlineProd :
       L1HfRingEtScaleOnlineProd(const edm::ParameterSet&);
       ~L1HfRingEtScaleOnlineProd();
 
-  virtual boost::shared_ptr< L1CaloEtScale > newObject(
+  virtual std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 
@@ -74,7 +74,7 @@ L1HfRingEtScaleOnlineProd::~L1HfRingEtScaleOnlineProd()
 
 }
 
-boost::shared_ptr< L1CaloEtScale >
+std::shared_ptr< L1CaloEtScale >
 L1HfRingEtScaleOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
@@ -182,7 +182,7 @@ L1HfRingEtScaleOnlineProd::newObject( const std::string& objectKey )
      }
 
      //~~~~~~~~~ Instantiate new L1HfRingEtScale object. ~~~~~~~~~
-     return boost::shared_ptr< L1CaloEtScale >( new L1CaloEtScale(0xff, 0x7, rgnEtLsb, thresholds ) );
+     return std::make_shared<L1CaloEtScale>(0xff, 0x7, rgnEtLsb, thresholds);
 }
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1HtMissScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1HtMissScaleOnlineProd.cc
@@ -36,7 +36,7 @@ class L1HtMissScaleOnlineProd :
       L1HtMissScaleOnlineProd(const edm::ParameterSet&);
       ~L1HtMissScaleOnlineProd();
 
-  virtual boost::shared_ptr< L1CaloEtScale > newObject(
+  virtual std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 
@@ -74,7 +74,7 @@ L1HtMissScaleOnlineProd::~L1HtMissScaleOnlineProd()
 
 }
 
-boost::shared_ptr< L1CaloEtScale >
+std::shared_ptr< L1CaloEtScale >
 L1HtMissScaleOnlineProd::newObject( const std::string& objectKey )
 {
   using namespace edm::es;
@@ -305,7 +305,7 @@ L1HtMissScaleOnlineProd::newObject( const std::string& objectKey )
      }
 
      // return object
-     return boost::shared_ptr< L1CaloEtScale >( new L1CaloEtScale( 0, 0x7f, rgnEtLsb, thresholds ) );
+     return std::make_shared<L1CaloEtScale>( 0, 0x7f, rgnEtLsb, thresholds );
 
 }
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1JetEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1JetEtScaleOnlineProd.cc
@@ -36,7 +36,7 @@ class L1JetEtScaleOnlineProd :
       L1JetEtScaleOnlineProd(const edm::ParameterSet&);
       ~L1JetEtScaleOnlineProd();
 
-  virtual boost::shared_ptr< L1CaloEtScale > newObject(
+  virtual std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 
@@ -74,7 +74,7 @@ L1JetEtScaleOnlineProd::~L1JetEtScaleOnlineProd()
 
 }
 
-boost::shared_ptr< L1CaloEtScale >
+std::shared_ptr< L1CaloEtScale >
 L1JetEtScaleOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
@@ -237,7 +237,7 @@ L1JetEtScaleOnlineProd::newObject( const std::string& objectKey )
      }
 
      // return object
-     return boost::shared_ptr< L1CaloEtScale >( new L1CaloEtScale( rgnEtLsb, thresholds ) );
+     return std::make_shared<L1CaloEtScale>( rgnEtLsb, thresholds );
 }
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleOnlineProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleOnlineProducer.cc
@@ -36,7 +36,7 @@ L1MuTriggerPtScaleOnlineProducer::~L1MuTriggerPtScaleOnlineProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<L1MuTriggerPtScale> 
+std::shared_ptr<L1MuTriggerPtScale> 
 L1MuTriggerPtScaleOnlineProducer::newObject(const std::string& objectKey )
 {
    using namespace edm::es;
@@ -98,7 +98,7 @@ SQL> describe cms_gt.l1t_scale_muon_pt;
    vector<double> scales;
    h.extractScales(resultRecord, scales);
    
-   boost::shared_ptr<L1MuTriggerPtScale> result( new L1MuTriggerPtScale(m_nbitsPacking, m_signedPacking, m_nBins, scales) );
+   auto result = std::make_shared<L1MuTriggerPtScale>(m_nbitsPacking, m_signedPacking, m_nBins, scales);
    
 #ifdef DEBUG_PT_SCALE
    cout << "PT scale:" << endl << result->getPtScale()->print() << endl;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesOnlineProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesOnlineProducer.cc
@@ -111,7 +111,7 @@ const string PhiScaleHelper::LowMarkColumn = "PHI_DEG_BIN_LOW_0";
 const string PhiScaleHelper::StepColumn = "PHI_DEG_BIN_STEP";
 
 // ------------ method called to produce the data  ------------
-boost::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(const std::string& objectKey ) 
+std::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(const std::string& objectKey ) 
 {
    using namespace edm::es;   
 
@@ -198,8 +198,5 @@ boost::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(
 
    m_scales.setPhiScale(*ptrPhiScale);
 
-   boost::shared_ptr<L1MuTriggerScales> l1muscale =
-     boost::shared_ptr<L1MuTriggerScales>( new L1MuTriggerScales( m_scales ) );
-
-   return l1muscale ;
+   return std::make_shared<L1MuTriggerScales>(m_scales);
 }

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
@@ -41,7 +41,7 @@ class L1RCTChannelMaskOnlineProd :
     : L1ConfigOnlineProdBase< L1RCTChannelMaskRcd, L1RCTChannelMask > (iConfig) {}
   ~L1RCTChannelMaskOnlineProd() {}
   
-  virtual boost::shared_ptr< L1RCTChannelMask > newObject(const std::string& objectKey ) override ;
+  virtual std::shared_ptr< L1RCTChannelMask > newObject(const std::string& objectKey ) override ;
 
 
    private:
@@ -60,7 +60,7 @@ class L1RCTChannelMaskOnlineProd :
 // constructors and destructor
 //
 
-boost::shared_ptr< L1RCTChannelMask >
+std::shared_ptr< L1RCTChannelMask >
 L1RCTChannelMaskOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
@@ -165,7 +165,7 @@ L1RCTChannelMaskOnlineProd::newObject( const std::string& objectKey )
 	 
 
 	 std::cout << " Returened rows " << dcMaskResults.numberRows() <<std::endl;
-	 return boost::shared_ptr< L1RCTChannelMask >() ;
+	 return std::shared_ptr< L1RCTChannelMask >() ;
        }
      
       L1RCTChannelMask* m = new L1RCTChannelMask;
@@ -300,7 +300,7 @@ L1RCTChannelMaskOnlineProd::newObject( const std::string& objectKey )
      //~~~~~~~~~ Instantiate new L1RCTChannelMask object. ~~~~~~~~~
 
 
-     return boost::shared_ptr< L1RCTChannelMask >(m);
+     return std::shared_ptr< L1RCTChannelMask >(m);
 } 
 	
 

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -58,7 +57,7 @@ public:
   L1RCTOmdsFedVectorProducer(const edm::ParameterSet&);
   ~L1RCTOmdsFedVectorProducer();
   
-  typedef boost::shared_ptr<RunInfo> ReturnType;
+  typedef std::shared_ptr<RunInfo> ReturnType;
   
   ReturnType produce(const RunInfoRcd&);
 private:
@@ -113,7 +112,7 @@ L1RCTOmdsFedVectorProducer::produce(const RunInfoRcd& iRecord)
   //  std::cout << "ENTERING L1RCTOmdsFedVectorProducer::produce()" << std::endl;
 
   using namespace edm::es;
-  boost::shared_ptr<RunInfo> pRunInfo ;
+  std::shared_ptr<RunInfo> pRunInfo ;
 
   //  std::cout << "GETTING FED VECTOR FROM OMDS" << std::endl;
   
@@ -124,7 +123,7 @@ L1RCTOmdsFedVectorProducer::produce(const RunInfoRcd& iRecord)
   int runNumber = summary->m_run; 
   
   // CREATING NEW RUNINFO WHICH WILL GET NEW FED VECTOR AND BE RETURNED
-  pRunInfo = boost::shared_ptr<RunInfo>( new RunInfo() ); 
+  pRunInfo = std::make_shared<RunInfo>(); 
   
   
   // DO THE DATABASE STUFF

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersOnlineProd.cc
@@ -38,7 +38,7 @@ class L1RCTParametersOnlineProd :
       L1RCTParametersOnlineProd(const edm::ParameterSet&);
       ~L1RCTParametersOnlineProd();
 
-  virtual boost::shared_ptr< L1RCTParameters > newObject(
+  virtual std::shared_ptr< L1RCTParameters > newObject(
     const std::string& objectKey ) override ;
 
   void fillScaleFactors(
@@ -84,7 +84,7 @@ L1RCTParametersOnlineProd::~L1RCTParametersOnlineProd()
 
 }
 
-boost::shared_ptr< L1RCTParameters >
+std::shared_ptr< L1RCTParameters >
 L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
@@ -133,7 +133,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 	 paremResults.numberRows() != 1 ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1RCTParameters key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
      double eGammaLSB, jetMETLSB, eMinForFGCut, eMaxForFGCut, hOeCut ;
@@ -206,7 +206,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( egammaEcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with EgammaEcal key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaEcal " ;
@@ -236,7 +236,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( egammaHcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with EgammaHcal key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaHcal " ;
@@ -266,7 +266,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( jetmetEcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with JetmetEcal key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "jetmetEcal " ;
@@ -296,7 +296,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( jetmetHcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with JetmetHcal key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "jetmetHcal " ;
@@ -340,7 +340,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
        if( hcalCalibResults.queryFailed() ) {// check query successful
 	 
 	 edm::LogError( "L1-O2O" ) << "Problem with JetmetHcal key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
        
 //      std::cout << "jetmetHcal " ;
@@ -362,7 +362,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( hcalCalibHighResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with hcalHigh key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 
@@ -384,7 +384,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( ecalCalibResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with ecal calib key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
      
@@ -414,7 +414,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( crossTermResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with crossTerms key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
      fillScaleFactors( crossTermResults, crossTermsScaleFactors,6 ) ;
@@ -434,7 +434,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( hoveresmearhighResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with low h over e smear key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaEcal " ;
@@ -456,7 +456,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( hoveresmearlowResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with low h over e smear key." ;
-	 return boost::shared_ptr< L1RCTParameters >() ;
+	 return std::shared_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaEcal " ;
@@ -468,8 +468,8 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 
      // Default objects for Lindsey 
 
-     return boost::shared_ptr< L1RCTParameters >(
-        new L1RCTParameters( eGammaLSB,
+     return std::make_shared< L1RCTParameters >(
+                             eGammaLSB,
                              jetMETLSB,
                              eMinForFGCut,
                              eMaxForFGCut,
@@ -496,7 +496,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 			    crossTermsScaleFactors,
 			     lowHoverE_smear,
 			     highHoverE_smear
-			     ) ) ;
+			     ) ;
 }
 
 //

--- a/L1TriggerConfig/RCTConfigProducers/src/RCTConfigProducers.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/RCTConfigProducers.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -43,13 +42,13 @@ public:
   RCTConfigProducers(const edm::ParameterSet&);
   ~RCTConfigProducers();
   
-  //typedef boost::shared_ptr<L1RCTParameters> ReturnType;
-  //typedef edm::ESProducts< boost::shared_ptr<L1RCTParameters>, boost::shared_ptr<L1RCTChannelMask> > ReturnType;
+  //typedef std::shared_ptr<L1RCTParameters> ReturnType;
+  //typedef edm::ESProducts< std::shared_ptr<L1RCTParameters>, std::shared_ptr<L1RCTChannelMask> > ReturnType;
   
   //ReturnType produce(const L1RCTParametersRcd&);
-  boost::shared_ptr<L1RCTParameters> produceL1RCTParameters(const L1RCTParametersRcd&);
-  boost::shared_ptr<L1RCTChannelMask> produceL1RCTChannelMask(const L1RCTChannelMaskRcd&);
-  boost::shared_ptr<L1RCTNoisyChannelMask> produceL1RCTNoisyChannelMask(const L1RCTNoisyChannelMaskRcd&);
+  std::shared_ptr<L1RCTParameters> produceL1RCTParameters(const L1RCTParametersRcd&);
+  std::shared_ptr<L1RCTChannelMask> produceL1RCTChannelMask(const L1RCTChannelMaskRcd&);
+  std::shared_ptr<L1RCTNoisyChannelMask> produceL1RCTNoisyChannelMask(const L1RCTNoisyChannelMaskRcd&);
 
 private:
   // ----------member data ---------------------------
@@ -173,32 +172,26 @@ RCTConfigProducers::~RCTConfigProducers()
 
 // ------------ method called to produce the data  ------------
 //RCTConfigProducers::ReturnType
-boost::shared_ptr<L1RCTParameters>
+std::shared_ptr<L1RCTParameters>
 RCTConfigProducers::produceL1RCTParameters(const L1RCTParametersRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1RCTParameters> pL1RCTParameters =
-     boost::shared_ptr<L1RCTParameters>( new L1RCTParameters( rctParameters ) ) ;
-   return pL1RCTParameters ;
+   return std::make_shared<L1RCTParameters>( rctParameters ) ;
    //return products( pL1RCTParameters, pL1RCTChannelMask );
 }
 
-boost::shared_ptr<L1RCTChannelMask>
+std::shared_ptr<L1RCTChannelMask>
 RCTConfigProducers::produceL1RCTChannelMask(const L1RCTChannelMaskRcd& iRecord)
 {
   using namespace edm::es;
-   boost::shared_ptr<L1RCTChannelMask> pL1RCTChannelMask =
-     boost::shared_ptr<L1RCTChannelMask>( new L1RCTChannelMask( rctChannelMask ) ) ;
-   return pL1RCTChannelMask ;
+   return std::make_shared<L1RCTChannelMask>( rctChannelMask ) ;
 }
 
-boost::shared_ptr<L1RCTNoisyChannelMask>
+std::shared_ptr<L1RCTNoisyChannelMask>
 RCTConfigProducers::produceL1RCTNoisyChannelMask(const L1RCTNoisyChannelMaskRcd& iRecord)
 {
   using namespace edm::es;
-   boost::shared_ptr<L1RCTNoisyChannelMask> pL1RCTChannelMask =
-     boost::shared_ptr<L1RCTNoisyChannelMask>( new L1RCTNoisyChannelMask( rctNoisyChannelMask ) ) ;
-   return pL1RCTChannelMask ;
+   return std::make_shared<L1RCTNoisyChannelMask>( rctNoisyChannelMask ) ;
 }
 
 

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCBxOrConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCBxOrConfigOnlineProd.cc
@@ -31,7 +31,7 @@ class L1RPCBxOrConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCBxOrConfig
       L1RPCBxOrConfigOnlineProd(const edm::ParameterSet&);
       ~L1RPCBxOrConfigOnlineProd();
 
-  virtual boost::shared_ptr< L1RPCBxOrConfig > newObject(
+  virtual std::shared_ptr< L1RPCBxOrConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -67,16 +67,16 @@ L1RPCBxOrConfigOnlineProd::~L1RPCBxOrConfigOnlineProd()
 
 }
 
-boost::shared_ptr< L1RPCBxOrConfig >
+std::shared_ptr< L1RPCBxOrConfig >
 L1RPCBxOrConfigOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCBxOrConfig object with key "
 			    << objectKey << " not in ORCON!" ;
-  boost::shared_ptr< L1RPCBxOrConfig > pBxOrConfig (new L1RPCBxOrConfig());
+  auto pBxOrConfig = std::make_shared< L1RPCBxOrConfig >();
   pBxOrConfig->setFirstBX(0);
   pBxOrConfig->setLastBX(0);
   return pBxOrConfig;
-//  return boost::shared_ptr< L1RPCBxOrConfig >() ;
+//  return std::shared_ptr< L1RPCBxOrConfig >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionOnlineProd.cc
@@ -38,7 +38,7 @@ class L1RPCConeDefinitionOnlineProd : public L1ConfigOnlineProdBase<
       L1RPCConeDefinitionOnlineProd(const edm::ParameterSet&);
       ~L1RPCConeDefinitionOnlineProd();
 
-  virtual boost::shared_ptr< L1RPCConeDefinition > newObject(
+  virtual std::shared_ptr< L1RPCConeDefinition > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -75,13 +75,13 @@ L1RPCConeDefinitionOnlineProd::~L1RPCConeDefinitionOnlineProd()
 
 }
 
-boost::shared_ptr< L1RPCConeDefinition >
+std::shared_ptr< L1RPCConeDefinition >
 L1RPCConeDefinitionOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCConeDefinition object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1RPCConeDefinition >() ;
+  return std::shared_ptr< L1RPCConeDefinition >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionProducer.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionProducer.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -40,7 +39,7 @@ class L1RPCConeDefinitionProducer : public edm::ESProducer {
       L1RPCConeDefinitionProducer(const edm::ParameterSet&);
       ~L1RPCConeDefinitionProducer();
 
-      typedef boost::shared_ptr<L1RPCConeDefinition> ReturnType;
+      typedef std::shared_ptr<L1RPCConeDefinition> ReturnType;
 
       ReturnType produce(const L1RPCConeDefinitionRcd&);
    private:
@@ -190,7 +189,7 @@ L1RPCConeDefinitionProducer::ReturnType
 L1RPCConeDefinitionProducer::produce(const L1RPCConeDefinitionRcd& iRecord)
 {
    using namespace edm::es;
-   boost::shared_ptr<L1RPCConeDefinition> pL1RPCConeDefinition(new L1RPCConeDefinition);
+   auto pL1RPCConeDefinition = std::make_shared<L1RPCConeDefinition>();
 
    pL1RPCConeDefinition->setFirstTower(m_towerBeg);
    pL1RPCConeDefinition->setLastTower(m_towerEnd);

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCHsbConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCHsbConfigOnlineProd.cc
@@ -31,7 +31,7 @@ class L1RPCHsbConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCHsbConfigRc
       L1RPCHsbConfigOnlineProd(const edm::ParameterSet&);
       ~L1RPCHsbConfigOnlineProd();
 
-  virtual boost::shared_ptr< L1RPCHsbConfig > newObject(
+  virtual std::shared_ptr< L1RPCHsbConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -67,12 +67,12 @@ L1RPCHsbConfigOnlineProd::~L1RPCHsbConfigOnlineProd()
 
 }
 
-boost::shared_ptr< L1RPCHsbConfig >
+std::shared_ptr< L1RPCHsbConfig >
 L1RPCHsbConfigOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCHsbConfig object with key "
 			    << objectKey << " not in ORCON!" ;
-  boost::shared_ptr< L1RPCHsbConfig > pHsbConfig (new L1RPCHsbConfig());
+  auto pHsbConfig = std::make_shared< L1RPCHsbConfig >();
   std::vector<int> hsbconf;
   int mask=3;
   // XX was: i<9, corrected
@@ -80,7 +80,7 @@ L1RPCHsbConfigOnlineProd::newObject( const std::string& objectKey )
   pHsbConfig->setHsbMask(0, hsbconf);
   pHsbConfig->setHsbMask(1, hsbconf);
   return pHsbConfig;
-//  return boost::shared_ptr< L1RPCHsbConfig >() ;
+//  return std::shared_ptr< L1RPCHsbConfig >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCConfigOnlineProd.cc
@@ -38,7 +38,7 @@ class RPCConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCConfigRcd,
       RPCConfigOnlineProd(const edm::ParameterSet&);
       ~RPCConfigOnlineProd();
 
-  virtual boost::shared_ptr< L1RPCConfig > newObject(
+  virtual std::shared_ptr< L1RPCConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -74,13 +74,13 @@ RPCConfigOnlineProd::~RPCConfigOnlineProd()
 
 }
 
-boost::shared_ptr< L1RPCConfig >
+std::shared_ptr< L1RPCConfig >
 RPCConfigOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCConfig object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return boost::shared_ptr< L1RPCConfig >() ;
+  return std::shared_ptr< L1RPCConfig >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"


### PR DESCRIPTION
The only place that the CMS framework still uses boost::shared_ptr is in the interface to the EventSetup system, where std::shared_ptr is also supported. In order to remove this last vestige of boost::shared_ptr,
users of EventSetup need to be converted to std::shared_ptr. This PR does this for L1 packages, and the necessary changes to DB that the L1 changes require. Also, std::make_shared is implemented where it makes sense, because it simplifies the code and saves a memory allocation.
This PR is totally technical.
