### PR TITLE
Fixed static analyzer warning in PuppiProducer.cc & TrackerMap.cc

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -157,7 +157,6 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     else if(lPack->vertexRef().isNonnull() )  {
       pDZ        = lPack->dz();
       pD0        = lPack->dxy();
-      closestVtx = &(*(lPack->vertexRef()));
       pReco.dZ      = pDZ;
       pReco.d0      = pD0;
   

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -551,7 +551,6 @@ void TrackerMap::drawModule(TmModule * mod, int key,int mlay, bool print_total, 
   int numod=0;
   phi = phival(mod->posx,mod->posy);
   r = sqrt(mod->posx*mod->posx+mod->posy*mod->posy);
-  vhbot = mod->width;
   vhtop=mod->width;
   vhapo=mod->length;
   if(mlay < 31){ //endcap


### PR DESCRIPTION
By deleting the line 160: closestVtx = &(*(lPack->vertexRef()));
