### PR TITLE
re-enable testCommonToolsUtil unit tests

### DIFF
--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -8,7 +8,6 @@
   <use   name="DataFormats/SiStripCluster"/>
   <use   name="CommonTools/Utils"/>
   <use   name="cppunit"/>
-  <flags NO_TESTRUN="1"/>
 </bin>
 
 <bin name="testCommonToolsUtilThreaded" file="testCutParserThreaded.cc">


### PR DESCRIPTION
few tests were disabled as those either needed input or were hang due to some other reason.
