### PR TITLE
Use bin center for HGCal UncalibHits + Speedup in Digitizer

### DIFF
--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -33,10 +33,10 @@ public:
   void setData(uint16_t data)           { setWord(data, kDataMask,   kDataShift);   }
   void set(bool thr, bool mode,uint16_t toa, uint16_t data) 
   { 
-    setThreshold(thr);
-    setMode(mode);
-    setToA(toa);
-    setData(data);
+    value_ = ( ( (uint32_t)thr  & kThreshMask ) << kThreshShift | 
+               ( (uint32_t)mode & kModeMask   ) << kModeShift   |
+               ( (uint32_t)toa  & kToAMask    ) << kToAShift    | 
+               ( (uint32_t)data & kDataMask   ) << kDataShift     );    
   }  
   void print(std::ostream &out=std::cout)
   {
@@ -65,9 +65,10 @@ private:
   void setWord(uint32_t word, uint32_t mask, uint32_t pos)
   {
     //clear required bits
-    value_ &= ~((word & mask) << pos); 
+    const uint32_t masked_word = (word & mask) << pos;
+    value_ &= ~(masked_word); 
     //now set the new value
-    value_ |= ((word & mask) << pos);
+    value_ |= (masked_word);
   }
 
   // a 32-bit word

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -65,7 +65,9 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
         //to get a continuous energy spectrum we must add here the maximum value in fC ever
         //reported by the ADC. Namely: floor(tdcOnset/adcLSB_) * adcLSB_
         // need to increment by one so TDC doesn't overlap with ADC last bin
-	amplitude_ = ( std::floor(tdcOnsetfC_/adcLSB_) + 1.0 )* adcLSB_ + double(sample.data()) * tdcLSB_;
+        // LG (11/04/2016):
+        // offset the TDC upwards to reflect the bin center
+	amplitude_ = ( std::floor(tdcOnsetfC_/adcLSB_) + 1.0 )* adcLSB_ + ( double(sample.data()) + 0.5) * tdcLSB_;
 	jitter_    = double(sample.toa()) * toaLSBToNS_;
 	LogDebug("HGCUncalibratedRecHit") << "TDC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << tdcLSB_ << std::endl

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -82,7 +82,8 @@ class HGCFEElectronics
   
   //private members
   uint32_t fwVersion_;
-  std::vector<double> adcPulse_,pulseAvgT_, tdcChargeDrainParameterisation_;
+  std::array<float,6> adcPulse_, pulseAvgT_;
+  std::vector<float> tdcChargeDrainParameterisation_;
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_,
     adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_, tdcResolutionInNs_; 
   uint32_t toaMode_;

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -24,6 +24,7 @@ hgceeDigitizer = cms.PSet(
             # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
             fwVersion         = cms.uint32(2),
             # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
+            #NOTE: this is a fixed-size array inside the simulation (for speed) change accordingly!
             adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
             pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 
             # n bits for the ADC 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -148,7 +148,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
   
   //configuration to apply for the computation of time-of-flight
   bool weightToAbyEnergy(false);
-  float tdcOnset(0),keV2fC(0.0);
+  float tdcOnset(0.f),keV2fC(0.f);
   switch( mySubDet_ ) {
   case ForwardSubdetector::HGCEE:
     weightToAbyEnergy = theHGCEEDigitizer_->toaModeByEnergy();

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -31,12 +31,12 @@ void HGCDigitizerBase<DFr>::runSimple(std::auto_ptr<HGCDigitizerBase::DColl> &co
       
       //convert total energy in GeV to charge (fC)
       //double totalEn=rawEn*1e6*keV2fC_;
-      double totalCharge=rawCharge;
+      float totalCharge=rawCharge;
       
       //add noise (in fC)
       //we assume it's randomly distributed and won't impact ToA measurement
-      totalCharge += std::max( CLHEP::RandGaussQ::shoot(engine,0,noise_fC_) , 0. );
-      if(totalCharge<0) totalCharge=0;
+      totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0,noise_fC_) , 0.f );
+      if(totalCharge<0.f) totalCharge=0.f;
       
       chargeColl[i]= totalCharge;
     }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -1,5 +1,8 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "FWCore/Utilities/interface/transform.h"
+
+#include "vdt/vdtMath.h"
 
 using namespace hgc_digi;
 
@@ -14,8 +17,18 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet &ps) :
   edm::LogVerbatim("HGCFE") << "[HGCFEElectronics] running with version " << fwVersion_ << std::endl;
   if( ps.exists("adcPulse") )                       
     {
-      adcPulse_  = ps.getParameter< std::vector<double> >("adcPulse");
-      pulseAvgT_ = ps.getParameter< std::vector<double> >("pulseAvgT");
+      auto temp = ps.getParameter< std::vector<double> >("adcPulse");
+      for( unsigned i = 0; i < temp.size(); ++i ) {
+        adcPulse_[i] = (float)temp[i];
+      }
+      // normalize adc pulse
+      for( unsigned i = 0; i < adcPulse_.size(); ++i ) {
+        adcPulse_[i] = adcPulse_[i]/adcPulse_[2];
+      }
+      temp = ps.getParameter< std::vector<double> >("pulseAvgT");
+      for( unsigned i = 0; i < temp.size(); ++i ) {
+        pulseAvgT_[i] = (float)temp[i];
+      }
     }
   adcSaturation_fC_=-1.0;
   if( ps.exists("adcNbits") )
@@ -42,7 +55,11 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet &ps) :
   if( ps.exists("adcThreshold_fC") )                adcThreshold_fC_                = ps.getParameter<double>("adcThreshold_fC");
   if( ps.exists("tdcOnset_fC") )                    tdcOnset_fC_                    = ps.getParameter<double>("tdcOnset_fC");
   if( ps.exists("toaLSB_ns") )                      toaLSB_ns_                      = ps.getParameter<double>("toaLSB_ns");
-  if( ps.exists("tdcChargeDrainParameterisation") ) tdcChargeDrainParameterisation_ = ps.getParameter< std::vector<double> >("tdcChargeDrainParameterisation");
+  if( ps.exists("tdcChargeDrainParameterisation") ) {
+    for( auto val : ps.getParameter< std::vector<double> >("tdcChargeDrainParameterisation") ) {
+      tdcChargeDrainParameterisation_.push_back((float)val);
+    }
+  }
   if( ps.exists("tdcResolutionInPs") )              tdcResolutionInNs_              = ps.getParameter<double>("tdcResolutionInPs")*1e-3; // convert to ns
   if( ps.exists("toaMode") )                        toaMode_                        = ps.getParameter<uint32_t>("toaMode");
 }
@@ -90,7 +107,7 @@ void HGCFEElectronics<DFr>::runSimpleShaper(DFr &dataFrame, HGCSimHitData& charg
   for(int it=0; it<(int)(chargeColl.size()); it++)
     {
       const float charge(chargeColl[it]);
-      if(charge==0) continue;
+      if(charge==0.f) continue;
             
 #ifdef EDM_ML_DEBUG
       debug|=(charge>adcThreshold_fC_);
@@ -102,7 +119,7 @@ void HGCFEElectronics<DFr>::runSimpleShaper(DFr &dataFrame, HGCSimHitData& charg
 	{
 	  if(it+ipulse<0) continue;
 	  if(it+ipulse>=(int)(dataFrame.size())) continue;
-	  const float chargeLeak=charge*adcPulse_[(ipulse+2)]/adcPulse_[2];
+          const float chargeLeak=charge*adcPulse_[(ipulse+2)];
 	  newCharge[it+ipulse]+= chargeLeak;
 	  
 	  if(debug) edm::LogVerbatim("HGCFE") << " | " << it+ipulse << " " << chargeLeak;
@@ -193,8 +210,6 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
         const float newIntegTime = ( ( tdcChargeDrainParameterisation_[poffset]*charge_mod + 
                                        tdcChargeDrainParameterisation_[poffset+1]            )*charge_mod +
                                        tdcChargeDrainParameterisation_[poffset+2] );
-                                      
-          
         
         const int newBusyBxs=std::floor(newIntegTime/25.f)+1;      
         
@@ -220,19 +235,14 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
         //add leakage from previous bunches in SARS ADC mode
         for(int jt=0; jt<it; ++jt)
           {
-            if(totFlags[jt] || busyFlags[jt]) continue;
+            const unsigned int deltaT=(it-jt);
+            if((deltaT+2) >  adcPulse_.size() || chargeColl[jt]==0.f || totFlags[jt] || busyFlags[jt]) continue;
             
-            const float chargeDep_jt(chargeColl[jt]);
-            if(chargeDep_jt==0) continue;
+            const float leakCharge = chargeColl[jt]*adcPulse_[deltaT+2];
+            totalCharge += leakCharge;
+            if(toaMode_==WEIGHTEDBYE) finalToA += leakCharge*pulseAvgT_[deltaT+2];
             
-            const int deltaT=(it-jt);
-            if(deltaT+2>=(int)(adcPulse_.size())) continue;
-            
-            const float leakCharge( chargeDep_jt*adcPulse_[deltaT+2]/adcPulse_[2] );
-            if(debug) edm::LogVerbatim("HGCFE") << "\t\t leaking " << chargeDep_jt << " fC @ deltaT=-" << deltaT << " -> +" << leakCharge << " with avgT=" << pulseAvgT_[deltaT+2] << std::endl;
-            
-            totalCharge  += leakCharge;
-            if(toaMode_==WEIGHTEDBYE) finalToA     += leakCharge*pulseAvgT_[deltaT+2];
+            if(debug) edm::LogVerbatim("HGCFE") << "\t\t leaking " << chargeColl[jt] << " fC @ deltaT=-" << deltaT << " -> +" << leakCharge << " with avgT=" << pulseAvgT_[deltaT+2] << std::endl;
           }
         
         //add contamination from posterior bunches
@@ -243,7 +253,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
             busyFlags[jt]=true; 
             
             const float extraCharge=chargeColl[jt];
-            if(extraCharge==0) continue;
+            if(extraCharge==0.f) continue;
             if(debug) edm::LogVerbatim("HGCFE") << "\t\t adding " << extraCharge << " fC @ deltaT=+" << (jt-it) << std::endl; 
             
             totalCharge += extraCharge;
@@ -264,7 +274,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
       if(it+busyBxs<(int)(newCharge.size())) 
 	{
 	  const float deltaT2nextBx((busyBxs*25-integTime));
-	  const float tdcOnsetLeakage(tdcOnset_fC_*exp(-deltaT2nextBx/tdcChargeDrainParameterisation_[11]));
+	  const float tdcOnsetLeakage(tdcOnset_fC_*vdt::fast_expf(-deltaT2nextBx/tdcChargeDrainParameterisation_[11]));
 	  if(debug) edm::LogVerbatim("HGCFE") << "\t Leaking remainder of TDC onset " << tdcOnset_fC_ 
 			                      << " fC, to be dissipated in " << deltaT2nextBx 
 			                      << " DeltaT/tau=" << deltaT2nextBx << " / " << tdcChargeDrainParameterisation_[11] 
@@ -272,28 +282,26 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	  newCharge[it+busyBxs] +=  tdcOnsetLeakage;
 	}
     }
-  
+
   //including the leakage from bunches in SARS ADC when not declared busy or in ToT
   for(int it=0; it<(int)(chargeColl.size()); it++)
     {
       //if busy, charge has been already integrated
       if(totFlags[it] || busyFlags[it]) continue;
-      const float charge(chargeColl[it]);
-      if(charge==0) continue;
-
+      if(chargeColl[it]==0.f) continue;
+      
       if(debug) edm::LogVerbatim("HGCFE") << "\t SARS ADC pulse activated @ " << it << " : ";
-      for(int ipulse=-2; ipulse<(int)(adcPulse_.size())-2; ipulse++)
+      for(int ipulse=0; ipulse<(int)(adcPulse_.size()); ipulse++)
 	{
-	  if(it+ipulse<0) continue;
-	  if(it+ipulse>=(int)(newCharge.size())) continue;
-
+          const int itoffset = it + ipulse - 2;
+	  if(itoffset<0) continue;
+	  if(itoffset>=(int)(newCharge.size())) continue;
 	  //notice that if the channel is already busy,
 	  //it has already been affected by the leakage of the SARS ADC
-	  if(totFlags[it] || busyFlags[it+ipulse]) continue;
-	  const float chargeLeak=charge*adcPulse_[(ipulse+2)]/adcPulse_[2];
-	  if(debug) edm::LogVerbatim("HGCFE") << " | " << it+ipulse << " " << chargeLeak << "( " << charge << "->";
-	  newCharge[it+ipulse]+=chargeLeak;
-	  if(debug) edm::LogVerbatim("HGCFE") << newCharge[it+ipulse] << ") ";
+	  if(totFlags[it] || busyFlags[itoffset]) continue;
+	  newCharge[itoffset]+=chargeColl[it]*adcPulse_[ipulse];
+          if(debug) edm::LogVerbatim("HGCFE") << " | " << itoffset << " " << chargeColl[it]*adcPulse_[ipulse] << "( " << chargeColl[it] << "->";
+	  if(debug) edm::LogVerbatim("HGCFE") << newCharge[itoffset] << ") ";
 	}
       
       if(debug) edm::LogVerbatim("HGCFE") << std::endl;
@@ -315,7 +323,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	      while(finalToA>25) finalToA-=25;
 
 	      //brute force saturation, maybe could to better with an exponential like saturation
-	      float saturatedCharge(std::min(newCharge[it],tdcSaturation_fC_));	      
+	      const float saturatedCharge(std::min(newCharge[it],tdcSaturation_fC_));	      
 	      newSample.set(true,true,finalToA/toaLSB_ns_,floor(saturatedCharge/tdcLSB_fC_));
 	    }
 	  else
@@ -326,7 +334,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
       else
 	{
 	   //brute force saturation, maybe could to better with an exponential like saturation
-          float saturatedCharge(std::min(newCharge[it],adcSaturation_fC_));
+          const float saturatedCharge(std::min(newCharge[it],adcSaturation_fC_));
 	  newSample.set(newCharge[it]>thickness*adcThreshold_fC_,false,0,saturatedCharge/adcLSB_fC_);
 	}
       dataFrame.setSample(it,newSample);

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -290,7 +290,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
       {
         //if busy, charge has been already integrated
         //if(debug) edm::LogVerbatim("HGCFE") << "\t SARS ADC pulse activated @ " << it << " : ";
-        if( !totFlags[it] && !busyFlags[it] ) {
+        if( !totFlags[it] & !busyFlags[it] ) {
           const int start = std::max(0,2-it);
           const int stop  = std::min((int)adcPulse_.size(),(int)newCharge.size()-it+2);          
           for(ipulse = start; ipulse < stop; ++ipulse) {
@@ -298,7 +298,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
             //notice that if the channel is already busy,
             //it has already been affected by the leakage of the SARS ADC
             //if(totFlags[itoffset] || busyFlags[itoffset]) continue;
-            if( totFlags[itoffset] || busyFlags[itoffset] ) {
+            if( !totFlags[itoffset] & !busyFlags[itoffset] ) {
               newCharge[itoffset] += chargeColl[it]*adcPulse_[ipulse];
             }
             //if(debug) edm::LogVerbatim("HGCFE") << " | " << itoffset << " " << chargeColl[it]*adcPulse_[ipulse] << "( " << chargeColl[it] << "->";


### PR DESCRIPTION
Speed up in digitizer (was spending lots of time converting float to double or other silly things).
Try to remove branching or streamline it where possible.
Likely some significant improvement is still possible, but requires redesign.

Also change RecHits to use the bin center for TDC energy readout rather than the bin low edge.
