### PR TITLE
80x Fireworks: Fix redraw problems when change collection properties.

### DIFF
--- a/Fireworks/Core/src/FWGUIManager.cc
+++ b/Fireworks/Core/src/FWGUIManager.cc
@@ -1396,6 +1396,7 @@ FWGUIManager::setFrom(const FWConfiguration& iFrom) {
       }
    }
 
+   gEve->EnableRedraw();
    // disable first docked view
    checkSubviewAreaIconState(0);
 


### PR DESCRIPTION
With change from  commit https://github.com/cms-sw/cmssw/pull/13942/commits/a878c4d305b9cfb0caf246bec65fab4a1e02c764, items did not redraw when change color or filter settings.

The change was in pr #13942
