### PR TITLE
Enable pixel templates for phase1 pixel

### DIFF
--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -12,10 +12,6 @@ duplicateDisplacedTrackCandidates = DuplicateTrackMerger.clone(
     useInnermostState  = cms.bool(True),
     ttrhBuilderName    = cms.string("WithAngleAndTemplate")
     )
-# This customization will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(duplicateDisplacedTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
 #for displaced global muons
 mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = cms.InputTag("duplicateDisplacedTrackCandidates","candidates"),

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -44,8 +44,3 @@ GlobalMuonRefitter = cms.PSet(
 
     RefitFlag = cms.bool( True )
 )
-
-# These customizations will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(GlobalMuonRefitter, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -68,12 +68,3 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
 	RefitFlag = cms.bool(True)
         ),
 )
-
-# This customization will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(GlobalTrajectoryBuilderCommon, # FIXME
-    TrackerRecHitBuilder = 'WithTrackAngle',
-    TrackTransformer = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
-    GlbRefitterParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
-)

--- a/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
+++ b/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
@@ -17,8 +17,3 @@ TrackerKinkFinderParametersBlock = cms.PSet(
         Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
     )
 )
-
-# This customization will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(TrackerKinkFinderParametersBlock, TrackerKinkFinderParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle')) # FIXME

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -83,8 +83,3 @@ MuonTrackLoaderForCosmic = cms.PSet(
         TTRHBuilder = cms.string('WithAngleAndTemplate')
     )
 )
-
-# These customizations will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(MuonTrackLoaderForGLB, TrackLoaderParameters = dict(TTRHBuilder = 'WithTrackAngle')) # FIXME

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
@@ -48,9 +48,3 @@ trackerDrivenElectronSeeds = cms.EDProducer("GoodSeedProducer",
     PtThresholdSavePreId = cms.untracked.double(1.0),
     Min_dr = cms.double(0.2)
 )
-
-
-# This customization will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(trackerDrivenElectronSeeds, TTRHBuilder  = 'WithTrackAngle') # FIXME

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
 from RecoTracker.FinalTrackSelectors.DuplicateTrackMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.DuplicateListMerger_cfi import *
@@ -8,9 +7,6 @@ duplicateTrackCandidates = DuplicateTrackMerger.clone()
 duplicateTrackCandidates.source = cms.InputTag("preDuplicateMergingGeneralTracks")
 duplicateTrackCandidates.useInnermostState  = True
 duplicateTrackCandidates.ttrhBuilderName   = "WithAngleAndTemplate"
-# This customization will be removed once we get the templates for
-# phase1 pixel
-eras.phase1Pixel.toModify(duplicateTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
                                      
 import RecoTracker.TrackProducer.TrackProducer_cfi
 mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()

--- a/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
@@ -20,8 +20,3 @@ inOutSeedsFromTrackerMuons = cms.EDProducer("MuonReSeeder",
     RefitRPCHits = cms.bool(True),
     Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
 )
-
-# This customization will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(inOutSeedsFromTrackerMuons, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME

--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -26,9 +26,3 @@ TrackProducer = cms.EDProducer("TrackProducer",
     MeasurementTracker = cms.string(''),
     MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent'),                   
 )
-
-# This customization will be removed once we get the templates for
-# phase1 pixel
-from Configuration.StandardSequences.Eras import eras
-eras.phase1Pixel.toModify(TrackProducer, TTRHBuilder = 'WithTrackAngle') # FIXME
-


### PR DESCRIPTION
The title says it all. The templates are already part of the GTs, so enabling them is just a matter of removing all customizations changing TransientTrackingRecHitBuilder to "WithTrackAngle".

Tested in 8_1_0_pre2, small changes expected in tracking and downstream (most notably dxy and dz resolutions improve). I have the usual set of MTV plots with 1000 TTbar+35PU events here (RAW from 810pre1, ideal GT) https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre2_template

@rovere @VinInn @dkotlins 
