### PR TITLE
SIM code cleanup

### DIFF
--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02Analysis.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02Analysis.h
@@ -37,8 +37,6 @@
 #include "G4Track.hh"
 #include "G4ThreeVector.hh"
 
-#include <boost/cstdint.hpp>
-
 class HcalTB02Analysis : public SimProducer,
 			 public Observer<const BeginOfEvent *>,
 			 public Observer<const EndOfEvent *> {

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
@@ -46,7 +46,7 @@ namespace CLHEP {
 // constructors and destructor
 //
 
-HcalTB02Analysis::HcalTB02Analysis(const edm::ParameterSet &p): histo(0) {
+HcalTB02Analysis::HcalTB02Analysis(const edm::ParameterSet &p) {
 
   edm::ParameterSet m_Anal = p.getParameter<edm::ParameterSet>("HcalTB02Analysis");
   hcalOnly      = m_Anal.getUntrackedParameter<bool>("HcalClusterOnly",true);
@@ -64,12 +64,7 @@ HcalTB02Analysis::HcalTB02Analysis(const edm::ParameterSet &p): histo(0) {
 HcalTB02Analysis::~HcalTB02Analysis() {
 
   finish();
-
-  if (histo)   {
-    delete histo;
-    histo  = 0;
-  }
-  edm::LogInfo("HcalTBSim") << "HcalTB02Analysis is deleting";
+  delete histo;
 }
 
 //
@@ -106,8 +101,7 @@ void HcalTB02Analysis::update(const EndOfEvent * evt) {
   // HCAL
   std::string sd = names[0];
   int HCHCid = G4SDManager::GetSDMpointer()->GetCollectionID(sd);
-  CaloG4HitCollection* theHCHC = (CaloG4HitCollection*) allHC->GetHC(HCHCid);
-  HcalTB02HcalNumberingScheme *org = new HcalTB02HcalNumberingScheme();   
+  CaloG4HitCollection* theHCHC = (CaloG4HitCollection*) allHC->GetHC(HCHCid); 
   LogDebug("HcalTBSim") << "HcalTB02Analysis :: Hit Collection for " << sd 
 			<< " of ID " << HCHCid << " is obtained at " <<theHCHC;
 
@@ -123,10 +117,7 @@ void HcalTB02Analysis::update(const EndOfEvent * evt) {
     // XTALS
     sd      = names[1];
     XTALSid = G4SDManager::GetSDMpointer()->GetCollectionID(sd);
-    //    assert (XTALSid != 0);
     theXTHC = (CaloG4HitCollection*) allHC->GetHC(XTALSid);
-    //    assert (theXTHC != 0);
-    //HcalTB02XtalNumberingScheme *xorg = new HcalTB02XtalNumberingScheme();
     LogDebug("HcalTBSim") << "HcalTB02Analysis :: Hit Collection for " << sd
 			  << " of ID " << XTALSid << " is obtained at " 
 			  << theXTHC;
@@ -138,11 +129,10 @@ void HcalTB02Analysis::update(const EndOfEvent * evt) {
 			<< " HCal hits, and" << xentries  << " xtal hits";
 
   float ETot=0., xETot=0.;
-  //float maxE = 0.; 
-  //int maxI=0, 
   int scintID=0, xtalID=0;
 
   // HCAL
+  HcalTB02HcalNumberingScheme *org = new HcalTB02HcalNumberingScheme();   
 
   if (HCHCid >= 0 && theHCHC > 0) {
     for ( ihit = 0; ihit < nentries; ihit++) {
@@ -215,15 +205,8 @@ void HcalTB02Analysis::update(const EndOfEvent * evt) {
     for (int iphi=0 ; iphi<8; iphi++) {
       for (int jeta=0 ; jeta<18; jeta++) {
 	
-	//SEnergyN += TowerEneCF[iphi][jeta] + 3.2*randGauss.fire(); // LHEP
 	SEnergyN += TowerEneCF[iphi][jeta] + 3.*randGauss.fire(); // QGSP
 
-	//double dR=0.08727*sqrt( (jeta-8.)*(jeta-8.)+(iphi-3.)*(iphi-3.) );
-	//cout.testOut << " phi= " << iphi << " eta= " << jeta 
-	//	     << " TowerEne[iphi,jeta]= " << TowerEne[iphi][jeta] 
-	//	     << "dR= "  << dR << endl;
-	
-      	//double Rand = 3.2*randGauss.fire(); // LHEP
       	double Rand = 3.*randGauss.fire(); // QGSP
 	
 	if ( (iphi>=0) && (iphi<7) ) {

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB06Analysis.cc
@@ -133,7 +133,7 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
 
   unsigned int ne = 0;
   unsigned int nh = 0;
-  if(EcalHits) {  
+  if(m_ECAL) {  
     ne = EcalHits->size();
     for (unsigned int i=0; i<ne; ++i) {
       EBDetId ecalid((*EcalHits)[i].id());
@@ -161,10 +161,10 @@ void HcalTB06Analysis::analyze(const edm::Event & evt, const edm::EventSetup&)
 	ehcals += (*HcalHits)[i].energy();
       }
     }
-    if(m_widthHcal > 0.0) {
-      eecals += G4RandGauss::shoot(0.0,m_widthHcal);
-    }
     ehcals *= m_factHcal;
+    if(m_widthHcal > 0.0) {
+      ehcals += G4RandGauss::shoot(0.0,m_widthHcal);
+    }
   }
   double etots = eecals + ehcals;
   LogDebug("HcalTBSim") << "HcalTB06Analysis:: Etot(MeV)= " << etots 

--- a/SimG4CMS/HcalTestBeam/python/TB2006Analysis_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TB2006Analysis_cfi.py
@@ -95,8 +95,6 @@ def testbeam2006(process):
     process.g4SimHits.StackingAction.MaxTimeNames = cms.vstring()
     process.g4SimHits.StackingAction.MaxTrackTimes = cms.vdouble()
     process.g4SimHits.StackingAction.DeadRegions = cms.vstring()
-    process.g4SimHits.StackingAction.RusRoGammaEnergyLimit = cms.double(0.0)
-    process.g4SimHits.StackingAction.RusRoNeutronEnergyLimit = cms.double(0.0)
 
     process.g4SimHits.SteppingAction.MaxTrackTime = cms.double(1000.0)
     process.g4SimHits.SteppingAction.MaxTimeNames = cms.vstring()

--- a/SimG4Core/Application/interface/OscarMTMasterThread.h
+++ b/SimG4Core/Application/interface/OscarMTMasterThread.h
@@ -27,16 +27,16 @@ namespace HepPDT {
 
 class OscarMTMasterThread {
 public:
-  OscarMTMasterThread(const edm::ParameterSet& iConfig);
+  explicit OscarMTMasterThread(const edm::ParameterSet& iConfig);
   ~OscarMTMasterThread();
 
   void beginRun(const edm::EventSetup& iSetup) const;
   void endRun() const;
   void stopThread();
 
-  const RunManagerMT& runManagerMaster() const { return *m_runManagerMaster; }
-  const RunManagerMT *runManagerMasterPtr() const { return m_runManagerMaster.get(); }
-  
+  inline RunManagerMT& runManagerMaster() const { return *m_runManagerMaster; }
+  inline RunManagerMT *runManagerMasterPtr() const { return m_runManagerMaster.get(); }
+
 private:
   void readES(const edm::EventSetup& iSetup) const;
 

--- a/SimG4Core/Application/interface/OscarMTProducer.h
+++ b/SimG4Core/Application/interface/OscarMTProducer.h
@@ -10,8 +10,6 @@
 
 #include "SimG4Core/Application/interface/OscarMTMasterThread.h"
 
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-
 #include <memory>
 
 class SimProducer;
@@ -33,14 +31,12 @@ public:
   static void globalEndRun(const edm::Run& iRun, const edm::EventSetup& iSetup, const RunContext *iContext);
   static void globalEndJob(OscarMTMasterThread *masterThread);
 
-
   virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override;
   virtual void produce(edm::Event & e, const edm::EventSetup& c) override;
 
 private:
   Producers     m_producers;
   std::unique_ptr<RunManagerMTWorker> m_runManagerWorker;
-  //edm::EDGetTokenT<edm::HepMCProduct> m_HepMC;
 };
 
 #endif

--- a/SimG4Core/Application/interface/OscarProducer.h
+++ b/SimG4Core/Application/interface/OscarProducer.h
@@ -11,8 +11,6 @@
 #include "SimG4Core/Application/interface/RunManager.h"
 #include "SimG4Core/Application/interface/CustomUIsession.h"
 
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-
 #include <memory>
 
 class OscarProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns>
@@ -30,7 +28,6 @@ private:
   std::unique_ptr<RunManager> m_runManager;
   Producers     m_producers;
   std::unique_ptr<CustomUIsession> m_UIsession;
-  //edm::EDGetTokenT<edm::HepMCProduct> m_HepMC;
 };
 
 #endif

--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -1,14 +1,10 @@
 #ifndef SimG4Core_RunManager_H
 #define SimG4Core_RunManager_H
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "DataFormats/Common/interface/Handle.h"
+#include "SimDataFormats/Forward/interface/LHCTransportLinkContainer.h"
 
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
@@ -20,6 +16,14 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include <memory>
+
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+  class ConsumesCollector;
+  class HepMCProduct;
+}
 
 namespace CLHEP {
   class HepJamesRandom;
@@ -59,7 +63,7 @@ class RunManager
 {
 public:
 
-  RunManager(edm::ParameterSet const & p);
+  RunManager(edm::ParameterSet const & p, edm::ConsumesCollector&& i);
   ~RunManager();
   void initG4(const edm::EventSetup & es);
   void initializeUserActions();
@@ -102,7 +106,8 @@ private:
   G4RunManagerKernel * m_kernel;
     
   Generator * m_generator;
-  std::string m_InTag ;
+  edm::EDGetTokenT<edm::HepMCProduct> m_HepMC;
+  edm::EDGetTokenT<edm::LHCTransportLinkContainer> m_LHCtr;
     
   bool m_nonBeam;
   std::auto_ptr<PhysicsList> m_physicsList;
@@ -118,8 +123,6 @@ private:
   G4SimEvent * m_simEvent;
   RunAction * m_userRunAction;
   SimRunInterface * m_runInterface;
-
-  //edm::EDGetTokenT<edm::HepMCProduct> m_HepMC;
 
   std::string m_PhysicsTablesDir;
   bool m_StorePhysicsTables;
@@ -156,8 +159,6 @@ private:
   edm::ESWatcher<IdealGeometryRecord> idealGeomRcdWatcher_;
   edm::ESWatcher<IdealMagneticFieldRecord> idealMagRcdWatcher_;
     
-  edm::InputTag m_theLHCTlinkTag;
-
   std::string m_FieldFile;
   std::string m_WriteFile;
   std::string m_RegionFile;

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -10,7 +10,6 @@
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include <memory>
 
@@ -62,7 +61,7 @@ class RunManagerMT
   friend class RunManagerMTWorker;
 
 public:
-  RunManagerMT(edm::ParameterSet const & p);
+  explicit RunManagerMT(edm::ParameterSet const & p);
   ~RunManagerMT();
 
   void initG4(const DDCompactView *pDD, const MagneticField *pMF, const HepPDT::ParticleDataTable *fPDGTable);
@@ -75,24 +74,24 @@ public:
 
   // Keep this to keep ExceptionHandler to compile, probably removed
   // later (or functionality moved to RunManagerMTWorker)
-  void abortRun(bool softAbort=false) {}
+  inline void abortRun(bool softAbort=false) {}
 
-  const DDDWorld& world() const {
+  inline const DDDWorld& world() const {
     return *m_world;
   }
 
-  const SensitiveDetectorCatalog& catalog() const {
+  inline const SensitiveDetectorCatalog& catalog() const {
     return m_catalog;
   }
 
-  const std::vector<std::string>& G4Commands() const {
+  inline const std::vector<std::string>& G4Commands() const {
     return m_G4Commands;
   }
 
   // In order to share the physics list with the worker threads, we
   // need a non-const pointer. Thread-safety is handled inside Geant4
   // with TLS. 
-  PhysicsList *physicsListForWorker() const {
+  inline PhysicsList *physicsListForWorker() const {
     return m_physicsList.get();
   }
 
@@ -100,7 +99,7 @@ public:
   // G4MonopoleTransportation) with the worker threads, we need a
   // non-const pointer. Thread-safety is handled inside
   // ChordFinderStter with TLS. 
-  sim::ChordFinderSetter *chordFinderSetterForWorker() const {
+  inline sim::ChordFinderSetter *chordFinderSetterForWorker() const {
     return m_chordFinderSetter.get();
   }
 
@@ -133,7 +132,7 @@ private:
   SimActivityRegistry m_registry;
   SensitiveDetectorCatalog m_catalog;
     
-  sim::FieldBuilder             *m_fieldBuilder;
+  sim::FieldBuilder  *m_fieldBuilder;
   std::unique_ptr<sim::ChordFinderSetter> m_chordFinderSetter;
     
   std::string m_FieldFile;

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -37,22 +37,22 @@ class SimProducer;
 
 class RunManagerMTWorker {
 public:
-  RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& i);
+  explicit RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& i);
   ~RunManagerMTWorker();
 
-  void beginRun(const RunManagerMT& runManagerMaster, const edm::EventSetup& es);
   void endRun();
 
-  void produce(const edm::Event& inpevt, const edm::EventSetup& es, const RunManagerMT& runManagerMaster);
+  void produce(const edm::Event& inpevt, const edm::EventSetup& es, RunManagerMT& runManagerMaster);
 
   void abortEvent();
   void abortRun(bool softAbort=false);
 
-  G4SimEvent * simEvent() { return m_simEvent.get(); }
-  void             Connect(RunAction*);
-  void             Connect(EventAction*);
-  void             Connect(TrackingAction*);
-  void             Connect(SteppingAction*);
+  inline G4SimEvent * simEvent() { return m_simEvent.get(); }
+
+  void Connect(RunAction*);
+  void Connect(EventAction*);
+  void Connect(TrackingAction*);
+  void Connect(SteppingAction*);
 
   SimTrackManager* GetSimTrackManager();
   std::vector<SensitiveTkDetector*>& sensTkDetectors();
@@ -60,8 +60,9 @@ public:
   std::vector<std::shared_ptr<SimProducer> > producers();
 
 private:
+
   void initializeTLS();
-  void initializeThread(const RunManagerMT& runManagerMaster, const edm::EventSetup& es);
+  void initializeThread(RunManagerMT& runManagerMaster, const edm::EventSetup& es);
   void initializeUserActions();
 
   void initializeRun();

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -1,6 +1,7 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimG4Core/Application/interface/OscarProducer.h"
@@ -10,6 +11,7 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "SimG4Core/Watcher/interface/SimProducer.h"
 
@@ -67,8 +69,7 @@ OscarProducer::OscarProducer(edm::ParameterSet const & p)
   usesResource(edm::SharedResourceNames::kCLHEPRandomEngine);
 
   consumes<edm::HepMCProduct>(p.getParameter<edm::InputTag>("HepMCProductLabel"));
-  m_runManager.reset(new RunManager(p));
-  //m_runManager.reset(new RunManager(p, consumesCollector()));
+  m_runManager.reset(new RunManager(p, consumesCollector()));
 
   produces<edm::SimTrackContainer>().setBranchAlias("SimTracks");
   produces<edm::SimVertexContainer>().setBranchAlias("SimVertices");

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -55,7 +55,6 @@
 #include <thread>
 #include <sstream>
 
-
 // from https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3302/2.html
 namespace {
   static std::atomic<int> thread_counter{ 0 };
@@ -176,7 +175,7 @@ void RunManagerMTWorker::initializeTLS() {
   createWatchers(m_p, m_tls->registry, m_tls->watchers, m_tls->producers, thisID);
 }
 
-void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, const edm::EventSetup& es) {
+void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const edm::EventSetup& es) {
   // I guess everything initialized here should be in thread_local storage
   initializeTLS();
 
@@ -376,7 +375,9 @@ void RunManagerMTWorker::terminateRun() {
   }
 }
 
-void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup& es, const RunManagerMT& runManagerMaster) {
+void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup& es, 
+                                 RunManagerMT& runManagerMaster) {
+  //void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup& es, const RunManagerMT& runManagerMaster) {
   // The initialization and begin/end run is a bit convoluted due to
   // - Geant4 deals per-thread
   // - OscarMTProducer deals per-stream

--- a/SimG4Core/Application/src/SimRunInterface.cc
+++ b/SimG4Core/Application/src/SimRunInterface.cc
@@ -12,7 +12,8 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 SimRunInterface::SimRunInterface(RunManager* runm, bool master)
-  : m_runManager(runm),m_runManagerMT(0),m_runManagerMTWorker(nullptr),m_SimTrackManager(0),
+  : m_runManager(runm),m_runManagerMT(nullptr),m_runManagerMTWorker(nullptr),
+    m_SimTrackManager(nullptr),
     m_isMaster(master)
 {
   if(m_runManager) {
@@ -21,13 +22,13 @@ SimRunInterface::SimRunInterface(RunManager* runm, bool master)
 }
 
 SimRunInterface::SimRunInterface(RunManagerMT* runm, bool master)
-  : m_runManager(0),m_runManagerMT(runm),m_runManagerMTWorker(nullptr),m_SimTrackManager(0),
-    m_isMaster(master)
+  : m_runManager(nullptr),m_runManagerMT(runm),m_runManagerMTWorker(nullptr),
+    m_SimTrackManager(nullptr),m_isMaster(master)
 {}
 
 SimRunInterface::SimRunInterface(RunManagerMTWorker* runm, bool master)
-  : m_runManager(0),m_runManagerMT(nullptr),m_runManagerMTWorker(runm),m_SimTrackManager(0),
-    m_isMaster(master)
+  : m_runManager(nullptr),m_runManagerMT(nullptr),m_runManagerMTWorker(runm),
+    m_SimTrackManager(nullptr),m_isMaster(master)
 {
   if(m_runManagerMTWorker) {
     m_SimTrackManager = m_runManagerMTWorker->GetSimTrackManager();

--- a/SimG4Core/GFlash/src/ParametrisedPhysics.cc
+++ b/SimG4Core/GFlash/src/ParametrisedPhysics.cc
@@ -23,7 +23,6 @@ ParametrisedPhysics::~ParametrisedPhysics() {
     delete tpdata->theEMShowerModel;
     delete tpdata->theHadShowerModel;
     delete tpdata->theHadronShowerModel;
-    delete tpdata->theHadronShowerModel;
     delete tpdata->theFastSimulationManagerProcess;
     tpdata = nullptr;
   }

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -5,6 +5,9 @@
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include <vector>
 
+namespace edm {
+  class ParameterSet;
+}
 class SensitiveTkDetector;
 class SensitiveCaloDetector;
 class SimActivityRegistry;


### PR DESCRIPTION
Fixed some static analyser warnings; removed commented lines and unused headers; added getByToken; added c++11 keywords. For HcalTestBeam enable Russian roulette by default; fixed sampling of noise in HCAL.
