### PR TITLE
Fixed workflows for MT mode

### DIFF
--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -26,6 +26,12 @@ def customise(process):
 
     process.g4SimHits.Generator.HepMCProductLabel = cms.string('generatorSmeared')
 
+    # use OscarProducer
+    for label, prod in process.producers_().iteritems():
+        if prod.type_() == "OscarMTProducer":
+            # replace
+            prod.__dict__['_TypedParameterizable__type'] = "OscarProducer"
+
     # modify the content
 
     #process.output.outputCommands.append("keep *_simHcalUnsuppressedDigis_*_*")
@@ -52,8 +58,6 @@ def customise(process):
     process.ecalRecHit.recoverEEIsolatedChannels = cms.bool(False)
     process.ecalRecHit.recoverEBFE = cms.bool(False)
     process.ecalRecHit.recoverEEFE = cms.bool(False)
-
-#    process.local_digireco = cms.Path(process.mix * process.calDigi * process.ecalLocalRecoSequence * process.hbhereco * process.hfreco * process.horeco * (process.ecalClusters+process.caloTowersRec) * process.reducedEcalRecHitsSequence )
 
     process.reducedEcalRecHitsEB.interestingDetIdCollections = cms.VInputTag(
             # ecal


### PR DESCRIPTION
In workflows 101.0 and 102.0 watchers are used, OscarMTProducer is substituted by OscarProducer in this custom fragment to avoid exception in MT validations. The reason: watchers cannot be used for more than 1 thread. 
