### PR TITLE
Migrate customiseForRunI to era (81X)

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -39,6 +39,7 @@ class Eras (object):
         # phase1Pixel detector.
         self.trackingPhase1 = cms.Modifier()
         self.trackingPhase1PU70 = cms.Modifier()
+        self.trackingLowPU = cms.Modifier()
         
         # This era should not be set by the user with the "--era" command, it's
         # activated automatically if the "--fast" command is used.
@@ -64,6 +65,9 @@ class Eras (object):
         # Phase2dev is everything for the 2023 (2026?) detector that is still in development.
         self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.phase2dev_hgcal, self.phase2dev_muon )
 
+        # Scenarios with low-PU tracking (for B=0T reconstruction)
+        self.Run2_2016_trackingLowPU = cms.ModifierChain(self.Run2_2016, self.trackingLowPU)
+
         # 2017 scenarios with customized tracking for expert use
         # Will be used as reference points for 2017 tracking development
         self.Run2_2017_trackingPhase1PU70 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.trackingPhase1PU70 )
@@ -82,7 +86,7 @@ class Eras (object):
                                 self.phase2_hgcal, self.phase2_muon,
                                 self.phase2dev_common, self.phase2dev_tracker,
                                 self.phase2dev_hgcal, self.phase2dev_muon,
-                                self.trackingPhase1, self.trackingPhase1PU70,
+                                self.trackingLowPU, self.trackingPhase1, self.trackingPhase1PU70,
                                ]
 
 eras=Eras()

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -59,9 +59,10 @@ globalreco_tracking = cms.Sequence(offlineBeamSpot*
                           standalonemuontracking*
                           trackingGlobalReco*
                           vertexreco)
-_globalreco_tracking_Phase1PU70 = globalreco_tracking.copy()
-_globalreco_tracking_Phase1PU70.replace(trackingGlobalReco, recopixelvertexing+trackingGlobalReco)
-eras.trackingPhase1PU70.toReplaceWith(globalreco_tracking, _globalreco_tracking_Phase1PU70)
+_globalreco_tracking_LowPU_Phase1PU70 = globalreco_tracking.copy()
+_globalreco_tracking_LowPU_Phase1PU70.replace(trackingGlobalReco, recopixelvertexing+trackingGlobalReco)
+eras.trackingLowPU.toReplaceWith(globalreco_tracking, _globalreco_tracking_LowPU_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(globalreco_tracking, _globalreco_tracking_LowPU_Phase1PU70)
 
 globalreco = cms.Sequence(globalreco_tracking*
                           hcalGlobalRecoSequence*

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ### load which are the tracks collection 2 be monitored
 from DQM.TrackingMonitorSource.TrackCollections2monitor_cff import *
@@ -174,6 +175,7 @@ for tracks in selectedTracks :
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
     TrackingDQMSourceTier0 += locals()[label]
+eras.trackingLowPU.toReplaceWith(TrackingDQMSourceTier0, TrackingDQMSourceTier0.copyAndExclude([TrackSeedMonjetCoreRegionalStep]))
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
@@ -194,6 +196,7 @@ for tracks in selectedTracks :
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
     TrackingDQMSourceTier0Common += locals()[label]
+eras.trackingLowPU.toReplaceWith(TrackingDQMSourceTier0Common, TrackingDQMSourceTier0Common.copyAndExclude([TrackSeedMonjetCoreRegionalStep]))
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
@@ -215,6 +218,7 @@ for tracks in selectedTracks :
 for step in selectedIterTrackingStep :
     label = 'TrackSeedMon'+str(step)
     TrackingDQMSourceTier0MinBias += locals()[label]
+eras.trackingLowPU.toReplaceWith(TrackingDQMSourceTier0MinBias, TrackingDQMSourceTier0MinBias.copyAndExclude([TrackSeedMonjetCoreRegionalStep]))
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonMB'

--- a/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
+++ b/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
@@ -5,6 +5,9 @@ from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
 caloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbheprereco'))
 ak4CaloJetsForTrk = ak4CaloJets.clone(srcPVs = cms.InputTag('firstStepPrimaryVertices'), src= cms.InputTag('caloTowerForTrk'))
+eras.trackingLowPU.toModify(ak4CaloJetsForTrk,
+    srcPVs = "pixelVertices"
+)
 eras.trackingPhase1PU70.toModify(ak4CaloJetsForTrk,
     srcPVs = "pixelVertices"
 )

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
@@ -17,6 +17,5 @@ SiStripClusterChargeCutTight = cms.PSet(
     value     = cms.double(1945.0) 
 )
 
-eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTiny, SiStripClusterChargeCutNone)
-eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutLoose, SiStripClusterChargeCutNone)
-eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTight, SiStripClusterChargeCutNone)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutLoose, SiStripClusterChargeCutTiny)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTight, SiStripClusterChargeCutTiny)

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterChargeCut_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 SiStripClusterChargeCutNone = cms.PSet(
     value     = cms.double(-1.0)
@@ -16,3 +17,6 @@ SiStripClusterChargeCutTight = cms.PSet(
     value     = cms.double(1945.0) 
 )
 
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTiny, SiStripClusterChargeCutNone)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutLoose, SiStripClusterChargeCutNone)
+eras.trackingLowPU.toReplaceWith(SiStripClusterChargeCutTight, SiStripClusterChargeCutNone)

--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -9,11 +9,12 @@ from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
 recopixelvertexing = cms.Sequence(PixelLayerTriplets*pixelTracks*pixelVertices)
 
-# For Phase1PU70
+# For LowPU and Phase1PU70
 PixelLayerTripletsPreSplitting = PixelLayerTriplets.clone(
     BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
     FPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
 )
-_recopixelvertexing_Phase1PU70 = recopixelvertexing.copy()
-_recopixelvertexing_Phase1PU70.replace(PixelLayerTriplets, PixelLayerTripletsPreSplitting)
-eras.trackingPhase1PU70.toReplaceWith(recopixelvertexing, _recopixelvertexing_Phase1PU70)
+_recopixelvertexing_LowPU_Phase1PU70 = recopixelvertexing.copy()
+_recopixelvertexing_LowPU_Phase1PU70.replace(PixelLayerTriplets, PixelLayerTripletsPreSplitting)
+eras.trackingLowPU.toReplaceWith(recopixelvertexing, _recopixelvertexing_LowPU_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(recopixelvertexing, _recopixelvertexing_LowPU_Phase1PU70)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTrackReconstruction_cfi.py
@@ -36,6 +36,11 @@ PixelTrackReconstructionBlock = cms.PSet (
     )
 )
 
+_OrderedHitsFactoryPSet_LowPU_Phase1PU70 = dict(
+    SeedingLayers = "PixelLayerTripletsPreSplitting",
+    GeneratorPSet = dict(SeedComparitorPSet = dict(clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"))
+)
+eras.trackingLowPU.toModify(PixelTrackReconstructionBlock, OrderedHitsFactoryPSet = _OrderedHitsFactoryPSet_LowPU_Phase1PU70)
 eras.trackingPhase1PU70.toModify(PixelTrackReconstructionBlock,
     SeedMergerPSet = cms.PSet(
         layerList = cms.PSet(refToPSet_ = cms.string('PixelSeedMergerQuadruplets')),
@@ -48,8 +53,5 @@ eras.trackingPhase1PU70.toModify(PixelTrackReconstructionBlock,
         tipMax = 0.05
     ),
     RegionFactoryPSet = dict(RegionPSet = dict(originRadius =  0.02)),
-    OrderedHitsFactoryPSet = dict(
-        SeedingLayers = "PixelLayerTripletsPreSplitting",
-        GeneratorPSet = dict(SeedComparitorPSet = dict(clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"))
-    ),
+    OrderedHitsFactoryPSet = _OrderedHitsFactoryPSet_LowPU_Phase1PU70,
 )

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -315,6 +315,7 @@ photonConvTrajSeedFromSingleLeg.TrackRefitter = cms.InputTag('generalTracks')
 photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrimaryVertices')
 #photonConvTrajSeedFromQuadruplets.TrackRefitter = cms.InputTag('generalTracks')
 #photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertices')
+eras.trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = "pixelVertices")
 eras.trackingPhase1PU70.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag = "pixelVertices")
 
 # TRACKER DATA CONTROL

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
@@ -45,6 +45,14 @@ photonConvTrajSeedFromSingleLeg  = cms.EDProducer("PhotonConversionTrajectorySee
                                                       TTRHBuilder = cms.string('WithTrackAngle')
                                                       )
                                                   )
+eras.trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg,
+    OrderedHitsFactoryPSet = dict(maxElement = 10000),
+    ClusterCheckPSet = dict(
+        MaxNumberOfCosmicClusters = 150000,
+        MaxNumberOfPixelClusters = 20000,
+        cut = "strip < 150000 && pixel < 20000 && (strip < 20000 + 7* pixel)"
+    )
+)
 eras.trackingPhase1PU70.toModify(photonConvTrajSeedFromSingleLeg,
     ClusterCheckPSet = dict(
         MaxNumberOfCosmicClusters = 1000000,

--- a/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/TrackCutClassifier_cff.py
@@ -1,5 +1,8 @@
 from Configuration.StandardSequences.Eras import eras
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import *
+eras.trackingLowPU.toModify(TrackCutClassifier,
+    vertices = "pixelVertices"
+)
 eras.trackingPhase1PU70.toModify(TrackCutClassifier,
     vertices = "pixelVertices"
 )

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -22,6 +22,26 @@ earlyGeneralTracks.inputClassifiers =["initialStep",
                                       "pixelLessStep",
                                       "tobTecStep"
                                       ]
+eras.trackingLowPU.toModify(earlyGeneralTracks,
+    trackProducers = [
+        'initialStepTracks',
+        'lowPtTripletStepTracks',
+        'pixelPairStepTracks',
+        'detachedTripletStepTracks',
+        'mixedTripletStepTracks',
+        'pixelLessStepTracks',
+        'tobTecStepTracks'
+    ],
+    inputClassifiers = [
+        "initialStepSelector",
+        "lowPtTripletStepSelector",
+        "pixelPairStepSelector",
+        "detachedTripletStep",
+        "mixedTripletStep",
+        "pixelLessStepSelector",
+        "tobTecStep"
+    ]
+)
 eras.trackingPhase1.toModify(
     earlyGeneralTracks,
     trackProducers = [

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -90,6 +90,9 @@ multiTrackSelector = cms.EDProducer("MultiTrackSelector",
                                tightMTS,
                                highpurityMTS)
  ) 
+eras.trackingLowPU.toModify(multiTrackSelector,
+    vertices = "pixelVertices"
+)
 eras.trackingPhase1PU70.toModify(multiTrackSelector,
     vertices = "pixelVertices"
 )

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -110,9 +110,6 @@ detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEst
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
-eras.trackingLowPU.toModify(detachedTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -7,17 +7,24 @@ from Configuration.StandardSequences.Eras import eras
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-detachedTripletStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_detachedTripletStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("initialStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag(""),
-    trackClassifier                          = cms.InputTag('initialStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+detachedTripletStepClusters = _detachedTripletStepClustersBase.clone(
+   trackClassifier                          = cms.InputTag('initialStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(detachedTripletStepClusters, _detachedTripletStepClustersBase.clone(
+    trajectories                             = "pixelPairStepTracks",
+    oldClusterRemovalInfo                    = "pixelPairStepClusters",
+    overrideTrkQuals                         = "pixelPairStepSelector:QualityMasks",
+))
 eras.trackingPhase1.toModify(detachedTripletStepClusters,
     trajectories                             = "detachedQuadStepTracks",
     oldClusterRemovalInfo                    = "detachedQuadStepClusters",
@@ -71,14 +78,20 @@ detachedTripletStepSeeds.SeedComparitorPSet = cms.PSet(
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
 #    maxLostHitsFraction = cms.double(1./10.),
 #    constantValueForLostHitsFractionFilter = cms.double(0.701),
     minimumNumberOfHits = 3,
     minPt = 0.075,
+)
+detachedTripletStepTrajectoryFilterBase = _detachedTripletStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
-    )
+)
+eras.trackingLowPU.toReplaceWith(detachedTripletStepTrajectoryFilterBase, _detachedTripletStepTrajectoryFilterBase.clone(
+    maxLostHitsFraction = 1./10.,
+    constantValueForLostHitsFractionFilter = 0.701,
+))
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 detachedTripletStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
 detachedTripletStepTrajectoryFilter = cms.PSet(
@@ -97,6 +110,9 @@ detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEst
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
+eras.trackingLowPU.toModify(detachedTripletStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -109,6 +125,10 @@ detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
+eras.trackingLowPU.toModify(detachedTripletStepTrajectoryBuilder,
+    maxCand = 2,
+    alwaysUseInvalidHits = False,
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -130,6 +150,7 @@ detachedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits
             allowSharedFirstHit = cms.bool(True)
             )
 detachedTripletStepTrackCandidates.TrajectoryCleaner = 'detachedTripletStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(detachedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 
 # TRACK FITTING
@@ -158,6 +179,102 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 detachedTripletStep = ClassifierMerger.clone()
 detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+detachedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'detachedTripletStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter3'),
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedTripletStepVtxLoose',
+            chi2n_par = 1.6,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 1.2, 3.0 ),
+            dz_par1 = ( 1.2, 3.0 ),
+            d0_par2 = ( 1.3, 3.0 ),
+            dz_par2 = ( 1.3, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedTripletStepTrkLoose',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 1.6, 4.0 ),
+            dz_par1 = ( 1.6, 4.0 ),
+            d0_par2 = ( 1.6, 4.0 ),
+            dz_par2 = ( 1.6, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedTripletStepVtxTight',
+            preFilterName = 'detachedTripletStepVtxLoose',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.95, 3.0 ),
+            dz_par1 = ( 0.9, 3.0 ),
+            d0_par2 = ( 1.0, 3.0 ),
+            dz_par2 = ( 1.0, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedTripletStepTrkTight',
+            preFilterName = 'detachedTripletStepTrkLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedTripletStepVtx',
+            preFilterName = 'detachedTripletStepVtxTight',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.85, 3.0 ),
+            dz_par1 = ( 0.8, 3.0 ),
+            d0_par2 = ( 0.9, 3.0 ),
+            dz_par2 = ( 0.9, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedTripletStepTrk',
+            preFilterName = 'detachedTripletStepTrkTight',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 1.0, 4.0 ),
+            dz_par1 = ( 1.0, 4.0 ),
+            d0_par2 = ( 1.0, 4.0 ),
+            dz_par2 = ( 1.0, 4.0 )
+        )
+    ] #end of vpset
+) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+eras.trackingLowPU.toReplaceWith(detachedTripletStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers = [
+        'detachedTripletStepTracks',
+        'detachedTripletStepTracks',
+    ],
+    hasSelector = [1,1],
+    selectedTrackQuals = [
+        cms.InputTag("detachedTripletStepSelector","detachedTripletStepVtx"),
+        cms.InputTag("detachedTripletStepSelector","detachedTripletStepTrk")
+    ],
+    setsToMerge = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
+    writeOnlyTrkQuals =True
+))
 
 DetachedTripletStep = cms.Sequence(detachedTripletStepClusters*
                                    detachedTripletStepSeedLayers*
@@ -166,3 +283,6 @@ DetachedTripletStep = cms.Sequence(detachedTripletStepClusters*
                                    detachedTripletStepTracks*
                                    detachedTripletStepClassifier1*detachedTripletStepClassifier2*
                                    detachedTripletStep)
+_DetachedTripletStep_LowPU = DetachedTripletStep.copyAndExclude([detachedTripletStepClassifier2])
+_DetachedTripletStep_LowPU.replace(detachedTripletStepClassifier1, detachedTripletStepSelector)
+eras.trackingLowPU.toReplaceWith(DetachedTripletStep, _DetachedTripletStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -150,7 +150,7 @@ InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
                                        MeasurementTrackerEvent*
                                        siPixelClusterShapeCache)
 
-# Although InitialStepPreSplitting is not really part of Phase1PU70
+# Although InitialStepPreSplitting is not really part of LowPU/Run1/Phase1PU70
 # tracking, we use it to get siPixelClusters and siPixelRecHits
 # collections for non-splitted pixel clusters. All modules before
 # iterTracking sequence use siPixelClustersPreSplitting and
@@ -159,16 +159,19 @@ InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
 # If siPixelClusters would be defined in
 # RecoLocalTracker.Configuration.RecoLocalTracker_cff, we would have a
 # situation where
-# - Phase1PU70 has siPixelClusters defined in RecoLocalTracker_cff
+# - LowPU/Phase1PU70 has siPixelClusters defined in RecoLocalTracker_cff
 # - everything else has siPixelClusters defined here
 # and this leads to a mess. The way it is done here we have only
 # one place (within Reconstruction_cff) where siPixelClusters
 # module is defined.
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+eras.trackingLowPU.toReplaceWith(siPixelClusters, _siPixelClusters)
 eras.trackingPhase1PU70.toReplaceWith(siPixelClusters, _siPixelClusters)
-eras.trackingPhase1PU70.toReplaceWith(InitialStepPreSplitting, cms.Sequence(
+_InitialStepPreSplitting_LowPU_Phase1PU70 = cms.Sequence(
     siPixelClusters +
     siPixelRecHits +
     MeasurementTrackerEvent +
     siPixelClusterShapeCache
-))
+)
+eras.trackingLowPU.toReplaceWith(InitialStepPreSplitting, _InitialStepPreSplitting_LowPU_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(InitialStepPreSplitting, _InitialStepPreSplitting_LowPU_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -75,9 +75,6 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_c
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
-eras.trackingLowPU.toModify(initialStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-)
 eras.trackingPhase1PU70.toModify(initialStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -113,9 +113,6 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     MaxChi2 = cms.double(9.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
 )
-eras.trackingLowPU.toModify(lowPtTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-)
 eras.trackingPhase1PU70.toModify(lowPtTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -80,9 +80,7 @@ eras.trackingLowPU.toModify(mixedTripletStepSeedLayersA,
         'FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg',
         'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'
     ],
-    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
-    FPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
-    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
 )
 eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersA,
     layerList = [
@@ -154,8 +152,7 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
 )
 eras.trackingLowPU.toModify(mixedTripletStepSeedLayersB,
     layerList = ['BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'],
-    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
-    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
 )
 eras.trackingPhase1.toModify(mixedTripletStepSeedLayersB, layerList = ['BPix3+BPix4+TIB1'])
 eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersB,
@@ -248,7 +245,7 @@ mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 eras.trackingLowPU.toModify(mixedTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 eras.trackingPhase1PU70.toModify(mixedTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -28,6 +28,11 @@ _mixedTripletStepClustersBase = _trackClusterRemover.clone(
 mixedTripletStepClusters = _mixedTripletStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('pixelPairStep',"QualityMasks"),
 )
+eras.trackingLowPU.toReplaceWith(mixedTripletStepClusters, _mixedTripletStepClustersBase.clone(
+    trajectories                             = "detachedTripletStepTracks",
+    oldClusterRemovalInfo                    = "detachedTripletStepClusters",
+    overrideTrkQuals                         = "detachedTripletStep",
+))
 eras.trackingPhase1.toModify(mixedTripletStepClusters,
     trajectories                             = "lowPtTripletStepTracks",
     trackClassifier                          = "lowPtTripletStep:QualityMasks",
@@ -65,6 +70,19 @@ mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(1),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
+)
+eras.trackingLowPU.toModify(mixedTripletStepSeedLayersA,
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg',
+        'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'
+    ],
+    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
+    FPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
 )
 eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersA,
     layerList = [
@@ -110,6 +128,10 @@ mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
+eras.trackingLowPU.toModify(mixedTripletStepSeedsA,
+    RegionFactoryPSet = dict(RegionPSet = dict(originHalfLength = 10.0)),
+    SeedComparitorPSet = dict(ClusterShapeHitFilterName = 'ClusterShapeHitFilter')
+)
 eras.trackingPhase1PU70.toModify(
     mixedTripletStepSeedsA,
     RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)),
@@ -129,6 +151,11 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
+)
+eras.trackingLowPU.toModify(mixedTripletStepSeedLayersB,
+    layerList = ['BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'],
+    BPix = dict(clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))),
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
 )
 eras.trackingPhase1.toModify(mixedTripletStepSeedLayersB, layerList = ['BPix3+BPix4+TIB1'])
 eras.trackingPhase1PU70.toModify(mixedTripletStepSeedLayersB,
@@ -159,6 +186,7 @@ mixedTripletStepSeedsB.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
+eras.trackingLowPU.toModify(mixedTripletStepSeedsB, SeedComparitorPSet = dict(ClusterShapeHitFilterName = 'ClusterShapeHitFilter'))
 eras.trackingPhase1PU70.toModify(
     mixedTripletStepSeedsB,
     RegionFactoryPSet = dict(
@@ -188,7 +216,10 @@ _mixedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Trajec
 )
 mixedTripletStepTrajectoryFilter = _mixedTripletStepTrajectoryFilterBase.clone(
     constantValueForLostHitsFractionFilter = 1.4,
-    )
+)
+eras.trackingLowPU.toReplaceWith(mixedTripletStepTrajectoryFilter, _mixedTripletStepTrajectoryFilterBase.clone(
+    maxLostHits = 0,
+))
 eras.trackingPhase1PU70.toReplaceWith(mixedTripletStepTrajectoryFilter, _mixedTripletStepTrajectoryFilterBase.clone(
     maxLostHits = 0,
 ))
@@ -215,6 +246,9 @@ mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingLowPU.toModify(mixedTripletStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 eras.trackingPhase1PU70.toModify(mixedTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
@@ -255,6 +289,7 @@ mixedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
             allowSharedFirstHit = cms.bool(True)
             )
 mixedTripletStepTrackCandidates.TrajectoryCleaner = 'mixedTripletStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 eras.trackingPhase1PU70.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.095)
 
 
@@ -282,10 +317,95 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 mixedTripletStep = ClassifierMerger.clone()
 mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
 
-# For Phase1PU70
+# For LowPU and Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+# First LowPU
 mixedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
     src = 'mixedTripletStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter4'),
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'mixedTripletStepVtxLoose',
+            chi2n_par = 1.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.2, 3.0 ),
+            dz_par1 = ( 1.2, 3.0 ),
+            d0_par2 = ( 1.3, 3.0 ),
+            dz_par2 = ( 1.3, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'mixedTripletStepTrkLoose',
+            chi2n_par = 0.6,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.2, 4.0 ),
+            dz_par1 = ( 1.2, 4.0 ),
+            d0_par2 = ( 1.2, 4.0 ),
+            dz_par2 = ( 1.2, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'mixedTripletStepVtxTight',
+            preFilterName = 'mixedTripletStepVtxLoose',
+            chi2n_par = 0.6,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 3.0 ),
+            dz_par1 = ( 1.1, 3.0 ),
+            d0_par2 = ( 1.2, 3.0 ),
+            dz_par2 = ( 1.2, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'mixedTripletStepTrkTight',
+            preFilterName = 'mixedTripletStepTrkLoose',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'mixedTripletStepVtx',
+            preFilterName = 'mixedTripletStepVtxTight',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 3.0 ),
+            dz_par1 = ( 1.1, 3.0 ),
+            d0_par2 = ( 1.2, 3.0 ),
+            dz_par2 = ( 1.2, 3.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'mixedTripletStepTrk',
+            preFilterName = 'mixedTripletStepTrkTight',
+            chi2n_par = 0.3,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 0.9, 4.0 ),
+            dz_par1 = ( 0.9, 4.0 ),
+            d0_par2 = ( 0.9, 4.0 ),
+            dz_par2 = ( 0.9, 4.0 )
+        )
+    ] #end of vpset
+) #end of clone
+eras.trackingPhase1PU70.toModify(mixedTripletStepSelector,
+    useAnyMVA = None,
+    GBRForestLabel = None,
     trackSelectors = [
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'mixedTripletStepVtxLoose',
@@ -368,17 +488,21 @@ mixedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
     ] #end of vpset
 ) #end of clone
 
-from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
-eras.trackingPhase1PU70.toReplaceWith(mixedTripletStep, _trackListMerger.clone(
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+_trackListMergerBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = ['mixedTripletStepTracks',
                       'mixedTripletStepTracks'],
     hasSelector = [1,1],
-    shareFrac = cms.double(0.095),
-    indivShareFrac = [0.095,0.095],
     selectedTrackQuals = [cms.InputTag("mixedTripletStepSelector","mixedTripletStepVtx"),
                           cms.InputTag("mixedTripletStepSelector","mixedTripletStepTrk")],
     setsToMerge = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
     writeOnlyTrkQuals = True
+)
+eras.trackingLowPU.toReplaceWith(mixedTripletStep, _trackListMergerBase)
+eras.trackingPhase1PU70.toReplaceWith(mixedTripletStep, _trackListMergerBase.clone(
+    shareFrac = cms.double(0.095),
+    indivShareFrac = [0.095,0.095],
 ))
 
 
@@ -393,6 +517,7 @@ MixedTripletStep = cms.Sequence(chargeCut2069Clusters*mixedTripletStepClusters*
                                 mixedTripletStepTracks*
                                 mixedTripletStepClassifier1*mixedTripletStepClassifier2*
                                 mixedTripletStep)
-_MixedTripletStep_Phase1PU70 = MixedTripletStep.copyAndExclude([chargeCut2069Clusters, mixedTripletStepClassifier1])
-_MixedTripletStep_Phase1PU70.replace(mixedTripletStepClassifier2, mixedTripletStepSelector)
-eras.trackingPhase1PU70.toReplaceWith(MixedTripletStep, _MixedTripletStep_Phase1PU70)
+_MixedTripletStep_LowPU_Phase1PU70 = MixedTripletStep.copyAndExclude([chargeCut2069Clusters, mixedTripletStepClassifier1])
+_MixedTripletStep_LowPU_Phase1PU70.replace(mixedTripletStepClassifier2, mixedTripletStepSelector)
+eras.trackingLowPU.toReplaceWith(MixedTripletStep, _MixedTripletStep_LowPU_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(MixedTripletStep, _MixedTripletStep_LowPU_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -94,8 +94,7 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(3)
     )
 )
-eras.trackingLowPU.toModify(
-    pixelLessStepSeedLayers,
+eras.trackingLowPU.toModify(pixelLessStepSeedLayers,
     layerList = [
         'TIB1+TIB2',
         'TID1_pos+TID2_pos','TID2_pos+TID3_pos',
@@ -103,9 +102,9 @@ eras.trackingLowPU.toModify(
         'TID1_neg+TID2_neg','TID2_neg+TID3_neg',
         'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg','TEC4_neg+TEC5_neg'
     ],
-    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
-    TID = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
-    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
+    TID = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
     MTIB = None,
     MTID = None,
     MTEC = None,
@@ -188,7 +187,7 @@ pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 eras.trackingLowPU.toModify(pixelLessStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -1,20 +1,26 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 ##########################################################################
 # Large impact parameter tracking using TIB/TID/TEC stereo layer seeding #
 ##########################################################################
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-pixelLessStepClusters = trackClusterRemover.clone(
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_pixelLessStepClustersBase = _trackClusterRemover.clone(
     maxChi2                                  = cms.double(9.0),
     trajectories                             = cms.InputTag("mixedTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
     oldClusterRemovalInfo                    = cms.InputTag("mixedTripletStepClusters"),
-    trackClassifier                          = cms.InputTag('mixedTripletStep',"QualityMasks"),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
 )
+pixelLessStepClusters = _pixelLessStepClustersBase.clone(
+    trackClassifier                          = cms.InputTag('mixedTripletStep',"QualityMasks"),
+)
+eras.trackingLowPU.toReplaceWith(pixelLessStepClusters, _pixelLessStepClustersBase.clone(
+    overrideTrkQuals                         = "mixedTripletStep",
+))
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
@@ -88,6 +94,22 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(3)
     )
 )
+eras.trackingLowPU.toModify(
+    pixelLessStepSeedLayers,
+    layerList = [
+        'TIB1+TIB2',
+        'TID1_pos+TID2_pos','TID2_pos+TID3_pos',
+        'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos','TEC4_pos+TEC5_pos',
+        'TID1_neg+TID2_neg','TID2_neg+TID3_neg',
+        'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg','TEC4_neg+TEC5_neg'
+    ],
+    TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TID = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')),
+    MTIB = None,
+    MTID = None,
+    MTEC = None,
+)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
@@ -127,15 +149,36 @@ pixelLessStepSeeds.SeedComparitorPSet = cms.PSet(
             RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
         )
     )
+import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+eras.trackingLowPU.toReplaceWith(pixelLessStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
+    OrderedHitsFactoryPSet = dict(SeedingLayers = 'pixelLessStepSeedLayers'),
+    RegionFactoryPSet = dict(RegionPSet = dict(
+        ptMin = 0.7,
+        originHalfLength = 10.0,
+        originRadius = 2.0,
+    )),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(False),
+        FilterStripHits = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    )
+))
+
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-pixelLessStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_pixelLessStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     maxLostHits = 0,
     minimumNumberOfHits = 4,
-    seedPairPenalty = 1,
     minPt = 0.1
     )
+pixelLessStepTrajectoryFilter = _pixelLessStepTrajectoryFilterBase.clone(
+    seedPairPenalty = 1,
+)
+eras.trackingLowPU.toReplaceWith(pixelLessStepTrajectoryFilter, _pixelLessStepTrajectoryFilterBase)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -143,6 +186,9 @@ pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingLowPU.toModify(pixelLessStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
 # TRACK BUILDING
@@ -176,6 +222,7 @@ pixelLessStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone
     allowSharedFirstHit = cms.bool(True)
     )
 pixelLessStepTrackCandidates.TrajectoryCleaner = 'pixelLessStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(pixelLessStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 
 # TRACK FITTING
@@ -204,6 +251,54 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 pixelLessStep = ClassifierMerger.clone()
 pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
 
+# For LowPU
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='pixelLessStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter5'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'pixelLessStepLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.3, 4.0 ),
+            dz_par1 = ( 1.3, 4.0 ),
+            d0_par2 = ( 1.3, 4.0 ),
+            dz_par2 = ( 1.3, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'pixelLessStepTight',
+            preFilterName = 'pixelLessStepLoose',
+            chi2n_par = 0.35,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'pixelLessStepTight',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.9, 4.0 ),
+            dz_par1 = ( 0.9, 4.0 ),
+            d0_par2 = ( 0.9, 4.0 ),
+            dz_par2 = ( 0.9, 4.0 )
+        ),
+    ),
+    vertices = cms.InputTag("pixelVertices")#end of vpset
+) #end of clone
 
 
 PixelLessStep = cms.Sequence(pixelLessStepClusters*
@@ -213,3 +308,6 @@ PixelLessStep = cms.Sequence(pixelLessStepClusters*
                              pixelLessStepTracks*
                              pixelLessStepClassifier1*pixelLessStepClassifier2*
                              pixelLessStep)
+_PixelLessStep_LowPU = PixelLessStep.copyAndExclude([pixelLessStepClassifier1, pixelLessStepClassifier2])
+_PixelLessStep_LowPU.replace(pixelLessStep, pixelLessStepSelector)
+eras.trackingLowPU.toReplaceWith(PixelLessStep, _PixelLessStep_LowPU)

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -125,7 +125,7 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     pTChargeCutThreshold = cms.double(15.)
 )
 eras.trackingLowPU.toModify(pixelPairStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
 )
 eras.trackingPhase1PU70.toModify(pixelPairStepChi2Est,
     MaxChi2 = 16.0,

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -16,6 +16,9 @@ _pixelPairStepClustersBase = _trackClusterRemover.clone(
 pixelPairStepClusters = _pixelPairStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('lowPtTripletStep',"QualityMasks"),
 )
+eras.trackingLowPU.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
+    overrideTrkQuals                         = "lowPtTripletStepSelector:QualityMasks",
+))
 eras.trackingPhase1PU70.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
     trajectories                             = "mixedTripletStepTracks",
     oldClusterRemovalInfo                    = "mixedTripletStepClusters",
@@ -69,6 +72,12 @@ pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache'),
     )
+eras.trackingLowPU.toModify(pixelPairStepSeeds,
+    RegionFactoryPSet = dict(RegionPSet = dict(
+        VertexCollection = 'pixelVertices',
+        useMultipleScattering = False
+    ))
+)
 eras.trackingPhase1PU70.toModify(pixelPairStepSeeds,
     RegionFactoryPSet = dict(
         RegionPSet = dict(
@@ -84,12 +93,13 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 _pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.1,
-    maxCCCLostHits = 2,
-    )
+)
 pixelPairStepTrajectoryFilterBase = _pixelPairStepTrajectoryFilterBase.clone(
     seedPairPenalty =0,
+    maxCCCLostHits = 2,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
+eras.trackingLowPU.toReplaceWith(pixelPairStepTrajectoryFilterBase, _pixelPairStepTrajectoryFilterBase)
 eras.trackingPhase1PU70.toReplaceWith(pixelPairStepTrajectoryFilterBase, _pixelPairStepTrajectoryFilterBase.clone(
     maxLostHitsFraction = 1./10.,
     constantValueForLostHitsFractionFilter = 0.801,
@@ -114,6 +124,9 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
     pTChargeCutThreshold = cms.double(15.)
 )
+eras.trackingLowPU.toModify(pixelPairStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
+)
 eras.trackingPhase1PU70.toModify(pixelPairStepChi2Est,
     MaxChi2 = 16.0,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
@@ -129,6 +142,7 @@ pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
+eras.trackingLowPU.toModify(pixelPairStepTrajectoryBuilder, maxCand = 2)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -166,10 +180,31 @@ pixelPairStep.src = 'pixelPairStepTracks'
 pixelPairStep.GBRForestLabel = 'MVASelectorIter2_13TeV'
 pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
 
-# For Phase1PU70
+# For LowPU and Phase1PU70
+import RecoTracker.IterativeTracking.LowPtTripletStep_cff
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 pixelPairStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
-    src = 'pixelPairStepTracks',
+    src='pixelPairStepTracks',
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('MVASelectorIter2'),
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'pixelPairStepLoose',
+        ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'pixelPairStepTight',
+            preFilterName = 'pixelPairStepLoose',
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'pixelPairStepTight',
+        ),
+    ),
+    vertices = cms.InputTag("pixelVertices")#end of vpset
+) #end of clone
+eras.trackingPhase1PU70.toModify(pixelPairStepSelector,
+    useAnyMVA = None,
+    GBRForestLabel = None,
     trackSelectors = [
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'pixelPairStepLoose',
@@ -221,6 +256,7 @@ PixelPairStep = cms.Sequence(pixelPairStepClusters*
                          pixelPairStepTrackCandidates*
                          pixelPairStepTracks*
                          pixelPairStep)
-_PixelPairStep_Phase1PU70 = PixelPairStep.copy()
-_PixelPairStep_Phase1PU70.replace(pixelPairStep, pixelPairStepSelector)
-eras.trackingPhase1PU70.toReplaceWith(PixelPairStep, _PixelPairStep_Phase1PU70)
+_PixelPairStep_LowPU_Phase1PU70 = PixelPairStep.copy()
+_PixelPairStep_LowPU_Phase1PU70.replace(pixelPairStep, pixelPairStepSelector)
+eras.trackingLowPU.toReplaceWith(PixelPairStep, _PixelPairStep_LowPU_Phase1PU70)
+eras.trackingPhase1PU70.toReplaceWith(PixelPairStep, _PixelPairStep_LowPU_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -215,7 +215,7 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 eras.trackingLowPU.toModify(tobTecStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 eras.trackingPhase1PU70.toModify(tobTecStepChi2Est,
     MaxChi2 = 9.0,
@@ -441,14 +441,14 @@ tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         skipClusters = cms.InputTag('tobTecStepClusters'),
-        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny'))
     ),
     TEC = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         skipClusters = cms.InputTag('tobTecStepClusters'),
         #    untracked bool useSimpleRphiHitsCleaner = false
         useRingSlector = cms.bool(True),
-        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny')),
         minRing = cms.int32(5),
         maxRing = cms.int32(5)
     )

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -18,6 +18,9 @@ _tobTecStepClustersBase = _trackClusterRemover.clone(
 tobTecStepClusters = _tobTecStepClustersBase.clone(
     trackClassifier                          = cms.InputTag('pixelLessStep',"QualityMasks"),
 )
+eras.trackingLowPU.toReplaceWith(tobTecStepClusters, _tobTecStepClustersBase.clone(
+    overrideTrkQuals                         = "pixelLessStepSelector:QualityMasks",
+))
 eras.trackingPhase1PU70.toReplaceWith(tobTecStepClusters, _tobTecStepClustersBase.clone(
     trajectories                             = "pixelPairStepTracks",
     oldClusterRemovalInfo                    = "pixelPairStepClusters",
@@ -149,8 +152,17 @@ tobTecStepSeedsPair.SeedComparitorPSet = cms.PSet(
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
 tobTecStepSeeds.seedCollections = cms.VInputTag(cms.InputTag('tobTecStepSeedsTripl'),cms.InputTag('tobTecStepSeedsPair'))
-# Phase1PU70
+# LowPU
 import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff
+eras.trackingLowPU.toReplaceWith(tobTecStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
+    OrderedHitsFactoryPSet = dict(SeedingLayers = 'tobTecStepSeedLayers'),
+    RegionFactoryPSet = dict(RegionPSet = dict(
+        ptMin = 0.6,
+        originHalfLength = 30.0,
+        originRadius = 6.0,
+    ))
+))
+# Phase1PU70
 eras.trackingPhase1PU70.toReplaceWith(tobTecStepSeeds, RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff.globalMixedSeeds.clone(
     OrderedHitsFactoryPSet = dict(SeedingLayers = 'tobTecStepSeedLayers'),
     RegionFactoryPSet = dict(
@@ -183,6 +195,9 @@ _tobTecStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFi
 tobTecStepTrajectoryFilter = _tobTecStepTrajectoryFilterBase.clone(
     seedPairPenalty = 1,
 )
+eras.trackingLowPU.toReplaceWith(tobTecStepTrajectoryFilter, _tobTecStepTrajectoryFilterBase.clone(
+    minimumNumberOfHits = 6,
+))
 eras.trackingPhase1PU70.toReplaceWith(tobTecStepTrajectoryFilter, _tobTecStepTrajectoryFilterBase.clone(
     minimumNumberOfHits = 6,
 ))
@@ -198,6 +213,9 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(16.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
+eras.trackingLowPU.toModify(tobTecStepChi2Est,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 eras.trackingPhase1PU70.toModify(tobTecStepChi2Est,
     MaxChi2 = 9.0,
@@ -219,6 +237,16 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
     )
+# Important note for LowPU: in RunI_TobTecStep the
+# inOutTrajectoryFilter parameter is spelled as
+# inOutTrajectoryFilterName, and I suspect it has no effect there. I
+# chose to "fix" the behaviour here, so the era is not fully
+# equivalent to the customize. To restore the customize behaviour,
+# uncomment the following lines
+eras.trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
+    inOutTrajectoryFilter = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.inOutTrajectoryFilter.clone(),
+    inOutTrajectoryFilterName = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter'))
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -242,6 +270,7 @@ tobTecStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
     allowSharedFirstHit = cms.bool(True)
     )
 tobTecStepTrackCandidates.TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
+eras.trackingLowPU.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 eras.trackingPhase1PU70.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.08)
 
 # TRACK FITTING AND SMOOTHING OPTIONS
@@ -253,6 +282,7 @@ tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFi
     Fitter = cms.string('tobTecStepRKFitter'),
     Smoother = cms.string('tobTecStepRKSmoother')
     )
+eras.trackingLowPU.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
 eras.trackingPhase1PU70.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
 
 tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
@@ -266,7 +296,9 @@ tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.
     ComponentName = cms.string('tobTecStepRKFitter'),
     minHits = 7
 )
+eras.trackingLowPU.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
 eras.trackingPhase1PU70.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
+
 tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
     ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -277,7 +309,9 @@ tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cf
     errorRescaling = 10.0,
     minHits = 7
 )
+eras.trackingLowPU.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
 eras.trackingPhase1PU70.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
+
 tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
     ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),
     Propagator = cms.string('PropagatorWithMaterialForLoopers'),
@@ -318,6 +352,52 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 tobTecStep = ClassifierMerger.clone()
 tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
 
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+eras.trackingLowPU.toReplaceWith(tobTecStep, RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'tobTecStepTracks',
+    useAnyMVA = cms.bool(False),
+    GBRForestLabel = cms.string('MVASelectorIter6'),
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'tobTecStepLoose',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 2.0, 4.0 ),
+            dz_par1 = ( 1.8, 4.0 ),
+            d0_par2 = ( 2.0, 4.0 ),
+            dz_par2 = ( 1.8, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'tobTecStepTight',
+            preFilterName = 'tobTecStepLoose',
+            chi2n_par = 0.3,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.5, 4.0 ),
+            dz_par1 = ( 1.4, 4.0 ),
+            d0_par2 = ( 1.5, 4.0 ),
+            dz_par2 = ( 1.4, 4.0 )
+        ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'QualityMasks',
+            preFilterName = 'tobTecStepTight',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 2,
+            d0_par1 = ( 1.4, 4.0 ),
+            dz_par1 = ( 1.3, 4.0 ),
+            d0_par2 = ( 1.4, 4.0 ),
+            dz_par2 = ( 1.3, 4.0 )
+        ),
+    ] #end of vpset
+)) #end of clone
 
 
 
@@ -334,7 +414,7 @@ TobTecStep = cms.Sequence(tobTecStepClusters*
 
 
 
-### Following are specific for Phase1PU70, they're collected here to
+### Following are specific for LowPU and/or Phase1PU70, they're collected here to
 ### not to interfere too much with the default configuration
 # For Phase1PU70
 tobTecStepSeedClusters = _trackClusterRemover.clone(
@@ -360,18 +440,28 @@ tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'),
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        skipClusters = cms.InputTag('tobTecStepSeedClusters'),
+        skipClusters = cms.InputTag('tobTecStepClusters'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
     ),
     TEC = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        skipClusters = cms.InputTag('tobTecStepSeedClusters'),
+        skipClusters = cms.InputTag('tobTecStepClusters'),
         #    untracked bool useSimpleRphiHitsCleaner = false
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
         minRing = cms.int32(5),
         maxRing = cms.int32(5)
     )
+)
+eras.trackingPhase1PU70.toModify(tobTecStepSeedLayers,
+    TOB = dict(
+        skipClusters = 'tobTecStepSeedClusters',
+        clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    ),
+    TEC = dict(
+        skipClusters = 'tobTecStepSeedClusters',
+        clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
+    ),
 )
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
@@ -421,6 +511,14 @@ tobTecStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.mult
     ] #end of vpset
 ) #end of clone
 
+eras.trackingLowPU.toReplaceWith(TobTecStep, cms.Sequence(
+    tobTecStepClusters*
+    tobTecStepSeedLayers*
+    tobTecStepSeeds*
+    tobTecStepTrackCandidates*
+    tobTecStepTracks*
+    tobTecStep
+))
 eras.trackingPhase1PU70.toReplaceWith(TobTecStep, cms.Sequence(
     tobTecStepClusters*
     tobTecStepSeedClusters*

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -243,10 +243,10 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
 # chose to "fix" the behaviour here, so the era is not fully
 # equivalent to the customize. To restore the customize behaviour,
 # uncomment the following lines
-eras.trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
-    inOutTrajectoryFilter = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.inOutTrajectoryFilter.clone(),
-    inOutTrajectoryFilterName = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter'))
-)
+#eras.trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
+#    inOutTrajectoryFilter = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.inOutTrajectoryFilter.clone(),
+#    inOutTrajectoryFilterName = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter'))
+#)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -40,6 +40,7 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
 
 from Configuration.StandardSequences.Eras import eras
 eras.trackingLowPU.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStepPreSplitting*
     InitialStep*
     LowPtTripletStep*
     PixelPairStep*

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -39,6 +39,21 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
                             )
 
 from Configuration.StandardSequences.Eras import eras
+eras.trackingLowPU.toReplaceWith(iterTracking, cms.Sequence(
+    InitialStep*
+    LowPtTripletStep*
+    PixelPairStep*
+    DetachedTripletStep*
+    MixedTripletStep*
+    PixelLessStep*
+    TobTecStep*
+    earlyGeneralTracks*
+    muonSeededStep*
+    preDuplicateMergingGeneralTracks*
+    generalTracksSequence*
+    ConvStep*
+    conversionStepTracks
+))
 eras.trackingPhase1.toReplaceWith(iterTracking, cms.Sequence(
     InitialStepPreSplitting +
     InitialStep +

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 RegionPSetWithVerticesBlock = cms.PSet(
     RegionPSet = cms.PSet(
@@ -16,4 +17,6 @@ RegionPSetWithVerticesBlock = cms.PSet(
         nSigmaZ = cms.double(4.0)
     )
 )
-
+eras.trackingLowPU.toModify(RegionPSetWithVerticesBlock,
+    RegionPSet = dict(VertexCollection = "pixelVertices")
+)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -35,6 +35,18 @@ _algos = [
     "muonSeededStepOutIn",
     "duplicateMerge",
 ]
+_algos_trackingLowPU = [
+    "generalTracks",
+    "initialStep",
+    "lowPtTripletStep",
+    "pixelPairStep",
+    "detachedTripletStep",
+    "mixedTripletStep",
+    "pixelLessStep",
+    "tobTecStep",
+    "muonSeededStepInOut",
+    "muonSeededStepOutIn",
+]
 _algos_trackingPhase1 = [
     "generalTracks",
     "initialStep",
@@ -87,6 +99,18 @@ _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "muonSeededSeedsOutIn"]
 _seedProducers_fastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
 
+_seedProducers_trackingLowPU = [
+    "initialStepSeeds",
+    "lowPtTripletStepSeeds",
+    "pixelPairStepSeeds",
+    "detachedTripletStepSeeds",
+    "mixedTripletStepSeedsA",
+    "mixedTripletStepSeedsB",
+    "pixelLessStepSeeds",
+    "tobTecStepSeeds",
+    "muonSeededSeedsInOut",
+    "muonSeededSeedsOutIn",
+]
 _seedProducers_trackingPhase1 = [
     "initialStepSeedsPreSplitting",
     "initialStepSeeds",
@@ -138,6 +162,17 @@ _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "muonSeededTracksOutIn"]
 _trackProducers_fastSim = [ x for x in _trackProducers if x not in _removeForFastTrackProducers]
 
+_trackProducers_trackingLowPU = [
+    "initialStepTracks",
+    "lowPtTripletStepTracks",
+    "pixelPairStepTracks",
+    "detachedTripletStepTracks",
+    "mixedTripletStepTracks",
+    "pixelLessStepTracks",
+    "tobTecStepTracks",
+    "muonSeededTracksInOut",
+    "muonSeededTracksOutIn",
+]
 _trackProducers_trackingPhase1 = [
     "initialStepTracksPreSplitting",
     "initialStepTracks",
@@ -255,6 +290,7 @@ def _eraPostfix(era):
     return (era, "_"+era)
 _relevantEras = [
     _eraPostfix(""),
+    _eraPostfix("trackingLowPU"),
     _eraPostfix("trackingPhase1"),
     _eraPostfix("trackingPhase1PU70"),
 ]


### PR DESCRIPTION
This PR is a partial forward-port of #13945, that is, migrating `RecoTracker/Configuration/customiseForRunI.customiseForRunI` to `Run2_2016_trackingLowPU` era (I'll leave the DataProcessing part for @slava77 to do). I should also note that the "erafication" is not fully equivalent to the customize:
- bugfix in TobTecStep: https://github.com/cms-sw/cmssw/commit/a36e96f5103ec633ede3ba6f70f6c992a2263132
- CCC is set to Tiny instead of None
  - as a (precautionary) workaround for 0-charge strip clusters (see https://github.com/cms-sw/cmssw/pull/13945#issuecomment-206525824 for more details)

Compared to #13945, the new configuration code is a bit tidied up, and the tracking validation is also included (was much easier to do here than in 80X thanks to the earlier phase1 era work).

Tested in 8_1_0_pre2 (rebased on top of CMSSW_8_1_X_2016-04-19-2300), no changes expected in standard workflows.

@rovere @VinInn 
