### PR TITLE
Declare liblogintpack functions as inline

### DIFF
--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -10,6 +10,7 @@ namespace logintpack
         // is no "x" such that "unpack(x) == -unpack(0)"
         constexpr int8_t smallestNegative = -1;
 
+        inline
         int8_t pack8logCeil(double x,double lmin, double lmax, uint8_t base=128)
         {
                 if(base>128) base=128;
@@ -22,6 +23,7 @@ namespace logintpack
                 return r;
         }
 
+	inline
 	int8_t pack8log(double x,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
@@ -36,6 +38,7 @@ namespace logintpack
 
         /// pack a value x distributed in [-1,1], with guarantee that -1 and 1 are preserved exactly in packing and unpacking.
         /// tries to keep the best precision for x close to the endpoints, sacrifying that in the middle
+	inline
 	int8_t pack8logClosed(double x,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
@@ -48,7 +51,7 @@ namespace logintpack
 		return r;
 	}
 
-
+	inline
 	double unpack8log(int8_t i,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
@@ -59,6 +62,7 @@ namespace logintpack
 	}
 
         /// reverse of pack8logClosed
+	inline
 	double unpack8logClosed(int8_t i,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;


### PR DESCRIPTION
As the functions are defined in a header, they should be declared inline. Should affect only `testDataFormatsPatCandidates`, which
- #includes the header directly `testlogintpack.cc`
- links a library (`DataFormats/PatCandidates`) that has a source #including the header

Without declaring the functions inline, if one adds `<use name="vdt"/>` to `DataFormats/PatCandidates/BuildFile.xml`, the `std::exp` in `unpack8logClosed` gives 1 ulp difference for `unpack8logClosed(-1, -15, 0)` wrt. not "using" `vdt`. Note that the effect is visible only when calling the `unpack8logClosed` function. If I copy-paste the contents to the test program, I get consistently the "not-using-vdt" values. With inline the return value of `unpack8logClosed` is does not depend on linking against `vdt`.

With this PR, the (older version of) #13959 (with `DataFormats/ParticleFlowReco/BuildFile.xml` using `vdt` instead of `vdt_headers`) would not cause `testDataFormatsPatCandidates` to fail.

Tested in 8_1_0_pre2, no changes expected.

@VinInn 
