### PR TITLE
use unique_ptr, not auto_ptr, in EventSetup

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentProducer.cc
@@ -46,23 +46,23 @@ public:
   FakeAlignmentProducer(const edm::ParameterSet&);
   ~FakeAlignmentProducer() {}
 
-  std::auto_ptr<Alignments>
-  produceTkAli(const TrackerAlignmentRcd&) { return std::auto_ptr<Alignments>(new Alignments);}
-  std::auto_ptr<Alignments> 
-  produceDTAli(const DTAlignmentRcd&) { return std::auto_ptr<Alignments>(new Alignments);}
-  std::auto_ptr<Alignments>
-  produceCSCAli(const CSCAlignmentRcd&)  { return std::auto_ptr<Alignments>(new Alignments);}
-  std::auto_ptr<Alignments>
-  produceGlobals(const GlobalPositionRcd&) {return std::auto_ptr<Alignments>(new Alignments);}
+  std::unique_ptr<Alignments>
+  produceTkAli(const TrackerAlignmentRcd&) { return std::make_unique<Alignments>();}
+  std::unique_ptr<Alignments> 
+  produceDTAli(const DTAlignmentRcd&) { return std::make_unique<Alignments>();}
+  std::unique_ptr<Alignments>
+  produceCSCAli(const CSCAlignmentRcd&)  { return std::make_unique<Alignments>();}
+  std::unique_ptr<Alignments>
+  produceGlobals(const GlobalPositionRcd&) {return std::make_unique<Alignments>();}
 
-  std::auto_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) {
-    return std::auto_ptr<AlignmentErrorsExtended>(new AlignmentErrorsExtended);
+  std::unique_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) {
+    return std::make_unique<AlignmentErrorsExtended>();
   }
-  std::auto_ptr<AlignmentErrorsExtended> produceDTAliErr(const DTAlignmentErrorExtendedRcd&) {
-    return std::auto_ptr<AlignmentErrorsExtended>(new AlignmentErrorsExtended);
+  std::unique_ptr<AlignmentErrorsExtended> produceDTAliErr(const DTAlignmentErrorExtendedRcd&) {
+    return std::make_unique<AlignmentErrorsExtended>();
   }
-  std::auto_ptr<AlignmentErrorsExtended> produceCSCAliErr(const CSCAlignmentErrorExtendedRcd&) {
-    return std::auto_ptr<AlignmentErrorsExtended>(new AlignmentErrorsExtended);
+  std::unique_ptr<AlignmentErrorsExtended> produceCSCAliErr(const CSCAlignmentErrorExtendedRcd&) {
+    return std::make_unique<AlignmentErrorsExtended>();
   }
 
 };

--- a/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentSource.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentSource.cc
@@ -49,38 +49,38 @@ public:
   ~FakeAlignmentSource() {}
 
   /// Tracker and its APE
-  std::auto_ptr<Alignments> produceTkAli(const TrackerAlignmentRcd&) {
-    return std::auto_ptr<Alignments>(new Alignments);
+  std::unique_ptr<Alignments> produceTkAli(const TrackerAlignmentRcd&) {
+    return std::make_unique<Alignments>();
   }
-  std::auto_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) { 
-    return std::auto_ptr<AlignmentErrorsExtended>(new AlignmentErrorsExtended);
+  std::unique_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) { 
+    return std::make_unique<AlignmentErrorsExtended>();
   }
 
   /// DT and its APE
-  std::auto_ptr<Alignments> produceDTAli(const DTAlignmentRcd&) {
-    return std::auto_ptr<Alignments>(new Alignments);
+  std::unique_ptr<Alignments> produceDTAli(const DTAlignmentRcd&) {
+    return std::make_unique<Alignments>();
   }
-  std::auto_ptr<AlignmentErrorsExtended> produceDTAliErr(const DTAlignmentErrorExtendedRcd&) {
-    return std::auto_ptr<AlignmentErrorsExtended>(new AlignmentErrorsExtended);
+  std::unique_ptr<AlignmentErrorsExtended> produceDTAliErr(const DTAlignmentErrorExtendedRcd&) {
+    return std::make_unique<AlignmentErrorsExtended>();
   }
 
   /// CSC and its APE
-  std::auto_ptr<Alignments> produceCSCAli(const CSCAlignmentRcd&) {
-    return std::auto_ptr<Alignments>(new Alignments);
+  std::unique_ptr<Alignments> produceCSCAli(const CSCAlignmentRcd&) {
+    return std::make_unique<Alignments>();
   }
-  std::auto_ptr<AlignmentErrorsExtended> produceCSCAliErr(const CSCAlignmentErrorExtendedRcd&) {
-    return std::auto_ptr<AlignmentErrorsExtended>(new AlignmentErrorsExtended);
+  std::unique_ptr<AlignmentErrorsExtended> produceCSCAliErr(const CSCAlignmentErrorExtendedRcd&) {
+    return std::make_unique<AlignmentErrorsExtended>();
   }
 
   /// GlobalPositions
-  std::auto_ptr<Alignments> produceGlobals(const GlobalPositionRcd&) {
-    return std::auto_ptr<Alignments>(new Alignments);
+  std::unique_ptr<Alignments> produceGlobals(const GlobalPositionRcd&) {
+    return std::make_unique<Alignments>();
   }
 
   /// Tracker surface deformations
-  std::auto_ptr<AlignmentSurfaceDeformations>
+  std::unique_ptr<AlignmentSurfaceDeformations>
   produceTrackerSurfaceDeformation(const TrackerSurfaceDeformationRcd&) {
-    return std::auto_ptr<AlignmentSurfaceDeformations>(new AlignmentSurfaceDeformations);
+    return std::make_unique<AlignmentSurfaceDeformations>();
   }
 
  protected:

--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -46,7 +46,7 @@ public:
   CaloTPGTranscoderULUTs(const edm::ParameterSet&);
   ~CaloTPGTranscoderULUTs();
   
-  typedef std::auto_ptr<CaloTPGTranscoder> ReturnType;
+  typedef std::unique_ptr<CaloTPGTranscoder> ReturnType;
   
   ReturnType produce(const CaloTPGRecord&);
 

--- a/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.cc
@@ -132,9 +132,9 @@ CastorHardcodeCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRec
   oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
 }
 
-std::auto_ptr<CastorPedestals> CastorHardcodeCalibrations::producePedestals (const CastorPedestalsRcd&) {
+std::unique_ptr<CastorPedestals> CastorHardcodeCalibrations::producePedestals (const CastorPedestalsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::producePedestals-> ...";
-  std::auto_ptr<CastorPedestals> result (new CastorPedestals (false));
+  auto result = std::make_unique<CastorPedestals>(false);
   std::vector <HcalGenericDetId> cells = allCells(h2mode_);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     CastorPedestal item = CastorDbHardcode::makePedestal (*cell);
@@ -143,9 +143,9 @@ std::auto_ptr<CastorPedestals> CastorHardcodeCalibrations::producePedestals (con
   return result;
 }
 
-std::auto_ptr<CastorPedestalWidths> CastorHardcodeCalibrations::producePedestalWidths (const CastorPedestalWidthsRcd&) {
+std::unique_ptr<CastorPedestalWidths> CastorHardcodeCalibrations::producePedestalWidths (const CastorPedestalWidthsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::producePedestalWidths-> ...";
-  std::auto_ptr<CastorPedestalWidths> result (new CastorPedestalWidths (false));
+  auto result = std::make_unique<CastorPedestalWidths>(false);
   std::vector <HcalGenericDetId> cells = allCells(h2mode_);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     CastorPedestalWidth item = CastorDbHardcode::makePedestalWidth (*cell);
@@ -154,9 +154,9 @@ std::auto_ptr<CastorPedestalWidths> CastorHardcodeCalibrations::producePedestalW
   return result;
 }
 
-std::auto_ptr<CastorGains> CastorHardcodeCalibrations::produceGains (const CastorGainsRcd&) {
+std::unique_ptr<CastorGains> CastorHardcodeCalibrations::produceGains (const CastorGainsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceGains-> ...";
-  std::auto_ptr<CastorGains> result (new CastorGains ());
+  auto result = std::make_unique<CastorGains>();
   std::vector <HcalGenericDetId> cells = allCells(h2mode_);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     CastorGain item = CastorDbHardcode::makeGain (*cell);
@@ -165,9 +165,9 @@ std::auto_ptr<CastorGains> CastorHardcodeCalibrations::produceGains (const Casto
   return result;
 }
 
-std::auto_ptr<CastorGainWidths> CastorHardcodeCalibrations::produceGainWidths (const CastorGainWidthsRcd&) {
+std::unique_ptr<CastorGainWidths> CastorHardcodeCalibrations::produceGainWidths (const CastorGainWidthsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceGainWidths-> ...";
-  std::auto_ptr<CastorGainWidths> result (new CastorGainWidths ());
+  auto result = std::make_unique<CastorGainWidths>();
   std::vector <HcalGenericDetId> cells = allCells(h2mode_);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     CastorGainWidth item = CastorDbHardcode::makeGainWidth (*cell);
@@ -176,9 +176,9 @@ std::auto_ptr<CastorGainWidths> CastorHardcodeCalibrations::produceGainWidths (c
   return result;
 }
 
-std::auto_ptr<CastorQIEData> CastorHardcodeCalibrations::produceQIEData (const CastorQIEDataRcd& rcd) {
+std::unique_ptr<CastorQIEData> CastorHardcodeCalibrations::produceQIEData (const CastorQIEDataRcd& rcd) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceQIEData-> ...";
-  std::auto_ptr<CastorQIEData> result (new CastorQIEData ());
+  auto result = std::make_unique<CastorQIEData>();
   std::vector <HcalGenericDetId> cells = allCells(h2mode_);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     CastorQIECoder coder = CastorDbHardcode::makeQIECoder (*cell);
@@ -187,9 +187,9 @@ std::auto_ptr<CastorQIEData> CastorHardcodeCalibrations::produceQIEData (const C
   return result;
 }
 
-std::auto_ptr<CastorChannelQuality> CastorHardcodeCalibrations::produceChannelQuality (const CastorChannelQualityRcd& rcd) {
+std::unique_ptr<CastorChannelQuality> CastorHardcodeCalibrations::produceChannelQuality (const CastorChannelQualityRcd& rcd) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceChannelQuality-> ...";
-  std::auto_ptr<CastorChannelQuality> result (new CastorChannelQuality ());
+  auto result = std::make_unique<CastorChannelQuality>();
   std::vector <HcalGenericDetId> cells = allCells(h2mode_);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     CastorChannelStatus item(cell->rawId(),CastorChannelStatus::GOOD);
@@ -198,17 +198,17 @@ std::auto_ptr<CastorChannelQuality> CastorHardcodeCalibrations::produceChannelQu
   return result;
 }
 
-std::auto_ptr<CastorElectronicsMap> CastorHardcodeCalibrations::produceElectronicsMap (const CastorElectronicsMapRcd& rcd) {
+std::unique_ptr<CastorElectronicsMap> CastorHardcodeCalibrations::produceElectronicsMap (const CastorElectronicsMapRcd& rcd) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceElectronicsMap-> ...";
 
-  std::auto_ptr<CastorElectronicsMap> result (new CastorElectronicsMap ());
+  auto result = std::make_unique<CastorElectronicsMap>();
   CastorDbHardcode::makeHardcodeMap(*result);
   return result;
 }
 
-std::auto_ptr<CastorRecoParams> CastorHardcodeCalibrations::produceRecoParams (const CastorRecoParamsRcd& rcd) {
+std::unique_ptr<CastorRecoParams> CastorHardcodeCalibrations::produceRecoParams (const CastorRecoParamsRcd& rcd) {
 	edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceRecoParams-> ...";
-	std::auto_ptr<CastorRecoParams> result (new CastorRecoParams ());
+        auto result = std::make_unique<CastorRecoParams>();
 	std::vector <HcalGenericDetId> cells = allCells(h2mode_);
 	for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
 		CastorRecoParam item = CastorDbHardcode::makeRecoParam (*cell);
@@ -217,9 +217,9 @@ std::auto_ptr<CastorRecoParams> CastorHardcodeCalibrations::produceRecoParams (c
 	return result;
 }
 
-std::auto_ptr<CastorSaturationCorrs> CastorHardcodeCalibrations::produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd) {
+std::unique_ptr<CastorSaturationCorrs> CastorHardcodeCalibrations::produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd) {
 	edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceSaturationCorrs-> ...";
-	std::auto_ptr<CastorSaturationCorrs> result (new CastorSaturationCorrs ());
+        auto result = std::make_unique<CastorSaturationCorrs>();
 	std::vector <HcalGenericDetId> cells = allCells(h2mode_);
 	for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
 		CastorSaturationCorr item = CastorDbHardcode::makeSaturationCorr (*cell);

--- a/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.h
@@ -34,15 +34,15 @@ protected:
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) ;
 
-  std::auto_ptr<CastorPedestals> producePedestals (const CastorPedestalsRcd& rcd);
-  std::auto_ptr<CastorPedestalWidths> producePedestalWidths (const CastorPedestalWidthsRcd& rcd);
-  std::auto_ptr<CastorGains> produceGains (const CastorGainsRcd& rcd);
-  std::auto_ptr<CastorGainWidths> produceGainWidths (const CastorGainWidthsRcd& rcd);
-  std::auto_ptr<CastorQIEData> produceQIEData (const CastorQIEDataRcd& rcd);
-  std::auto_ptr<CastorChannelQuality> produceChannelQuality (const CastorChannelQualityRcd& rcd);
-  std::auto_ptr<CastorElectronicsMap> produceElectronicsMap (const CastorElectronicsMapRcd& rcd);
-  std::auto_ptr<CastorRecoParams> produceRecoParams (const CastorRecoParamsRcd& rcd);
-  std::auto_ptr<CastorSaturationCorrs> produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd);
+  std::unique_ptr<CastorPedestals> producePedestals (const CastorPedestalsRcd& rcd);
+  std::unique_ptr<CastorPedestalWidths> producePedestalWidths (const CastorPedestalWidthsRcd& rcd);
+  std::unique_ptr<CastorGains> produceGains (const CastorGainsRcd& rcd);
+  std::unique_ptr<CastorGainWidths> produceGainWidths (const CastorGainWidthsRcd& rcd);
+  std::unique_ptr<CastorQIEData> produceQIEData (const CastorQIEDataRcd& rcd);
+  std::unique_ptr<CastorChannelQuality> produceChannelQuality (const CastorChannelQualityRcd& rcd);
+  std::unique_ptr<CastorElectronicsMap> produceElectronicsMap (const CastorElectronicsMapRcd& rcd);
+  std::unique_ptr<CastorRecoParams> produceRecoParams (const CastorRecoParamsRcd& rcd);
+  std::unique_ptr<CastorSaturationCorrs> produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd);
   bool h2mode_;
 };
 

--- a/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.cc
@@ -106,8 +106,8 @@ CastorTextCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecordK
 }
 
 template <class T>
-std::auto_ptr<T> produce_impl (const std::string& fFile) {
-  std::auto_ptr<T> result (new T ());
+std::unique_ptr<T> produce_impl (const std::string& fFile) {
+  std::unique_ptr<T> result (new T ());
   std::ifstream inStream (fFile.c_str ());
   if (!inStream.good ()) {
     std::cerr << "CastorTextCalibrations-> Unable to open file '" << fFile << "'" << std::endl;
@@ -121,38 +121,38 @@ std::auto_ptr<T> produce_impl (const std::string& fFile) {
 }
 
 
-std::auto_ptr<CastorPedestals> CastorTextCalibrations::producePedestals (const CastorPedestalsRcd&) {
+std::unique_ptr<CastorPedestals> CastorTextCalibrations::producePedestals (const CastorPedestalsRcd&) {
   return produce_impl<CastorPedestals> (mInputs ["Pedestals"]);
 }
 
-std::auto_ptr<CastorPedestalWidths> CastorTextCalibrations::producePedestalWidths (const CastorPedestalWidthsRcd&) {
+std::unique_ptr<CastorPedestalWidths> CastorTextCalibrations::producePedestalWidths (const CastorPedestalWidthsRcd&) {
   return produce_impl<CastorPedestalWidths> (mInputs ["PedestalWidths"]);
 }
 
-std::auto_ptr<CastorGains> CastorTextCalibrations::produceGains (const CastorGainsRcd&) {
+std::unique_ptr<CastorGains> CastorTextCalibrations::produceGains (const CastorGainsRcd&) {
   return produce_impl<CastorGains> (mInputs ["Gains"]);
 }
 
-std::auto_ptr<CastorGainWidths> CastorTextCalibrations::produceGainWidths (const CastorGainWidthsRcd&) {
+std::unique_ptr<CastorGainWidths> CastorTextCalibrations::produceGainWidths (const CastorGainWidthsRcd&) {
   return produce_impl<CastorGainWidths> (mInputs ["GainWidths"]);
 }
 
-std::auto_ptr<CastorQIEData> CastorTextCalibrations::produceQIEData (const CastorQIEDataRcd& rcd) {
+std::unique_ptr<CastorQIEData> CastorTextCalibrations::produceQIEData (const CastorQIEDataRcd& rcd) {
   return produce_impl<CastorQIEData> (mInputs ["QIEData"]);
 }
 
-std::auto_ptr<CastorChannelQuality> CastorTextCalibrations::produceChannelQuality (const CastorChannelQualityRcd& rcd) {
+std::unique_ptr<CastorChannelQuality> CastorTextCalibrations::produceChannelQuality (const CastorChannelQualityRcd& rcd) {
   return produce_impl<CastorChannelQuality> (mInputs ["ChannelQuality"]);
 }
 
-std::auto_ptr<CastorElectronicsMap> CastorTextCalibrations::produceElectronicsMap (const CastorElectronicsMapRcd& rcd) {
+std::unique_ptr<CastorElectronicsMap> CastorTextCalibrations::produceElectronicsMap (const CastorElectronicsMapRcd& rcd) {
   return produce_impl<CastorElectronicsMap> (mInputs ["ElectronicsMap"]);
 }
 
-std::auto_ptr<CastorRecoParams> CastorTextCalibrations::produceRecoParams (const CastorRecoParamsRcd& rcd) {
+std::unique_ptr<CastorRecoParams> CastorTextCalibrations::produceRecoParams (const CastorRecoParamsRcd& rcd) {
   return produce_impl<CastorRecoParams> (mInputs ["RecoParams"]);
 }
 
-std::auto_ptr<CastorSaturationCorrs> CastorTextCalibrations::produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd) {
+std::unique_ptr<CastorSaturationCorrs> CastorTextCalibrations::produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd) {
   return produce_impl<CastorSaturationCorrs> (mInputs ["SaturationCorrs"]);
 }

--- a/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.h
@@ -39,15 +39,15 @@ protected:
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) ;
 
-  std::auto_ptr<CastorPedestals> producePedestals (const CastorPedestalsRcd& rcd);
-  std::auto_ptr<CastorPedestalWidths> producePedestalWidths (const CastorPedestalWidthsRcd& rcd);
-  std::auto_ptr<CastorGains> produceGains (const CastorGainsRcd& rcd);
-  std::auto_ptr<CastorGainWidths> produceGainWidths (const CastorGainWidthsRcd& rcd);
-  std::auto_ptr<CastorQIEData> produceQIEData (const CastorQIEDataRcd& rcd);
-  std::auto_ptr<CastorChannelQuality> produceChannelQuality (const CastorChannelQualityRcd& rcd);
-  std::auto_ptr<CastorElectronicsMap> produceElectronicsMap (const CastorElectronicsMapRcd& rcd);
-  std::auto_ptr<CastorRecoParams> produceRecoParams (const CastorRecoParamsRcd& rcd);
-  std::auto_ptr<CastorSaturationCorrs> produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd);
+  std::unique_ptr<CastorPedestals> producePedestals (const CastorPedestalsRcd& rcd);
+  std::unique_ptr<CastorPedestalWidths> producePedestalWidths (const CastorPedestalWidthsRcd& rcd);
+  std::unique_ptr<CastorGains> produceGains (const CastorGainsRcd& rcd);
+  std::unique_ptr<CastorGainWidths> produceGainWidths (const CastorGainWidthsRcd& rcd);
+  std::unique_ptr<CastorQIEData> produceQIEData (const CastorQIEDataRcd& rcd);
+  std::unique_ptr<CastorChannelQuality> produceChannelQuality (const CastorChannelQualityRcd& rcd);
+  std::unique_ptr<CastorElectronicsMap> produceElectronicsMap (const CastorElectronicsMapRcd& rcd);
+  std::unique_ptr<CastorRecoParams> produceRecoParams (const CastorRecoParamsRcd& rcd);
+  std::unique_ptr<CastorSaturationCorrs> produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd);
 
  private:
   std::map <std::string, std::string> mInputs;

--- a/CalibCalorimetry/EcalCorrectionModules/src/EcalGlobalShowerContainmentCorrectionsVsEtaESProducer.cc
+++ b/CalibCalorimetry/EcalCorrectionModules/src/EcalGlobalShowerContainmentCorrectionsVsEtaESProducer.cc
@@ -33,7 +33,7 @@ class EcalGlobalShowerContainmentCorrectionsVsEtaESProducer : public edm::ESProd
       EcalGlobalShowerContainmentCorrectionsVsEtaESProducer(const edm::ParameterSet&);
      ~EcalGlobalShowerContainmentCorrectionsVsEtaESProducer();
 
-      typedef std::auto_ptr<EcalGlobalShowerContainmentCorrectionsVsEta> ReturnType;
+      typedef std::unique_ptr<EcalGlobalShowerContainmentCorrectionsVsEta> ReturnType;
 
       ReturnType produce(const EcalGlobalShowerContainmentCorrectionsVsEtaRcd&);
    private:
@@ -62,7 +62,7 @@ EcalGlobalShowerContainmentCorrectionsVsEtaESProducer::produce(const EcalGlobalS
    using namespace edm::es;
    using namespace std;
 
-   auto_ptr<EcalGlobalShowerContainmentCorrectionsVsEta> pEcalGlobalShowerContainmentCorrectionsVsEta(new EcalGlobalShowerContainmentCorrectionsVsEta) ;
+   auto pEcalGlobalShowerContainmentCorrectionsVsEta = std::make_unique<EcalGlobalShowerContainmentCorrectionsVsEta>();
    
    double values[] = {   43.77,       // 3x3 
 			 1.,	  

--- a/CalibCalorimetry/EcalCorrectionModules/src/EcalShowerContainmentCorrectionsESProducer.cc
+++ b/CalibCalorimetry/EcalCorrectionModules/src/EcalShowerContainmentCorrectionsESProducer.cc
@@ -34,7 +34,7 @@ class EcalShowerContainmentCorrectionsESProducer : public edm::ESProducer {
       EcalShowerContainmentCorrectionsESProducer(const edm::ParameterSet&);
      ~EcalShowerContainmentCorrectionsESProducer();
 
-      typedef std::auto_ptr<EcalShowerContainmentCorrections> ReturnType;
+      typedef std::unique_ptr<EcalShowerContainmentCorrections> ReturnType;
 
       ReturnType produce(const EcalShowerContainmentCorrectionsRcd&);
    private:
@@ -63,7 +63,7 @@ EcalShowerContainmentCorrectionsESProducer::produce(const EcalShowerContainmentC
    using namespace edm::es;
    using namespace std;
 
-   auto_ptr<EcalShowerContainmentCorrections> pEcalShowerContainmentCorrections(new EcalShowerContainmentCorrections) ;
+   auto pEcalShowerContainmentCorrections = std::make_unique<EcalShowerContainmentCorrections>();
    int sm=1; // in testbeam data sw believes we always are on sm01
 
    // where is the n of xtals per sm coded ?

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/ESTrivialConditionRetriever.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/ESTrivialConditionRetriever.h
@@ -46,19 +46,19 @@ public:
   virtual ~ESTrivialConditionRetriever();
 
   // ---------- member functions ---------------------------
-  virtual std::auto_ptr<ESPedestals> produceESPedestals( const ESPedestalsRcd& );
-  virtual std::auto_ptr<ESWeightStripGroups> produceESWeightStripGroups( const ESWeightStripGroupsRcd& );
-  virtual std::auto_ptr<ESIntercalibConstants> produceESIntercalibConstants( const ESIntercalibConstantsRcd& );
+  virtual std::unique_ptr<ESPedestals> produceESPedestals( const ESPedestalsRcd& );
+  virtual std::unique_ptr<ESWeightStripGroups> produceESWeightStripGroups( const ESWeightStripGroupsRcd& );
+  virtual std::unique_ptr<ESIntercalibConstants> produceESIntercalibConstants( const ESIntercalibConstantsRcd& );
 
-  //  virtual std::auto_ptr<ESIntercalibErrors> produceESIntercalibErrors( const ESIntercalibErrorsRcd& );
-  //  virtual std::auto_ptr<ESIntercalibErrors>  getIntercalibErrorsFromConfiguration ( const ESIntercalibErrorsRcd& ) ;
+  //  virtual std::unique_ptr<ESIntercalibErrors> produceESIntercalibErrors( const ESIntercalibErrorsRcd& );
+  //  virtual std::unique_ptr<ESIntercalibErrors>  getIntercalibErrorsFromConfiguration ( const ESIntercalibErrorsRcd& ) ;
 
-  virtual std::auto_ptr<ESADCToGeVConstant> produceESADCToGeVConstant( const ESADCToGeVConstantRcd& );
-  virtual std::auto_ptr<ESTBWeights> produceESTBWeights( const ESTBWeightsRcd& );
-  //  virtual std::auto_ptr<ESIntercalibConstants>  getIntercalibConstantsFromConfiguration ( const ESIntercalibConstantsRcd& ) ;
+  virtual std::unique_ptr<ESADCToGeVConstant> produceESADCToGeVConstant( const ESADCToGeVConstantRcd& );
+  virtual std::unique_ptr<ESTBWeights> produceESTBWeights( const ESTBWeightsRcd& );
+  //  virtual std::unique_ptr<ESIntercalibConstants>  getIntercalibConstantsFromConfiguration ( const ESIntercalibConstantsRcd& ) ;
 
-  virtual std::auto_ptr<ESChannelStatus> produceESChannelStatus( const ESChannelStatusRcd& );
-  virtual std::auto_ptr<ESChannelStatus> getChannelStatusFromConfiguration( const ESChannelStatusRcd& );
+  virtual std::unique_ptr<ESChannelStatus> produceESChannelStatus( const ESChannelStatusRcd& );
+  virtual std::unique_ptr<ESChannelStatus> getChannelStatusFromConfiguration( const ESChannelStatusRcd& );
 
 protected:
   //overriding from ContextRecordIntervalFinder

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
@@ -124,61 +124,61 @@ public:
   virtual ~EcalTrivialConditionRetriever();
 
   // ---------- member functions ---------------------------
-  virtual std::auto_ptr<EcalPedestals> produceEcalPedestals( const EcalPedestalsRcd& );
-  virtual std::auto_ptr<EcalWeightXtalGroups> produceEcalWeightXtalGroups( const EcalWeightXtalGroupsRcd& );
-  virtual std::auto_ptr<EcalLinearCorrections> produceEcalLinearCorrections( const EcalLinearCorrectionsRcd& );
-  virtual std::auto_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& );
-  virtual std::auto_ptr<EcalIntercalibConstantsMC> produceEcalIntercalibConstantsMC( const EcalIntercalibConstantsMCRcd& );
-  virtual std::auto_ptr<EcalIntercalibErrors> produceEcalIntercalibErrors( const EcalIntercalibErrorsRcd& );
-  virtual std::auto_ptr<EcalTimeCalibConstants> produceEcalTimeCalibConstants( const EcalTimeCalibConstantsRcd& );
-  virtual std::auto_ptr<EcalTimeCalibErrors> produceEcalTimeCalibErrors( const EcalTimeCalibErrorsRcd& );
-  virtual std::auto_ptr<EcalGainRatios> produceEcalGainRatios( const EcalGainRatiosRcd& );
-  virtual std::auto_ptr<EcalADCToGeVConstant> produceEcalADCToGeVConstant( const EcalADCToGeVConstantRcd& );
-  virtual std::auto_ptr<EcalTBWeights> produceEcalTBWeights( const EcalTBWeightsRcd& );
-  virtual std::auto_ptr<EcalIntercalibConstants>  getIntercalibConstantsFromConfiguration ( const EcalIntercalibConstantsRcd& ) ;
-  virtual std::auto_ptr<EcalIntercalibConstantsMC>  getIntercalibConstantsMCFromConfiguration ( const EcalIntercalibConstantsMCRcd& ) ;
-  virtual std::auto_ptr<EcalIntercalibErrors>  getIntercalibErrorsFromConfiguration ( const EcalIntercalibErrorsRcd& ) ;
-  virtual std::auto_ptr<EcalTimeCalibConstants>  getTimeCalibConstantsFromConfiguration ( const EcalTimeCalibConstantsRcd& ) ;
-  virtual std::auto_ptr<EcalTimeCalibErrors>  getTimeCalibErrorsFromConfiguration ( const EcalTimeCalibErrorsRcd& ) ;
-  virtual std::auto_ptr<EcalTimeOffsetConstant> produceEcalTimeOffsetConstant( const EcalTimeOffsetConstantRcd& );
+  virtual std::unique_ptr<EcalPedestals> produceEcalPedestals( const EcalPedestalsRcd& );
+  virtual std::unique_ptr<EcalWeightXtalGroups> produceEcalWeightXtalGroups( const EcalWeightXtalGroupsRcd& );
+  virtual std::unique_ptr<EcalLinearCorrections> produceEcalLinearCorrections( const EcalLinearCorrectionsRcd& );
+  virtual std::unique_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& );
+  virtual std::unique_ptr<EcalIntercalibConstantsMC> produceEcalIntercalibConstantsMC( const EcalIntercalibConstantsMCRcd& );
+  virtual std::unique_ptr<EcalIntercalibErrors> produceEcalIntercalibErrors( const EcalIntercalibErrorsRcd& );
+  virtual std::unique_ptr<EcalTimeCalibConstants> produceEcalTimeCalibConstants( const EcalTimeCalibConstantsRcd& );
+  virtual std::unique_ptr<EcalTimeCalibErrors> produceEcalTimeCalibErrors( const EcalTimeCalibErrorsRcd& );
+  virtual std::unique_ptr<EcalGainRatios> produceEcalGainRatios( const EcalGainRatiosRcd& );
+  virtual std::unique_ptr<EcalADCToGeVConstant> produceEcalADCToGeVConstant( const EcalADCToGeVConstantRcd& );
+  virtual std::unique_ptr<EcalTBWeights> produceEcalTBWeights( const EcalTBWeightsRcd& );
+  virtual std::unique_ptr<EcalIntercalibConstants>  getIntercalibConstantsFromConfiguration ( const EcalIntercalibConstantsRcd& ) ;
+  virtual std::unique_ptr<EcalIntercalibConstantsMC>  getIntercalibConstantsMCFromConfiguration ( const EcalIntercalibConstantsMCRcd& ) ;
+  virtual std::unique_ptr<EcalIntercalibErrors>  getIntercalibErrorsFromConfiguration ( const EcalIntercalibErrorsRcd& ) ;
+  virtual std::unique_ptr<EcalTimeCalibConstants>  getTimeCalibConstantsFromConfiguration ( const EcalTimeCalibConstantsRcd& ) ;
+  virtual std::unique_ptr<EcalTimeCalibErrors>  getTimeCalibErrorsFromConfiguration ( const EcalTimeCalibErrorsRcd& ) ;
+  virtual std::unique_ptr<EcalTimeOffsetConstant> produceEcalTimeOffsetConstant( const EcalTimeOffsetConstantRcd& );
 
 
-  virtual std::auto_ptr<EcalLaserAlphas> produceEcalLaserAlphas( const EcalLaserAlphasRcd& );
-  virtual std::auto_ptr<EcalLaserAPDPNRatiosRef> produceEcalLaserAPDPNRatiosRef( const EcalLaserAPDPNRatiosRefRcd& );
-  virtual std::auto_ptr<EcalLaserAPDPNRatios> produceEcalLaserAPDPNRatios( const EcalLaserAPDPNRatiosRcd& );
+  virtual std::unique_ptr<EcalLaserAlphas> produceEcalLaserAlphas( const EcalLaserAlphasRcd& );
+  virtual std::unique_ptr<EcalLaserAPDPNRatiosRef> produceEcalLaserAPDPNRatiosRef( const EcalLaserAPDPNRatiosRefRcd& );
+  virtual std::unique_ptr<EcalLaserAPDPNRatios> produceEcalLaserAPDPNRatios( const EcalLaserAPDPNRatiosRcd& );
 
-  virtual std::auto_ptr<EcalClusterLocalContCorrParameters> produceEcalClusterLocalContCorrParameters( const EcalClusterLocalContCorrParametersRcd& );
-  virtual std::auto_ptr<EcalClusterCrackCorrParameters> produceEcalClusterCrackCorrParameters( const EcalClusterCrackCorrParametersRcd& );
-  virtual std::auto_ptr<EcalClusterEnergyCorrectionParameters> produceEcalClusterEnergyCorrectionParameters( const EcalClusterEnergyCorrectionParametersRcd& );
-  virtual std::auto_ptr<EcalClusterEnergyUncertaintyParameters> produceEcalClusterEnergyUncertaintyParameters( const EcalClusterEnergyUncertaintyParametersRcd& );
-  virtual std::auto_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters> produceEcalClusterEnergyCorrectionObjectSpecificParameters( const EcalClusterEnergyCorrectionObjectSpecificParametersRcd& );
+  virtual std::unique_ptr<EcalClusterLocalContCorrParameters> produceEcalClusterLocalContCorrParameters( const EcalClusterLocalContCorrParametersRcd& );
+  virtual std::unique_ptr<EcalClusterCrackCorrParameters> produceEcalClusterCrackCorrParameters( const EcalClusterCrackCorrParametersRcd& );
+  virtual std::unique_ptr<EcalClusterEnergyCorrectionParameters> produceEcalClusterEnergyCorrectionParameters( const EcalClusterEnergyCorrectionParametersRcd& );
+  virtual std::unique_ptr<EcalClusterEnergyUncertaintyParameters> produceEcalClusterEnergyUncertaintyParameters( const EcalClusterEnergyUncertaintyParametersRcd& );
+  virtual std::unique_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters> produceEcalClusterEnergyCorrectionObjectSpecificParameters( const EcalClusterEnergyCorrectionObjectSpecificParametersRcd& );
 
-  virtual std::auto_ptr<EcalChannelStatus> produceEcalChannelStatus( const EcalChannelStatusRcd& );
-  virtual std::auto_ptr<EcalChannelStatus> getChannelStatusFromConfiguration( const EcalChannelStatusRcd& );
+  virtual std::unique_ptr<EcalChannelStatus> produceEcalChannelStatus( const EcalChannelStatusRcd& );
+  virtual std::unique_ptr<EcalChannelStatus> getChannelStatusFromConfiguration( const EcalChannelStatusRcd& );
 
-  virtual std::auto_ptr<EcalTPGCrystalStatus> produceEcalTrgChannelStatus( const EcalTPGCrystalStatusRcd& );
-  virtual std::auto_ptr<EcalTPGCrystalStatus> getTrgChannelStatusFromConfiguration( const EcalTPGCrystalStatusRcd& );
+  virtual std::unique_ptr<EcalTPGCrystalStatus> produceEcalTrgChannelStatus( const EcalTPGCrystalStatusRcd& );
+  virtual std::unique_ptr<EcalTPGCrystalStatus> getTrgChannelStatusFromConfiguration( const EcalTPGCrystalStatusRcd& );
 
-  virtual std::auto_ptr<EcalDCSTowerStatus> produceEcalDCSTowerStatus( const EcalDCSTowerStatusRcd& );
-  virtual std::auto_ptr<EcalDAQTowerStatus> produceEcalDAQTowerStatus( const EcalDAQTowerStatusRcd& );
-  virtual std::auto_ptr<EcalDQMTowerStatus> produceEcalDQMTowerStatus( const EcalDQMTowerStatusRcd& );
-  virtual std::auto_ptr<EcalDQMChannelStatus> produceEcalDQMChannelStatus( const EcalDQMChannelStatusRcd& );
+  virtual std::unique_ptr<EcalDCSTowerStatus> produceEcalDCSTowerStatus( const EcalDCSTowerStatusRcd& );
+  virtual std::unique_ptr<EcalDAQTowerStatus> produceEcalDAQTowerStatus( const EcalDAQTowerStatusRcd& );
+  virtual std::unique_ptr<EcalDQMTowerStatus> produceEcalDQMTowerStatus( const EcalDQMTowerStatusRcd& );
+  virtual std::unique_ptr<EcalDQMChannelStatus> produceEcalDQMChannelStatus( const EcalDQMChannelStatusRcd& );
 
-  virtual std::auto_ptr<EcalMappingElectronics> produceEcalMappingElectronics( const EcalMappingElectronicsRcd& );
-  virtual std::auto_ptr<EcalMappingElectronics> getMappingFromConfiguration( const EcalMappingElectronicsRcd& );
+  virtual std::unique_ptr<EcalMappingElectronics> produceEcalMappingElectronics( const EcalMappingElectronicsRcd& );
+  virtual std::unique_ptr<EcalMappingElectronics> getMappingFromConfiguration( const EcalMappingElectronicsRcd& );
 
-  //  virtual std::auto_ptr<EcalAlignmentEB> produceEcalAlignmentEB( const EcalAlignmentEBRcd& );
-  //  virtual std::auto_ptr<EcalAlignmentEE> produceEcalAlignmentEE( const EcalAlignmentEERcd& );
-  //  virtual std::auto_ptr<EcalAlignmentES> produceEcalAlignmentES( const EcalAlignmentESRcd& );
-  virtual std::auto_ptr<Alignments> produceEcalAlignmentEB( const EBAlignmentRcd& );
-  virtual std::auto_ptr<Alignments> produceEcalAlignmentEE( const EEAlignmentRcd& );
-  virtual std::auto_ptr<Alignments> produceEcalAlignmentES( const ESAlignmentRcd& );
+  //  virtual std::unique_ptr<EcalAlignmentEB> produceEcalAlignmentEB( const EcalAlignmentEBRcd& );
+  //  virtual std::unique_ptr<EcalAlignmentEE> produceEcalAlignmentEE( const EcalAlignmentEERcd& );
+  //  virtual std::unique_ptr<EcalAlignmentES> produceEcalAlignmentES( const EcalAlignmentESRcd& );
+  virtual std::unique_ptr<Alignments> produceEcalAlignmentEB( const EBAlignmentRcd& );
+  virtual std::unique_ptr<Alignments> produceEcalAlignmentEE( const EEAlignmentRcd& );
+  virtual std::unique_ptr<Alignments> produceEcalAlignmentES( const ESAlignmentRcd& );
 
-  virtual std::auto_ptr<EcalSampleMask> produceEcalSampleMask( const EcalSampleMaskRcd& );
+  virtual std::unique_ptr<EcalSampleMask> produceEcalSampleMask( const EcalSampleMaskRcd& );
 
-  virtual std::auto_ptr<EcalTimeBiasCorrections> produceEcalTimeBiasCorrections( const EcalTimeBiasCorrectionsRcd& );
+  virtual std::unique_ptr<EcalTimeBiasCorrections> produceEcalTimeBiasCorrections( const EcalTimeBiasCorrectionsRcd& );
 
-  virtual std::auto_ptr<EcalSamplesCorrelation> produceEcalSamplesCorrelation( const EcalSamplesCorrelationRcd& );
+  virtual std::unique_ptr<EcalSamplesCorrelation> produceEcalSamplesCorrelation( const EcalSamplesCorrelationRcd& );
 
 protected:
   //overriding from ContextRecordIntervalFinder

--- a/CalibCalorimetry/EcalTrivialCondModules/src/ESTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/ESTrivialConditionRetriever.cc
@@ -135,10 +135,10 @@ ESTrivialConditionRetriever::setIntervalFor( const edm::eventsetup::EventSetupRe
 }
 
 //produce methods
-std::auto_ptr<ESPedestals>
+std::unique_ptr<ESPedestals>
 ESTrivialConditionRetriever::produceESPedestals( const ESPedestalsRcd& ) {
   std::cout<< " producing pedestals"<< std::endl;
-  std::auto_ptr<ESPedestals>  peds = std::auto_ptr<ESPedestals>( new ESPedestals() );
+  auto peds = std::make_unique<ESPedestals>();
   ESPedestals::Item ESitem;
   ESitem.mean  = ESpedMean_;
   ESitem.rms   = ESpedRMS_;
@@ -162,15 +162,15 @@ ESTrivialConditionRetriever::produceESPedestals( const ESPedestalsRcd& ) {
       }
     }
   }
-  //return std::auto_ptr<ESPedestals>( peds );
+  //return std::unique_ptr<ESPedestals>( peds );
   std::cout<< " produced pedestals"<< std::endl;
   return peds;
 }
 
-std::auto_ptr<ESWeightStripGroups>
+std::unique_ptr<ESWeightStripGroups>
 ESTrivialConditionRetriever::produceESWeightStripGroups( const ESWeightStripGroupsRcd& )
 {
-  std::auto_ptr<ESWeightStripGroups> xtalGroups = std::auto_ptr<ESWeightStripGroups>( new ESWeightStripGroups() );
+  auto xtalGroups = std::make_unique<ESWeightStripGroups>();
   ESStripGroupId defaultGroupId(1);
   std::cout << "entering produce weight groups"<< std::endl;
   for (int istrip=ESDetId::ISTRIP_MIN;istrip<=ESDetId::ISTRIP_MAX;istrip++) {
@@ -198,10 +198,10 @@ ESTrivialConditionRetriever::produceESWeightStripGroups( const ESWeightStripGrou
   return xtalGroups;
 }
 
-std::auto_ptr<ESIntercalibConstants>
+std::unique_ptr<ESIntercalibConstants>
 ESTrivialConditionRetriever::produceESIntercalibConstants( const ESIntercalibConstantsRcd& )
 {
-  std::auto_ptr<ESIntercalibConstants>  ical = std::auto_ptr<ESIntercalibConstants>( new ESIntercalibConstants() );
+  auto ical = std::make_unique<ESIntercalibConstants>();
   std::cout << "entring produce intercalib "<< std::endl;
 
   for (int istrip=ESDetId::ISTRIP_MIN;istrip<=ESDetId::ISTRIP_MAX;istrip++) {
@@ -230,17 +230,17 @@ ESTrivialConditionRetriever::produceESIntercalibConstants( const ESIntercalibCon
 }
 
 
-std::auto_ptr<ESADCToGeVConstant>
+std::unique_ptr<ESADCToGeVConstant>
 ESTrivialConditionRetriever::produceESADCToGeVConstant( const ESADCToGeVConstantRcd& )
 {
-  return std::auto_ptr<ESADCToGeVConstant>( new ESADCToGeVConstant(adcToGeVLowConstant_,adcToGeVHighConstant_) );
+  return std::make_unique<ESADCToGeVConstant>(adcToGeVLowConstant_,adcToGeVHighConstant_);
 }
 
-std::auto_ptr<ESTBWeights>
+std::unique_ptr<ESTBWeights>
 ESTrivialConditionRetriever::produceESTBWeights( const ESTBWeightsRcd& )
 {
   // create weights for the test-beam
-  std::auto_ptr<ESTBWeights> tbwgt = std::auto_ptr<ESTBWeights>( new ESTBWeights() );
+  auto tbwgt = std::make_unique<ESTBWeights>();
 
   int igrp=1;
   ESWeightSet wgt = ESWeightSet(amplWeights_);
@@ -297,10 +297,10 @@ void ESTrivialConditionRetriever::getWeightsFromConfiguration(const edm::Paramet
 
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<ESChannelStatus>
+std::unique_ptr<ESChannelStatus>
 ESTrivialConditionRetriever::getChannelStatusFromConfiguration (const ESChannelStatusRcd&)
 {
-  std::auto_ptr<ESChannelStatus> ecalStatus = std::auto_ptr<ESChannelStatus>( new ESChannelStatus() );
+  auto ecalStatus = std::make_unique<ESChannelStatus>();
   
 
   // start by setting all statuses to 0
@@ -377,11 +377,11 @@ ESTrivialConditionRetriever::getChannelStatusFromConfiguration (const ESChannelS
 
 
 
-std::auto_ptr<ESChannelStatus>
+std::unique_ptr<ESChannelStatus>
 ESTrivialConditionRetriever::produceESChannelStatus( const ESChannelStatusRcd& )
 {
 
-  std::auto_ptr<ESChannelStatus>  ical = std::auto_ptr<ESChannelStatus>( new ESChannelStatus() );
+  auto ical = std::make_unique<ESChannelStatus>();
   for (int istrip=ESDetId::ISTRIP_MIN;istrip<=ESDetId::ISTRIP_MAX;istrip++) {
     for (int ix=ESDetId::IX_MIN;ix<=ESDetId::IX_MAX;ix++){
       for (int iy=ESDetId::IY_MIN;iy<=ESDetId::IY_MAX;iy++){

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
@@ -467,9 +467,9 @@ EcalTrivialConditionRetriever::setIntervalFor( const edm::eventsetup::EventSetup
 }
 
 //produce methods
-std::auto_ptr<EcalPedestals>
+std::unique_ptr<EcalPedestals>
 EcalTrivialConditionRetriever::produceEcalPedestals( const EcalPedestalsRcd& ) {
-  std::auto_ptr<EcalPedestals>  peds = std::auto_ptr<EcalPedestals>( new EcalPedestals() );
+  auto peds = std::make_unique<EcalPedestals>();
   EcalPedestals::Item EBitem;
   EcalPedestals::Item EEitem;
   
@@ -538,16 +538,16 @@ EcalTrivialConditionRetriever::produceEcalPedestals( const EcalPedestalsRcd& ) {
     }
   }
 
-  //return std::auto_ptr<EcalPedestals>( peds );
+  //return std::unique_ptr<EcalPedestals>( peds );
   return peds;
 }
 
 
 
-std::auto_ptr<EcalWeightXtalGroups>
+std::unique_ptr<EcalWeightXtalGroups>
 EcalTrivialConditionRetriever::produceEcalWeightXtalGroups( const EcalWeightXtalGroupsRcd& )
 {
-  std::auto_ptr<EcalWeightXtalGroups> xtalGroups = std::auto_ptr<EcalWeightXtalGroups>( new EcalWeightXtalGroups() );
+  auto xtalGroups = std::make_unique<EcalWeightXtalGroups>();
   EcalXtalGroupId defaultGroupId(1);
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
     if(ieta==0) continue;
@@ -581,10 +581,10 @@ EcalTrivialConditionRetriever::produceEcalWeightXtalGroups( const EcalWeightXtal
 }
 
 
-std::auto_ptr<EcalLinearCorrections>
+std::unique_ptr<EcalLinearCorrections>
 EcalTrivialConditionRetriever::produceEcalLinearCorrections( const EcalLinearCorrectionsRcd& )
 {
-  std::auto_ptr<EcalLinearCorrections>  ical = std::auto_ptr<EcalLinearCorrections>( new EcalLinearCorrections() );
+  auto ical = std::make_unique<EcalLinearCorrections>();
 
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
     if(ieta==0) continue;
@@ -655,10 +655,10 @@ EcalTrivialConditionRetriever::produceEcalLinearCorrections( const EcalLinearCor
 
 //------------------------------
 
-std::auto_ptr<EcalIntercalibConstants>
+std::unique_ptr<EcalIntercalibConstants>
 EcalTrivialConditionRetriever::produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& )
 {
-  std::auto_ptr<EcalIntercalibConstants>  ical = std::auto_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+  auto ical = std::make_unique<EcalIntercalibConstants>();
 
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
     if(ieta==0) continue;
@@ -694,10 +694,10 @@ EcalTrivialConditionRetriever::produceEcalIntercalibConstants( const EcalInterca
   return ical;
 }
 
-std::auto_ptr<EcalIntercalibConstantsMC>
+std::unique_ptr<EcalIntercalibConstantsMC>
 EcalTrivialConditionRetriever::produceEcalIntercalibConstantsMC( const EcalIntercalibConstantsMCRcd& )
 {
-  std::auto_ptr<EcalIntercalibConstantsMC>  ical = std::auto_ptr<EcalIntercalibConstantsMC>( new EcalIntercalibConstantsMC() );
+  auto ical = std::make_unique<EcalIntercalibConstantsMC>();
 
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
     if(ieta==0) continue;
@@ -733,10 +733,10 @@ EcalTrivialConditionRetriever::produceEcalIntercalibConstantsMC( const EcalInter
   return ical;
 }
 
-std::auto_ptr<EcalIntercalibErrors>
+std::unique_ptr<EcalIntercalibErrors>
 EcalTrivialConditionRetriever::produceEcalIntercalibErrors( const EcalIntercalibErrorsRcd& )
 {
-  std::auto_ptr<EcalIntercalibErrors>  ical = std::auto_ptr<EcalIntercalibErrors>( new EcalIntercalibErrors() );
+  auto ical = std::make_unique<EcalIntercalibErrors>();
 
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
     if(ieta==0) continue;
@@ -769,10 +769,10 @@ EcalTrivialConditionRetriever::produceEcalIntercalibErrors( const EcalIntercalib
   return ical;
 }
 
-std::auto_ptr<EcalTimeCalibConstants>
+std::unique_ptr<EcalTimeCalibConstants>
 EcalTrivialConditionRetriever::produceEcalTimeCalibConstants( const EcalTimeCalibConstantsRcd& )
 {
-  std::auto_ptr<EcalTimeCalibConstants>  ical = std::auto_ptr<EcalTimeCalibConstants>( new EcalTimeCalibConstants() );
+  auto ical = std::make_unique<EcalTimeCalibConstants>();
 
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
     if(ieta==0) continue;
@@ -808,10 +808,10 @@ EcalTrivialConditionRetriever::produceEcalTimeCalibConstants( const EcalTimeCali
   return ical;
 }
 
-std::auto_ptr<EcalTimeCalibErrors>
+std::unique_ptr<EcalTimeCalibErrors>
 EcalTrivialConditionRetriever::produceEcalTimeCalibErrors( const EcalTimeCalibErrorsRcd& )
 {
-  std::auto_ptr<EcalTimeCalibErrors>  ical = std::auto_ptr<EcalTimeCalibErrors>( new EcalTimeCalibErrors() );
+  auto ical = std::make_unique<EcalTimeCalibErrors>();
 
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
     if(ieta==0) continue;
@@ -844,18 +844,18 @@ EcalTrivialConditionRetriever::produceEcalTimeCalibErrors( const EcalTimeCalibEr
   return ical;
 }
 
-std::auto_ptr<EcalTimeOffsetConstant>
+std::unique_ptr<EcalTimeOffsetConstant>
 EcalTrivialConditionRetriever::produceEcalTimeOffsetConstant( const EcalTimeOffsetConstantRcd& )
 {
   std::cout << " produceEcalTimeOffsetConstant: " << std::endl;
   std::cout << "  EB " << timeOffsetEBConstant_ << " EE " <<  timeOffsetEEConstant_<< std::endl;
-  return std::auto_ptr<EcalTimeOffsetConstant>( new EcalTimeOffsetConstant(timeOffsetEBConstant_,timeOffsetEEConstant_) );
+  return std::make_unique<EcalTimeOffsetConstant>(timeOffsetEBConstant_,timeOffsetEEConstant_);
 }
 
-std::auto_ptr<EcalGainRatios>
+std::unique_ptr<EcalGainRatios>
 EcalTrivialConditionRetriever::produceEcalGainRatios( const EcalGainRatiosRcd& )
 {
-  std::auto_ptr<EcalGainRatios> gratio = std::auto_ptr<EcalGainRatios>( new EcalGainRatios() );
+  auto gratio = std::make_unique<EcalGainRatios>();
   EcalMGPAGainRatio gr;
   gr.setGain12Over6( gainRatio12over6_ );
   gr.setGain6Over1( gainRatio6over1_ );
@@ -890,17 +890,17 @@ EcalTrivialConditionRetriever::produceEcalGainRatios( const EcalGainRatiosRcd& )
   return gratio;
 }
 
-std::auto_ptr<EcalADCToGeVConstant>
+std::unique_ptr<EcalADCToGeVConstant>
 EcalTrivialConditionRetriever::produceEcalADCToGeVConstant( const EcalADCToGeVConstantRcd& )
 {
-  return std::auto_ptr<EcalADCToGeVConstant>( new EcalADCToGeVConstant(adcToGeVEBConstant_,adcToGeVEEConstant_) );
+  return std::make_unique<EcalADCToGeVConstant>(adcToGeVEBConstant_,adcToGeVEEConstant_);
 }
 
-std::auto_ptr<EcalTBWeights>
+std::unique_ptr<EcalTBWeights>
 EcalTrivialConditionRetriever::produceEcalTBWeights( const EcalTBWeightsRcd& )
 {
   // create weights for the test-beam
-  std::auto_ptr<EcalTBWeights> tbwgt = std::auto_ptr<EcalTBWeights>( new EcalTBWeights() );
+  auto tbwgt = std::make_unique<EcalTBWeights>();
 
   // create weights for each distinct group ID
   //  int nMaxTDC = 10;
@@ -985,46 +985,46 @@ EcalTrivialConditionRetriever::produceEcalTBWeights( const EcalTBWeightsRcd& )
 
 
 // cluster functions/corrections
-std::auto_ptr<EcalClusterLocalContCorrParameters>
+std::unique_ptr<EcalClusterLocalContCorrParameters>
 EcalTrivialConditionRetriever::produceEcalClusterLocalContCorrParameters( const EcalClusterLocalContCorrParametersRcd &)
 {
-        std::auto_ptr<EcalClusterLocalContCorrParameters> ipar = std::auto_ptr<EcalClusterLocalContCorrParameters>( new EcalClusterLocalContCorrParameters() );
+        auto ipar = std::make_unique<EcalClusterLocalContCorrParameters>();
         for (size_t i = 0; i < localContCorrParameters_.size(); ++i ) {
                 ipar->params().push_back( localContCorrParameters_[i] );
         }
         return ipar;
 }
-std::auto_ptr<EcalClusterCrackCorrParameters>
+std::unique_ptr<EcalClusterCrackCorrParameters>
 EcalTrivialConditionRetriever::produceEcalClusterCrackCorrParameters( const EcalClusterCrackCorrParametersRcd &)
 {
-        std::auto_ptr<EcalClusterCrackCorrParameters> ipar = std::auto_ptr<EcalClusterCrackCorrParameters>( new EcalClusterCrackCorrParameters() );
+        auto ipar = std::make_unique<EcalClusterCrackCorrParameters>();
         for (size_t i = 0; i < crackCorrParameters_.size(); ++i ) {
                 ipar->params().push_back( crackCorrParameters_[i] );
         }
         return ipar;
 }
-std::auto_ptr<EcalClusterEnergyCorrectionParameters>
+std::unique_ptr<EcalClusterEnergyCorrectionParameters>
 EcalTrivialConditionRetriever::produceEcalClusterEnergyCorrectionParameters( const EcalClusterEnergyCorrectionParametersRcd &)
 {
-        std::auto_ptr<EcalClusterEnergyCorrectionParameters> ipar = std::auto_ptr<EcalClusterEnergyCorrectionParameters>( new EcalClusterEnergyCorrectionParameters() );
+        auto ipar = std::make_unique<EcalClusterEnergyCorrectionParameters>();
         for (size_t i = 0; i < energyCorrectionParameters_.size(); ++i ) {
                 ipar->params().push_back( energyCorrectionParameters_[i] );
         }
         return ipar;
 }
-std::auto_ptr<EcalClusterEnergyUncertaintyParameters>
+std::unique_ptr<EcalClusterEnergyUncertaintyParameters>
 EcalTrivialConditionRetriever::produceEcalClusterEnergyUncertaintyParameters( const EcalClusterEnergyUncertaintyParametersRcd &)
 {
-        std::auto_ptr<EcalClusterEnergyUncertaintyParameters> ipar = std::auto_ptr<EcalClusterEnergyUncertaintyParameters>( new EcalClusterEnergyUncertaintyParameters() );
+        auto ipar = std::make_unique<EcalClusterEnergyUncertaintyParameters>();
         for (size_t i = 0; i < energyUncertaintyParameters_.size(); ++i ) {
                 ipar->params().push_back( energyUncertaintyParameters_[i] );
         }
         return ipar;
 }
-std::auto_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters>
+std::unique_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters>
 EcalTrivialConditionRetriever::produceEcalClusterEnergyCorrectionObjectSpecificParameters( const EcalClusterEnergyCorrectionObjectSpecificParametersRcd &)
 {
-  std::auto_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters> ipar = std::auto_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters>( new EcalClusterEnergyCorrectionObjectSpecificParameters() );
+  auto ipar = std::make_unique<EcalClusterEnergyCorrectionObjectSpecificParameters>();
   for (size_t i = 0; i < energyCorrectionObjectSpecificParameters_.size(); ++i ) {
     ipar->params().push_back( energyCorrectionObjectSpecificParameters_[i] );
   }
@@ -1033,12 +1033,12 @@ EcalTrivialConditionRetriever::produceEcalClusterEnergyCorrectionObjectSpecificP
 
 
 // laser records
-std::auto_ptr<EcalLaserAlphas>
+std::unique_ptr<EcalLaserAlphas>
 EcalTrivialConditionRetriever::produceEcalLaserAlphas( const EcalLaserAlphasRcd& )
 {
 
   std::cout << " produceEcalLaserAlphas " << std::endl;
-  std::auto_ptr<EcalLaserAlphas> ical = std::auto_ptr<EcalLaserAlphas>( new EcalLaserAlphas() );
+  auto ical = std::make_unique<EcalLaserAlphas>();
   if(getLaserAlphaFromFile_) {
     std::ifstream fEB(edm::FileInPath(EBLaserAlphaFile_).fullPath().c_str());
     int SMpos[36] = {-10, 4, -7, -16, 6, -9, 11, -17, 5, 18, 3, -8, 1, -3, -13, 14, -6, 2,
@@ -1165,10 +1165,10 @@ EcalTrivialConditionRetriever::produceEcalLaserAlphas( const EcalLaserAlphasRcd&
 }
 
 
-std::auto_ptr<EcalLaserAPDPNRatiosRef>
+std::unique_ptr<EcalLaserAPDPNRatiosRef>
 EcalTrivialConditionRetriever::produceEcalLaserAPDPNRatiosRef( const EcalLaserAPDPNRatiosRefRcd& )
 {
-  std::auto_ptr<EcalLaserAPDPNRatiosRef>  ical = std::auto_ptr<EcalLaserAPDPNRatiosRef>( new EcalLaserAPDPNRatiosRef() );
+  auto ical = std::make_unique<EcalLaserAPDPNRatiosRef>();
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
     if(ieta==0) continue;
     for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
@@ -1201,7 +1201,7 @@ EcalTrivialConditionRetriever::produceEcalLaserAPDPNRatiosRef( const EcalLaserAP
 }
 
 
-std::auto_ptr<EcalLaserAPDPNRatios>
+std::unique_ptr<EcalLaserAPDPNRatios>
 EcalTrivialConditionRetriever::produceEcalLaserAPDPNRatios( const EcalLaserAPDPNRatiosRcd& )
 {
   EnergyResolutionVsLumi ageing;
@@ -1209,7 +1209,7 @@ EcalTrivialConditionRetriever::produceEcalLaserAPDPNRatios( const EcalLaserAPDPN
   ageing.setInstLumi(instLumi_);
 
 
-  std::auto_ptr<EcalLaserAPDPNRatios>  ical = std::auto_ptr<EcalLaserAPDPNRatios>( new EcalLaserAPDPNRatios() );
+  auto ical = std::make_unique<EcalLaserAPDPNRatios>();
   for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
     if(ieta==0) continue;
 
@@ -1913,10 +1913,10 @@ void EcalTrivialConditionRetriever::getWeightsFromConfiguration(const edm::Param
 
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<EcalChannelStatus>
+std::unique_ptr<EcalChannelStatus>
 EcalTrivialConditionRetriever::getChannelStatusFromConfiguration (const EcalChannelStatusRcd&)
 {
-  std::auto_ptr<EcalChannelStatus> ecalStatus = std::auto_ptr<EcalChannelStatus>( new EcalChannelStatus() );
+  auto ecalStatus = std::make_unique<EcalChannelStatus>();
   
 
   // start by setting all statuses to 0
@@ -2003,11 +2003,11 @@ EcalTrivialConditionRetriever::getChannelStatusFromConfiguration (const EcalChan
 
 
 
-std::auto_ptr<EcalChannelStatus>
+std::unique_ptr<EcalChannelStatus>
 EcalTrivialConditionRetriever::produceEcalChannelStatus( const EcalChannelStatusRcd& )
 {
 
-        std::auto_ptr<EcalChannelStatus>  ical = std::auto_ptr<EcalChannelStatus>( new EcalChannelStatus() );
+        auto ical = std::make_unique<EcalChannelStatus>();
         // barrel
         for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
                 if(ieta==0) continue;
@@ -2036,12 +2036,12 @@ EcalTrivialConditionRetriever::produceEcalChannelStatus( const EcalChannelStatus
 }
 
 // --------------------------------------------------------------------------------
-std::auto_ptr<EcalDQMChannelStatus>
+std::unique_ptr<EcalDQMChannelStatus>
 EcalTrivialConditionRetriever::produceEcalDQMChannelStatus( const EcalDQMChannelStatusRcd& )
 {
   uint32_t sta(0);
 
-        std::auto_ptr<EcalDQMChannelStatus>  ical = std::auto_ptr<EcalDQMChannelStatus>( new EcalDQMChannelStatus() );
+        auto ical = std::make_unique<EcalDQMChannelStatus>();
         // barrel
         for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
                 if(ieta==0) continue;
@@ -2070,11 +2070,11 @@ EcalTrivialConditionRetriever::produceEcalDQMChannelStatus( const EcalDQMChannel
 }
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<EcalDQMTowerStatus>
+std::unique_ptr<EcalDQMTowerStatus>
 EcalTrivialConditionRetriever::produceEcalDQMTowerStatus( const EcalDQMTowerStatusRcd& )
 {
 
-        std::auto_ptr<EcalDQMTowerStatus>  ical = std::auto_ptr<EcalDQMTowerStatus>( new EcalDQMTowerStatus() );
+        auto ical = std::make_unique<EcalDQMTowerStatus>();
 
 	uint32_t sta(0);
 	
@@ -2113,11 +2113,11 @@ EcalTrivialConditionRetriever::produceEcalDQMTowerStatus( const EcalDQMTowerStat
 }
 
 // --------------------------------------------------------------------------------
-std::auto_ptr<EcalDCSTowerStatus>
+std::unique_ptr<EcalDCSTowerStatus>
 EcalTrivialConditionRetriever::produceEcalDCSTowerStatus( const EcalDCSTowerStatusRcd& )
 {
 
-        std::auto_ptr<EcalDCSTowerStatus>  ical = std::auto_ptr<EcalDCSTowerStatus>( new EcalDCSTowerStatus() );
+        auto ical = std::make_unique<EcalDCSTowerStatus>();
 
 	int status(0);
 	
@@ -2156,11 +2156,11 @@ EcalTrivialConditionRetriever::produceEcalDCSTowerStatus( const EcalDCSTowerStat
 }
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<EcalDAQTowerStatus>
+std::unique_ptr<EcalDAQTowerStatus>
 EcalTrivialConditionRetriever::produceEcalDAQTowerStatus( const EcalDAQTowerStatusRcd& )
 {
 
-        std::auto_ptr<EcalDAQTowerStatus>  ical = std::auto_ptr<EcalDAQTowerStatus>( new EcalDAQTowerStatus() );
+        auto ical = std::make_unique<EcalDAQTowerStatus>();
 
 	int status(0);
 	
@@ -2199,10 +2199,10 @@ EcalTrivialConditionRetriever::produceEcalDAQTowerStatus( const EcalDAQTowerStat
 }
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<EcalTPGCrystalStatus>
+std::unique_ptr<EcalTPGCrystalStatus>
 EcalTrivialConditionRetriever::getTrgChannelStatusFromConfiguration (const EcalTPGCrystalStatusRcd&)
 {
-  std::auto_ptr<EcalTPGCrystalStatus> ecalStatus = std::auto_ptr<EcalTPGCrystalStatus>( new EcalTPGCrystalStatus() );
+  auto ecalStatus = std::make_unique<EcalTPGCrystalStatus>();
   
 
   // start by setting all statuses to 0
@@ -2289,11 +2289,11 @@ EcalTrivialConditionRetriever::getTrgChannelStatusFromConfiguration (const EcalT
 
 
 
-std::auto_ptr<EcalTPGCrystalStatus>
+std::unique_ptr<EcalTPGCrystalStatus>
 EcalTrivialConditionRetriever::produceEcalTrgChannelStatus( const EcalTPGCrystalStatusRcd& )
 {
 
-        std::auto_ptr<EcalTPGCrystalStatus>  ical = std::auto_ptr<EcalTPGCrystalStatus>( new EcalTPGCrystalStatus() );
+        auto ical = std::make_unique<EcalTPGCrystalStatus>();
         // barrel
         for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
                 if(ieta==0) continue;
@@ -2324,12 +2324,12 @@ EcalTrivialConditionRetriever::produceEcalTrgChannelStatus( const EcalTPGCrystal
 
 
 
-std::auto_ptr<EcalIntercalibConstants> 
+std::unique_ptr<EcalIntercalibConstants> 
 EcalTrivialConditionRetriever::getIntercalibConstantsFromConfiguration 
 ( const EcalIntercalibConstantsRcd& )
 {
-  std::auto_ptr<EcalIntercalibConstants>  ical;
-  //        std::auto_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+  std::unique_ptr<EcalIntercalibConstants> ical;
+  //        std::make_unique<EcalIntercalibConstants>();
 
   // Read the values from a txt file
   // -------------------------------
@@ -2465,7 +2465,7 @@ EcalTrivialConditionRetriever::getIntercalibConstantsFromConfiguration
 	}
       }
       
-      ical = std::auto_ptr<EcalIntercalibConstants> (rcd);
+      ical = std::unique_ptr<EcalIntercalibConstants>(rcd);
 
       delete gRandom;
 
@@ -2474,7 +2474,7 @@ EcalTrivialConditionRetriever::getIntercalibConstantsFromConfiguration
 
   } else {
 
-    ical =std::auto_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+    ical = std::make_unique<EcalIntercalibConstants>();
 
     FILE *inpFile ;
     inpFile = fopen (intercalibConstantsFile_.c_str (),"r") ;
@@ -2582,12 +2582,12 @@ EcalTrivialConditionRetriever::getIntercalibConstantsFromConfiguration
 
 }
 
-std::auto_ptr<EcalIntercalibConstantsMC> 
+std::unique_ptr<EcalIntercalibConstantsMC> 
 EcalTrivialConditionRetriever::getIntercalibConstantsMCFromConfiguration 
 ( const EcalIntercalibConstantsMCRcd& )
 {
-  std::auto_ptr<EcalIntercalibConstantsMC>  ical;
-  //        std::auto_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+  std::unique_ptr<EcalIntercalibConstantsMC> ical;
+  //        std::make_unique<EcalIntercalibConstants>();
 
   // Read the values from a xml file
   // -------------------------------
@@ -2603,7 +2603,7 @@ EcalTrivialConditionRetriever::getIntercalibConstantsMCFromConfiguration
     EcalIntercalibConstantsMC * rcd = new EcalIntercalibConstantsMC;
     EcalIntercalibConstantsMCXMLTranslator::readXML(intercalibConstantsMCFile_,h,*rcd);
 
-      ical = std::auto_ptr<EcalIntercalibConstants> (rcd);
+      ical = std::unique_ptr<EcalIntercalibConstants>(rcd);
 
   } else {
 
@@ -2616,12 +2616,11 @@ EcalTrivialConditionRetriever::getIntercalibConstantsMCFromConfiguration
 }
 
 
-std::auto_ptr<EcalIntercalibErrors> 
+std::unique_ptr<EcalIntercalibErrors> 
 EcalTrivialConditionRetriever::getIntercalibErrorsFromConfiguration 
 ( const EcalIntercalibErrorsRcd& )
 {
-  std::auto_ptr<EcalIntercalibErrors>  ical = 
-      std::auto_ptr<EcalIntercalibErrors>( new EcalIntercalibErrors() );
+  auto ical = std::make_unique<EcalIntercalibErrors>();
 
   // Read the values from a txt file
   // -------------------------------
@@ -2737,12 +2736,11 @@ EcalTrivialConditionRetriever::getIntercalibErrorsFromConfiguration
 // --------------------------------------------------------------------------------
 
 
-std::auto_ptr<EcalTimeCalibConstants> 
+std::unique_ptr<EcalTimeCalibConstants> 
 EcalTrivialConditionRetriever::getTimeCalibConstantsFromConfiguration 
 ( const EcalTimeCalibConstantsRcd& )
 {
-  std::auto_ptr<EcalTimeCalibConstants>  ical = 
-      std::auto_ptr<EcalTimeCalibConstants>( new EcalTimeCalibConstants() );
+  auto ical = std::make_unique<EcalTimeCalibConstants>();
 
   // Read the values from a txt file
   // -------------------------------
@@ -2851,12 +2849,11 @@ EcalTrivialConditionRetriever::getTimeCalibConstantsFromConfiguration
 }
 
 
-std::auto_ptr<EcalTimeCalibErrors> 
+std::unique_ptr<EcalTimeCalibErrors> 
 EcalTrivialConditionRetriever::getTimeCalibErrorsFromConfiguration 
 ( const EcalTimeCalibErrorsRcd& )
 {
-  std::auto_ptr<EcalTimeCalibErrors>  ical = 
-      std::auto_ptr<EcalTimeCalibErrors>( new EcalTimeCalibErrors() );
+  auto ical = std::make_unique<EcalTimeCalibErrors>();
 
   // Read the values from a txt file
   // -------------------------------
@@ -2966,10 +2963,10 @@ EcalTrivialConditionRetriever::getTimeCalibErrorsFromConfiguration
 
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<EcalMappingElectronics>
+std::unique_ptr<EcalMappingElectronics>
 EcalTrivialConditionRetriever::getMappingFromConfiguration (const EcalMappingElectronicsRcd&)
 {
-  std::auto_ptr<EcalMappingElectronics> mapping = std::auto_ptr<EcalMappingElectronics>( new EcalMappingElectronics() );
+  auto mapping = std::make_unique<EcalMappingElectronics>();
   edm::LogInfo("EcalTrivialConditionRetriever") << "Reading mapping from file " << edm::FileInPath(mappingFile_).fullPath().c_str() ;
   
   std::ifstream f(edm::FileInPath(mappingFile_).fullPath().c_str());
@@ -3013,17 +3010,17 @@ EcalTrivialConditionRetriever::getMappingFromConfiguration (const EcalMappingEle
 
 
 
-std::auto_ptr<EcalMappingElectronics>
+std::unique_ptr<EcalMappingElectronics>
 EcalTrivialConditionRetriever::produceEcalMappingElectronics( const EcalMappingElectronicsRcd& )
 {
 
-        std::auto_ptr<EcalMappingElectronics>  ical = std::auto_ptr<EcalMappingElectronics>( new EcalMappingElectronics() );
+        auto ical = std::make_unique<EcalMappingElectronics>();
         return ical;
 }
 
 // --------------------------------------------------------------------------------
 
-std::auto_ptr<Alignments>
+std::unique_ptr<Alignments>
 EcalTrivialConditionRetriever::produceEcalAlignmentEB( const EBAlignmentRcd& ) {
   double mytrans[3] = {0., 0., 0.};
   double myeuler[3] = {0., 0., 0.};
@@ -3076,11 +3073,10 @@ EcalTrivialConditionRetriever::produceEcalAlignmentEB( const EBAlignmentRcd& ) {
   Alignments a; 
   a.m_align = my_align; 
 
-  std::auto_ptr<Alignments> ical = std::auto_ptr<Alignments>( new Alignments(a) );
-  return ical;
+  return std::make_unique<Alignments>(a);
 }
 
-std::auto_ptr<Alignments>
+std::unique_ptr<Alignments>
 EcalTrivialConditionRetriever::produceEcalAlignmentEE( const EEAlignmentRcd& ) {
   double mytrans[3] = {0., 0., 0.};
   double myeuler[3] = {0., 0., 0.};
@@ -3111,11 +3107,10 @@ EcalTrivialConditionRetriever::produceEcalAlignmentEE( const EEAlignmentRcd& ) {
   }
   Alignments a; 
   a.m_align = my_align; 
-  std::auto_ptr<Alignments> ical = std::auto_ptr<Alignments>( new Alignments(a) );
-  return ical;
+  return std::make_unique<Alignments>(a);
 }
 
-std::auto_ptr<Alignments>
+std::unique_ptr<Alignments>
 EcalTrivialConditionRetriever::produceEcalAlignmentES( const ESAlignmentRcd& ) {
   double mytrans[3] = {0., 0., 0.};
   double myeuler[3] = {0., 0., 0.};
@@ -3146,19 +3141,18 @@ EcalTrivialConditionRetriever::produceEcalAlignmentES( const ESAlignmentRcd& ) {
   }
   Alignments a; 
   a.m_align = my_align; 
-  std::auto_ptr<Alignments> ical = std::auto_ptr<Alignments>( new Alignments(a) );
-  return ical;
+  return std::make_unique<Alignments>(a);
 }
 
-std::auto_ptr<EcalSampleMask>
+std::unique_ptr<EcalSampleMask>
 EcalTrivialConditionRetriever::produceEcalSampleMask( const EcalSampleMaskRcd& )
 {
-  return std::auto_ptr<EcalSampleMask>( new EcalSampleMask(sampleMaskEB_, sampleMaskEE_) );
+  return std::unique_ptr<EcalSampleMask>( new EcalSampleMask(sampleMaskEB_, sampleMaskEE_) );
 }
 
-std::auto_ptr<EcalTimeBiasCorrections>
+std::unique_ptr<EcalTimeBiasCorrections>
 EcalTrivialConditionRetriever::produceEcalTimeBiasCorrections( const EcalTimeBiasCorrectionsRcd &) {
-  std::auto_ptr<EcalTimeBiasCorrections> ipar = std::auto_ptr<EcalTimeBiasCorrections>( new EcalTimeBiasCorrections() );
+  auto ipar = std::make_unique<EcalTimeBiasCorrections>();
   copy(EBtimeCorrAmplitudeBins_.begin(), EBtimeCorrAmplitudeBins_.end(),
        back_inserter(ipar->EBTimeCorrAmplitudeBins));
   copy(EBtimeCorrShiftBins_.begin(), EBtimeCorrShiftBins_.end(),
@@ -3170,7 +3164,7 @@ EcalTrivialConditionRetriever::produceEcalTimeBiasCorrections( const EcalTimeBia
   return ipar;
 }
 
-std::auto_ptr<EcalSamplesCorrelation>
+std::unique_ptr<EcalSamplesCorrelation>
 EcalTrivialConditionRetriever::produceEcalSamplesCorrelation( const EcalSamplesCorrelationRcd &) {
   if(getSamplesCorrelationFromFile_) {
     std::ifstream f;
@@ -3202,7 +3196,7 @@ EcalTrivialConditionRetriever::produceEcalSamplesCorrelation( const EcalSamplesC
     }
    f.close();
   }
-  std::auto_ptr<EcalSamplesCorrelation> ipar = std::auto_ptr<EcalSamplesCorrelation>( new EcalSamplesCorrelation() );
+  auto ipar = std::make_unique<EcalSamplesCorrelation>();
   copy(EBG12samplesCorrelation_.begin(), EBG12samplesCorrelation_.end(),
        back_inserter(ipar->EBG12SamplesCorrelation));
   copy(EBG6samplesCorrelation_.begin(), EBG6samplesCorrelation_.end(),

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -270,13 +270,13 @@ HcalHardcodeCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecor
   oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
 }
 
-std::auto_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const HcalPedestalsRcd& rec) {
+std::unique_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const HcalPedestalsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::producePedestals-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalPedestals> result (new HcalPedestals (topo,false));
+  auto result = std::make_unique<HcalPedestals>(topo,false);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalPedestal item = HcalDbHardcode::makePedestal (*cell, false, iLumi);
@@ -285,13 +285,13 @@ std::auto_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const H
   return result;
 }
 
-std::auto_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rec) {
+std::unique_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::producePedestalWidths-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalPedestalWidths> result (new HcalPedestalWidths (topo,false));
+  auto result = std::make_unique<HcalPedestalWidths>(topo,false);
   std::vector <HcalGenericDetId> cells = allCells(*htopo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalPedestalWidth item = HcalDbHardcode::makePedestalWidth (*cell, iLumi);
@@ -300,13 +300,13 @@ std::auto_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidth
   return result;
 }
 
-std::auto_ptr<HcalGains> HcalHardcodeCalibrations::produceGains (const HcalGainsRcd& rec) {
+std::unique_ptr<HcalGains> HcalHardcodeCalibrations::produceGains (const HcalGainsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceGains-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalGains> result (new HcalGains (topo));
+  auto result = std::make_unique<HcalGains>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalGain item = HcalDbHardcode::makeGain (*cell);
@@ -315,13 +315,13 @@ std::auto_ptr<HcalGains> HcalHardcodeCalibrations::produceGains (const HcalGains
   return result;
 }
 
-std::auto_ptr<HcalGainWidths> HcalHardcodeCalibrations::produceGainWidths (const HcalGainWidthsRcd& rec) {
+std::unique_ptr<HcalGainWidths> HcalHardcodeCalibrations::produceGainWidths (const HcalGainWidthsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceGainWidths-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalGainWidths> result (new HcalGainWidths (topo));
+  auto result = std::make_unique<HcalGainWidths>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
 
@@ -337,7 +337,7 @@ std::auto_ptr<HcalGainWidths> HcalHardcodeCalibrations::produceGainWidths (const
   return result;
 }
 
-std::auto_ptr<HcalQIEData> HcalHardcodeCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
+std::unique_ptr<HcalQIEData> HcalHardcodeCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceQIEData-> ...";
 
   /*
@@ -349,7 +349,7 @@ std::auto_ptr<HcalQIEData> HcalHardcodeCalibrations::produceQIEData (const HcalQ
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalQIEData> result (new HcalQIEData (topo));
+  auto result = std::make_unique<HcalQIEData>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalQIECoder coder = HcalDbHardcode::makeQIECoder (*cell);
@@ -358,13 +358,13 @@ std::auto_ptr<HcalQIEData> HcalHardcodeCalibrations::produceQIEData (const HcalQ
   return result;
 }
 
-std::auto_ptr<HcalQIETypes> HcalHardcodeCalibrations::produceQIETypes (const HcalQIETypesRcd& rcd) {
+std::unique_ptr<HcalQIETypes> HcalHardcodeCalibrations::produceQIETypes (const HcalQIETypesRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceQIETypes-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-    std::auto_ptr<HcalQIETypes> result (new HcalQIETypes (topo));
+    auto result = std::make_unique<HcalQIETypes>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalQIEType item = HcalDbHardcode::makeQIEType(*cell,testHFQIE10);
@@ -373,13 +373,13 @@ std::auto_ptr<HcalQIETypes> HcalHardcodeCalibrations::produceQIETypes (const Hca
   return result;
 }
 
-std::auto_ptr<HcalChannelQuality> HcalHardcodeCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
+std::unique_ptr<HcalChannelQuality> HcalHardcodeCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceChannelQuality-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalChannelQuality> result (new HcalChannelQuality (topo));
+  auto result = std::make_unique<HcalChannelQuality>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalChannelStatus item(cell->rawId(),0);
@@ -389,7 +389,7 @@ std::auto_ptr<HcalChannelQuality> HcalHardcodeCalibrations::produceChannelQualit
 }
 
 
-std::auto_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
+std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceRespCorrs-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
@@ -416,7 +416,7 @@ std::auto_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const H
     */
   }
  
-  std::auto_ptr<HcalRespCorrs> result (new HcalRespCorrs (topo));
+  auto result = std::make_unique<HcalRespCorrs>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
 
@@ -454,13 +454,13 @@ std::auto_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const H
   return result;
 }
 
-std::auto_ptr<HcalLUTCorrs> HcalHardcodeCalibrations::produceLUTCorrs (const HcalLUTCorrsRcd& rcd) {
+std::unique_ptr<HcalLUTCorrs> HcalHardcodeCalibrations::produceLUTCorrs (const HcalLUTCorrsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceLUTCorrs-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalLUTCorrs> result (new HcalLUTCorrs (topo));
+  auto result = std::make_unique<HcalLUTCorrs>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalLUTCorr item(cell->rawId(),1.0);
@@ -469,13 +469,13 @@ std::auto_ptr<HcalLUTCorrs> HcalHardcodeCalibrations::produceLUTCorrs (const Hca
   return result;
 }
 
-std::auto_ptr<HcalPFCorrs> HcalHardcodeCalibrations::producePFCorrs (const HcalPFCorrsRcd& rcd) {
+std::unique_ptr<HcalPFCorrs> HcalHardcodeCalibrations::producePFCorrs (const HcalPFCorrsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::producePFCorrs-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalPFCorrs> result (new HcalPFCorrs (topo));
+  auto result = std::make_unique<HcalPFCorrs>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalPFCorr item(cell->rawId(),1.0);
@@ -484,13 +484,13 @@ std::auto_ptr<HcalPFCorrs> HcalHardcodeCalibrations::producePFCorrs (const HcalP
   return result;
 }
 
-std::auto_ptr<HcalTimeCorrs> HcalHardcodeCalibrations::produceTimeCorrs (const HcalTimeCorrsRcd& rcd) {
+std::unique_ptr<HcalTimeCorrs> HcalHardcodeCalibrations::produceTimeCorrs (const HcalTimeCorrsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceTimeCorrs-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalTimeCorrs> result (new HcalTimeCorrs (topo));
+  auto result = std::make_unique<HcalTimeCorrs>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalTimeCorr item(cell->rawId(),0.0);
@@ -499,13 +499,13 @@ std::auto_ptr<HcalTimeCorrs> HcalHardcodeCalibrations::produceTimeCorrs (const H
   return result;
 }
 
-std::auto_ptr<HcalZSThresholds> HcalHardcodeCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {
+std::unique_ptr<HcalZSThresholds> HcalHardcodeCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceZSThresholds-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalZSThresholds> result (new HcalZSThresholds (topo));
+  auto result = std::make_unique<HcalZSThresholds>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalZSThreshold item(cell->rawId(),0);
@@ -515,13 +515,13 @@ std::auto_ptr<HcalZSThresholds> HcalHardcodeCalibrations::produceZSThresholds (c
 }
 
 
-std::auto_ptr<HcalL1TriggerObjects> HcalHardcodeCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
+std::unique_ptr<HcalL1TriggerObjects> HcalHardcodeCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceL1TriggerObjects-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalL1TriggerObjects> result (new HcalL1TriggerObjects (topo));
+  auto result = std::make_unique<HcalL1TriggerObjects>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalL1TriggerObject item(cell->rawId(),0., 1., 0);
@@ -536,21 +536,21 @@ std::auto_ptr<HcalL1TriggerObjects> HcalHardcodeCalibrations::produceL1TriggerOb
 
 
 
-std::auto_ptr<HcalElectronicsMap> HcalHardcodeCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
+std::unique_ptr<HcalElectronicsMap> HcalHardcodeCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceElectronicsMap-> ...";
 
-  std::auto_ptr<HcalElectronicsMap> result (new HcalElectronicsMap ());
+  auto result = std::make_unique<HcalElectronicsMap>();
   HcalDbHardcode::makeHardcodeMap(*result);
   return result;
 }
 
-std::auto_ptr<HcalValidationCorrs> HcalHardcodeCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
+std::unique_ptr<HcalValidationCorrs> HcalHardcodeCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceValidationCorrs-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalValidationCorrs> result (new HcalValidationCorrs (topo));
+  auto result = std::make_unique<HcalValidationCorrs>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalValidationCorr item(cell->rawId(),1.0);
@@ -559,13 +559,13 @@ std::auto_ptr<HcalValidationCorrs> HcalHardcodeCalibrations::produceValidationCo
   return result;
 }
 
-std::auto_ptr<HcalLutMetadata> HcalHardcodeCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
+std::unique_ptr<HcalLutMetadata> HcalHardcodeCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceLutMetadata-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalLutMetadata> result (new HcalLutMetadata (topo));
+  auto result = std::make_unique<HcalLutMetadata>(topo);
 
   result->setRctLsb( 0.5 );
   result->setNominalGain(0.003333);  // for HBHE SiPMs
@@ -590,28 +590,27 @@ std::auto_ptr<HcalLutMetadata> HcalHardcodeCalibrations::produceLutMetadata (con
   return result;
 }
 
-std::auto_ptr<HcalDcsValues> 
-  HcalHardcodeCalibrations::produceDcsValues (const HcalDcsRcd& rcd) {
+std::unique_ptr<HcalDcsValues> HcalHardcodeCalibrations::produceDcsValues (const HcalDcsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceDcsValues-> ...";
-  std::auto_ptr<HcalDcsValues> result(new HcalDcsValues);
+  auto result = std::make_unique<HcalDcsValues>();
   return result;
 }
 
-std::auto_ptr<HcalDcsMap> HcalHardcodeCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
+std::unique_ptr<HcalDcsMap> HcalHardcodeCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceDcsMap-> ...";
 
-  std::auto_ptr<HcalDcsMap> result (new HcalDcsMap ());
+  auto result = std::make_unique<HcalDcsMap>();
   HcalDbHardcode::makeHardcodeDcsMap(*result);
   return result;
 }
 
-std::auto_ptr<HcalRecoParams> HcalHardcodeCalibrations::produceRecoParams (const HcalRecoParamsRcd& rec) {
+std::unique_ptr<HcalRecoParams> HcalHardcodeCalibrations::produceRecoParams (const HcalRecoParamsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceRecoParams-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalRecoParams> result (new HcalRecoParams (topo));
+  auto result = std::make_unique<HcalRecoParams>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalRecoParam item = HcalDbHardcode::makeRecoParam (*cell);
@@ -619,13 +618,13 @@ std::auto_ptr<HcalRecoParams> HcalHardcodeCalibrations::produceRecoParams (const
   }
   return result;
 }
-std::auto_ptr<HcalTimingParams> HcalHardcodeCalibrations::produceTimingParams (const HcalTimingParamsRcd& rec) {
+std::unique_ptr<HcalTimingParams> HcalHardcodeCalibrations::produceTimingParams (const HcalTimingParamsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceTimingParams-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalTimingParams> result (new HcalTimingParams (topo));
+  auto result = std::make_unique<HcalTimingParams>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalTimingParam item = HcalDbHardcode::makeTimingParam (*cell);
@@ -633,13 +632,13 @@ std::auto_ptr<HcalTimingParams> HcalHardcodeCalibrations::produceTimingParams (c
   }
   return result;
 }
-std::auto_ptr<HcalLongRecoParams> HcalHardcodeCalibrations::produceLongRecoParams (const HcalLongRecoParamsRcd& rec) {
+std::unique_ptr<HcalLongRecoParams> HcalHardcodeCalibrations::produceLongRecoParams (const HcalLongRecoParamsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceLongRecoParams-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalLongRecoParams> result (new HcalLongRecoParams (topo));
+  auto result = std::make_unique<HcalLongRecoParams>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   std::vector <unsigned int> mSignal; 
   mSignal.push_back(4); 
@@ -659,13 +658,13 @@ std::auto_ptr<HcalLongRecoParams> HcalHardcodeCalibrations::produceLongRecoParam
   return result;
 }
 
-std::auto_ptr<HcalZDCLowGainFractions> HcalHardcodeCalibrations::produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rec) {
+std::unique_ptr<HcalZDCLowGainFractions> HcalHardcodeCalibrations::produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceZDCLowGainFractions-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalZDCLowGainFractions> result (new HcalZDCLowGainFractions (topo));
+  auto result = std::make_unique<HcalZDCLowGainFractions>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
     HcalZDCLowGainFraction item(cell->rawId(),0.0);
@@ -674,7 +673,7 @@ std::auto_ptr<HcalZDCLowGainFractions> HcalHardcodeCalibrations::produceZDCLowGa
   return result;
 }
 
-std::auto_ptr<HcalMCParams> HcalHardcodeCalibrations::produceMCParams (const HcalMCParamsRcd& rec) {
+std::unique_ptr<HcalMCParams> HcalHardcodeCalibrations::produceMCParams (const HcalMCParamsRcd& rec) {
 
 
   //  std::cout << std::endl << " .... HcalHardcodeCalibrations::produceMCParams ->"<< std::endl;
@@ -683,7 +682,7 @@ std::auto_ptr<HcalMCParams> HcalHardcodeCalibrations::produceMCParams (const Hca
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  std::auto_ptr<HcalMCParams> result (new HcalMCParams (topo));
+  auto result = std::make_unique<HcalMCParams>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
 
@@ -695,13 +694,13 @@ std::auto_ptr<HcalMCParams> HcalHardcodeCalibrations::produceMCParams (const Hca
 }
 
 
-std::auto_ptr<HcalFlagHFDigiTimeParams> HcalHardcodeCalibrations::produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rec) {
+std::unique_ptr<HcalFlagHFDigiTimeParams> HcalHardcodeCalibrations::produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rec) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceFlagHFDigiTimeParams-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  std::auto_ptr<HcalFlagHFDigiTimeParams> result (new HcalFlagHFDigiTimeParams (topo));
+  auto result = std::make_unique<HcalFlagHFDigiTimeParams>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   
   std::vector<double> coef;
@@ -723,12 +722,12 @@ std::auto_ptr<HcalFlagHFDigiTimeParams> HcalHardcodeCalibrations::produceFlagHFD
 } 
 
 
-std::auto_ptr<HcalCholeskyMatrices> HcalHardcodeCalibrations::produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rec) {
+std::unique_ptr<HcalCholeskyMatrices> HcalHardcodeCalibrations::produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rec) {
 
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  std::auto_ptr<HcalCholeskyMatrices> result (new HcalCholeskyMatrices (topo));
+  auto result = std::make_unique<HcalCholeskyMatrices>(topo);
 
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
@@ -746,12 +745,12 @@ std::auto_ptr<HcalCholeskyMatrices> HcalHardcodeCalibrations::produceCholeskyMat
   return result;
 
 }
-std::auto_ptr<HcalCovarianceMatrices> HcalHardcodeCalibrations::produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rec) {
+std::unique_ptr<HcalCovarianceMatrices> HcalHardcodeCalibrations::produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rec) {
 
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  std::auto_ptr<HcalCovarianceMatrices> result (new HcalCovarianceMatrices (topo));
+  auto result = std::make_unique<HcalCovarianceMatrices>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -59,37 +59,37 @@ protected:
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) ;
 
-  std::auto_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
-  std::auto_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
-  std::auto_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
-  std::auto_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
-  std::auto_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);
-  std::auto_ptr<HcalQIETypes> produceQIETypes (const HcalQIETypesRcd& rcd); 
-  std::auto_ptr<HcalChannelQuality> produceChannelQuality (const HcalChannelQualityRcd& rcd);
-  std::auto_ptr<HcalElectronicsMap> produceElectronicsMap (const HcalElectronicsMapRcd& rcd);
+  std::unique_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
+  std::unique_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
+  std::unique_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
+  std::unique_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
+  std::unique_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);
+  std::unique_ptr<HcalQIETypes> produceQIETypes (const HcalQIETypesRcd& rcd); 
+  std::unique_ptr<HcalChannelQuality> produceChannelQuality (const HcalChannelQualityRcd& rcd);
+  std::unique_ptr<HcalElectronicsMap> produceElectronicsMap (const HcalElectronicsMapRcd& rcd);
 
-  std::auto_ptr<HcalRespCorrs> produceRespCorrs (const HcalRespCorrsRcd& rcd);
-  std::auto_ptr<HcalZSThresholds> produceZSThresholds (const HcalZSThresholdsRcd& rcd);
-  std::auto_ptr<HcalL1TriggerObjects> produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd);
-  std::auto_ptr<HcalTimeCorrs> produceTimeCorrs (const HcalTimeCorrsRcd& rcd);
-  std::auto_ptr<HcalLUTCorrs> produceLUTCorrs (const HcalLUTCorrsRcd& rcd);
-  std::auto_ptr<HcalPFCorrs> producePFCorrs (const HcalPFCorrsRcd& rcd);
+  std::unique_ptr<HcalRespCorrs> produceRespCorrs (const HcalRespCorrsRcd& rcd);
+  std::unique_ptr<HcalZSThresholds> produceZSThresholds (const HcalZSThresholdsRcd& rcd);
+  std::unique_ptr<HcalL1TriggerObjects> produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd);
+  std::unique_ptr<HcalTimeCorrs> produceTimeCorrs (const HcalTimeCorrsRcd& rcd);
+  std::unique_ptr<HcalLUTCorrs> produceLUTCorrs (const HcalLUTCorrsRcd& rcd);
+  std::unique_ptr<HcalPFCorrs> producePFCorrs (const HcalPFCorrsRcd& rcd);
 
-  std::auto_ptr<HcalValidationCorrs> produceValidationCorrs (const HcalValidationCorrsRcd& rcd);
-  std::auto_ptr<HcalLutMetadata> produceLutMetadata (const HcalLutMetadataRcd& rcd);
-  std::auto_ptr<HcalDcsValues> produceDcsValues (const HcalDcsRcd& rcd);
-  std::auto_ptr<HcalDcsMap> produceDcsMap (const HcalDcsMapRcd& rcd);
+  std::unique_ptr<HcalValidationCorrs> produceValidationCorrs (const HcalValidationCorrsRcd& rcd);
+  std::unique_ptr<HcalLutMetadata> produceLutMetadata (const HcalLutMetadataRcd& rcd);
+  std::unique_ptr<HcalDcsValues> produceDcsValues (const HcalDcsRcd& rcd);
+  std::unique_ptr<HcalDcsMap> produceDcsMap (const HcalDcsMapRcd& rcd);
 
-  std::auto_ptr<HcalRecoParams> produceRecoParams (const HcalRecoParamsRcd& rcd);
-  std::auto_ptr<HcalTimingParams> produceTimingParams (const HcalTimingParamsRcd& rcd);
-  std::auto_ptr<HcalLongRecoParams> produceLongRecoParams (const HcalLongRecoParamsRcd& rcd);
-  std::auto_ptr<HcalZDCLowGainFractions> produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd);
+  std::unique_ptr<HcalRecoParams> produceRecoParams (const HcalRecoParamsRcd& rcd);
+  std::unique_ptr<HcalTimingParams> produceTimingParams (const HcalTimingParamsRcd& rcd);
+  std::unique_ptr<HcalLongRecoParams> produceLongRecoParams (const HcalLongRecoParamsRcd& rcd);
+  std::unique_ptr<HcalZDCLowGainFractions> produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd);
 
-  std::auto_ptr<HcalMCParams> produceMCParams (const HcalMCParamsRcd& rcd);
-  std::auto_ptr<HcalFlagHFDigiTimeParams> produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd);
+  std::unique_ptr<HcalMCParams> produceMCParams (const HcalMCParamsRcd& rcd);
+  std::unique_ptr<HcalFlagHFDigiTimeParams> produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd);
 
-  std::auto_ptr<HcalCholeskyMatrices> produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rcd);
-  std::auto_ptr<HcalCovarianceMatrices> produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rcd);
+  std::unique_ptr<HcalCholeskyMatrices> produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rcd);
+  std::unique_ptr<HcalCovarianceMatrices> produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rcd);
 
 
 private:

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -168,9 +168,9 @@ HcalTextCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecordKey
 }
 
 template <class T>
-std::auto_ptr<T> produce_impl (const HcalTopology* topo, const std::string& fFile) {
-  std::auto_ptr<T> result (new T (topo));
-  //  std::auto_ptr<T> result;
+std::unique_ptr<T> produce_impl (const HcalTopology* topo, const std::string& fFile) {
+  auto result = std::make_unique<T>(topo);
+  //  std::unique_ptr<T> result;
   std::ifstream inStream (fFile.c_str ());
   if (!inStream.good ()) {
     std::cerr << "HcalTextCalibrations-> Unable to open file '" << fFile << "'" << std::endl;
@@ -184,9 +184,9 @@ std::auto_ptr<T> produce_impl (const HcalTopology* topo, const std::string& fFil
 }
 
 template <class T>
-std::auto_ptr<T> produce_impl (const std::string& fFile) {
-  std::auto_ptr<T> result (new T ());
-  //  std::auto_ptr<T> result;
+std::unique_ptr<T> produce_impl (const std::string& fFile) {
+  auto result = std::make_unique<T>();
+  //  std::unique_ptr<T> result;
   std::ifstream inStream (fFile.c_str ());
   if (!inStream.good ()) {
     std::cerr << "HcalTextCalibrations-> Unable to open file '" << fFile << "'" << std::endl;
@@ -201,7 +201,7 @@ std::auto_ptr<T> produce_impl (const std::string& fFile) {
 
 
 
-std::auto_ptr<HcalPedestals> HcalTextCalibrations::producePedestals (const HcalPedestalsRcd& rcd) {
+std::unique_ptr<HcalPedestals> HcalTextCalibrations::producePedestals (const HcalPedestalsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -209,165 +209,165 @@ std::auto_ptr<HcalPedestals> HcalTextCalibrations::producePedestals (const HcalP
   return produce_impl<HcalPedestals> (topo,mInputs ["Pedestals"]);
 }
 
-std::auto_ptr<HcalPedestalWidths> HcalTextCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
+std::unique_ptr<HcalPedestalWidths> HcalTextCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalPedestalWidths> (topo,mInputs ["PedestalWidths"]);
 }
 
-std::auto_ptr<HcalGains> HcalTextCalibrations::produceGains (const HcalGainsRcd& rcd) {
+std::unique_ptr<HcalGains> HcalTextCalibrations::produceGains (const HcalGainsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalGains> (topo,mInputs ["Gains"]);
 }
 
-std::auto_ptr<HcalGainWidths> HcalTextCalibrations::produceGainWidths (const HcalGainWidthsRcd& rcd) {
+std::unique_ptr<HcalGainWidths> HcalTextCalibrations::produceGainWidths (const HcalGainWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalGainWidths> (topo,mInputs ["GainWidths"]);
 }
 
-std::auto_ptr<HcalQIEData> HcalTextCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
+std::unique_ptr<HcalQIEData> HcalTextCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalQIEData> (topo,mInputs ["QIEData"]);
 }
 
-std::auto_ptr<HcalQIETypes> HcalTextCalibrations::produceQIETypes (const HcalQIETypesRcd& rcd) {
+std::unique_ptr<HcalQIETypes> HcalTextCalibrations::produceQIETypes (const HcalQIETypesRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalQIETypes> (topo,mInputs ["QIETypes"]);
 }
 
-std::auto_ptr<HcalChannelQuality> HcalTextCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
+std::unique_ptr<HcalChannelQuality> HcalTextCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalChannelQuality> (topo,mInputs ["ChannelQuality"]);
 }
 
-std::auto_ptr<HcalZSThresholds> HcalTextCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {  edm::ESHandle<HcalTopology> htopo;
+std::unique_ptr<HcalZSThresholds> HcalTextCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {  edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalZSThresholds> (topo,mInputs ["ZSThresholds"]);
 }
 
-std::auto_ptr<HcalRespCorrs> HcalTextCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
+std::unique_ptr<HcalRespCorrs> HcalTextCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalRespCorrs> (topo,mInputs ["RespCorrs"]);
 }
 
-std::auto_ptr<HcalLUTCorrs> HcalTextCalibrations::produceLUTCorrs (const HcalLUTCorrsRcd& rcd) {
+std::unique_ptr<HcalLUTCorrs> HcalTextCalibrations::produceLUTCorrs (const HcalLUTCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalLUTCorrs> (topo,mInputs ["LUTCorrs"]);
 }
 
-std::auto_ptr<HcalPFCorrs> HcalTextCalibrations::producePFCorrs (const HcalPFCorrsRcd& rcd) {
+std::unique_ptr<HcalPFCorrs> HcalTextCalibrations::producePFCorrs (const HcalPFCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalPFCorrs> (topo,mInputs ["PFCorrs"]);
 }
 
-std::auto_ptr<HcalTimeCorrs> HcalTextCalibrations::produceTimeCorrs (const HcalTimeCorrsRcd& rcd) {
+std::unique_ptr<HcalTimeCorrs> HcalTextCalibrations::produceTimeCorrs (const HcalTimeCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalTimeCorrs> (topo,mInputs ["TimeCorrs"]);
 }
 
-std::auto_ptr<HcalL1TriggerObjects> HcalTextCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
+std::unique_ptr<HcalL1TriggerObjects> HcalTextCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalL1TriggerObjects> (topo,mInputs ["L1TriggerObjects"]);
 }
 
-std::auto_ptr<HcalElectronicsMap> HcalTextCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
+std::unique_ptr<HcalElectronicsMap> HcalTextCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
   return produce_impl<HcalElectronicsMap> (mInputs ["ElectronicsMap"]);
 }
 
-std::auto_ptr<HcalValidationCorrs> HcalTextCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
+std::unique_ptr<HcalValidationCorrs> HcalTextCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalValidationCorrs> (topo,mInputs ["ValidationCorrs"]);
 }
 
-std::auto_ptr<HcalLutMetadata> HcalTextCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
+std::unique_ptr<HcalLutMetadata> HcalTextCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalLutMetadata> (topo,mInputs ["LutMetadata"]);
 }
 
-std::auto_ptr<HcalDcsValues>
+std::unique_ptr<HcalDcsValues>
   HcalTextCalibrations::produceDcsValues(HcalDcsRcd const & rcd) {
   return produce_impl<HcalDcsValues> (mInputs ["DcsValues"]);
 }
 
-std::auto_ptr<HcalDcsMap> HcalTextCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
+std::unique_ptr<HcalDcsMap> HcalTextCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
   return produce_impl<HcalDcsMap> (mInputs ["DcsMap"]);
 }
 
-std::auto_ptr<HcalCovarianceMatrices> HcalTextCalibrations::produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rcd) {
+std::unique_ptr<HcalCovarianceMatrices> HcalTextCalibrations::produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalCovarianceMatrices> (topo,mInputs ["CovarianceMatrices"]);
 }
 
-std::auto_ptr<HcalCholeskyMatrices> HcalTextCalibrations::produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rcd) {
+std::unique_ptr<HcalCholeskyMatrices> HcalTextCalibrations::produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalCholeskyMatrices> (topo,mInputs ["CholeskyMatrices"]);
 }
 
-std::auto_ptr<HcalRecoParams> HcalTextCalibrations::produceRecoParams (const HcalRecoParamsRcd& rcd) {
+std::unique_ptr<HcalRecoParams> HcalTextCalibrations::produceRecoParams (const HcalRecoParamsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalRecoParams> (topo,mInputs ["RecoParams"]);
 }
 
-std::auto_ptr<HcalLongRecoParams> HcalTextCalibrations::produceLongRecoParams (const HcalLongRecoParamsRcd& rcd) {
+std::unique_ptr<HcalLongRecoParams> HcalTextCalibrations::produceLongRecoParams (const HcalLongRecoParamsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalLongRecoParams> (topo,mInputs ["LongRecoParams"]);
 }
 
-std::auto_ptr<HcalZDCLowGainFractions> HcalTextCalibrations::produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd) {
+std::unique_ptr<HcalZDCLowGainFractions> HcalTextCalibrations::produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalZDCLowGainFractions> (topo,mInputs ["ZDCLowGainFractions"]);
 }
 
-std::auto_ptr<HcalTimingParams> HcalTextCalibrations::produceTimingParams (const HcalTimingParamsRcd& rcd) {
+std::unique_ptr<HcalTimingParams> HcalTextCalibrations::produceTimingParams (const HcalTimingParamsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalTimingParams> (topo,mInputs ["TimingParams"]);
 }
-std::auto_ptr<HcalMCParams> HcalTextCalibrations::produceMCParams (const HcalMCParamsRcd& rcd) {  
+std::unique_ptr<HcalMCParams> HcalTextCalibrations::produceMCParams (const HcalMCParamsRcd& rcd) {  
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return produce_impl<HcalMCParams> (topo,mInputs ["MCParams"]);
 }
 
-std::auto_ptr<HcalFlagHFDigiTimeParams> HcalTextCalibrations::produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd) {  
+std::unique_ptr<HcalFlagHFDigiTimeParams> HcalTextCalibrations::produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd) {  
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -53,36 +53,36 @@ protected:
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) ;
 
-  std::auto_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
-  std::auto_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
-  std::auto_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
-  std::auto_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
-  std::auto_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);
-  std::auto_ptr<HcalQIETypes> produceQIETypes (const HcalQIETypesRcd& rcd);
-  std::auto_ptr<HcalChannelQuality> produceChannelQuality (const HcalChannelQualityRcd& rcd);
-  std::auto_ptr<HcalElectronicsMap> produceElectronicsMap (const HcalElectronicsMapRcd& rcd);
+  std::unique_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
+  std::unique_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
+  std::unique_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
+  std::unique_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
+  std::unique_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);
+  std::unique_ptr<HcalQIETypes> produceQIETypes (const HcalQIETypesRcd& rcd);
+  std::unique_ptr<HcalChannelQuality> produceChannelQuality (const HcalChannelQualityRcd& rcd);
+  std::unique_ptr<HcalElectronicsMap> produceElectronicsMap (const HcalElectronicsMapRcd& rcd);
 
-  std::auto_ptr<HcalRespCorrs> produceRespCorrs (const HcalRespCorrsRcd& rcd);
-  std::auto_ptr<HcalZSThresholds> produceZSThresholds (const HcalZSThresholdsRcd& rcd);
-  std::auto_ptr<HcalL1TriggerObjects> produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd);
-  std::auto_ptr<HcalTimeCorrs> produceTimeCorrs (const HcalTimeCorrsRcd& rcd);
-  std::auto_ptr<HcalLUTCorrs> produceLUTCorrs (const HcalLUTCorrsRcd& rcd);
-  std::auto_ptr<HcalPFCorrs> producePFCorrs (const HcalPFCorrsRcd& rcd);
+  std::unique_ptr<HcalRespCorrs> produceRespCorrs (const HcalRespCorrsRcd& rcd);
+  std::unique_ptr<HcalZSThresholds> produceZSThresholds (const HcalZSThresholdsRcd& rcd);
+  std::unique_ptr<HcalL1TriggerObjects> produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd);
+  std::unique_ptr<HcalTimeCorrs> produceTimeCorrs (const HcalTimeCorrsRcd& rcd);
+  std::unique_ptr<HcalLUTCorrs> produceLUTCorrs (const HcalLUTCorrsRcd& rcd);
+  std::unique_ptr<HcalPFCorrs> producePFCorrs (const HcalPFCorrsRcd& rcd);
 
-  std::auto_ptr<HcalRecoParams> produceRecoParams (const HcalRecoParamsRcd& rcd);
-  std::auto_ptr<HcalLongRecoParams> produceLongRecoParams (const HcalLongRecoParamsRcd& rcd);
-  std::auto_ptr<HcalZDCLowGainFractions> produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd);
-  std::auto_ptr<HcalMCParams> produceMCParams (const HcalMCParamsRcd& rcd);
-  std::auto_ptr<HcalFlagHFDigiTimeParams> produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd);
+  std::unique_ptr<HcalRecoParams> produceRecoParams (const HcalRecoParamsRcd& rcd);
+  std::unique_ptr<HcalLongRecoParams> produceLongRecoParams (const HcalLongRecoParamsRcd& rcd);
+  std::unique_ptr<HcalZDCLowGainFractions> produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd);
+  std::unique_ptr<HcalMCParams> produceMCParams (const HcalMCParamsRcd& rcd);
+  std::unique_ptr<HcalFlagHFDigiTimeParams> produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd);
 
-  std::auto_ptr<HcalValidationCorrs> produceValidationCorrs (const HcalValidationCorrsRcd& rcd);
-  std::auto_ptr<HcalLutMetadata> produceLutMetadata (const HcalLutMetadataRcd& rcd);
-  std::auto_ptr<HcalDcsValues> produceDcsValues (HcalDcsRcd const & rcd);
-  std::auto_ptr<HcalDcsMap> produceDcsMap (const HcalDcsMapRcd& rcd);
-  std::auto_ptr<HcalCholeskyMatrices> produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rcd);
-  std::auto_ptr<HcalCovarianceMatrices> produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rcd);
+  std::unique_ptr<HcalValidationCorrs> produceValidationCorrs (const HcalValidationCorrsRcd& rcd);
+  std::unique_ptr<HcalLutMetadata> produceLutMetadata (const HcalLutMetadataRcd& rcd);
+  std::unique_ptr<HcalDcsValues> produceDcsValues (HcalDcsRcd const & rcd);
+  std::unique_ptr<HcalDcsMap> produceDcsMap (const HcalDcsMapRcd& rcd);
+  std::unique_ptr<HcalCholeskyMatrices> produceCholeskyMatrices (const HcalCholeskyMatricesRcd& rcd);
+  std::unique_ptr<HcalCovarianceMatrices> produceCovarianceMatrices (const HcalCovarianceMatricesRcd& rcd);
   
-  std::auto_ptr<HcalTimingParams> produceTimingParams (const HcalTimingParamsRcd& rcd);
+  std::unique_ptr<HcalTimingParams> produceTimingParams (const HcalTimingParamsRcd& rcd);
  private:
   std::map <std::string, std::string> mInputs;
 };

--- a/CalibMuon/RPCCalibration/interface/RPCPerformanceESSource.h
+++ b/CalibMuon/RPCCalibration/interface/RPCPerformanceESSource.h
@@ -23,7 +23,7 @@ class RPCPerformanceESSource : public edm::ESProducer, public edm::EventSetupRec
   RPCPerformanceESSource( const edm::ParameterSet& );
   virtual ~RPCPerformanceESSource() {;}
   
-  std::auto_ptr<RPCStripNoises> produce( const RPCStripNoisesRcd& );
+  std::unique_ptr<RPCStripNoises> produce( const RPCStripNoisesRcd& );
   
   // protected:
 

--- a/CalibMuon/RPCCalibration/src/RPCPerformanceESSource.cc
+++ b/CalibMuon/RPCCalibration/src/RPCPerformanceESSource.cc
@@ -17,12 +17,11 @@ RPCPerformanceESSource::RPCPerformanceESSource( const edm::ParameterSet& pset ) 
 
 // -----------------------------------------------------------------------------
 //
-auto_ptr<RPCStripNoises> RPCPerformanceESSource::produce( const RPCStripNoisesRcd&) { 
+unique_ptr<RPCStripNoises> RPCPerformanceESSource::produce( const RPCStripNoisesRcd&) { 
     
   RPCStripNoises* noise = makeNoise();
   
-  auto_ptr<RPCStripNoises> ptr(noise);
-  return ptr;
+  return unique_ptr<RPCStripNoises>(noise);
 
 }
 

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
@@ -15,7 +15,7 @@ class SiPixelFakeCPEGenericErrorParmESSource : public edm::ESProducer, public ed
   SiPixelFakeCPEGenericErrorParmESSource(const edm::ParameterSet &);
   ~SiPixelFakeCPEGenericErrorParmESSource();
   
-   virtual std::auto_ptr<SiPixelCPEGenericErrorParm>  produce(const SiPixelCPEGenericErrorParmRcd &);
+   virtual std::unique_ptr<SiPixelCPEGenericErrorParm>  produce(const SiPixelCPEGenericErrorParmRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
@@ -40,7 +40,7 @@ class SiPixelFakeGainESSource : public edm::ESProducer, public edm::EventSetupRe
   
   //      typedef edm::ESProducts<> ReturnType;
   
-  virtual std::auto_ptr<SiPixelGainCalibration>  produce(const SiPixelGainCalibrationRcd &);
+  virtual std::unique_ptr<SiPixelGainCalibration>  produce(const SiPixelGainCalibrationRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
@@ -40,7 +40,7 @@ class SiPixelFakeGainForHLTESSource : public edm::ESProducer, public edm::EventS
   
   //      typedef edm::ESProducts<> ReturnType;
   
-  virtual std::auto_ptr<SiPixelGainCalibrationForHLT>  produce(const SiPixelGainCalibrationForHLTRcd &);
+  virtual std::unique_ptr<SiPixelGainCalibrationForHLT>  produce(const SiPixelGainCalibrationForHLTRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
@@ -40,7 +40,7 @@ class SiPixelFakeGainOfflineESSource : public edm::ESProducer, public edm::Event
   
   //      typedef edm::ESProducts<> ReturnType;
   
-  virtual std::auto_ptr<SiPixelGainCalibrationOffline>  produce(const SiPixelGainCalibrationOfflineRcd &);
+  virtual std::unique_ptr<SiPixelGainCalibrationOffline>  produce(const SiPixelGainCalibrationOfflineRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
@@ -17,7 +17,7 @@ class SiPixelFakeGenErrorDBObjectESSource : public edm::ESProducer, public edm::
   
   typedef std::vector<std::string> vstring;
   
-  virtual std::auto_ptr<SiPixelGenErrorDBObject>  produce(const SiPixelGenErrorDBObjectRcd &);
+  virtual std::unique_ptr<SiPixelGenErrorDBObject>  produce(const SiPixelGenErrorDBObjectRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
@@ -41,7 +41,7 @@ class SiPixelFakeLorentzAngleESSource : public edm::ESProducer, public edm::Even
   
   //      typedef edm::ESProducts<> ReturnType;
   
-  virtual std::auto_ptr<SiPixelLorentzAngle>  produce(const SiPixelLorentzAngleRcd &);
+  virtual std::unique_ptr<SiPixelLorentzAngle>  produce(const SiPixelLorentzAngleRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
@@ -41,7 +41,7 @@ class SiPixelFakeQualityESSource : public edm::ESProducer, public edm::EventSetu
   
   //      typedef edm::ESProducts<> ReturnType;
   
-  virtual std::auto_ptr<SiPixelQuality>  produce(const SiPixelQualityFromDbRcd &);
+  virtual std::unique_ptr<SiPixelQuality>  produce(const SiPixelQualityFromDbRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
@@ -17,7 +17,7 @@ class SiPixelFakeTemplateDBObjectESSource : public edm::ESProducer, public edm::
   
   typedef std::vector<std::string> vstring;
   
-  virtual std::auto_ptr<SiPixelTemplateDBObject>  produce(const SiPixelTemplateDBObjectRcd &);
+  virtual std::unique_ptr<SiPixelTemplateDBObject>  produce(const SiPixelTemplateDBObjectRcd &);
   
  protected:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
@@ -43,7 +43,7 @@ class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupR
   ~SiPixelQualityESProducer();
   
   
-  /* virtual*/ std::auto_ptr<SiPixelQuality> produce(const SiPixelQualityRcd & iRecord) ;
+  /* virtual*/ std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityRcd & iRecord) ;
   
 protected:
   

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeCPEGenericErrorParmESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeCPEGenericErrorParmESSource.cc
@@ -14,14 +14,14 @@ SiPixelFakeCPEGenericErrorParmESSource::~SiPixelFakeCPEGenericErrorParmESSource(
 {
 }
 
-std::auto_ptr<SiPixelCPEGenericErrorParm> SiPixelFakeCPEGenericErrorParmESSource::produce(const SiPixelCPEGenericErrorParmRcd & )
+std::unique_ptr<SiPixelCPEGenericErrorParm> SiPixelFakeCPEGenericErrorParmESSource::produce(const SiPixelCPEGenericErrorParmRcd & )
 {
 	using namespace edm::es;
 	SiPixelCPEGenericErrorParm * obj = new SiPixelCPEGenericErrorParm();
 	obj->fillCPEGenericErrorParm(version_, fp_.fullPath());
 	//std::cout << *obj << std::endl;
 
-	return std::auto_ptr<SiPixelCPEGenericErrorParm>(obj);
+	return std::unique_ptr<SiPixelCPEGenericErrorParm>(obj);
 }
 
 void SiPixelFakeCPEGenericErrorParmESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
@@ -44,7 +44,7 @@ SiPixelFakeGainESSource::~SiPixelFakeGainESSource()
 
 }
 
-std::auto_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const SiPixelGainCalibrationRcd & )
+std::unique_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const SiPixelGainCalibrationRcd & )
 {
 
    using namespace edm::es;
@@ -81,7 +81,7 @@ std::auto_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const SiP
    
 
    // 
-   return std::auto_ptr<SiPixelGainCalibration>(obj);
+   return std::unique_ptr<SiPixelGainCalibration>(obj);
 
 
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
@@ -44,7 +44,7 @@ SiPixelFakeGainForHLTESSource::~SiPixelFakeGainForHLTESSource()
 
 }
 
-std::auto_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::produce(const SiPixelGainCalibrationForHLTRcd & )
+std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::produce(const SiPixelGainCalibrationForHLTRcd & )
 {
 
    using namespace edm::es;
@@ -95,7 +95,7 @@ std::auto_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::produ
    
 
    // 
-   return std::auto_ptr<SiPixelGainCalibrationForHLT>(obj);
+   return std::unique_ptr<SiPixelGainCalibrationForHLT>(obj);
 
 
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
@@ -44,7 +44,7 @@ SiPixelFakeGainOfflineESSource::~SiPixelFakeGainOfflineESSource()
 
 }
 
-std::auto_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::produce(const SiPixelGainCalibrationOfflineRcd & )
+std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::produce(const SiPixelGainCalibrationOfflineRcd & )
 {
 
    using namespace edm::es;
@@ -92,7 +92,7 @@ std::auto_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::pro
    
 
    // 
-   return std::auto_ptr<SiPixelGainCalibrationOffline>(obj);
+   return std::unique_ptr<SiPixelGainCalibrationOffline>(obj);
 
 
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
@@ -16,7 +16,7 @@ SiPixelFakeGenErrorDBObjectESSource::~SiPixelFakeGenErrorDBObjectESSource()
 {
 }
 
-std::auto_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::produce(const SiPixelGenErrorDBObjectRcd & )
+std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::produce(const SiPixelGenErrorDBObjectRcd & )
 {
 	using namespace edm::es;
 
@@ -84,7 +84,7 @@ std::auto_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::prod
 	}
 
 	//std::cout << *obj << std::endl;
-	return std::auto_ptr<SiPixelGenErrorDBObject>(obj);
+	return std::unique_ptr<SiPixelGenErrorDBObject>(obj);
 }
 
 void SiPixelFakeGenErrorDBObjectESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -43,7 +43,7 @@ SiPixelFakeLorentzAngleESSource::~SiPixelFakeLorentzAngleESSource()
 
 }
 
-std::auto_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(const SiPixelLorentzAngleRcd & )
+std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(const SiPixelLorentzAngleRcd & )
 {
 
 	using namespace edm::es;
@@ -63,7 +63,7 @@ std::auto_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(cons
 	
 	//std::cout << "Modules = " << nmodules << std::endl;
 
-	return std::auto_ptr<SiPixelLorentzAngle>(obj);
+	return std::unique_ptr<SiPixelLorentzAngle>(obj);
 	
 
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeQualityESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeQualityESSource.cc
@@ -43,7 +43,7 @@ SiPixelFakeQualityESSource::~SiPixelFakeQualityESSource()
 
 }
 
-std::auto_ptr<SiPixelQuality> SiPixelFakeQualityESSource::produce(const SiPixelQualityFromDbRcd & )
+std::unique_ptr<SiPixelQuality> SiPixelFakeQualityESSource::produce(const SiPixelQualityFromDbRcd & )
 {
 
 
@@ -59,7 +59,7 @@ std::auto_ptr<SiPixelQuality> SiPixelFakeQualityESSource::produce(const SiPixelQ
     SiPixelQuality::disabledModuleType BadModule;
     BadModule.DetID = 1; BadModule.errorType = 0; BadModule.BadRocs = 65535; obj->addDisabledModule(BadModule);
 
-    return std::auto_ptr<SiPixelQuality>(obj);
+    return std::unique_ptr<SiPixelQuality>(obj);
 
 }
 

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
@@ -16,7 +16,7 @@ SiPixelFakeTemplateDBObjectESSource::~SiPixelFakeTemplateDBObjectESSource()
 {
 }
 
-std::auto_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::produce(const SiPixelTemplateDBObjectRcd & )
+std::unique_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::produce(const SiPixelTemplateDBObjectRcd & )
 {
 	using namespace edm::es;
 
@@ -84,7 +84,7 @@ std::auto_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::prod
 	}
 
 	//std::cout << *obj << std::endl;
-	return std::auto_ptr<SiPixelTemplateDBObject>(obj);
+	return std::unique_ptr<SiPixelTemplateDBObject>(obj);
 }
 
 void SiPixelFakeTemplateDBObjectESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
@@ -55,7 +55,7 @@ SiPixelQualityESProducer::~SiPixelQualityESProducer()
 
 }
 
-std::auto_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQualityRcd & iRecord)
+std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQualityRcd & iRecord)
 {
   
   std::string recordName;
@@ -90,7 +90,7 @@ std::auto_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQua
   
   //now the dbobject is the one copied from the db
   //here make a copy of dbobject, but now the label has to be empty not to interfeare with the Reco
-  std::auto_ptr<SiPixelQuality> dbptr(new SiPixelQuality(*(dbobject)));
+  auto dbptr = std::make_unique<SiPixelQuality>(*(dbobject));
   
   //here is the magic line in which it switches off Bad Modules
   dbptr->add(Voff.product());

--- a/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
@@ -16,7 +16,7 @@ class Phase2TrackerCablingESProducer : public edm::ESProducer {
   Phase2TrackerCablingESProducer( const edm::ParameterSet& );
   virtual ~Phase2TrackerCablingESProducer();
   
-  virtual std::auto_ptr<Phase2TrackerCabling> produce( const Phase2TrackerCablingRcd& );
+  virtual std::unique_ptr<Phase2TrackerCabling> produce( const Phase2TrackerCablingRcd& );
   
  private:
   

--- a/CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h
@@ -22,7 +22,7 @@ class SiStripFedCablingESProducer : public edm::ESProducer {
   virtual ~SiStripFedCablingESProducer();
   
   /** Calls pure virtual make() method, to force concrete implementation. */
-  virtual std::auto_ptr<SiStripFedCabling> produce( const SiStripFedCablingRcd& );
+  virtual std::unique_ptr<SiStripFedCabling> produce( const SiStripFedCablingRcd& );
   
  private:
   

--- a/CalibTracker/SiStripESProducers/interface/SiStripGainESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripGainESSource.h
@@ -22,7 +22,7 @@ class SiStripGainESSource : public edm::ESProducer, public edm::EventSetupRecord
   SiStripGainESSource( const edm::ParameterSet& );
   virtual ~SiStripGainESSource() {;}
   
-  virtual std::auto_ptr<SiStripApvGain> produce( const SiStripApvGainRcd& );
+  virtual std::unique_ptr<SiStripApvGain> produce( const SiStripApvGainRcd& );
   
  protected:
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripHashedDetIdESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripHashedDetIdESProducer.h
@@ -22,7 +22,7 @@ class SiStripHashedDetIdESProducer : public edm::ESProducer {
   virtual ~SiStripHashedDetIdESProducer();
 
   /** Calls pure virtual make() method, to force concrete implementation. */
-  virtual std::auto_ptr<SiStripHashedDetId> produce( const SiStripHashedDetIdRcd& );
+  virtual std::unique_ptr<SiStripHashedDetId> produce( const SiStripHashedDetIdRcd& );
   
  private:
   

--- a/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
@@ -23,7 +23,7 @@ class SiStripNoiseESSource : public edm::ESProducer, public edm::EventSetupRecor
   SiStripNoiseESSource( const edm::ParameterSet& );
   virtual ~SiStripNoiseESSource() {;}
   
-  virtual std::auto_ptr<SiStripNoises> produce( const SiStripNoisesRcd& );
+  virtual std::unique_ptr<SiStripNoises> produce( const SiStripNoisesRcd& );
   
  protected:
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
@@ -23,7 +23,7 @@ class SiStripPedestalsESSource : public edm::ESProducer, public edm::EventSetupR
   SiStripPedestalsESSource( const edm::ParameterSet& );
   virtual ~SiStripPedestalsESSource() {;}
   
-  virtual std::auto_ptr<SiStripPedestals> produce( const SiStripPedestalsRcd& );
+  virtual std::unique_ptr<SiStripPedestals> produce( const SiStripPedestalsRcd& );
   
  protected:
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
@@ -25,10 +25,9 @@ SiStripQualityFakeESSource::SiStripQualityFakeESSource(const edm::ParameterSet& 
 }
 
 
-std::auto_ptr<SiStripQuality> SiStripQualityFakeESSource::produce(const SiStripQualityRcd& iRecord)
+std::unique_ptr<SiStripQuality> SiStripQualityFakeESSource::produce(const SiStripQualityRcd& iRecord)
 {
-  std::auto_ptr<SiStripQuality> ptr(new SiStripQuality);
-  return ptr;
+  return std::make_unique<SiStripQuality>();
 }
 
 void SiStripQualityFakeESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
@@ -28,7 +28,7 @@ class SiStripQualityFakeESSource : public edm::ESProducer, public edm::EventSetu
   ~SiStripQualityFakeESSource(){};
   
   
-  std::auto_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
+  std::unique_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
   
 private:
   

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateDepFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateDepFakeESSource.h
@@ -26,7 +26,7 @@ class SiStripTemplateDepFakeESSource : public edm::ESProducer, public edm::Event
   ~SiStripTemplateDepFakeESSource(){};
   
   
-  std::auto_ptr<TObject> produce(const TRecord&);
+  std::unique_ptr<TObject> produce(const TRecord&);
   
 private:
   
@@ -46,7 +46,7 @@ SiStripTemplateDepFakeESSource<TObject,TRecord,TService,DepTRecord,DepTObj>::SiS
 }
 
 template< typename TObject , typename TRecord, typename TService, typename DepTRecord, typename DepTObj>
-std::auto_ptr<TObject> SiStripTemplateDepFakeESSource<TObject,TRecord,TService,DepTRecord,DepTObj>::produce(const TRecord& iRecord)
+std::unique_ptr<TObject> SiStripTemplateDepFakeESSource<TObject,TRecord,TService,DepTRecord,DepTObj>::produce(const TRecord& iRecord)
 {
   edm::ESHandle<DepTObj> depObjHandle;
   iRecord.template getRecord<DepTRecord>().get(depObjHandle);
@@ -55,7 +55,7 @@ std::auto_ptr<TObject> SiStripTemplateDepFakeESSource<TObject,TRecord,TService,D
   edm::Service<TService> condObjBuilder;
   TObject *obj=0; 
   condObjBuilder->getObj(obj,depObject);
-  std::auto_ptr<TObject> ptr(obj);
+  std::unique_ptr<TObject> ptr(obj);
   return ptr;
 }
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
@@ -25,7 +25,7 @@ class SiStripTemplateEmptyFakeESSource : public edm::ESProducer, public edm::Eve
   ~SiStripTemplateEmptyFakeESSource(){};
   
   
-  std::auto_ptr<TObject> produce(const TRecord&);
+  std::unique_ptr<TObject> produce(const TRecord&);
   
 private:
   
@@ -45,10 +45,9 @@ SiStripTemplateEmptyFakeESSource<TObject,TRecord>::SiStripTemplateEmptyFakeESSou
 }
 
 template< typename TObject , typename TRecord>
-std::auto_ptr<TObject> SiStripTemplateEmptyFakeESSource<TObject,TRecord>::produce(const TRecord& iRecord)
+std::unique_ptr<TObject> SiStripTemplateEmptyFakeESSource<TObject,TRecord>::produce(const TRecord& iRecord)
 {
-  std::auto_ptr<TObject> ptr(new TObject);
-  return ptr;
+  return std::make_unique<TObject>();
 }
 
 template< typename TObject , typename TRecord>

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateFakeESSource.h
@@ -26,7 +26,7 @@ class SiStripTemplateFakeESSource : public edm::ESProducer, public edm::EventSet
   ~SiStripTemplateFakeESSource(){};
   
   
-  std::auto_ptr<TObject> produce(const TRecord&);
+  std::unique_ptr<TObject> produce(const TRecord&);
   
 private:
   
@@ -46,12 +46,12 @@ SiStripTemplateFakeESSource<TObject,TRecord,TService>::SiStripTemplateFakeESSour
 }
 
 template< typename TObject , typename TRecord, typename TService>
-std::auto_ptr<TObject> SiStripTemplateFakeESSource<TObject,TRecord,TService>::produce(const TRecord& iRecord)
+std::unique_ptr<TObject> SiStripTemplateFakeESSource<TObject,TRecord,TService>::produce(const TRecord& iRecord)
 {
   edm::Service<TService> condObjBuilder;
   TObject *obj=0; 
   condObjBuilder->getObj(obj);
-  std::auto_ptr<TObject> ptr(obj);
+  std::unique_ptr<TObject> ptr(obj);
   return ptr;
 }
 

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.cc
@@ -16,15 +16,15 @@ SiStripConnectivity::~SiStripConnectivity() {
 
 // ------------ methods called to produce the data  ------------
 
-std::auto_ptr<SiStripFecCabling> SiStripConnectivity::produceFecCabling( const SiStripFecCablingRcd& iRecord ){
+std::unique_ptr<SiStripFecCabling> SiStripConnectivity::produceFecCabling( const SiStripFecCablingRcd& iRecord ){
   edm::ESHandle<SiStripFedCabling> pDD;
   iRecord.getRecord<SiStripFedCablingRcd>().get(pDD );
   //here build an object of type SiStripFecCabling using  **ONLY** the information from class SiStripFedCabling, 
   SiStripFecCabling * FecConnections = new SiStripFecCabling( *(pDD.product()));
-  return std::auto_ptr<SiStripFecCabling>( FecConnections );
+  return std::unique_ptr<SiStripFecCabling>( FecConnections );
 }
 
-std::auto_ptr<SiStripDetCabling> SiStripConnectivity::produceDetCabling( const SiStripDetCablingRcd& iRecord ){
+std::unique_ptr<SiStripDetCabling> SiStripConnectivity::produceDetCabling( const SiStripDetCablingRcd& iRecord ){
   edm::ESHandle<SiStripFedCabling> pDD;
   iRecord.getRecord<SiStripFedCablingRcd>().get(pDD );
   edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -32,7 +32,7 @@ std::auto_ptr<SiStripDetCabling> SiStripConnectivity::produceDetCabling( const S
   const TrackerTopology* const tTopo = tTopoHandle.product();
   //here build an object of type SiStripDetCabling using  **ONLY** the information from class SiStripFedCabling, 
   SiStripDetCabling * DetConnections = new SiStripDetCabling( *(pDD.product()),tTopo);
-  return std::auto_ptr<SiStripDetCabling>( DetConnections );
+  return std::unique_ptr<SiStripDetCabling>( DetConnections );
 }
 
 //define this as a plug-in

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.h
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.h
@@ -15,8 +15,8 @@ class SiStripConnectivity: public edm::ESProducer {
   SiStripConnectivity( const edm::ParameterSet& );
   virtual ~SiStripConnectivity();
   
-  std::auto_ptr<SiStripFecCabling> produceFecCabling( const SiStripFecCablingRcd& );
-  std::auto_ptr<SiStripDetCabling> produceDetCabling( const SiStripDetCablingRcd& );
+  std::unique_ptr<SiStripFecCabling> produceFecCabling( const SiStripFecCablingRcd& );
+  std::unique_ptr<SiStripDetCabling> produceDetCabling( const SiStripDetCablingRcd& );
   
  private:
   

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
@@ -22,7 +22,7 @@ SiStripRegionConnectivity::SiStripRegionConnectivity(const edm::ParameterSet& ps
 
 SiStripRegionConnectivity::~SiStripRegionConnectivity() {}
 
-std::auto_ptr<SiStripRegionCabling> SiStripRegionConnectivity::produceRegionCabling( const SiStripRegionCablingRcd& iRecord ) {
+std::unique_ptr<SiStripRegionCabling> SiStripRegionConnectivity::produceRegionCabling( const SiStripRegionCablingRcd& iRecord ) {
 
   edm::ESHandle<SiStripDetCabling> detcabling;
   iRecord.getRecord<SiStripDetCablingRcd>().get( detcabling );
@@ -82,6 +82,6 @@ std::auto_ptr<SiStripRegionCabling> SiStripRegionConnectivity::produceRegionCabl
   //Add map to region cabling object
   RegionConnections->setRegionCabling(regioncabling);
   
-  return std::auto_ptr<SiStripRegionCabling>( RegionConnections );
+  return std::unique_ptr<SiStripRegionCabling>( RegionConnections );
 }
 

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.h
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.h
@@ -19,7 +19,7 @@ class SiStripRegionConnectivity: public edm::ESProducer {
   SiStripRegionConnectivity( const edm::ParameterSet& );
   virtual ~SiStripRegionConnectivity();
   
-  std::auto_ptr<SiStripRegionCabling> produceRegionCabling( const SiStripRegionCablingRcd&  );
+  std::unique_ptr<SiStripRegionCabling> produceRegionCabling( const SiStripRegionCablingRcd&  );
   
  private:
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducerTemplate.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducerTemplate.h
@@ -27,7 +27,7 @@ class SiStripGainESProducerTemplate : public edm::ESProducer {
   SiStripGainESProducerTemplate(const edm::ParameterSet&);
   ~SiStripGainESProducerTemplate(){};
   
-  std::auto_ptr<SiStripGain> produce(const TDependentRecord&);
+  std::unique_ptr<SiStripGain> produce(const TDependentRecord&);
 
  private:
 
@@ -73,9 +73,9 @@ SiStripGainESProducerTemplate<TDependentRecord,TInputRecord>::SiStripGainESProdu
 }
 
 template<typename TDependentRecord, typename TInputRecord>
-std::auto_ptr<SiStripGain> SiStripGainESProducerTemplate<TDependentRecord,TInputRecord>::produce(const TDependentRecord& iRecord)
+std::unique_ptr<SiStripGain> SiStripGainESProducerTemplate<TDependentRecord,TInputRecord>::produce(const TDependentRecord& iRecord)
 {
-  std::auto_ptr<SiStripGain> ptr(SiStripGainNormalizationFunction(iRecord));
+  std::unique_ptr<SiStripGain> ptr(SiStripGainNormalizationFunction(iRecord));
   return ptr;
 }
 

--- a/CalibTracker/SiStripESProducers/plugins/stubs/SiStripHashedDetIdESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/stubs/SiStripHashedDetIdESProducer.cc
@@ -20,7 +20,7 @@ SiStripHashedDetIdESProducer::~SiStripHashedDetIdESProducer() {}
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<SiStripHashedDetId> SiStripHashedDetIdESProducer::produce( const SiStripHashedDetIdRcd& rcd ) {
+std::unique_ptr<SiStripHashedDetId> SiStripHashedDetIdESProducer::produce( const SiStripHashedDetIdRcd& rcd ) {
 
   // Retrieve geometry
   edm::ESHandle<TrackerGeometry> geom;
@@ -48,7 +48,7 @@ std::auto_ptr<SiStripHashedDetId> SiStripHashedDetIdESProducer::produce( const S
     << " DetId hash map: " << std::endl
     << *hash;
   
-  return std::auto_ptr<SiStripHashedDetId>( hash );
+  return std::unique_ptr<SiStripHashedDetId>( hash );
 
 }
 

--- a/CalibTracker/SiStripESProducers/plugins/stubs/SiStripHashedDetIdESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/stubs/SiStripHashedDetIdESProducer.h
@@ -14,7 +14,7 @@ class SiStripHashedDetIdESProducer : public edm::ESProducer {
   
   virtual ~SiStripHashedDetIdESProducer();
   
-  std::auto_ptr<SiStripHashedDetId> produce( const SiStripHashedDetIdRcd& );
+  std::unique_ptr<SiStripHashedDetId> produce( const SiStripHashedDetIdRcd& );
   
 };
 

--- a/CalibTracker/SiStripESProducers/src/Phase2TrackerCablingESProducer.cc
+++ b/CalibTracker/SiStripESProducers/src/Phase2TrackerCablingESProducer.cc
@@ -15,7 +15,7 @@ Phase2TrackerCablingESProducer::~Phase2TrackerCablingESProducer() {}
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<Phase2TrackerCabling> Phase2TrackerCablingESProducer::produce( const Phase2TrackerCablingRcd& rcd ) { 
+std::unique_ptr<Phase2TrackerCabling> Phase2TrackerCablingESProducer::produce( const Phase2TrackerCablingRcd& rcd ) { 
   
   Phase2TrackerCabling* temp = make( rcd );
   
@@ -25,7 +25,7 @@ std::auto_ptr<Phase2TrackerCabling> Phase2TrackerCablingESProducer::produce( con
       << " Null pointer to Phase2TrackerCabling object!";
   }
   
-  std::auto_ptr<Phase2TrackerCabling> ptr( temp );
+  std::unique_ptr<Phase2TrackerCabling> ptr( temp );
   return ptr;
 
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripFedCablingESProducer.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripFedCablingESProducer.cc
@@ -19,7 +19,7 @@ SiStripFedCablingESProducer::~SiStripFedCablingESProducer() {}
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<SiStripFedCabling> SiStripFedCablingESProducer::produce( const SiStripFedCablingRcd& rcd ) { 
+std::unique_ptr<SiStripFedCabling> SiStripFedCablingESProducer::produce( const SiStripFedCablingRcd& rcd ) { 
   
   SiStripFedCabling* temp = make( rcd );
   
@@ -29,7 +29,7 @@ std::auto_ptr<SiStripFedCabling> SiStripFedCablingESProducer::produce( const SiS
       << " Null pointer to SiStripFedCabling object!";
   }
   
-  std::auto_ptr<SiStripFedCabling> ptr( temp );
+  std::unique_ptr<SiStripFedCabling> ptr( temp );
   return ptr;
 
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripGainESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripGainESSource.cc
@@ -17,7 +17,7 @@ SiStripGainESSource::SiStripGainESSource( const edm::ParameterSet& pset ) {
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<SiStripApvGain> SiStripGainESSource::produce( const SiStripApvGainRcd& ) { 
+std::unique_ptr<SiStripApvGain> SiStripGainESSource::produce( const SiStripApvGainRcd& ) { 
   
   SiStripApvGain* gain = makeGain();
   
@@ -27,7 +27,7 @@ std::auto_ptr<SiStripApvGain> SiStripGainESSource::produce( const SiStripApvGain
       << " Null pointer to SiStripApvGain object!";
   }
   
-  std::auto_ptr<SiStripApvGain> ptr(gain);
+  std::unique_ptr<SiStripApvGain> ptr(gain);
   return ptr;
 
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripHashedDetIdESProducer.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripHashedDetIdESProducer.cc
@@ -19,7 +19,7 @@ SiStripHashedDetIdESProducer::~SiStripHashedDetIdESProducer() {}
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<SiStripHashedDetId> SiStripHashedDetIdESProducer::produce( const SiStripHashedDetIdRcd& rcd ) { 
+std::unique_ptr<SiStripHashedDetId> SiStripHashedDetIdESProducer::produce( const SiStripHashedDetIdRcd& rcd ) { 
   
   SiStripHashedDetId* temp = make( rcd );
   
@@ -29,7 +29,7 @@ std::auto_ptr<SiStripHashedDetId> SiStripHashedDetIdESProducer::produce( const S
       << " Null pointer to SiStripHashedDetId object!";
   }
   
-  std::auto_ptr<SiStripHashedDetId> ptr( temp );
+  std::unique_ptr<SiStripHashedDetId> ptr( temp );
   return ptr;
   
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripNoiseESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripNoiseESSource.cc
@@ -16,7 +16,7 @@ SiStripNoiseESSource::SiStripNoiseESSource( const edm::ParameterSet& pset ) {
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<SiStripNoises> SiStripNoiseESSource::produce( const SiStripNoisesRcd& ) { 
+std::unique_ptr<SiStripNoises> SiStripNoiseESSource::produce( const SiStripNoisesRcd& ) { 
   
   SiStripNoises* noise = makeNoise();
   
@@ -26,7 +26,7 @@ std::auto_ptr<SiStripNoises> SiStripNoiseESSource::produce( const SiStripNoisesR
       << " Null pointer to SiStripNoises object!";
   }
   
-  std::auto_ptr<SiStripNoises> ptr(noise);
+  std::unique_ptr<SiStripNoises> ptr(noise);
   return ptr;
 
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripPedestalsESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripPedestalsESSource.cc
@@ -16,7 +16,7 @@ SiStripPedestalsESSource::SiStripPedestalsESSource( const edm::ParameterSet& pse
 
 // -----------------------------------------------------------------------------
 //
-std::auto_ptr<SiStripPedestals> SiStripPedestalsESSource::produce( const SiStripPedestalsRcd& ) { 
+std::unique_ptr<SiStripPedestals> SiStripPedestalsESSource::produce( const SiStripPedestalsRcd& ) { 
   
   SiStripPedestals* peds = makePedestals();
   
@@ -26,7 +26,7 @@ std::auto_ptr<SiStripPedestals> SiStripPedestalsESSource::produce( const SiStrip
       << " Null pointer to SiStripPedestals object!";
   }
   
-  std::auto_ptr<SiStripPedestals> ptr(peds);
+  std::unique_ptr<SiStripPedestals> ptr(peds);
   return ptr;
 
 }

--- a/CalibTracker/SiStripLorentzAngle/src/SymmetryFit.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/SymmetryFit.cc
@@ -172,7 +172,7 @@ std::vector<double> SymmetryFit::pol2_from_pol2(TH1* hist) {
 std::vector<double> SymmetryFit::pol2_from_pol3(TH1* hist) {
   std::vector<double> v;
 
-  std::unique_ptr<TF1> func( new TF1("mypol3","pol3")); 
+  auto func = std::make_unique<TF1>("mypol3","pol3"); 
   int status = hist->Fit(func.get(),"WQ");
   if(!status) {
     std::vector<double> p;

--- a/CaloOnlineTools/HcalOnlineDb/interface/HcalOmdsCalibrations.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/HcalOmdsCalibrations.h
@@ -41,20 +41,20 @@ protected:
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) ;
 
-  std::auto_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
-  std::auto_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
-  std::auto_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
-  std::auto_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
-  std::auto_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);
-  std::auto_ptr<HcalChannelQuality> produceChannelQuality (const HcalChannelQualityRcd& rcd);
-  std::auto_ptr<HcalElectronicsMap> produceElectronicsMap (const HcalElectronicsMapRcd& rcd);
+  std::unique_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
+  std::unique_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
+  std::unique_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
+  std::unique_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
+  std::unique_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);
+  std::unique_ptr<HcalChannelQuality> produceChannelQuality (const HcalChannelQualityRcd& rcd);
+  std::unique_ptr<HcalElectronicsMap> produceElectronicsMap (const HcalElectronicsMapRcd& rcd);
 
-  std::auto_ptr<HcalRespCorrs> produceRespCorrs (const HcalRespCorrsRcd& rcd);
-  std::auto_ptr<HcalZSThresholds> produceZSThresholds (const HcalZSThresholdsRcd& rcd);
-  std::auto_ptr<HcalL1TriggerObjects> produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd);
-  std::auto_ptr<HcalValidationCorrs> produceValidationCorrs (const HcalValidationCorrsRcd& rcd);
-  std::auto_ptr<HcalLutMetadata> produceLutMetadata (const HcalLutMetadataRcd& rcd);
-  std::auto_ptr<HcalDcsValues> produceDcsValues (const HcalDcsRcd& rcd);
+  std::unique_ptr<HcalRespCorrs> produceRespCorrs (const HcalRespCorrsRcd& rcd);
+  std::unique_ptr<HcalZSThresholds> produceZSThresholds (const HcalZSThresholdsRcd& rcd);
+  std::unique_ptr<HcalL1TriggerObjects> produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd);
+  std::unique_ptr<HcalValidationCorrs> produceValidationCorrs (const HcalValidationCorrsRcd& rcd);
+  std::unique_ptr<HcalLutMetadata> produceLutMetadata (const HcalLutMetadataRcd& rcd);
+  std::unique_ptr<HcalDcsValues> produceDcsValues (const HcalDcsRcd& rcd);
 
  private:
   std::map <std::string, std::string> mInputs;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalOmdsCalibrations.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalOmdsCalibrations.cc
@@ -140,14 +140,14 @@ const static std::string default_version = "";
 const static std::string default_query = "";
 
 template <class T>
-std::auto_ptr<T> produce_impl (const HcalTopology* topo,
+std::unique_ptr<T> produce_impl (const HcalTopology* topo,
 			       const std::string & fTag, 
 			       const std::string & fVersion=default_version, 
 			       const int fSubversion=1, 
 			       const int fIOVBegin=1,
 			       const std::string & fQuery = default_query, 
 			       const std::string& fAccessor = omds_occi_default_accessor ) {
-  std::auto_ptr<T> result (new T (topo));
+  std::unique_ptr<T> result (new T (topo));
 
   HCALConfigDB * db = new HCALConfigDB();
   try {
@@ -168,13 +168,13 @@ std::auto_ptr<T> produce_impl (const HcalTopology* topo,
   return result;
 }
 template <class T>
-std::auto_ptr<T> produce_impl (const std::string & fTag, 
+std::unique_ptr<T> produce_impl (const std::string & fTag, 
 			       const std::string & fVersion=default_version, 
 			       const int fSubversion=1, 
 			       const int fIOVBegin=1,
 			       const std::string & fQuery = default_query, 
 			       const std::string& fAccessor = omds_occi_default_accessor ) {
-  std::auto_ptr<T> result (new T ());
+  std::unique_ptr<T> result (new T ());
 
   HCALConfigDB * db = new HCALConfigDB();
   try {
@@ -197,7 +197,7 @@ std::auto_ptr<T> produce_impl (const std::string & fTag,
 
 
 
-std::auto_ptr<HcalPedestals> HcalOmdsCalibrations::producePedestals (const HcalPedestalsRcd& rcd) {
+std::unique_ptr<HcalPedestals> HcalOmdsCalibrations::producePedestals (const HcalPedestalsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -210,7 +210,7 @@ std::auto_ptr<HcalPedestals> HcalOmdsCalibrations::producePedestals (const HcalP
 				      mAccessor["Pedestals"]);
 }
 
-std::auto_ptr<HcalPedestalWidths> HcalOmdsCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
+std::unique_ptr<HcalPedestalWidths> HcalOmdsCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -222,7 +222,7 @@ std::auto_ptr<HcalPedestalWidths> HcalOmdsCalibrations::producePedestalWidths (c
 					   mAccessor["PedestalWidths"]);
 }
 
-std::auto_ptr<HcalGains> HcalOmdsCalibrations::produceGains (const HcalGainsRcd& rcd) {
+std::unique_ptr<HcalGains> HcalOmdsCalibrations::produceGains (const HcalGainsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -234,7 +234,7 @@ std::auto_ptr<HcalGains> HcalOmdsCalibrations::produceGains (const HcalGainsRcd&
 				  mAccessor["Gains"]);
 }
 
-std::auto_ptr<HcalGainWidths> HcalOmdsCalibrations::produceGainWidths (const HcalGainWidthsRcd& rcd) {
+std::unique_ptr<HcalGainWidths> HcalOmdsCalibrations::produceGainWidths (const HcalGainWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -246,7 +246,7 @@ std::auto_ptr<HcalGainWidths> HcalOmdsCalibrations::produceGainWidths (const Hca
 				       mAccessor["GainWidths"]);
 }
 
-std::auto_ptr<HcalQIEData> HcalOmdsCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
+std::unique_ptr<HcalQIEData> HcalOmdsCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -258,7 +258,7 @@ std::auto_ptr<HcalQIEData> HcalOmdsCalibrations::produceQIEData (const HcalQIEDa
 				    mAccessor["QIEData"]);
 }
 
-std::auto_ptr<HcalChannelQuality> HcalOmdsCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
+std::unique_ptr<HcalChannelQuality> HcalOmdsCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -270,7 +270,7 @@ std::auto_ptr<HcalChannelQuality> HcalOmdsCalibrations::produceChannelQuality (c
 					   mAccessor["ChannelQuality"]);
 }
 
-std::auto_ptr<HcalZSThresholds> HcalOmdsCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {
+std::unique_ptr<HcalZSThresholds> HcalOmdsCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -282,7 +282,7 @@ std::auto_ptr<HcalZSThresholds> HcalOmdsCalibrations::produceZSThresholds (const
 					 mAccessor["ZSThresholds"]);
 }
 
-std::auto_ptr<HcalRespCorrs> HcalOmdsCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
+std::unique_ptr<HcalRespCorrs> HcalOmdsCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -294,7 +294,7 @@ std::auto_ptr<HcalRespCorrs> HcalOmdsCalibrations::produceRespCorrs (const HcalR
 				      mAccessor["RespCorrs"]);
 }
 
-std::auto_ptr<HcalL1TriggerObjects> HcalOmdsCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
+std::unique_ptr<HcalL1TriggerObjects> HcalOmdsCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -306,7 +306,7 @@ std::auto_ptr<HcalL1TriggerObjects> HcalOmdsCalibrations::produceL1TriggerObject
 					     mAccessor["L1TriggerObjects"]);
 }
 
-std::auto_ptr<HcalElectronicsMap> HcalOmdsCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
+std::unique_ptr<HcalElectronicsMap> HcalOmdsCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
   return produce_impl<HcalElectronicsMap> (mInputs ["ElectronicsMap"], 
 					   mVersion["ElectronicsMap"], 
 					   mSubversion["ElectronicsMap"], 
@@ -315,7 +315,7 @@ std::auto_ptr<HcalElectronicsMap> HcalOmdsCalibrations::produceElectronicsMap (c
 					   mAccessor["ElectronicsMap"]);
 }
 
-std::auto_ptr<HcalValidationCorrs> HcalOmdsCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
+std::unique_ptr<HcalValidationCorrs> HcalOmdsCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -327,7 +327,7 @@ std::auto_ptr<HcalValidationCorrs> HcalOmdsCalibrations::produceValidationCorrs 
 					    mAccessor["ValidationCorrs"]);
 }
 
-std::auto_ptr<HcalLutMetadata> HcalOmdsCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
+std::unique_ptr<HcalLutMetadata> HcalOmdsCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -339,7 +339,7 @@ std::auto_ptr<HcalLutMetadata> HcalOmdsCalibrations::produceLutMetadata (const H
 					mAccessor["LutMetadata"]);
 }
 
-std::auto_ptr<HcalDcsValues> HcalOmdsCalibrations::produceDcsValues (const HcalDcsRcd& rcd) {
+std::unique_ptr<HcalDcsValues> HcalOmdsCalibrations::produceDcsValues (const HcalDcsRcd& rcd) {
   return produce_impl<HcalDcsValues> (mInputs ["DcsValues"], 
 					mVersion["DcsValues"], 
 					mSubversion["DcsValues"], 

--- a/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
@@ -54,7 +54,7 @@ public:
 private:
 #ifdef USE_STORAGE_MANAGER
   typedef IOOffset filepos_t;
-  typedef std::auto_ptr<Storage> FILE_t;
+  typedef std::unique_ptr<Storage> FILE_t;
 #else
   typedef off_t filepos_t;
   typedef FILE* FILE_t;

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.cc
@@ -67,9 +67,9 @@ CaloTowerConstituentsMapBuilder::produce(const CaloGeometryRecord& iRecord)
   edm::ESHandle<CaloTowerTopology> cttopo;
   iRecord.getRecord<HcalRecNumberingRecord>().get(cttopo);
 
-  std::auto_ptr<CaloTowerConstituentsMap> prod( new CaloTowerConstituentsMap( &*hcaltopo, &*cttopo ));
+  auto prod = std::make_unique<CaloTowerConstituentsMap>( &*hcaltopo, &*cttopo );
 
-//std::auto_ptr<CaloTowerConstituentsMap> prod( new CaloTowerConstituentsMap( &*hcaltopo ));
+//auto prod = std::make_unique<CaloTowerConstituentsMap>( &*hcaltopo );
 
   //keep geometry pointer as member for alternate EE->HE mapping
   edm::ESHandle<CaloGeometry> pG;

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -42,7 +42,7 @@ public:
   CaloTowerConstituentsMapBuilder(const edm::ParameterSet&);
   ~CaloTowerConstituentsMapBuilder();
 
-  typedef std::auto_ptr<CaloTowerConstituentsMap> ReturnType;
+  typedef std::unique_ptr<CaloTowerConstituentsMap> ReturnType;
 
   ReturnType produce(const CaloGeometryRecord&);
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.cc
@@ -36,7 +36,7 @@ EcalTrigTowerConstituentsMapBuilder::~EcalTrigTowerConstituentsMapBuilder()
 EcalTrigTowerConstituentsMapBuilder::ReturnType
 EcalTrigTowerConstituentsMapBuilder::produce(const IdealGeometryRecord& iRecord)
 {
-   std::auto_ptr<EcalTrigTowerConstituentsMap> prod(new EcalTrigTowerConstituentsMap());
+   auto prod = std::make_unique<EcalTrigTowerConstituentsMap>();
 
    if (!mapFile_.empty()) {
      parseTextMap(mapFile_,*prod);

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
@@ -38,7 +38,7 @@ class EcalTrigTowerConstituentsMapBuilder : public edm::ESProducer {
   EcalTrigTowerConstituentsMapBuilder(const edm::ParameterSet&);
   ~EcalTrigTowerConstituentsMapBuilder();
 
-  typedef std::auto_ptr<EcalTrigTowerConstituentsMap> ReturnType;
+  typedef std::unique_ptr<EcalTrigTowerConstituentsMap> ReturnType;
 
   ReturnType produce(const IdealGeometryRecord&);
 

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
@@ -58,7 +58,7 @@ EcalElectronicsMappingBuilder::ReturnType
 EcalElectronicsMappingBuilder::produce(const EcalMappingRcd& iRecord)
 {
    using namespace edm::es;
-   std::auto_ptr<EcalElectronicsMapping> prod(new EcalElectronicsMapping());
+   auto prod = std::make_unique<EcalElectronicsMapping>();
    const std::vector<EcalMappingElement>& ee = Mapping_ -> endcapItems();
    FillFromDatabase(ee,*prod);
    return prod;

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
@@ -36,7 +36,7 @@ class EcalElectronicsMappingBuilder : public edm::ESProducer
   EcalElectronicsMappingBuilder(const edm::ParameterSet&);
   ~EcalElectronicsMappingBuilder();
   
-  typedef std::auto_ptr<EcalElectronicsMapping> ReturnType;
+  typedef std::unique_ptr<EcalElectronicsMapping> ReturnType;
   
   // ReturnType produce(const IdealGeometryRecord&);
   ReturnType produce(const EcalMappingRcd&);

--- a/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.cc
@@ -51,7 +51,7 @@ EcalTBGeometryBuilder::produce(const IdealGeometryRecord& iRecord)
 {
    edm::ESHandle<CaloSubdetectorGeometry> pG;
 
-   std::auto_ptr<CaloGeometry> pCaloGeom(new CaloGeometry());
+   auto pCaloGeom = std::make_unique<CaloGeometry>();
 
    // TODO: Look for ECAL parts
    try {

--- a/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
@@ -37,7 +37,7 @@ class EcalTBGeometryBuilder : public edm::ESProducer {
   EcalTBGeometryBuilder(const edm::ParameterSet&);
   ~EcalTBGeometryBuilder();
 
-  typedef std::auto_ptr<CaloGeometry> ReturnType;
+  typedef std::unique_ptr<CaloGeometry> ReturnType;
 
   ReturnType produce(const IdealGeometryRecord&);
 private:

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.cc
@@ -59,8 +59,7 @@ EcalTBHodoscopeGeometryEP::produce(const IdealGeometryRecord& iRecord)
    iRecord.get( cpv );
    
    std::cout << "[EcalTBHodoscopeGeometryEP]::Constructing EcalTBHodoscopeGeometry" <<  std::endl;
-   std::auto_ptr<CaloSubdetectorGeometry> pCaloSubdetectorGeometry(loader_->load(&(*cpv))) ;
-   return pCaloSubdetectorGeometry ;
+   return std::unique_ptr<CaloSubdetectorGeometry>(loader_->load(&(*cpv)));
 }
 
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
@@ -27,7 +27,7 @@ class EcalTBHodoscopeGeometryEP : public edm::ESProducer {
   EcalTBHodoscopeGeometryEP(const edm::ParameterSet&);
   ~EcalTBHodoscopeGeometryEP();
   
-  typedef std::auto_ptr<CaloSubdetectorGeometry> ReturnType;
+  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
   
   ReturnType produce(const IdealGeometryRecord&);
 

--- a/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.cc
+++ b/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.cc
@@ -28,9 +28,7 @@ CastorHardcodeGeometryEP::ReturnType
 CastorHardcodeGeometryEP::produce(const CastorGeometryRecord& iRecord)
 {
    loader_=new CastorHardcodeGeometryLoader();
-   std::auto_ptr<CaloSubdetectorGeometry> pCaloSubdetectorGeometry(loader_->load()) ;
-
-   return pCaloSubdetectorGeometry ;
+   return std::unique_ptr<CaloSubdetectorGeometry>(loader_->load());
 }
 
 

--- a/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.h
+++ b/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.h
@@ -21,7 +21,7 @@ class CastorHardcodeGeometryEP : public edm::ESProducer {
       CastorHardcodeGeometryEP(const edm::ParameterSet&);
       ~CastorHardcodeGeometryEP();
 
-      typedef std::auto_ptr<CaloSubdetectorGeometry> ReturnType;
+      typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
 
       ReturnType produce(const CastorGeometryRecord&);
 private:

--- a/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
@@ -39,7 +39,7 @@ public:
   FastTimeNumberingInitialization(const edm::ParameterSet&);
   ~FastTimeNumberingInitialization();
 
-  typedef std::auto_ptr<FastTimeDDDConstants> ReturnType;
+  typedef std::unique_ptr<FastTimeDDDConstants> ReturnType;
 
   ReturnType produce(const IdealGeometryRecord&);
 

--- a/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
@@ -38,7 +38,7 @@ public:
   HGCalNumberingInitialization(const edm::ParameterSet&);
   ~HGCalNumberingInitialization();
 
-  typedef std::auto_ptr<HGCalDDDConstants> ReturnType;
+  typedef std::unique_ptr<HGCalDDDConstants> ReturnType;
 
   ReturnType produce(const IdealGeometryRecord&);
 

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
@@ -66,9 +66,8 @@ CaloTowerHardcodeGeometryEP::produce(const CaloTowerGeometryRecord& iRecord) {
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
   iRecord.getRecord<HcalRecNumberingRecord>().get( pHRNDC );
   
-  std::auto_ptr<CaloSubdetectorGeometry> pCaloSubdetectorGeometry( loader_->load( &*cttopo, &*hcaltopo, &*pHRNDC ));
+  return std::unique_ptr<CaloSubdetectorGeometry>( loader_->load( &*cttopo, &*hcaltopo, &*pHRNDC ));
 
-  return pCaloSubdetectorGeometry ;
 }
 
 

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -25,7 +25,7 @@ public:
   CaloTowerHardcodeGeometryEP(const edm::ParameterSet&);
   ~CaloTowerHardcodeGeometryEP();
 
-  typedef std::auto_ptr<CaloSubdetectorGeometry> ReturnType;
+  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
 
   ReturnType produce(const CaloTowerGeometryRecord&);
 

--- a/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
@@ -36,7 +36,7 @@ public:
   MuonNumberingInitialization( const edm::ParameterSet& );
   ~MuonNumberingInitialization();
 
-  typedef std::auto_ptr<MuonDDDConstants> ReturnType;
+  typedef std::unique_ptr<MuonDDDConstants> ReturnType;
 
   ReturnType produce( const MuonNumberingRecord& );
 

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.cc
@@ -36,7 +36,7 @@ TrackerGeometricDetESModule::fillDescriptions( edm::ConfigurationDescriptions & 
   descriptions.add( "trackerNumberingGeometry", desc );
 }
 
-std::auto_ptr<GeometricDet> 
+std::unique_ptr<GeometricDet> 
 TrackerGeometricDetESModule::produce( const IdealGeometryRecord & iRecord )
 { 
   if( fromDDD_ )
@@ -45,7 +45,7 @@ TrackerGeometricDetESModule::produce( const IdealGeometryRecord & iRecord )
     iRecord.get( cpv );
 
     DDDCmsTrackerContruction theDDDCmsTrackerContruction;
-    return std::auto_ptr<GeometricDet> (const_cast<GeometricDet*>( theDDDCmsTrackerContruction.construct(&(*cpv), dbl_to_int( DDVectorGetter::get( "detIdShifts" )))));
+    return std::unique_ptr<GeometricDet> (const_cast<GeometricDet*>( theDDDCmsTrackerContruction.construct(&(*cpv), dbl_to_int( DDVectorGetter::get( "detIdShifts" )))));
   }
   else
   {
@@ -53,7 +53,7 @@ TrackerGeometricDetESModule::produce( const IdealGeometryRecord & iRecord )
     iRecord.get( pgd );
     
     CondDBCmsTrackerConstruction cdbtc;
-    return std::auto_ptr<GeometricDet> ( const_cast<GeometricDet*>( cdbtc.construct( *pgd )));
+    return std::unique_ptr<GeometricDet> ( const_cast<GeometricDet*>( cdbtc.construct( *pgd )));
   }
 }
 

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.h
@@ -16,7 +16,7 @@ class TrackerGeometricDetESModule : public edm::ESProducer
 public:
   TrackerGeometricDetESModule( const edm::ParameterSet & p );
   virtual ~TrackerGeometricDetESModule( void ); 
-  std::auto_ptr<GeometricDet> produce( const IdealGeometryRecord & );
+  std::unique_ptr<GeometricDet> produce( const IdealGeometryRecord & );
 
   static void fillDescriptions( edm::ConfigurationDescriptions & descriptions );
   

--- a/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
+++ b/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
@@ -19,9 +19,9 @@ class XMLIdealGeometryESSource : public edm::ESProducer,
 public:
     XMLIdealGeometryESSource(const edm::ParameterSet & p);
     virtual ~XMLIdealGeometryESSource(); 
-    std::auto_ptr<DDCompactView> produceGeom(const IdealGeometryRecord &);
-    std::auto_ptr<DDCompactView> produceMagField(const IdealMagneticFieldRecord &);
-    std::auto_ptr<DDCompactView> produce();
+    std::unique_ptr<DDCompactView> produceGeom(const IdealGeometryRecord &);
+    std::unique_ptr<DDCompactView> produceMagField(const IdealMagneticFieldRecord &);
+    std::unique_ptr<DDCompactView> produce();
 protected:
     virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
 				const edm::IOVSyncValue &,edm::ValidityInterval &);

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
@@ -52,7 +52,7 @@ public:
   XMLIdealGeometryESProducer(const edm::ParameterSet&);
   ~XMLIdealGeometryESProducer();
   
-  typedef std::auto_ptr<DDCompactView> ReturnType;
+  typedef std::unique_ptr<DDCompactView> ReturnType;
   
   ReturnType produce(const IdealGeometryRecord&);
 private:

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESSource.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESSource.cc
@@ -41,26 +41,26 @@ XMLIdealGeometryESSource::XMLIdealGeometryESSource(const edm::ParameterSet & p):
 
 XMLIdealGeometryESSource::~XMLIdealGeometryESSource() { }
 
-std::auto_ptr<DDCompactView>
+std::unique_ptr<DDCompactView>
 XMLIdealGeometryESSource::produceGeom(const IdealGeometryRecord &)
 {
   return produce();
 }
 
-std::auto_ptr<DDCompactView>
+std::unique_ptr<DDCompactView>
 XMLIdealGeometryESSource::produceMagField(const IdealMagneticFieldRecord &)
 { 
   return produce();
 }
 
 
-std::auto_ptr<DDCompactView>
+std::unique_ptr<DDCompactView>
 XMLIdealGeometryESSource::produce() {
   
   DDName ddName(rootNodeName_);
   DDLogicalPart rootNode(ddName);
   DDRootDef::instance().set(rootNode);
-  std::auto_ptr<DDCompactView> returnValue(new DDCompactView(rootNode));
+  std::unique_ptr<DDCompactView> returnValue(new DDCompactView(rootNode));
   DDLParser parser(*returnValue); //* parser = DDLParser::instance();
   parser.getDDLSAX2FileHandler()->setUserNS(userNS_);
   int result2 = parser.parse(geoConfig_);

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
@@ -28,7 +28,7 @@ public:
   XMLIdealMagneticFieldGeometryESProducer( const edm::ParameterSet& );
   ~XMLIdealMagneticFieldGeometryESProducer();
   
-  typedef std::auto_ptr<DDCompactView> ReturnType;
+  typedef std::unique_ptr<DDCompactView> ReturnType;
   
   ReturnType produce( const IdealMagneticFieldRecord& );
 

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFConfigProducer.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFConfigProducer.h
@@ -23,9 +23,9 @@ private:
 	std::string         ptLUT_path;
 
 public:
-	std::auto_ptr<L1MuCSCTFConfiguration> produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord);
-	std::auto_ptr<L1MuCSCTFAlignment>     produceL1MuCSCTFAlignmentRcd    (const L1MuCSCTFAlignmentRcd&     iRecord);
-	std::auto_ptr<L1MuCSCPtLut>           produceL1MuCSCPtLutRcd          (const L1MuCSCPtLutRcd&           iRecord);
+	std::unique_ptr<L1MuCSCTFConfiguration> produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord);
+	std::unique_ptr<L1MuCSCTFAlignment>     produceL1MuCSCTFAlignmentRcd    (const L1MuCSCTFAlignmentRcd&     iRecord);
+	std::unique_ptr<L1MuCSCPtLut>           produceL1MuCSCPtLutRcd          (const L1MuCSCPtLutRcd&           iRecord);
 	void readLUT(std::string path, unsigned short* lut, unsigned long length);
 
 	CSCTFConfigProducer(const edm::ParameterSet& pset);

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigProducer.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigProducer.cc
@@ -25,31 +25,31 @@ CSCTFConfigProducer::CSCTFConfigProducer(const edm::ParameterSet& pset) {
 
 }
 
-std::auto_ptr<L1MuCSCTFConfiguration> CSCTFConfigProducer::produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord){
+std::unique_ptr<L1MuCSCTFConfiguration> CSCTFConfigProducer::produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord){
 
   edm::LogInfo( "L1-O2O: CSCTFConfigProducer" ) << "Producing "
 						<< " L1MuCSCTFConfiguration from PSET";
 						
-  std::auto_ptr<L1MuCSCTFConfiguration> config = std::auto_ptr<L1MuCSCTFConfiguration>( new L1MuCSCTFConfiguration(registers) );
+  std::unique_ptr<L1MuCSCTFConfiguration> config = std::unique_ptr<L1MuCSCTFConfiguration>( new L1MuCSCTFConfiguration(registers) );
   return config;
 }
 
-std::auto_ptr<L1MuCSCTFAlignment> CSCTFConfigProducer::produceL1MuCSCTFAlignmentRcd(const L1MuCSCTFAlignmentRcd& iRecord){
+std::unique_ptr<L1MuCSCTFAlignment> CSCTFConfigProducer::produceL1MuCSCTFAlignmentRcd(const L1MuCSCTFAlignmentRcd& iRecord){
   edm::LogInfo( "L1-O2O: CSCTFConfigProducer" ) << "Producing "
 						<< " L1MuCSCTFAlignment from PSET";
   
 
-  std::auto_ptr<L1MuCSCTFAlignment> al = std::auto_ptr<L1MuCSCTFAlignment>( new L1MuCSCTFAlignment(alignment) );
+  std::unique_ptr<L1MuCSCTFAlignment> al = std::unique_ptr<L1MuCSCTFAlignment>( new L1MuCSCTFAlignment(alignment) );
   return al;
 }
 
-std::auto_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const L1MuCSCPtLutRcd& iRecord){
+std::unique_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const L1MuCSCPtLutRcd& iRecord){
   edm::LogInfo( "L1-O2O: CSCTFConfigProducer" ) << "Producing "
 						<< " L1MuCSCPtLut from PSET";
   
 
 
-  std::auto_ptr<L1MuCSCPtLut> pt_lut = std::auto_ptr<L1MuCSCPtLut>( new L1MuCSCPtLut() );
+  std::unique_ptr<L1MuCSCPtLut> pt_lut = std::unique_ptr<L1MuCSCPtLut>( new L1MuCSCPtLut() );
 
   if( ptLUT_path.length() ){
     readLUT(ptLUT_path, (unsigned short *)pt_lut->pt_lut, 1<<21); //CSCBitWidths::kPtAddressWidth

--- a/L1TriggerConfig/CSCTFConfigProducers/test/CSCTFConfigProducer.cc-readFromOMDS
+++ b/L1TriggerConfig/CSCTFConfigProducers/test/CSCTFConfigProducer.cc-readFromOMDS
@@ -17,7 +17,7 @@ CSCTFConfigProducer::CSCTFConfigProducer(const edm::ParameterSet& pset) {
 
 }
 
-std::auto_ptr<L1MuCSCTFConfiguration> CSCTFConfigProducer::produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord){
+std::unique_ptr<L1MuCSCTFConfiguration> CSCTFConfigProducer::produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord){
 
   std::string objectKey("170210");
   l1t::OMDSReader m_omdsReader("oracle://CMS_OMDS_LB/CMS_TRG_R",".");
@@ -54,7 +54,7 @@ std::auto_ptr<L1MuCSCTFConfiguration> CSCTFConfigProducer::produceL1MuCSCTFConfi
     if( results.queryFailed() ) // check if query was successful
       {
 	edm::LogError( "L1-O2O" ) << "Problem with L1CSCTFParameters key." ;
-	return std::auto_ptr<L1MuCSCTFConfiguration>( new L1MuCSCTFConfiguration() );
+	return std::unique_ptr<L1MuCSCTFConfiguration>( new L1MuCSCTFConfiguration() );
       }
   
     //    double datum ;
@@ -86,17 +86,17 @@ std::auto_ptr<L1MuCSCTFConfiguration> CSCTFConfigProducer::produceL1MuCSCTFConfi
     
   }  
   
-  std::auto_ptr<L1MuCSCTFConfiguration> config = std::auto_ptr<L1MuCSCTFConfiguration>( new L1MuCSCTFConfiguration(registers) );
+  std::unique_ptr<L1MuCSCTFConfiguration> config = std::unique_ptr<L1MuCSCTFConfiguration>( new L1MuCSCTFConfiguration(registers) );
   return config;
 
 }
 
-std::auto_ptr<L1MuCSCTFAlignment> CSCTFConfigProducer::produceL1MuCSCTFAlignmentRcd(const L1MuCSCTFAlignmentRcd& iRecord){
-	std::auto_ptr<L1MuCSCTFAlignment> al = std::auto_ptr<L1MuCSCTFAlignment>( new L1MuCSCTFAlignment(alignment) );
+std::unique_ptr<L1MuCSCTFAlignment> CSCTFConfigProducer::produceL1MuCSCTFAlignmentRcd(const L1MuCSCTFAlignmentRcd& iRecord){
+	std::unique_ptr<L1MuCSCTFAlignment> al = std::unique_ptr<L1MuCSCTFAlignment>( new L1MuCSCTFAlignment(alignment) );
 	return al;
 }
 
-std::auto_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const L1MuCSCPtLutRcd& iRecord){
+std::unique_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const L1MuCSCPtLutRcd& iRecord){
   
   std::string objectKey("1");
   l1t::OMDSReader m_omdsReader("oracle://CMS_OMDS_LB/CMS_TRG_R",".");
@@ -118,7 +118,7 @@ std::auto_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const L1
   if( results.queryFailed() ) // check if query was successful
     {
       edm::LogError( "L1-O2O" ) << "Problem with L1MuCSCPtLutParameters key." ;
-      return std::auto_ptr<L1MuCSCPtLut>( new L1MuCSCPtLut() );
+      return std::unique_ptr<L1MuCSCPtLut>( new L1MuCSCPtLut() );
     }
   
   std::string ptlut;
@@ -133,7 +133,7 @@ std::auto_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const L1
   L1MuCSCPtLut* CSCTFPtLut = new L1MuCSCPtLut();
   CSCTFPtLut->readFromDBS(ptlut);
 
-  std::auto_ptr<L1MuCSCPtLut> pt_lut = std::auto_ptr<L1MuCSCPtLut>( CSCTFPtLut );
+  std::unique_ptr<L1MuCSCPtLut> pt_lut = std::unique_ptr<L1MuCSCPtLut>( CSCTFPtLut );
  
   return pt_lut;
 }

--- a/L1TriggerConfig/CSCTFConfigProducers/test/CSCTFConfigProducer.h-readFromOMDS
+++ b/L1TriggerConfig/CSCTFConfigProducers/test/CSCTFConfigProducer.h-readFromOMDS
@@ -23,9 +23,9 @@ private:
 	std::string         ptLUT_path;
 
 public:
-	std::auto_ptr<L1MuCSCTFConfiguration> produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord);
-	std::auto_ptr<L1MuCSCTFAlignment>     produceL1MuCSCTFAlignmentRcd    (const L1MuCSCTFAlignmentRcd&     iRecord);
-	std::auto_ptr<L1MuCSCPtLut>           produceL1MuCSCPtLutRcd          (const L1MuCSCPtLutRcd&           iRecord);
+	std::unique_ptr<L1MuCSCTFConfiguration> produceL1MuCSCTFConfigurationRcd(const L1MuCSCTFConfigurationRcd& iRecord);
+	std::unique_ptr<L1MuCSCTFAlignment>     produceL1MuCSCTFAlignmentRcd    (const L1MuCSCTFAlignmentRcd&     iRecord);
+	std::unique_ptr<L1MuCSCPtLut>           produceL1MuCSCPtLutRcd          (const L1MuCSCPtLutRcd&           iRecord);
 
 	CSCTFConfigProducer(const edm::ParameterSet& pset);
 	~CSCTFConfigProducer(void){}

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -25,7 +25,7 @@
 using std::cout;
 using std::endl;
 using std::vector;
-using std::auto_ptr;
+using std::unique_ptr;
 
 //
 // constructors and destructor
@@ -67,11 +67,11 @@ DTConfigDBProducer::~DTConfigDBProducer()
 // member functions
 //
 
-std::auto_ptr<DTConfigManager> DTConfigDBProducer::produce(const DTConfigManagerRcd& iRecord)
+std::unique_ptr<DTConfigManager> DTConfigDBProducer::produce(const DTConfigManagerRcd& iRecord)
 {
    using namespace edm;
 
-   std::auto_ptr<DTConfigManager> dtConfig = std::auto_ptr<DTConfigManager>( new DTConfigManager() );
+   std::unique_ptr<DTConfigManager> dtConfig = std::unique_ptr<DTConfigManager>( new DTConfigManager() );
    DTConfigManager & dttpgConfig = *(dtConfig.get());
 
    // DB specific requests

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.h
@@ -54,7 +54,7 @@ class DTConfigDBProducer : public edm::ESProducer{
   ~DTConfigDBProducer();
   
   //! ES produce method
-  std::auto_ptr<DTConfigManager> produce(const DTConfigManagerRcd&);
+  std::unique_ptr<DTConfigManager> produce(const DTConfigManagerRcd&);
   
  private :
 

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.cc
@@ -7,7 +7,7 @@
 using std::cout;
 using std::endl;
 using std::vector;
-using std::auto_ptr;
+using std::unique_ptr;
 
 //
 // constructors and destructor
@@ -55,7 +55,7 @@ DTConfigTrivialProducer::~DTConfigTrivialProducer()
 // member functions
 //
 
-std::auto_ptr<DTConfigManager> DTConfigTrivialProducer::produce (const DTConfigManagerRcd& iRecord)
+std::unique_ptr<DTConfigManager> DTConfigTrivialProducer::produce (const DTConfigManagerRcd& iRecord)
 {
 
   if (m_debug) 
@@ -66,7 +66,7 @@ std::auto_ptr<DTConfigManager> DTConfigTrivialProducer::produce (const DTConfigM
 
    //m_manager->getDTConfigPedestals()->print();
 
-   std::auto_ptr<DTConfigManager> dtConfig = std::auto_ptr<DTConfigManager>( m_manager );
+   std::unique_ptr<DTConfigManager> dtConfig = std::unique_ptr<DTConfigManager>( m_manager );
 
    return dtConfig ;
 

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.h
@@ -48,7 +48,7 @@ public:
   ~DTConfigTrivialProducer();
 
   //! ES produce method
-  std::auto_ptr<DTConfigManager> produce(const DTConfigManagerRcd&);
+  std::unique_ptr<DTConfigManager> produce(const DTConfigManagerRcd&);
 
 private:
 

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTrackFinderConfig.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTrackFinderConfig.h
@@ -44,19 +44,19 @@ class DTTrackFinderConfig : public edm::ESProducer {
 
   ~DTTrackFinderConfig();
   
-  std::auto_ptr<L1MuDTExtLut> produceL1MuDTExtLut(const L1MuDTExtLutRcd&);
+  std::unique_ptr<L1MuDTExtLut> produceL1MuDTExtLut(const L1MuDTExtLutRcd&);
 
-  std::auto_ptr<L1MuDTPhiLut> produceL1MuDTPhiLut(const L1MuDTPhiLutRcd&);
+  std::unique_ptr<L1MuDTPhiLut> produceL1MuDTPhiLut(const L1MuDTPhiLutRcd&);
 
-  std::auto_ptr<L1MuDTPtaLut> produceL1MuDTPtaLut(const L1MuDTPtaLutRcd&);
+  std::unique_ptr<L1MuDTPtaLut> produceL1MuDTPtaLut(const L1MuDTPtaLutRcd&);
 
-  std::auto_ptr<L1MuDTEtaPatternLut> produceL1MuDTEtaPatternLut(const L1MuDTEtaPatternLutRcd&);
+  std::unique_ptr<L1MuDTEtaPatternLut> produceL1MuDTEtaPatternLut(const L1MuDTEtaPatternLutRcd&);
 
-  std::auto_ptr<L1MuDTQualPatternLut> produceL1MuDTQualPatternLut(const L1MuDTQualPatternLutRcd&);
+  std::unique_ptr<L1MuDTQualPatternLut> produceL1MuDTQualPatternLut(const L1MuDTQualPatternLutRcd&);
 
-  std::auto_ptr<L1MuDTTFParameters> produceL1MuDTTFParameters(const L1MuDTTFParametersRcd&);
+  std::unique_ptr<L1MuDTTFParameters> produceL1MuDTTFParameters(const L1MuDTTFParametersRcd&);
 
-  std::auto_ptr<L1MuDTTFMasks> produceL1MuDTTFMasks(const L1MuDTTFMasksRcd&);
+  std::unique_ptr<L1MuDTTFMasks> produceL1MuDTTFMasks(const L1MuDTTFMasksRcd&);
 
  private:
 

--- a/L1TriggerConfig/DTTrackFinder/src/DTTrackFinderConfig.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTrackFinderConfig.cc
@@ -34,9 +34,9 @@ DTTrackFinderConfig::DTTrackFinderConfig(const edm::ParameterSet& pset) {
 DTTrackFinderConfig::~DTTrackFinderConfig() {}
 
 
-auto_ptr<L1MuDTExtLut> DTTrackFinderConfig::produceL1MuDTExtLut(const L1MuDTExtLutRcd& iRecord) {
+unique_ptr<L1MuDTExtLut> DTTrackFinderConfig::produceL1MuDTExtLut(const L1MuDTExtLutRcd& iRecord) {
 
-   auto_ptr<L1MuDTExtLut> extlut = auto_ptr<L1MuDTExtLut>( new L1MuDTExtLut() );
+   unique_ptr<L1MuDTExtLut> extlut = unique_ptr<L1MuDTExtLut>( new L1MuDTExtLut() );
 
    if ( extlut->load() != 0 ) {
      cout << "Can not open files to load  extrapolation look-up tables for DTTrackFinder!" << endl;
@@ -45,9 +45,9 @@ auto_ptr<L1MuDTExtLut> DTTrackFinderConfig::produceL1MuDTExtLut(const L1MuDTExtL
    return extlut;
 }
 
-auto_ptr<L1MuDTPhiLut> DTTrackFinderConfig::produceL1MuDTPhiLut(const L1MuDTPhiLutRcd& iRecord) {
+unique_ptr<L1MuDTPhiLut> DTTrackFinderConfig::produceL1MuDTPhiLut(const L1MuDTPhiLutRcd& iRecord) {
 
-   auto_ptr<L1MuDTPhiLut> philut = auto_ptr<L1MuDTPhiLut>( new L1MuDTPhiLut() );
+   unique_ptr<L1MuDTPhiLut> philut = unique_ptr<L1MuDTPhiLut>( new L1MuDTPhiLut() );
 
    if ( philut->load() != 0 ) {
      cout << "Can not open files to load phi-assignment look-up tables for DTTrackFinder!" << endl;
@@ -56,9 +56,9 @@ auto_ptr<L1MuDTPhiLut> DTTrackFinderConfig::produceL1MuDTPhiLut(const L1MuDTPhiL
    return philut;
 }
 
-auto_ptr<L1MuDTPtaLut> DTTrackFinderConfig::produceL1MuDTPtaLut(const L1MuDTPtaLutRcd& iRecord) {
+unique_ptr<L1MuDTPtaLut> DTTrackFinderConfig::produceL1MuDTPtaLut(const L1MuDTPtaLutRcd& iRecord) {
 
-   auto_ptr<L1MuDTPtaLut> ptalut = auto_ptr<L1MuDTPtaLut>( new L1MuDTPtaLut() );
+   unique_ptr<L1MuDTPtaLut> ptalut = unique_ptr<L1MuDTPtaLut>( new L1MuDTPtaLut() );
 
    if ( ptalut->load() != 0 ) {
      cout << "Can not open files to load pt-assignment look-up tables for DTTrackFinder!" << endl;
@@ -67,9 +67,9 @@ auto_ptr<L1MuDTPtaLut> DTTrackFinderConfig::produceL1MuDTPtaLut(const L1MuDTPtaL
    return ptalut;
 }
 
-auto_ptr<L1MuDTEtaPatternLut> DTTrackFinderConfig::produceL1MuDTEtaPatternLut(const L1MuDTEtaPatternLutRcd& iRecord) {
+unique_ptr<L1MuDTEtaPatternLut> DTTrackFinderConfig::produceL1MuDTEtaPatternLut(const L1MuDTEtaPatternLutRcd& iRecord) {
 
-   auto_ptr<L1MuDTEtaPatternLut> etalut = auto_ptr<L1MuDTEtaPatternLut>( new L1MuDTEtaPatternLut() );
+   unique_ptr<L1MuDTEtaPatternLut> etalut = unique_ptr<L1MuDTEtaPatternLut>( new L1MuDTEtaPatternLut() );
 
    if ( etalut->load() != 0 ) {
      cout << "Can not open files to load eta track finder look-up tables for DTTrackFinder!" << endl;
@@ -78,9 +78,9 @@ auto_ptr<L1MuDTEtaPatternLut> DTTrackFinderConfig::produceL1MuDTEtaPatternLut(co
    return etalut;
 }
 
-auto_ptr<L1MuDTQualPatternLut> DTTrackFinderConfig::produceL1MuDTQualPatternLut(const L1MuDTQualPatternLutRcd& iRecord) {
+unique_ptr<L1MuDTQualPatternLut> DTTrackFinderConfig::produceL1MuDTQualPatternLut(const L1MuDTQualPatternLutRcd& iRecord) {
 
-   auto_ptr<L1MuDTQualPatternLut> qualut = auto_ptr<L1MuDTQualPatternLut>( new L1MuDTQualPatternLut() );
+   unique_ptr<L1MuDTQualPatternLut> qualut = unique_ptr<L1MuDTQualPatternLut>( new L1MuDTQualPatternLut() );
 
    if ( qualut->load() != 0 ) {
      cout << "Can not open files to load eta matching look-up tables for DTTrackFinder!" << endl;
@@ -89,18 +89,18 @@ auto_ptr<L1MuDTQualPatternLut> DTTrackFinderConfig::produceL1MuDTQualPatternLut(
    return qualut;
 }
 
-auto_ptr<L1MuDTTFParameters> DTTrackFinderConfig::produceL1MuDTTFParameters(const L1MuDTTFParametersRcd& iRecord) {
+unique_ptr<L1MuDTTFParameters> DTTrackFinderConfig::produceL1MuDTTFParameters(const L1MuDTTFParametersRcd& iRecord) {
 
-   auto_ptr<L1MuDTTFParameters> dttfpar = auto_ptr<L1MuDTTFParameters>( new L1MuDTTFParameters() );
+   unique_ptr<L1MuDTTFParameters> dttfpar = unique_ptr<L1MuDTTFParameters>( new L1MuDTTFParameters() );
 
    dttfpar->reset();
 
    return dttfpar;
 }
 
-auto_ptr<L1MuDTTFMasks> DTTrackFinderConfig::produceL1MuDTTFMasks(const L1MuDTTFMasksRcd& iRecord) {
+unique_ptr<L1MuDTTFMasks> DTTrackFinderConfig::produceL1MuDTTFMasks(const L1MuDTTFMasksRcd& iRecord) {
 
-   auto_ptr<L1MuDTTFMasks> dttfmsk = auto_ptr<L1MuDTTFMasks>( new L1MuDTTFMasks() );
+   unique_ptr<L1MuDTTFMasks> dttfmsk = unique_ptr<L1MuDTTFMasks>( new L1MuDTTFMasks() );
 
    dttfmsk->reset();
 

--- a/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersProducer.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersProducer.h
@@ -36,8 +36,8 @@ public:
   L1MuGMTParametersProducer(const edm::ParameterSet&);
   ~L1MuGMTParametersProducer();
   
-  std::auto_ptr<L1MuGMTParameters> produceL1MuGMTParameters(const L1MuGMTParametersRcd&);
-  std::auto_ptr<L1MuGMTChannelMask> produceL1MuGMTChannelMask(const L1MuGMTChannelMaskRcd&);
+  std::unique_ptr<L1MuGMTParameters> produceL1MuGMTParameters(const L1MuGMTParametersRcd&);
+  std::unique_ptr<L1MuGMTChannelMask> produceL1MuGMTChannelMask(const L1MuGMTChannelMaskRcd&);
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersProducer.cc
@@ -31,12 +31,12 @@ L1MuGMTParametersProducer::~L1MuGMTParametersProducer() {
 //
 
 // ------------ methods called to produce the data  ------------
-std::auto_ptr<L1MuGMTParameters> 
+std::unique_ptr<L1MuGMTParameters> 
 L1MuGMTParametersProducer::produceL1MuGMTParameters(const L1MuGMTParametersRcd& iRecord)
 {
   using namespace edm::es;
 
-  std::auto_ptr<L1MuGMTParameters> gmtparams = std::auto_ptr<L1MuGMTParameters>( new L1MuGMTParameters() );
+  std::unique_ptr<L1MuGMTParameters> gmtparams = std::unique_ptr<L1MuGMTParameters>( new L1MuGMTParameters() );
 
   gmtparams->setEtaWeight_barrel(m_ps->getParameter<double>("EtaWeight_barrel"));
   gmtparams->setPhiWeight_barrel(m_ps->getParameter<double>("PhiWeight_barrel"));
@@ -84,12 +84,12 @@ L1MuGMTParametersProducer::produceL1MuGMTParameters(const L1MuGMTParametersRcd& 
   return gmtparams ;
 }
 
-std::auto_ptr<L1MuGMTChannelMask> 
+std::unique_ptr<L1MuGMTChannelMask> 
 L1MuGMTParametersProducer::produceL1MuGMTChannelMask(const L1MuGMTChannelMaskRcd& iRecord)
 {
   using namespace edm::es;
 
-  std::auto_ptr<L1MuGMTChannelMask> gmtchanmask = std::auto_ptr<L1MuGMTChannelMask>( new L1MuGMTChannelMask() );
+  std::unique_ptr<L1MuGMTChannelMask> gmtchanmask = std::unique_ptr<L1MuGMTChannelMask>( new L1MuGMTChannelMask() );
 
   gmtchanmask->setSubsystemMask(m_ps->getParameter<unsigned>("SubsystemMask"));
 

--- a/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.cc
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.cc
@@ -114,13 +114,13 @@ L1CSCTriggerPrimitivesConfigProducer::~L1CSCTriggerPrimitivesConfigProducer() {
 //------------------
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<CSCDBL1TPParameters>
+std::unique_ptr<CSCDBL1TPParameters>
 L1CSCTriggerPrimitivesConfigProducer::produce(const CSCDBL1TPParametersRcd& iRecord) {
   using namespace edm::es;
   //std::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> pL1CSCTPConfigProducer;
 
   // Create empty collection of CSCTPParameters.
-  std::auto_ptr<CSCDBL1TPParameters> pL1CSCTPParams(new CSCDBL1TPParameters);
+  auto pL1CSCTPParams = std::make_unique<CSCDBL1TPParameters>();
 
   // Set ALCT parameters.
   pL1CSCTPParams->setAlctFifoTbins(m_alct_fifo_tbins);

--- a/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.h
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.h
@@ -28,7 +28,7 @@ class L1CSCTriggerPrimitivesConfigProducer : public edm::ESProducer {
 
   //typedef std::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> ReturnType;
 
-  std::auto_ptr<CSCDBL1TPParameters> produce(const CSCDBL1TPParametersRcd&);
+  std::unique_ptr<CSCDBL1TPParameters> produce(const CSCDBL1TPParametersRcd&);
 
  private:
   /** ALCT configuration parameters. */

--- a/L1TriggerConfig/L1GeometryProducers/interface/L1CaloGeometryProd.h
+++ b/L1TriggerConfig/L1GeometryProducers/interface/L1CaloGeometryProd.h
@@ -35,7 +35,7 @@ class L1CaloGeometryProd : public edm::ESProducer {
       L1CaloGeometryProd(const edm::ParameterSet&);
       ~L1CaloGeometryProd();
 
-      typedef std::auto_ptr<L1CaloGeometry> ReturnType;
+      typedef std::unique_ptr<L1CaloGeometry> ReturnType;
 
       ReturnType produce(const L1CaloGeometryRecord&);
    private:

--- a/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryProd.cc
+++ b/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryProd.cc
@@ -77,9 +77,9 @@ L1CaloGeometryProd::ReturnType
 L1CaloGeometryProd::produce(const L1CaloGeometryRecord& iRecord)
 {
    using namespace edm::es;
-   std::auto_ptr<L1CaloGeometry> pL1CaloGeometry ;
+   std::unique_ptr<L1CaloGeometry> pL1CaloGeometry ;
 
-   pL1CaloGeometry = std::auto_ptr< L1CaloGeometry >(
+   pL1CaloGeometry = std::unique_ptr< L1CaloGeometry >(
       new L1CaloGeometry( m_geom ) ) ;
 
    return pL1CaloGeometry ;

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuGMTScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuGMTScalesProducer.h
@@ -35,7 +35,7 @@ public:
   L1MuGMTScalesProducer(const edm::ParameterSet&);
   ~L1MuGMTScalesProducer();
   
-  std::auto_ptr<L1MuGMTScales> produceL1MuGMTScales(const L1MuGMTScalesRcd&);
+  std::unique_ptr<L1MuGMTScales> produceL1MuGMTScales(const L1MuGMTScalesRcd&);
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleProducer.h
@@ -35,7 +35,7 @@ public:
   L1MuTriggerPtScaleProducer(const edm::ParameterSet&);
   ~L1MuTriggerPtScaleProducer();
   
-  std::auto_ptr<L1MuTriggerPtScale> produceL1MuTriggerPtScale(const L1MuTriggerPtScaleRcd&);
+  std::unique_ptr<L1MuTriggerPtScale> produceL1MuTriggerPtScale(const L1MuTriggerPtScaleRcd&);
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesProducer.h
@@ -35,7 +35,7 @@ public:
   L1MuTriggerScalesProducer(const edm::ParameterSet&);
   ~L1MuTriggerScalesProducer();
   
-  std::auto_ptr<L1MuTriggerScales> produceL1MuTriggerScales(const L1MuTriggerScalesRcd&);
+  std::unique_ptr<L1MuTriggerScales> produceL1MuTriggerScales(const L1MuTriggerScalesRcd&);
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTrivialProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTrivialProducer.h
@@ -46,10 +46,10 @@ public:
   L1ScalesTrivialProducer(const edm::ParameterSet&);
   ~L1ScalesTrivialProducer();
   
-  std::auto_ptr<L1CaloEtScale> produceEmScale(const L1EmEtScaleRcd&);
-  std::auto_ptr<L1CaloEtScale> produceJetScale(const L1JetEtScaleRcd&);
-  std::auto_ptr<L1CaloEtScale> produceHtMissScale(const L1HtMissScaleRcd&);
-  std::auto_ptr<L1CaloEtScale> produceHfRingScale(const L1HfRingEtScaleRcd&);
+  std::unique_ptr<L1CaloEtScale> produceEmScale(const L1EmEtScaleRcd&);
+  std::unique_ptr<L1CaloEtScale> produceJetScale(const L1JetEtScaleRcd&);
+  std::unique_ptr<L1CaloEtScale> produceHtMissScale(const L1HtMissScaleRcd&);
+  std::unique_ptr<L1CaloEtScale> produceHfRingScale(const L1HfRingEtScaleRcd&);
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuGMTScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuGMTScalesProducer.cc
@@ -63,12 +63,12 @@ L1MuGMTScalesProducer::~L1MuGMTScalesProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<L1MuGMTScales> 
+std::unique_ptr<L1MuGMTScales> 
 L1MuGMTScalesProducer::produceL1MuGMTScales(const L1MuGMTScalesRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1MuGMTScales> l1muscale = std::auto_ptr<L1MuGMTScales>( new L1MuGMTScales( m_scales ) );
+   std::unique_ptr<L1MuGMTScales> l1muscale = std::unique_ptr<L1MuGMTScales>( new L1MuGMTScales( m_scales ) );
 
    return l1muscale ;
 }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleProducer.cc
@@ -28,13 +28,13 @@ L1MuTriggerPtScaleProducer::~L1MuTriggerPtScaleProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<L1MuTriggerPtScale> 
+std::unique_ptr<L1MuTriggerPtScale> 
 L1MuTriggerPtScaleProducer::produceL1MuTriggerPtScale(const L1MuTriggerPtScaleRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1MuTriggerPtScale> l1muscale =
-     std::auto_ptr<L1MuTriggerPtScale>( new L1MuTriggerPtScale( m_scales ) );
+   std::unique_ptr<L1MuTriggerPtScale> l1muscale =
+     std::unique_ptr<L1MuTriggerPtScale>( new L1MuTriggerPtScale( m_scales ) );
 
    return l1muscale ;
 }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesOnlineProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesOnlineProducer.cc
@@ -173,7 +173,7 @@ std::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(co
    vector<double> etaScales;
    etaHelper.extractScales(etaRecord, etaScales);
    
-   auto_ptr<L1MuSymmetricBinnedScale> ptrEtaScale(new L1MuSymmetricBinnedScale(m_nbitPackingEta, m_nbinsEta, etaScales));
+   unique_ptr<L1MuSymmetricBinnedScale> ptrEtaScale(new L1MuSymmetricBinnedScale(m_nbitPackingEta, m_nbinsEta, etaScales));
    m_scales.setGMTEtaScale(*ptrEtaScale);
 
    columns.clear();   
@@ -194,7 +194,7 @@ std::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(co
 	  // WHERE rhs
 	  m_omdsReader.singleAttribute( phiKeyValue  ) );
 
-   auto_ptr<L1MuBinnedScale> ptrPhiScale(phiHelper.makeBinnedScale(phiRecord, m_nbitPackingPhi, m_signedPackingPhi));
+   unique_ptr<L1MuBinnedScale> ptrPhiScale(phiHelper.makeBinnedScale(phiRecord, m_nbitPackingPhi, m_signedPackingPhi));
 
    m_scales.setPhiScale(*ptrPhiScale);
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesProducer.cc
@@ -55,13 +55,13 @@ L1MuTriggerScalesProducer::~L1MuTriggerScalesProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<L1MuTriggerScales> 
+std::unique_ptr<L1MuTriggerScales> 
 L1MuTriggerScalesProducer::produceL1MuTriggerScales(const L1MuTriggerScalesRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1MuTriggerScales> l1muscale =
-     std::auto_ptr<L1MuTriggerScales>( new L1MuTriggerScales( m_scales ) );
+   std::unique_ptr<L1MuTriggerScales> l1muscale =
+     std::unique_ptr<L1MuTriggerScales>( new L1MuTriggerScales( m_scales ) );
 
    return l1muscale ;
 }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTrivialProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTrivialProducer.cc
@@ -51,40 +51,40 @@ L1ScalesTrivialProducer::~L1ScalesTrivialProducer()
 //
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceEmScale(const L1EmEtScaleRcd& iRecord)
+std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceEmScale(const L1EmEtScaleRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1CaloEtScale> emScale = std::auto_ptr<L1CaloEtScale>( new L1CaloEtScale(m_emEtScaleInputLsb, m_emEtThresholds) );
+   std::unique_ptr<L1CaloEtScale> emScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(m_emEtScaleInputLsb, m_emEtThresholds) );
 
    return emScale ;
 }
 
-std::auto_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceJetScale(const L1JetEtScaleRcd& iRecord)
+std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceJetScale(const L1JetEtScaleRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1CaloEtScale> jetEtScale = std::auto_ptr<L1CaloEtScale>( new L1CaloEtScale(m_jetEtScaleInputLsb, m_jetEtThresholds) );
+   std::unique_ptr<L1CaloEtScale> jetEtScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(m_jetEtScaleInputLsb, m_jetEtThresholds) );
 
    return jetEtScale ;
 }
 
 
-std::auto_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHtMissScale(const L1HtMissScaleRcd& iRecord)
+std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHtMissScale(const L1HtMissScaleRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1CaloEtScale> htMissScale = std::auto_ptr<L1CaloEtScale>( new L1CaloEtScale(0, 0x7f, m_jetEtScaleInputLsb, m_htMissThresholds) );
+   std::unique_ptr<L1CaloEtScale> htMissScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(0, 0x7f, m_jetEtScaleInputLsb, m_htMissThresholds) );
 
    return htMissScale ;
 }
 
 
-std::auto_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHfRingScale(const L1HfRingEtScaleRcd& iRecord)
+std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHfRingScale(const L1HfRingEtScaleRcd& iRecord)
 {
    using namespace edm::es;
 
-   std::auto_ptr<L1CaloEtScale> hfRingEtScale = std::auto_ptr<L1CaloEtScale>( new L1CaloEtScale(0xff, 0x7, m_jetEtScaleInputLsb, m_hfRingThresholds) );
+   std::unique_ptr<L1CaloEtScale> hfRingEtScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(0xff, 0x7, m_jetEtScaleInputLsb, m_hfRingThresholds) );
 
    return hfRingEtScale ;
 }

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
@@ -40,7 +40,7 @@ class RPCTriggerBxOrConfig : public edm::ESProducer {
       RPCTriggerBxOrConfig(const edm::ParameterSet&);
       ~RPCTriggerBxOrConfig();
 
-      typedef std::auto_ptr<L1RPCBxOrConfig> ReturnType;
+      typedef std::unique_ptr<L1RPCBxOrConfig> ReturnType;
 
       ReturnType produce(const L1RPCBxOrConfigRcd&);
    private:
@@ -89,7 +89,7 @@ RPCTriggerBxOrConfig::ReturnType
 RPCTriggerBxOrConfig::produce(const L1RPCBxOrConfigRcd& iRecord)
 {
    using namespace edm::es;
-   std::auto_ptr<L1RPCBxOrConfig> pRPCTriggerBxOrConfig = std::auto_ptr<L1RPCBxOrConfig>( new L1RPCBxOrConfig() );
+   auto pRPCTriggerBxOrConfig = std::make_unique<L1RPCBxOrConfig>();
 
    if (m_firstBX > m_lastBX )
         throw cms::Exception("BadConfig") << " firstBX < m_lastBX  " << "\n";

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
@@ -44,7 +44,7 @@ class RPCTriggerConfig : public edm::ESProducer {
       RPCTriggerConfig(const edm::ParameterSet&);
       ~RPCTriggerConfig();
 
-      typedef std::auto_ptr<L1RPCConfig> ReturnType;
+      typedef std::unique_ptr<L1RPCConfig> ReturnType;
 
       ReturnType produce(const L1RPCConfigRcd&);
    private:
@@ -105,7 +105,7 @@ RPCTriggerConfig::ReturnType
 RPCTriggerConfig::produce(const L1RPCConfigRcd& iRecord)
 {
    using namespace edm::es;
-   std::auto_ptr<L1RPCConfig> pL1RPCConfig = std::auto_ptr<L1RPCConfig>( new L1RPCConfig() );
+   auto pL1RPCConfig = std::make_unique<L1RPCConfig>();
 
    pL1RPCConfig->setPPT(m_ppt);
    

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
@@ -40,7 +40,7 @@ class RPCTriggerHsbConfig : public edm::ESProducer {
       RPCTriggerHsbConfig(const edm::ParameterSet&);
       ~RPCTriggerHsbConfig();
 
-      typedef std::auto_ptr<L1RPCHsbConfig> ReturnType;
+      typedef std::unique_ptr<L1RPCHsbConfig> ReturnType;
 
       ReturnType produce(const L1RPCHsbConfigRcd&);
    private:
@@ -96,7 +96,7 @@ RPCTriggerHsbConfig::produce(const L1RPCHsbConfigRcd& iRecord)
 {
 
    using namespace edm::es;
-   std::auto_ptr<L1RPCHsbConfig> pRPCTriggerHsbConfig = std::auto_ptr<L1RPCHsbConfig>( new L1RPCHsbConfig() );
+   auto pRPCTriggerHsbConfig = std::make_unique<L1RPCHsbConfig>();
 
    pRPCTriggerHsbConfig->setHsbMask(0, m_hsb0);
    pRPCTriggerHsbConfig->setHsbMask(1, m_hsb1);

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
@@ -40,7 +40,7 @@ class RPCTriggerHwConfig : public edm::ESProducer {
       RPCTriggerHwConfig(const edm::ParameterSet&);
       ~RPCTriggerHwConfig();
 
-      typedef std::auto_ptr<L1RPCHwConfig> ReturnType;
+      typedef std::unique_ptr<L1RPCHwConfig> ReturnType;
 
       ReturnType produce(const L1RPCHwConfigRcd&);
    private:
@@ -115,7 +115,7 @@ RPCTriggerHwConfig::ReturnType
 RPCTriggerHwConfig::produce(const L1RPCHwConfigRcd& iRecord)
 {
    using namespace edm::es;
-   std::auto_ptr<L1RPCHwConfig> pL1RPCHwConfig = std::auto_ptr<L1RPCHwConfig>( new L1RPCHwConfig() );
+   auto pL1RPCHwConfig = std::make_unique<L1RPCHwConfig>();
 
    if (m_disableAll) {
      pL1RPCHwConfig->enableAll(false);

--- a/MagneticField/GeomBuilder/plugins/AutoMagneticFieldESProducer.cc
+++ b/MagneticField/GeomBuilder/plugins/AutoMagneticFieldESProducer.cc
@@ -43,7 +43,7 @@ AutoMagneticFieldESProducer::~AutoMagneticFieldESProducer()
 }
 
 
-std::auto_ptr<MagneticField>
+std::unique_ptr<MagneticField>
 AutoMagneticFieldESProducer::produce(const IdealMagneticFieldRecord& iRecord)
 {
   float current = pset.getParameter<int>("valueOverride");
@@ -70,9 +70,7 @@ AutoMagneticFieldESProducer::produce(const IdealMagneticFieldRecord& iRecord)
 
   MagneticField* result = map.product()->clone();
 
-  std::auto_ptr<MagneticField> s(result);
-  
-  return s;
+  return std::unique_ptr<MagneticField>(result);
 }
 
 

--- a/MagneticField/GeomBuilder/plugins/AutoMagneticFieldESProducer.h
+++ b/MagneticField/GeomBuilder/plugins/AutoMagneticFieldESProducer.h
@@ -25,7 +25,7 @@ namespace magneticfield {
     AutoMagneticFieldESProducer(const edm::ParameterSet&);
     ~AutoMagneticFieldESProducer();
     
-    std::auto_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
+    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
     edm::ParameterSet pset;
   private:
     std::string closerModel(float current);

--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.cc
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.cc
@@ -33,7 +33,7 @@ VolumeBasedMagneticFieldESProducer::VolumeBasedMagneticFieldESProducer(const edm
 }
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<MagneticField> VolumeBasedMagneticFieldESProducer::produce(const IdealMagneticFieldRecord & iRecord)
+std::unique_ptr<MagneticField> VolumeBasedMagneticFieldESProducer::produce(const IdealMagneticFieldRecord & iRecord)
 {
   bool debug = pset.getUntrackedParameter<bool>("debugBuilder", false);
   if (debug) {
@@ -65,9 +65,7 @@ std::auto_ptr<MagneticField> VolumeBasedMagneticFieldESProducer::produce(const I
   if (pset.getParameter<bool>("useParametrizedTrackerField")) {;
     iRecord.get(pset.getParameter<string>("paramLabel"),paramField);
   }
-  std::auto_ptr<MagneticField> s(new VolumeBasedMagneticField(conf.geometryVersion,builder.barrelLayers(), builder.endcapSectors(), builder.barrelVolumes(), builder.endcapVolumes(), builder.maxR(), builder.maxZ(), paramField.product(), false));
-  
-  return s;
+  return std::make_unique<VolumeBasedMagneticField>(conf.geometryVersion,builder.barrelLayers(), builder.endcapSectors(), builder.barrelVolumes(), builder.endcapVolumes(), builder.maxR(), builder.maxZ(), paramField.product(), false);
 }
 
 

--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.h
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.h
@@ -22,7 +22,7 @@ namespace magneticfield {
   public:
     VolumeBasedMagneticFieldESProducer(const edm::ParameterSet& iConfig);
   
-    std::auto_ptr<MagneticField> produce(const IdealMagneticFieldRecord & iRecord);
+    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord & iRecord);
 
   private:
     // forbid copy ctor and assignment op.

--- a/MagneticField/ParametrizedEngine/plugins/AutoParametrizedMagneticFieldProducer.cc
+++ b/MagneticField/ParametrizedEngine/plugins/AutoParametrizedMagneticFieldProducer.cc
@@ -32,7 +32,7 @@ namespace magneticfield{
     AutoParametrizedMagneticFieldProducer(const edm::ParameterSet&);
     ~AutoParametrizedMagneticFieldProducer(){}
     
-    std::auto_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
+    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
 
     int closerNominaCurrent(float current);
     edm::ParameterSet pset;
@@ -49,7 +49,7 @@ AutoParametrizedMagneticFieldProducer::AutoParametrizedMagneticFieldProducer(con
   //  nominalLabels  ={"3.8T","0T","2T", "3T", "3.5T", "3.8T", "4T"};
 }
 
-std::auto_ptr<MagneticField>
+std::unique_ptr<MagneticField>
 AutoParametrizedMagneticFieldProducer::produce(const IdealMagneticFieldRecord& iRecord)
 {
   string version = pset.getParameter<string>("version");

--- a/MagneticField/ParametrizedEngine/plugins/ParametrizedMagneticFieldProducer.cc
+++ b/MagneticField/ParametrizedEngine/plugins/ParametrizedMagneticFieldProducer.cc
@@ -28,7 +28,7 @@ ParametrizedMagneticFieldProducer::ParametrizedMagneticFieldProducer(const edm::
 ParametrizedMagneticFieldProducer::~ParametrizedMagneticFieldProducer(){}
 
 
-std::auto_ptr<MagneticField>
+std::unique_ptr<MagneticField>
 ParametrizedMagneticFieldProducer::produce(const IdealMagneticFieldRecord& iRecord)
 {
   string version = pset.getParameter<string>("version");

--- a/MagneticField/ParametrizedEngine/plugins/ParametrizedMagneticFieldProducer.h
+++ b/MagneticField/ParametrizedEngine/plugins/ParametrizedMagneticFieldProducer.h
@@ -22,7 +22,7 @@ namespace magneticfield {
     ParametrizedMagneticFieldProducer(const edm::ParameterSet&);
     ~ParametrizedMagneticFieldProducer();
     
-    std::auto_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
+    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
     edm::ParameterSet pset;
   };
 }

--- a/MagneticField/UniformEngine/plugins/UniformMagneticFieldESProducer.cc
+++ b/MagneticField/UniformEngine/plugins/UniformMagneticFieldESProducer.cc
@@ -17,10 +17,9 @@ UniformMagneticFieldESProducer::UniformMagneticFieldESProducer(const edm::Parame
 }
 
 
-std::auto_ptr<MagneticField> UniformMagneticFieldESProducer::produce(const IdealMagneticFieldRecord & iRecord)
+std::unique_ptr<MagneticField> UniformMagneticFieldESProducer::produce(const IdealMagneticFieldRecord & iRecord)
 {
-  std::auto_ptr<MagneticField> s(new UniformMagneticField(value));
-  return s;
+  return std::make_unique<UniformMagneticField>(value);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(UniformMagneticFieldESProducer);

--- a/MagneticField/UniformEngine/plugins/UniformMagneticFieldESProducer.h
+++ b/MagneticField/UniformEngine/plugins/UniformMagneticFieldESProducer.h
@@ -21,7 +21,7 @@ namespace magneticfield {
   public:
     UniformMagneticFieldESProducer(const edm::ParameterSet& pset);
   
-    std::auto_ptr<MagneticField> produce(const IdealMagneticFieldRecord &);
+    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord &);
 
   private:
     // forbid copy ctor and assignment op.

--- a/PhysicsTools/CondLiteIO/test/IntProductESSource.cc
+++ b/PhysicsTools/CondLiteIO/test/IntProductESSource.cc
@@ -30,7 +30,7 @@ class IntProductESSource :
 public:
    IntProductESSource(const edm::ParameterSet&);
    
-   std::auto_ptr<edmtest::IntProduct> produce(const IntProductRecord&) ;
+   std::unique_ptr<edmtest::IntProduct> produce(const IntProductRecord&) ;
    
 protected:
    
@@ -72,12 +72,12 @@ IntProductESSource::IntProductESSource(const edm::ParameterSet&)
 // member functions
 //
 
-std::auto_ptr<edmtest::IntProduct> 
+std::unique_ptr<edmtest::IntProduct> 
 IntProductESSource::produce(const IntProductRecord&) {
-   std::auto_ptr<edmtest::IntProduct> data(new edmtest::IntProduct());
+   auto data = std::make_unique<edmtest::IntProduct>();
    data->value = nCalls_;
    ++nCalls_;
-   return data;
+   return std::move(data);
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/StringResolutionProviderESProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/StringResolutionProviderESProducer.cc
@@ -10,7 +10,7 @@ class StringResolutionProviderESProducer : public edm::ESProducer
                 StringResolutionProviderESProducer() { }
                 StringResolutionProviderESProducer(const edm::ParameterSet &iConfig) ;
 
-                std::auto_ptr<KinematicResolutionProvider>  produce(const KinematicResolutionRcd &rcd) ;
+                std::unique_ptr<KinematicResolutionProvider>  produce(const KinematicResolutionRcd &rcd) ;
 
         private:
                 edm::ParameterSet cfg_;
@@ -22,9 +22,9 @@ StringResolutionProviderESProducer::StringResolutionProviderESProducer(const edm
    setWhatProduced(this,myName);
 }
 
-std::auto_ptr<KinematicResolutionProvider> 
+std::unique_ptr<KinematicResolutionProvider> 
 StringResolutionProviderESProducer::produce(const KinematicResolutionRcd &rcd) {
-        return std::auto_ptr<KinematicResolutionProvider>(new StringResolutionProvider(cfg_));
+        return std::make_unique<StringResolutionProvider>(cfg_);
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.cc
@@ -29,7 +29,7 @@ EcalBasicClusterLocalContCorrectionsESProducer::produce(const EcalClusterLocalCo
    using namespace edm::es;
    using namespace std;
 
-   auto_ptr<EcalClusterLocalContCorrParameters> pEcalClusterLocalContCorrParameters(new EcalClusterLocalContCorrParameters) ;
+   auto pEcalClusterLocalContCorrParameters = std::make_unique<EcalClusterLocalContCorrParameters>();
 
    double values[] = {  1.00603 , 0.00300789 , 0.0667232 , // local eta, mod1
 			1.00655 , 0.00386189 , 0.073931  , // local eta, mod2

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.h
@@ -23,7 +23,7 @@ class EcalBasicClusterLocalContCorrectionsESProducer : public edm::ESProducer {
       EcalBasicClusterLocalContCorrectionsESProducer(const edm::ParameterSet&);
      ~EcalBasicClusterLocalContCorrectionsESProducer();
 
-  typedef std::auto_ptr<EcalClusterLocalContCorrParameters> ReturnType;
+  typedef std::unique_ptr<EcalClusterLocalContCorrParameters> ReturnType;
   
   ReturnType produce(const EcalClusterLocalContCorrParametersRcd&);
 

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h
@@ -42,7 +42,7 @@ class ElectronLikelihoodESSource : public edm::ESProducer, public  edm::EventSet
   /// destructor
   ~ElectronLikelihoodESSource();
   /// define the return type
-  typedef std::auto_ptr<ElectronLikelihood> ReturnType;
+  typedef std::unique_ptr<ElectronLikelihood> ReturnType;
   /// return the particle table
   ReturnType produce( const ElectronLikelihoodRcd &);
   /// set validity interval

--- a/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
@@ -41,7 +41,7 @@ protected:
                                edm::ValidityInterval& ) ;
   
    private:
-  virtual std::auto_ptr<CentralityTable> produceTable( const HeavyIonRcd& );
+  virtual std::unique_ptr<CentralityTable> produceTable( const HeavyIonRcd& );
   void printBin(const CentralityTable::CBin*);
 
   // ----------member data ---------------------------
@@ -71,10 +71,10 @@ HiTrivialConditionRetriever::HiTrivialConditionRetriever(const edm::ParameterSet
   inputFileName_ = iConfig.getParameter<string>("inputFile");
 }
 
-std::auto_ptr<CentralityTable> 
+std::unique_ptr<CentralityTable>
 HiTrivialConditionRetriever::produceTable( const HeavyIonRcd& ){
 
-  std::auto_ptr<CentralityTable> CT(new CentralityTable()) ;
+  auto CT = std::make_unique<CentralityTable>();
 
   // Get values from text file
   ifstream in( edm::FileInPath(inputFileName_).fullPath().c_str() );
@@ -98,7 +98,7 @@ HiTrivialConditionRetriever::produceTable( const HeavyIonRcd& ){
     i++;
   }
 
-  return CT; 
+  return std::move(CT);
 }
 
 void HiTrivialConditionRetriever::printBin(const CentralityTable::CBin* thisBin){

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
@@ -43,7 +43,7 @@ class ClusterShapeHitFilterESProducer : public edm::ESProducer
   ClusterShapeHitFilterESProducer(const edm::ParameterSet&);
   ~ClusterShapeHitFilterESProducer();
 
-  typedef std::auto_ptr<ClusterShapeHitFilter> ReturnType;
+  typedef std::unique_ptr<ClusterShapeHitFilter> ReturnType;
   ReturnType produce(const ClusterShapeHitFilter::Record &);
 
  private:

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
@@ -97,9 +97,9 @@ EcalTrigPrimESProducer::~EcalTrigPrimESProducer()
 // ------------ method called to produce the data  ------------
 
 
-std::auto_ptr<EcalTPGPedestals> EcalTrigPrimESProducer::producePedestals(const EcalTPGPedestalsRcd & iRecord)
+std::unique_ptr<EcalTPGPedestals> EcalTrigPrimESProducer::producePedestals(const EcalTPGPedestalsRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGPedestals> prod(new EcalTPGPedestals());
+  auto prod = std::make_unique<EcalTPGPedestals>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
   for (it = mapXtal_.begin() ; it != mapXtal_.end() ; it++) {
@@ -109,12 +109,12 @@ std::auto_ptr<EcalTPGPedestals> EcalTrigPrimESProducer::producePedestals(const E
     item.mean_x1  = (it->second)[6] ;
     prod->setValue(it->first,item) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGLinearizationConst> EcalTrigPrimESProducer::produceLinearizationConst(const EcalTPGLinearizationConstRcd & iRecord)
+std::unique_ptr<EcalTPGLinearizationConst> EcalTrigPrimESProducer::produceLinearizationConst(const EcalTPGLinearizationConstRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGLinearizationConst> prod(new EcalTPGLinearizationConst());
+  auto prod = std::make_unique<EcalTPGLinearizationConst>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
   for (it = mapXtal_.begin() ; it != mapXtal_.end() ; it++) {
@@ -127,12 +127,12 @@ std::auto_ptr<EcalTPGLinearizationConst> EcalTrigPrimESProducer::produceLineariz
     item.shift_x1  = (it->second)[8] ;
     prod->setValue(it->first,item) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGSlidingWindow> EcalTrigPrimESProducer::produceSlidingWindow(const EcalTPGSlidingWindowRcd & iRecord)
+std::unique_ptr<EcalTPGSlidingWindow> EcalTrigPrimESProducer::produceSlidingWindow(const EcalTPGSlidingWindowRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGSlidingWindow> prod(new EcalTPGSlidingWindow());
+  auto prod = std::make_unique<EcalTPGSlidingWindow>();
   parseTextFile() ;
   for (int subdet=0 ; subdet<2 ; subdet++) {
     std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -140,12 +140,12 @@ std::auto_ptr<EcalTPGSlidingWindow> EcalTrigPrimESProducer::produceSlidingWindow
       prod->setValue(it->first,(it->second)[0]) ;
     }
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGFineGrainEBIdMap> EcalTrigPrimESProducer::produceFineGrainEB(const EcalTPGFineGrainEBIdMapRcd & iRecord)
+std::unique_ptr<EcalTPGFineGrainEBIdMap> EcalTrigPrimESProducer::produceFineGrainEB(const EcalTPGFineGrainEBIdMapRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGFineGrainEBIdMap> prod(new EcalTPGFineGrainEBIdMap());
+  auto prod = std::make_unique<EcalTPGFineGrainEBIdMap>();
   parseTextFile() ;
   EcalTPGFineGrainConstEB fg ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -153,12 +153,12 @@ std::auto_ptr<EcalTPGFineGrainEBIdMap> EcalTrigPrimESProducer::produceFineGrainE
     fg.setValues((it->second)[0], (it->second)[1], (it->second)[2], (it->second)[3], (it->second)[4]) ;
     prod->setValue(it->first,fg) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGFineGrainStripEE> EcalTrigPrimESProducer::produceFineGrainEEstrip(const EcalTPGFineGrainStripEERcd & iRecord)
+std::unique_ptr<EcalTPGFineGrainStripEE> EcalTrigPrimESProducer::produceFineGrainEEstrip(const EcalTPGFineGrainStripEERcd & iRecord)
 {
-  std::auto_ptr<EcalTPGFineGrainStripEE> prod(new EcalTPGFineGrainStripEE());
+  auto prod = std::make_unique<EcalTPGFineGrainStripEE>();
   parseTextFile() ;
   // EE Strips
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -175,23 +175,23 @@ std::auto_ptr<EcalTPGFineGrainStripEE> EcalTrigPrimESProducer::produceFineGrainE
     item.lut  = (it->second)[3] ;
     prod->setValue(it->first,item) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGFineGrainTowerEE> EcalTrigPrimESProducer::produceFineGrainEEtower(const EcalTPGFineGrainTowerEERcd & iRecord)
+std::unique_ptr<EcalTPGFineGrainTowerEE> EcalTrigPrimESProducer::produceFineGrainEEtower(const EcalTPGFineGrainTowerEERcd & iRecord)
 {
-  std::auto_ptr<EcalTPGFineGrainTowerEE> prod(new EcalTPGFineGrainTowerEE());
+  auto prod = std::make_unique<EcalTPGFineGrainTowerEE>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
   for (it = mapTower_[1].begin() ; it != mapTower_[1].end() ; it++) {
     prod->setValue(it->first,(it->second)[1]) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGLutIdMap> EcalTrigPrimESProducer::produceLUT(const EcalTPGLutIdMapRcd & iRecord)
+std::unique_ptr<EcalTPGLutIdMap> EcalTrigPrimESProducer::produceLUT(const EcalTPGLutIdMapRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGLutIdMap> prod(new EcalTPGLutIdMap());
+  auto prod = std::make_unique<EcalTPGLutIdMap>();
   parseTextFile() ;
   EcalTPGLut lut ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -201,12 +201,12 @@ std::auto_ptr<EcalTPGLutIdMap> EcalTrigPrimESProducer::produceLUT(const EcalTPGL
     lut.setLut(lutArray) ;
     prod->setValue(it->first,lut) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGWeightIdMap> EcalTrigPrimESProducer::produceWeight(const EcalTPGWeightIdMapRcd & iRecord)
+std::unique_ptr<EcalTPGWeightIdMap> EcalTrigPrimESProducer::produceWeight(const EcalTPGWeightIdMapRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGWeightIdMap> prod(new EcalTPGWeightIdMap());
+  auto prod = std::make_unique<EcalTPGWeightIdMap>();
   parseTextFile() ;
   EcalTPGWeights weights ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -218,12 +218,12 @@ std::auto_ptr<EcalTPGWeightIdMap> EcalTrigPrimESProducer::produceWeight(const Ec
 		      (it->second)[4]) ;
     prod->setValue(it->first,weights) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGWeightGroup> EcalTrigPrimESProducer::produceWeightGroup(const EcalTPGWeightGroupRcd & iRecord)
+std::unique_ptr<EcalTPGWeightGroup> EcalTrigPrimESProducer::produceWeightGroup(const EcalTPGWeightGroupRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGWeightGroup> prod(new EcalTPGWeightGroup());
+  auto prod = std::make_unique<EcalTPGWeightGroup>();
   parseTextFile() ;
   for (int subdet=0 ; subdet<2 ; subdet++) {
     std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -231,12 +231,12 @@ std::auto_ptr<EcalTPGWeightGroup> EcalTrigPrimESProducer::produceWeightGroup(con
       prod->setValue(it->first,(it->second)[1]) ;
     }
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGLutGroup> EcalTrigPrimESProducer::produceLutGroup(const EcalTPGLutGroupRcd & iRecord)
+std::unique_ptr<EcalTPGLutGroup> EcalTrigPrimESProducer::produceLutGroup(const EcalTPGLutGroupRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGLutGroup> prod(new EcalTPGLutGroup());
+  auto prod = std::make_unique<EcalTPGLutGroup>();
   parseTextFile() ;
   for (int subdet=0 ; subdet<2 ; subdet++) {
     std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
@@ -244,23 +244,23 @@ std::auto_ptr<EcalTPGLutGroup> EcalTrigPrimESProducer::produceLutGroup(const Eca
       prod->setValue(it->first,(it->second)[0]) ;
     }
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGFineGrainEBGroup> EcalTrigPrimESProducer::produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd & iRecord)
+std::unique_ptr<EcalTPGFineGrainEBGroup> EcalTrigPrimESProducer::produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGFineGrainEBGroup> prod(new EcalTPGFineGrainEBGroup());
+  auto prod = std::make_unique<EcalTPGFineGrainEBGroup>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
   for (it = mapTower_[0].begin() ; it != mapTower_[0].end() ; it++) {
     prod->setValue(it->first,(it->second)[1]) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGPhysicsConst> EcalTrigPrimESProducer::producePhysicsConst(const EcalTPGPhysicsConstRcd & iRecord)
+std::unique_ptr<EcalTPGPhysicsConst> EcalTrigPrimESProducer::producePhysicsConst(const EcalTPGPhysicsConstRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGPhysicsConst> prod(new EcalTPGPhysicsConst());
+  auto prod = std::make_unique<EcalTPGPhysicsConst>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<float> >::const_iterator it ;
   for (it = mapPhys_.begin() ; it != mapPhys_.end() ; it++) {
@@ -274,12 +274,12 @@ std::auto_ptr<EcalTPGPhysicsConst> EcalTrigPrimESProducer::producePhysicsConst(c
     item.FG_highRatio = (it->second)[6] ;
     prod->setValue(it->first,item) ;
   }
-  return prod;
+  return std::move(prod);
 }
 
-std::auto_ptr<EcalTPGCrystalStatus> EcalTrigPrimESProducer::produceBadX(const EcalTPGCrystalStatusRcd & iRecord)
+std::unique_ptr<EcalTPGCrystalStatus> EcalTrigPrimESProducer::produceBadX(const EcalTPGCrystalStatusRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGCrystalStatus> prod(new EcalTPGCrystalStatus());
+  auto prod = std::make_unique<EcalTPGCrystalStatus>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
   for (it = mapXtal_.begin() ; it != mapXtal_.end() ; it++) {
@@ -288,21 +288,21 @@ std::auto_ptr<EcalTPGCrystalStatus> EcalTrigPrimESProducer::produceBadX(const Ec
     badXValue.setStatusCode(0);
     prod->setValue(it->first,badXValue) ;
   }
-  return prod;
+  return std::move(prod);
   
 }
 
-std::auto_ptr<EcalTPGStripStatus> EcalTrigPrimESProducer::produceBadStrip(const EcalTPGStripStatusRcd & iRecord)
+std::unique_ptr<EcalTPGStripStatus> EcalTrigPrimESProducer::produceBadStrip(const EcalTPGStripStatusRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGStripStatus> prod(new EcalTPGStripStatus());
+  auto prod = std::make_unique<EcalTPGStripStatus>();
   // returns an empty map     
-  return prod;
+  return std::move(prod);
   
 }
 
-std::auto_ptr<EcalTPGTowerStatus> EcalTrigPrimESProducer::produceBadTT(const EcalTPGTowerStatusRcd & iRecord)
+std::unique_ptr<EcalTPGTowerStatus> EcalTrigPrimESProducer::produceBadTT(const EcalTPGTowerStatusRcd & iRecord)
 {
-  std::auto_ptr<EcalTPGTowerStatus> prod(new EcalTPGTowerStatus());
+  auto prod = std::make_unique<EcalTPGTowerStatus>();
   parseTextFile() ;
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it ;
   //Barrel
@@ -316,12 +316,12 @@ std::auto_ptr<EcalTPGTowerStatus> EcalTrigPrimESProducer::produceBadTT(const Eca
     prod->setValue(it->first,0) ;
   }
   
-  return prod; 
+  return std::move(prod); 
 }
 
-std::auto_ptr<EcalTPGSpike> EcalTrigPrimESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord)
+std::unique_ptr<EcalTPGSpike> EcalTrigPrimESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord)
 {
-  std::auto_ptr<EcalTPGSpike> prod(new EcalTPGSpike());
+  auto prod = std::make_unique<EcalTPGSpike>();
   parseTextFile();
   // Only need to do barrel
   std::map<uint32_t, std::vector<uint32_t> >::const_iterator it;
@@ -329,7 +329,7 @@ std::auto_ptr<EcalTPGSpike> EcalTrigPrimESProducer::produceSpike(const EcalTPGSp
   {
     prod->setValue(it->first, (it->second)[2]);
   }
-  return prod;
+  return std::move(prod);
 }
 
 void EcalTrigPrimESProducer::parseTextFile()

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.h
@@ -52,22 +52,22 @@ class EcalTrigPrimESProducer : public edm::ESProducer {
   EcalTrigPrimESProducer(const edm::ParameterSet&);
   ~EcalTrigPrimESProducer();
 
-  std::auto_ptr<EcalTPGPedestals> producePedestals(const EcalTPGPedestalsRcd &) ;
-  std::auto_ptr<EcalTPGLinearizationConst> produceLinearizationConst(const EcalTPGLinearizationConstRcd &) ;
-  std::auto_ptr<EcalTPGSlidingWindow> produceSlidingWindow(const EcalTPGSlidingWindowRcd &) ;
-  std::auto_ptr<EcalTPGFineGrainEBIdMap> produceFineGrainEB(const EcalTPGFineGrainEBIdMapRcd &) ;
-  std::auto_ptr<EcalTPGFineGrainStripEE> produceFineGrainEEstrip(const EcalTPGFineGrainStripEERcd &) ;
-  std::auto_ptr<EcalTPGFineGrainTowerEE> produceFineGrainEEtower(const EcalTPGFineGrainTowerEERcd &) ;
-  std::auto_ptr<EcalTPGLutIdMap> produceLUT(const EcalTPGLutIdMapRcd &) ;
-  std::auto_ptr<EcalTPGWeightIdMap> produceWeight(const EcalTPGWeightIdMapRcd &) ;
-  std::auto_ptr<EcalTPGWeightGroup> produceWeightGroup(const EcalTPGWeightGroupRcd &) ;
-  std::auto_ptr<EcalTPGLutGroup> produceLutGroup(const EcalTPGLutGroupRcd &) ;
-  std::auto_ptr<EcalTPGFineGrainEBGroup> produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd &) ;
-  std::auto_ptr<EcalTPGPhysicsConst> producePhysicsConst(const EcalTPGPhysicsConstRcd &) ;
-  std::auto_ptr<EcalTPGCrystalStatus> produceBadX(const EcalTPGCrystalStatusRcd &) ;
-  std::auto_ptr<EcalTPGStripStatus> produceBadStrip(const EcalTPGStripStatusRcd &) ;
-  std::auto_ptr<EcalTPGTowerStatus> produceBadTT(const EcalTPGTowerStatusRcd &) ;
-  std::auto_ptr<EcalTPGSpike> produceSpike(const EcalTPGSpikeRcd &) ;
+  std::unique_ptr<EcalTPGPedestals> producePedestals(const EcalTPGPedestalsRcd &) ;
+  std::unique_ptr<EcalTPGLinearizationConst> produceLinearizationConst(const EcalTPGLinearizationConstRcd &) ;
+  std::unique_ptr<EcalTPGSlidingWindow> produceSlidingWindow(const EcalTPGSlidingWindowRcd &) ;
+  std::unique_ptr<EcalTPGFineGrainEBIdMap> produceFineGrainEB(const EcalTPGFineGrainEBIdMapRcd &) ;
+  std::unique_ptr<EcalTPGFineGrainStripEE> produceFineGrainEEstrip(const EcalTPGFineGrainStripEERcd &) ;
+  std::unique_ptr<EcalTPGFineGrainTowerEE> produceFineGrainEEtower(const EcalTPGFineGrainTowerEERcd &) ;
+  std::unique_ptr<EcalTPGLutIdMap> produceLUT(const EcalTPGLutIdMapRcd &) ;
+  std::unique_ptr<EcalTPGWeightIdMap> produceWeight(const EcalTPGWeightIdMapRcd &) ;
+  std::unique_ptr<EcalTPGWeightGroup> produceWeightGroup(const EcalTPGWeightGroupRcd &) ;
+  std::unique_ptr<EcalTPGLutGroup> produceLutGroup(const EcalTPGLutGroupRcd &) ;
+  std::unique_ptr<EcalTPGFineGrainEBGroup> produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd &) ;
+  std::unique_ptr<EcalTPGPhysicsConst> producePhysicsConst(const EcalTPGPhysicsConstRcd &) ;
+  std::unique_ptr<EcalTPGCrystalStatus> produceBadX(const EcalTPGCrystalStatusRcd &) ;
+  std::unique_ptr<EcalTPGStripStatus> produceBadStrip(const EcalTPGStripStatusRcd &) ;
+  std::unique_ptr<EcalTPGTowerStatus> produceBadTT(const EcalTPGTowerStatusRcd &) ;
+  std::unique_ptr<EcalTPGSpike> produceSpike(const EcalTPGSpikeRcd &) ;
 
  private:
 

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimProducer.cc
@@ -239,8 +239,8 @@ EcalTrigPrimProducer::produce(edm::Event& e, const edm::EventSetup&  iSetup)
   if (!barrelOnly_)   LogDebug("EcalTPG") <<" =================> Treating event  "<<e.id()<<", Number of EBDataFrames "<<ebDigis.product()->size()<<", Number of EEDataFrames "<<eeDigis.product()->size() ;
   else  LogDebug("EcalTPG") <<" =================> Treating event  "<<e.id()<<", Number of EBDataFrames "<<ebDigis.product()->size();
 
-  std::auto_ptr<EcalTrigPrimDigiCollection> pOut(new  EcalTrigPrimDigiCollection);
-  std::auto_ptr<EcalTrigPrimDigiCollection> pOutTcp(new  EcalTrigPrimDigiCollection);
+  auto pOut = std::make_unique<EcalTrigPrimDigiCollection>();
+  auto pOutTcp = std::make_unique<EcalTrigPrimDigiCollection>();
  
 
   // invoke algorithm 
@@ -273,8 +273,8 @@ EcalTrigPrimProducer::produce(edm::Event& e, const edm::EventSetup&  iSetup)
 
   // put result into the Event
 
-  e.put(pOut);
-  if (tcpFormat_) e.put(pOutTcp,"formatTCP");
+  e.put(std::move(pOut));
+  if (tcpFormat_) e.put(std::move(pOutTcp),"formatTCP");
 }
 
 void 

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimSpikeESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimSpikeESProducer.cc
@@ -32,13 +32,13 @@ EcalTrigPrimSpikeESProducer::~EcalTrigPrimSpikeESProducer()
 
 
 // ------------ method called to produce the data  ------------
-std::auto_ptr<EcalTPGSpike> EcalTrigPrimSpikeESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord)
+std::unique_ptr<EcalTPGSpike> EcalTrigPrimSpikeESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord)
 {
-  std::auto_ptr<EcalTPGSpike> prod(new EcalTPGSpike());
+  auto prod = std::make_unique<EcalTPGSpike>();
   for(std::vector<uint32_t>::const_iterator it = towerIDs_.begin(); it != towerIDs_.end(); ++it)
   {
     prod->setValue(*it, zeroThresh_);
   }
-  return prod;
+  return std::move(prod);
 }
 

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimSpikeESProducer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimSpikeESProducer.h
@@ -22,7 +22,7 @@ class EcalTrigPrimSpikeESProducer : public edm::ESProducer {
   EcalTrigPrimSpikeESProducer(const edm::ParameterSet&);
   ~EcalTrigPrimSpikeESProducer();
 
-  std::auto_ptr<EcalTPGSpike> produceSpike(const EcalTPGSpikeRcd &) ;
+  std::unique_ptr<EcalTPGSpike> produceSpike(const EcalTPGSpikeRcd &) ;
 
  private:
   std::vector<uint32_t> towerIDs_;

--- a/SimGeneral/HepPDTESSource/interface/HepPDTESSource.h
+++ b/SimGeneral/HepPDTESSource/interface/HepPDTESSource.h
@@ -36,7 +36,7 @@ public:
   /// define the particle data table type
   typedef HepPDT::ParticleDataTable PDT;
   /// define the return type
-  typedef std::auto_ptr<PDT> ReturnType;
+  typedef std::unique_ptr<PDT> ReturnType;
   /// return the particle table
   ReturnType produce( const PDTRecord & );
   /// set validity interval

--- a/SimGeneral/HepPDTESSource/src/HepPDTESSource.cc
+++ b/SimGeneral/HepPDTESSource/src/HepPDTESSource.cc
@@ -13,7 +13,7 @@ HepPDTESSource::~HepPDTESSource() {
 HepPDTESSource::ReturnType
 HepPDTESSource::produce( const PDTRecord & iRecord ) {
   using namespace edm::es;
-  std::auto_ptr<PDT> pdt( new PDT( "PDG table" , new HepPDT::HeavyIonUnknownID) ); 
+  auto pdt = std::make_unique<PDT>( "PDG table" , new HepPDT::HeavyIonUnknownID );
   std::ifstream pdtFile( pdtFileName.fullPath().c_str() );
   if( ! pdtFile ) 
     throw cms::Exception( "FileNotFound", "can't open pdt file" )


### PR DESCRIPTION
auto_ptr is deprecated in C++, but is still used in the framework in three places. One of these is the EventSetup interface, which also supports unique_ptr. This PR changes every user of EventSetup outside the framework that uses auto_ptr to use unique_ptr instead. It also uses std::make_unique when appropriate. THis PR is totally technical.
