### PR TITLE
Fastsim tracking memory leak fix and rawaodsim event content definition

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -769,9 +769,27 @@ from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroE
 MINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
 
+#
+#
+# RAWSIM Data Tier definition
+# Meant as means to temporarily hold the RAW + AODSIM information as to allow the
+# L1+HLT to be rerun at a later time.
+#
+RAWAODSIMEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *'),
+    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(4)
+)
+
+RAWAODSIMEventContent.outputCommands.extend(AODSIMEventContent.outputCommands)
+RAWAODSIMEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+RAWAODSIMEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
+
+
 # in fastsim, normal digis are edaliases of simdigis
 # drop the simdigis to avoid complaints from the outputmodule related to duplicated branches
 if eras.fastSim.isChosen():
-    for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent]:
+    for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent,RAWAODSIMEventContent]:
         fastSimEC.dropSimDigis(_entry.outputCommands)
     

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -193,12 +193,14 @@ void TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
 	    std::vector<BaseTrackerRecHit const *> innerHits(1,(const BaseTrackerRecHit*) innerHit->hit());
 	    std::vector<BaseTrackerRecHit const *> outerHits(1,(const BaseTrackerRecHit*) outerHit->hit());
 		
-	    const RecHitsSortedInPhi* ihm=new RecHitsSortedInPhi (innerHits, selectedTrackingRegion->origin(), innerLayer);
-	    const RecHitsSortedInPhi* ohm=new RecHitsSortedInPhi (outerHits, selectedTrackingRegion->origin(), outerLayer);
+	    //const RecHitsSortedInPhi* ihm=new RecHitsSortedInPhi (innerHits, selectedTrackingRegion->origin(), innerLayer);
+	    //const RecHitsSortedInPhi* ohm=new RecHitsSortedInPhi (outerHits, selectedTrackingRegion->origin(), outerLayer);
+	    const RecHitsSortedInPhi ihm(innerHits, selectedTrackingRegion->origin(), innerLayer);
+	    const RecHitsSortedInPhi ohm(outerHits, selectedTrackingRegion->origin(), outerLayer);
 		
-	    HitDoublets result(*ihm,*ohm); 
-	    HitPairGeneratorFromLayerPair::doublets(*selectedTrackingRegion,*innerLayer,*outerLayer,*ihm,*ohm,es,0,result);
-		
+	    HitDoublets result(ihm,ohm); 
+	    HitPairGeneratorFromLayerPair::doublets(*selectedTrackingRegion,*innerLayer,*outerLayer,ihm,ohm,es,0,result);
+	    
 	    if(result.size()!=0)
 	    {
 		return true; 


### PR DESCRIPTION
two changes for 803 based patch release:
 -- fastsim memory leak fix 
 -- forward port of RAWAODSIM event content from 76x (where it was tested)
