### PR TITLE
Migrate the temporary 2017 DQM+validation customizations to eras

### DIFF
--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from DQM.Physics.bphysicsOniaDQM_cfi import *
 from DQM.Physics.ewkMuDQM_cfi import *
@@ -34,6 +35,11 @@ dqmPhysics = cms.Sequence( bphysicsOniaDQM
                            *ExoticaDQM
                            *B2GDQM
                            )
+eras.phase1Pixel.toReplaceWith(dqmPhysics, dqmPhysics.copyAndExclude([ # FIXME
+    ewkMuDQM,            # Excessive printouts because 2017 doesn't have HLT yet
+    ewkElecDQM,          # Excessive printouts because 2017 doesn't have HLT yet
+    ewkMuLumiMonitorDQM, # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
 dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # FED integrity Check
 from DQM.SiStripMonitorHardware.siStripFEDCheck_cfi import *
@@ -142,6 +143,9 @@ SiStripDQMTier0 = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackCommon*MonitorTrackResiduals
     *dqmInfoSiStrip)
+eras.phase1Pixel.toReplaceWith(SiStripDQMTier0, SiStripDQMTier0.copyAndExclude([ # FIXME
+    MonitorTrackResiduals # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 SiStripDQMTier0Common = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
@@ -152,6 +156,9 @@ SiStripDQMTier0MinBias = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*MonitorTrackResiduals
     *dqmInfoSiStrip)
+eras.phase1Pixel.toReplaceWith(SiStripDQMTier0MinBias, SiStripDQMTier0MinBias.copyAndExclude([ # FIXME
+    MonitorTrackResiduals # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 
 

--- a/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 siStripCertificationInfo = cms.EDAnalyzer("SiStripCertificationInfo")
 from DQM.SiPixelCommon.SiPixelOfflineDQM_client_cff import *
@@ -26,4 +27,6 @@ crt_dqmoffline = cms.Sequence( siStripCertificationInfo *
                                dataCertificationJetMETSequence *
                                egammaDataCertificationTask *
                                dqmOfflineTriggerCert )
-
+eras.phase1Pixel.toReplaceWith(crt_dqmoffline, crt_dqmoffline.copyAndExclude([ # FIXME
+    dqmOfflineTriggerCert # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+]))

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from CondTools.DQM.DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi import *
 from DQMServices.Components.DQMMessageLoggerClient_cff import *
@@ -51,6 +52,10 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( TrackingOfflineDQMClient *
                                              alcaBeamMonitorClient *
                                              SusyPostProcessorSequence *
                                              runTauEff)
+eras.phase1Pixel.toReplaceWith(DQMOffline_SecondStep_PrePOG, DQMOffline_SecondStep_PrePOG.copyAndExclude([
+    hltOfflineDQMClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+    runTauEff,           # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 DQMOffline_SecondStepPOG = cms.Sequence( dqmRefHistoRootFileGetter *
                                          DQMOffline_SecondStep_PrePOG *
@@ -64,6 +69,9 @@ DQMOffline_SecondStep = cms.Sequence( dqmRefHistoRootFileGetter *
                                       HLTMonitoringClient *
                                       DQMMessageLoggerClientSeq *
                                       dqmFastTimerServiceClient)
+eras.phase1Pixel.toReplaceWith(DQMOffline_SecondStep, DQMOffline_SecondStep.copyAndExclude([
+    HLTMonitoringClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+]))
 
 DQMOffline_SecondStep_FakeHLT = cms.Sequence( DQMOffline_SecondStep )
 DQMOffline_SecondStep_FakeHLT.remove( HLTMonitoringClient )

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from DQMServices.Components.DQMMessageLogger_cfi import *
 from DQMServices.Components.DQMDcsInfo_cfi import *
@@ -31,6 +32,9 @@ DQMOfflinePreDPG = cms.Sequence( dqmDcsInfo *
                                  es_dqm_source_offline *
                                  castorSources *
                                  HcalDQMOfflineSequence )
+eras.phase1Pixel.toReplaceWith(DQMOfflinePreDPG, DQMOfflinePreDPG.copyAndExclude([ # FIXME
+    siPixelOfflineDQM_source, # Pixel DQM needs to be updated for phase1
+]))
 
 DQMOfflineDPG = cms.Sequence( DQMOfflinePreDPG *
                               DQMMessageLogger )
@@ -60,6 +64,11 @@ DQMOfflinePrePOG = cms.Sequence( TrackingDQMSourceTier0 *
                                  dqmPhysics *
                                  produceDenoms *
                                  pfTauRunDQMValidation)
+eras.phase1Pixel.toReplaceWith(DQMOfflinePrePOG, DQMOfflinePrePOG.copyAndExclude([ # FIXME
+    TrackingDQMSourceTier0,  # Tracking DQM needs to be migrated for phase1
+    triggerOfflineDQMSource, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+    pfTauRunDQMValidation,   # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 DQMOfflinePOG = cms.Sequence( DQMOfflinePrePOG *
                               DQMMessageLogger )
@@ -71,6 +80,9 @@ DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            HLTMonitoring *
                            dqmFastTimerServiceLuminosity *
                            DQMMessageLogger )
+eras.phase1Pixel.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([
+    HLTMonitoring # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+]))
 
 DQMOfflineFakeHLT = cms.Sequence( DQMOffline )
 DQMOfflineFakeHLT.remove( HLTMonitoring )
@@ -116,6 +128,9 @@ DQMOfflineCommonSiStripZeroBias = cms.Sequence( dqmDcsInfo *
 DQMOfflineTracking = cms.Sequence( TrackingDQMSourceTier0Common *
                                    pvMonitor
                                  )
+eras.phase1Pixel.toReplaceWith(DQMOfflineTracking, DQMOfflineTracking.copyAndExclude([ # FIXME
+    TrackingDQMSourceTier0Common # Tracking DQM needs to be migrated for phase1
+]))
 DQMOfflineMuon = cms.Sequence( dtSources *
                                rpcTier0Source *
                                cscSources *

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from DQMOffline.JetMET.metDQMConfig_cff     import *
 from DQMOffline.JetMET.jetAnalyzer_cff   import *
@@ -108,6 +109,10 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
                                       CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQM
                                       *METDQMAnalyzerSequence)
+eras.phase1Pixel.toReplaceWith(jetMETDQMOfflineSource, jetMETDQMOfflineSource.copyAndExclude([ # FIXME
+    jetDQMAnalyzerSequence, # Excessive printouts because 2017 doesn't have HLT yet
+    METDQMAnalyzerSequence, # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 jetMETDQMOfflineRedoProductsMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD)
 

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from DQMOffline.Muon.muonRecoOneHLT_cfi import *
 from DQMOffline.Muon.muonEfficiencyAnalyzer_cfi import *
@@ -22,6 +23,9 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             TightMuonEfficiencyAnalyzer*
                             muonPFsequence*
                             muonRecoOneHLT)
+eras.phase1Pixel.toReplaceWith(muonAnalyzer, muonAnalyzer.copyAndExclude([ # FIXME
+    muonRecoOneHLT # Doesn't work because TriggerResults::HLT is missing (because HLT not yet being part of 2017 workflow)
+]))
 
 muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
                                   muonSeedsAnalyzer*

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -1,3 +1,5 @@
+from Configuration.StandardSequences.Eras import eras
+
 from HLTriggerOffline.Tau.Validation.HLTTauPostValidation_cfi import *
 from HLTriggerOffline.Muon.HLTMuonPostVal_cff import *
 from HLTriggerOffline.Egamma.EgammaPostProcessor_cfi import *
@@ -35,6 +37,7 @@ hltpostvalidation = cms.Sequence(
     +HLTSMPPostVal
     +HltBTagPostVal
     )
+eras.phase1Pixel.toReplaceWith(hltpostvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
 
 # fastsim customs
 from Configuration.StandardSequences.Eras import eras

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -1,3 +1,5 @@
+from Configuration.StandardSequences.Eras import eras
+
 from Validation.RecoTrack.HLTmultiTrackValidator_cff import *
 from Validation.RecoVertex.HLTmultiPVvalidator_cff import *
 from HLTriggerOffline.Muon.HLTMuonVal_cff import *
@@ -31,6 +33,7 @@ hltassociation = cms.Sequence(
     +egammaSelectors
     +ExoticaValidationProdSeq
     )
+eras.phase1Pixel.toReplaceWith(hltassociation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
 
 hltvalidation = cms.Sequence(
     HLTMuonVal
@@ -47,11 +50,11 @@ hltvalidation = cms.Sequence(
     +SMPValidationSequence
     +hltbtagValidationSequence
     )
+eras.phase1Pixel.toReplaceWith(hltvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
 
 # some hlt collections have no direct fastsim equivalent
 # remove the dependent modules for now
 # probably it would be rather easy to add or fake these collections
-from Configuration.StandardSequences.Eras import eras
 if eras.fastSim.isChosen():
     hltassociation.remove(hltMultiTrackValidation)
     hltassociation.remove(hltMultiPVValidation)

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -130,38 +130,6 @@ def customise_Digi(process):
 
 # DQM steps change
 def customise_DQM(process,pileup):
-    # FIXME
-    #
-    # These should be added back once somebody checks that they work,
-    # and those that do not, get fixed
-    #
-    # The customizations are done here instead of in the central files
-    # with era because they are temporary
-
-    # Tracking DQM needs to be migrated for phase1
-    process.DQMOfflinePrePOG.remove(process.TrackingDQMSourceTier0)
-    process.DQMOfflineTracking.remove(process.TrackingDQMSourceTier0Common)
-
-    # Pixel DQM needs to be updated for phase1
-    process.DQMOfflinePreDPG.remove(process.siPixelOfflineDQM_source)
-
-    # Doesn't work because TriggerResults::HLT is missing
-    process.muonAnalyzer.remove(process.muonRecoOneHLT)
-
-    # Excessive printouts because 2017 doesn't have HLT yet
-    process.SiStripDQMTier0.remove(process.MonitorTrackResiduals)
-    process.SiStripDQMTier0MinBias.remove(process.MonitorTrackResiduals)
-    process.jetMETDQMOfflineSource.remove(process.jetDQMAnalyzerSequence)
-    process.jetMETDQMOfflineSource.remove(process.METDQMAnalyzerSequence)
-    process.dqmPhysics.remove(process.ewkMuDQM)
-    process.dqmPhysics.remove(process.ewkElecDQM)
-    process.dqmPhysics.remove(process.ewkMuLumiMonitorDQM)
-    process.DQMOfflinePrePOG.remove(process.pfTauRunDQMValidation)
-
-    # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-    process.DQMOffline.remove(process.HLTMonitoring)
-    process.DQMOfflinePrePOG.remove(process.triggerOfflineDQMSource)
-
     # Ok, this customization does not work currently at all
     # Need to be fixed before the tracking DQM can be enabled
     return process
@@ -190,31 +158,6 @@ def customise_DQM(process,pileup):
     return process
 
 def customise_Validation(process):
-    # FIXME
-    #
-    # For starters, include only tracking validation
-    # The rest should be added back once somebody checks that they
-    # work, and those that do not, get fixed
-    #
-    # The customizations are done here instead of in the central files
-    # with era because they are temporary
-    # With era, would modify process.globalValidation
-
-    # Pixel validation needs to be migrated to phase1
-    process.trackingRecHitsValid.remove(process.PixelTrackingRecHitsValid)
-
-    # Excessive printouts because 2017 doesn't have HLT yet
-    process.globalValidation.remove(process.TauValNumeratorAndDenominatorRealData)
-    process.globalValidation.remove(process.TauValNumeratorAndDenominatorRealElectronsData)
-    process.globalValidation.remove(process.TauValNumeratorAndDenominatorRealMuonsData)
-    process.validation.remove(process.TauValNumeratorAndDenominatorRealData)
-    process.validation.remove(process.TauValNumeratorAndDenominatorRealElectronsData)
-    process.validation.remove(process.TauValNumeratorAndDenominatorRealMuonsData)
-
-    # No HLT yet for 2017, so no need to run the validation
-    process.hltassociation = cms.Sequence()
-    process.hltvalidation = cms.Sequence()
-
     # these were migrated in #12359
     if eras.phase1Pixel.isChosen():
         return process
@@ -250,29 +193,6 @@ def customise_Validation_Trackingonly(process):
     return process
 
 def customise_harvesting(process):
-    # FIXME
-    #
-    # These should be added back once they get fixed
-    #
-    # The customizations are done here instead of in the central files
-    # with era because they are temporary
-
-    # Tracking DQM needs to be migrated for phase1
-    process.DQMHarvestTracking.remove(process.TrackingOfflineDQMClient)
-
-    # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-    process.DQMOffline_SecondStep.remove(process.HLTMonitoringClient)
-    process.DQMOffline_SecondStep_PrePOG.remove(process.hltOfflineDQMClient)
-    process.hltpostvalidation = cms.Sequence()
-    process.crt_dqmoffline.remove(process.dqmOfflineTriggerCert)
-
-    # Excessive printouts because 2017 doesn't have HLT yet
-    process.DQMOffline_SecondStep_PrePOG.remove(process.efficienciesRealData)
-    process.DQMOffline_SecondStep_PrePOG.remove(process.efficienciesRealElectronsData)
-    process.DQMOffline_SecondStep_PrePOG.remove(process.efficienciesRealMuonsData)
-    process.DQMOffline_SecondStep_PrePOG.remove(process.normalizePlotsRealMuonsData)
-    process.postValidation.remove(process.runTauEff)
-
     # these were migrated in #12440
     if eras.phase1Pixel.isChosen():
         return process

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from Validation.RecoMuon.PostProcessor_cff import *
 from Validation.RecoTrack.PostProcessorTracker_cfi import *
@@ -35,6 +36,9 @@ postValidation = cms.Sequence(
     + bTagCollectorSequenceMCbcl
     + METPostProcessor
 )
+eras.phase1Pixel.toReplaceWith(postValidation, postValidation.copyAndExclude([ # FIXME
+    runTauEff # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 postValidation_preprod = cms.Sequence(
     recoMuonPostProcessors

--- a/Validation/RecoTau/python/DQMMCValidation_cfi.py
+++ b/Validation/RecoTau/python/DQMMCValidation_cfi.py
@@ -1,3 +1,5 @@
+from Configuration.StandardSequences.Eras import eras
+
 from Validation.RecoTau.dataTypes.ValidateTausOnQCD_cff import *
 from Validation.RecoTau.dataTypes.ValidateTausOnRealData_cff import *
 from Validation.RecoTau.dataTypes.ValidateTausOnRealElectronsData_cff import *
@@ -17,6 +19,11 @@ pfTauRunDQMValidation = cms.Sequence(
     TauValNumeratorAndDenominatorZMM+
     TauValNumeratorAndDenominatorZTT
     )
+eras.phase1Pixel.toReplaceWith(pfTauRunDQMValidation, pfTauRunDQMValidation.copyAndExclude([ # FIXME
+    TauValNumeratorAndDenominatorRealData,          # Excessive printouts because 2017 doesn't have HLT yet
+    TauValNumeratorAndDenominatorRealElectronsData, # Excessive printouts because 2017 doesn't have HLT yet
+    TauValNumeratorAndDenominatorRealMuonsData,     # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 produceDenoms = cms.Sequence(
     produceDenominatorQCD+

--- a/Validation/RecoTrack/python/SiTrackingRecHitsValid_cff.py
+++ b/Validation/RecoTrack/python/SiTrackingRecHitsValid_cff.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPE_cfi import *
 from Validation.RecoTrack.SiPixelTrackingRecHitsValid_cfi import *
 from Validation.RecoTrack.SiStripTrackingRecHitsValid_cfi import *
 trackingRecHitsValid = cms.Sequence(PixelTrackingRecHitsValid*StripTrackingRecHitsValid)
-
+eras.phase1Pixel.toReplaceWith(trackingRecHitsValid, trackingRecHitsValid.copyAndExclude([ # FIXME
+    PixelTrackingRecHitsValid # Pixel validation needs to be migrated to phase1
+]))


### PR DESCRIPTION
Title pretty much says it all. All era-customizations are marked such that they can be found with `git grep "phase1Pixel.*FIXME"`.

These are the last pieces of `phase1TkCustoms` not yet controlled by eras. After this PR, I'll start cleaning up the customize.

Tested in CMSSW_8_1_X_2016-04-07-1100, no changes expected in standard workflows.
