### PR TITLE
The return values of gSystem->Load(library) can be 0 or 1.

### DIFF
--- a/FWCore/Utilities/scripts/edmAddClassVersion
+++ b/FWCore/Utilities/scripts/edmAddClassVersion
@@ -227,11 +227,11 @@ if __name__ == '__main__':
     import ROOT
     ROOT.PyConfig.DisableRootLogon = True
     if options.library is None:
-        if 0 != ROOT.gSystem.Load("libFWCoreFWLite"):
+        if ROOT.gSystem.Load("libFWCoreFWLite") < 0:
             raise RuntimeError("failed to load libFWCoreFWLite")
         ROOT.fwlite.enable()
     else:
-        if 0 != ROOT.gSystem.Load(options.library):
+        if ROOT.gSystem.Load(options.library) < 0:
             raise RuntimeError("failed to load library '"+options.library+"'")
 
     import subprocess,sys

--- a/FWCore/Utilities/scripts/edmCheckClassTransients
+++ b/FWCore/Utilities/scripts/edmCheckClassTransients
@@ -68,7 +68,7 @@ ROOT.gROOT.ProcessLine(".autodict")
 if options.library is None:
     print "Transient member check requires a specific library"
 else:
-    if 0 != ROOT.gSystem.Load(options.library):
+    if ROOT.gSystem.Load(options.library) < 0 :
         raise RuntimeError("failed to load library '"+options.library+"'")
 
 p = RMParser(options.rmfiles)

--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -172,7 +172,7 @@ if options.library is None:
     if options.checkdict :
         print "Dictionary checks require a specific library"
 else:
-    if 0 != ROOT.gSystem.Load(options.library):
+    if ROOT.gSystem.Load(options.library) < 0 :
         raise RuntimeError("failed to load library '"+options.library+"'")
 
 missingDict = 0


### PR DESCRIPTION
The current check for 0 causes an error when the return code is 1.
