### PR TITLE
Change of VBF Hbb HLT path names in DQM code (online,offline,relval) (backport of #13966 in 80X)

### DIFF
--- a/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
+++ b/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
@@ -30,8 +30,8 @@ rsq_mr_moduleName = "hltRsqMR240Rsq0p09MR200"
 
 bJet_pathNameCalo = "HLT_PFMET120_BTagCSV_p067"
 bJet_moduleNameCalo = "hltBTagCaloCSVp067Single"
-bJet_pathNamePF = "HLT_QuadPFJet_BTagCSV_p037_VBF_Mqq500"
-bJet_moduleNamePF = "hltBTagPFCSVp037SingleWithMatching"
+bJet_pathNamePF = "HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq500_v1"
+bJet_moduleNamePF = "hltBTagPFCSVp016SingleWithMatching"
 
 #To avoid booking histogram, set pathName = cms.string("")
 

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -19,7 +19,7 @@ BTVHLTOfflineSource = cms.EDAnalyzer(
     #
     pathPairs = cms.VPSet(
         cms.PSet(
-            pathname = cms.string("HLT_QuadPFJet_BTagCSV_p037_VBF"),
+            pathname = cms.string("HLT_QuadPFJet_BTagCSV"),
             pathtype = cms.string("PF"),
         ),
         cms.PSet(

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -275,11 +275,8 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     VBFHbb_2btag  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_QuadPFJet_BTagCSV_p037_0p11_VBF_Mqq200_v",
-            "HLT_QuadPFJet_BTagCSV_p037_0p11_VBF_Mqq240_v",
-	    # old csv version
-	    "HLT_QuadPFJet_DoubleBTagCSV_VBF_Mqq200_v",
-            "HLT_QuadPFJet_DoubleBTagCSV_VBF_Mqq240_v"
+            "HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200_v",
+            "HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240_v",
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexV2BJetTags"),
@@ -289,11 +286,8 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     VBFHbb_1btag  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_QuadPFJet_BTagCSV_p037_VBF_Mqq460_v",
-            "HLT_QuadPFJet_BTagCSV_p037_VBF_Mqq500_v",
-	    # old csv version
-            "HLT_QuadPFJet_SingleBTagCSV_VBF_Mqq460_v",
-            "HLT_QuadPFJet_SingleBTagCSV_VBF_Mqq500_v",
+            "HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq460_v",
+            "HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq500_v",
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexV2BJetTags"),


### PR DESCRIPTION
Fix of HLT names in DQM after JIRA-717 (backport of #13966 in 80X)

Hi all,
with JIRA-717 [1] we are changing the name of a few trigger paths, related to the VBF H->bb.
This PR fix the HLT path names in the DQM code (online,offline,relval).
Silvio.
[1] https://its.cern.ch/jira/browse/CMSHLT-717
