### PR TITLE
add fillDescriptions function needed by the HLT

### DIFF
--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -24,6 +24,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h"
 #include "DataFormats/METReco/interface/CorrMETData.h"
@@ -82,6 +84,13 @@ class CorrectedMETProducerT : public edm::stream::EDProducer<>
     delete algorithm_;
   }
     
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("@module_label");
+    desc.add<edm::InputTag>("src");
+    descriptions.addDefault(desc);
+  }
+
  private:
 
   void produce(edm::Event& evt, const edm::EventSetup& es)

--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -86,9 +86,8 @@ class CorrectedMETProducerT : public edm::stream::EDProducer<>
     
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<std::string>("@module_label");
-    desc.add<edm::InputTag>("src");
-    descriptions.addDefault(desc);
+    desc.add<edm::InputTag>("src",edm::InputTag("corrPfMetType1", "type1"));
+    descriptions.add("CorrectedMETProducerT",desc);
   }
 
  private:

--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -31,6 +31,8 @@
 #include "DataFormats/METReco/interface/CorrMETData.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
 #include <vector>
 
 namespace CorrectedMETProducer_namespace
@@ -87,7 +89,7 @@ class CorrectedMETProducerT : public edm::stream::EDProducer<>
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("src",edm::InputTag("corrPfMetType1", "type1"));
-    descriptions.add("CorrectedMETProducerT",desc);
+    descriptions.add(defaultModuleLabel<CorrectedMETProducerT<T> >(),desc);
   }
 
  private:

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -137,18 +137,17 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<std::string>("@module_label");
-    desc.add<edm::InputTag>("src");
-    desc.add<edm::InputTag>("offsetCorrLabel");
-    desc.add<edm::InputTag>("jetCorrLabel");
-    desc.add<edm::InputTag>("jetCorrLabelRes");
+    desc.add<edm::InputTag>("src",edm::InputTag("ak4PFJetsCHS"));
+    desc.add<edm::InputTag>("offsetCorrLabel",edm::InputTag("ak4PFCHSL1FastjetCorrector"));
+    desc.add<edm::InputTag>("jetCorrLabel",edm::InputTag("ak4PFCHSL1FastL2L3Corrector"));
+    desc.add<edm::InputTag>("jetCorrLabelRes",edm::InputTag("ak4PFCHSL1FastL2L3ResidualCorrector"));
     desc.add<double>("jetCorrEtaMax",9.9);
-    desc.add<double>("type1JetPtThreshold");
-    desc.add<bool>("skipEM");
-    desc.add<double>("skipEMfractionThreshold");
-    desc.add<bool>("skipMuons");
-    desc.add<std::string>("skipMuonSelection");
-    descriptions.addDefault(desc);
+    desc.add<double>("type1JetPtThreshold",15);
+    desc.add<bool>("skipEM",true);
+    desc.add<double>("skipEMfractionThreshold",0.90);
+    desc.add<bool>("skipMuons",true);
+    desc.add<std::string>("skipMuonSelection","isGlobalMuon | isStandAloneMuon");
+    descriptions.add("PFJetMETcorrInputProducer",desc);
     }
 
 

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -38,6 +38,8 @@
 
 #include "JetMETCorrections/Type1MET/interface/JetCorrExtractorT.h"
 
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
 #include <string>
 #include <type_traits>
 
@@ -147,7 +149,7 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
     desc.add<double>("skipEMfractionThreshold",0.90);
     desc.add<bool>("skipMuons",true);
     desc.add<std::string>("skipMuonSelection","isGlobalMuon | isStandAloneMuon");
-    descriptions.add("PFJetMETcorrInputProducer",desc);
+    descriptions.add(defaultModuleLabel< PFJetMETcorrInputProducerT<T, Textractor> >(), desc);
     }
 
 

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -22,6 +22,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefToBase.h"
@@ -132,6 +134,23 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
       delete (*it);
     }
   }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("@module_label");
+    desc.add<edm::InputTag>("src");
+    desc.add<edm::InputTag>("offsetCorrLabel");
+    desc.add<edm::InputTag>("jetCorrLabel");
+    desc.add<edm::InputTag>("jetCorrLabelRes");
+    desc.add<double>("jetCorrEtaMax",9.9);
+    desc.add<double>("type1JetPtThreshold");
+    desc.add<bool>("skipEM");
+    desc.add<double>("skipEMfractionThreshold");
+    desc.add<bool>("skipMuons");
+    desc.add<std::string>("skipMuonSelection");
+    descriptions.addDefault(desc);
+    }
+
 
  private:
 

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -41,11 +41,6 @@ patPFMetT1T2Corr = cms.EDProducer("PATPFJetMETcorrInputProducer",
     jetCorrLabel = cms.InputTag("L3Absolute"), # for MC
     jetCorrLabelRes = cms.InputTag("L2L3Residual"), # for Data automatic switch
     type1JetPtThreshold = cms.double(15.0),
-    type2ResidualCorrLabel = cms.InputTag(""),
-    type2ResidualCorrEtaMax = cms.double(9.9),
-    type2ExtraCorrFactor = cms.double(1.),
-    type2ResidualCorrOffset = cms.double(0.),
-    isMC = cms.bool(False), # CV: only used to decide whether to apply "unclustered energy" calibration to MC or Data
     skipEM = cms.bool(True),
     skipEMfractionThreshold = cms.double(0.90),
     skipMuons = cms.bool(True),
@@ -181,7 +176,6 @@ patPFMetT1 = cms.EDProducer("CorrectedPATMETProducer",
     srcCorrections = cms.VInputTag(
         cms.InputTag('patPFMetT1T2Corr', 'type1'),
     ),
-    applyType2Corrections = cms.bool(False)
 )
 
 patPFMetT1T2 = patPFMetT1.clone()


### PR DESCRIPTION
This PR only adds the fillDecription function for two modules that are needed by the HLT.

Changes expected in physics results and performances : none

Packages touched :
- JetMETCorrections/Type1MET
