### PR TITLE
Remove EventSetup support for boost::shared_ptr and std::auto_ptr

### DIFF
--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -22,7 +22,6 @@
          produced.  (The choice depends on if the EventSetup or the ESProducer is managing the lifetime of 
          the object).  If multiple items are being Produced they the 'produce' method must return an
          ESProducts<> object which holds all of the items.
-         Note: std::auto_ptr and boost::shared_ptr are also supported, but are deprecated.
       2) add 'setWhatProduced(this);' to their classes constructor
 
 Example: one algorithm creating only one object

--- a/FWCore/Framework/interface/ESProducts.h
+++ b/FWCore/Framework/interface/ESProducts.h
@@ -47,25 +47,6 @@ namespace edm {
             typedef Null head_type;
          };
 
-         template< typename T> struct OneHolder< std::auto_ptr<T> > {
-            typedef std::auto_ptr<T> Type;
-            OneHolder() {}
-            OneHolder(const OneHolder<Type>& iOther): value_(const_cast<OneHolder<Type>& >(iOther).value_) {}
-            OneHolder(Type iPtr): value_(iPtr) {}
-            
-            
-            const OneHolder<Type> & operator=(OneHolder<Type> iRHS) { value_ =iRHS.value_; return *this; }
-            template<typename S>
-            void setFromRecursive(S& iGiveValues) {
-               iGiveValues.setFrom(value_);
-            }
-            
-            void assignTo(Type& oValue) { oValue = value_;}
-            mutable Type value_; //mutable needed for std::auto_ptr
-            typedef Type tail_type;
-            typedef Null head_type;
-         };
-         
          template<typename T> struct OneHolder<std::unique_ptr<T>> {
             typedef std::unique_ptr<T> Type;
             OneHolder() {}

--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -21,7 +21,6 @@
 // system include files
 #include <memory>
 // user include files
-#include "boost/shared_ptr.hpp"
 
 // forward declarations
 namespace edm {
@@ -50,14 +49,8 @@ namespace edm {
          template< typename T> struct product_traits<T*> {
             typedef EndList<T*> type;
          };
-         template< typename T> struct product_traits<std::auto_ptr<T> > {
-            typedef EndList<std::auto_ptr<T> > type;
-         };
          template< typename T> struct product_traits<std::unique_ptr<T> > {
             typedef EndList<std::unique_ptr<T> > type;
-         };
-         template< typename T> struct product_traits<boost::shared_ptr<T> > {
-            typedef EndList<boost::shared_ptr<T> > type;
          };
          template< typename T> struct product_traits<std::shared_ptr<T> > {
             typedef EndList<std::shared_ptr<T> > type;

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -37,7 +37,7 @@ namespace edm {
 	std::string const& productInstanceName) {
       throw Exception(errors::NullPointerError)
 	<< principalType
-	<< "::put: A null auto_ptr was passed to 'put'.\n"
+	<< "::put: A null auto_ptr or unique_ptr was passed to 'put'.\n"
 	<< "The pointer is of type "
 	<< productType
         << ".\nThe specified productInstanceName was '"

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -38,8 +38,8 @@ namespace callbacktest {
       Data data_;
    };
 
-   struct AutoPtrProd {
-      AutoPtrProd() : value_(0) {}
+   struct UniquePtrProd {
+      UniquePtrProd() : value_(0) {}
       std::unique_ptr<Data> method(const Record&) {
          return std::make_unique<Data>(++value_);
       }
@@ -80,7 +80,7 @@ class testCallback: public CppUnit::TestFixture
 CPPUNIT_TEST_SUITE(testCallback);
 
 CPPUNIT_TEST(constPtrTest);
-CPPUNIT_TEST(autoPtrTest);
+CPPUNIT_TEST(uniquePtrTest);
 CPPUNIT_TEST(sharedPtrTest);
 CPPUNIT_TEST(ptrProductsTest);
 
@@ -90,7 +90,7 @@ public:
   void tearDown(){}
 
   void constPtrTest();
-  void autoPtrTest();
+  void uniquePtrTest();
   void sharedPtrTest();
   void ptrProductsTest();
 };
@@ -127,13 +127,13 @@ void testCallback::constPtrTest()
    
 }
 
-typedef Callback<AutoPtrProd, std::unique_ptr<Data>, Record> AutoPtrCallback;
+typedef Callback<UniquePtrProd, std::unique_ptr<Data>, Record> UniquePtrCallback;
 
-void testCallback::autoPtrTest()
+void testCallback::uniquePtrTest()
 {
-   AutoPtrProd prod;
+   UniquePtrProd prod;
    
-   AutoPtrCallback callback(&prod, &AutoPtrProd::method);
+   UniquePtrCallback callback(&prod, &UniquePtrProd::method);
    std::unique_ptr<Data> handle;
    
    

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -30,7 +30,6 @@ CPPUNIT_TEST(registerTest);
 CPPUNIT_TEST(getFromTest);
 CPPUNIT_TEST(getfromShareTest);
 CPPUNIT_TEST(getfromUniqueTest);
-CPPUNIT_TEST(getfromAutoTest);
 CPPUNIT_TEST(decoratorTest);
 CPPUNIT_TEST(dependsOnTest);
 CPPUNIT_TEST(labelTest);
@@ -46,7 +45,6 @@ public:
   void getFromTest();
   void getfromShareTest();
   void getfromUniqueTest();
-  void getfromAutoTest();
   void decoratorTest();
   void dependsOnTest();
   void labelTest();
@@ -103,20 +101,6 @@ public:
    std::unique_ptr<DummyData> produce(const DummyRecord&) {
       ++data_.value_;
       return std::make_unique<DummyData>(data_);
-   }
-private:
-   DummyData data_;
-};
-
-class AutoProducer : public ESProducer {
-public:
-   AutoProducer() {
-      setWhatProduced(this);
-   }
-   std::auto_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
-      ++data_.value_;
-      std::auto_ptr<DummyData> ptr(new DummyData(data_));
-      return ptr;
    }
 private:
    DummyData data_;
@@ -218,27 +202,6 @@ void testEsproducer::getfromUniqueTest()
    EventSetupProvider provider;
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<UniqueProducer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
-      const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-      edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(iTime == pDummy->value_);
-   }
-}
-
-void testEsproducer::getfromAutoTest()
-{
-   EventSetupProvider provider;
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<AutoProducer>();
    provider.add(pProxyProv);
    
    std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();

--- a/FWCore/Utilities/interface/get_underlying_safe.h
+++ b/FWCore/Utilities/interface/get_underlying_safe.h
@@ -29,8 +29,6 @@
 
 // user include files
 
-#include "boost/shared_ptr.hpp"
-
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
@@ -44,10 +42,6 @@ namespace edm {
   // for bare pointer
   template<typename T> T*& get_underlying_safe(propagate_const<T*>& iP) {return get_underlying(iP);}
   template<typename T> T const* get_underlying_safe(propagate_const<T*> const& iP) {T const* copy = get_underlying(iP); return copy;}
-
-  // for boost::shared_ptr
-  template<typename T> boost::shared_ptr<T>& get_underlying_safe(propagate_const<boost::shared_ptr<T>>& iP) {return get_underlying(iP);}
-  template<typename T> boost::shared_ptr<T const> get_underlying_safe(propagate_const<boost::shared_ptr<T>> const& iP) {boost::shared_ptr<T const> copy = get_underlying(iP); return copy;}
 
   // for std::unique_ptr
   template<typename T> std::unique_ptr<T>& get_underlying_safe(propagate_const<std::unique_ptr<T>>& iP) {return get_underlying(iP);}


### PR DESCRIPTION
Recently merged PR's removed all uses of boost::shared_ptr and std::auto_ptr in the EventSetup interface in all of CMSSW, replacing them with std::shared_ptr and std::unique_ptr respectively. This PR removes support for these pointers in the EventSetup interface itself. Support for boost::shared_ptr in get_underlying safe() is also being removed. With this PR, boost::shared_ptr is not used anywhere in the framework, and std::auto_ptr is used only in the "put" interface for EDProducts, at least once the PR removing auto_ptr from OwnVector is also merged.
