### PR TITLE
80x Fireworks: open file dialogue & geometry browsing

### DIFF
--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -713,7 +713,9 @@ CmsShowMain::setupDataHandling()
          setupConfiguration();
       }
 
-      if (m_monitor.get() == 0 && (configurationManager()->getIgnore() == false)) {
+      bool geoBrowser = (configFilename()[0] !='\0') && (eiManager()->begin() == eiManager()->end());
+
+      if (m_monitor.get() == 0 && (configurationManager()->getIgnore() == false) && ( !geoBrowser)) {
          if (m_inputFiles.empty())
             openDataViaURL();
          else


### PR DESCRIPTION
Don't pop file dialogue when configuration has no event items set.
