### PR TITLE
Initialize lastModuleIndex to 0

### DIFF
--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1362,7 +1362,7 @@ namespace edm {
         
         streamSchedules_[0]->modulesInPath(path,moduleNames);
         std::string lastModuleName;
-        unsigned int lastModuleIndex;
+        unsigned int lastModuleIndex = 0;
         for(auto const& name: moduleNames) {
           auto found = alreadySeenNames.insert(name);
           if(found.second) {


### PR DESCRIPTION
While compiling with GCC 6.0.0 (r234771) in C++1z mode compiler produces
extra diagnostic:

```
FWCore/Framework/src/Schedule.cc:1372:43: error: 'lastModuleIndex'
```

may be used uninitialized in this function [-Werror=maybe-uninitialized]

Initialize lastModuleIndex to 0.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
