### PR TITLE
Save L1 stage2 info in offline data tiers (81X)

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # RAW content 
 L1TriggerRAW = cms.PSet(
@@ -93,3 +94,20 @@ L1TriggerFEVTDEBUG = cms.PSet(
         'keep LumiSummary_lumiProducer_*_*')
 )
 
+
+if eras.stage2L1Trigger.isChosen():
+    # stage 2 L1 trigger
+    l1Stage2Digis = [
+        'keep *_gtStage2Digis__*', 
+        'keep *_gmtStage2Digis_Muon_*',
+        'keep *_caloStage2Digis_Jet_*',
+        'keep *_caloStage2Digis_Tau_*',
+        'keep *_caloStage2Digis_EGamma_*',
+        'keep *_caloStage2Digis_EtSum_*',
+    ]
+    # adding them to all places where we had l1extraParticles
+    L1TriggerRAWDEBUG.outputCommands += l1Stage2Digis
+    L1TriggerRECO.outputCommands += l1Stage2Digis
+    L1TriggerAOD.outputCommands += l1Stage2Digis
+    L1TriggerFEVTDEBUG.outputCommands += l1Stage2Digis   
+ 

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -95,8 +95,7 @@ L1TriggerFEVTDEBUG = cms.PSet(
 )
 
 
-if eras.stage2L1Trigger.isChosen():
-    # stage 2 L1 trigger
+def _appendStage2Digis(obj):
     l1Stage2Digis = [
         'keep *_gtStage2Digis__*', 
         'keep *_gmtStage2Digis_Muon_*',
@@ -104,10 +103,11 @@ if eras.stage2L1Trigger.isChosen():
         'keep *_caloStage2Digis_Tau_*',
         'keep *_caloStage2Digis_EGamma_*',
         'keep *_caloStage2Digis_EtSum_*',
-    ]
-    # adding them to all places where we had l1extraParticles
-    L1TriggerRAWDEBUG.outputCommands += l1Stage2Digis
-    L1TriggerRECO.outputCommands += l1Stage2Digis
-    L1TriggerAOD.outputCommands += l1Stage2Digis
-    L1TriggerFEVTDEBUG.outputCommands += l1Stage2Digis   
- 
+        ]
+    obj.outputCommands += l1Stage2Digis
+
+# adding them to all places where we had l1extraParticles
+eras.stage2L1Trigger.toModify(L1TriggerRAWDEBUG, func=_appendStage2Digis)
+eras.stage2L1Trigger.toModify(L1TriggerRECO, func=_appendStage2Digis)
+eras.stage2L1Trigger.toModify(L1TriggerAOD, func=_appendStage2Digis)
+eras.stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendStage2Digis)

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -47,8 +47,17 @@ MicroEventContent = cms.PSet(
         'keep patPackedTriggerPrescales_patTrigger__*',
         'keep patPackedTriggerPrescales_patTrigger_l1max_*',
         'keep patPackedTriggerPrescales_patTrigger_l1min_*',
+        # old L1 trigger
         'keep *_l1extraParticles_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        # stage 2 L1 trigger
+        'keep *_gtStage2Digis__*', 
+        'keep *_gmtStage2Digis_Muon_*',
+        'keep *_caloStage2Digis_Jet_*',
+        'keep *_caloStage2Digis_Tau_*',
+        'keep *_caloStage2Digis_EGamma_*',
+        'keep *_caloStage2Digis_EtSum_*',
+        # HLT
         'keep *_TriggerResults_*_HLT',
         'keep *_TriggerResults_*_*', # for MET filters (a catch all for the moment, but ideally it should be only the current process)
         'keep patPackedCandidates_lostTracks_*_*',


### PR DESCRIPTION
Add L1 info from Stage2 unpackers to all the data tiers: L1 bits from GT, L1 objects from GMT and Calo. This works if era `Run2_2016`, or any other era that satisfies `eras.stage2L1Trigger.isChosen()`.

Checked on `CMSSW_8_1_X_2016-04-13-1100` for matrix workflow 1324.0, verifying by hand in that in those events the L1 muons and jets in the MiniAOD file are in agreement with the corresponding offline objects. Will do a sanity check on data on run 269610 too.

I did _not_ remove the old L1 objects from the event content, as I've seen that in the raw2digi sequence the reco is configured to unpack both the old and the new L1.
