### PR TITLE
Use unique_ptr, not auto_ptr in FastSimulation

### DIFF
--- a/FastSimulation/EventProducer/src/FamosProducer.cc
+++ b/FastSimulation/EventProducer/src/FamosProducer.cc
@@ -83,15 +83,15 @@ void FamosProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
    CalorimetryManager * calo = famosManager_->calorimetryManager();
    TrajectoryManager * tracker = famosManager_->trackerManager();
    
-   std::auto_ptr<edm::SimTrackContainer> p1(new edm::SimTrackContainer);
-   std::auto_ptr<edm::SimTrackContainer> m1(new edm::SimTrackContainer);
-   std::auto_ptr<edm::SimVertexContainer> p2(new edm::SimVertexContainer);
-   std::auto_ptr<FSimVertexTypeCollection> v1(new FSimVertexTypeCollection);
-   std::auto_ptr<edm::PSimHitContainer> p3(new edm::PSimHitContainer);
-   std::auto_ptr<edm::PCaloHitContainer> p4(new edm::PCaloHitContainer);
-   std::auto_ptr<edm::PCaloHitContainer> p5(new edm::PCaloHitContainer);
-   std::auto_ptr<edm::PCaloHitContainer> p6(new edm::PCaloHitContainer); 
-   std::auto_ptr<edm::PCaloHitContainer> p7(new edm::PCaloHitContainer);
+   std::unique_ptr<edm::SimTrackContainer> p1(new edm::SimTrackContainer);
+   std::unique_ptr<edm::SimTrackContainer> m1(new edm::SimTrackContainer);
+   std::unique_ptr<edm::SimVertexContainer> p2(new edm::SimVertexContainer);
+   std::unique_ptr<FSimVertexTypeCollection> v1(new FSimVertexTypeCollection);
+   std::unique_ptr<edm::PSimHitContainer> p3(new edm::PSimHitContainer);
+   std::unique_ptr<edm::PCaloHitContainer> p4(new edm::PCaloHitContainer);
+   std::unique_ptr<edm::PCaloHitContainer> p5(new edm::PCaloHitContainer);
+   std::unique_ptr<edm::PCaloHitContainer> p6(new edm::PCaloHitContainer); 
+   std::unique_ptr<edm::PCaloHitContainer> p7(new edm::PCaloHitContainer);
    
    FSimEvent* fevt = famosManager_->simEvent();
    fevt->load(*p1,*m1);
@@ -108,15 +108,15 @@ void FamosProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
      calo->loadMuonSimTracks(*m1);
    }
 
-   if ( simulateMuons ) iEvent.put(m1,"MuonSimTracks");
-   iEvent.put(p1);
-   iEvent.put(p2);
-   iEvent.put(p3,"TrackerHits");
-   iEvent.put(v1,"VertexTypes");
-   iEvent.put(p4,"EcalHitsEB");
-   iEvent.put(p5,"EcalHitsEE");
-   iEvent.put(p6,"EcalHitsES");
-   iEvent.put(p7,"HcalHits");
+   if ( simulateMuons ) iEvent.put(std::move(m1),"MuonSimTracks");
+   iEvent.put(std::move(p1));
+   iEvent.put(std::move(p2));
+   iEvent.put(std::move(p3),"TrackerHits");
+   iEvent.put(std::move(v1),"VertexTypes");
+   iEvent.put(std::move(p4),"EcalHitsEB");
+   iEvent.put(std::move(p5),"EcalHitsEE");
+   iEvent.put(std::move(p6),"EcalHitsES");
+   iEvent.put(std::move(p7),"HcalHits");
 
 }
 

--- a/FastSimulation/ForwardDetectors/plugins/CastorFastClusterProducer.cc
+++ b/FastSimulation/ForwardDetectors/plugins/CastorFastClusterProducer.cc
@@ -95,7 +95,7 @@ CastorFastClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
    iEvent.getByLabel("genParticles", genParticles);
    
    // make pointer to towers that will be made
-   auto_ptr<CastorClusterCollection> CastorClusters (new CastorClusterCollection);
+   unique_ptr<CastorClusterCollection> CastorClusters (new CastorClusterCollection);
    
    /*
    // declare castor array
@@ -341,7 +341,7 @@ CastorFastClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
    }
    */
     	
-   iEvent.put(CastorClusters); 
+   iEvent.put(std::move(CastorClusters));
    
 }
 

--- a/FastSimulation/ForwardDetectors/plugins/CastorFastTowerProducer.cc
+++ b/FastSimulation/ForwardDetectors/plugins/CastorFastTowerProducer.cc
@@ -95,7 +95,7 @@ CastorFastTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    iEvent.getByLabel("genParticles", genParticles);
    
    // make pointer to towers that will be made
-   auto_ptr<CastorTowerCollection> CastorTowers (new CastorTowerCollection);
+   unique_ptr<CastorTowerCollection> CastorTowers (new CastorTowerCollection);
    
    // declare castor array
    double castorplus [4][16]; // (0,x): Energies - (1,x): emEnergies - (2,x): hadEnergies - (3,x): phi position - eta = 5.9
@@ -362,7 +362,7 @@ CastorFastTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	}
    }
     	
-   iEvent.put(CastorTowers); 
+   iEvent.put(std::move(CastorTowers));
    
 }
 

--- a/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
+++ b/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
@@ -745,7 +745,7 @@ testNuclearInteractions::analyze(const edm::Event& iEvent, const edm::EventSetup
     std::cout << "Number of event analysed/NU "
 	      << totalNEvt << " / " << totalNU << std::endl; 
 
-  std::auto_ptr<edm::SimTrackContainer> nuclSimTracks(new edm::SimTrackContainer);
+  std::unique_ptr<edm::SimTrackContainer> nuclSimTracks(new edm::SimTrackContainer);
 
   //  std::cout << "Fill full event " << std::endl;
   edm::Handle<std::vector<SimTrack> > fullSimTracks;

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -502,32 +502,32 @@ MuonSimHitProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup) {
   }
   }
 
-  std::auto_ptr<edm::PSimHitContainer> pcsc(new edm::PSimHitContainer);
+  std::unique_ptr<edm::PSimHitContainer> pcsc(new edm::PSimHitContainer);
   int n = 0;
   for ( std::vector<PSimHit>::const_iterator i = theCSCHits.begin();
         i != theCSCHits.end(); i++ ) {
     pcsc->push_back(*i);
     n += 1;
   }
-  iEvent.put(pcsc,"MuonCSCHits");
+  iEvent.put(std::move(pcsc),"MuonCSCHits");
 
-  std::auto_ptr<edm::PSimHitContainer> pdt(new edm::PSimHitContainer);
+  std::unique_ptr<edm::PSimHitContainer> pdt(new edm::PSimHitContainer);
   n = 0;
   for ( std::vector<PSimHit>::const_iterator i = theDTHits.begin();
         i != theDTHits.end(); i++ ) {
     pdt->push_back(*i);
     n += 1;
   }
-  iEvent.put(pdt,"MuonDTHits");
+  iEvent.put(std::move(pdt),"MuonDTHits");
 
-  std::auto_ptr<edm::PSimHitContainer> prpc(new edm::PSimHitContainer);
+  std::unique_ptr<edm::PSimHitContainer> prpc(new edm::PSimHitContainer);
   n = 0;
   for ( std::vector<PSimHit>::const_iterator i = theRPCHits.begin();
         i != theRPCHits.end(); i++ ) {
     prpc->push_back(*i);
     n += 1;
   }
-  iEvent.put(prpc,"MuonRPCHits");
+  iEvent.put(std::move(prpc),"MuonRPCHits");
 
 }
 

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -69,7 +69,7 @@ FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es)
 {
 
   // Initialize the output product
-  std::auto_ptr<L3MuonTrajectorySeedCollection> result(new L3MuonTrajectorySeedCollection());
+  std::unique_ptr<L3MuonTrajectorySeedCollection> result(new L3MuonTrajectorySeedCollection());
   
   // Region builder
   theRegionBuilder->setEvent(ev);
@@ -164,7 +164,7 @@ FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es)
   // if(h_nGoodSeedPerEvent) h_nGoodSeedPerEvent->Fill(result->size());
   
   //put in the event
-  ev.put(result);
+  ev.put(std::move(result));
 
 }
 

--- a/FastSimulation/Tracking/plugins/ConversionTrackRefFix.cc
+++ b/FastSimulation/Tracking/plugins/ConversionTrackRefFix.cc
@@ -31,7 +31,7 @@ ConversionTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   Handle<TrackCollection> newTracks;
   iEvent.getByToken(newTracksToken,newTracks);
 
-  auto_ptr<ConversionTrackCollection> output(new ConversionTrackCollection);
+  unique_ptr<ConversionTrackCollection> output(new ConversionTrackCollection);
   
   for(const ConversionTrack &  conversion : *(conversionTracks.product())){
     size_t trackIndex = conversion.trackRef().key();
@@ -43,7 +43,7 @@ ConversionTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     output->back().setIsArbitratedMergedEcalGeneral(conversion.isArbitratedMergedEcalGeneral());
   }
 
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 
 }
 

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.cc
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.cc
@@ -81,9 +81,9 @@ ElectronSeedTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    Handle<ValueMap<PreIdRef> > iIdMap;
    iEvent.getByToken(idMapToken,iIdMap);
 
-  auto_ptr<ElectronSeedCollection> oSeeds(new ElectronSeedCollection);
-  auto_ptr<PreIdCollection> oIds(new PreIdCollection);
-  auto_ptr<ValueMap<PreIdRef> > oIdMap(new ValueMap<PreIdRef>);
+  unique_ptr<ElectronSeedCollection> oSeeds(new ElectronSeedCollection);
+  unique_ptr<PreIdCollection> oIds(new PreIdCollection);
+  unique_ptr<ValueMap<PreIdRef> > oIdMap(new ValueMap<PreIdRef>);
 
    ValueMap<PreIdRef>::Filler mapFiller(*oIdMap);
    
@@ -99,8 +99,8 @@ ElectronSeedTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSet
      oIds->back().setTrack(newTrackRef);
    }
 
-   iEvent.put(oSeeds,preidgsfLabel);
-   const edm::OrphanHandle<reco::PreIdCollection> preIdProd = iEvent.put(oIds,preidLabel);
+   iEvent.put(std::move(oSeeds),preidgsfLabel);
+   const edm::OrphanHandle<reco::PreIdCollection> preIdProd = iEvent.put(std::move(oIds),preidLabel);
 
    vector<PreIdRef> values;
    for(unsigned int t = 0;t<newTracks->size();++t){
@@ -115,7 +115,7 @@ ElectronSeedTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    mapFiller.insert(newTracks,values.begin(),values.end());
    mapFiller.fill();
 
-   iEvent.put(oIdMap,preidLabel);
+   iEvent.put(std::move(oIdMap),preidLabel);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -79,9 +79,9 @@ PixelTracksProducer::~PixelTracksProducer() {
 void 
 PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {        
   
-  std::auto_ptr<reco::TrackCollection> tracks(new reco::TrackCollection);    
-  std::auto_ptr<TrackingRecHitCollection> recHits(new TrackingRecHitCollection);
-  std::auto_ptr<reco::TrackExtraCollection> trackExtras(new reco::TrackExtraCollection);
+  std::unique_ptr<reco::TrackCollection> tracks(new reco::TrackCollection);    
+  std::unique_ptr<TrackingRecHitCollection> recHits(new TrackingRecHitCollection);
+  std::unique_ptr<reco::TrackExtraCollection> trackExtras(new reco::TrackExtraCollection);
   typedef std::vector<const TrackingRecHit *> RecHits;
   
   TracksWithRecHits pixeltracks;
@@ -96,9 +96,9 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   // No seed -> output an empty track collection
   if(theSeeds->size() == 0) {
-    e.put(tracks);
-    e.put(recHits);
-    e.put(trackExtras);
+    e.put(std::move(tracks));
+    e.put(std::move(recHits));
+    e.put(std::move(trackExtras));
     return;
   }
   
@@ -159,7 +159,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     
   }
   
-  edm::OrphanHandle <TrackingRecHitCollection> ohRH = e.put( recHits );
+  edm::OrphanHandle <TrackingRecHitCollection> ohRH = e.put(std::move(recHits ));
   edm::RefProd<TrackingRecHitCollection> ohRHProd(ohRH);
 
   for (int k = 0; k < nTracks; ++k) {
@@ -178,7 +178,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     //delete theTrackExtra;
   }
   
-  edm::OrphanHandle<reco::TrackExtraCollection> ohTE = e.put(trackExtras);
+  edm::OrphanHandle<reco::TrackExtraCollection> ohTE = e.put(std::move(trackExtras));
   
   for (int k = 0; k < nTracks; k++) {
 
@@ -187,7 +187,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   }
   
-  e.put(tracks);
+  e.put(std::move(tracks));
 
 }
 

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -26,9 +26,9 @@ RecoTrackAccumulator::~RecoTrackAccumulator() {
   
 void RecoTrackAccumulator::initializeEvent(edm::Event const& e, edm::EventSetup const& iSetup) {
     
-  newTracks_ = std::auto_ptr<reco::TrackCollection>(new reco::TrackCollection);
-  newHits_ = std::auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection);
-  newTrackExtras_ = std::auto_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection);
+  newTracks_ = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection);
+  newHits_ = std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection);
+  newTrackExtras_ = std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection);
   
   // this is needed to get the ProductId of the TrackExtra and TrackingRecHit and Track collections
   rNewTracks=const_cast<edm::Event&>( e ).getRefBeforePut<reco::TrackCollection>(outputLabel);
@@ -48,9 +48,9 @@ void RecoTrackAccumulator::accumulate(PileUpEventPrincipal const& e, edm::EventS
 
 void RecoTrackAccumulator::finalizeEvent(edm::Event& e, const edm::EventSetup& iSetup) {
   
-  e.put( newTracks_, outputLabel );
-  e.put( newHits_, outputLabel );
-  e.put( newTrackExtras_, outputLabel );
+  e.put(std::move(newTracks_), outputLabel );
+  e.put(std::move(newHits_), outputLabel );
+  e.put(std::move(newTrackExtras_), outputLabel );
 }
 
 

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -48,9 +48,9 @@ class RecoTrackAccumulator : public DigiAccumulatorMixMod
  private:
   template<class T> void accumulateEvent(const T& e, edm::EventSetup const& c,const edm::InputTag & label);
 
-  std::auto_ptr<reco::TrackCollection>  newTracks_;
-  std::auto_ptr<reco::TrackExtraCollection> newTrackExtras_;
-  std::auto_ptr<TrackingRecHitCollection> newHits_;
+  std::unique_ptr<reco::TrackCollection>  newTracks_;
+  std::unique_ptr<reco::TrackExtraCollection> newTrackExtras_;
+  std::unique_ptr<TrackingRecHitCollection> newHits_;
 
   reco::TrackRefProd rNewTracks;
   reco::TrackExtraRefProd rNewTrackExtras;

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -170,7 +170,7 @@ testGeneralTracks::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     std::cout << "Number of event analysed "
 	      << totalNEvt << std::endl; 
   
-  std::auto_ptr<edm::SimTrackContainer> nuclSimTracks(new edm::SimTrackContainer);
+  std::unique_ptr<edm::SimTrackContainer> nuclSimTracks(new edm::SimTrackContainer);
   
   edm::Handle<std::vector<SimTrack> > fastSimTracks;
   iEvent.getByLabel("famosSimHits",fastSimTracks);


### PR DESCRIPTION
The last use of the deprecated std::auto_ptr in the CMS framework is the "put" interface for EDProducts, which also supports std::unique:ptr. This PR changes all put calls in FastSimulation to use std::unique_ptr instead of std::auto_ptr. Some other instances of std::auto_ptr in fastsim may also have been changed to std::unique_ptr.
