### PR TITLE
commented out closestVtx in line 160

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -157,7 +157,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     else if(lPack->vertexRef().isNonnull() )  {
       pDZ        = lPack->dz();
       pD0        = lPack->dxy();
-      closestVtx = &(*(lPack->vertexRef()));
+      //closestVtx = &(*(lPack->vertexRef())); "Value stored to 'closestVtx' is never read"
       pReco.dZ      = pDZ;
       pReco.d0      = pD0;
   


### PR DESCRIPTION
This commit fixes the following error in /CommonTools/PileupAlgos/plugins/PuppiProducer.cc
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_8_1_X_2016-03-29-2300/slc6_amd64_gcc530/llvm-analysis/report-408799.html
