### PR TITLE
Add missing std::move() in LuminosityBlock::put()

### DIFF
--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -110,7 +110,7 @@ namespace edm {
 
     template <typename PROD>
     void
-    put(std::unique_ptr<PROD> product) {put<PROD>(product, std::string());}
+    put(std::unique_ptr<PROD> product) {put<PROD>(std::move(product), std::string());}
 
     ///Put a new product with a 'product instance name'
     template <typename PROD>
@@ -177,7 +177,7 @@ namespace edm {
   template <typename PROD>
   void
   LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(product.get() == 0) {                // null pointer is illegal
+    if(product.get() == nullptr) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
     }


### PR DESCRIPTION
In the function edm::LuminosityBlock::put() that takes a std::unique_ptr, a necessary call to std::move() was omitted, such that this function would never compile if instantiated. This was first noticed in converting the use of std::auto_ptr to std::unique_ptr outside the framework.
The std::move() call was correctly present for event or run products.
Please expedite this trivial, technical PR, as other pending changes depend on it.
