### PR TITLE
Finalizing JSON monitoring for 2016

### DIFF
--- a/HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h
@@ -1,15 +1,14 @@
-#ifndef JSONMonitoring_TriggerJSONMonitoring_h
-#define JSONMonitoring_TriggerJSONMonitoring_h
+#ifndef JSONMonitoring_HLTriggerJSONMonitoring_h
+#define JSONMonitoring_HLTriggerJSONMonitoring_h
 
-/** \class TriggerJSONMonitoring         
+/** \class HLTriggerJSONMonitoring         
  *     
  *  
- *  Description: This class prints JSON files with trigger info.
+ *  Description: This class prints JSON files with HLT info.
  *          
- *  Created:  Wed, 09 Jul 2014     
+ *  Created:  Fri, 11 Mar 2016     
  *       
  *  \author Aram Avetisyan   
- *  \author Daniel Salerno  
  * 
  */
 
@@ -32,17 +31,10 @@
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"          
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"  
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"  
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"  
-#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
 
 #include <atomic>
 
-namespace trigJson {
+namespace hltJson {
   //Struct for storing variables that must be written and reset every lumi section 
   struct lumiVars {
     jsoncollector::HistoJ<unsigned int> *processed; // # of events processed
@@ -54,42 +46,27 @@ namespace trigJson {
     jsoncollector::HistoJ<unsigned int> *hltErrors; // # of events with error in HLT[i]
     jsoncollector::HistoJ<unsigned int> *hltDatasets; // # of events accepted by each dataset 
 
-    unsigned int prescaleIndex; // Prescale index for each lumi section
-
     std::string baseRunDir; //Base directory from EvFDaqDirector 
     std::string stHltJsd;   //Definition file name for JSON with rates  
 
-    jsoncollector::HistoJ<unsigned int> *L1AlgoAccept;            // # of events accepted by L1T[i]  
-    jsoncollector::HistoJ<unsigned int> *L1TechAccept;            // # of events accepted by L1 Technical Triggers[i]  
-    jsoncollector::HistoJ<unsigned int> *L1AlgoAcceptPhysics;     // # of Physics events accepted by L1T[i]  
-    jsoncollector::HistoJ<unsigned int> *L1TechAcceptPhysics;     // # of Physics events accepted by L1 Technical Triggers[i]  
-    jsoncollector::HistoJ<unsigned int> *L1AlgoAcceptCalibration; // # of Calibration events accepted by L1T[i]  
-    jsoncollector::HistoJ<unsigned int> *L1TechAcceptCalibration; // # of Calibration events accepted by L1 Technical Triggers[i]  
-    jsoncollector::HistoJ<unsigned int> *L1AlgoAcceptRandom;      // # of Random events accepted by L1T[i]  
-    jsoncollector::HistoJ<unsigned int> *L1TechAcceptRandom;      // # of Random events accepted by L1 Technical Triggers[i]  
-    jsoncollector::HistoJ<unsigned int> *L1Global;                // Global # of Phyics, Cailibration and Random L1 triggers 
-    
-    std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            
-    std::string streamL1Destination;
     std::string streamHLTDestination;
   };
   //End lumi struct
   //Struct for storing variable written once per run
   struct runVars{
     mutable std::atomic<bool> wroteFiles;
-    mutable std::string streamL1Destination;
     mutable std::string streamHLTDestination;
   };
-}//End trigJson namespace   
+}//End hltJson namespace   
 
 // 
 // class declaration
 // 
-class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trigJson::runVars>, edm::LuminosityBlockSummaryCache<trigJson::lumiVars>>
+class HLTriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJson::runVars>, edm::LuminosityBlockSummaryCache<hltJson::lumiVars>>
 {
  public:
-  explicit TriggerJSONMonitoring(const edm::ParameterSet&);
-  ~TriggerJSONMonitoring();
+  explicit HLTriggerJSONMonitoring(const edm::ParameterSet&);
+  ~HLTriggerJSONMonitoring();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
   void analyze(edm::Event const&,
@@ -98,11 +75,10 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trig
   void beginRun(edm::Run const&,
                 edm::EventSetup const&);
 
-  static std::shared_ptr<trigJson::runVars> globalBeginRun(edm::Run const&, edm::EventSetup const&, void const*){
-    std::shared_ptr<trigJson::runVars> rv(new trigJson::runVars);
+  static std::shared_ptr<hltJson::runVars> globalBeginRun(edm::Run const&, edm::EventSetup const&, void const*){
+    std::shared_ptr<hltJson::runVars> rv(new hltJson::runVars);
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
       rv->streamHLTDestination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamHLTRates");
-      rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
     }
     rv->wroteFiles = false;
     return rv;
@@ -112,42 +88,31 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trig
 
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
-  static std::shared_ptr<trigJson::lumiVars> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+  static std::shared_ptr<hltJson::lumiVars> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
                                                                               edm::EventSetup const&,
                                                                               LuminosityBlockContext const*);
 
   void endLuminosityBlockSummary(edm::LuminosityBlock const&,
                                  edm::EventSetup const&,
-                                 trigJson::lumiVars*) const;
+                                 hltJson::lumiVars*) const;
 
 
   static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
                                               edm::EventSetup const&,
                                               LuminosityBlockContext const*,
-                                              trigJson::lumiVars*);
+                                              hltJson::lumiVars*);
 
   void resetRun(bool changed);   //Reset run-related info
   void resetLumi();              //Reset all counters 
 
-  void writeDefJson(std::string path);
-
-  void writeL1DefJson(std::string path);       
+  void writeHLTDefJson(std::string path);
 
   //Variables from cfg and associated tokens 
   edm::InputTag triggerResults_;                               // Input tag for TriggerResults 
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults
 
-  edm::InputTag level1Results_;                                 // Input tag for L1 Global collection   
-  edm::EDGetTokenT<GlobalAlgBlkBxCollection> m_l1t_results; // Token for L1 Global collection 
-
   //Variables that change at most once per run 
   HLTConfigProvider hltConfig_;         // to get configuration for HLT
-  const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu   
-  AlgorithmMap algorithmMap;            // L1 algorithm map  
-  AlgorithmMap technicalMap;            // L1 technical triggeral map 
-
-  const L1GtTriggerMask* m_l1tAlgoMask;
-  const L1GtTriggerMask* m_l1tTechMask;
 
   std::string baseRunDir_; //Base directory from EvFDaqDirector
 
@@ -162,17 +127,8 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trig
 
   std::string stHltJsd_;                  //Definition file name for JSON with rates
 
-  std::vector<std::string> L1AlgoNames_;  // name of each L1 algorithm trigger      
-  std::vector<int> L1AlgoBitNumber_;      // bit number of each L1 algo trigger     
-  std::vector<std::string> L1TechNames_;  // name of each L1 technical trigger      
-  std::vector<int> L1TechBitNumber_;      // bit number of each L1 tech trigger     
-  std::vector<std::string> L1GlobalType_; // experimentType: Physics, Calibration, Random  
-
-  std::string stL1Jsd_;                   //Definition file name for JSON with L1 rates           
-
   //Variables that need to be reset at lumi section boundaries 
   unsigned int              processed_;      // # of events processed 
-  unsigned int              prescaleIndex_;  //Prescale index for each lumi section
 
   std::vector<unsigned int> hltWasRun_; // # of events where HLT[i] was run   
   std::vector<unsigned int> hltL1s_;    // # of events after L1 seed
@@ -182,20 +138,6 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trig
   std::vector<unsigned int> hltErrors_; // # of events with error in HLT[i]
 
   std::vector<unsigned int> hltDatasets_; // # of events accepted by each dataset 
-
-  std::vector<unsigned int> L1AlgoAccept_;            // # of events accepted by L1T[i]  
-  std::vector<unsigned int> L1TechAccept_;            // # of events accepted by L1 Technical Triggers[i]  
-  std::vector<unsigned int> L1AlgoAcceptPhysics_;     // # of Physics events accepted by L1T[i]  
-  std::vector<unsigned int> L1TechAcceptPhysics_;     // # of Physics events accepted by L1 Technical Triggers[i]  
-  std::vector<unsigned int> L1AlgoAcceptCalibration_; // # of Calibration events accepted by L1T[i]  
-  std::vector<unsigned int> L1TechAcceptCalibration_; // # of Calibration events accepted by L1 Technical Triggers[i]  
-  std::vector<unsigned int> L1AlgoAcceptRandom_;      // # of Random events accepted by L1T[i]  
-  std::vector<unsigned int> L1TechAcceptRandom_;      // # of Random events accepted by L1 Technical Triggers[i]  
-  std::vector<unsigned int> L1Global_;                // Global # of Physics, Calibration and Random L1 triggers 
-
-  //Variables for confirming that prescale index did not change
-  unsigned int oldLumi;
-  unsigned int oldPrescaleIndex;
 
  private:
 

--- a/HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h
@@ -1,0 +1,143 @@
+#ifndef JSONMonitoring_L1TriggerJSONMonitoring_h
+#define JSONMonitoring_L1TriggerJSONMonitoring_h
+
+/** \class L1TriggerJSONMonitoring         
+ *     
+ *  
+ *  Description: This class prints JSON files with L1 trigger info.
+ *          
+ *  Created:  Fri, 11 Mar 2016     
+ *       
+ *  \author Aram Avetisyan   
+ * 
+ */
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Adler32Calculator.h"
+
+#include "EventFilter/Utilities/interface/JsonMonitorable.h"
+#include "EventFilter/Utilities/interface/FastMonitor.h"
+#include "EventFilter/Utilities/interface/JSONSerializer.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"          
+
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+
+#include <atomic>
+
+namespace l1Json {
+  //Struct for storing variables that must be written and reset every lumi section 
+  struct lumiVars {
+
+    unsigned int prescaleIndex; // Prescale index for each lumi section
+
+    std::string baseRunDir; //Base directory from EvFDaqDirector 
+
+    jsoncollector::HistoJ<unsigned int> *processed;               // # of events processed
+    jsoncollector::HistoJ<unsigned int> *L1AlgoAccept;            // # of events accepted by L1T[i]  
+    jsoncollector::HistoJ<unsigned int> *L1AlgoAcceptPhysics;     // # of Physics events accepted by L1T[i]  
+    jsoncollector::HistoJ<unsigned int> *L1AlgoAcceptCalibration; // # of Calibration events accepted by L1T[i]  
+    jsoncollector::HistoJ<unsigned int> *L1AlgoAcceptRandom;      // # of Random events accepted by L1T[i]  
+    jsoncollector::HistoJ<unsigned int> *L1Global;                // Global # of Phyics, Cailibration and Random L1 triggers 
+    
+    std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            
+    std::string streamL1Destination;
+  };
+  //End lumi struct
+  //Struct for storing variable written once per run
+  struct runVars{
+    mutable std::atomic<bool> wroteFiles;
+    mutable std::string streamL1Destination;
+  };
+}//End l1Json namespace   
+
+// 
+// class declaration
+// 
+class L1TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<l1Json::runVars>, edm::LuminosityBlockSummaryCache<l1Json::lumiVars>>
+{
+ public:
+  explicit L1TriggerJSONMonitoring(const edm::ParameterSet&);
+  ~L1TriggerJSONMonitoring();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+  void analyze(edm::Event const&,
+               edm::EventSetup const&);
+
+  void beginRun(edm::Run const&,
+                edm::EventSetup const&);
+
+  static std::shared_ptr<l1Json::runVars> globalBeginRun(edm::Run const&, edm::EventSetup const&, void const*){
+    std::shared_ptr<l1Json::runVars> rv(new l1Json::runVars);
+    if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
+      rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
+    }
+    rv->wroteFiles = false;
+    return rv;
+  }
+  
+  static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext){ } 
+
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+
+  static std::shared_ptr<l1Json::lumiVars> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                                              edm::EventSetup const&,
+                                                                              LuminosityBlockContext const*);
+
+  void endLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                 edm::EventSetup const&,
+                                 l1Json::lumiVars*) const;
+
+
+  static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                              edm::EventSetup const&,
+                                              LuminosityBlockContext const*,
+                                              l1Json::lumiVars*);
+
+  void resetLumi(); //Reset all counters 
+
+  void writeL1DefJson(std::string path);       
+
+  //Variables from cfg and associated tokens 
+  edm::InputTag level1Results_;                                  // Input tag for L1 Global collection   
+  edm::EDGetTokenT<GlobalAlgBlkBxCollection> level1ResultsToken_; // Token for L1 Global collection 
+
+  //Variables that change at most once per run 
+  std::string baseRunDir_; //Base directory from EvFDaqDirector
+
+  std::vector<std::string> L1AlgoNames_;  // name of each L1 algorithm trigger      
+  std::vector<int> L1AlgoBitNumber_;      // bit number of each L1 algo trigger     
+  std::vector<std::string> L1GlobalType_; // experimentType: Physics, Calibration, Random  
+
+  std::string stL1Jsd_;                   //Definition file name for JSON with L1 rates           
+
+  //Variables that need to be reset at lumi section boundaries 
+  unsigned int              processed_;      // # of events processed 
+  unsigned int              prescaleIndex_;  //Prescale index for each lumi section
+
+  std::vector<unsigned int> L1AlgoAccept_;            // # of events accepted by L1T[i]  
+  std::vector<unsigned int> L1AlgoAcceptPhysics_;     // # of Physics events accepted by L1T[i]  
+  std::vector<unsigned int> L1AlgoAcceptCalibration_; // # of Calibration events accepted by L1T[i]  
+  std::vector<unsigned int> L1AlgoAcceptRandom_;      // # of Random events accepted by L1T[i]  
+  std::vector<unsigned int> L1Global_;                // Global # of Physics, Calibration and Random L1 triggers 
+
+  //Variables for confirming that prescale index did not change
+  unsigned int oldLumi;
+  unsigned int oldPrescaleIndex;
+
+ private:
+
+};
+#endif

--- a/HLTrigger/JSONMonitoring/plugins/BuildFile.xml
+++ b/HLTrigger/JSONMonitoring/plugins/BuildFile.xml
@@ -4,5 +4,6 @@
   <use   name="FWCore/Utilities"/>
   <use   name="HLTrigger/HLTcore"/>
   <use   name="EventFilter/Utilities"/>
+  <use   name="L1Trigger/L1TGlobal"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -1,0 +1,473 @@
+/** \class HLTriggerJSONMonitoring
+ *  
+ * See header file for documentation
+ *
+ * 
+ *  \author Aram Avetisyan
+ * 
+ */
+
+#include "HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+
+#include <fstream>
+using namespace jsoncollector;
+
+HLTriggerJSONMonitoring::HLTriggerJSONMonitoring(const edm::ParameterSet& ps) :
+  triggerResults_(ps.getParameter<edm::InputTag>("triggerResults")),
+  triggerResultsToken_(consumes<edm::TriggerResults>(triggerResults_))
+{
+
+                                                     
+}
+
+HLTriggerJSONMonitoring::~HLTriggerJSONMonitoring()
+{
+}
+
+void
+HLTriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("triggerResults",edm::InputTag("TriggerResults","","HLT"));
+  descriptions.add("HLTriggerJSONMonitoring", desc);
+}
+
+void
+HLTriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  using namespace std;
+  using namespace edm;
+
+  processed_++;
+  
+  //Get hold of TriggerResults  
+  Handle<TriggerResults> HLTR;
+  if (not iEvent.getByToken(triggerResultsToken_, HLTR) or not HLTR.isValid()){
+    LogDebug("HLTriggerJSONMonitoring") << "HLT TriggerResults with label ["+triggerResults_.encode()+"] not found!" << std::endl;
+    return;
+  }
+
+  //Decision for each HLT path   
+  const unsigned int n(hltNames_.size());
+  for (unsigned int i=0; i<n; i++) {
+    if (HLTR->wasrun(i))                     hltWasRun_[i]++;
+    if (HLTR->accept(i))                     hltAccept_[i]++;
+    if (HLTR->wasrun(i) && !HLTR->accept(i)) hltReject_[i]++;
+    if (HLTR->error(i))                      hltErrors_[i]++;
+    //Count L1 seeds and Prescales   
+    const int index(static_cast<int>(HLTR->index(i)));
+    if (HLTR->accept(i)) {
+      if (index >= posL1s_[i]) hltL1s_[i]++;
+      if (index >= posPre_[i]) hltPre_[i]++;
+    } else {
+      if (index >  posL1s_[i]) hltL1s_[i]++;
+      if (index >  posPre_[i]) hltPre_[i]++;
+    }
+  }
+
+  //Decision for each HLT dataset     
+  std::vector<bool> acceptedByDS(hltIndex_.size(), false);
+  for (unsigned int ds=0; ds < hltIndex_.size(); ds++) {  // ds = index of dataset       
+    for (unsigned int p=0; p<hltIndex_[ds].size(); p++) {   // p = index of path with dataset ds       
+      if (acceptedByDS[ds]>0 || HLTR->accept(hltIndex_[ds][p]) ) {
+	acceptedByDS[ds] = true;
+      }
+    }
+    if (acceptedByDS[ds]) hltDatasets_[ds]++;
+  }
+
+}//End analyze function     
+
+void
+HLTriggerJSONMonitoring::resetRun(bool changed){
+
+  //Update trigger and dataset names, clear L1 names and counters   
+  if (changed){
+    hltNames_        = hltConfig_.triggerNames();
+    datasetNames_    = hltConfig_.datasetNames();
+    datasetContents_ = hltConfig_.datasetContents();
+  }
+
+  const unsigned int n  = hltNames_.size();
+  const unsigned int d  = datasetNames_.size();
+
+  if (changed) {
+    //Resize per-path counters   
+    hltWasRun_.resize(n);
+    hltL1s_.resize(n);
+    hltPre_.resize(n);
+    hltAccept_.resize(n);
+    hltReject_.resize(n);
+    hltErrors_.resize(n);
+
+    //Resize per-dataset counter    
+    hltDatasets_.resize(d);
+    //Resize htlIndex     
+    hltIndex_.resize(d);
+    //Set-up hltIndex          
+    for (unsigned int ds = 0; ds < d; ds++) {
+      unsigned int size = datasetContents_[ds].size();
+      hltIndex_[ds].reserve(size);
+      for (unsigned int p = 0; p < size; p++) {
+	unsigned int i = hltConfig_.triggerIndex(datasetContents_[ds][p]);
+	if (i<n) {
+	  hltIndex_[ds].push_back(i);
+	}
+      }
+    }
+    //Find the positions of seeding and prescaler modules     
+    posL1s_.resize(n);
+    posPre_.resize(n);
+    for (unsigned int i = 0; i < n; ++i) {
+      posL1s_[i] = -1;
+      posPre_[i] = -1;
+      const std::vector<std::string> & moduleLabels(hltConfig_.moduleLabels(i));
+      for (unsigned int j = 0; j < moduleLabels.size(); ++j) {
+	const std::string & label = hltConfig_.moduleType(moduleLabels[j]);
+	if (label == "HLTLevel1GTSeed")
+	  posL1s_[i] = j;
+	else if (label == "HLTPrescaler")
+	  posPre_[i] = j;
+      }
+    }
+  }
+  resetLumi();
+}//End resetRun function                  
+
+void
+HLTriggerJSONMonitoring::resetLumi(){
+  //Reset total number of events     
+  processed_ = 0;
+
+  //Reset per-path counters 
+  for (unsigned int i = 0; i < hltWasRun_.size(); i++) {
+    hltWasRun_[i] = 0;
+    hltL1s_[i]    = 0;
+    hltPre_[i]    = 0;
+    hltAccept_[i] = 0;
+    hltReject_[i] = 0;
+    hltErrors_[i] = 0;
+  }
+  //Reset per-dataset counter         
+  for (unsigned int i = 0; i < hltDatasets_.size(); i++) {
+    hltDatasets_[i] = 0;
+  }
+
+}//End resetLumi function  
+
+void
+HLTriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
+{
+  //Get the run directory from the EvFDaqDirector                
+  if (edm::Service<evf::EvFDaqDirector>().isAvailable()) baseRunDir_ = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
+  else                                                   baseRunDir_ = ".";
+
+  std::string monPath = baseRunDir_ + "/";
+
+  //Initialize hltConfig_     
+  bool changed = true;
+  if (hltConfig_.init(iRun, iSetup, triggerResults_.process(), changed)) resetRun(changed);
+  else{
+    LogDebug("HLTriggerJSONMonitoring") << "HLTConfigProvider initialization failed!" << std::endl;
+    return;
+  }
+
+  //Write the once-per-run files if not already written
+  //Eventually must rewrite this with proper multithreading (i.e. globalBeginRun)
+  bool expected = false;
+  if( runCache()->wroteFiles.compare_exchange_strong(expected, true) ){
+    runCache()->wroteFiles = true;
+
+    unsigned int nRun = iRun.run();
+    
+    //Create definition file for HLT Rates                 
+    std::stringstream ssHltJsd;
+    ssHltJsd << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000";
+    ssHltJsd << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
+    stHltJsd_ = ssHltJsd.str();
+
+    writeHLTDefJson(baseRunDir_ + "/" + stHltJsd_);
+        
+    //Write ini files
+    //HLT
+    Json::Value hltIni;
+    Json::StyledWriter writer;
+
+    Json::Value hltNamesVal(Json::arrayValue);
+    for (unsigned int ui = 0; ui < hltNames_.size(); ui++){
+      hltNamesVal.append(hltNames_.at(ui));
+    }
+
+    Json::Value datasetNamesVal(Json::arrayValue);
+    for (unsigned int ui = 0; ui < datasetNames_.size(); ui++){
+      datasetNamesVal.append(datasetNames_.at(ui));
+    }
+
+    hltIni["Path-Names"]    = hltNamesVal;
+    hltIni["Dataset-Names"] = datasetNamesVal;
+    
+    std::string && result = writer.write(hltIni);
+  
+    std::stringstream ssHltIni;
+    ssHltIni << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".ini";
+    
+    std::ofstream outHltIni( monPath + ssHltIni.str() );
+    outHltIni<<result;
+    outHltIni.close();
+  }
+
+}//End beginRun function        
+
+void HLTriggerJSONMonitoring::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup){ resetLumi(); }
+
+std::shared_ptr<hltJson::lumiVars>
+HLTriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext)
+{
+  std::shared_ptr<hltJson::lumiVars> iSummary(new hltJson::lumiVars);
+
+  unsigned int MAXPATHS = 1000;
+
+  iSummary->processed = new HistoJ<unsigned int>(1, 1);
+
+  iSummary->hltWasRun = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltL1s    = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltPre    = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltAccept = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltReject = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltErrors = new HistoJ<unsigned int>(1, MAXPATHS);
+
+  iSummary->hltDatasets = new HistoJ<unsigned int>(1, MAXPATHS);
+
+  iSummary->baseRunDir           = "";
+  iSummary->stHltJsd             = "";
+  iSummary->streamHLTDestination = "";
+
+  return iSummary;
+}//End globalBeginLuminosityBlockSummary function  
+
+void
+HLTriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup, hltJson::lumiVars* iSummary) const{
+
+  //Whichever stream gets there first does the initialiazation 
+  if (iSummary->hltWasRun->value().size() == 0){
+    iSummary->processed->update(processed_);
+
+    for (unsigned int ui = 0; ui < hltWasRun_.size(); ui++){
+      iSummary->hltWasRun->update(hltWasRun_.at(ui));
+      iSummary->hltL1s   ->update(hltL1s_   .at(ui));
+      iSummary->hltPre   ->update(hltPre_   .at(ui));
+      iSummary->hltAccept->update(hltAccept_.at(ui));
+      iSummary->hltReject->update(hltReject_.at(ui));
+      iSummary->hltErrors->update(hltErrors_.at(ui));
+    }
+    for (unsigned int ui = 0; ui < hltDatasets_.size(); ui++){
+      iSummary->hltDatasets->update(hltDatasets_.at(ui));
+    }
+
+    iSummary->stHltJsd   = stHltJsd_;
+    iSummary->baseRunDir = baseRunDir_;
+    
+    iSummary->streamHLTDestination = runCache()->streamHLTDestination;
+  }
+
+  else{
+    iSummary->processed->value().at(0) += processed_;
+
+    for (unsigned int ui = 0; ui < hltWasRun_.size(); ui++){
+      iSummary->hltWasRun->value().at(ui) += hltWasRun_.at(ui);
+      iSummary->hltL1s   ->value().at(ui) += hltL1s_   .at(ui);
+      iSummary->hltPre   ->value().at(ui) += hltPre_   .at(ui);
+      iSummary->hltAccept->value().at(ui) += hltAccept_.at(ui);
+      iSummary->hltReject->value().at(ui) += hltReject_.at(ui);
+      iSummary->hltErrors->value().at(ui) += hltErrors_.at(ui);
+    }
+    for (unsigned int ui = 0; ui < hltDatasets_.size(); ui++){
+      iSummary->hltDatasets->value().at(ui) += hltDatasets_.at(ui);
+    }
+  }
+
+}//End endLuminosityBlockSummary function                                             
+
+
+void
+HLTriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, hltJson::lumiVars* iSummary)
+{
+
+  unsigned int iLs  = iLumi.luminosityBlock();
+  unsigned int iRun = iLumi.run();
+
+  bool writeFiles=true;
+  if (edm::Service<evf::MicroStateService>().isAvailable()) {
+    evf::FastMonitoringService * fms = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
+    if (fms) {
+      writeFiles = fms->shouldWriteFiles(iLumi.luminosityBlock());
+    }
+  }
+
+  if (writeFiles) {
+    Json::StyledWriter writer;
+
+    char hostname[33];
+    gethostname(hostname,32);
+    std::string sourceHost(hostname);
+
+    //Get the output directory                                        
+    std::string monPath = iSummary->baseRunDir + "/";
+
+    std::stringstream sOutDef;
+    sOutDef << monPath << "output_" << getpid() << ".jsd";
+
+    //Write the .jsndata files which contain the actual rates
+    //HLT .jsndata file
+    Json::Value hltJsnData;
+    hltJsnData[DataPoint::SOURCE] = sourceHost;
+    hltJsnData[DataPoint::DEFINITION] = iSummary->stHltJsd;
+
+    hltJsnData[DataPoint::DATA].append(iSummary->processed->toJsonValue());
+    hltJsnData[DataPoint::DATA].append(iSummary->hltWasRun->toJsonValue());
+    hltJsnData[DataPoint::DATA].append(iSummary->hltL1s   ->toJsonValue());
+    hltJsnData[DataPoint::DATA].append(iSummary->hltPre   ->toJsonValue());
+    hltJsnData[DataPoint::DATA].append(iSummary->hltAccept->toJsonValue());
+    hltJsnData[DataPoint::DATA].append(iSummary->hltReject->toJsonValue());
+    hltJsnData[DataPoint::DATA].append(iSummary->hltErrors->toJsonValue());
+
+    hltJsnData[DataPoint::DATA].append(iSummary->hltDatasets->toJsonValue());
+
+    std::string && result = writer.write(hltJsnData);
+
+    std::stringstream ssHltJsnData;
+    ssHltJsnData <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssHltJsnData << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsndata";
+
+    if (iSummary->processed->value().at(0)!=0) {
+      std::ofstream outHltJsnData( monPath + ssHltJsnData.str() );
+      outHltJsnData<<result;
+      outHltJsnData.close();
+    }
+
+    //HLT jsn entries
+    StringJ hltJsnFilelist;
+    IntJ hltJsnFilesize    = 0;
+    unsigned int hltJsnFileAdler32 = 1;
+    if (iSummary->processed->value().at(0)!=0) {
+      hltJsnFilelist.update(ssHltJsnData.str());
+      hltJsnFilesize    = result.size();
+      hltJsnFileAdler32 = cms::Adler32(result.c_str(),result.size());
+    }
+    StringJ hltJsnInputFiles;
+    hltJsnInputFiles.update("");
+
+    //Create special DAQ JSON file for L1 and HLT rates pseudo-streams
+    //Only three variables are different between the files: 
+    //the file list, the file size and the Adler32 value
+    IntJ daqJsnProcessed   = iSummary->processed->value().at(0);
+    IntJ daqJsnAccepted    = daqJsnProcessed;
+    IntJ daqJsnErrorEvents = 0;                  
+    IntJ daqJsnRetCodeMask = 0;                 
+    IntJ daqJsnHLTErrorEvents = 0;                  
+
+    //write out HLT metadata jsn
+    Json::Value hltDaqJsn;
+    hltDaqJsn[DataPoint::SOURCE] = sourceHost;
+    hltDaqJsn[DataPoint::DEFINITION] = sOutDef.str();
+
+    hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnProcessed.value());
+    hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnAccepted.value());
+    hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnErrorEvents.value());
+    hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnRetCodeMask.value());
+    hltDaqJsn[DataPoint::DATA].append(hltJsnFilelist.value());
+    hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFilesize.value());
+    hltDaqJsn[DataPoint::DATA].append(hltJsnInputFiles.value());
+    hltDaqJsn[DataPoint::DATA].append(hltJsnFileAdler32);
+    hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTDestination);
+    hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnHLTErrorEvents.value());
+
+    result = writer.write(hltDaqJsn);
+
+    std::stringstream ssHltDaqJsn;
+    ssHltDaqJsn <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssHltDaqJsn << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
+
+    std::ofstream outHltDaqJsn( monPath + ssHltDaqJsn.str() );
+    outHltDaqJsn<<result;
+    outHltDaqJsn.close();
+  }
+
+  //Delete the individual HistoJ pointers   
+  delete iSummary->processed;
+
+  delete iSummary->hltWasRun;
+  delete iSummary->hltL1s   ;
+  delete iSummary->hltPre   ;
+  delete iSummary->hltAccept;
+  delete iSummary->hltReject;
+  delete iSummary->hltErrors;
+
+  delete iSummary->hltDatasets;
+
+  //Note: Do not delete the iSummary pointer. The framework does something with it later on    
+  //      and deleting it results in a segmentation fault.  
+
+}//End globalEndLuminosityBlockSummary function     
+
+
+void
+HLTriggerJSONMonitoring::writeHLTDefJson(std::string path){
+
+  std::ofstream outfile( path );
+  outfile << "{" << std::endl;
+  outfile << "   \"data\" : [" << std::endl;
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Processed\"," ;  //***  
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Path-WasRun\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Path-AfterL1Seed\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Path-AfterPrescale\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Path-Accepted\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Path-Rejected\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Path-Errors\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Dataset-Accepted\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}" << std::endl;
+
+  outfile << "   ]" << std::endl;
+  outfile << "}" << std::endl;
+
+  outfile.close();
+}//End writeHLTDefJson function                    

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -1,0 +1,452 @@
+/** \class L1TriggerJSONMonitoring
+ *  
+ * See header file for documentation
+ *
+ * 
+ *  \author Aram Avetisyan
+ * 
+ */
+
+#include "HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+
+#include <fstream>
+using namespace jsoncollector;
+
+L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(const edm::ParameterSet& ps) :
+  level1Results_(ps.getParameter<edm::InputTag>("L1Results")),   
+  level1ResultsToken_(consumes<GlobalAlgBlkBxCollection>(level1Results_))             
+{
+
+                                                     
+}
+
+L1TriggerJSONMonitoring::~L1TriggerJSONMonitoring()
+{
+}
+
+void
+L1TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("L1Results",edm::InputTag("hltGtStage2Digis"));                
+  descriptions.add("L1TMonitoring", desc);
+}
+
+void
+L1TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  using namespace std;
+  using namespace edm;
+
+  processed_++;
+
+  int ex = iEvent.experimentType();
+  if      (ex == 1) L1Global_[0]++; 
+  else if (ex == 2) L1Global_[1]++;
+  else if (ex == 3) L1Global_[2]++;
+  else{
+    LogDebug("L1TriggerJSONMonitoring") << "Not Physics, Calibration or Random. experimentType = " << ex << std::endl;
+  }   
+
+  //Get hold of L1TResults 
+  edm::Handle<GlobalAlgBlkBxCollection> l1tResults;
+  if (not iEvent.getByToken(level1ResultsToken_, l1tResults) or (l1tResults->begin(0) == l1tResults->end(0))){
+    LogDebug("L1TriggerJSONMonitoring") << "Could not get L1 trigger results" << std::endl;
+    return;
+  }
+  
+  //The GlobalAlgBlkBxCollection is a vector of vectors, but the second layer can only ever
+  //have one entry since there can't be more than one collection per bunch crossing. The "0"
+  //here means BX = 0, the "begin" is used to access the first and only element
+  std::vector<GlobalAlgBlk>::const_iterator algBlk = l1tResults->begin(0);
+  
+  for (unsigned int i = 0; i < algBlk->maxPhysicsTriggers; i++){
+    if (algBlk->getAlgoDecisionFinal(i)){
+      L1AlgoAccept_[i]++;
+      if (ex == 1) L1AlgoAcceptPhysics_[i]++;
+      if (ex == 2) L1AlgoAcceptCalibration_[i]++;
+      if (ex == 3) L1AlgoAcceptRandom_[i]++;
+    }
+  }  
+  
+  //Prescale index
+  prescaleIndex_ = static_cast<unsigned int>(algBlk->getPreScColumn());
+  
+  //Check that the prescale index hasn't changed inside a lumi section
+  unsigned int newLumi = (unsigned int) iEvent.eventAuxiliary().luminosityBlock();
+  if (oldLumi == newLumi and prescaleIndex_ != oldPrescaleIndex){
+    LogWarning("L1TriggerJSONMonitoring")<<"Prescale index has changed from "<<oldPrescaleIndex<<" to "<<prescaleIndex_<<" inside lumi section "<<newLumi;
+  }
+  oldLumi = newLumi;
+  oldPrescaleIndex = prescaleIndex_;
+
+}//End analyze function     
+
+void
+L1TriggerJSONMonitoring::resetLumi(){
+  //Reset total number of events     
+  processed_ = 0;
+
+  //Reset per-path counters 
+  //Reset L1 per-algo counters -     
+  for (unsigned int i = 0; i < L1AlgoAccept_.size(); i++) {
+    L1AlgoAccept_[i]            = 0;
+    L1AlgoAcceptPhysics_[i]     = 0;
+    L1AlgoAcceptCalibration_[i] = 0;
+    L1AlgoAcceptRandom_[i]      = 0;
+  }
+  //Reset L1 global counters -      
+  for (unsigned int i = 0; i < L1GlobalType_.size(); i++) {
+    L1Global_[i] = 0;
+  }
+
+  //Prescale index
+  prescaleIndex_ = 100;
+
+}//End resetLumi function  
+
+void
+L1TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
+{
+  edm::ESHandle<L1TUtmTriggerMenu> l1GtMenu;
+  iSetup.get<L1TUtmTriggerMenuRcd>().get(l1GtMenu);
+
+  //Get the run directory from the EvFDaqDirector                
+  if (edm::Service<evf::EvFDaqDirector>().isAvailable()) baseRunDir_ = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
+  else                                                   baseRunDir_ = ".";
+
+  std::string monPath = baseRunDir_ + "/";
+
+  //Need this to get at maximum number of triggers
+  GlobalAlgBlk alg = GlobalAlgBlk();
+
+  //Update trigger and dataset names, clear L1 names and counters   
+  L1AlgoNames_.resize(alg.maxPhysicsTriggers);         
+  for (unsigned int i = 0; i < L1AlgoNames_.size(); i++) {
+    L1AlgoNames_.at(i) = "";
+  }
+  
+  //Get L1 algorithm trigger names -      
+  const L1TUtmTriggerMenu* m_l1GtMenu;
+  const std::map<std::string, L1TUtmAlgorithm>* m_algorithmMap;
+
+  m_l1GtMenu = l1GtMenu.product();
+  m_algorithmMap = &(m_l1GtMenu->getAlgorithmMap());
+
+  for (std::map<std::string, L1TUtmAlgorithm>::const_iterator itAlgo = m_algorithmMap->begin(); itAlgo != m_algorithmMap->end(); itAlgo++) {
+    int bitNumber = (itAlgo->second).getIndex();
+    L1AlgoNames_.at(bitNumber) = itAlgo->first;
+  }
+  
+  L1GlobalType_.clear();   
+  L1Global_.clear();     
+  
+  //Set the experimentType -          
+  L1GlobalType_.push_back( "Physics" );
+  L1GlobalType_.push_back( "Calibration" );
+  L1GlobalType_.push_back( "Random" );
+
+  const unsigned int la = L1AlgoNames_.size();       
+  const unsigned int lg = L1GlobalType_.size();      
+  
+  //Resize per-path counters   
+  L1AlgoAccept_.resize(la);         
+  L1AlgoAcceptPhysics_.resize(la);         
+  L1AlgoAcceptCalibration_.resize(la);         
+  L1AlgoAcceptRandom_.resize(la);         
+  
+  L1Global_.resize(lg);                 
+  
+  resetLumi();
+
+  //Write the once-per-run files if not already written
+  //Eventually must rewrite this with proper multithreading (i.e. globalBeginRun)
+  bool expected = false;
+  if( runCache()->wroteFiles.compare_exchange_strong(expected, true) ){
+    runCache()->wroteFiles = true;
+
+    unsigned int nRun = iRun.run();
+        
+    //Create definition file for L1 Rates -  
+    std::stringstream ssL1Jsd;
+    ssL1Jsd << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000";
+    ssL1Jsd << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
+    stL1Jsd_ = ssL1Jsd.str();
+
+    writeL1DefJson(baseRunDir_ + "/" + stL1Jsd_);
+    
+    //Write ini files    
+    //L1
+    Json::Value l1Ini;
+    Json::StyledWriter writer;
+
+    Json::Value l1AlgoNamesVal(Json::arrayValue);
+    for (unsigned int ui = 0; ui < L1AlgoNames_.size(); ui++){
+      l1AlgoNamesVal.append(L1AlgoNames_.at(ui));
+    }
+
+    Json::Value eventTypeVal(Json::arrayValue);
+    for (unsigned int ui = 0; ui < L1GlobalType_.size(); ui++){
+      eventTypeVal.append(L1GlobalType_.at(ui));
+    }
+
+    l1Ini["L1-Algo-Names"] = l1AlgoNamesVal;
+    l1Ini["Event-Type"]    = eventTypeVal;
+    
+    std::string && result = writer.write(l1Ini);
+  
+    std::stringstream ssL1Ini;
+    ssL1Ini << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".ini";
+    
+    std::ofstream outL1Ini( monPath + ssL1Ini.str() );
+    outL1Ini<<result;
+    outL1Ini.close();
+  }
+
+  //Initialize variables for verification of prescaleIndex
+  oldLumi          = 0;
+  oldPrescaleIndex = 100;
+
+}//End beginRun function        
+
+void L1TriggerJSONMonitoring::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup){ resetLumi(); }
+
+std::shared_ptr<l1Json::lumiVars>
+L1TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext)
+{
+  std::shared_ptr<l1Json::lumiVars> iSummary(new l1Json::lumiVars);
+
+  unsigned int MAXPATHS = 512;
+
+  iSummary->processed = new HistoJ<unsigned int>(1, 1);
+
+  iSummary->prescaleIndex = 100;
+
+  iSummary->L1AlgoAccept            = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1AlgoAcceptPhysics     = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1AlgoAcceptCalibration = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1AlgoAcceptRandom      = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1Global                = new HistoJ<unsigned int>(1, MAXPATHS);  
+
+  iSummary->baseRunDir           = "";
+  iSummary->stL1Jsd              = "";
+  iSummary->streamL1Destination  = "";
+
+  return iSummary;
+}//End globalBeginLuminosityBlockSummary function  
+
+void
+L1TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup, l1Json::lumiVars* iSummary) const{
+
+  //Whichever stream gets there first does the initialiazation 
+  if (iSummary->L1AlgoAccept->value().size() == 0){
+    iSummary->processed->update(processed_);
+
+    iSummary->prescaleIndex = prescaleIndex_;
+
+    iSummary->baseRunDir = baseRunDir_;
+    
+    for (unsigned int ui = 0; ui < L1AlgoAccept_.size(); ui++){    
+      iSummary->L1AlgoAccept           ->update(L1AlgoAccept_.at(ui));
+      iSummary->L1AlgoAcceptPhysics    ->update(L1AlgoAcceptPhysics_.at(ui));
+      iSummary->L1AlgoAcceptCalibration->update(L1AlgoAcceptCalibration_.at(ui));
+      iSummary->L1AlgoAcceptRandom     ->update(L1AlgoAcceptRandom_.at(ui));
+    }
+    for (unsigned int ui = 0; ui < L1GlobalType_.size(); ui++){    
+      iSummary->L1Global    ->update(L1Global_.at(ui));
+    }
+    iSummary->stL1Jsd = stL1Jsd_;      
+
+    iSummary->streamL1Destination  = runCache()->streamL1Destination;
+  }
+
+  else{
+    iSummary->processed->value().at(0) += processed_;
+
+    for (unsigned int ui = 0; ui < L1AlgoAccept_.size(); ui++){                             
+      iSummary->L1AlgoAccept->value().at(ui)            += L1AlgoAccept_.at(ui);
+      iSummary->L1AlgoAcceptPhysics->value().at(ui)     += L1AlgoAcceptPhysics_.at(ui);
+      iSummary->L1AlgoAcceptCalibration->value().at(ui) += L1AlgoAcceptCalibration_.at(ui);
+      iSummary->L1AlgoAcceptRandom->value().at(ui)      += L1AlgoAcceptRandom_.at(ui);
+    }
+    for (unsigned int ui = 0; ui < L1Global_.size(); ui++){                               
+      iSummary->L1Global->value().at(ui) += L1Global_.at(ui);
+    }
+
+  }
+
+}//End endLuminosityBlockSummary function                                             
+
+
+void
+L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, l1Json::lumiVars* iSummary)
+{
+
+  unsigned int iLs  = iLumi.luminosityBlock();
+  unsigned int iRun = iLumi.run();
+
+  bool writeFiles=true;
+  if (edm::Service<evf::MicroStateService>().isAvailable()) {
+    evf::FastMonitoringService * fms = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
+    if (fms) {
+      writeFiles = fms->shouldWriteFiles(iLumi.luminosityBlock());
+    }
+  }
+
+  if (writeFiles) {
+    Json::StyledWriter writer;
+
+    char hostname[33];
+    gethostname(hostname,32);
+    std::string sourceHost(hostname);
+
+    //Get the output directory                                        
+    std::string monPath = iSummary->baseRunDir + "/";
+
+    std::stringstream sOutDef;
+    sOutDef << monPath << "output_" << getpid() << ".jsd";
+
+    //Write the .jsndata files which contain the actual rates
+    //L1 .jsndata file
+    Json::Value l1JsnData;
+    l1JsnData[DataPoint::SOURCE] = sourceHost;
+    l1JsnData[DataPoint::DEFINITION] = iSummary->stL1Jsd;
+
+    l1JsnData[DataPoint::DATA].append(iSummary->processed->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAccept           ->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAcceptPhysics    ->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAcceptCalibration->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAcceptRandom     ->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1Global               ->toJsonValue());      
+
+    l1JsnData[DataPoint::DATA].append(iSummary->prescaleIndex);
+
+    std::string && result = writer.write(l1JsnData);
+
+    std::stringstream ssL1JsnData;
+    ssL1JsnData << "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssL1JsnData << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsndata";
+
+    if (iSummary->processed->value().at(0)!=0) {
+      std::ofstream outL1JsnData( monPath + "/" + ssL1JsnData.str() );
+      outL1JsnData<<result;
+      outL1JsnData.close();
+    }
+
+    //L1 jsn entries
+    StringJ l1JsnFilelist;
+    IntJ l1JsnFilesize    = 0;
+    unsigned int l1JsnFileAdler32 = 1;
+    if (iSummary->processed->value().at(0)!=0) {
+      l1JsnFilelist.update(ssL1JsnData.str());
+      l1JsnFilesize    = result.size();
+      l1JsnFileAdler32 = cms::Adler32(result.c_str(),result.size());
+    }
+    StringJ l1JsnInputFiles;
+    l1JsnInputFiles.update("");
+
+    //Create special DAQ JSON file for L1 and HLT rates pseudo-streams
+    //Only three variables are different between the files: 
+    //the file list, the file size and the Adler32 value
+    IntJ daqJsnProcessed   = iSummary->processed->value().at(0);
+    IntJ daqJsnAccepted    = daqJsnProcessed;
+    IntJ daqJsnErrorEvents = 0;                  
+    IntJ daqJsnRetCodeMask = 0;                 
+    IntJ daqJsnHLTErrorEvents = 0;                  
+
+    //write out L1 metadata jsn
+    Json::Value l1DaqJsn;
+    l1DaqJsn[DataPoint::SOURCE] = sourceHost;
+    l1DaqJsn[DataPoint::DEFINITION] = sOutDef.str();
+
+    l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnProcessed.value());
+    l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnAccepted.value());
+    l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnErrorEvents.value());
+    l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnRetCodeMask.value());
+    l1DaqJsn[DataPoint::DATA].append(l1JsnFilelist.value());
+    l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFilesize.value());
+    l1DaqJsn[DataPoint::DATA].append(l1JsnInputFiles.value());
+    l1DaqJsn[DataPoint::DATA].append(l1JsnFileAdler32);
+    l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1Destination);
+    l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnHLTErrorEvents.value());
+
+    result = writer.write(l1DaqJsn);
+
+    std::stringstream ssL1DaqJsn;
+    ssL1DaqJsn <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssL1DaqJsn << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
+
+    std::ofstream outL1DaqJsn( monPath + ssL1DaqJsn.str() );
+    outL1DaqJsn<<result;
+    outL1DaqJsn.close();
+  }
+
+  //Delete the individual HistoJ pointers   
+  delete iSummary->processed;
+
+  delete iSummary->L1AlgoAccept;         
+  delete iSummary->L1AlgoAcceptPhysics;         
+  delete iSummary->L1AlgoAcceptCalibration;         
+  delete iSummary->L1AlgoAcceptRandom;         
+  delete iSummary->L1Global;                       
+
+  //Note: Do not delete the iSummary pointer. The framework does something with it later on    
+  //      and deleting it results in a segmentation fault.  
+
+}//End globalEndLuminosityBlockSummary function     
+
+void
+L1TriggerJSONMonitoring::writeL1DefJson(std::string path){              
+
+  std::ofstream outfile( path );
+  outfile << "{" << std::endl;
+  outfile << "   \"data\" : [" << std::endl;
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Processed\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted-Physics\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted-Calibration\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted-Random\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-Global\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Prescale-Index\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"sample\"}" << std::endl;
+
+  outfile << "   ]" << std::endl;
+  outfile << "}" << std::endl;
+
+  outfile.close();
+}//End writeL1DefJson function            
+

--- a/HLTrigger/JSONMonitoring/plugins/SealModule.cc
+++ b/HLTrigger/JSONMonitoring/plugins/SealModule.cc
@@ -1,5 +1,9 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h"
+#include "HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h"
+#include "HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h"
 
+DEFINE_FWK_MODULE(HLTriggerJSONMonitoring);
+DEFINE_FWK_MODULE(L1TriggerJSONMonitoring);
 DEFINE_FWK_MODULE(TriggerJSONMonitoring);

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -414,10 +414,10 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
 
 void TriggerJSONMonitoring::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup){ resetLumi(); }
 
-std::shared_ptr<hltJson::lumiVars>
+std::shared_ptr<trigJson::lumiVars>
 TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext)
 {
-  std::shared_ptr<hltJson::lumiVars> iSummary(new hltJson::lumiVars);
+  std::shared_ptr<trigJson::lumiVars> iSummary(new trigJson::lumiVars);
 
   unsigned int MAXPATHS = 500;
 
@@ -454,7 +454,7 @@ TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBl
 }//End globalBeginLuminosityBlockSummary function  
 
 void
-TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup, hltJson::lumiVars* iSummary) const{
+TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup, trigJson::lumiVars* iSummary) const{
 
   //Whichever stream gets there first does the initialiazation 
   if (iSummary->hltWasRun->value().size() == 0){
@@ -533,7 +533,7 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
 
 
 void
-TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, hltJson::lumiVars* iSummary)
+TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, trigJson::lumiVars* iSummary)
 {
 
   unsigned int iLs  = iLumi.luminosityBlock();


### PR DESCRIPTION
This is hopefully the final form of the JSON monitoring for this year. TriggerJSONMonitoring has been split into L1TriggerJSONMonitoring and HLTriggerJSONMonitoring. The HLT JSON file is very similar to what it was (the only difference is that the prescale index is no longer stored there). The L1 JSON file is completely different: technical triggers are gone, algorithm tables are now 512 bits and the prescale index has been moved to here.

The old TriggerJSONMonitoring is still there for now so as to be able to easily revert in case we run into problems. The only change to it is the one of the namespace names. It will be deleted once the new way is proven to work.
