### PR TITLE
PCL SiPixel Alignment: integration of quality checks on payload and DQM module

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -38,6 +38,7 @@
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h"
 
 /*** Geometry ***/
 #include "Geometry/TrackingGeometryAligner/interface/GeometryAligner.h"
@@ -89,6 +90,9 @@ PCLTrackerAlProducer
   tkLasBeamTag_            (config.getParameter<edm::InputTag>("tkLasBeamTag")),
   clusterValueMapTag_      (config.getParameter<edm::InputTag>("hitPrescaleMapTag")),
   theFirstRun              (cond::timeTypeSpecs[cond::runnumber].endValue)
+
+  //millePedeLogFile_(config.getUntrackedParameter<std::string>("millePedeLogFile")),
+  //millePedeResFile_(config.getUntrackedParameter<std::string>("millePedeResFile"))
 {
   
   tjTkAssociationMapToken = consumes<TrajTrackAssociationCollection>(tjTkAssociationMapTag_);
@@ -985,7 +989,13 @@ void PCLTrackerAlProducer
                             << "Terminating algorithm.";
   theAlignmentAlgo->terminate();
 
-  storeAlignmentsToDB();
+  MillePedeFileReader mpReader(
+    theParameterSet.getParameter<edm::ParameterSet>("millePedeFileReaderConfig")
+  );
+  mpReader.read();
+  if (mpReader.storeAlignments()) {
+    storeAlignmentsToDB();
+  }
 }
 
 //_____________________________________________________________________________

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -90,9 +90,6 @@ PCLTrackerAlProducer
   tkLasBeamTag_            (config.getParameter<edm::InputTag>("tkLasBeamTag")),
   clusterValueMapTag_      (config.getParameter<edm::InputTag>("hitPrescaleMapTag")),
   theFirstRun              (cond::timeTypeSpecs[cond::runnumber].endValue)
-
-  //millePedeLogFile_(config.getUntrackedParameter<std::string>("millePedeLogFile")),
-  //millePedeResFile_(config.getUntrackedParameter<std::string>("millePedeResFile"))
 {
   
   tjTkAssociationMapToken = consumes<TrajTrackAssociationCollection>(tjTkAssociationMapTag_);
@@ -989,12 +986,17 @@ void PCLTrackerAlProducer
                             << "Terminating algorithm.";
   theAlignmentAlgo->terminate();
 
-  MillePedeFileReader mpReader(
-    theParameterSet.getParameter<edm::ParameterSet>("MillePedeFileReader")
-  );
-  mpReader.read();
-  if (mpReader.storeAlignments()) {
-    storeAlignmentsToDB();
+  if (saveToDB_ || saveApeToDB_ || saveDeformationsToDB_) {
+    // if this is not the harvesting step there is no reason to look for the PEDE log and res files and to call the storeAlignmentsToDB method
+    MillePedeFileReader mpReader(theParameterSet.getParameter<edm::ParameterSet>("MillePedeFileReader"));
+    mpReader.read();
+    if (mpReader.storeAlignments()) {
+      storeAlignmentsToDB();
+    }
+  } else {
+    edm::LogInfo("Alignment") << "@SUB=PCLTrackerAlProducer::finish"
+			      << "no payload to be stored!";
+
   }
 }
 

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -990,7 +990,7 @@ void PCLTrackerAlProducer
   theAlignmentAlgo->terminate();
 
   MillePedeFileReader mpReader(
-    theParameterSet.getParameter<edm::ParameterSet>("millePedeFileReaderConfig")
+    theParameterSet.getParameter<edm::ParameterSet>("MillePedeFileReader")
   );
   mpReader.read();
   if (mpReader.storeAlignments()) {

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
@@ -263,7 +263,12 @@ class PCLTrackerAlProducer : public edm::EDAnalyzer {
     edm::EDGetTokenT<TkFittedLasBeamCollection> tkLasBeamToken;
     edm::EDGetTokenT<TsosVectorCollection> tsosVectorToken;
     edm::EDGetTokenT<AliClusterValueMap> clusterValueMapToken;
- 
+    cond::Time_t theFirstRun;
+
+    // file-names
+    //std::string millePedeLogFile_ = "millepede.log";
+    //std::string millePedeResFile_ = "millepede.res";
+
 
     /*** ESWatcher ***/
 
@@ -287,7 +292,6 @@ class PCLTrackerAlProducer : public edm::EDAnalyzer {
     edm::ESWatcher<CSCSurveyErrorExtendedRcd>     watchCSCSurveyErrExtRcd;
 
 
-    cond::Time_t theFirstRun; 
 
     /*** Survey stuff ***/
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -13,6 +13,9 @@ from Alignment.MillePedeAlignmentAlgorithm.MillePedeAlignmentAlgorithm_cfi impor
 from Alignment.CommonAlignmentProducer.TrackerAlignmentProducerForPCL_cff import AlignmentProducer
 SiPixelAliPedeAlignmentProducer = copy.deepcopy(AlignmentProducer)
 
+from Alignment.MillePedeAlignmentAlgorithm.MillePedeDQMModule_cff import *
+
+
 SiPixelAliPedeAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
     alignParams = cms.vstring(
         'TrackerTPBHalfBarrel,111111',
@@ -56,4 +59,5 @@ SiPixelAliPedeAlignmentProducer.saveToDB = True
 
 
 ALCAHARVESTSiPixelAli = cms.Sequence(SiPixelAliMilleFileExtractor*
-                                     SiPixelAliPedeAlignmentProducer)
+                                     SiPixelAliPedeAlignmentProducer*
+                                     SiPixelAliDQMModule)

--- a/Alignment/CommonAlignmentProducer/python/TrackerAlignmentProducerForPCL_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/TrackerAlignmentProducerForPCL_cff.py
@@ -10,6 +10,7 @@ from Alignment.MillePedeAlignmentAlgorithm.MillePedeAlignmentAlgorithm_cfi impor
 #from Alignment.KalmanAlignmentAlgorithm.KalmanAlignmentAlgorithm_cfi import *
 # parameters
 from Alignment.CommonAlignmentAlgorithm.AlignmentParameterStore_cfi import *
+from Alignment.MillePedeAlignmentAlgorithm.MillePedeFileReader_cfi import *
 
 #looper = cms.Looper("AlignmentProducer",
 AlignmentProducer = cms.EDAnalyzer("PCLTrackerAlProducer",
@@ -76,5 +77,8 @@ AlignmentProducer = cms.EDAnalyzer("PCLTrackerAlProducer",
                     # Save alignment to DB: true requires configuration of PoolDBOutputService
                     saveToDB = cms.bool(False),            # save alignment?
                     saveApeToDB = cms.bool(False),         # save APE?
-                    saveDeformationsToDB = cms.bool(False) # save surface deformations (bows, etc.)?
+                    saveDeformationsToDB = cms.bool(False), # save surface deformations (bows, etc.)?
+
+                    #parameters used to read the pede files back for DQM and check on parameters
+                    MillePedeFileReader = cms.PSet(MillePedeFileReader)
                     )

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -52,20 +52,17 @@ class MillePedeFileReader {
     std::string millePedeLogFile_;
     std::string millePedeResFile_;
 
-    // Cutoff in micro-meter & micro-rad
+    // signifiance of movement must be above
+    double sigCut_;
+    // cutoff in micro-meter & micro-rad
     double Xcut_, tXcut_;
     double Ycut_, tYcut_;
     double Zcut_, tZcut_;
-
     // maximum movement in micro-meter/rad
     double maxMoveCut_, maxErrorCut_;
 
-    // Signifiance of movement must be above
-    double sigCut_;
-
-
-
-    double Cutoffs[6] = {Xcut_, Ycut_, Zcut_, tXcut_, tYcut_, tZcut_};
+    double Cutoffs[6] = {  Xcut_,  Ycut_,  Zcut_,
+                          tXcut_, tYcut_, tZcut_};
 
     bool PedeSuccess = false;
     bool Movements   = false;
@@ -76,6 +73,7 @@ class MillePedeFileReader {
     bool HitErrorMax = false;
 
     int Nrec = 0;
+
 
 
     std::array<double, 6> Xobs     = {{0.,0.,0.,0.,0.,0.}};
@@ -106,6 +104,7 @@ MillePedeFileReader
   millePedeLogFile_(config.getParameter<std::string>("millePedeLogFile")),
   millePedeResFile_(config.getParameter<std::string>("millePedeResFile")),
 
+  sigCut_     (config.getParameter<double>("sigCut")),
   Xcut_       (config.getParameter<double>("Xcut")),
   tXcut_      (config.getParameter<double>("tXcut")),
   Ycut_       (config.getParameter<double>("Ycut")),
@@ -113,8 +112,7 @@ MillePedeFileReader
   Zcut_       (config.getParameter<double>("Zcut")),
   tZcut_      (config.getParameter<double>("tZcut")),
   maxMoveCut_ (config.getParameter<double>("maxMoveCut")),
-  maxErrorCut_(config.getParameter<double>("maxErrorCut")),
-  sigCut_     (config.getParameter<double>("sigCut"))
+  maxErrorCut_(config.getParameter<double>("maxErrorCut"))
 {
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -1,0 +1,288 @@
+#ifndef ALIGNMENT_MILLEPEDEALIGNMENTALGORITHM_INTERFACE_MILLEPEDEFILEREADER_H_
+#define ALIGNMENT_MILLEPEDEALIGNMENTALGORITHM_INTERFACE_MILLEPEDEFILEREADER_H_
+
+/*** system includes ***/
+#include <array>
+#include <memory>
+#include <fstream>
+#include <string>
+
+/*** core framework functionality ***/
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+
+
+class MillePedeFileReader {
+
+  //========================== PUBLIC METHODS ==================================
+  public: //====================================================================
+
+    explicit MillePedeFileReader(const edm::ParameterSet&);
+    ~MillePedeFileReader() {}
+
+    void read();
+    bool storeAlignments();
+
+    std::array<double, 6> const& getXobs()     const { return Xobs;     }
+    std::array<double, 6> const& getXobsErr()  const { return XobsErr;  }
+    std::array<double, 6> const& getTXobs()    const { return tXobs;    }
+    std::array<double, 6> const& getTXobsErr() const { return tXobsErr; }
+
+    std::array<double, 6> const& getYobs()     const { return Yobs;     }
+    std::array<double, 6> const& getYobsErr()  const { return YobsErr;  }
+    std::array<double, 6> const& getTYobs()    const { return tYobs;    }
+    std::array<double, 6> const& getTYobsErr() const { return tYobsErr; }
+
+    std::array<double, 6> const& getZobs()     const { return Zobs;     }
+    std::array<double, 6> const& getZobsErr()  const { return ZobsErr;  }
+    std::array<double, 6> const& getTZobs()    const { return tZobs;    }
+    std::array<double, 6> const& getTZobsErr() const { return tZobsErr; }
+
+  //========================= PRIVATE METHODS ==================================
+  private: //===================================================================
+
+    void readMillePedeLogFile();
+    void readMillePedeResultFile();
+
+  //========================== PRIVATE DATA ====================================
+  //============================================================================
+
+    // file-names
+    std::string millePedeLogFile_;
+    std::string millePedeResFile_;
+
+    // Cutoff in micro-meter & micro-rad
+    double Xcut_, tXcut_;
+    double Ycut_, tYcut_;
+    double Zcut_, tZcut_;
+
+    // maximum movement in micro-meter/rad
+    double maxMoveCut_, maxErrorCut_;
+
+    // Signifiance of movement must be above
+    double sigCut_;
+
+
+
+    double Cutoffs[6] = {Xcut_, Ycut_, Zcut_, tXcut_, tYcut_, tZcut_};
+
+    bool PedeSuccess = false;
+    bool Movements   = false;
+    bool Error       = false;
+    bool Significant = false;
+    bool updateDB    = false;
+    bool HitMax      = false;
+    bool HitErrorMax = false;
+
+    int Nrec = 0;
+
+
+    std::array<double, 6> Xobs     = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> XobsErr  = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tXobs    = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tXobsErr = {{0.,0.,0.,0.,0.,0.}};
+
+    std::array<double, 6> Yobs     = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> YobsErr  = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tYobs    = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tYobsErr = {{0.,0.,0.,0.,0.,0.}};
+
+    std::array<double, 6> Zobs     = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> ZobsErr  = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tZobs    = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tZobsErr = {{0.,0.,0.,0.,0.,0.}};
+
+};
+
+
+
+//=============================================================================
+//===   PUBLIC METHOD IMPLEMENTATION                                        ===
+//=============================================================================
+
+MillePedeFileReader
+::MillePedeFileReader(const edm::ParameterSet& config) :
+  millePedeLogFile_(config.getParameter<std::string>("millePedeLogFile")),
+  millePedeResFile_(config.getParameter<std::string>("millePedeResFile")),
+
+  Xcut_       (config.getParameter<double>("Xcut")),
+  tXcut_      (config.getParameter<double>("tXcut")),
+  Ycut_       (config.getParameter<double>("Ycut")),
+  tYcut_      (config.getParameter<double>("tYcut")),
+  Zcut_       (config.getParameter<double>("Zcut")),
+  tZcut_      (config.getParameter<double>("tZcut")),
+  maxMoveCut_ (config.getParameter<double>("maxMoveCut")),
+  maxErrorCut_(config.getParameter<double>("maxErrorCut")),
+  sigCut_     (config.getParameter<double>("sigCut"))
+{
+}
+
+void MillePedeFileReader
+::read() {
+  readMillePedeLogFile();
+  readMillePedeResultFile();
+}
+
+bool MillePedeFileReader
+::storeAlignments() {
+  return updateDB;
+}
+
+
+
+//=============================================================================
+//===   PRIVATE METHOD IMPLEMENTATION                                       ===
+//=============================================================================
+
+void MillePedeFileReader
+::readMillePedeLogFile()
+{
+  std::ifstream logFile;
+  logFile.open(millePedeLogFile_.c_str());
+
+  if (logFile.is_open()) {
+    edm::LogInfo("MillePedeFileReader") << "Reading millepede log-file";
+    std::string line;
+
+    while (getline(logFile, line)) {
+      std::string Nrec_string = "NREC =";
+
+      if (line.find(Nrec_string) != std::string::npos) {
+        std::istringstream iss(line);
+        std::string trash;
+        iss >> trash >> trash >> Nrec;
+
+        if (Nrec < 25000) {
+          PedeSuccess = false;
+          Movements   = false;
+          Error       = false;
+          Significant = false;
+          updateDB   = false;
+        }
+      }
+    }
+
+  } else {
+    edm::LogError("MillePedeFileReader") << "Could not read millepede log-file.";
+
+    PedeSuccess = false;
+    Movements   = false;
+    Error       = false;
+    Significant = false;
+    updateDB   = false;
+    Nrec = 0;
+  }
+}
+
+void MillePedeFileReader
+::readMillePedeResultFile()
+{
+  std::ifstream resFile;
+  resFile.open(millePedeResFile_.c_str());
+
+  if (resFile.is_open()) {
+    edm::LogInfo("MillePedeFileReader") << "Reading millepede result-file";
+    double Multiplier[6] = {10000.,10000.,10000.,1000000.,1000000.,1000000.};
+
+    std::string line;
+    getline(resFile, line); // drop first line
+
+    while (getline(resFile, line)) {
+      std::istringstream iss(line);
+
+      std::vector<std::string> tokens;
+      std::string token;
+      while (iss >> token) {
+        tokens.push_back(token);
+      }
+
+      if (tokens.size() > 4 /*3*/) {
+        PedeSuccess = true;
+
+        int alignable      = std::stoi(tokens[0]);
+        int alignableIndex = alignable % 10 - 1;
+
+        double ObsMove = std::stof(tokens[3]) * Multiplier[alignableIndex];
+        double ObsErr  = std::stof(tokens[4]) * Multiplier[alignableIndex];
+
+        int det = -1;
+
+        if (alignable >= 60 && alignable <= 69) {
+          det = 2; // TPBHalfBarrel (x+)
+        } else if (alignable >= 8780 && alignable <= 8789) {
+          det = 3; // TPBHalfBarrel (x-)
+        } else if (alignable >= 17520 && alignable <= 17529) {
+          det = 4; // TPEHalfCylinder (x+,z+)
+        } else if (alignable >= 22380 && alignable <= 22389) {
+          det = 5; // TPEHalfCylinder (x-,z+)
+        } else if (alignable >= 27260 && alignable <= 27269) {
+          det = 0; // TPEHalfCylinder (x+,z-)
+        } else if (alignable >= 32120 && alignable <= 32129) {
+          det = 1; //TPEHalfCylinder (x-,z-)
+        } else {
+          continue;
+        }
+
+        if (alignableIndex == 0 && det >= 0 && det <= 5) {
+          Xobs[det] = ObsMove;
+          XobsErr[det] = ObsErr;
+        } else if (alignableIndex == 1 && det >= 0 && det <= 5) {
+          Yobs[det] = ObsMove;
+          YobsErr[det] = ObsErr;
+        } else if (alignableIndex == 2 && det >= 0 && det <= 5) {
+          Zobs[det] = ObsMove;
+          ZobsErr[det] = ObsErr;
+        } else if (alignableIndex == 3 && det >= 0 && det <= 5) {
+          tXobs[det] = ObsMove;
+          tXobsErr[det] = ObsErr;
+        } else if (alignableIndex == 4 && det >= 0 && det <= 5) {
+          tYobs[det] = ObsMove;
+          tYobsErr[det] = ObsErr;
+        } else if (alignableIndex == 5 && det >= 0 && det <= 5) {
+          tZobs[det] = ObsMove;
+          tZobsErr[det] = ObsErr;
+        }
+
+        if (abs(ObsMove) > maxMoveCut_) {
+          Movements   = false;
+          Error       = false;
+          Significant = false;
+          updateDB   = false;
+          HitMax      = false;
+          continue;
+
+        } else if (abs(ObsMove) > Cutoffs[alignableIndex]) {
+          Movements = true;
+
+          if (abs(ObsErr) > maxErrorCut_) {
+            Error       = false;
+            Significant = false;
+            updateDB   = false;
+            HitErrorMax = true;
+            continue;
+          } else {
+            Error = true;
+            if (abs(ObsMove/ObsErr) > sigCut_) {
+              Significant = true;
+            }
+          }
+        }
+        updateDB = true;
+      }
+    }
+  } else {
+    edm::LogError("MillePedeFileReader") << "Could not read millepede result-file.";
+
+    PedeSuccess = false;
+    Movements   = false;
+    Error       = false;
+    Significant = false;
+    updateDB   = false;
+    Nrec = 0;
+  }
+}
+
+
+
+#endif /* ALIGNMENT_MILLEPEDEALIGNMENTALGORITHM_INTERFACE_MILLEPEDEFILEREADER_H_ */

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/BuildFile.xml
@@ -3,6 +3,5 @@
 <use name="FWCore/ParameterSet"/>
 <use name="CondFormats/Common"/>
 <use name="DQMServices/Core"/>
-<use name="PhysicsTools/UtilAlgos"/>
 <use name="classlib"/>
 <flags EDM_PLUGIN="1"/>

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/BuildFile.xml
@@ -2,5 +2,7 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="CondFormats/Common"/>
+<use name="DQMServices/Core"/>
+<use name="PhysicsTools/UtilAlgos"/>
+<use name="classlib"/>
 <flags EDM_PLUGIN="1"/>
-

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -30,7 +30,8 @@ MillePedeDQMModule
   tYcut_      (mpReaderConfig_.getParameter<double>("tYcut")),
   Zcut_       (mpReaderConfig_.getParameter<double>("Zcut")),
   tZcut_      (mpReaderConfig_.getParameter<double>("tZcut")),
-  maxMoveCut_ (mpReaderConfig_.getParameter<double>("maxMoveCut"))
+  maxMoveCut_ (mpReaderConfig_.getParameter<double>("maxMoveCut")),
+  maxErrorCut_ (mpReaderConfig_.getParameter<double>("maxErrorCut"))  
 {
 }
 
@@ -51,35 +52,12 @@ void MillePedeDQMModule
   booker.cd();
   booker.setCurrentFolder("AlCaReco/SiPixelAli/");
 
-  h_xPos[0] = booker.book1D("Xpos",   "#Delta X;;#mu m", 6, 0, 6.);
-  h_xPos[1] = booker.book1D("Xpos_1", "Xpos_1",          6, 0, 6.);
-  h_xPos[2] = booker.book1D("Xpos_2", "Xpos_2",          6, 0, 6.);
-  h_xPos[3] = booker.book1D("Xpos_3", "Xpos_3",          6, 0, 6.);
-
-  h_xRot[0] = booker.book1D("Xrot",   "#Delta #theta_{X};;#mu rad", 6, 0, 6.);
-  h_xRot[1] = booker.book1D("Xrot_1", "Xrot_1",                     6, 0, 6.);
-  h_xRot[2] = booker.book1D("Xrot_2", "Xrot_2",                     6, 0, 6.);
-  h_xRot[3] = booker.book1D("Xrot_3", "Xrot_3",                     6, 0, 6.);
-
-  h_yPos[0] = booker.book1D("Ypos",   "#Delta Y;;#mu m", 6, 0., 6.);
-  h_yPos[1] = booker.book1D("Ypos_1", "Ypos_1",          6, 0., 6.);
-  h_yPos[2] = booker.book1D("Ypos_2", "Ypos_2",          6, 0., 6.);
-  h_yPos[3] = booker.book1D("Ypos_3", "Ypos_3",          6, 0., 6.);
-
-  h_yRot[0] = booker.book1D("Yrot",   "#Delta #theta_{Y};;#mu rad", 6, 0, 6.);
-  h_yRot[1] = booker.book1D("Yrot_1", "Yrot_1",                     6, 0, 6.);
-  h_yRot[2] = booker.book1D("Yrot_2", "Yrot_2",                     6, 0, 6.);
-  h_yRot[3] = booker.book1D("Yrot_3", "Yrot_3",                     6, 0, 6.);
-
-  h_zPos[0] = booker.book1D("Zpos",   "#Delta Z;;#mu m", 6, 0., 6.);
-  h_zPos[1] = booker.book1D("Zpos_1", "Zpos_1",          6, 0., 6.);
-  h_zPos[2] = booker.book1D("Zpos_2", "Zpos_2",          6, 0., 6.);
-  h_zPos[3] = booker.book1D("Zpos_3", "Zpos_3",          6, 0., 6.);
-
-  h_zRot[0] = booker.book1D("Zrot",   "#Delta #theta_{Z};;#mu rad", 6, 0, 6.);
-  h_zRot[1] = booker.book1D("Zrot_1", "Zrot_1",                     6, 0, 6.);
-  h_zRot[2] = booker.book1D("Zrot_2", "Zrot_2",                     6, 0, 6.);
-  h_zRot[3] = booker.book1D("Zrot_3", "Zrot_3",                     6, 0, 6.);
+  h_xPos = booker.book1D("Xpos",   "#Delta X;;#mu m", 10, 0, 10.);
+  h_xRot = booker.book1D("Xrot",   "#Delta #theta_{X};;#mu rad", 10, 0, 10.);
+  h_yPos = booker.book1D("Ypos",   "#Delta Y;;#mu m", 10, 0., 10.);
+  h_yRot = booker.book1D("Yrot",   "#Delta #theta_{Y};;#mu rad", 10, 0, 10.);
+  h_zPos = booker.book1D("Zpos",   "#Delta Z;;#mu m", 10, 0., 10.);
+  h_zRot = booker.book1D("Zrot",   "#Delta #theta_{Z};;#mu rad", 10, 0, 10.);
 
   booker.cd();
 }
@@ -103,36 +81,34 @@ void MillePedeDQMModule
 void MillePedeDQMModule
 ::fillExpertHistos()
 {
-  fillExpertHisto(h_xPos,  Xcut_, mpReader.getXobs(),  mpReader.getXobsErr());
-  fillExpertHisto(h_xRot, tXcut_, mpReader.getTXobs(), mpReader.getTXobsErr());
 
-  fillExpertHisto(h_yPos,  Ycut_, mpReader.getYobs(),  mpReader.getYobsErr());
-  fillExpertHisto(h_yRot, tYcut_, mpReader.getTYobs(), mpReader.getTYobsErr());
+  fillExpertHisto(h_xPos,  Xcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader.getXobs(),  mpReader.getXobsErr());
+  fillExpertHisto(h_xRot, tXcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader.getTXobs(), mpReader.getTXobsErr());
 
-  fillExpertHisto(h_zPos,  Zcut_, mpReader.getZobs(),  mpReader.getZobsErr());
-  fillExpertHisto(h_zRot, tZcut_, mpReader.getTZobs(), mpReader.getTZobsErr());
+  fillExpertHisto(h_yPos,  Ycut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader.getYobs(),  mpReader.getYobsErr());
+  fillExpertHisto(h_yRot, tYcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader.getTYobs(), mpReader.getTYobsErr());
+
+  fillExpertHisto(h_zPos,  Zcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader.getZobs(),  mpReader.getZobsErr());
+  fillExpertHisto(h_zRot, tZcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader.getTZobs(), mpReader.getTZobsErr());
 
 }
 
 void MillePedeDQMModule
-::fillExpertHisto(MonitorElement* histos[], const double cut,
+::fillExpertHisto(MonitorElement* histo, const double cut, const double sigCut, const double maxMoveCut, const double maxErrorCut,
                   std::array<double, 6> obs, std::array<double, 6> obsErr)
 {
-  TH1F* histo_0 = histos[0]->getTH1F();
-  TH1F* histo_1 = histos[1]->getTH1F();
-  TH1F* histo_2 = histos[2]->getTH1F();
-  TH1F* histo_3 = histos[3]->getTH1F();
-
+  TH1F* histo_0 = histo->getTH1F();
+  
   histo_0->SetMinimum(-(maxMoveCut_));
   histo_0->SetMaximum(  maxMoveCut_);
 
   for (size_t i = 0; i < obs.size(); ++i) {
     histo_0->SetBinContent(i+1, obs[i]);
-    histo_1->SetBinContent(i+1, obs[i]);
-    histo_2->SetBinContent(i+1,  cut);
-    histo_3->SetBinContent(i+1, -cut);
-
     histo_0->SetBinError(i+1, obsErr[i]);
-    histo_1->SetBinError(i+1, (histo_1->GetBinContent(i+1) / sigCut_));
   }
+  histo_0->SetBinContent(8,cut);
+  histo_0->SetBinContent(9,sigCut);
+  histo_0->SetBinContent(10,maxMoveCut);
+  histo_0->SetBinContent(11,maxErrorCut);  
+
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -19,18 +19,18 @@
 MillePedeDQMModule
 ::MillePedeDQMModule(const edm::ParameterSet& config) :
   mpReaderConfig_(
-    config.getParameter<edm::ParameterSet>("millePedeFileReaderConfig")
+    config.getParameter<edm::ParameterSet>("MillePedeFileReader")
   ),
   mpReader(mpReaderConfig_),
 
-  Xcut_       (config.getParameter<double>("Xcut")),
-  tXcut_      (config.getParameter<double>("tXcut")),
-  Ycut_       (config.getParameter<double>("Ycut")),
-  tYcut_      (config.getParameter<double>("tYcut")),
-  Zcut_       (config.getParameter<double>("Zcut")),
-  tZcut_      (config.getParameter<double>("tZcut")),
-  maxMoveCut_ (mpReaderConfig_.getParameter<double>("maxMoveCut")),
-  sigCut_     (mpReaderConfig_.getParameter<double>("sigCut"))
+  sigCut_     (mpReaderConfig_.getParameter<double>("sigCut")),
+  Xcut_       (mpReaderConfig_.getParameter<double>("Xcut")),
+  tXcut_      (mpReaderConfig_.getParameter<double>("tXcut")),
+  Ycut_       (mpReaderConfig_.getParameter<double>("Ycut")),
+  tYcut_      (mpReaderConfig_.getParameter<double>("tYcut")),
+  Zcut_       (mpReaderConfig_.getParameter<double>("Zcut")),
+  tZcut_      (mpReaderConfig_.getParameter<double>("tZcut")),
+  maxMoveCut_ (mpReaderConfig_.getParameter<double>("maxMoveCut"))
 {
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -44,9 +44,7 @@ MillePedeDQMModule
 //=============================================================================
 
 void MillePedeDQMModule
-::bookHistograms(DQMStore::IBooker& booker,
-                 edm::Run const& /* run */,
-                 edm::EventSetup const& /* setup */)
+::bookHistograms(DQMStore::IBooker& booker)
 {
   edm::LogInfo("MillePedeDQMModule") << "Booking histograms";
 
@@ -86,9 +84,12 @@ void MillePedeDQMModule
   booker.cd();
 }
 
+
 void MillePedeDQMModule
-::endRun(edm::Run const& /* run */, edm::EventSetup const& /* setup */)
+::dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter &)  
 {
+
+  bookHistograms(booker);
   mpReader.read();
   fillExpertHistos();
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -1,0 +1,158 @@
+/**
+ * @package   Alignment/MillePedeAlignmentAlgorithm
+ * @file      MillePedeDQMModule.cc
+ *
+ * @author    Max Stark (max.stark@cern.ch)
+ * @date      Feb 19, 2016
+ */
+
+
+/*** header-file ***/
+#include "Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h"
+
+/*** ROOT objects ***/
+#include "TCanvas.h"
+#include "TH1F.h"
+
+
+
+MillePedeDQMModule
+::MillePedeDQMModule(const edm::ParameterSet& config) :
+  mpReaderConfig_(
+    config.getParameter<edm::ParameterSet>("millePedeFileReaderConfig")
+  ),
+  mpReader(mpReaderConfig_),
+
+  Xcut_       (config.getParameter<double>("Xcut")),
+  tXcut_      (config.getParameter<double>("tXcut")),
+  Ycut_       (config.getParameter<double>("Ycut")),
+  tYcut_      (config.getParameter<double>("tYcut")),
+  Zcut_       (config.getParameter<double>("Zcut")),
+  tZcut_      (config.getParameter<double>("tZcut")),
+  maxMoveCut_ (mpReaderConfig_.getParameter<double>("maxMoveCut")),
+  sigCut_     (mpReaderConfig_.getParameter<double>("sigCut"))
+{
+}
+
+MillePedeDQMModule
+::~MillePedeDQMModule()
+{
+}
+
+void MillePedeDQMModule
+::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("millePedeLogFile", "")->setComment(
+    "The .log-file of the MillePede alignment algorithm (pede-mode)"
+  );
+  desc.add<std::string>("millePedeResFile", "")->setComment(
+    "The .res-file of the MillePede alignment algorithm (pede-mode)"
+  );
+
+  descriptions.add("MillePedeDQMModule", desc);
+  descriptions.setComment("Generic .cfi-file for the MillePedeDQMModule");
+}
+
+
+
+//=============================================================================
+//===   INTERFACE IMPLEMENTATION                                            ===
+//=============================================================================
+
+void MillePedeDQMModule
+::bookHistograms(DQMStore::IBooker& booker,
+                 edm::Run const& /* run */,
+                 edm::EventSetup const& /* setup */)
+{
+  edm::LogInfo("MillePedeDQMModule") << "Booking histograms";
+
+  booker.cd();
+  booker.setCurrentFolder("AlCaReco/SiPixelAli/");
+
+  h_xPos[0] = booker.book1D("Xpos",   "#Delta X;;#mu m", 6, 0, 6.);
+  h_xPos[1] = booker.book1D("Xpos_1", "Xpos_1",          6, 0, 6.);
+  h_xPos[2] = booker.book1D("Xpos_2", "Xpos_2",          6, 0, 6.);
+  h_xPos[3] = booker.book1D("Xpos_3", "Xpos_3",          6, 0, 6.);
+
+  h_xRot[0] = booker.book1D("Xrot",   "#Delta #theta_{X};;#mu rad", 6, 0, 6.);
+  h_xRot[1] = booker.book1D("Xrot_1", "Xrot_1",                     6, 0, 6.);
+  h_xRot[2] = booker.book1D("Xrot_2", "Xrot_2",                     6, 0, 6.);
+  h_xRot[3] = booker.book1D("Xrot_3", "Xrot_3",                     6, 0, 6.);
+
+  h_yPos[0] = booker.book1D("Ypos",   "#Delta Y;;#mu m", 6, 0., 6.);
+  h_yPos[1] = booker.book1D("Ypos_1", "Ypos_1",          6, 0., 6.);
+  h_yPos[2] = booker.book1D("Ypos_2", "Ypos_2",          6, 0., 6.);
+  h_yPos[3] = booker.book1D("Ypos_3", "Ypos_3",          6, 0., 6.);
+
+  h_yRot[0] = booker.book1D("Yrot",   "#Delta #theta_{Y};;#mu rad", 6, 0, 6.);
+  h_yRot[1] = booker.book1D("Yrot_1", "Yrot_1",                     6, 0, 6.);
+  h_yRot[2] = booker.book1D("Yrot_2", "Yrot_2",                     6, 0, 6.);
+  h_yRot[3] = booker.book1D("Yrot_3", "Yrot_3",                     6, 0, 6.);
+
+  h_zPos[0] = booker.book1D("Zpos",   "#Delta Z;;#mu m", 6, 0., 6.);
+  h_zPos[1] = booker.book1D("Zpos_1", "Zpos_1",          6, 0., 6.);
+  h_zPos[2] = booker.book1D("Zpos_2", "Zpos_2",          6, 0., 6.);
+  h_zPos[3] = booker.book1D("Zpos_3", "Zpos_3",          6, 0., 6.);
+
+  h_zRot[0] = booker.book1D("Zrot",   "#Delta #theta_{Z};;#mu rad", 6, 0, 6.);
+  h_zRot[1] = booker.book1D("Zrot_1", "Zrot_1",                     6, 0, 6.);
+  h_zRot[2] = booker.book1D("Zrot_2", "Zrot_2",                     6, 0, 6.);
+  h_zRot[3] = booker.book1D("Zrot_3", "Zrot_3",                     6, 0, 6.);
+
+  booker.cd();
+}
+
+void MillePedeDQMModule
+::endRun(edm::Run const& /* run */, edm::EventSetup const& /* setup */)
+{
+  mpReader.read();
+  fillExpertHistos();
+}
+
+
+
+//=============================================================================
+//===   PRIVATE METHOD IMPLEMENTATION                                       ===
+//=============================================================================
+
+void MillePedeDQMModule
+::fillExpertHistos()
+{
+  TCanvas c("PCL_SiPixAl_Expert", "PCL_SiPixAl_Expert", 1500, 800);
+  c.Divide(3, 2);
+
+  c.cd(1); fillExpertHisto(h_xPos,  Xcut_, mpReader.getXobs(),  mpReader.getXobsErr());
+  c.cd(4); fillExpertHisto(h_xRot, tXcut_, mpReader.getTXobs(), mpReader.getTXobsErr());
+
+  c.cd(2); fillExpertHisto(h_yPos,  Ycut_, mpReader.getYobs(),  mpReader.getYobsErr());
+  c.cd(5); fillExpertHisto(h_yRot, tYcut_, mpReader.getTYobs(), mpReader.getTYobsErr());
+
+  c.cd(3); fillExpertHisto(h_zPos,  Zcut_, mpReader.getZobs(),  mpReader.getZobsErr());
+  c.cd(6); fillExpertHisto(h_zRot, tZcut_, mpReader.getTZobs(), mpReader.getTZobsErr());
+
+  c.Write();
+}
+
+void MillePedeDQMModule
+::fillExpertHisto(MonitorElement* histos[], const double cut,
+                  std::array<double, 6> obs, std::array<double, 6> obsErr)
+{
+  TH1F* histo_0 = histos[0]->getTH1F();
+  TH1F* histo_1 = histos[1]->getTH1F();
+  TH1F* histo_2 = histos[2]->getTH1F();
+  TH1F* histo_3 = histos[3]->getTH1F();
+
+  histo_0->SetMinimum(-(maxMoveCut_));
+  histo_0->SetMaximum(  maxMoveCut_);
+
+  for (size_t i = 0; i < obs.size(); ++i) {
+    histo_0->SetBinContent(i+1, obs[i]);
+    histo_1->SetBinContent(i+1, obs[i]);
+    histo_2->SetBinContent(i+1,  cut);
+    histo_3->SetBinContent(i+1, -cut);
+
+    histo_0->SetBinError(i+1, obsErr[i]);
+    histo_1->SetBinError(i+1, (histo_1->GetBinContent(i+1) / sigCut_));
+  }
+}

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -39,23 +39,6 @@ MillePedeDQMModule
 {
 }
 
-void MillePedeDQMModule
-::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;
-
-  desc.add<std::string>("millePedeLogFile", "")->setComment(
-    "The .log-file of the MillePede alignment algorithm (pede-mode)"
-  );
-  desc.add<std::string>("millePedeResFile", "")->setComment(
-    "The .res-file of the MillePede alignment algorithm (pede-mode)"
-  );
-
-  descriptions.add("MillePedeDQMModule", desc);
-  descriptions.setComment("Generic .cfi-file for the MillePedeDQMModule");
-}
-
-
-
 //=============================================================================
 //===   INTERFACE IMPLEMENTATION                                            ===
 //=============================================================================
@@ -119,19 +102,15 @@ void MillePedeDQMModule
 void MillePedeDQMModule
 ::fillExpertHistos()
 {
-  TCanvas c("PCL_SiPixAl_Expert", "PCL_SiPixAl_Expert", 1500, 800);
-  c.Divide(3, 2);
+  fillExpertHisto(h_xPos,  Xcut_, mpReader.getXobs(),  mpReader.getXobsErr());
+  fillExpertHisto(h_xRot, tXcut_, mpReader.getTXobs(), mpReader.getTXobsErr());
 
-  c.cd(1); fillExpertHisto(h_xPos,  Xcut_, mpReader.getXobs(),  mpReader.getXobsErr());
-  c.cd(4); fillExpertHisto(h_xRot, tXcut_, mpReader.getTXobs(), mpReader.getTXobsErr());
+  fillExpertHisto(h_yPos,  Ycut_, mpReader.getYobs(),  mpReader.getYobsErr());
+  fillExpertHisto(h_yRot, tYcut_, mpReader.getTYobs(), mpReader.getTYobsErr());
 
-  c.cd(2); fillExpertHisto(h_yPos,  Ycut_, mpReader.getYobs(),  mpReader.getYobsErr());
-  c.cd(5); fillExpertHisto(h_yRot, tYcut_, mpReader.getTYobs(), mpReader.getTYobsErr());
+  fillExpertHisto(h_zPos,  Zcut_, mpReader.getZobs(),  mpReader.getZobsErr());
+  fillExpertHisto(h_zRot, tZcut_, mpReader.getTZobs(), mpReader.getTZobsErr());
 
-  c.cd(3); fillExpertHisto(h_zPos,  Zcut_, mpReader.getZobs(),  mpReader.getZobsErr());
-  c.cd(6); fillExpertHisto(h_zRot, tZcut_, mpReader.getTZobs(), mpReader.getTZobsErr());
-
-  c.Write();
 }
 
 void MillePedeDQMModule

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -11,7 +11,6 @@
 #include "Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h"
 
 /*** ROOT objects ***/
-#include "TCanvas.h"
 #include "TH1F.h"
 
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -15,9 +15,6 @@
 
 /*** system includes ***/
 #include <array>
-//#include <memory>
-//#include <fstream>
-//#include <string>
 
 /*** core framework functionality ***/
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -69,14 +69,15 @@ class MillePedeDQMModule : public DQMEDAnalyzer {
     const edm::ParameterSet& mpReaderConfig_;
     MillePedeFileReader mpReader;
 
+    // Signifiance of movement must be above
+    double sigCut_;
     // Cutoff in micro-meter & micro-rad
     double Xcut_, tXcut_;
     double Ycut_, tYcut_;
     double Zcut_, tZcut_;
     // maximum movement in micro-meter/rad
     double maxMoveCut_;
-    // Signifiance of movement must be above
-    double sigCut_;
+
 
     // Histograms
     MonitorElement* h_xPos[4];

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -25,11 +25,13 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 /*** DQM ***/
+
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 /*** MillePede ***/
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h"
+
 
 
 
@@ -40,6 +42,7 @@ class MillePedeDQMModule : public DQMEDHarvester {
 
     MillePedeDQMModule(const edm::ParameterSet&);
     virtual ~MillePedeDQMModule();
+
 
 
 
@@ -54,8 +57,11 @@ class MillePedeDQMModule : public DQMEDHarvester {
 
     void fillExpertHistos();
 
-    void fillExpertHisto(MonitorElement* histos[],
+    void fillExpertHisto(MonitorElement* histo,
                          const double cut,
+                         const double sigCut,
+                         const double maxMoveCut,
+                         const double maxErrorCut,
                          std::array<double, 6> obs,
                          std::array<double, 6> obsErr);
 
@@ -73,15 +79,15 @@ class MillePedeDQMModule : public DQMEDHarvester {
     double Zcut_, tZcut_;
     // maximum movement in micro-meter/rad
     double maxMoveCut_;
-
+    double maxErrorCut_;
 
     // Histograms
-    MonitorElement* h_xPos[4];
-    MonitorElement* h_xRot[4];
-    MonitorElement* h_yPos[4];
-    MonitorElement* h_yRot[4];
-    MonitorElement* h_zPos[4];
-    MonitorElement* h_zRot[4];
+    MonitorElement* h_xPos;
+    MonitorElement* h_xRot;
+    MonitorElement* h_yPos;
+    MonitorElement* h_yRot;
+    MonitorElement* h_zPos;
+    MonitorElement* h_zRot;
 
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -25,7 +25,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 /*** DQM ***/
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 /*** MillePede ***/
@@ -33,7 +33,7 @@
 
 
 
-class MillePedeDQMModule : public DQMEDAnalyzer {
+class MillePedeDQMModule : public DQMEDHarvester {
 
   //========================== PUBLIC METHODS ==================================
   public: //====================================================================
@@ -41,15 +41,16 @@ class MillePedeDQMModule : public DQMEDAnalyzer {
     MillePedeDQMModule(const edm::ParameterSet&);
     virtual ~MillePedeDQMModule();
 
-    virtual void bookHistograms(DQMStore::IBooker&, edm::Run const&,
-                                edm::EventSetup const&) override;
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& es) {}
 
-    virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+    
+    virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &)  override;
+    //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
 
   //========================= PRIVATE METHODS ==================================
   private: //===================================================================
+
+    void bookHistograms(DQMStore::IBooker&);
 
     void fillExpertHistos();
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -1,0 +1,94 @@
+#ifndef Alignment_MillePedeAlignmentAlgorithm_MillePedeDQMModule_h
+#define Alignment_MillePedeAlignmentAlgorithm_MillePedeDQMModule_h
+
+/**
+ * @package   Alignment/MillePedeAlignmentAlgorithm
+ * @file      MillePedeDQMModule.h
+ *
+ * @author    Max Stark (max.stark@cern.ch)
+ * @date      Oct 26, 2015
+ *
+ * @brief     DQM Plotter for PCL-Alignment
+ */
+
+
+
+/*** system includes ***/
+#include <array>
+//#include <memory>
+//#include <fstream>
+//#include <string>
+
+/*** core framework functionality ***/
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+/*** DQM ***/
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+/*** MillePede ***/
+#include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h"
+
+
+
+class MillePedeDQMModule : public DQMEDAnalyzer {
+
+  //========================== PUBLIC METHODS ==================================
+  public: //====================================================================
+
+    MillePedeDQMModule(const edm::ParameterSet&);
+    virtual ~MillePedeDQMModule();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    virtual void bookHistograms(DQMStore::IBooker&, edm::Run const&,
+                                edm::EventSetup const&) override;
+
+    virtual void analyze(edm::Event const& e, edm::EventSetup const& es) {}
+
+    virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+
+  //========================= PRIVATE METHODS ==================================
+  private: //===================================================================
+
+    void fillExpertHistos();
+
+    void fillExpertHisto(MonitorElement* histos[],
+                         const double cut,
+                         std::array<double, 6> obs,
+                         std::array<double, 6> obsErr);
+
+  //========================== PRIVATE DATA ====================================
+  //============================================================================
+
+    const edm::ParameterSet& mpReaderConfig_;
+    MillePedeFileReader mpReader;
+
+    // Cutoff in micro-meter & micro-rad
+    double Xcut_, tXcut_;
+    double Ycut_, tYcut_;
+    double Zcut_, tZcut_;
+    // maximum movement in micro-meter/rad
+    double maxMoveCut_;
+    // Signifiance of movement must be above
+    double sigCut_;
+
+    // Histograms
+    MonitorElement* h_xPos[4];
+    MonitorElement* h_xRot[4];
+    MonitorElement* h_yPos[4];
+    MonitorElement* h_yRot[4];
+    MonitorElement* h_zPos[4];
+    MonitorElement* h_zRot[4];
+
+};
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(MillePedeDQMModule);
+
+#endif /* Alignment_MillePedeAlignmentAlgorithm_MillePedeDQMModule_h */

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -41,8 +41,6 @@ class MillePedeDQMModule : public DQMEDAnalyzer {
     MillePedeDQMModule(const edm::ParameterSet&);
     virtual ~MillePedeDQMModule();
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
     virtual void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                                 edm::EventSetup const&) override;
 

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.MillePedeAlignmentAlgorithm.MillePedeFileReader_cfi import *
+
+SiPixelAliDQMModule = cms.EDAnalyzer("MillePedeDQMModule",
+                                     MillePedeFileReader = cms.PSet(MillePedeFileReader)
+    )

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Alignment.MillePedeAlignmentAlgorithm.MillePedeFileReader_cfi import *
+import  Alignment.MillePedeAlignmentAlgorithm.MillePedeFileReader_cfi as MillePedeFileReader_cfi
 
 SiPixelAliDQMModule = cms.EDAnalyzer("MillePedeDQMModule",
-                                     MillePedeFileReader = cms.PSet(MillePedeFileReader)
+                                     MillePedeFileReader = cms.PSet(MillePedeFileReader_cfi.MillePedeFileReader.clone())
     )

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+MillePedeFileReader = cms.PSet(
+  millePedeLogFile = cms.string('millepede.log'),
+  millePedeResFile = cms.string('millepede.res'),
+
+  # signifiance of movement must be above
+  sigCut = cms.double(2.5),
+
+  # cutoff in micro-meter & micro-rad
+  Xcut  = cms.double( 5.0),
+  tXcut = cms.double(30.0), # thetaX
+  Ycut  = cms.double(10.0),
+  tYcut = cms.double(30.0), # thetaY
+  Zcut  = cms.double(15.0),
+  tZcut = cms.double(30.0), # thetaZ
+
+  # maximum movement in micro-meter/rad
+  maxMoveCut  = cms.double(200.0),
+  maxErrorCut = cms.double( 10.0)
+)


### PR DESCRIPTION
This PR modifies only the PCL sequences for the alignment of the Pixel large structures.
It integrates the needed checks for the creation of the payload and the DQM module to monitor the movements of the alignables.

This is needed to start testing the new workflow in production environment.

This is equivalent to PR #13983 for 81X.
