### PR TITLE
Updated WaitingTaskList to handle exception

### DIFF
--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -1,0 +1,74 @@
+#ifndef FWCore_Concurrency_WaitingTask_h
+#define FWCore_Concurrency_WaitingTask_h
+// -*- C++ -*-
+//
+// Package:     Concurrency
+// Class  :     WaitingTask
+// 
+/**\class WaitingTask WaitingTask.h FWCore/Concurrency/interface/WaitingTask.h
+
+ Description: Task used by WaitingTaskList.
+
+ Usage:
+    Used as a callback to happen after a task has been completed. Includes the ability to hold an exception which has occurred while waiting.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu Feb 21 13:46:31 CST 2013
+// $Id$
+//
+
+// system include files
+#include <atomic>
+#include <exception>
+#include "tbb/task.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  class WaitingTaskList;
+  
+  class WaitingTask : public tbb::task {
+      
+   public:
+    friend class WaitingTaskList;
+    
+    ///Constructor
+    WaitingTask() : m_ptr{nullptr} {}
+    ~WaitingTask() override {
+      delete m_ptr.load();
+    };
+      
+    // ---------- const member functions ---------------------------
+      
+    ///Returns exception thrown by dependent task
+    /** If the value is non-null then the dependent task failed.
+    */
+    std::exception_ptr const * exceptionPtr() const {
+      return m_ptr.load();
+    }
+   private:
+    
+    ///Called if waited for task failed
+    /**Allows transfer of the exception caused by the dependent task to be
+     * moved to another thread.
+     * This method should only be called by WaitingTaskList
+     */
+    void dependentTaskFailed(std::exception_ptr iPtr) {
+      if (iPtr and not m_ptr) {
+        auto temp = std::make_unique<std::exception_ptr>(iPtr);
+        std::exception_ptr* expected = nullptr;
+        if( m_ptr.compare_exchange_strong(expected, temp.get()) ) {
+          temp.release();
+        }
+      }
+    }
+    
+    std::atomic<std::exception_ptr*> m_ptr;
+  };
+  
+}
+
+#endif

--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -21,6 +21,7 @@
 // system include files
 #include <atomic>
 #include <exception>
+#include <memory>
 #include "tbb/task.h"
 
 // user include files

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -23,32 +23,40 @@ class WaitingTaskList_test : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(WaitingTaskList_test);
   CPPUNIT_TEST(addThenDone);
   CPPUNIT_TEST(doneThenAdd);
+  CPPUNIT_TEST(addThenDoneFailed);
+  CPPUNIT_TEST(doneThenAddFailed);
   CPPUNIT_TEST(stressTest);
   CPPUNIT_TEST_SUITE_END();
   
 public:
   void addThenDone();
   void doneThenAdd();
+  void addThenDoneFailed();
+  void doneThenAddFailed();
   void stressTest();
   void setUp(){}
   void tearDown(){}
 };
 
 namespace  {
-   class TestCalledTask : public tbb::task {
+   class TestCalledTask : public edm::WaitingTask {
    public:
-      TestCalledTask(std::atomic<bool>& iCalled): m_called(iCalled) {}
+     TestCalledTask(std::atomic<bool>& iCalled, std::exception_ptr& iPtr): m_called(iCalled), m_ptr(iPtr) {}
 
       tbb::task* execute() {
+         if(exceptionPtr()) {
+           m_ptr = *exceptionPtr();
+         }
          m_called = true;
          return nullptr;
       }
       
    private:
       std::atomic<bool>& m_called;
+      std::exception_ptr& m_ptr;
    };
    
-   class TestValueSetTask : public tbb::task {
+   class TestValueSetTask : public edm::WaitingTask {
    public:
       TestValueSetTask(std::atomic<bool>& iValue): m_value(iValue) {}
          tbb::task* execute() {
@@ -65,14 +73,15 @@ namespace  {
 void WaitingTaskList_test::addThenDone()
 {
    std::atomic<bool> called{false};
-   
+   std::exception_ptr excPtr;
+  
    edm::WaitingTaskList waitList;
    {
-      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
-                                            [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
+      std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
+                                                 [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(2);
       //NOTE: allocate_child does NOT increment the ref_count of waitTask!
-      tbb::task* t = new (waitTask->allocate_child()) TestCalledTask{called};
+      auto t = new (waitTask->allocate_child()) TestCalledTask{called,excPtr};
    
       waitList.add(t);
 
@@ -80,55 +89,111 @@ void WaitingTaskList_test::addThenDone()
       __sync_synchronize();
       CPPUNIT_ASSERT(false==called);
    
-      waitList.doneWaiting();
+      waitList.doneWaiting(std::exception_ptr{});
       waitTask->wait_for_all();
       __sync_synchronize();
       CPPUNIT_ASSERT(true==called);
+      CPPUNIT_ASSERT( bool(excPtr) == false);
    }
    
    waitList.reset();
    called = false;
    
    {
-      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
-                                            [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
+      std::exception_ptr excPtr;
+
+      std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
+                                                 [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(2);
    
-      tbb::task* t = new (waitTask->allocate_child()) TestCalledTask{called};
+      auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr};
    
       waitList.add(t);
 
       usleep(10);
       CPPUNIT_ASSERT(false==called);
    
-      waitList.doneWaiting();
+      waitList.doneWaiting(std::exception_ptr{});
       waitTask->wait_for_all();
       CPPUNIT_ASSERT(true==called);
+      CPPUNIT_ASSERT( bool(excPtr) == false);
    }
 }
 
 void WaitingTaskList_test::doneThenAdd()
 {
    std::atomic<bool> called{false};
+   std::exception_ptr excPtr;
+
    edm::WaitingTaskList waitList;
    {
-      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
-                                            [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
+     std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
+                                              [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(2);
    
-      tbb::task* t = new (waitTask->allocate_child()) TestCalledTask{called};
+      auto t = new (waitTask->allocate_child()) TestCalledTask{called,excPtr};
 
-      waitList.doneWaiting();
+      waitList.doneWaiting(std::exception_ptr{});
    
       waitList.add(t);
       waitTask->wait_for_all();
       CPPUNIT_ASSERT(true==called);
+      CPPUNIT_ASSERT( bool(excPtr) == false);
    }
+}
+
+void WaitingTaskList_test::addThenDoneFailed()
+{
+  std::atomic<bool> called{false};
+  std::exception_ptr excPtr;
+  
+  edm::WaitingTaskList waitList;
+  {
+    std::exception_ptr excPtr;
+    
+    std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
+      [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+    waitTask->set_ref_count(2);
+    
+    auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr};
+    
+    waitList.add(t);
+    
+    usleep(10);
+    CPPUNIT_ASSERT(false==called);
+    
+    waitList.doneWaiting(std::make_exception_ptr(std::string("failed")));
+    waitTask->wait_for_all();
+    CPPUNIT_ASSERT(true==called);
+    CPPUNIT_ASSERT( bool(excPtr) == true);
+  }
+}
+
+void WaitingTaskList_test::doneThenAddFailed()
+{
+  std::atomic<bool> called{false};
+  std::exception_ptr excPtr;
+  
+  edm::WaitingTaskList waitList;
+  {
+    std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
+      [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+    waitTask->set_ref_count(2);
+    
+    auto t = new (waitTask->allocate_child()) TestCalledTask{called,excPtr};
+    
+    waitList.doneWaiting(std::make_exception_ptr(std::string("failed")));
+    
+    waitList.add(t);
+    waitTask->wait_for_all();
+    CPPUNIT_ASSERT(true==called);
+    CPPUNIT_ASSERT( bool(excPtr) == true);
+  }
 }
 
 namespace {
 #if defined(CXX_THREAD_AVAILABLE)
-   void join_thread(std::thread* iThread){ 
+   void join_thread(std::thread* iThread){
       if(iThread->joinable()){iThread->join();}
    }
 #endif
@@ -138,21 +203,22 @@ void WaitingTaskList_test::stressTest()
 {
 #if defined(CXX_THREAD_AVAILABLE)
    std::atomic<bool> called{false};
+   std::exception_ptr excPtr;
    edm::WaitingTaskList waitList;
    
    unsigned int index = 1000;
    const unsigned int nTasks = 10000;
    while(0 != --index) {
       called = false;
-      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
-                                            [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
+     std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
+                                                [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
       waitTask->set_ref_count(3);
       tbb::task* pWaitTask=waitTask.get();
       
       {
-         std::thread makeTasksThread([&waitList,pWaitTask,&called]{
+         std::thread makeTasksThread([&waitList,pWaitTask,&called,&excPtr]{
             for(unsigned int i = 0; i<nTasks;++i) {
-               auto t = new (tbb::task::allocate_additional_child_of(*pWaitTask)) TestCalledTask{called};
+               auto t = new (tbb::task::allocate_additional_child_of(*pWaitTask)) TestCalledTask{called, excPtr};
                waitList.add(t);
             }
          
@@ -162,7 +228,7 @@ void WaitingTaskList_test::stressTest()
          
          std::thread doneWaitThread([&waitList,&called,pWaitTask]{
             called=true;
-            waitList.doneWaiting();
+            waitList.doneWaiting(std::exception_ptr{});
             pWaitTask->decrement_ref_count();
             });
          std::shared_ptr<std::thread>(&doneWaitThread,join_thread);


### PR DESCRIPTION
If the task waited upon throws an exception, that exception is communicated to the waiting tasks. This requires a new base class for tasks, WaitingTask.
The unit test was update to reflect the new API and to test the exception case.
