### PR TITLE
add selection based on PV error (needed by HI @HLT)

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
@@ -99,10 +99,9 @@ namespace {
 
     float dzErrPV = std::sqrt(dzE*dzE+zPVerr*zPVerr);
     for (int i=2; i>=0; --i) {
+      dzCut[i] = par[i]*dzErrPV; 	
       if (exp[i] != 0)
-	dzCut[i] = par[i]*pow(nLayers,exp[i])*dzErrPV; 
-      else
-	dzCut[i] = par[i]*dzErrPV; 	
+	dzCut[i] *= pow(nLayers,exp[i]);
     }
   }
 
@@ -112,10 +111,9 @@ namespace {
 
     float drErrPV = std::sqrt(drE*drE+rPVerr*rPVerr);
     for (int i=2; i>=0; --i) {
+      drCut[i] = par[i]*drErrPV;
       if (exp[i] != 0)
-	drCut[i] = par[i]*pow(nLayers,exp[i])*drErrPV;
-      else
-	drCut[i] = par[i]*drErrPV;
+	drCut[i] *= pow(nLayers,exp[i]);
     }
 
   }

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
@@ -93,6 +93,33 @@ namespace {
     }
   }
   
+  inline void dzCut_wPVerror_par(reco::Track const & trk, int & nLayers, const float * par, const int * exp, Point const & bestVertexError, float dzCut[]) {
+    float dzE = trk.dzError();
+    float zPVerr = bestVertexError.z();
+
+    float dzErrPV = std::sqrt(dzE*dzE+zPVerr*zPVerr);
+    for (int i=2; i>=0; --i) {
+      if (exp[i] != 0)
+	dzCut[i] = par[i]*pow(nLayers,exp[i])*dzErrPV; 
+      else
+	dzCut[i] = par[i]*dzErrPV; 	
+    }
+  }
+
+  inline void drCut_wPVerror_par(reco::Track const & trk, int & nLayers, const float* par, const int * exp, Point const & bestVertexError, float drCut[]) {
+    float drE = trk.d0Error();
+    float rPVerr = sqrt(bestVertexError.x()*bestVertexError.y()); // shouldn't it be bestVertex.xError()*bestVertex.xError()+bestVertex.yError()*bestVertex.yError() ?!?!?
+
+    float drErrPV = std::sqrt(drE*drE+rPVerr*rPVerr);
+    for (int i=2; i>=0; --i) {
+      if (exp[i] != 0)
+	drCut[i] = par[i]*pow(nLayers,exp[i])*drErrPV;
+      else
+	drCut[i] = par[i]*drErrPV;
+    }
+
+  }
+  
   struct Cuts {
     
     Cuts(const edm::ParameterSet & cfg) {
@@ -111,12 +138,14 @@ namespace {
       fillArrayI(dz_exp,       dz_par,"dz_exp");
       fillArrayF(dz_par1,      dz_par,"dz_par1");
       fillArrayF(dz_par2,      dz_par,"dz_par2");
+      fillArrayF(dzWPVerr_par, dz_par,"dzWPVerr_par");
       edm::ParameterSet dr_par = cfg.getParameter<edm::ParameterSet>("dr_par");
       fillArrayI(dr_exp,       dr_par,"dr_exp");
       fillArrayF(dr_par1,      dr_par,"dr_par1");
       fillArrayF(dr_par2,      dr_par,"dr_par2");
       fillArrayF(d0err,        dr_par,"d0err");
       fillArrayF(d0err_par,    dr_par,"d0err_par");
+      fillArrayF(drWPVerr_par, dr_par,"drWPVerr_par");
     }
     
     
@@ -165,8 +194,28 @@ namespace {
 
 	ret = std::min(ret,cut(dz(trk,bestVertex), maxDzcut,std::less<float>()));
 	if (ret==-1.f) return ret;
+
       }
 
+
+      // parametrized dz and dr cut by using PV error
+      if (dzWPVerr_par[2]<std::numeric_limits<float>::max() || drWPVerr_par[2]<std::numeric_limits<float>::max()) {
+	
+	Point bestVertexError(-1.,-1.,-1.);
+	Point bestVertex = getBestVertex_withError(trk,vertices,bestVertexError,minNVtxTrk); // min number of tracks [2 (=default) for offline, 3 for HLT]
+	
+	float maxDz_par[3];
+	float maxDr_par[3];
+	dzCut_wPVerror_par(trk,nLayers,dzWPVerr_par,dz_exp,bestVertexError, maxDz_par);
+	drCut_wPVerror_par(trk,nLayers,drWPVerr_par,dr_exp,bestVertexError, maxDr_par);
+	
+	ret = std::min(ret,cut(dr(trk,bestVertex), maxDr_par,std::less<float>()));
+	if (ret==-1.f) return ret;
+
+	ret = std::min(ret,cut(dz(trk,bestVertex), maxDr_par,std::less<float>()));
+	if (ret==-1.f) return ret;
+
+      }
 
       // parametrized dz and dr cut by using their error
       if (dz_par1[2]<std::numeric_limits<float>::max() || dr_par1[2]<std::numeric_limits<float>::max()) {
@@ -206,6 +255,7 @@ namespace {
         ret = std::min(ret,cut(dr(trk,bestVertex), maxDr_par,std::less<float>()));	
 	if (ret==-1.f) return ret;
 
+
       }
       if (ret==-1.f) return ret;
 
@@ -233,9 +283,10 @@ namespace {
       desc.add<std::vector<double>>("maxDr",{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()});
 
       edm::ParameterSetDescription dz_par;
-      dz_par.add<std::vector<int>>   ("dz_exp", {std::numeric_limits<int>::max(),  std::numeric_limits<int>::max(),  std::numeric_limits<int>::max()}  ); // par = 4
-      dz_par.add<std::vector<double>>("dz_par1",{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 0.4
-      dz_par.add<std::vector<double>>("dz_par2",{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 0.35
+      dz_par.add<std::vector<int>>   ("dz_exp",      {std::numeric_limits<int>::max(),  std::numeric_limits<int>::max(),  std::numeric_limits<int>::max()}  ); // par = 4
+      dz_par.add<std::vector<double>>("dz_par1",     {std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 0.4
+      dz_par.add<std::vector<double>>("dz_par2",     {std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 0.35
+      dz_par.add<std::vector<double>>("dzWPVerr_par",{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 3.
       desc.add<edm::ParameterSetDescription>("dz_par", dz_par);
 
       edm::ParameterSetDescription dr_par;
@@ -244,6 +295,7 @@ namespace {
       dr_par.add<std::vector<double>>("dr_par2",{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 0.3
       dr_par.add<std::vector<double>>("d0err",     {0.003, 0.003, 0.003});
       dr_par.add<std::vector<double>>("d0err_par", {0.001, 0.001, 0.001});
+      dr_par.add<std::vector<double>>("drWPVerr_par",{std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max()}); // par = 3.
       desc.add<edm::ParameterSetDescription>("dr_par", dr_par);
 
     }
@@ -262,11 +314,13 @@ namespace {
     int   dz_exp[3];
     float dz_par1[3];
     float dz_par2[3];
+    float dzWPVerr_par[3];
     int   dr_exp[3];
     float dr_par1[3];
     float dr_par2[3];
     float d0err[3];
     float d0err_par[3];
+    float drWPVerr_par[3];
   };
 
 

--- a/RecoTracker/FinalTrackSelectors/plugins/getBestVertex.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/getBestVertex.h
@@ -27,7 +27,28 @@ namespace {
 
   }
 
-  /*
+  Point getBestVertex_withError(reco::Track const & trk, reco::VertexCollection const & vertices, Point& error, const size_t minNtracks = 2) {
+
+    Point p_dz(0,0,-99999);
+    float dzmin = std::numeric_limits<float>::max();
+    for(auto const & vertex : vertices) {
+      size_t tracks = vertex.tracksSize();
+      if (tracks < minNtracks) {
+      continue;
+    }
+      float dz = std::abs(trk.dz(vertex.position()));
+      if(dz < dzmin){
+        p_dz = vertex.position();
+	error.SetXYZ(vertex.xError(),vertex.yError(),vertex.zError());
+        dzmin = dz;
+      }
+    }
+
+    return p_dz;
+
+  }
+
+  /* 
     Point getBestVertex(reco::Track const & trk,, VertexCollection const & vertices)  {
 
     //    Point p(0,0,-99999);


### PR DESCRIPTION
backport in 80x PR https://github.com/cms-sw/cmssw/pull/13980

this PR is meant to add the possibility of selecting tracks considering also the PV error
this feature was present in the AnalyticalTrackSelector, and it was missing in the new TrackCutClassifier

in last days, it turned out that it is used by HI
