### PR TITLE
Cleanup sim mergeable products

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h
@@ -13,7 +13,6 @@ class GenRunInfoProduct {
 	// constructors, destructors
 	GenRunInfoProduct();
 	GenRunInfoProduct(const GenRunInfoProduct &other);
-	virtual ~GenRunInfoProduct();
 
 	// getters
 
@@ -60,8 +59,7 @@ class GenRunInfoProduct {
 	{ return externalXSecLO_ ? externalXSecLO_.value() : internalXSec_.value(); }
 
 	// methods used by EDM
-	virtual bool mergeProduct(const GenRunInfoProduct &other);
-	virtual bool isProductEqual(const GenRunInfoProduct &other) const;
+	bool isProductEqual(const GenRunInfoProduct &other) const;
 
     private:
 	// cross sections

--- a/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
@@ -12,7 +12,6 @@
 
 class LHERunInfoProduct {
     public:
-    typedef std::vector<std::pair<std::string,std::string> > weights_defs;
 	class Header {
 	    public:
 		typedef std::vector<std::string>::const_iterator const_iterator;

--- a/SimDataFormats/GeneratorProducts/src/GenRunInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenRunInfoProduct.cc
@@ -21,34 +21,17 @@ GenRunInfoProduct::GenRunInfoProduct(GenRunInfoProduct const &other) :
 {
 }
 
-GenRunInfoProduct::~GenRunInfoProduct()
-{
-}
-
-bool GenRunInfoProduct::mergeProduct(GenRunInfoProduct const &other)
-{
-	// if external xsec and filter efficiency are identical we allow merging
-	// unfortunately we cannot merge on-the-fly xsec, as we do not have
-	// information about the corresponding statistics (i.e. uncertainty)
-	// so we just ignore it.
-	// So in the end this merger is a dummy (just a safety check)
-
-	if (externalXSecLO_ == other.externalXSecLO_ &&
-	    externalXSecNLO_ == other.externalXSecNLO_ &&
-	    externalFilterEfficiency_ == other.externalFilterEfficiency_)
-		return true;
-
-	edm::LogWarning("GenRunInfoProduct|ProductsNotMergeable")
-		<< "You are merging runs with different cross-sections and/or "
-		   "filter efficiencies (from GenRunInfoProduct)\n"
-		   "The resulting cross-section will not be consistent." << std::endl;
-
-	return true;
-}
-
 bool GenRunInfoProduct::isProductEqual(GenRunInfoProduct const &other) const
 {
-	return externalXSecLO_ == other.externalXSecLO_ &&
-	       externalXSecNLO_ == other.externalXSecNLO_ &&
-	       externalFilterEfficiency_ == other.externalFilterEfficiency_;
+	bool result =  externalXSecLO_ == other.externalXSecLO_ &&
+                       externalXSecNLO_ == other.externalXSecNLO_ &&
+	               externalFilterEfficiency_ == other.externalFilterEfficiency_;
+        if( not result) {
+          edm::LogWarning("GenRunInfoProduct|ProductsNotMergeable")
+            << "You are merging runs with different cross-sections and/or "
+               "filter efficiencies (from GenRunInfoProduct)\n"
+               "The resulting cross-section will not be consistent." << std::endl;
+        }
+
+        return result;
 }


### PR DESCRIPTION
Made non-critical changes to Sim Run products in order to clean them up. Removing the non-useful isMergeable method of GenRunInfoProduct will allow this product to be read at beginRun time and avoids the framework difficulties with mergeable run products.
