### PR TITLE
Fix compilation with Clang (3.7.1)

### DIFF
--- a/DataFormats/ForwardDetId/src/HGCTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCTriggerDetId.cc
@@ -3,6 +3,17 @@
 #include <ostream>
 #include <iostream>
 
+const uint32_t HGCTriggerDetId::cell_shift;
+const uint32_t HGCTriggerDetId::cell_mask;
+const uint32_t HGCTriggerDetId::module_mask;
+const uint32_t HGCTriggerDetId::module_shift;
+const uint32_t HGCTriggerDetId::sector_shift;
+const uint32_t HGCTriggerDetId::sector_mask;
+const uint32_t HGCTriggerDetId::layer_shift;
+const uint32_t HGCTriggerDetId::layer_mask;
+const uint32_t HGCTriggerDetId::zside_shift;
+const uint32_t HGCTriggerDetId::zside_mask;
+
 const HGCTriggerDetId HGCTriggerDetId::Undefined(ForwardEmpty,0,0,0,0,0);
 
 HGCTriggerDetId::HGCTriggerDetId() : DetId() {


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.

The following undefined references were reported by linker:

```
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0x61): undefined reference to GCTriggerDetId::cell_mask'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0x6e): undefined reference to GCTriggerDetId::cell_shift'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0x7b): undefined reference to GCTriggerDetId::sector_mask'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0x85): undefined reference to GCTriggerDetId::sector_shift'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0x94): undefined reference to GCTriggerDetId::module_mask'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0x9e): undefined reference to GCTriggerDetId::module_shift'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0xad): undefined reference to GCTriggerDetId::layer_mask'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0xb7): undefined reference to GCTriggerDetId::layer_shift'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0xc6): undefined reference to GCTriggerDetId::zside_mask'
DataFormats/ForwardDetId/src/HGCTriggerDetId.cc:(.text+0xcf): undefined reference to GCTriggerDetId::zside_shift'
```

These are odr-used because

```
inline void setMaskedId( const uint32_t value, const uint32_t &shift, const uint32_t &mask )
```

2nd and 3rd arguments are passed by a reference.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
