### PR TITLE
Update L1 uGT menu to v5 and add payloads for GBRWrapperRcd for tracking MVA 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,13 +10,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v11',
+    'run2_design'       :   '80X_mcRun2_design_v12',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v11',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v12',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v11',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v12',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v10',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v8',
     # GlobalTag for Run1 data reprocessing
@@ -24,19 +24,19 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '80X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v8',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v10',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v11',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '80X_upgrade2017_realistic_v2',
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '80X_dataRun2_relval_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v10',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v10',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v6',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v12) as [80X_mcRun2_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v12/80X_mcRun2_design_v11): 
  - update L1 uGT menu to v5 (dev_v5)
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v12) as [80X_mcRun2cosmics_startup_peak_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v12/80X_mcRun2cosmics_startup_peak_v11): 
  - update L1 uGT menu to v5 (dev_v5)
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v12) as [80X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v12/80X_mcRun2_asymptotic_v11): 
  - update L1 uGT menu to v5 (dev_v5)
- **RunII Startup scenario** : [80X_mcRun2_startup_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v12) as [80X_mcRun2_startup_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v12/80X_mcRun2_startup_v11): 
  - update L1 uGT menu to v5 (dev_v5)
## RunII data
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v8) as [80X_dataRun2_HLT_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v8/80X_dataRun2_HLT_relval_v6): 
  - Adding 7 payloads for GBRWrapperRcd for tracking MVA 
  - update L1 uGT menu to v5 (dev_v5)
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v11) as [80X_dataRun2_HLT_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v11/80X_dataRun2_HLT_frozen_v10): 
  - Adding 7 payloads for GBRWrapperRcd for tracking MVA 
  - update L1 uGT menu to v5 (dev_v5)
- **RunII Offline relval processing** : [80X_dataRun2_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v7) as [80X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v7/80X_dataRun2_relval_v6): 
  - update L1 uGT menu to v5 (dev_v5)
## Upgrade
- **PhaseI design scenario** : [80X_upgrade2017_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v11) as [80X_upgrade2017_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v11/80X_upgrade2017_design_v10): 
  - update L1 uGT menu to v5 (dev_v5)
