### PR TITLE
Protect access to updatedState

### DIFF
--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -118,6 +118,8 @@ bool TempTrajectory::badForCCC(const TrajectoryMeasurement &tm) {
     return false;
   if (thit->isPixel())
     return false;
+  if (!tm.updatedState().isValid())
+    return false;
   return siStripClusterTools::chargePerCM(thit->rawId(),
                                           thit->firstClusterRef().stripCluster(),
                                           tm.updatedState().localParameters()) < theCCCThreshold_;

--- a/TrackingTools/PatternTools/src/Trajectory.cc
+++ b/TrackingTools/PatternTools/src/Trajectory.cc
@@ -165,6 +165,8 @@ bool Trajectory::badForCCC(const TrajectoryMeasurement &tm) {
     return false;
   if (thit->isPixel())
     return false;
+  if (!tm.updatedState().isValid())
+    return false;
   return siStripClusterTools::chargePerCM(thit->rawId(),
                                           thit->firstClusterRef().stripCluster(),
                                           tm.updatedState().localParameters()) < theCCCThreshold_;


### PR DESCRIPTION
While testing if a newly added TrajectoryMeasurement to a Trajectory is
compatible or not with the cut on the cluster charge, a protection has
been added to test the validity of the updatedState before using it.
This fix a segmentation fault that was due to an invalid updatedState
caused by a failed KfUpdator. Full log avaialable here:
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1436.html
