### PR TITLE
OwnVector should use unique_ptr, not auto_ptr

### DIFF
--- a/CommonTools/CandAlgos/interface/CandDecaySelector.h
+++ b/CommonTools/CandAlgos/interface/CandDecaySelector.h
@@ -23,7 +23,7 @@ namespace helper {
 	add( cands, * * i );
     }
     edm::OrphanHandle<reco::CandidateCollection> put( edm::Event & evt ) {
-      return evt.put( selCands_ );
+      return evt.put( std::move(selCands_) );
     }
     size_t size() const { return selCands_->size(); }
     
@@ -31,16 +31,16 @@ namespace helper {
     reco::CandidateRef add( reco::CandidateRefProd cands, const reco::Candidate & c ) {
       using namespace reco;
       using namespace std;
-      std::auto_ptr<CompositeRefCandidate> cmp( new CompositeRefCandidate( c ) );
+      auto cmp = std::make_unique<CompositeRefCandidate>( c );
       CompositeRefCandidate * p = cmp.get();
       CandidateRef ref( cands, selCands_->size() );
-      selCands_->push_back( cmp );
+      selCands_->push_back( std::move(cmp) );
       size_t n = c.numberOfDaughters(); 
       for( size_t i = 0; i < n; ++ i )
 	p->addDaughter( add( cands, * c.daughter( i ) ) );
       return ref;
     }
-    std::auto_ptr<reco::CandidateCollection> selCands_;
+    std::unique_ptr<reco::CandidateCollection> selCands_;
   };
   
   template<typename EdmFilter>

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -28,7 +28,7 @@ namespace helper {
   
   template<typename T>
   struct IteratorToObjectConverter<edm::OwnVector<T> > {
-    typedef std::auto_ptr<T> value_type;
+    typedef std::unique_ptr<T> value_type;
     template<typename I>
     static value_type convert( const I & i ) {
       return value_type( (*i)->clone() );
@@ -78,15 +78,15 @@ namespace helper {
       using namespace std;
       for( I i = begin; i != end; ++ i ) {
 	typename ClonePolicy::value_type v = ClonePolicy::convert( i );
-        selected_->push_back( v );
+        selected_->push_back( std::move(v) );
       }
     }
     edm::OrphanHandle<collection> put( edm::Event & evt ) {
-      return evt.put( selected_ );
+      return evt.put( std::move(selected_) );
     }
     size_t size() const { return selected_->size(); }
   private:
-    std::auto_ptr<collection> selected_;
+    std::unique_ptr<collection> selected_;
   };
 
   template<typename OutputCollection, typename EdmFilter>

--- a/DataFormats/Candidate/interface/CompositeCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeCandidate.h
@@ -59,7 +59,7 @@ namespace reco {
     /// add a clone of the passed candidate as daughter 
     void addDaughter( const Candidate &, const std::string& s="" );
     /// add a clone of the passed candidate as daughter 
-    void addDaughter( std::auto_ptr<Candidate>, const std::string& s="" );
+    void addDaughter( std::unique_ptr<Candidate>, const std::string& s="" );
     /// clear daughters
     void clearDaughters() { dau.clear(); }
     // clear roles

--- a/DataFormats/Candidate/interface/NamedCompositeCandidate.h
+++ b/DataFormats/Candidate/interface/NamedCompositeCandidate.h
@@ -59,7 +59,7 @@ namespace reco {
     virtual const Candidate * daughter( size_type i ) const  { return CompositeCandidate::daughter(i); }
     // Add daughters
     void                    addDaughter( const Candidate &, const std::string&s );
-    void                    addDaughter( std::auto_ptr<Candidate>, const std::string& s );
+    void                    addDaughter( std::unique_ptr<Candidate>, const std::string& s );
     // Clear daughters and roles
     void                    clearDaughters() { CompositeCandidate::clearDaughters(); }
     void                    clearRoles() { roles_.clear(); }

--- a/DataFormats/Candidate/src/CompositeCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeCandidate.cc
@@ -133,7 +133,7 @@ void CompositeCandidate::addDaughter(const Candidate & cand, const std::string& 
   dau.push_back(c);
 }
 
-void CompositeCandidate::addDaughter(std::auto_ptr<Candidate> cand, const std::string& s) {
+void CompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std::string& s) {
   if (s != "") {
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
     bool isFound = (find(begin, end, s) != end);
@@ -148,7 +148,7 @@ void CompositeCandidate::addDaughter(std::auto_ptr<Candidate> cand, const std::s
       c1->setName(s);
     }
   }
-  dau.push_back(cand);
+  dau.push_back(std::move(cand));
 }
 
 

--- a/DataFormats/Candidate/src/NamedCompositeCandidate.cc
+++ b/DataFormats/Candidate/src/NamedCompositeCandidate.cc
@@ -101,15 +101,15 @@ void NamedCompositeCandidate::addDaughter( const Candidate & cand, const std::st
   }
 
   roles_.push_back( s );
-  std::auto_ptr<Candidate> c( cand.clone() );
+  std::unique_ptr<Candidate> c( cand.clone() );
   NamedCompositeCandidate * c1 =  dynamic_cast<NamedCompositeCandidate*>(&*c);
   if ( c1 != 0 ) {
     c1->setName( s );
   }
-  CompositeCandidate::addDaughter( c );
+  CompositeCandidate::addDaughter( std::move(c) );
 }
 
-void NamedCompositeCandidate::addDaughter( std::auto_ptr<Candidate> cand, const std::string& s )
+void NamedCompositeCandidate::addDaughter( std::unique_ptr<Candidate> cand, const std::string& s )
 {
   role_collection::iterator begin = roles_.begin(), end = roles_.end();
   bool isFound = ( find( begin, end, s) != end );
@@ -124,7 +124,7 @@ void NamedCompositeCandidate::addDaughter( std::auto_ptr<Candidate> cand, const 
   if ( c1 != 0 ) {
     c1->setName( s );
   }
-  CompositeCandidate::addDaughter( cand );
+  CompositeCandidate::addDaughter( std::move(cand) );
 }
 
 

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -133,19 +133,16 @@ namespace edm {
     void reserve(size_t);
     template <typename D> void push_back(D*& d);
     template <typename D> void push_back(D* const& d);
-    template <typename D> void push_back(std::auto_ptr<D> d);
     template <typename D> void push_back(std::unique_ptr<D> d);
     void push_back(T const& valueToCopy);
 
     template <typename D> void set(size_t i, D*& d);
     template <typename D> void set(size_t i, D* const & d);
-    template <typename D> void set(size_t i, std::auto_ptr<D> d);
     template <typename D> void set(size_t i, std::unique_ptr<D> d);
     void set(size_t i, T const& valueToCopy);
 
     template <typename D> void insert(const_iterator i, D*& d);
     template <typename D> void insert(const_iterator i, D* const & d);
-    template <typename D> void insert(const_iterator i, std::auto_ptr<D> d);
     template <typename D> void insert(const_iterator i, std::unique_ptr<D> d);
     void insert(const_iterator i, T const& valueToCopy);
 
@@ -311,12 +308,6 @@ namespace edm {
 
   template<typename T, typename P>
   template<typename D>
-  inline void OwnVector<T, P>::push_back(std::auto_ptr<D> d) {
-    data_.push_back(d.release());
-  }
-
-  template<typename T, typename P>
-  template<typename D>
   inline void OwnVector<T, P>::push_back(std::unique_ptr<D> d) {
     data_.push_back(d.release());
   }
@@ -347,14 +338,6 @@ namespace edm {
 
   template<typename T, typename P>
   template<typename D>
-  inline void OwnVector<T, P>::set(size_t i, std::auto_ptr<D> d) {
-    if (d.get() == data_[i]) return; 
-    delete data_[i];
-    data_[i] = d.release();
-  }
-
-  template<typename T, typename P>
-  template<typename D>
   inline void OwnVector<T, P>::set(size_t i, std::unique_ptr<D> d) {
     if (d.get() == data_[i]) return; 
     delete data_[i];
@@ -380,12 +363,6 @@ namespace edm {
   template<typename D>
   inline void OwnVector<T, P>::insert(const_iterator it, D* const& d) {
     data_.insert(it.base_iter(), d);
-  }
-
-  template<typename T, typename P>
-  template<typename D>
-  inline void OwnVector<T, P>::insert(const_iterator it, std::auto_ptr<D> d) {
-    data_.insert(it.base_iter(), d.release());
   }
 
   template<typename T, typename P>

--- a/DataFormats/PatCandidates/interface/UserData.h
+++ b/DataFormats/PatCandidates/interface/UserData.h
@@ -51,7 +51,7 @@ namespace pat {
     /// Make a UserData pointer from some value, wrapping it appropriately.
     /// It will check for dictionaries, unless 'transientOnly' is true
     template<typename T>
-    static std::auto_ptr<UserData> make(const T &value, bool transientOnly=false) ;
+    static std::unique_ptr<UserData> make(const T &value, bool transientOnly=false) ;
 
   protected:
     /// Get out the data (can't template non virtual functions)
@@ -86,12 +86,12 @@ namespace pat {
 
 
 template<typename T>
-std::auto_ptr<pat::UserData> pat::UserData::make(const T &value, bool transientOnly) {
+std::unique_ptr<pat::UserData> pat::UserData::make(const T &value, bool transientOnly) {
     if (!transientOnly) {
         checkDictionaries(typeid(T));
         checkDictionaries(typeid(pat::UserHolder<T>));
     }
-    return std::auto_ptr<UserData>(new pat::UserHolder<T>(value));  
+    return std::unique_ptr<UserData>(new pat::UserHolder<T>(value));  
 }
 
 template<typename T> 

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
@@ -634,14 +634,14 @@ void SiTrackerGaussianSmearingRecHitConverter::produce(edm::Event& e, const edm:
 			     error.yy()+lape.yy() );
 
       // insert rechit in rechit collection
-      std::auto_ptr<FastSingleTrackerRecHit> recHit (new FastSingleTrackerRecHit(position, error, 
-										 *geometry->idToDetUnit(det),
-										 subdet > 2 
-										 ? fastTrackerRecHitType::siStrip2D
-										 : fastTrackerRecHitType::siPixel));
+      auto recHit = std::make_unique<FastSingleTrackerRecHit>(position, error, 
+								*geometry->idToDetUnit(det),
+								subdet > 2 
+								? fastTrackerRecHitType::siStrip2D
+								: fastTrackerRecHitType::siPixel);
       recHit->addSimTrackId(simHit.trackId());
       recHit->setId(simHitCounter);
-      output_recHits->push_back(recHit);
+      output_recHits->push_back(std::move(recHit));
 				
 
       // update map simHit->recHit

--- a/MuonAnalysis/MuonAssociators/plugins/MatcherUsingTracks.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MatcherUsingTracks.cc
@@ -129,7 +129,7 @@ pat::MatcherUsingTracks::produce(edm::Event & iEvent, const edm::EventSetup & iS
     storeValueMap<reco::CandidatePtr>(iEvent, src, ptrs, "");
 
     if (writeExtraPATOutput_) {
-        std::auto_ptr<edm::OwnVector<pat::UserData> > outUDVect(new edm::OwnVector<pat::UserData>());
+        auto outUDVect = std::make_unique<edm::OwnVector<pat::UserData> >();
         std::vector<int>                              idxUD(nsrc, -1);
         for (isrc = 0; isrc < nsrc; ++isrc) {
             if (match[isrc] != -1) {
@@ -137,7 +137,7 @@ pat::MatcherUsingTracks::produce(edm::Event & iEvent, const edm::EventSetup & iS
                 idxUD[isrc] = outUDVect->size() - 1;
             }
         }
-        edm::OrphanHandle<edm::OwnVector<pat::UserData> > doneUDVect = iEvent.put(outUDVect);
+        edm::OrphanHandle<edm::OwnVector<pat::UserData> > doneUDVect = iEvent.put(std::move(outUDVect));
         std::vector<edm::Ptr<pat::UserData> > ptrUD(nsrc);
         for (isrc = 0; isrc < nsrc; ++isrc) {
             if (idxUD[isrc] != -1) ptrUD[isrc] = edm::Ptr<pat::UserData>(doneUDVect, idxUD[isrc]);

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
@@ -51,7 +51,7 @@ void PATCompositeCandidateProducer::produce(Event & iEvent, const EventSetup & i
   if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
   if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
 
-  auto_ptr<vector<pat::CompositeCandidate> > myCompositeCandidates ( new vector<pat::CompositeCandidate>() );
+  auto myCompositeCandidates = std::make_unique<vector<pat::CompositeCandidate> >();
 
   if ( cands.isValid() ) {
 
@@ -68,12 +68,12 @@ void PATCompositeCandidateProducer::produce(Event & iEvent, const EventSetup & i
       if (efficiencyLoader_.enabled()) efficiencyLoader_.setEfficiencies( cand, cands->refAt(i - cands->begin()) );
       if (resolutionLoader_.enabled()) resolutionLoader_.setResolutions(cand);
 
-      myCompositeCandidates->push_back( cand );
+      myCompositeCandidates->push_back( std::move(cand) );
     }
 
   }// end if the two handles are valid
 
-  iEvent.put(myCompositeCandidates);
+  iEvent.put(std::move(myCompositeCandidates));
 
 }
 

--- a/PhysicsTools/PatAlgos/test/private/PATUserDataTestModule.cc
+++ b/PhysicsTools/PatAlgos/test/private/PATUserDataTestModule.cc
@@ -119,7 +119,7 @@ PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
        edm::Handle<View<pat::Muon> > muons;
        iEvent.getByToken(muonsToken_,muons);
 
-       std::auto_ptr<std::vector<pat::Muon> > output(new std::vector<pat::Muon>());
+       auto output = std::make_unique<std::vector<pat::Muon> >();
 
        for (View<pat::Muon>::const_iterator muon = muons->begin(), end = muons->end(); muon != end; ++muon) {
            if (mode_ == TestWrite) {
@@ -136,7 +136,7 @@ PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
                // myMuon.addUserData("tmp self", *muon, true);
                // myMuon.addUserData("tmp crazy", CrazyDataType(), true);
 
-               output->push_back(myMuon);
+               output->push_back(std::move(myMuon));
            } else {
                std::cout << "Muon #" << (muon - muons->begin()) << ":" << std::endl;
                std::cout << "\tanswer   = " << muon->userInt("answer") << std::endl;
@@ -163,7 +163,7 @@ PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
                }
            }
        }
-       iEvent.put(output);
+       iEvent.put(std::move(output));
    } else {
        using namespace std;
        Handle<View<reco::Muon> > recoMuons;


### PR DESCRIPTION
auto_ptr is deprecated in C++, but is still used in the framework in three places. One of these is OwnVector, which also supports unique_ptr. This PR changes every user of OwnVector that uses auto_ptr to use unique_ptr instead. and removes support for auto_ptr in OwnVector. It also uses std::make_unique when appropriate.
This PR also changes a very small number of auto_ptr's to unique_ptr's unrelated to OwnVector in files that were modified anyway.
In cases where auto_ptr was passed by reference (a bad practice), the code was modified to pass unique_ptr by value in those cases where ownership is being transferred, and to pass a bare pointer (get()) in cases where ownership is not transferred,
 This PR is totally technical.
