### PR TITLE
tracking and strip DQM : trigger selection via DB

### DIFF
--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -84,6 +84,7 @@ GenericTriggerEventFlag::GenericTriggerEventFlag( const edm::ParameterSet & conf
         gtEvmInputToken_ = iC.mayConsume< L1GlobalTriggerEvmReadoutRecord >( gtEvmInputTag_ );
       }
       if ( config.exists( "gtDBKey" ) ) gtDBKey_ = config.getParameter< std::string >( "gtDBKey" );
+      std::cout << "[GenericTriggerEventFlag::GenericTriggerEventFlag] gtDBKey: " << gtDBKey_ << std::endl;
     } else {
       onGt_ = false;
     }
@@ -92,6 +93,7 @@ GenericTriggerEventFlag::GenericTriggerEventFlag( const edm::ParameterSet & conf
       l1LogicalExpressionsCache_ = config.getParameter< std::vector< std::string > >( "l1Algorithms" );
       errorReplyL1_              = config.getParameter< bool >( "errorReplyL1" );
       if ( config.exists( "l1DBKey" ) )      l1DBKey_      = config.getParameter< std::string >( "l1DBKey" );
+      std::cout << "[GenericTriggerEventFlag::GenericTriggerEventFlag] l1DBKey: " << l1DBKey_ << std::endl;
       if ( config.exists( "l1BeforeMask" ) ) l1BeforeMask_ = config.getParameter< bool >( "l1BeforeMask" );
     } else {
       onL1_ = false;
@@ -103,12 +105,14 @@ GenericTriggerEventFlag::GenericTriggerEventFlag( const edm::ParameterSet & conf
       hltLogicalExpressionsCache_ = config.getParameter< std::vector< std::string > >( "hltPaths" );
       errorReplyHlt_              = config.getParameter< bool >( "errorReplyHlt" );
       if ( config.exists( "hltDBKey" ) ) hltDBKey_ = config.getParameter< std::string >( "hltDBKey" );
+      std::cout << "[GenericTriggerEventFlag::GenericTriggerEventFlag] hltDBKey: " << hltDBKey_ << std::endl;
     } else {
       onHlt_ = false;
     }
     if ( ! onDcs_ && ! onGt_ && ! onL1_ && ! onHlt_ ) on_ = false;
     else {
       if ( config.exists( "dbLabel" ) ) dbLabel_ = config.getParameter< std::string >( "dbLabel" );
+      std::cout << "[GenericTriggerEventFlag::GenericTriggerEventFlag] dbLabel_: " << dbLabel_ << std::endl;
       watchDB_ = new edm::ESWatcher< AlCaRecoTriggerBitsRcd >;
     }
   }
@@ -135,12 +139,26 @@ void GenericTriggerEventFlag::initRun( const edm::Run & run, const edm::EventSet
       if ( exprs.empty() || exprs.at( 0 ) != configError_ ) gtLogicalExpressions_ = exprs;
     }
     if ( onL1_ && l1DBKey_.size() > 0 ) {
+      std::cout << "onL1" << std::endl;
       const std::vector< std::string > exprs( expressionsFromDB( l1DBKey_, setup ) );
+      std::cout << "exprs" << exprs.size() << std::endl;
+      if ( exprs.empty() ) std::cout << "exprs.at( 0 ): " << exprs.at( 0 ) << std::endl;
       if ( exprs.empty() || exprs.at( 0 ) != configError_ ) l1LogicalExpressionsCache_ = exprs;
+      for ( unsigned iExpr = 0; iExpr < l1LogicalExpressionsCache_.size(); ++iExpr ) {
+	std::string l1LogicalExpression( l1LogicalExpressionsCache_.at( iExpr ) );  
+	std::cout << "l1LogicalExpressionsCache_: " << l1LogicalExpression << std::endl;
+      }
     }
     if ( onHlt_ && hltDBKey_.size() > 0 ) {
+      std::cout << "onHlt_: " << std::endl;
       const std::vector< std::string > exprs( expressionsFromDB( hltDBKey_, setup ) );
+      std::cout << "exprs" << exprs.size() << std::endl;
+      if ( exprs.empty() ) std::cout << "exprs.at( 0 ): " << exprs.at( 0 ) << std::endl;
       if ( exprs.empty() || exprs.at( 0 ) != configError_ ) hltLogicalExpressionsCache_ = exprs;
+      for ( unsigned iExpr = 0; iExpr < hltLogicalExpressionsCache_.size(); ++iExpr ) {
+	std::string hltLogicalExpression( hltLogicalExpressionsCache_.at( iExpr ) );
+	std::cout << "hltLogicalExpressionsCache_: " << hltLogicalExpression << std::endl;
+      }
     }
   }
 
@@ -605,23 +623,38 @@ bool GenericTriggerEventFlag::negate( std::string & word ) const
 /// Reads and returns logical expressions from DB
 std::vector< std::string > GenericTriggerEventFlag::expressionsFromDB( const std::string & key, const edm::EventSetup & setup )
 {
-
-  if ( key.size() == 0 ) return std::vector< std::string >( 1, emptyKeyError_ );
+  std::cout << "[GenericTriggerEventFlag::expressionsFromDB] key: " << key.size() << " --> " << key << std::endl;
+  if ( key.size() == 0 ) {
+    std::cout << " returning " << emptyKeyError_ << std::endl;
+    return std::vector< std::string >( 1, emptyKeyError_ );
+  }
   edm::ESHandle< AlCaRecoTriggerBits > logicalExpressions;
   std::vector< edm::eventsetup::DataKey > labels;
   setup.get< AlCaRecoTriggerBitsRcd >().fillRegisteredDataKeys( labels );
   std::vector< edm::eventsetup::DataKey >::const_iterator iKey = labels.begin();
+  std::cout << "labels: " << labels.size() << std::endl;
   while ( iKey != labels.end() && iKey->name().value() != dbLabel_ ) ++iKey;
+
   if ( iKey == labels.end() ) {
     if ( verbose_ > 0 ) edm::LogWarning( "GenericTriggerEventFlag" ) << "Label " << dbLabel_ << " not found in DB for 'AlCaRecoTriggerBitsRcd'";
+    std::cout << " returning " << configError_ << std::endl;
     return std::vector< std::string >( 1, configError_ );
+  } else {
+    std::cout << "iKey->name().value(): " << iKey->name().value() << " <----> " << dbLabel_ << std::endl;
   }
   setup.get< AlCaRecoTriggerBitsRcd >().get( dbLabel_, logicalExpressions );
   const std::map< std::string, std::string > & expressionMap = logicalExpressions->m_alcarecoToTrig;
+  for (std::map< std::string, std::string >::const_iterator iter = expressionMap.begin();
+       iter != expressionMap.end(); iter++)
+    std::cout << "expressionMap: " << iter->first << " " << iter->second << std::endl;
   std::map< std::string, std::string >::const_iterator listIter = expressionMap.find( key );
   if ( listIter == expressionMap.end() ) {
+    std::cout << "verbose_: " << verbose_ << std::endl;
     if ( verbose_ > 0 ) edm::LogWarning( "GenericTriggerEventFlag" ) << "No logical expressions found under key " << key << " in 'AlCaRecoTriggerBitsRcd'";
+    std::cout << " returning " << configError_ << std::endl;
     return std::vector< std::string >( 1, configError_ );
+  } else {
+    std::cout << "listIter " << listIter->first << " " << listIter->second << std::endl;
   }
   return logicalExpressions->decompose( listIter->second );
 

--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -613,9 +613,7 @@ bool GenericTriggerEventFlag::negate( std::string & word ) const
 /// Reads and returns logical expressions from DB
 std::vector< std::string > GenericTriggerEventFlag::expressionsFromDB( const std::string & key, const edm::EventSetup & setup )
 {
-  if ( key.size() == 0 ) {
-    return std::vector< std::string >( 1, emptyKeyError_ );
-  }
+  if ( key.size() == 0 ) return std::vector< std::string >( 1, emptyKeyError_ );
   edm::ESHandle< AlCaRecoTriggerBits > logicalExpressions;
   std::vector< edm::eventsetup::DataKey > labels;
   setup.get< AlCaRecoTriggerBitsRcd >().fillRegisteredDataKeys( labels );

--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -137,16 +137,10 @@ void GenericTriggerEventFlag::initRun( const edm::Run & run, const edm::EventSet
     if ( onL1_ && l1DBKey_.size() > 0 ) {
       const std::vector< std::string > exprs( expressionsFromDB( l1DBKey_, setup ) );
       if ( exprs.empty() || exprs.at( 0 ) != configError_ ) l1LogicalExpressionsCache_ = exprs;
-      for ( unsigned iExpr = 0; iExpr < l1LogicalExpressionsCache_.size(); ++iExpr ) {
-	std::string l1LogicalExpression( l1LogicalExpressionsCache_.at( iExpr ) );  
-      }
     }
     if ( onHlt_ && hltDBKey_.size() > 0 ) {
       const std::vector< std::string > exprs( expressionsFromDB( hltDBKey_, setup ) );
       if ( exprs.empty() || exprs.at( 0 ) != configError_ ) hltLogicalExpressionsCache_ = exprs;
-      for ( unsigned iExpr = 0; iExpr < hltLogicalExpressionsCache_.size(); ++iExpr ) {
-	std::string hltLogicalExpression( hltLogicalExpressionsCache_.at( iExpr ) );
-      }
     }
   }
 

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -33,6 +33,8 @@ SiStripMonitorDigi.TProfNShotsVsTime.subdetswitchon = True
 SiStripMonitorDigi.TProfNShotsVsTime.globalswitchon = True
 SiStripMonitorDigi.TProfGlobalNShots.globalswitchon = True
 
+from DQM.SiStripMonitorClient.pset4GenericTriggerEventFlag_cfi import *
+
 # SiStripMonitorCluster ####
 from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
 SiStripMonitorClusterBPTX = SiStripMonitorCluster.clone()
@@ -72,7 +74,6 @@ SiStripMonitorTrackCommon = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiSt
 SiStripMonitorTrackCommon.TrackProducer = 'generalTracks'
 SiStripMonitorTrackCommon.Mod_On        = False
 
-from DQM.SiStripMonitorClient.pset4GenericTriggerEventFlag_cfi import *
 # Clone for SiStripMonitorTrack for Minimum Bias ####
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrackMB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -79,26 +79,14 @@ import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrackMB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
 SiStripMonitorTrackMB.TrackProducer = 'generalTracks'
 SiStripMonitorTrackMB.Mod_On        = False
-SiStripMonitorTrackMB.andOr         = genericTriggerEventFlag4HLTdb.andOr
-SiStripMonitorTrackMB.dbLabel       = genericTriggerEventFlag4HLTdb.dbLabel
-SiStripMonitorTrackMB.hltInputTag   = genericTriggerEventFlag4HLTdb.hltInputTag
-SiStripMonitorTrackMB.hltPaths      = genericTriggerEventFlag4HLTdb.hltPaths 
-SiStripMonitorTrackMB.hltDBKey      = genericTriggerEventFlag4HLTdb.hltDBKey
-SiStripMonitorTrackMB.errorReplyHlt = genericTriggerEventFlag4HLTdb.errorReplyHlt
-SiStripMonitorTrackMB.andOrHlt      = genericTriggerEventFlag4HLTdb.andOrHlt
+SiStripMonitorTrackMB.genericTriggerEventPSet = genericTriggerEventFlag4HLTdb
 
 ### TrackerMonitorTrack defined and used only for MinimumBias ####
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
 MonitorTrackResiduals.trajectoryInput = 'generalTracks'
 MonitorTrackResiduals.Tracks          = 'generalTracks'
 MonitorTrackResiduals.Mod_On          = False
-MonitorTrackResiduals.andOr           = genericTriggerEventFlag4HLTdb.andOr
-MonitorTrackResiduals.dbLabel         = genericTriggerEventFlag4HLTdb.dbLabel
-MonitorTrackResiduals.hltInputTag     = genericTriggerEventFlag4HLTdb.hltInputTag
-MonitorTrackResiduals.hltPaths        = genericTriggerEventFlag4HLTdb.hltPaths
-MonitorTrackResiduals.hltDBKey        = genericTriggerEventFlag4HLTdb.hltDBKey
-MonitorTrackResiduals.errorReplyHlt   = genericTriggerEventFlag4HLTdb.errorReplyHlt
-MonitorTrackResiduals.andOrHlt        = genericTriggerEventFlag4HLTdb.andOrHlt
+MonitorTrackResiduals.genericTriggerEventPSet = genericTriggerEventFlag4HLTdb
 
 # DQM Services
 dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -47,14 +47,8 @@ SiStripMonitorClusterBPTX.TH1MainDiagonalPosition.globalswitchon = True
 SiStripMonitorClusterBPTX.TH1StripNoise2ApvCycle.globalswitchon  = True
 SiStripMonitorClusterBPTX.TH1StripNoise3ApvCycle.globalswitchon  = True
 SiStripMonitorClusterBPTX.ClusterHisto = True
-SiStripMonitorClusterBPTX.BPTXfilter = cms.PSet(
-    andOr         = cms.bool( False ),
-    dbLabel       = cms.string("SiStripDQMTrigger"),
-    l1Algorithms = cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' ),
-    andOrL1       = cms.bool( True ),
-    errorReplyL1  = cms.bool( True ),
-    l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied. 
-)
+SiStripMonitorClusterBPTX.BPTXfilter = genericTriggerEventFlag4L1bd
+
 SiStripMonitorClusterBPTX.PixelDCSfilter = cms.PSet(
     andOr         = cms.bool( False ),
     dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
@@ -84,26 +78,26 @@ import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrackMB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
 SiStripMonitorTrackMB.TrackProducer = 'generalTracks'
 SiStripMonitorTrackMB.Mod_On        = False
-SiStripMonitorTrackMB.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
-SiStripMonitorTrackMB.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
-SiStripMonitorTrackMB.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
-SiStripMonitorTrackMB.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths 
-SiStripMonitorTrackMB.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
-SiStripMonitorTrackMB.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
-SiStripMonitorTrackMB.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
+SiStripMonitorTrackMB.andOr         = genericTriggerEventFlag4HLTdb.andOr
+SiStripMonitorTrackMB.dbLabel       = genericTriggerEventFlag4HLTdb.dbLabel
+SiStripMonitorTrackMB.hltInputTag   = genericTriggerEventFlag4HLTdb.hltInputTag
+SiStripMonitorTrackMB.hltPaths      = genericTriggerEventFlag4HLTdb.hltPaths 
+SiStripMonitorTrackMB.hltDBKey      = genericTriggerEventFlag4HLTdb.hltDBKey
+SiStripMonitorTrackMB.errorReplyHlt = genericTriggerEventFlag4HLTdb.errorReplyHlt
+SiStripMonitorTrackMB.andOrHlt      = genericTriggerEventFlag4HLTdb.andOrHlt
 
 ### TrackerMonitorTrack defined and used only for MinimumBias ####
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
 MonitorTrackResiduals.trajectoryInput = 'generalTracks'
 MonitorTrackResiduals.Tracks          = 'generalTracks'
 MonitorTrackResiduals.Mod_On          = False
-MonitorTrackResiduals.andOr           = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
-MonitorTrackResiduals.dbLabel         = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
-MonitorTrackResiduals.hltInputTag     = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
-MonitorTrackResiduals.hltPaths        = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
-MonitorTrackResiduals.hltDBKey        = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
-MonitorTrackResiduals.errorReplyHlt   = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
-MonitorTrackResiduals.andOrHlt        = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
+MonitorTrackResiduals.andOr           = genericTriggerEventFlag4HLTdb.andOr
+MonitorTrackResiduals.dbLabel         = genericTriggerEventFlag4HLTdb.dbLabel
+MonitorTrackResiduals.hltInputTag     = genericTriggerEventFlag4HLTdb.hltInputTag
+MonitorTrackResiduals.hltPaths        = genericTriggerEventFlag4HLTdb.hltPaths
+MonitorTrackResiduals.hltDBKey        = genericTriggerEventFlag4HLTdb.hltDBKey
+MonitorTrackResiduals.errorReplyHlt   = genericTriggerEventFlag4HLTdb.errorReplyHlt
+MonitorTrackResiduals.andOrHlt        = genericTriggerEventFlag4HLTdb.andOrHlt
 
 # DQM Services
 dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -78,31 +78,32 @@ SiStripMonitorTrackCommon = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiSt
 SiStripMonitorTrackCommon.TrackProducer = 'generalTracks'
 SiStripMonitorTrackCommon.Mod_On        = False
 
+from DQM.SiStripMonitorClient.pset4GenericTriggerEventFlag_cfi import *
 # Clone for SiStripMonitorTrack for Minimum Bias ####
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrackMB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
 SiStripMonitorTrackMB.TrackProducer = 'generalTracks'
 SiStripMonitorTrackMB.Mod_On        = False
-SiStripMonitorTrackMB.andOr         = cms.bool( False )
-SiStripMonitorTrackMB.dbLabel       = cms.string("SiStripDQMTrigger")
-SiStripMonitorTrackMB.hltInputTag = cms.InputTag( "TriggerResults::HLT" )
-SiStripMonitorTrackMB.hltPaths = cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*")
-SiStripMonitorTrackMB.hltDBKey = cms.string("Tracker_MB")
-SiStripMonitorTrackMB.errorReplyHlt  = cms.bool( False )
-SiStripMonitorTrackMB.andOrHlt = cms.bool(True) # True:=OR; False:=AND
+SiStripMonitorTrackMB.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
+SiStripMonitorTrackMB.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
+SiStripMonitorTrackMB.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
+SiStripMonitorTrackMB.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths 
+SiStripMonitorTrackMB.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
+SiStripMonitorTrackMB.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
+SiStripMonitorTrackMB.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
 
 ### TrackerMonitorTrack defined and used only for MinimumBias ####
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
 MonitorTrackResiduals.trajectoryInput = 'generalTracks'
 MonitorTrackResiduals.Tracks          = 'generalTracks'
-MonitorTrackResiduals.Mod_On        = False
-MonitorTrackResiduals.andOr         = cms.bool( False )
-MonitorTrackResiduals.dbLabel       = cms.string("SiStripDQMTrigger")
-MonitorTrackResiduals.hltInputTag = cms.InputTag( "TriggerResults::HLT" )
-MonitorTrackResiduals.hltPaths = cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*")
-MonitorTrackResiduals.hltDBKey = cms.string("Tracker_MB")
-MonitorTrackResiduals.errorReplyHlt  = cms.bool( False )
-MonitorTrackResiduals.andOrHlt = cms.bool(True) 
+MonitorTrackResiduals.Mod_On          = False
+MonitorTrackResiduals.andOr           = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
+MonitorTrackResiduals.dbLabel         = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
+MonitorTrackResiduals.hltInputTag     = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
+MonitorTrackResiduals.hltPaths        = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
+MonitorTrackResiduals.hltDBKey        = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
+MonitorTrackResiduals.errorReplyHlt   = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
+MonitorTrackResiduals.andOrHlt        = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
 
 # DQM Services
 dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -73,6 +73,8 @@ import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrackCommon = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
 SiStripMonitorTrackCommon.TrackProducer = 'generalTracks'
 SiStripMonitorTrackCommon.Mod_On        = False
+SiStripMonitorTrackCommon.TH1ClusterCharge.ringView = cms.bool( True )
+SiStripMonitorTrackCommon.TH1ClusterStoNCorr.ringView = cms.bool( True )
 
 # Clone for SiStripMonitorTrack for Minimum Bias ####
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
@@ -80,6 +82,8 @@ SiStripMonitorTrackMB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripM
 SiStripMonitorTrackMB.TrackProducer = 'generalTracks'
 SiStripMonitorTrackMB.Mod_On        = False
 SiStripMonitorTrackMB.genericTriggerEventPSet = genericTriggerEventFlag4HLTdb
+SiStripMonitorTrackMB.TH1ClusterCharge.ringView = cms.bool( True )
+SiStripMonitorTrackMB.TH1ClusterStoNCorr.ringView = cms.bool( True )
 
 ### TrackerMonitorTrack defined and used only for MinimumBias ####
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *

--- a/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
@@ -8,6 +8,7 @@ genericTriggerEventFlag4HLTdb = cms.PSet(
    hltPaths      = cms.vstring(""), #cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*")
    hltDBKey      = cms.string("SiStrip_HLT"),
    errorReplyHlt = cms.bool( False ),
+   verbosityLevel = cms.uint32(1)
 )
 
 genericTriggerEventFlag4L1bd = cms.PSet(
@@ -18,5 +19,6 @@ genericTriggerEventFlag4L1bd = cms.PSet(
 #   errorReplyL1  = cms.bool( True ),
    errorReplyL1  = cms.bool( False ),
    l1DBKey       = cms.string("SiStrip_L1"),
-   l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
+   l1BeforeMask  = cms.bool( True ), # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
+   verbosityLevel = cms.uint32(1)
 )

--- a/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
+   andOr         = cms.bool( False ),
+   dbLabel       = cms.string("TrackerDQMTrigger"),
+   andOrHlt      = cms.bool(True), # True:=OR; False:=AND
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring(""), #cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*")
+   hltDBKey      = cms.string("SiStrip_HLT"),
+   errorReplyHlt = cms.bool( False ),
+)

--- a/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
+genericTriggerEventFlag4HLTdb = cms.PSet(
    andOr         = cms.bool( False ),
    dbLabel       = cms.string("TrackerDQMTrigger"),
    andOrHlt      = cms.bool(True), # True:=OR; False:=AND
@@ -8,4 +8,13 @@ genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
    hltPaths      = cms.vstring(""), #cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*")
    hltDBKey      = cms.string("SiStrip_HLT"),
    errorReplyHlt = cms.bool( False ),
+)
+
+genericTriggerEventFlag4L1bd = cms.PSet(
+   andOr         = cms.bool( False ),
+   dbLabel       = cms.string("TrackerDQMTrigger"),
+   l1Algorithms  = cms.vstring(""), # cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' )
+   andOrL1       = cms.bool( True ),
+   errorReplyL1  = cms.bool( True ),
+   l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
 )

--- a/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
@@ -16,5 +16,6 @@ genericTriggerEventFlag4L1bd = cms.PSet(
    l1Algorithms  = cms.vstring(""), # cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' )
    andOrL1       = cms.bool( True ),
    errorReplyL1  = cms.bool( True ),
+   l1DBKey       = cms.string("SiStrip_L1"),
    l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
 )

--- a/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/SiStripMonitorClient/python/pset4GenericTriggerEventFlag_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 genericTriggerEventFlag4HLTdb = cms.PSet(
    andOr         = cms.bool( False ),
-   dbLabel       = cms.string("TrackerDQMTrigger"),
+   dbLabel       = cms.string("SiStripDQMTrigger"), # ("TrackerDQMTrigger"),
    andOrHlt      = cms.bool(True), # True:=OR; False:=AND
    hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
    hltPaths      = cms.vstring(""), #cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*")
@@ -12,10 +12,11 @@ genericTriggerEventFlag4HLTdb = cms.PSet(
 
 genericTriggerEventFlag4L1bd = cms.PSet(
    andOr         = cms.bool( False ),
-   dbLabel       = cms.string("TrackerDQMTrigger"),
+   dbLabel       = cms.string("SiStripDQMTrigger"), # ("TrackerDQMTrigger"),
    l1Algorithms  = cms.vstring(""), # cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' )
    andOrL1       = cms.bool( True ),
-   errorReplyL1  = cms.bool( True ),
+#   errorReplyL1  = cms.bool( True ),
+   errorReplyL1  = cms.bool( False ),
    l1DBKey       = cms.string("SiStrip_L1"),
    l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
 )

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -15,6 +15,8 @@ SiStripMonitorTrack = cms.EDAnalyzer(
     RawDigiLabel    = cms.string('VirginRaw'),
     
     Cluster_src = cms.InputTag('siStripClusters'),
+
+    genericTriggerEventPSet = cms.PSet(),
     
     ModulesToBeExcluded = cms.vuint32(),
     

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -26,7 +26,7 @@ SiStripMonitorTrack::SiStripMonitorTrack(const edm::ParameterSet& conf):
   conf_(conf),
   tracksCollection_in_EventTree(true),
   firstEvent(-1),
-  genTriggerEventFlag_(new GenericTriggerEventFlag(conf, consumesCollector(), *this))
+  genTriggerEventFlag_(new GenericTriggerEventFlag(conf.getParameter<edm::ParameterSet>("genericTriggerEventPSet"), consumesCollector(), *this))
 {
   Cluster_src_   = conf.getParameter<edm::InputTag>("Cluster_src");
   Mod_On_        = conf.getParameter<bool>("Mod_On");

--- a/DQM/TrackerCommon/test/AlCaRecoTriggerBits_SiStripDQM_create_cfg.py
+++ b/DQM/TrackerCommon/test/AlCaRecoTriggerBits_SiStripDQM_create_cfg.py
@@ -19,16 +19,17 @@ process.SiStripDQMCreate = cms.EDAnalyzer( "AlCaRecoTriggerBitsRcdUpdate"
 , listNamesRemove = cms.vstring()
 , triggerListsAdd = cms.VPSet(
     cms.PSet(
-      listName = cms.string( 'SiStripDQM_L1' )
-    , hltPaths = cms.vstring(
-        'NOT L1Tech_BSC_halo_beam2_inner.v0'                                   # NOT 36
-      , 'NOT L1Tech_BSC_halo_beam2_outer.v0'                                   # NOT 37
-      , 'NOT L1Tech_BSC_halo_beam1_inner.v0'                                   # NOT 38
-      , 'NOT L1Tech_BSC_halo_beam1_outer.v0'                                   # NOT 39
-      , 'NOT (L1Tech_BSC_splash_beam1.v0 AND NOT L1Tech_BSC_splash_beam2.v0)'  # NOT (42 AND NOT 43)
-      , 'NOT (L1Tech_BSC_splash_beam2.v0 AND NOT L1Tech_BSC_splash_beam1.v0)'  # NOT (43 AND NOT 42)
-      )
-    )
+      listName = cms.string( 'Tracking_HLT' )
+    , hltPaths = cms.vstring( 'HLT_ZeroBias_v*', 'HLT_BptxAnd_*' )
+    ),
+    cms.PSet(
+      listName = cms.string( 'SiStrip_L1' )
+    , hltPaths = cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias', 'L1_ExtCond_032' )
+    ),
+    cms.PSet(
+      listName = cms.string( 'SiStrip_HLT' )
+    , hltPaths = cms.vstring( 'HLT_ZeroBias_v*', 'HLT_HIZeroBias_v*', 'HLT_BptxAnd_*' )
+    ),
   )
 )
 
@@ -45,11 +46,12 @@ process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
 , CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup
 # , logconnect = cms.untracked.string( 'sqlite_file:AlCaRecoTriggerBits_SiStripDQM_create_log.db' )
 , timetype = cms.untracked.string( 'runnumber' )
-, connect  = cms.string( 'sqlite_file:AlCaRecoTriggerBits_SiStripDQM.db' )
+, connect  = cms.string( 'sqlite_file:AlCaRecoTriggerBits_TrackerDQM.db' )
 , toPut    = cms.VPSet(
     cms.PSet(
       record = cms.string( 'AlCaRecoTriggerBitsRcd' )
-    , tag    = cms.string( 'AlCaRecoTriggerBits_SiStripDQM_v2_test' )
+    , tag    = cms.string( 'AlCaRecoTriggerBits_TrackerDQM_v1' )
+    , label  = cms.untracked.string( 'TrackerDQMTrigger' ) 
     )
   )
 )

--- a/DQM/TrackerCommon/test/AlCaRecoTriggerBits_SiStripDQM_read_cfg.py
+++ b/DQM/TrackerCommon/test/AlCaRecoTriggerBits_SiStripDQM_read_cfg.py
@@ -28,11 +28,18 @@ process.maxEvents = cms.untracked.PSet(
 import CondCore.DBCommon.CondDBSetup_cfi
 process.dbInput = cms.ESSource( "PoolDBESSource"
 , CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup
-, connect = cms.string( 'sqlite_file:AlCaRecoTriggerBits_SiStripDQM.db' )
-, toGet   = cms.VPSet(
+#, connect = cms.string( 'sqlite_file:AlCaRecoTriggerBits_SiStripDQM.db' )
+#, toGet   = cms.VPSet(
+#    cms.PSet(
+#      record = cms.string( 'AlCaRecoTriggerBitsRcd' )
+#    , tag    = cms.string( 'AlCaRecoTriggerBits_SiStripDQM_v2_express' )
+#    )
+#  )
+, connect  = cms.string( 'sqlite_file:AlCaRecoTriggerBits_TrackerDQM.db' )
+, toGet    = cms.VPSet(
     cms.PSet(
       record = cms.string( 'AlCaRecoTriggerBitsRcd' )
-    , tag    = cms.string( 'AlCaRecoTriggerBits_SiStripDQM_v2_test' )
+    , tag    = cms.string( 'AlCaRecoTriggerBits_TrackerDQM_v1' )
     )
   )
 )

--- a/DQM/TrackerCommon/test/DQMXMLFile_SiStripDQM_create_cfg.py
+++ b/DQM/TrackerCommon/test/DQMXMLFile_SiStripDQM_create_cfg.py
@@ -34,19 +34,22 @@ process.dqmXmlFileTest = cms.EDAnalyzer( "DQMXMLFilePopConAnalyzer"
 print "Used XML file: " + process.dqmXmlFileTest.Source.XMLFile.pythonValue()
 
 process.load( "CondCore.DBCommon.CondDBCommon_cfi" )
-process.CondDBCommon.connect          = cms.string( 'sqlite_file:DQMXMLFile_SiStripDQM.db' )
+process.CondDBCommon.connect          = cms.string( 'sqlite_file:AlCaRecoTriggerBits_SiStripDQM.db' )
+#process.CondDBCommon.connect          = cms.string( 'sqlite_file:DQMXMLFile_SiStripDQM.db' )
 process.CondDBCommon.BlobStreamerName = cms.untracked.string( 'TBufferBlobStreamingService' )
 process.CondDBCommon.DBParameters.authenticationPath = cms.untracked.string( '' )
 # process.CondDBCommon.DBParameters.messageLevel       = cms.untracked.int32( 3 )
 
 process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
 , process.CondDBCommon
-, logconnect = cms.untracked.string( 'sqlite_file:DQMXMLFile_SiStripDQM_create_log.db' )
+, logconnect = cms.untracked.string( 'sqlite_file:AlCaRecoTriggerBits_SiStripDQM.db' )
+#, logconnect = cms.untracked.string( 'sqlite_file:DQMXMLFile_SiStripDQM_create_log.db' )
 , timetype   = cms.untracked.string( 'runnumber' )
 , toPut      = cms.VPSet(
     cms.PSet(
       record = cms.string( 'FileBlob' )
-    , tag    = cms.string( 'DQMXMLFile_SiStripDQM_v1_test' )
+#    , tag    = cms.string( 'DQMXMLFile_SiStripDQM_v1_test' )
+    , tag    = cms.string( 'AlCaRecoTriggerBits_SiStripDQM_v2_express' )
     )
   )
 )

--- a/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
@@ -6,6 +6,7 @@ MonitorTrackResiduals = cms.EDAnalyzer("MonitorTrackResiduals",
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(True),
     OutputFileName = cms.string('test_monitortracks.root'),
+    genericTriggerEventPSet = cms.PSet(),
     # bining and range for absolute and normalized residual histogramms
     TH1ResModules = cms.PSet(
         xmin = cms.double(-0.05),   # native unit in CMS is [cm], so these are 500um

--- a/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
@@ -6,6 +6,7 @@ SiPixelMonitorTrackResiduals = cms.EDAnalyzer("SiPixelMonitorTrackResiduals",
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(False),
     OutputFileName = cms.string('test_monitortracks.root'),
+    genericTriggerEventPSet = cms.PSet(),                                              
     # bining and range for absolute and normalized residual histogramms
     TH1ResModules = cms.PSet(
         xmin = cms.double(-0.05),   # native unit in CMS is [cm], so these are 500um

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -19,7 +19,7 @@
 template<TrackerType pixel_or_strip>
 MonitorTrackResidualsBase<pixel_or_strip>::MonitorTrackResidualsBase(const edm::ParameterSet& iConfig)
    : conf_(iConfig), m_cacheID_(0)
-   , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig, consumesCollector(), *this))
+   , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"), consumesCollector(), *this))
    , avalidator_(iConfig, consumesCollector()) {
   ModOn = conf_.getParameter<bool>("Mod_On");
   offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));

--- a/DQM/TrackingMonitor/python/LogMessageMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/LogMessageMonitor_cfi.py
@@ -45,5 +45,6 @@ LogMessageMon = cms.EDAnalyzer("LogMessageMonitor",
     LogFolderName       = cms.string('Tracking/MessageLog'),
     OutputMEsInRootFile = cms.bool(False),
     OutputFileName      = cms.string('MonitorTrack.root'),
-    BXlumiSetup         = BXlumiSetup.clone()
+    BXlumiSetup         = BXlumiSetup.clone(),
+    genericTriggerEventPSet = cms.PSet()
 )    

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -17,6 +17,7 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     stripCluster     = cms.InputTag('siStripClusters'),
     pixelCluster     = cms.InputTag('siPixelClusters'),                          
     BXlumiSetup      = BXlumiSetup.clone(),                              
+    genericTriggerEventPSet = cms.PSet(),
 #    lumi             = cms.InputTag('lumiProducer'),
 #  # taken from 
 #  # DPGAnalysis/SiStripTools/src/DigiLumiCorrHistogramMaker.cc

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
@@ -13,6 +13,8 @@ dEdxAnalyzer = cms.EDAnalyzer("dEdxAnalyzer",
        TracksForDeDx       = cms.string('generalTracks'),
        deDxProducers       = cms.vstring('dedxDQMHarm2SP', 'dedxDQMHarm2SO', 'dedxDQMHarm2PO'),
 
+       genericTriggerEventPSet = cms.PSet(),
+
        #cuts on number of hits
        TrackHitMin         = cms.double(8),
        HIPdEdxMin          = cms.double(3.5),
@@ -55,6 +57,8 @@ dEdxHitAnalyzer = cms.EDAnalyzer("dEdxHitAnalyzer",
        #input collections
        TracksForDeDx       = cms.string('generalTracks'),
        deDxHitProducers       = cms.vstring('dedxHitInfo'),
+
+       genericTriggerEventPSet = cms.PSet(),
 
        #histograms definition
        dEdxNHitBin         = cms.int32(30),

--- a/DQM/TrackingMonitor/src/LogMessageMonitor.cc
+++ b/DQM/TrackingMonitor/src/LogMessageMonitor.cc
@@ -91,7 +91,7 @@ LogMessageMonitor::LogMessageMonitor(const edm::ParameterSet& iConfig)
   edm::ConsumesCollector c{ consumesCollector() };
    //now do what ever initialization is needed
   lumiDetails_         = new GetLumi( iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c );
-  genTriggerEventFlag_ = new GenericTriggerEventFlag(iConfig, consumesCollector(), *this);
+  genTriggerEventFlag_ = new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),consumesCollector(), *this);
 }
 
 

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -70,7 +70,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
     , doGeneralPropertiesPlots_( conf_.getParameter<bool>("doGeneralPropertiesPlots"))
     , doHitPropertiesPlots_    ( conf_.getParameter<bool>("doHitPropertiesPlots"))
     , doPUmonitoring_          ( conf_.getParameter<bool>("doPUmonitoring") )
-    , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig,consumesCollector(), *this))
+    , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),consumesCollector(), *this))
     , numSelection_       (conf_.getParameter<std::string>("numCut"))
     , denSelection_       (conf_.getParameter<std::string>("denCut"))
 {

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -25,7 +25,7 @@ dEdxAnalyzer::dEdxAnalyzer(const edm::ParameterSet& iConfig)
   , conf_    (fullconf_.getParameter<edm::ParameterSet>("dEdxParameters") )
   , doAllPlots_  ( conf_.getParameter<bool>("doAllPlots") )
   , doDeDxPlots_ ( conf_.getParameter<bool>("doDeDxPlots") )    
-  , genTriggerEventFlag_( new GenericTriggerEventFlag(conf_,consumesCollector(), *this) )
+  , genTriggerEventFlag_( new GenericTriggerEventFlag(conf_.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),consumesCollector(), *this) )
 {
 
   trackInputTag_ = edm::InputTag(conf_.getParameter<std::string>("TracksForDeDx") );

--- a/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
@@ -24,7 +24,7 @@ dEdxHitAnalyzer::dEdxHitAnalyzer(const edm::ParameterSet& iConfig)
   , conf_    (fullconf_.getParameter<edm::ParameterSet>("dEdxParameters") )
   , doAllPlots_  ( conf_.getParameter<bool>("doAllPlots") )
   , doDeDxPlots_ ( conf_.getParameter<bool>("doDeDxPlots") )    
-  , genTriggerEventFlag_( new GenericTriggerEventFlag(conf_,consumesCollector(), *this) )
+  , genTriggerEventFlag_( new GenericTriggerEventFlag(conf_.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),consumesCollector(), *this) )
 {
 
   trackInputTag_ = edm::InputTag(conf_.getParameter<std::string>("TracksForDeDx") );

--- a/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
@@ -1,28 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.LogMessageMonitor_cfi
+from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 
+import DQM.TrackingMonitor.LogMessageMonitor_cfi
 # Clone for all PDs but MinBias ####
 LogMessageMonCommon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-LogMessageMonCommon.andOr         = cms.bool( False )
-LogMessageMonCommon.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-LogMessageMonCommon.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29)
-LogMessageMonCommon.andOrDcs      = cms.bool( False )
-LogMessageMonCommon.errorReplyDcs = cms.bool( True )
+LogMessageMonCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
 
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 # Clone for MinBias ###
 LogMessageMonMB = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-LogMessageMonMB.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
-LogMessageMonMB.dcsInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsInputTag
-LogMessageMonMB.dcsPartitions = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsPartitions
-LogMessageMonMB.andOrDcs      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrDcs
-LogMessageMonMB.errorReplyDcs = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyDcs
-LogMessageMonMB.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
-LogMessageMonMB.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
-LogMessageMonMB.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
-LogMessageMonMB.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
-LogMessageMonMB.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
-LogMessageMonMB.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
-
+LogMessageMonMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 

--- a/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
@@ -10,17 +10,19 @@ LogMessageMonCommon.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29)
 LogMessageMonCommon.andOrDcs      = cms.bool( False )
 LogMessageMonCommon.errorReplyDcs = cms.bool( True )
 
+from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 # Clone for MinBias ###
 LogMessageMonMB = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-LogMessageMonMB.andOr         = cms.bool( False )
-LogMessageMonMB.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-LogMessageMonMB.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29)
-LogMessageMonMB.andOrDcs      = cms.bool( False )
-LogMessageMonMB.errorReplyDcs = cms.bool( True )
-LogMessageMonMB.dbLabel       = cms.string("SiStripDQMTrigger")
-LogMessageMonMB.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-LogMessageMonMB.hltPaths      = cms.vstring("HLT_ZeroBias_*")
-LogMessageMonMB.hltDBKey      = cms.string("Tracker_MB")
-LogMessageMonMB.errorReplyHlt = cms.bool( False )
-LogMessageMonMB.andOrHlt      = cms.bool(True) 
+LogMessageMonMB.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
+LogMessageMonMB.dcsInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsInputTag
+LogMessageMonMB.dcsPartitions = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsPartitions
+LogMessageMonMB.andOrDcs      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrDcs
+LogMessageMonMB.errorReplyDcs = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyDcs
+LogMessageMonMB.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
+LogMessageMonMB.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
+LogMessageMonMB.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
+LogMessageMonMB.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
+LogMessageMonMB.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
+LogMessageMonMB.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
+
 

--- a/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
@@ -1,29 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-# Clone for TrackingMonitor for all PDs but MinBias ###
+from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
+
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
+
+# Clone for TrackingMonitor for all PDs but MinBias ###
 TrackerCollisionTrackMonCommon = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonCommon.andOr         = cms.bool( False )
-TrackerCollisionTrackMonCommon.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-TrackerCollisionTrackMonCommon.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29)
-TrackerCollisionTrackMonCommon.andOrDcs      = cms.bool( False )
-TrackerCollisionTrackMonCommon.errorReplyDcs = cms.bool( True )
+TrackerCollisionTrackMonCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
 TrackerCollisionTrackMonCommon.setLabel("TrackerCollisionTrackMonCommon")
 
-from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 # Clone for TrackingMonitor for MinBias ###
 TrackerCollisionTrackMonMB = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonMB.andOr                = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
-TrackerCollisionTrackMonMB.dcsInputTag          = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsInputTag
-TrackerCollisionTrackMonMB.dcsPartitions        = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsPartitions
-TrackerCollisionTrackMonMB.andOrDcs             = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrDcs
-TrackerCollisionTrackMonMB.errorReplyDcs        = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyDcs
-TrackerCollisionTrackMonMB.dbLabel              = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
-TrackerCollisionTrackMonMB.andOrHlt             = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
-TrackerCollisionTrackMonMB.hltInputTag          = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
-TrackerCollisionTrackMonMB.hltPaths             = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
-TrackerCollisionTrackMonMB.hltDBKey             = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
-TrackerCollisionTrackMonMB.errorReplyHlt        = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
+TrackerCollisionTrackMonMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 TrackerCollisionTrackMonMB.doPrimaryVertexPlots = cms.bool(True)
 TrackerCollisionTrackMonMB.setLabel("TrackerCollisionTrackMonMB")
 

--- a/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
@@ -10,20 +10,20 @@ TrackerCollisionTrackMonCommon.andOrDcs      = cms.bool( False )
 TrackerCollisionTrackMonCommon.errorReplyDcs = cms.bool( True )
 TrackerCollisionTrackMonCommon.setLabel("TrackerCollisionTrackMonCommon")
 
+from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 # Clone for TrackingMonitor for MinBias ###
-import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
 TrackerCollisionTrackMonMB = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonMB.andOr                = cms.bool( False )
-TrackerCollisionTrackMonMB.dcsInputTag          = cms.InputTag( "scalersRawToDigi" )
-TrackerCollisionTrackMonMB.dcsPartitions        = cms.vint32 ( 24, 25, 26, 27, 28, 29)
-TrackerCollisionTrackMonMB.andOrDcs             = cms.bool( False )
-TrackerCollisionTrackMonMB.errorReplyDcs        = cms.bool( True )
-TrackerCollisionTrackMonMB.dbLabel              = cms.string("SiStripDQMTrigger")
-TrackerCollisionTrackMonMB.hltInputTag          = cms.InputTag( "TriggerResults::HLT" )
-TrackerCollisionTrackMonMB.hltPaths             = cms.vstring("HLT_ZeroBias_*")
-TrackerCollisionTrackMonMB.hltDBKey             = cms.string("Tracker_MB")
-TrackerCollisionTrackMonMB.errorReplyHlt        = cms.bool( False )
-TrackerCollisionTrackMonMB.andOrHlt             = cms.bool(True)
+TrackerCollisionTrackMonMB.andOr                = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
+TrackerCollisionTrackMonMB.dcsInputTag          = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsInputTag
+TrackerCollisionTrackMonMB.dcsPartitions        = genericTriggerEventFlag4fullTrackerAndHLTdb.dcsPartitions
+TrackerCollisionTrackMonMB.andOrDcs             = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrDcs
+TrackerCollisionTrackMonMB.errorReplyDcs        = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyDcs
+TrackerCollisionTrackMonMB.dbLabel              = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
+TrackerCollisionTrackMonMB.andOrHlt             = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
+TrackerCollisionTrackMonMB.hltInputTag          = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
+TrackerCollisionTrackMonMB.hltPaths             = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
+TrackerCollisionTrackMonMB.hltDBKey             = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
+TrackerCollisionTrackMonMB.errorReplyHlt        = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
 TrackerCollisionTrackMonMB.doPrimaryVertexPlots = cms.bool(True)
 TrackerCollisionTrackMonMB.setLabel("TrackerCollisionTrackMonMB")
 

--- a/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
@@ -3,27 +3,30 @@ import FWCore.ParameterSet.Config as cms
 # dEdx monitor ####
 #from DQM.TrackingMonitor.dEdxAnalyzer_cff import *
 import DQM.TrackingMonitor.dEdxAnalyzer_cfi
-# Clone for all PDs but MinBias ####
+# Clone for all PDs but ZeroBias ####
 dEdxMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
 
 dEdxHitMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
 
-# Clone for MinBias ####
+from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
+# Clone for ZeroBias ####
 dEdxMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
-dEdxMonMB.dEdxParameters.andOr         = cms.bool( False )
-dEdxMonMB.dEdxParameters.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-dEdxMonMB.dEdxParameters.hltPaths      = cms.vstring("HLT_ZeroBias_*")
-dEdxMonMB.dEdxParameters.hltDBKey      = cms.string("Tracker_MB")
-dEdxMonMB.dEdxParameters.errorReplyHlt = cms.bool( False )
-dEdxMonMB.dEdxParameters.andOrHlt      = cms.bool(True) 
+dEdxMonMB.dEdxParameters.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
+dEdxMonMB.dEdxParameters.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
+dEdxMonMB.dEdxParameters.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
+dEdxMonMB.dEdxParameters.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
+dEdxMonMB.dEdxParameters.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
+dEdxMonMB.dEdxParameters.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
+dEdxMonMB.dEdxParameters.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
 
 dEdxHitMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
-dEdxHitMonMB.dEdxParameters.andOr         = cms.bool( False )
-dEdxHitMonMB.dEdxParameters.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-dEdxHitMonMB.dEdxParameters.hltPaths      = cms.vstring("HLT_ZeroBias_*")
-dEdxHitMonMB.dEdxParameters.hltDBKey      = cms.string("Tracker_MB")
-dEdxHitMonMB.dEdxParameters.errorReplyHlt = cms.bool( False )
-dEdxHitMonMB.dEdxParameters.andOrHlt      = cms.bool(True) 
+dEdxHitMonMB.dEdxParameters.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
+dEdxHitMonMB.dEdxParameters.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
+dEdxHitMonMB.dEdxParameters.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
+dEdxHitMonMB.dEdxParameters.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
+dEdxHitMonMB.dEdxParameters.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
+dEdxHitMonMB.dEdxParameters.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
+dEdxHitMonMB.dEdxParameters.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
 
 # Clone for SingleMu ####
 dEdxMonMU = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()

--- a/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
@@ -11,22 +11,10 @@ dEdxHitMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 # Clone for ZeroBias ####
 dEdxMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
-dEdxMonMB.dEdxParameters.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
-dEdxMonMB.dEdxParameters.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
-dEdxMonMB.dEdxParameters.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
-dEdxMonMB.dEdxParameters.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
-dEdxMonMB.dEdxParameters.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
-dEdxMonMB.dEdxParameters.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
-dEdxMonMB.dEdxParameters.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
+dEdxMonMB.dEdxParameters.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 
 dEdxHitMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
-dEdxHitMonMB.dEdxParameters.andOr         = genericTriggerEventFlag4fullTrackerAndHLTdb.andOr
-dEdxHitMonMB.dEdxParameters.dbLabel       = genericTriggerEventFlag4fullTrackerAndHLTdb.dbLabel
-dEdxHitMonMB.dEdxParameters.andOrHlt      = genericTriggerEventFlag4fullTrackerAndHLTdb.andOrHlt
-dEdxHitMonMB.dEdxParameters.hltInputTag   = genericTriggerEventFlag4fullTrackerAndHLTdb.hltInputTag
-dEdxHitMonMB.dEdxParameters.hltPaths      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltPaths
-dEdxHitMonMB.dEdxParameters.hltDBKey      = genericTriggerEventFlag4fullTrackerAndHLTdb.hltDBKey
-dEdxHitMonMB.dEdxParameters.errorReplyHlt = genericTriggerEventFlag4fullTrackerAndHLTdb.errorReplyHlt
+dEdxHitMonMB.dEdxParameters.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 
 # Clone for SingleMu ####
 dEdxMonMU = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()

--- a/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
@@ -6,7 +6,7 @@ genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
    dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
    andOrDcs      = cms.bool( False ),
    errorReplyDcs = cms.bool( True ),
-   dbLabel       = cms.string("TrackerDQMTrigger"),
+   dbLabel       = cms.string("SiStripDQMTrigger"), #("TrackerDQMTrigger"),
    andOrHlt      = cms.bool(True),# True:=OR; False:=AND
    hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
    hltPaths      = cms.vstring(""), # HLT_ZeroBias_v*

--- a/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
+   andOr         = cms.bool( False ),
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+   dbLabel       = cms.string("TrackerDQMTrigger"),
+   andOrHlt      = cms.bool(True),
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring(""),
+   hltDBKey      = cms.string("Tracking_HLT"),
+   errorReplyHlt = cms.bool( False ),
+)

--- a/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
@@ -1,5 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
+genericTriggerEventFlag4fullTracker = cms.PSet(
+   andOr         = cms.bool( False ),
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+)
+genericTriggerEventFlag4onlyStrip = cms.PSet(
+   andOr         = cms.bool( False ),
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+)
 genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
    andOr         = cms.bool( False ),
    dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
@@ -12,4 +26,5 @@ genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
    hltPaths      = cms.vstring(""), # HLT_ZeroBias_v*
    hltDBKey      = cms.string("Tracking_HLT"),
    errorReplyHlt = cms.bool( False ),
+   verbosityLevel = cms.uint32(1)
 )

--- a/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
@@ -7,9 +7,9 @@ genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
    andOrDcs      = cms.bool( False ),
    errorReplyDcs = cms.bool( True ),
    dbLabel       = cms.string("TrackerDQMTrigger"),
-   andOrHlt      = cms.bool(True),
+   andOrHlt      = cms.bool(True),# True:=OR; False:=AND
    hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
-   hltPaths      = cms.vstring(""),
+   hltPaths      = cms.vstring(""), # HLT_ZeroBias_v*
    hltDBKey      = cms.string("Tracking_HLT"),
    errorReplyHlt = cms.bool( False ),
 )


### PR DESCRIPTION
this PR is meant to --finally-- enable the trigger selection via DB

I run runTheMatrix -l limited, and it runs smoothly

in order to make use of the DB,
I use the following setting in the DQM config

import CondCore.DBCommon.CondDBSetup_cfi
process.dbInput = cms.ESSource( "PoolDBESSource"
, CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup
, connect  = cms.string( 'sqlite_file:/afs/cern.ch/work/t/tosi/public/DQM/checkDB/CMSSW_8_0_4/src/DQM/TrackerCommon/test/AlCaRecoTriggerBits_TrackerDQM.db' )
, toGet    = cms.VPSet(
    cms.PSet(
      record = cms.string( 'AlCaRecoTriggerBitsRcd' )
    , tag    = cms.string( 'AlCaRecoTriggerBits_TrackerDQM_v1' )
    , label  = cms.untracked.string( 'SiStripDQMTrigger' )
    )
  )
)
process.es_prefer = cms.ESPrefer("PoolDBESSource","dbInput")

where the sqlite file is like
# 
# AlCaRecoTriggerBits settings for IOV 132000-132999:
# 

trigger list key: 'SiStripDQM_L1'
paths:
'NOT L1Tech_BSC_halo_beam2_inner.v0', 'NOT L1Tech_BSC_halo_beam2_outer.v0', 'NOT L1Tech_BSC_halo_beam1_inner.v0', 'NOT L1Tech_BSC_halo_beam1_outer.v0',
'NOT (L1Tech_BSC_splash_beam1.v0 AND NOT L1Tech_BSC_splash_beam2.v0)', 'NOT (L1Tech_BSC_splash_beam2.v0 AND NOT L1Tech_BSC_splash_beam1.v0)'
# 

trigger list key: 'SiStrip_HLT'
paths:
'HLT_ZeroBias_v_', 'HLT_HIZeroBias_v_'
# 

trigger list key: 'SiStrip_L1'
paths:
'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias'
# 

trigger list key: 'Tracking_HLT'
paths:
'HLT_ZeroBias_v*'
# 

we will need to update the payload, indeed

@mmusich @fioriNTU @rovere @VinInn 
