### PR TITLE
Fix era treatments for FastSim seeds in TrackValidation_cff

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -282,17 +282,17 @@ def _sequenceForEachEra(function, args, names, sequence, modDict, plainArgs=[], 
         modDict[sequence+postfix] = ret[1]
 
     # The sequence of the first era will be the default one
-    defaultSequenceName = sequence+_relevantEras[0][0]
+    defaultSequenceName = sequence+_eras[0][0]
     defaultSequence = modDict[defaultSequenceName]
     modDict[defaultSequenceName[1:]] = defaultSequence # remove leading underscore
 
     # Optionally modify sequences before applying the era
     if modifySequence is not None:
-        for eraName, postfix in _relevantEras:
+        for eraName, postfix in _eras:
             modifySequence(modDict[sequence+postfix])
 
     # Apply eras
-    for eraName, postfix in _relevantEras[1:]:
+    for eraName, postfix in _eras[1:]:
         getattr(eras, eraName).toReplaceWith(defaultSequence, modDict[sequence+postfix])
 def _setForEra(module, era, **kwargs):
     if era == "":


### PR DESCRIPTION
This PR fixes a bug affecting tracking seed validation for FastSim introduced in #13736. The bug is that the `eras.fastSim.toReplaceWith(tracksValidationSeedSelectorsTrackingOnly, _tracksValidationSeedSelectorsTrackingOnly_fastSim)` does not get executed, leading to an exception 
due to missing `initialStepSeedsPreSplitting` collection (which is not present in FastSim). Thanks @ANSH0712 for reporting the bug.

Tested in CMSSW_8_1_X_2016-04-10-1100, no changes expected in standard workflows.

@rovere @VinInn 
