### PR TITLE
Removed use of assert(nullptr)

### DIFF
--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -799,13 +799,13 @@ namespace edm {
 
   WrapperBase const*
   Principal::getIt(ProductID const&) const {
-    assert(nullptr);
+    assert(false);
     return nullptr;
   }
 
   WrapperBase const*
   Principal::getThinnedProduct(ProductID const&, unsigned int&) const {
-    assert(nullptr);
+    assert(false);
     return nullptr;
   }
 
@@ -813,7 +813,7 @@ namespace edm {
   Principal::getThinnedProducts(ProductID const&,
                                   std::vector<WrapperBase const*>&,
                                   std::vector<unsigned int>&) const {
-    assert(nullptr);
+    assert(false);
   }
 
   void


### PR DESCRIPTION
Using gcc 5.3 on OS X failed to compile because nullptr could not auto convert to bool in the assert expression. Given the expressing does not make much sense, it was replaced with assert(false).
