### PR TITLE
fix up zero suppression for QIE10

### DIFF
--- a/DataFormats/HcalDigi/interface/QIE10DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE10DataFrame.h
@@ -66,11 +66,8 @@ public:
   /// was this a mark-and-pass ZS event?
   static const int MASK_MARKPASS = 0x100;
   bool zsMarkAndPass() const {return m_data[0]&MASK_MARKPASS; }
-  /// other ZS functions (TODO: real implementation)
-  bool zsUnsuppressed() const { return false; }
-  uint32_t zsCrossingMask() const { return 0; }
   /// set ZS params
-  void setZSInfo(bool unsuppressed, bool markAndPass, uint32_t crossingMask=0);
+  void setZSInfo(bool markAndPass);
   /// get the sample
   inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(m_data,i*WORDS_PER_SAMPLE+HEADER_WORDS); }
   /// set the sample contents

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -64,9 +64,6 @@ public:
   bool capidError() const { return m_data[0]&MASK_CAPIDERROR; } 
   /// was this a mark-and-pass ZS event?
   bool zsMarkAndPass() const {return (flavor()==1); }
-  /// other ZS functions (TODO: real implementation)
-  bool zsUnsuppressed() const { return false; }
-  uint32_t zsCrossingMask() const { return 0; }
   /// get the sample
   inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(m_data,i+HEADER_WORDS); }
   void setCapid0(int cap0);

--- a/DataFormats/HcalDigi/src/QIE10DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE10DataFrame.cc
@@ -25,7 +25,7 @@ int QIE10DataFrame::presamples() const {
   return -1;
 }
 
-void QIE10DataFrame::setZSInfo(bool unsuppressed, bool markAndPass, uint32_t crossingMask){
+void QIE10DataFrame::setZSInfo(bool markAndPass){
 	if(markAndPass) m_data[0] |= MASK_MARKPASS;
 }
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.cc
@@ -103,7 +103,7 @@ bool HcalZSAlgoRealistic::keepMe(const HFDataFrame& inp, int start, int finish, 
   return keepIt;
 }
 
-bool HcalZSAlgoRealistic::keepMe(const QIE10DataFrame& inp, int start, int finish, int threshold, uint32_t hfzsmask) const{
+bool HcalZSAlgoRealistic::keepMe(const QIE10DataFrame& inp, int start, int finish, int threshold) const{
   
   bool keepIt=false;
   //  int mask = 999;
@@ -119,8 +119,7 @@ bool HcalZSAlgoRealistic::keepMe(const QIE10DataFrame& inp, int start, int finis
       sum+=inp[j].adc();
       //pedsum+=pedave;
     }
-    if ((hfzsmask&(1<<i)) !=0) continue; 
-    else if (sum>=threshold) keepIt=true;
+    if (sum>=threshold) keepIt=true;
   }
   return keepIt;
 }
@@ -183,7 +182,7 @@ bool HcalZSAlgoRealistic::shouldKeep(const QIE10DataFrame& digi) const{
 
   int start  = std::max(0,HFsearchTS_.first);
   int finish = std::min((int)digi.size()-1,HFsearchTS_.second);
-  return keepMe(digi,start,finish,thresholdHF_,digi.zsCrossingMask());
+  return keepMe(digi,start,finish,thresholdHF_);
 }
 
 bool HcalZSAlgoRealistic::shouldKeep(const HcalUpgradeDataFrame& digi) const{

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
@@ -29,7 +29,7 @@ private:
   bool keepMe(const HBHEDataFrame& inp, int start, int finish, int threshold, uint32_t hbhezsmask) const;
   bool keepMe(const HODataFrame& inp, int start, int finish, int threshold, uint32_t hozsmask) const;
   bool keepMe(const HFDataFrame& inp, int start, int finish, int threshold, uint32_t hfzsmask) const;
-  bool keepMe(const QIE10DataFrame& inp, int start, int finish, int threshold, uint32_t hfzsmask) const;
+  bool keepMe(const QIE10DataFrame& inp, int start, int finish, int threshold) const;
   bool keepMe(const HcalUpgradeDataFrame& inp, int start, int finish, int threshold, uint32_t zsmask) const;
 };
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.cc
@@ -93,12 +93,12 @@ void HcalZeroSuppressionAlgo::suppress(const QIE10DigiCollection& input, QIE10Di
 	output.push_back(*i);
       } else {
 	QIE10DataFrame df(*i);
-	//df.setZSInfo(true,false);
+	df.setZSInfo(false);
 	output.push_back(df);
       }
     } else if (m_markAndPass) {
       QIE10DataFrame df(*i);
-      //df.setZSInfo(true,true);
+      df.setZSInfo(true);
       output.push_back(df);
     }
   }


### PR DESCRIPTION
Simplified the QIE10 zero suppression (uses only MarkAndPass info) after discussion with @jmmans. The ZS algos should handle this consistently now. This PR will be backported to 80X.
