### PR TITLE
restrict NHF-cut to eta<2.4 to prevent it from being applied in the HF

### DIFF
--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -83,7 +83,7 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
             pass = true;
             pass = pass && (ntot > NTOT_);
             pass = pass && (nef < NEF_);
-            pass = pass && (nhf < NHF_); //to be revisited if PF-reconstruction at HLT changes to be in line with offline code
+            pass = pass && (nhf < NHF_ || std::abs(eta) >= 2.4); //NHF-cut does not work in HF anymore with recent PF
             pass = pass && (cef < CEF_ || std::abs(eta) >= 2.4);
             pass = pass && (chf > CHF_ || std::abs(eta) >= 2.4);
             pass = pass && (nch > NCH_ || std::abs(eta) >= 2.4);


### PR DESCRIPTION
JetID-fix for 2016 datataking
