### PR TITLE
Update Run1 and Run2 GT in autoCond for 50ns JEC uncertaities

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,11 +20,11 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v8',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v11',
+    'run1_data'         :   '80X_dataRun2_v12',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v11',
+    'run2_data'         :   '80X_dataRun2_v12',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v12) as [80X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v12/80X_dataRun2_v11): 
  - Fall15 v3 Jet Energy corrections (adds uncertainties for 50ns)
- **RunII Offline relval processing** : [80X_dataRun2_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v8) as [80X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v8/80X_dataRun2_relval_v6): 
  - Fall15 v3 Jet Energy corrections (adds uncertainties for 50ns)
  - update the L1 menu to v5
