### PR TITLE
Fix for runtestTqafTopEventSelection unit test

### DIFF
--- a/PhysicsTools/PatAlgos/python/cleaningLayer1/tauCleaner_cfi.py
+++ b/PhysicsTools/PatAlgos/python/cleaningLayer1/tauCleaner_cfi.py
@@ -8,7 +8,7 @@ cleanPatTaus = cms.EDProducer("PATTauCleaner",
         'tauID("decayModeFinding") > 0.5 &'
         ' tauID("byLooseCombinedIsolationDeltaBetaCorr3Hits") > 0.5 &'
         ' tauID("againstMuonTight3") > 0.5 &'
-        ' tauID("againstElectronVLooseMVA5") > 0.5'
+        ' tauID("againstElectronVLooseMVA6") > 0.5'
     ),
 
     # overlap checking configurables


### PR DESCRIPTION
use againstElectronVLooseMVA6 instead of againstElectronVLooseMVA5
