### PR TITLE
Let the Compiler Provide the Default Implementation of the Destructor

### DIFF
--- a/DetectorDescription/Core/interface/DDValue.h
+++ b/DetectorDescription/Core/interface/DDValue.h
@@ -43,8 +43,6 @@ public:
   
   explicit DDValue( unsigned int );
   
-  ~DDValue( void );
-  
   //! returns the ID of the DDValue
   unsigned int id( void ) const { return id_; }
   

--- a/DetectorDescription/Core/src/DDValue.cc
+++ b/DetectorDescription/Core/src/DDValue.cc
@@ -109,9 +109,6 @@ DDValue::DDValue( unsigned int i )
     id_ = i;
 }
 
-DDValue::~DDValue( void )
-{}
-
 DDValue::NamesToIndicies&
 DDValue::indexer( void )
 { 


### PR DESCRIPTION
- No need for an empty non-inline destructor definition

igprof result before and after:

```
    7.0       3.42  HGCalGeomParameters::loadSpecParsHexagon(DDFilteredView const&, HGCalParameters&, DDCompactView const*, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) [58]
    6.7       3.27  std::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long) [59]
    6.6       3.20  DDValue::~DDValue() [60]
    5.3       2.59  _init [61]
    4.9       2.37  std::basic_string<char, std::char_traits<char>, std::allocator<char> >::append(std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) [62]
    4.4       2.14  std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Rep::_M_clone(std::allocator<char> const&, unsigned long) [63]
    4.0       1.96  DDFilteredView::copyNumbers() const [64]
    4.0       1.93  DDExpandedView::copyNumbers() const [65]
    3.9       1.89  DDCompareEqual::operator()() [66]
    3.8       1.88  _dl_update_slotinfo [67]

```

after the fix:

```
    6.8       3.21  HGCalGeomParameters::loadSpecParsHexagon(DDFilteredView const&, HGCalParameters&, DDCompactView const*, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) [58]
    5.0       2.37  _init [59]
    5.0       2.35  @{slc6_am+347476} [60]
    4.9       2.29  std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Rep::_M_clone(std::allocator<char> const&, unsigned long) [61]
    4.8       2.27  std::basic_string<char, std::char_traits<char>, std::allocator<char> >::append(std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) [62]
    4.4       2.05  DDCompareEqual::operator()() [63]
    4.0       1.90  _dl_update_slotinfo [64]

```
