### PR TITLE
HCAL Phase1 bug fixes

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -66,9 +66,10 @@ HcalPedestal HcalDbHardcode::makePedestal (HcalGenericDetId fId, bool fSmear) {
   HcalPedestalWidth width = makePedestalWidth (fId);
   float value0 = getParameters(fId).pedestal();
   // Temporary disabling of lumi-dependent pedestal to avoid it being too big for TDC evaluations...
-  float value [4] = {0.0f,0.0f,0.0f,0.0f};
+  float value [4] = {value0,value0,value0,value0};
   if (fSmear) {
     for (int i = 0; i < 4; i++) {
+      value[i] = 0.0f;
       while (value [i] <= 0.0f) value [i] = value0 + (float)CLHEP::RandGauss::shoot (value0, width.getWidth (i) / 100.); // ignore correlations, assume 10K pedestal run 
     }
   }
@@ -94,8 +95,8 @@ HcalPedestalWidth HcalDbHardcode::makePedestalWidth (HcalGenericDetId fId) {
   }
 
   HcalPedestalWidth result (fId.rawId ());
+  float width2 = value*value;
   for (int i = 0; i < 4; i++) {
-    double width2 = value*value;
     for (int j = 0; j < 4; j++) {
       result.setSigma (i, j, 0.0);
     }
@@ -110,7 +111,8 @@ HcalGain HcalDbHardcode::makeGain (HcalGenericDetId fId, bool fSmear) { // GeV/f
   float value [4] = {value0, value0, value0, value0};
   if (fSmear) {
     for (int i = 0; i < 4; i++) {
-      value [i] = value0 + (float)CLHEP::RandGauss::shoot (0.0, width.getValue (i)); 
+      value[i] = 0.0f;
+      while (value [i] <= 0.0f) value [i] = value0 + (float)CLHEP::RandGauss::shoot (0.0, width.getValue (i)); 
     }
   }
   HcalGain result (fId.rawId (), value[0], value[1], value[2], value[3]);

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -96,6 +96,7 @@ private:
   CaloHitResponse * theHOResponse;
   CaloHitResponse * theHOSiPMResponse;
   CaloHitResponse * theHFResponse;
+  CaloHitResponse * theHFQIE10Response;
   CaloHitResponse * theZDCResponse;
 
   // we need separate amplifiers (and electronicssims)

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -94,6 +94,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theHOResponse(0),   
   theHOSiPMResponse(0),
   theHFResponse(new CaloHitResponse(theParameterMap, theShapes)),
+  theHFQIE10Response(new CaloHitResponse(theParameterMap, theShapes)),
   theZDCResponse(new CaloHitResponse(theParameterMap, theShapes)),
   theHBHEAmplifier(0),
   theHFAmplifier(0),
@@ -258,6 +259,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   }
 
   theHFResponse->setHitFilter(&theHFHitFilter);
+  theHFQIE10Response->setHitFilter(&theHFHitFilter);
   theZDCResponse->setHitFilter(&theZDCHitFilter);
 
   bool doTimeSlew = ps.getParameter<bool>("doTimeSlew");
@@ -272,7 +274,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   }
 
   if (doHFQIE10 || doHFQIE8) { //QIE8 and QIE10 can coexist in HF
-    if(doHFQIE10) theHFQIE10Digitizer = new QIE10Digitizer(theHFResponse, theHFQIE10ElectronicsSim, doEmpty);
+    if(doHFQIE10) theHFQIE10Digitizer = new QIE10Digitizer(theHFQIE10Response, theHFQIE10ElectronicsSim, doEmpty);
 	if(doHFQIE8) theHFDigitizer = new HFDigitizer(theHFResponse, theHFElectronicsSim, doEmpty);
   }
   else if (doHFUpgrade) {
@@ -347,6 +349,7 @@ HcalDigitizer::~HcalDigitizer() {
   delete theHOResponse;
   delete theHOSiPMResponse;
   delete theHFResponse;
+  delete theHFQIE10Response;
   delete theZDCResponse;
   delete theHBHEElectronicsSim;
   delete theHFElectronicsSim;
@@ -662,6 +665,7 @@ void  HcalDigitizer::updateGeometry(const edm::EventSetup & eventSetup) {
   if(theHOResponse) theHOResponse->setGeometry(theGeometry);
   if(theHOSiPMResponse) theHOSiPMResponse->setGeometry(theGeometry);
   theHFResponse->setGeometry(theGeometry);
+  theHFQIE10Response->setGeometry(theGeometry);
   theZDCResponse->setGeometry(theGeometry);
   if(theRelabeller) theRelabeller->setGeometry(theGeometry,theRecNumber);
 


### PR DESCRIPTION
1) It was found in private tests that QIE10 simulated digis appeared to have only pedestals with no signals. The problem was traced to:
https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h#L130

```
theHitResponse->clear();
```

The same CaloHitResponse was being used for HF QIE8 and HF QIE10. Using separate CaloHitResponse objects solves the problem. This fix will be backported to 80X.

2) In #13861, a bug was introduced in HcalDbHardcode: pedestals were set to 0 unless `fSmear` was enabled. This has been corrected. I also addressed a few lingering code review comments from @civanch that didn't make it into the previous PR. These fixes are 81X-only.
