### PR TITLE
Backport of puppi changes from 80X to 76X

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
@@ -1,0 +1,187 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Math/interface/deltaR.h"
+//Main File
+#include "CommonTools/PileupAlgos/plugins/PuppiPhoton.h"
+
+// ------------------------------------------------------------------------------------------
+PuppiPhoton::PuppiPhoton(const edm::ParameterSet& iConfig) {
+  tokenPFCandidates_     = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("candName"));
+  tokenPuppiCandidates_  = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("puppiCandName"));
+  tokenPhotonCandidates_ = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("photonName"));
+  tokenPhotonId_         = consumes<edm::ValueMap<bool>  >(iConfig.getParameter<edm::InputTag>("photonId")); 
+  pt_                    = iConfig.getParameter<double>("pt");
+  dRMatch_               = iConfig.getParameter<std::vector<double> > ("dRMatch");
+  pdgIds_                = iConfig.getParameter<std::vector<int32_t> >("pdgids");
+  usePFRef_              = iConfig.getParameter<bool>("useRefs");
+  weight_                = iConfig.getParameter<double>("weight");
+  useValueMap_           = iConfig.getParameter<bool>("useValueMap");
+  tokenWeights_          = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("weightsName"));
+
+  usePhotonId_  = (iConfig.getParameter<edm::InputTag>("photonId")).label().size() == 0;
+  produces<PFOutputCollection>();
+  produces< edm::ValueMap<reco::CandidatePtr> >(); 
+}
+// ------------------------------------------------------------------------------------------
+PuppiPhoton::~PuppiPhoton(){}
+// ------------------------------------------------------------------------------------------
+void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  edm::Handle<CandidateView> hPhoProduct;
+  iEvent.getByToken(tokenPhotonCandidates_,hPhoProduct);
+  const CandidateView *phoCol = hPhoProduct.product();
+
+  edm::Handle<edm::ValueMap<bool> > photonId;
+  if(usePhotonId_) iEvent.getByToken(tokenPhotonId_,photonId);
+  int iC = -1;
+  std::vector<const reco::Candidate*> phoCands;
+  std::vector<uint16_t> phoIndx;
+
+  // Get PFCandidate Collection
+  edm::Handle<CandidateView> hPFProduct;
+  iEvent.getByToken(tokenPFCandidates_,hPFProduct);
+  const CandidateView *pfCol = hPFProduct.product();
+
+  edm::Handle<CandidateView> hPuppiProduct;
+  iEvent.getByToken(tokenPuppiCandidates_,hPuppiProduct);
+  const CandidateView *pupCol = hPuppiProduct.product();
+  for(CandidateView::const_iterator itPho = phoCol->begin(); itPho!=phoCol->end(); itPho++) {
+    iC++;
+    bool passObject = false;
+    if(itPho->isPhoton() && usePhotonId_)   passObject =  (*photonId)  [phoCol->ptrAt(iC)];
+    if(itPho->pt() < pt_) continue;
+    if(!passObject && usePhotonId_) continue;
+    if(!usePFRef_) phoCands.push_back(&(*itPho)); 
+    if(!usePFRef_) continue;
+    const pat::Photon *pPho = dynamic_cast<const pat::Photon*>(&(*itPho));
+    if(pPho != 0) {
+      for( const edm::Ref<pat::PackedCandidateCollection> & ref : pPho->associatedPackedPFCandidates() ) {
+	if(matchPFCandidate(&(*(pfCol->ptrAt(ref.key()))),&(*itPho))) {
+	  phoIndx.push_back(ref.key());
+	  phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
+	}
+      }
+      continue;
+    }
+    const pat::Electron *pElectron = dynamic_cast<const pat::Electron*>(&(*itPho));
+    if(pElectron != 0) {
+      for( const edm::Ref<pat::PackedCandidateCollection> & ref : pElectron->associatedPackedPFCandidates() ) 
+	if(matchPFCandidate(&(*(pfCol->ptrAt(ref.key()))),&(*itPho)))  {
+	  phoIndx.push_back(ref.key());
+	  phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
+	}
+    }
+  }
+  //Get Weights
+  edm::Handle<edm::ValueMap<float> > pupWeights; 
+  iEvent.getByToken(tokenWeights_,pupWeights);
+  std::auto_ptr<edm::ValueMap<LorentzVector> > p4PupOut(new edm::ValueMap<LorentzVector>());
+  LorentzVectorCollection puppiP4s;
+  std::vector<reco::CandidatePtr> values(hPFProduct->size());
+  int iPF = 0; 
+  std::vector<float> lWeights;
+  static const reco::PFCandidate dummySinceTranslateIsNotStatic;
+  corrCandidates_.reset( new PFOutputCollection );
+  std::vector<int> foundPhoIndex;
+  for(CandidateView::const_iterator itPF = pupCol->begin(); itPF!=pupCol->end(); itPF++) {  
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(itPF->pdgId());
+    const reco::PFCandidate *pPF = dynamic_cast<const reco::PFCandidate*>(&(*itPF));
+    reco::PFCandidate pCand( pPF ? *pPF : reco::PFCandidate(itPF->charge(), itPF->p4(), id) );
+    LorentzVector pVec = itPF->p4();
+    float pWeight = 1.;
+    if(useValueMap_) pWeight  = (*pupWeights)[pupCol->ptrAt(iPF)];     
+    if(!usePFRef_) { 
+      for(std::vector<const reco::Candidate*>::iterator itPho = phoCands.begin(); itPho!=phoCands.end(); itPho++) {
+	if(matchPFCandidate(&(*itPF),*itPho)) pWeight = weight_;
+      }
+    } else { 
+      int iPho = -1;
+      for(std::vector<uint16_t>::const_iterator itPho = phoIndx.begin(); itPho!=phoIndx.end(); itPho++) {
+        iPho++;
+        if(pupCol->refAt(iPF).key() != *itPho) continue;
+        pWeight = weight_;
+        if(!useValueMap_ && itPF->pt() != 0) pWeight = pWeight*(phoCands[iPho]->pt()/itPF->pt());
+        foundPhoIndex.push_back(iPho);      }
+    }
+
+    if(itPF->pt() != 0) pVec.SetPxPyPzE(itPF->px()*pWeight,itPF->py()*pWeight,itPF->pz()*pWeight,itPF->energy()*pWeight);
+
+    lWeights.push_back(pWeight);
+    pCand.setP4(pVec);
+    puppiP4s.push_back( pVec );
+    pCand.setSourceCandidatePtr( itPF->sourceCandidatePtr(0) );
+    corrCandidates_->push_back(pCand);
+    iPF++;
+  }
+  //Add the missing pfcandidates
+  for(unsigned int iPho = 0; iPho < phoCands.size(); iPho++) { 
+    bool pFound = false;
+    for(unsigned int jPho = 0; jPho < foundPhoIndex.size(); jPho++) { 
+      if(foundPhoIndex[jPho] == int(iPho)) {
+	pFound = true;
+	break;
+      }
+    }
+    if(pFound) continue;
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(phoCands[iPho]->pdgId());
+    reco::PFCandidate pCand(reco::PFCandidate(phoCands[iPho]->charge(), phoCands[iPho]->p4(),id) );
+    pCand.setSourceCandidatePtr( phoCands[iPho]->sourceCandidatePtr(0) );
+    LorentzVector pVec = phoCands[iPho]->p4();
+    pVec.SetPxPyPzE(phoCands[iPho]->px()*weight_,phoCands[iPho]->py()*weight_,phoCands[iPho]->pz()*weight_,phoCands[iPho]->energy()*weight_);
+    pCand.setP4(pVec);
+    lWeights.push_back(weight_);
+    puppiP4s.push_back( pVec );
+    corrCandidates_->push_back(pCand);
+  }
+  //Fill it into the event
+  edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( corrCandidates_ );
+  for(unsigned int ic=0, nc = pupCol->size(); ic < nc; ++ic) {
+      reco::CandidatePtr pkref( oh, ic );
+      values[ic] = pkref;
+  }  
+  std::auto_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
+  edm::ValueMap<reco::CandidatePtr>::Filler filler(*pfMap_p);
+  filler.insert(hPFProduct, values.begin(), values.end());
+  filler.fill();
+  iEvent.put(pfMap_p);
+}
+// ------------------------------------------------------------------------------------------
+bool PuppiPhoton::matchPFCandidate(const reco::Candidate *iPF,const reco::Candidate *iPho) { 
+  double lDR = deltaR(iPF->eta(),iPF->phi(),iPho->eta(),iPho->phi());
+  for(unsigned int i0 = 0; i0 < pdgIds_.size(); i0++) {
+    if(std::abs(iPF->pdgId()) == pdgIds_[i0] && lDR < dRMatch_[i0])  return true;
+  }
+  return false;
+}
+// ------------------------------------------------------------------------------------------
+void PuppiPhoton::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(PuppiPhoton);

--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.h
@@ -1,0 +1,48 @@
+#ifndef CommonTools_Puppi_PuppiPhoton_h_
+#define CommonTools_Puppi_PuppiPhoton_h_
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Math/interface/PtEtaPhiMass.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+// ------------------------------------------------------------------------------------------
+class PuppiPhoton : public edm::stream::EDProducer<> {
+
+public:
+	explicit PuppiPhoton(const edm::ParameterSet&);
+	~PuppiPhoton();
+
+	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+	typedef math::XYZTLorentzVector                        LorentzVector;
+	typedef std::vector<LorentzVector>                     LorentzVectorCollection;
+	typedef edm::View<reco::Candidate>                     CandidateView;
+	typedef std::vector< reco::PFCandidate >               PFOutputCollection;
+	typedef edm::View<reco::PFCandidate>                   PFView;
+
+private:
+	virtual void produce(edm::Event&, const edm::EventSetup&);
+	bool matchPFCandidate(const reco::Candidate *iPF,const reco::Candidate *iPho);
+	edm::EDGetTokenT< CandidateView >        tokenPFCandidates_;
+	edm::EDGetTokenT< CandidateView >        tokenPuppiCandidates_;
+	edm::EDGetTokenT< CandidateView >        tokenPhotonCandidates_;
+	edm::EDGetTokenT< edm::ValueMap<float> > tokenWeights_; 
+	edm::EDGetTokenT< edm::ValueMap<bool>  > tokenPhotonId_; 
+	double pt_;
+	bool   usePFRef_;
+	bool   usePhotonId_;
+	std::vector<double>  dRMatch_;
+	std::vector<int32_t> pdgIds_; 
+        std::auto_ptr< PFOutputCollection > corrCandidates_;
+	double weight_;
+	bool   useValueMap_;
+};
+#endif

--- a/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
+++ b/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+
+puppiPhoton = cms.EDProducer("PuppiPhoton",
+                             candName       = cms.InputTag('packedPFCandidates'),
+                             puppiCandName  = cms.InputTag('puppi'),
+                             photonName     = cms.InputTag('slimmedPhotons'),
+                             photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-PHYS14-PU20bx25-V2-standalone-loose"),
+                             pt             = cms.double(10),
+                             useRefs        = cms.bool(True),
+                             dRMatch        = cms.vdouble(10,10,10,10),
+                             pdgids         = cms.vint32 (22,11,211,130),
+                             weight         = cms.double(1.),
+                             useValueMap    = cms.bool(False),
+                             weightsName    = cms.InputTag('puppi'),
+                             )
+
+
+def setupPuppiPhoton(process):
+    my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_PHYS14_PU20bx25_V2_cff']
+    switchOnVIDPhotonIdProducer(process, DataFormat.MiniAOD)
+    for idmod in my_id_modules:
+        setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
+
+
+#puppiPhotonSeq = cms.Sequence(egmPhotonIDSequence*puppiPhoton)

--- a/CommonTools/PileupAlgos/test/testPUMods.py
+++ b/CommonTools/PileupAlgos/test/testPUMods.py
@@ -1,20 +1,26 @@
 import FWCore.ParameterSet.Config as cms
-
 process = cms.Process('TestPUMods')
+
 process.load('Configuration/StandardSequences/Services_cff')
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration/StandardSequences/GeometryDB_cff')
+process.load('Configuration/StandardSequences/MagneticField_38T_cff')
+
 process.MessageLogger.cerr.FwkReport.reportEvery = 10
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.load('CommonTools/PileupAlgos/Puppi_cff')
+process.load('CommonTools/PileupAlgos/PhotonPuppi_cff')
+from CommonTools.PileupAlgos.PhotonPuppi_cff import setupPuppiPhoton
+
 process.load('CommonTools/PileupAlgos/softKiller_cfi')
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source("PoolSource",
 	fileNames  = cms.untracked.vstring(
-		'/store/mc/RunIISpring15DR74/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/GEN-SIM-RECO/AsymptFlat0to50bx25Reco_MCRUN2_74_V9-v3/10000/0009D30B-0207-E511-B581-0026182FD753.root'
+		'/store/relval/CMSSW_7_6_4/RelValZMM_13/MINIAODSIM/76X_mcRun2_asymptotic_v14_reHLTtest2-v1/10000/58882EB9-EEED-E511-8A66-0CC47A4D767E.root'
 		)
 )
 process.source.inputCommands = cms.untracked.vstring("keep *",
@@ -35,8 +41,12 @@ process.puppiNoLep = process.puppi.clone()
 process.puppiNoLep.candName = cms.InputTag('packedPFCandidatesNoLep')
 process.puppiNoLep.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 
+process.load('RecoMET.METProducers.PFMET_cfi')
+process.pfMet.src = cms.InputTag('puppiPhoton')
+setupPuppiPhoton(process)
+process.puppiPhoton.puppiCandName    = 'puppiNoLep'
 
-process.puSequence = cms.Sequence(process.packedPFCandidatesNoLep+process.puppi+process.puppiNoLep)
+process.puSequence = cms.Sequence(process.packedPFCandidatesNoLep*process.puppi*process.puppiNoLep*process.egmPhotonIDSequence*process.puppiPhoton*process.pfMet)
 process.p = cms.Path(process.puSequence)
 process.output = cms.OutputModule("PoolOutputModule",
                                   outputCommands = cms.untracked.vstring('keep *'),

--- a/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
@@ -16,6 +16,7 @@ ak4CaloL1OffsetCorrector = cms.EDProducer(
 ak4PFL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PF')
 ak4PFCHSL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PFchs')
 ak4JPTL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4JPT')
+ak4PFPuppiL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PFPuppi')
 
 # L1 (JPT Offset) CORRECTOR
 ak4L1JPTOffsetCorrector = cms.EDProducer(
@@ -48,6 +49,12 @@ ak4PFCHSL1FastjetCorrector = cms.EDProducer(
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAll' )
     )
 ak4JPTL1FastjetCorrector = ak4CaloL1FastjetCorrector.clone()
+ak4PFPuppiL1FastjetCorrector = cms.EDProducer(
+    'L1FastjetCorrectorProducer',
+    level       = cms.string('L1FastJet'),
+    algorithm   = cms.string('AK4PFPuppi'),
+    srcRho      = cms.InputTag( 'fixedGridRhoFastjetAll' )
+    )
 
 # L2 (relative eta-conformity) CORRECTORS
 ak4CaloL2RelativeCorrector = cms.EDProducer(
@@ -59,6 +66,7 @@ ak4PFL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PF'
 ak4PFCHSL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PFchs' )
 ak4JPTL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4JPT' )
 ak4TrackL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4TRK' )
+ak4PFPuppiL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PFPuppi' )
 
 # L3 (absolute) CORRECTORS
 ak4CaloL3AbsoluteCorrector = cms.EDProducer(
@@ -70,6 +78,7 @@ ak4PFL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK
 ak4PFCHSL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4PFchs' )
 ak4JPTL3AbsoluteCorrector    = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4JPT' )
 ak4TrackL3AbsoluteCorrector  = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4TRK' )
+ak4PFPuppiL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4PFPuppi' )
 
 # Residual CORRECTORS
 ak4CaloResidualCorrector = cms.EDProducer(
@@ -80,6 +89,7 @@ ak4CaloResidualCorrector = cms.EDProducer(
 ak4PFResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PFchs' )
 ak4JPTResidualCorrector = ak4CaloResidualCorrector.clone( algorithm = 'AK4JPT' )
+ak4PFPuppiResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PFPuppi' )
 
 # L6 (semileptonically decaying b-jet) Correction Services
 ak4CaloL6SLBCorrector = cms.EDProducer(
@@ -142,6 +152,13 @@ ak4TrackL2L3Corrector = cms.EDProducer(
 ak4TrackL2L3CorrectorChain = cms.Sequence(
     ak4TrackL2RelativeCorrector * ak4TrackL3AbsoluteCorrector * ak4TrackL2L3Corrector
 )
+ak4PFPuppiL2L3Corrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFPuppiL2RelativeCorrector','ak4PFPuppiL3AbsoluteCorrector')
+    )
+ak4PFPuppiL2L3CorrectorChain = cms.Sequence(
+    ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiL2L3Corrector
+)
 
 # L2L3Residual CORRECTORS
 ak4CaloL2L3ResidualCorrector = cms.EDProducer(
@@ -173,6 +190,13 @@ ak4JPTL2L3ResidualCorrector = cms.EDProducer(
     )
 ak4JPTL2L3ResidualCorrectorChain = cms.Sequence(
     ak4L1JPTOffsetCorrectorChain * ak4JPTL2RelativeCorrector * ak4JPTL3AbsoluteCorrector * ak4JPTResidualCorrector * ak4JPTL2L3ResidualCorrector
+)
+ak4PFPuppiL2L3ResidualCorrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFPuppiL2RelativeCorrector','ak4PFPuppiL3AbsoluteCorrector','ak4PFPuppiResidualCorrector')
+    )
+ak4PFPuppiL2L3ResidualCorrectorChain = cms.Sequence(
+    ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiResidualCorrector * ak4PFPuppiL2L3ResidualCorrector
 )
 
 # L1L2L3 CORRECTORS
@@ -206,6 +230,13 @@ ak4JPTL1L2L3Corrector = cms.EDProducer(
 ak4JPTL1L2L3CorrectorChain = cms.Sequence(
     ak4L1JPTOffsetCorrectorChain * ak4JPTL2RelativeCorrector * ak4JPTL3AbsoluteCorrector * ak4JPTL1L2L3Corrector
 )
+ak4PFPuppiL1L2L3Corrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFPuppiL1OffsetCorrector','ak4PFPuppiL2RelativeCorrector','ak4PFPuppiL3AbsoluteCorrector')
+    )
+ak4PFPuppiL1L2L3CorrectorChain = cms.Sequence(
+    ak4PFPuppiL1OffsetCorrector * ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiL1L2L3Corrector
+)
 
 # L1L2L3Residual CORRECTORS
 ak4CaloL1L2L3ResidualCorrector = cms.EDProducer(
@@ -238,6 +269,13 @@ ak4JPTL1L2L3ResidualCorrector = cms.EDProducer(
 ak4JPTL1L2L3ResidualCorrectorChain = cms.Sequence(
     ak4L1JPTOffsetCorrectorChain * ak4JPTL2RelativeCorrector * ak4JPTL3AbsoluteCorrector * ak4JPTResidualCorrector * ak4JPTL1L2L3ResidualCorrector
 )
+ak4PFPuppiL1L2L3ResidualCorrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFPuppiL1OffsetCorrector','ak4PFPuppiL2RelativeCorrector','ak4PFPuppiL3AbsoluteCorrector','ak4PFPuppiResidualCorrector')
+    )
+ak4PFPuppiL1L2L3ResidualCorrectorChain = cms.Sequence(
+    ak4PFPuppiL1OffsetCorrector * ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiResidualCorrector * ak4PFPuppiL1L2L3ResidualCorrector
+)
 
 # L1L2L3 CORRECTORS WITH FASTJET
 ak4CaloL1FastL2L3Corrector = ak4CaloL2L3Corrector.clone()
@@ -263,6 +301,11 @@ ak4JPTL1FastL2L3Corrector = cms.EDProducer(
     )
 ak4JPTL1FastL2L3CorrectorChain = cms.Sequence(
     ak4JPTL1FastjetCorrector * ak4JPTL2RelativeCorrector * ak4JPTL3AbsoluteCorrector * ak4JPTL1FastL2L3Corrector
+)
+ak4PFPuppiL1FastL2L3Corrector = ak4PFPuppiL2L3Corrector.clone()
+ak4PFPuppiL1FastL2L3Corrector.correctors.insert(0,'ak4PFPuppiL1FastjetCorrector')
+ak4PFPuppiL1FastL2L3CorrectorChain = cms.Sequence(
+    ak4PFPuppiL1FastjetCorrector * ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiL1FastL2L3Corrector
 )
 
 # L1L2L3Residual CORRECTORS WITH FASTJET
@@ -295,6 +338,13 @@ ak4JPTL1FastL2L3ResidualCorrector = cms.EDProducer(
     )
 ak4JPTL1FastL2L3ResidualCorrectorChain = cms.Sequence(
     ak4JPTL1FastjetCorrector * ak4JPTL2RelativeCorrector * ak4JPTL3AbsoluteCorrector * ak4JPTResidualCorrector * ak4JPTL1FastL2L3ResidualCorrector
+)
+ak4PFPuppiL1FastL2L3ResidualCorrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFPuppiL1FastjetCorrector','ak4PFPuppiL2RelativeCorrector','ak4PFPuppiL3AbsoluteCorrector','ak4PFPuppiResidualCorrector')
+    )
+ak4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+    ak4PFPuppiL1FastjetCorrector * ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiResidualCorrector * ak4PFPuppiL1FastL2L3ResidualCorrector
 )
 
 # L2L3L6 CORRECTORS

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -1,0 +1,74 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.PileupAlgos.Puppi_cff import *
+# from CommonTools.PileupAlgos.PhotonPuppi_cff import setupPuppiPhoton
+
+def makePuppies( process ):
+
+    process.load('CommonTools.PileupAlgos.Puppi_cff')
+
+    process.pfNoLepPUPPI = cms.EDFilter("PdgIdCandViewSelector",
+                                        src = cms.InputTag("particleFlow"), 
+                                        pdgId = cms.vint32( 1,2,22,111,130,310,2112,211,-211,321,-321,999211,2212,-2212 )
+                                        )
+    process.pfLeptonsPUPPET = cms.EDFilter("PdgIdCandViewSelector",
+                                           src = cms.InputTag("particleFlow"),
+                                           pdgId = cms.vint32(-11,11,-13,13),
+                                           )
+
+
+    process.puppiNoLep = process.puppi.clone()
+    process.puppiNoLep.candName = cms.InputTag('pfNoLepPUPPI') 
+
+    process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
+
+## puppi met
+    process.puppiForMET = cms.EDProducer("PuppiPhoton",
+                                         candName       = cms.InputTag('packedPFCandidates'),
+                                         puppiCandName  = cms.InputTag('puppi'),
+                                         photonName     = cms.InputTag('slimmedPhotons'),
+                                         photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID_PHYS14_PU20bx25_V2p1-standalone-loose"),
+                                         pt             = cms.double(10),
+                                         useRefs        = cms.bool(True),
+                                         dRMatch        = cms.vdouble(10,10,10,10),
+                                         pdgids         = cms.vint32 (22,11,211,130),
+                                         weight         = cms.double(1.),
+                                         useValueMap    = cms.bool(False),
+                                         weightsName    = cms.InputTag('puppi'),
+                                         )
+    process.puppiForMET.puppiCandName    = 'puppiMerged'
+
+
+
+def makePuppiesFromMiniAOD( process ):
+
+    process.load('CommonTools.PileupAlgos.Puppi_cff')
+
+    process.puppi.candName = cms.InputTag('packedPFCandidates')
+    process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
+# kind of ugly, is there a better way to do this?
+
+    process.pfNoLepPUPPI = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut =  cms.string("abs(pdgId) != 13 && abs(pdgId) != 11 && abs(pdgId) != 15"))
+    process.pfLeptonsPUPPET   = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("abs(pdgId) == 13 || abs(pdgId) == 11 || abs(pdgId) == 15"))
+
+    process.puppiNoLep = process.puppi.clone()
+    process.puppiNoLep.candName = cms.InputTag('pfNoLepPUPPI') 
+
+    process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
+
+## puppi met
+    process.puppiForMET = cms.EDProducer("PuppiPhoton",
+                                         candName       = cms.InputTag('packedPFCandidates'),
+                                         puppiCandName  = cms.InputTag('puppi'),
+                                         photonName     = cms.InputTag('slimmedPhotons'),
+                                         photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID_PHYS14_PU20bx25_V2p1-standalone-loose"),
+                                         pt             = cms.double(10),
+                                         useRefs        = cms.bool(True),
+                                         dRMatch        = cms.vdouble(10,10,10,10),
+                                         pdgids         = cms.vint32 (22,11,211,130),
+                                         weight         = cms.double(1.),
+                                         useValueMap    = cms.bool(False),
+                                         weightsName    = cms.InputTag('puppi'),
+                                         )
+    process.puppiForMET.puppiCandName    = 'puppiMerged'
+    


### PR DESCRIPTION
These are changes to the puppi code in 80X. This includes : 
1. Addition of PuppiPhoton (with all fixes from 80X)
2. Addition of Puppi Jet corrector flags
3. Code to build puppi MET collections for MiniAOD Puppi MET

This does not include : 
1. 80X tune of puppi (with loosened forward particle cuts)
2. Updaed MiniAOD MET reconstruction code for Puppi

The 2 updates below will come with a bigger pull request that also includes the addition of the MET Uncertainties code. 
