### PR TITLE
DQM for B2G Ele + Single Jet paths 2016 - backport 80X

### DIFF
--- a/HLTriggerOffline/B2G/python/b2gHLTValidation_cff.py
+++ b/HLTriggerOffline/B2G/python/b2gHLTValidation_cff.py
@@ -7,6 +7,7 @@ from HLTriggerOffline.B2G.b2gHadronicHLTEventValidation_cfi import *
 b2gHLTriggerValidation = cms.Sequence(  
     b2gSingleMuonHLTValidation*
     b2gSingleElectronHLTValidation*
+    b2gElePlusSingleJetHLTValidation*
     b2gSingleJetHLTValidation*
     b2gDiJetHLTValidation
     )

--- a/HLTriggerOffline/B2G/python/b2gSingleLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/B2G/python/b2gSingleLeptonHLTEventValidation_cfi.py
@@ -51,3 +51,28 @@ b2gSingleElectronHLTValidation = cms.EDAnalyzer('B2GSingleLeptonHLTValidation',
         vsPaths      = cms.untracked.vstring(['HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50',
 		'HLT_Ele35_CaloIdVT_GsfTrkIdT_PFJet150_PFJet50']),
 )
+
+b2gElePlusSingleJetHLTValidation  = cms.EDAnalyzer('B2GSingleLeptonHLTValidation',
+        # Directory
+        sDir         = cms.untracked.string('HLT/B2GHLTValidation/B2G/ElePlusSingleJet/'),
+        # Electrons
+        sElectrons   = cms.untracked.string('gedGsfElectrons'),
+        ptElectrons  = cms.untracked.double(50.),
+        etaElectrons = cms.untracked.double(2.5),
+        minElectrons = cms.untracked.uint32(1),
+        # Muons
+        sMuons       = cms.untracked.string('muons'),
+        ptMuons      = cms.untracked.double(40.),
+        etaMuons     = cms.untracked.double(2.1),
+        minMuons     = cms.untracked.uint32(0),
+        # Jets
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
+        ptJets0      = cms.untracked.double(140.),
+        ptJets1      = cms.untracked.double(-1.0),
+        etaJets      = cms.untracked.double(2.4),
+        minJets      = cms.untracked.uint32(1),
+        # Trigger
+        sTrigger     = cms.untracked.string("TriggerResults"),
+        vsPaths      = cms.untracked.vstring(['HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet140',
+                                              'HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165']),
+)


### PR DESCRIPTION
This PR adds another instance of the B2G semi-leptonic DQM module, "B2GSingleLeptonHLTValidation", to the B2G group HLT validation sequence.

This will add DQM plots for the monitoring of the two paths, HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet140 and HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165, that will be deployed in 2016.

This is the 80X backport of #14129
