### PR TITLE
SiPixelDigiValid::analyse: blade number fix

### DIFF
--- a/Validation/TrackerDigis/interface/SiPixelDigiValid.h
+++ b/Validation/TrackerDigis/interface/SiPixelDigiValid.h
@@ -3,7 +3,10 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 
 #include <string>
 
@@ -266,6 +269,7 @@ class  SiPixelDigiValid: public DQMEDAnalyzer {
  
   DQMStore* dbe_;
   edm::EDGetTokenT< edm::DetSetVector<PixelDigi> > edmDetSetVector_PixelDigi_Token_;
+  edm::ESHandle<GeometricSearchTracker> tracker;
 
  
 };

--- a/Validation/TrackerDigis/plugins/BuildFile.xml
+++ b/Validation/TrackerDigis/plugins/BuildFile.xml
@@ -5,6 +5,8 @@
 <use   name="Geometry/Records"/>
 <use   name="boost"/>
 <use   name="root"/>
+<use name="RecoTracker/TkDetLayers" />
+<use name="RecoTracker/Record" />
 <library   file="*.cc" name="ValidationTrackerDigisPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
@@ -285,8 +285,12 @@ void SiPixelDigiValid::analyze(const edm::Event& e, const edm::EventSetup& c){
   edm::ESHandle<TrackerTopology> tTopoHandle;
   c.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
-  // Number of blades TODO: other Geometry-Dependent quantities.
+  // Number of blades and ladders.
+  // TODO: other Geometry-Dependent quantities, e.g. num layers.
   int nblades = tracker->posPixelForwardLayers()[0]->components().size();
+  int nladders1 = tracker->pixelBarrelLayers()[0]->components().size();
+  int nladders2 = tracker->pixelBarrelLayers()[1]->components().size();
+  int nladders3 = tracker->pixelBarrelLayers()[2]->components().size();
 
 
  int ndigiperRingLayer1[8];
@@ -318,19 +322,19 @@ for ( int i =0 ; i< nblades; i++) {
    ndigiZmDisk2PerPanel2[i] = 0;
 }
 
-int ndigilayer1ladders[20];
-int ndigilayer2ladders[32];
-int ndigilayer3ladders[44];
+int ndigilayer1ladders[nladders1];
+int ndigilayer2ladders[nladders2];
+int ndigilayer3ladders[nladders3];
 
-for ( int i =0 ; i< 20; i++) {
+for ( int i =0 ; i< nladders1; i++) {
    ndigilayer1ladders[i]= 0;
 }
 
-for ( int i =0 ; i< 32; i++) {
+for ( int i =0 ; i< nladders2; i++) {
    ndigilayer2ladders[i] = 0;
 }
 
-for ( int i =0 ; i< 44; i++) {
+for ( int i =0 ; i< nladders3; i++) {
    ndigilayer3ladders[i] = 0;
 }
 
@@ -734,15 +738,15 @@ for ( int i =0 ; i< 44; i++) {
          meNdigiZpDisk2PerPanel2_->Fill(ndigiZpDisk2PerPanel2[i]);
     } 
     
-   for (int i =0; i< 20; i++) {
+   for (int i =0; i< nladders1; i++) {
        meDigiMultiLayer1Ladders_->Fill(i+1,ndigilayer1ladders[i]);
    }
 
-   for (int i =0; i< 32; i++) {
+   for (int i =0; i< nladders2; i++) {
        meDigiMultiLayer2Ladders_->Fill(i+1,ndigilayer2ladders[i]);
    }
 
-   for (int i =0; i< 44; i++) {
+   for (int i =0; i< nladders3; i++) {
        meDigiMultiLayer3Ladders_->Fill(i+1,ndigilayer3ladders[i]);
    }
 

--- a/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
@@ -41,6 +41,8 @@ void SiPixelDigiValid::beginJob(){
 
 void SiPixelDigiValid::bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es){
    dbe_ = edm::Service<DQMStore>().operator->();
+   es.get<TrackerRecoGeometryRecord>().get( tracker );
+
 
    if ( dbe_ ) {
      ibooker.setCurrentFolder("TrackerDigisV/TrackerDigis/Pixel");
@@ -278,13 +280,13 @@ void SiPixelDigiValid::endJob() {
   if ( runStandalone && outputFile_.size() != 0 && dbe_ ){dbe_->save(outputFile_);}
 }
 
-
 void SiPixelDigiValid::analyze(const edm::Event& e, const edm::EventSetup& c){
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   c.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
-
+  // Number of blades TODO: other Geometry-Dependent quantities.
+  int nblades = tracker->posPixelForwardLayers()[0]->components().size();
 
 
  int ndigiperRingLayer1[8];
@@ -296,16 +298,16 @@ void SiPixelDigiValid::analyze(const edm::Event& e, const edm::EventSetup& c){
     ndigiperRingLayer3[i] = 0;
  }
 
-int ndigiZpDisk1PerPanel1[24];
-int ndigiZpDisk1PerPanel2[24];
-int ndigiZpDisk2PerPanel1[24];
-int ndigiZpDisk2PerPanel2[24];
-int ndigiZmDisk1PerPanel1[24];
-int ndigiZmDisk1PerPanel2[24];
-int ndigiZmDisk2PerPanel1[24];
-int ndigiZmDisk2PerPanel2[24];
+int ndigiZpDisk1PerPanel1[nblades];
+int ndigiZpDisk1PerPanel2[nblades];
+int ndigiZpDisk2PerPanel1[nblades];
+int ndigiZpDisk2PerPanel2[nblades];
+int ndigiZmDisk1PerPanel1[nblades];
+int ndigiZmDisk1PerPanel2[nblades];
+int ndigiZmDisk2PerPanel1[nblades];
+int ndigiZmDisk2PerPanel2[nblades];
 
-for ( int i =0 ; i< 24; i++) {
+for ( int i =0 ; i< nblades; i++) {
    ndigiZpDisk1PerPanel1[i] = 0;
    ndigiZpDisk1PerPanel2[i] = 0;
    ndigiZpDisk2PerPanel1[i] = 0;
@@ -721,7 +723,7 @@ for ( int i =0 ; i< 44; i++) {
     meDigiMultiLayer3Ring7_->Fill(ndigiperRingLayer3[6]);
     meDigiMultiLayer3Ring8_->Fill(ndigiperRingLayer3[7]);
 
-    for(int i =0; i< 24; i++) {
+    for(int i =0; i< nblades; i++) {
          meNdigiZmDisk1PerPanel1_->Fill(ndigiZmDisk1PerPanel1[i]);
          meNdigiZmDisk1PerPanel2_->Fill(ndigiZmDisk1PerPanel2[i]);
          meNdigiZmDisk2PerPanel1_->Fill(ndigiZmDisk2PerPanel1[i]);


### PR DESCRIPTION
This PR fixes #13858. 

The number of blades (and also ladders) is read from the GeometricSearchTracker structure. This means there is a new dependency to RecoTracker.

While the changes do fix the crash caused by the geometry dependence of this code, they do not fix the actual problem. The change to the ladder counts is more cosmetic to be consistent with the analogous blade counts; it should remove a number of false 0 entries from the result, but the result is not very meaningful for the upgraded detector anyways.
