### PR TITLE
Add consumes support for TestAssociator

### DIFF
--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -75,12 +75,12 @@ using namespace edm;
     std::string  rechitProducer = "siStripMatchedRecHits";
 
     if(doStrip_) {
-      e.getByLabel(rechitProducer,"matchedRecHit", rechitsmatched);
-      e.getByLabel(rechitProducer,"rphiRecHit", rechitsrphi);
-      e.getByLabel(rechitProducer,"stereoRecHit", rechitsstereo);
+      e.getByToken(matchedRecHitToken, rechitsmatched);
+      e.getByToken(rphiRecHitToken, rechitsrphi);
+      e.getByToken(stereoRecHitToken, rechitsstereo);
     }
     if(doPixel_) {
-      e.getByLabel("siPixelRecHits",pixelrechits);
+      e.getByToken(siPixelRecHitsToken,pixelrechits);
     }
     if(!doPixel_ && !doStrip_)  throw edm::Exception(errors::Configuration,"Strip and pixel association disabled");
 
@@ -241,7 +241,11 @@ TestAssociator::TestAssociator(edm::ParameterSet const& conf) :
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ) {
   cout << " Constructor " << endl;
- 
+  
+  matchedRecHitToken=consumes<edmNew::DetSetVector<SiStripMatchedRecHit2D> >(conf.getParameter<edm::InputTag>("matchedRecHit"));
+  rphiRecHitToken=consumes<edmNew::DetSetVector<SiStripRecHit2D> >(conf.getParameter<edm::InputTag>("rphiRecHit"));
+  stereoRecHitToken=consumes<edmNew::DetSetVector<SiStripRecHit2D> >(conf.getParameter<edm::InputTag>("stereoRecHit"));
+  siPixelRecHitsToken=consumes<edmNew::DetSetVector<SiPixelRecHit> >(conf.getParameter<edm::InputTag>("siPixelRecHits"));
 }
 
   TestAssociator::~TestAssociator() 

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.h
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.h
@@ -49,6 +49,10 @@ class TestAssociator : public edm::EDAnalyzer
   const StripTopology* topol;
   int numStrips;    // number of strips in the module
   bool doPixel_, doStrip_;
+
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripMatchedRecHit2D> > matchedRecHitToken;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripRecHit2D> > rphiRecHitToken,stereoRecHitToken;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelRecHit> > siPixelRecHitsToken;
 };
 
 


### PR DESCRIPTION
Switch to input by token and consumes (thanks to Nicola De Filippis).
