### PR TITLE
Fix getByLabelWithoutRegistration (81X).

### DIFF
--- a/GeneratorInterface/GenFilters/interface/EMEnrichingFilterAlgo.h
+++ b/GeneratorInterface/GenFilters/interface/EMEnrichingFilterAlgo.h
@@ -19,13 +19,14 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 
 class EMEnrichingFilterAlgo {
  public:
-  EMEnrichingFilterAlgo(const edm::ParameterSet&);
+  EMEnrichingFilterAlgo(const edm::ParameterSet&, edm::ConsumesCollector &&);
   ~EMEnrichingFilterAlgo();
   
   bool filter(const edm::Event& iEvent, const edm::EventSetup& iSetup);
@@ -69,5 +70,6 @@ class EMEnrichingFilterAlgo {
   bool requireTrackMatch_;
   edm::InputTag genParSource_;
 
+  edm::EDGetTokenT<reco::GenParticleCollection> genParSourceToken_;
 };
 #endif

--- a/GeneratorInterface/GenFilters/src/EMEnrichingFilter.cc
+++ b/GeneratorInterface/GenFilters/src/EMEnrichingFilter.cc
@@ -27,7 +27,7 @@ EMEnrichingFilter::EMEnrichingFilter(const edm::ParameterSet& iConfig) {
   
   ParameterSet filterPSet=iConfig.getParameter<edm::ParameterSet>("filterAlgoPSet");
   
-  EMEAlgo_=new EMEnrichingFilterAlgo(filterPSet);
+  EMEAlgo_=new EMEnrichingFilterAlgo(filterPSet, consumesCollector());
 
 }
 

--- a/GeneratorInterface/GenFilters/src/EMEnrichingFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/src/EMEnrichingFilterAlgo.cc
@@ -23,7 +23,7 @@ using namespace edm;
 using namespace std;
 
 
-EMEnrichingFilterAlgo::EMEnrichingFilterAlgo(const edm::ParameterSet& iConfig) { 
+EMEnrichingFilterAlgo::EMEnrichingFilterAlgo(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iConsumes) { 
 
   //set constants
   FILTER_TKISOCUT_=4;
@@ -46,6 +46,7 @@ EMEnrichingFilterAlgo::EMEnrichingFilterAlgo(const edm::ParameterSet& iConfig) {
   requireTrackMatch_=iConfig.getParameter<bool>("requireTrackMatch");
   genParSource_=iConfig.getParameter<edm::InputTag>("genParSource");
 
+  genParSourceToken_ = iConsumes.consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParSource"));
 }
 
 EMEnrichingFilterAlgo::~EMEnrichingFilterAlgo() {
@@ -56,7 +57,8 @@ bool EMEnrichingFilterAlgo::filter(const edm::Event& iEvent, const edm::EventSet
 
 
   Handle<reco::GenParticleCollection> genParsHandle;
-  iEvent.getByLabel(genParSource_,genParsHandle);
+  //iEvent.getByLabel(genParSource_,genParsHandle);
+  iEvent.getByToken(genParSourceToken_,genParsHandle);
   reco::GenParticleCollection genPars=*genParsHandle;
 
   //bending of traj. of charged particles under influence of B-field

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -219,6 +219,7 @@ namespace edm {
     std::vector<std::string> digiNames = digiPSet.getParameterNames();
     for(auto const& digiName : digiNames) {
         ParameterSet const& pset = digiPSet.getParameterSet(digiName);
+	consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("HepMCProductLabel"));
         std::auto_ptr<DigiAccumulatorMixMod> accumulator = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
         // Create appropriate DigiAccumulator
         if(accumulator.get() != 0) {

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -219,7 +219,6 @@ namespace edm {
     std::vector<std::string> digiNames = digiPSet.getParameterNames();
     for(auto const& digiName : digiNames) {
         ParameterSet const& pset = digiPSet.getParameterSet(digiName);
-	consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("HepMCProductLabel"));
         std::auto_ptr<DigiAccumulatorMixMod> accumulator = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
         // Create appropriate DigiAccumulator
         if(accumulator.get() != 0) {


### PR DESCRIPTION
This is an 81X version of #13041 that was created by @jingyucms. 
The changes fix a segmentation fault.
The fix is urgently needed by the TSG/STEAM subgroup.

An 80X backport version will follow.
