### PR TITLE
fix closing lumisection in HLT(DAQ) when stop requested for Cloud switchover (80X)

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -204,6 +204,7 @@ namespace evf{
       bool readEolsDefinition_ = true;
       unsigned int eolsNFilesIndex_ = 1;
       std::string stopFilePath_;
+      unsigned int stop_ls_override_ = 0;
 
       std::shared_ptr<Json::Value> transferSystemJson_;
   };

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -482,9 +482,16 @@ namespace evf {
     int stopFileLS = -1;
     if (stat(stopFilePath_.c_str(),&buf)==0) {
         stopFileLS = readLastLSEntry(stopFilePath_);
+        if (!stop_ls_override_) {
+          //if lumisection is higher than in stop file, should quit at next from current
+          if (stopFileLS>=0 && (int)ls>=stopFileLS) stopFileLS = stop_ls_override_ = ls;
+        }
+        else stopFileLS = stop_ls_override_;
         edm::LogWarning("EvFDaqDirector") << "Detected stop request from hltd. Ending run for this process after LS -: " << stopFileLS;
         //return runEnded;
     }
+    else //if file was removed before reaching stop condition, reset this
+      stop_ls_override_ = 0;
 
     timeval ts_lockbegin;
     gettimeofday(&ts_lockbegin,0);


### PR DESCRIPTION
Fix for a bug appearing with high ramdisk access latency
(exceptional condition that does not happen normally, but is a result of some other problem, usually network / NFS) whene LS value given by CMSSW_STOP file
(created by hltd usually when cloud switch is made mid-run) is older than the current LS processed by CMSSW.

In this condition, end run in can happen in the mid of current LS, which
rarely resulted in not writing EoLS file to disk and thus causing lumisection to remain unmerged on FU.

This patch sets higher "stop LS" value with which current LS is properly closedr (EoLS file gets written out as in the usual case).
