### PR TITLE
Fix for emulator match problem and incorrect tower binning.

### DIFF
--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -68,8 +68,9 @@ namespace ecaldqm
           if(tccid <= 36 || tccid >= 73){ // EE
             unsigned bin(ttId(_id));
             bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
-            if(outer) bin += 48;
-            bin += (tccid % 2) * (outer ? 16 : 24);
+            if(outer) bin += 56; // Sets bin number to increment by 56 for TTs in "outer" TCCs (closer to the barrel)
+            bin += (tccid % 2) * (outer ? 16 : 28); // 16 trigger towers per TCC for "outer" TCCs, 24 for "inner" TCCs but they are numbered from 0 to 27 with some missing
+	    // We have x-axis in the format inner1 (28 bins), inner2 (28 bins), outer1 (16 bins), outer2 (16 bins) -- 88 bins in total
             return bin;
           }
           else
@@ -146,8 +147,9 @@ namespace ecaldqm
           if(tccid <= 36 || tccid >= 73){ // EE
             unsigned bin(ttId(_id));
             bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
-            if(outer) bin += 48;
-            bin += (tccid % 2) * (outer ? 16 : 24);
+            if(outer) bin += 56; // Sets bin number to increment by 56 for TTs in "outer" TCCs (closer to the barrel)
+            bin += (tccid % 2) * (outer ? 16 : 28); // 16 trigger towers per TCC for "outer" TCCs, 24 for "inner" TCCs but they are numbered from 0 to 27 with some missing
+	    // We have x-axis in the format inner1 (28 bins), inner2 (28 bins), outer1 (16 bins), outer2 (16 bins) -- 88 bins in total
             return bin;
           }
           else

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -214,7 +214,7 @@ namespace ecaldqm
           break;
         case kTriggerTower:
         case kPseudoStrip:
-          specs.nbins = isBarrel ? 68 : 80;
+          specs.nbins = isBarrel ? 68 : 88; // 88 bins required for EE: 28 for two inner tccs, 16 for two outer TCCs
           specs.low = 0.;
           specs.high = specs.nbins;
           specs.title = "tower";

--- a/DQM/EcalCommon/src/MESetDet1D.cc
+++ b/DQM/EcalCommon/src/MESetDet1D.cc
@@ -85,18 +85,18 @@ namespace ecaldqm
           me->setBinLabel(1, ss.str());
           ss.str("");
           ss << "TCC" << inner.second << " TT1";
-          me->setBinLabel(25, ss.str());
+          me->setBinLabel(29, ss.str());
           ss.str("");
           ss << "TCC" << outer.first << " TT1";
-          me->setBinLabel(49, ss.str());
+          me->setBinLabel(57, ss.str());
           ss.str("");
           ss << "TCC" << outer.second << " TT1";
-          me->setBinLabel(65, ss.str());
+          me->setBinLabel(73, ss.str()); // Bins are numbered 1-->28, 29-->56 for two inner TCCs and 57-->72, 73-->88 for two outer TCCs
           int offset(0);
-          for(int iBin(4); iBin <= 80; iBin += 4){
-            if(iBin == 28) offset = 24;
-            else if(iBin == 52) offset = 48;
-            else if(iBin == 68) offset = 64;
+          for(int iBin(4); iBin <= 88; iBin += 4){
+            if(iBin == 32) offset = 28;
+            else if(iBin == 60) offset = 56;
+            else if(iBin == 76) offset = 72;
             ss.str("");
             ss << iBin - offset;
             me->setBinLabel(iBin, ss.str());

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -259,6 +259,9 @@ namespace ecaldqm
       bool match(true);
       bool matchFG(true);
 
+      // Loop over real TPs and look for an emulated TP index with matching Et:
+      // If an Et match is found, return TP index correpsonding to BX of emulated TP where match was found
+      // Standard TPG comparison: { TP index:matched BX } = { no emul:No Et match, 0:BX-2, 1:BX-1, 2:in-time, 3:BX+1, 4:BX+2 }
       EcalTrigPrimDigiCollection::const_iterator realItr(realTps_->find(ttid));
       if(realItr != realTps_->end()){
 
@@ -272,14 +275,30 @@ namespace ecaldqm
             if(et != realEt) match = false;
             if(tpItr->fineGrain() != realItr->fineGrain()) matchFG = false;
 
-            std::vector<int> matchedIndex(0);
-            for(int iDigi(0); iDigi < 5; iDigi++){
-              if((*tpItr)[iDigi].compressedEt() == realEt)
-                matchedIndex.push_back(iDigi + 1);
-            }
+	    // NOTE: matchedIndex comparison differs from Standard TPG comparison:
+	    // { matchedIndex:TP index } = { 0:no emul, 1:BX-2, 2:BX-1, 3:in-time, 4:BX+1, 5:BX+2 }
+	    std::vector<int> matchedIndex(0);
+	    // iDigi only loops over explicit Et matches:
+	    // { iDigi:TP index } = { 0:BX-2, 1:BX-1, 2:in-time, 3:BX+1, 4:BX+2 }
+	    for(int iDigi(0); iDigi < 5; iDigi++){
+	      if((*tpItr)[iDigi].compressedEt() == realEt) {
+		// matchedIndex = iDigi + 1
+		if (iDigi != 2) {
+		  matchedIndex.push_back(iDigi + 1);
+		}
+		// If an in-time match is found, exit loop and clear out any other matches:
+		// Ensures multiple matches are not returned (e.g. during saturation)
+		else {
+		  matchedIndex.clear();
+		  matchedIndex.push_back(3); // Et match is to in-time emulated TP
+		  break;
+		}
+	      } // Et match found
+	    } // iDigi
+	    if(!matchedIndex.size()) matchedIndex.push_back(0); // no Et match found => no emul
 
-            if(!matchedIndex.size()) matchedIndex.push_back(0);
-            for(std::vector<int>::iterator matchItr(matchedIndex.begin()); matchItr != matchedIndex.end(); ++matchItr){
+	    // Fill matchedIndex ME
+	    for(std::vector<int>::iterator matchItr(matchedIndex.begin()); matchItr != matchedIndex.end(); ++matchItr){
               meMatchedIndex.fill(ttid, *matchItr + 0.5);
 
               // timing information is only within emulated TPs (real TPs have one time sample)


### PR DESCRIPTION
(1) Fixed emulator match problem where, if two adjacent channels were saturated in energy, the emulated and data TP showed a match at two values
(2) Fixed incorrect trigger tower binning because of which emulator matches for TTs in a given TCC would overflow into the next TCC.
